### PR TITLE
Offer free Luna with a configurable weekly allowance and upgrades

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -19,6 +19,7 @@ import type {
   UpdateAutomation,
 } from "@openwork/types/automations";
 import { generatedArtifactViewSchema, savedAppDetailSchema, savedAppSummarySchema, type SaveApp, type WorkflowDetail } from "@openwork/types/workflows";
+import { inferenceAccessSchema } from "./inference-access";
 
 // Re-export the shared schema under the local alias so React consumers
 // (e.g. the cloud domain's desktop-config provider) can import it alongside
@@ -3010,6 +3011,14 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         organizationId: orgId,
       });
       return normalizeDenDesktopConfig(payload);
+    },
+
+    async getInferenceAccess(orgId: string) {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/inference/access", {
+        method: "GET", token, organizationId: orgId,
+      });
+      if (!isRecord(payload)) throw new Error("Inference access response was incomplete.");
+      return inferenceAccessSchema.parse(payload.access);
     },
 
     async getResourceSnapshot(orgId?: string | null): Promise<DenResourceSnapshot> {

--- a/apps/app/src/app/lib/inference-access.ts
+++ b/apps/app/src/app/lib/inference-access.ts
@@ -1,0 +1,68 @@
+import { INFERENCE_ACCESS_REASONS, type InferenceAccess } from "@openwork/types/den/inference";
+import { z } from "zod";
+import type { ModelRef } from "../types";
+
+export const FREE_LUNA_MODEL: ModelRef = { providerID: "openwork", modelID: "openai/gpt-5.6-luna" };
+export const inferenceAccessRefreshEvent = "openwork.inference-access-refresh";
+export const explicitModelChoiceKey = "openwork.modelChoice.explicit";
+
+const usd = z.number().finite().nonnegative().nullable();
+export const inferenceAccessSchema: z.ZodType<InferenceAccess & { canUpgrade: boolean }> = z.object({
+  kind: z.enum(["paid", "free", "exhausted", "unavailable"]),
+  modelID: z.string().nullable(),
+  weeklyLimitUsd: usd,
+  usedUsd: usd,
+  reservedUsd: usd,
+  remainingUsd: usd,
+  resetsAt: z.iso.datetime().nullable(),
+  reason: z.enum(INFERENCE_ACCESS_REASONS).nullable(),
+  canUpgrade: z.boolean(),
+});
+
+export type InferenceUpgradeReason = "free_allowance_exhausted" | "managed_model_requires_upgrade";
+
+export function modelSelectionUpgradeReason(access: InferenceAccess | null, model: ModelRef): InferenceUpgradeReason | null {
+  // Organization BYOK uses lpr_* identities, even when its provider is managed.
+  if (model.providerID !== FREE_LUNA_MODEL.providerID || !access || (access.kind !== "free" && access.kind !== "exhausted")) return null;
+  if (model.modelID !== FREE_LUNA_MODEL.modelID) return "managed_model_requires_upgrade";
+  return access.kind === "exhausted" ? "free_allowance_exhausted" : null;
+}
+
+export function shouldSelectInitialLuna(input: {
+  installationRequiresSignin: boolean;
+  signedIn: boolean;
+  access: InferenceAccess | null;
+  modelAvailable: boolean;
+  emptyFirstTask: boolean;
+  setupComplete: boolean;
+  explicitChoice: boolean;
+  currentModel: ModelRef | null;
+  variant: string | null;
+}) {
+  return input.installationRequiresSignin && input.signedIn && input.access?.kind === "free"
+    && input.access.modelID === FREE_LUNA_MODEL.modelID && input.modelAvailable && input.emptyFirstTask
+    && !input.setupComplete && !input.explicitChoice && input.variant === null
+    && (!input.currentModel || (input.currentModel.providerID === "opencode" && input.currentModel.modelID === "big-pickle"));
+}
+
+export function markExplicitModelChoice() {
+  try { window.localStorage.setItem(explicitModelChoiceKey, "1"); } catch { /* Storage can be unavailable. */ }
+}
+
+export function refreshInferenceAccess() {
+  if (typeof window !== "undefined") window.dispatchEvent(new Event(inferenceAccessRefreshEvent));
+}
+
+export function formatAllowanceUsd(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(value);
+}
+
+export function pendingInferenceUsageLabel(access: InferenceAccess) {
+  if (access.reason !== "free_request_in_progress") return null;
+  return `A Luna request is running or awaiting final usage.${access.reservedUsd !== null ? ` Estimated pending cost: ${formatAllowanceUsd(access.reservedUsd)}; the final charge may differ.` : ""} Wait for it to settle before starting another free request.`;
+}
+
+export function allowanceResetLabel(resetsAt: string | null | undefined) {
+  if (!resetsAt || !Number.isFinite(Date.parse(resetsAt))) return null;
+  return new Date(resetsAt).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short" });
+}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -32,7 +32,8 @@ import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { t } from "@/i18n"
 import { useOpenTargets } from "@/lib/target-provider"
 import { openTargetFromUrl } from "@/react-app/domains/session/artifacts/open-target"
-import { sessionErrorPresentationFromUIMessage } from "@/react-app/domains/session/sync/session-error"
+import { sessionErrorPresentationFromUIMessage, type OpencodeSessionErrorPresentation } from "@/react-app/domains/session/sync/session-error"
+import { InferenceErrorActions } from "@/react-app/domains/cloud/inference-access-provider"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
 import { EditTool } from "@/components/tools/edit"
@@ -834,6 +835,7 @@ const MessageComponent = React.memo(
           description={presentation?.description}
           resumePrompt={presentation?.recoveryPrompt}
           technicalDetails={presentation?.technicalDetails}
+          inference={presentation?.inference}
         />
       )
     }
@@ -923,6 +925,7 @@ const ReconnectingMessage = React.memo(({ lastConfirmedAt }: { lastConfirmedAt: 
 ReconnectingMessage.displayName = "ReconnectingMessage"
 
 interface ErrorMessageProps {
+  inference?: OpencodeSessionErrorPresentation["inference"]
   error: string | null
   description?: string | null
   /** Set only for interrupted runs (aborted / provider timeout) that can resume. */
@@ -993,8 +996,8 @@ function SessionErrorTechnicalDetails({ details, tone }: { details: string; tone
   )
 }
 
-function ErrorMessage({ error, description, resumePrompt, technicalDetails }: ErrorMessageProps) {
-  const { onResumeInterrupted, developerMode } = useMessageList()
+function ErrorMessage({ error, description, resumePrompt, technicalDetails, inference }: ErrorMessageProps) {
+  const { onResumeInterrupted, developerMode, sessionId } = useMessageList()
   // Status codes, provider names, and response bodies are for developers,
   // admins, and support — not the plain-language card end users see. They
   // surface only with Developer mode (Settings → Advanced), like the
@@ -1040,6 +1043,7 @@ function ErrorMessage({ error, description, resumePrompt, technicalDetails }: Er
               ) : null}
             </div>
           </div>
+          {inference ? <InferenceErrorActions {...inference} sessionId={sessionId} /> : null}
           {details ? <SessionErrorTechnicalDetails details={details} tone="card" /> : null}
         </div>
       </div>

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -19,6 +19,8 @@ import {
 import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import { InferenceAllowanceSummary, useInferenceAccess } from "@/react-app/domains/cloud/inference-access-provider";
+import { markExplicitModelChoice, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
 import {
   OPENWORK_MODELS_PROVIDER_ID,
   OPENWORK_MODELS_PROVIDER_NAME,
@@ -212,7 +214,7 @@ interface ModelSelectProps {
   disabled?: boolean;
   /** When set, "All models" opens the full picker scoped to this session. */
   sessionId?: string;
-  /** Den/import includes OpenWork Models. Kept for callers; picker no longer upsells here. */
+  /** Den/import includes OpenWork Models; allowance gates use member access instead. */
   openWorkModelsEntitled?: boolean;
   /** The server is waiting to reload this workspace with OpenWork Models. */
   openWorkModelsSyncing?: boolean;
@@ -245,6 +247,7 @@ export function ModelSelect({
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const platform = usePlatform();
   const denAuth = useDenAuth();
+  const inference = useInferenceAccess();
   const favorites = useModelCollectionsStore((state) => state.favorites);
   const recent = useModelCollectionsStore((state) => state.recent);
   const catalogOptions = useModelOptions(open, fallbackOptions, denAuth.isSignedIn);
@@ -335,12 +338,14 @@ export function ModelSelect({
   const selectedThinkingOptions = selectedOption ? thinkingOptionsFor(selectedOption) : [];
   const effectiveBehaviorLabel = behaviorLabel ?? selectedOption?.behaviorLabel ?? "Default";
   const currentFavorite = favoriteOptions.find((option) => isSameModel(value, option)) ?? favoriteOptions[0] ?? null;
-  const nextFavorite = nextFavoriteModel(favorites, value);
+  const nextFavorite = nextFavoriteModel(favorites.filter((model) => !modelSelectionUpgradeReason(inference.access, model)), value);
   const showBehavior = !hideValue
     && selectedThinkingOptions.length > 0
     && Boolean(effectiveBehaviorLabel);
 
   const applyModel = (option: ModelOption, behavior?: string | null) => {
+    if (!inference.checkSelection(option, sessionId)) { onOpenChange(false); return; }
+    markExplicitModelChoice();
     useModelCollectionsStore.getState().recordRecent(option);
     onChange({ providerID: option.providerID, modelID: option.modelID }, behavior);
     if (behavior !== undefined) {
@@ -353,6 +358,7 @@ export function ModelSelect({
   };
 
   const handleSelect = (option: ModelOption) => {
+    if (!inference.checkSelection(option, sessionId)) { onOpenChange(false); return; }
     const thinking = thinkingOptionsFor(option);
     if (thinking.length > 0 && onBehaviorChange) {
       setThinkingFor(option);
@@ -447,6 +453,7 @@ export function ModelSelect({
         align="start"
         initialFocus={false}
       >
+        <InferenceAllowanceSummary className="px-3 pt-2" available={catalogOptions.some((option) => option.providerID === "openwork")} />
         {pane === "root" ? (
           <div data-slot="model-select-root" className="space-y-0.5 p-2">
             <button

--- a/apps/app/src/react-app/domains/cloud/inference-access-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/inference-access-provider.tsx
@@ -1,0 +1,179 @@
+import { createContext, use, useEffect, useRef, useState, type ReactNode } from "react";
+import type { InferenceAccess } from "@openwork/types/den/inference";
+import type { ModelRef } from "@/app/types";
+import { createDenClient, readDenSettings } from "@/app/lib/den";
+import { denSessionUpdatedEvent, denSettingsChangedEvent } from "@/app/lib/den-session-events";
+import { newProvidersEvent } from "@/app/lib/provider-events";
+import { allowanceResetLabel, formatAllowanceUsd, inferenceAccessRefreshEvent, modelSelectionUpgradeReason, pendingInferenceUsageLabel, type InferenceUpgradeReason } from "@/app/lib/inference-access";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { usePlatform } from "@/react-app/kernel/platform";
+import { openModelPickerEvent } from "@/react-app/shell/new-providers-listener";
+import { useDenAuth } from "./den-auth-provider";
+import { getOpenWorkModelsActionUrl } from "./openwork-models-promo";
+
+type Access = InferenceAccess & { canUpgrade: boolean };
+type Upgrade = { reason: InferenceUpgradeReason; sessionId?: string };
+const InferenceAccessContext = createContext<{
+  access: Access | null;
+  checkSelection: (model: ModelRef, sessionId?: string) => boolean;
+  showUpgrade: (reason: InferenceUpgradeReason, sessionId?: string) => void;
+}>({ access: null, checkSelection: () => true, showUpgrade: () => undefined });
+
+export function useInferenceAccess() { return use(InferenceAccessContext); }
+
+export function InferenceAccessProvider({ children }: { children: ReactNode }) {
+  const auth = useDenAuth();
+  const platform = usePlatform();
+  const [revision, setRevision] = useState(0);
+  const [result, setResult] = useState<{ scope: string; access: Access } | null>(null);
+  const [upgrade, setUpgrade] = useState<Upgrade | null>(null);
+  const epoch = useRef(0);
+  const settings = readDenSettings();
+  const identity = auth.verifiedIdentity;
+  const scope = auth.status === "signed_in" && identity && identity.organizationId === settings.activeOrgId
+    ? JSON.stringify([settings.baseUrl, identity.principalId, identity.organizationId, revision]) : null;
+  const access = scope && result?.scope === scope ? result.access : null;
+
+  useEffect(() => {
+    const clear = () => {
+      epoch.current += 1;
+      setResult(null);
+      setUpgrade(null);
+      setRevision((value) => value + 1);
+    };
+    window.addEventListener(denSettingsChangedEvent, clear);
+    window.addEventListener(denSessionUpdatedEvent, clear);
+    return () => {
+      window.removeEventListener(denSettingsChangedEvent, clear);
+      window.removeEventListener(denSessionUpdatedEvent, clear);
+    };
+  }, []);
+
+  useEffect(() => {
+    const generation = ++epoch.current;
+    setResult(null);
+    setUpgrade(null);
+    if (!scope) return;
+    const captured = readDenSettings();
+    const token = captured.authToken;
+    const orgId = captured.activeOrgId;
+    if (!token || !orgId) return;
+    let running = false;
+    let refreshAgain = false;
+    let lastRead = 0;
+    let pendingRefresh: ReturnType<typeof setTimeout> | undefined;
+    const refresh = async () => {
+      if (document.visibilityState === "hidden") return;
+      if (running) { refreshAgain = true; return; }
+      // Coalesce completion/error/provider events without losing the final read.
+      if (Date.now() - lastRead < 3_000) {
+        pendingRefresh ??= setTimeout(() => { pendingRefresh = undefined; void refresh(); }, 3_000);
+        return;
+      }
+      running = true;
+      lastRead = Date.now();
+      try {
+        const next = await createDenClient({ baseUrl: captured.baseUrl, token }).getInferenceAccess(orgId);
+        const current = readDenSettings();
+        if (epoch.current === generation && current.authToken === token && current.activeOrgId === orgId && current.baseUrl === captured.baseUrl) {
+          setResult({ scope, access: next });
+        }
+      } catch {
+        if (epoch.current === generation) setResult(null);
+      } finally {
+        running = false;
+        if (refreshAgain && epoch.current === generation) {
+          refreshAgain = false;
+          void refresh();
+        }
+      }
+    };
+    const onRefresh = () => { void refresh(); };
+    void refresh();
+    const timer = setInterval(onRefresh, 60_000);
+    window.addEventListener("focus", onRefresh);
+    document.addEventListener("visibilitychange", onRefresh);
+    window.addEventListener(inferenceAccessRefreshEvent, onRefresh);
+    window.addEventListener(newProvidersEvent, onRefresh);
+    return () => {
+      epoch.current += 1;
+      clearInterval(timer);
+      clearTimeout(pendingRefresh);
+      window.removeEventListener("focus", onRefresh);
+      document.removeEventListener("visibilitychange", onRefresh);
+      window.removeEventListener(inferenceAccessRefreshEvent, onRefresh);
+      window.removeEventListener(newProvidersEvent, onRefresh);
+    };
+  }, [scope]);
+
+  const showUpgrade = (reason: InferenceUpgradeReason, sessionId?: string) => {
+    setUpgrade({ reason, sessionId });
+    window.dispatchEvent(new Event(inferenceAccessRefreshEvent));
+  };
+  const checkSelection = (model: ModelRef, sessionId?: string) => {
+    const reason = modelSelectionUpgradeReason(access, model);
+    if (!reason) return true;
+    showUpgrade(reason, sessionId);
+    return false;
+  };
+  const reset = allowanceResetLabel(access?.resetsAt);
+  return (
+    <InferenceAccessContext value={{ access, checkSelection, showUpgrade }}>
+      {children}
+      <Dialog open={upgrade !== null} onOpenChange={(open) => { if (!open) setUpgrade(null); }}>
+        <DialogContent className="sm:max-w-md" data-testid="inference-upgrade-dialog">
+          <DialogHeader>
+            <DialogTitle>{upgrade?.reason === "free_allowance_exhausted" ? "Your free Luna allowance is used up" : "This model requires OpenWork Models"}</DialogTitle>
+            <DialogDescription>
+              {upgrade?.reason === "free_allowance_exhausted"
+                ? `You've used this week's free allowance.${reset ? ` Resets ${reset}.` : " Check your allowance again after the weekly reset."}`
+                : "Free access includes standard Luna. Upgrade to use the other managed OpenWork models."}
+              {" Your selected model and draft have not changed."}
+            </DialogDescription>
+          </DialogHeader>
+          {access?.canUpgrade === false ? <p className="text-sm text-muted-foreground">Ask a workspace owner or admin to upgrade OpenWork Models. You can keep using your own providers.</p> : null}
+          <DialogFooter className="flex-wrap">
+            <Button variant="outline" onClick={() => {
+              window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { sessionId: upgrade?.sessionId } }));
+              setUpgrade(null);
+            }}>Choose another provider</Button>
+            {access?.canUpgrade === true ? <Button onClick={() => platform.openLink(getOpenWorkModelsActionUrl(true))}>Upgrade</Button> : null}
+            <Button variant="ghost" onClick={() => setUpgrade(null)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </InferenceAccessContext>
+  );
+}
+
+export function InferenceAllowanceSummary({ available = true, className = "" }: { available?: boolean; className?: string }) {
+  const { access } = useInferenceAccess();
+  if (!available || !access || (access.kind !== "free" && access.kind !== "exhausted")) return null;
+  const reset = allowanceResetLabel(access.resetsAt);
+  const pending = pendingInferenceUsageLabel(access);
+  return <p className={`text-xs text-muted-foreground ${className}`} data-testid="inference-allowance">
+    Free standard Luna{access.remainingUsd !== null && access.weeklyLimitUsd !== null ? `: ${formatAllowanceUsd(access.remainingUsd)} of ${formatAllowanceUsd(access.weeklyLimitUsd)} left this week` : ""}.
+    {reset ? ` Resets ${reset}.` : ""}
+    {pending ? ` ${pending}` : ""}
+  </p>;
+}
+
+export function InferenceErrorActions({ reason, resetsAt, sessionId, onOpenModelPicker }: {
+  reason: InferenceUpgradeReason; resetsAt?: string | null; sessionId?: string; onOpenModelPicker?: () => void;
+}) {
+  const { access, showUpgrade } = useInferenceAccess();
+  const platform = usePlatform();
+  const reset = allowanceResetLabel(resetsAt);
+  return <div className="flex flex-col gap-2" data-testid="inference-error-actions">
+    {reset && reason === "free_allowance_exhausted" ? <p className="text-sm">Allowance resets {reset}.</p> : null}
+    <div className="flex flex-wrap gap-2">
+      <Button size="sm" variant="outline" onClick={() => access?.canUpgrade === true
+        ? platform.openLink(getOpenWorkModelsActionUrl(true)) : showUpgrade(reason, sessionId)}>
+        {access?.canUpgrade === true ? "Upgrade" : access?.canUpgrade === false ? "Ask admin" : "View allowance"}
+      </Button>
+      <Button size="sm" variant="ghost" onClick={() => onOpenModelPicker ? onOpenModelPicker()
+        : window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { sessionId } }))}>Choose another provider</Button>
+    </div>
+  </div>;
+}

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
@@ -3,9 +3,13 @@ declare const describe: (name: string, fn: () => void) => void;
 declare const test: (name: string, fn: () => void | Promise<void>) => void;
 declare const expect: (value: unknown) => {
   toBe: (expected: unknown) => void;
+  toContain: (expected: unknown) => void;
 };
 
 import { DEFAULT_DEN_BASE_URL, HOSTED_DEFAULT_DEN_BASE_URL, setDenBootstrapConfig } from "../../../app/lib/den";
+import { INFERENCE_ACCESS_REASONS, type InferenceAccess } from "@openwork/types/den/inference";
+import { FREE_LUNA_MODEL, inferenceAccessSchema, modelSelectionUpgradeReason, pendingInferenceUsageLabel, shouldSelectInitialLuna } from "../../../app/lib/inference-access";
+import { nextFavoriteModel } from "../session/models/model-collections-store";
 import {
   hasOpenWorkModelsAvailable,
   isOpenWorkModelsPromoEligible,
@@ -70,5 +74,69 @@ describe("shouldShowOpenWorkModelsSyncing", () => {
       workspaceReady: true,
       reloadPending: true,
     })).toBe(true);
+  });
+});
+
+const freeAccess: InferenceAccess & { canUpgrade: boolean } = {
+  kind: "free", modelID: "openai/gpt-5.6-luna", weeklyLimitUsd: 1, usedUsd: 0.2,
+  reservedUsd: 0, remainingUsd: 0.8, resetsAt: "2026-09-14T00:00:00.000Z", reason: null, canUpgrade: true,
+};
+
+describe("member allowance model decisions", () => {
+  test("gates only paid OpenWork selections, never Luna or organization BYOK", () => {
+    expect(modelSelectionUpgradeReason(freeAccess, FREE_LUNA_MODEL)).toBe(null);
+    expect(modelSelectionUpgradeReason(freeAccess, { providerID: "openwork", modelID: "openai/gpt-5.6-luna-fast" })).toBe("managed_model_requires_upgrade");
+    expect(modelSelectionUpgradeReason(freeAccess, { providerID: "lpr_managed", modelID: "openai/gpt-5.6-luna-fast" })).toBe(null);
+    expect(modelSelectionUpgradeReason(freeAccess, { providerID: "opencode", modelID: "big-pickle" })).toBe(null);
+    expect(modelSelectionUpgradeReason({ ...freeAccess, kind: "paid" }, { providerID: "openwork", modelID: "minimax/minimax-m3" })).toBe(null);
+    expect(modelSelectionUpgradeReason({ ...freeAccess, kind: "exhausted" }, FREE_LUNA_MODEL)).toBe("free_allowance_exhausted");
+    expect(modelSelectionUpgradeReason({ ...freeAccess, kind: "unavailable", reason: "free_disabled" }, FREE_LUNA_MODEL)).toBe(null);
+    expect(modelSelectionUpgradeReason(null, FREE_LUNA_MODEL)).toBe(null);
+  });
+
+  test("selects Luna once for verified first setup, despite the automatic Big Pickle preference", () => {
+    const first = {
+      installationRequiresSignin: true, signedIn: true, access: freeAccess, modelAvailable: true,
+      emptyFirstTask: true, setupComplete: false, explicitChoice: false,
+      currentModel: { providerID: "opencode", modelID: "big-pickle" }, variant: null,
+    };
+    expect(shouldSelectInitialLuna(first)).toBe(true);
+    for (const change of [
+      { installationRequiresSignin: false }, { signedIn: false }, { modelAvailable: false },
+      { emptyFirstTask: false }, { setupComplete: true }, { explicitChoice: true },
+      { currentModel: { providerID: "openwork", modelID: "minimax/minimax-m3" } },
+      { currentModel: { providerID: "lpr_byok", modelID: "openai/gpt-5.6-luna" } },
+      { access: null }, { access: { ...freeAccess, kind: "paid" as const } },
+      { access: { ...freeAccess, kind: "unavailable" as const } },
+    ]) expect(shouldSelectInitialLuna({ ...first, ...change })).toBe(false);
+  });
+
+  test("validates USD and permissions and strips unrelated response fields", () => {
+    const parsed = inferenceAccessSchema.parse({ ...freeAccess, token: "not-for-the-ui" });
+    expect("token" in parsed).toBe(false);
+    expect(parsed.remainingUsd).toBe(0.8);
+    expect(inferenceAccessSchema.safeParse({ ...freeAccess, canUpgrade: undefined }).success).toBe(false);
+    expect(inferenceAccessSchema.safeParse({ ...freeAccess, remainingUsd: -1 }).success).toBe(false);
+    expect(inferenceAccessSchema.safeParse({ ...freeAccess, resetsAt: "invalid" }).success).toBe(false);
+  });
+
+  test("accepts canonical busy access as free and labels pending cost as an estimate", () => {
+    const busy = inferenceAccessSchema.parse({ ...freeAccess, reason: "free_request_in_progress", reservedUsd: 0.1 });
+    expect(busy.kind).toBe("free");
+    expect(busy.remainingUsd).toBe(0.8);
+    expect(modelSelectionUpgradeReason(busy, FREE_LUNA_MODEL)).toBe(null);
+    expect(pendingInferenceUsageLabel(busy)).toContain("awaiting final usage");
+    expect(pendingInferenceUsageLabel(busy)).toContain("Estimated pending cost: $0.10; the final charge may differ.");
+    for (const reason of INFERENCE_ACCESS_REASONS) {
+      expect(inferenceAccessSchema.safeParse({ ...freeAccess, reason }).success).toBe(true);
+    }
+    expect(inferenceAccessSchema.safeParse({ ...freeAccess, reason: "insufficient_request_budget" }).success).toBe(false);
+  });
+
+  test("keyboard cycling can reach Luna past paid favorites without selecting them", () => {
+    const current = { providerID: "opencode", modelID: "big-pickle" };
+    const favorites = [current, { providerID: "openwork", modelID: "minimax/minimax-m3" }, FREE_LUNA_MODEL];
+    const available = favorites.filter((model) => !modelSelectionUpgradeReason(freeAccess, model));
+    expect(nextFavoriteModel(available, current)?.modelID).toBe(FREE_LUNA_MODEL.modelID);
   });
 });

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1916,7 +1916,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         checkRestriction: options.checkDesktopAppRestriction,
       },
     );
-    if (replacement) writeStoredDefaultModel(replacement);
+    if (replacement) writeStoredDefaultModel(replacement, { automaticRepair: true });
   };
 
   const refreshProvidersAfterCloudSync = async (optionsArg: {

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -25,6 +25,8 @@ import type { ModelOption, ModelRef } from "../../../../app/types";
 import { isRecommendedModel } from "../../../../app/defaults";
 import { ProviderIcon } from "../../../design-system/provider-icon";
 import { useDenAuth } from "../../cloud/den-auth-provider";
+import { InferenceAllowanceSummary, useInferenceAccess } from "../../cloud/inference-access-provider";
+import { markExplicitModelChoice } from "@/app/lib/inference-access";
 import { usePlatform } from "../../../kernel/platform";
 import {
   OPENWORK_MODELS_PROVIDER_ID,
@@ -48,13 +50,14 @@ export type ModelPickerModalProps = {
   setQuery: (value: string) => void;
   subtitle?: string;
   target: "default" | "session";
+  sessionId?: string;
   current: ModelRef;
   onSelect: (model: ModelRef) => void;
   onBehaviorChange: (model: ModelRef, value: string | null) => void;
   onToggleProvider?: (providerId: string, enabled: boolean) => void;
   onOpenSettings: () => void;
   onClose: (options?: { restorePromptFocus?: boolean }) => void;
-  /** Den entitlement present. Picker no longer upsells here; callers still pass it. */
+  /** Den entitlement present; allowance gates use member access instead. */
   openWorkModelsEntitled?: boolean;
   /** The server is waiting to reload this workspace with OpenWork Models. */
   openWorkModelsSyncing?: boolean;
@@ -117,6 +120,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
   const [refreshingOrganizationModels, setRefreshingOrganizationModels] = useState(false);
   const denAuth = useDenAuth();
+  const inference = useInferenceAccess();
   const platform = usePlatform();
   const organizationModelsSettingsUrl = props.organizationModelsSettingsUrl;
   const organizationProviderLabel = useMemo(
@@ -239,10 +243,14 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     });
   }, []);
 
-  const handleSelect = useCallback(
-    (opt: ModelOption) => props.onSelect({ providerID: opt.providerID, modelID: opt.modelID }),
-    [props.onSelect],
-  );
+  const handleSelect = (opt: ModelOption) => {
+    if (!inference.checkSelection(opt, props.sessionId)) {
+      props.onClose({ restorePromptFocus: false });
+      return;
+    }
+    markExplicitModelChoice();
+    props.onSelect({ providerID: opt.providerID, modelID: opt.modelID });
+  };
 
   const handleRefreshOrganizationModels = useCallback(async () => {
     if (!props.onRefreshOrganizationModels || refreshingOrganizationModels) return;
@@ -285,6 +293,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
           <DialogDescription>
             {resolveModelPickerSubtitle(props.subtitle)}
           </DialogDescription>
+          <InferenceAllowanceSummary available={props.options.some((option) => option.providerID === "openwork")} />
         </DialogHeader>
 
         <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -76,6 +76,8 @@ import {
   resolveAdmissionOutcome,
 } from "./session-admission-outcome";
 import { describeOpencodeSessionError, interruptedTaskRecoveryPrompt, presentOpencodeSessionError } from "@/react-app/domains/session/sync/session-error";
+import { InferenceErrorActions } from "@/react-app/domains/cloud/inference-access-provider";
+import { refreshInferenceAccess } from "@/app/lib/inference-access";
 import { createSessionErrorUIMessage } from "@/react-app/domains/session/sync/usechat-adapter";
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
@@ -191,6 +193,7 @@ as $5 and $10 stay plain text.`,
 
 type SessionError = {
   message: string;
+  providerID?: string;
   kind?: "model-not-found" | "generic";
   /** For model-not-found: the model that failed. */
   failedModel?: { providerID: string; modelID: string };
@@ -833,23 +836,25 @@ function parseSessionError(thrown: unknown): SessionError {
   return { message: raw || "Failed to send prompt." };
 }
 
-function SessionErrorCard({ error, developerMode, onDismiss, onChangeModel, onOpenModelPicker }: {
+function SessionErrorCard({ error, sessionId, developerMode, onDismiss, onChangeModel, onOpenModelPicker }: {
   error: SessionError;
+  sessionId: string;
   developerMode: boolean;
   onDismiss: () => void;
   onChangeModel?: (model: { providerID: string; modelID: string }) => void;
   onOpenModelPicker?: () => void;
 }) {
-  const presentation = presentOpencodeSessionError(error.message);
+  const presentation = presentOpencodeSessionError(error.message, "Session failed", error.providerID);
   return (
     <div className="mx-auto max-w-[720px] px-3 py-3 sm:px-5" data-testid="session-error-card" role="alert">
       <div className="rounded-2xl border border-red-6/30 bg-red-3/15 px-5 py-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium text-red-11">{developerMode ? error.message : presentation.title}</div>
+            <div className="text-sm font-medium text-red-11">{developerMode && !presentation.inference ? error.message : presentation.title}</div>
             {!developerMode && presentation.description ? (
               <p className="mt-1 text-sm text-red-11">{presentation.description}</p>
             ) : null}
+            {presentation.inference ? <InferenceErrorActions {...presentation.inference} sessionId={sessionId} onOpenModelPicker={onOpenModelPicker} /> : null}
             {error.kind === "model-not-found" ? (
               <div className="mt-2 flex flex-wrap gap-2">
                 {error.suggestions && error.suggestions.length > 0 ? (
@@ -1449,17 +1454,22 @@ export function SessionSurface(props: SessionSurfaceProps) {
       sideEffect: "mutation",
       disabled: !props.sessionId,
       args: [
-        { name: "kind", type: "string", description: "Optional disk-full or database-error fixture." },
+        { name: "kind", type: "string", description: "Optional disk-full, database-error, free_allowance_exhausted, managed_model_requires_upgrade, or byok-allowance fixture." },
         { name: "surface", type: "string", description: "Optional banner instead of the transcript." },
       ],
       execute: (args) => {
         const kind = args && typeof args === "object" && "kind" in args ? args.kind : null;
+        const allowance = kind === "free_allowance_exhausted" || kind === "managed_model_requires_upgrade" || kind === "byok-allowance";
         const error = kind === "disk-full" || kind === "database-error"
           ? { name: "SqlError", data: { message: `effect/sql/SqlError: Failed to execute statement\n    at runLoop (/$bunfs/root/chunk.js:25:2045)${kind === "disk-full" ? "\nCaused by: ENOSPC: no space left on device, write" : ""}` } }
+          : allowance ? { name: "APIError", data: {
+              message: "The model request was declined.", statusCode: 402, providerID: kind === "byok-allowance" ? "lpr_organization_byok" : "openwork",
+              responseBody: JSON.stringify({ error: { code: kind === "byok-allowance" ? "free_allowance_exhausted" : kind, resetsAt: "2026-09-14T00:00:00Z" } }),
+            } }
           : SESSION_ERROR_EVAL_PAYLOAD;
         if (args && typeof args === "object" && "surface" in args && args.surface === "banner") {
           setEvalMarkdownMessages([]);
-          setError({ message: error.data.message });
+          setError({ message: allowance ? JSON.stringify(error) : error.data.message });
         } else {
           setError(null);
           setEvalMarkdownMessages(createSessionErrorEvalMessages(props.sessionId, error));
@@ -1821,7 +1831,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
       setAwaitingAssistantBaseline(renderedMessages.length);
       return result;
     } catch (nextError) {
-      const parsed = parseSessionError(nextError);
+      const parsed = { ...parseSessionError(nextError), providerID: sessionModel.selectedModel.providerID };
+      refreshInferenceAccess();
       captureAnalyticsEvent("task_send_failed", {});
       setError(parsed);
       useSessionActivityStore.getState().setError(props.workspaceId, props.sessionId, parsed.message);
@@ -1831,7 +1842,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       pendingSendsRef.current.delete(submissionId);
       setPendingSendSessions([...pendingSendsRef.current.values()]);
     }
-  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length]);
+  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length, sessionModel.selectedModel.providerID]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);
@@ -2757,6 +2768,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
             ) : null}
             {error && snapshot && snapshot.messages.length > 0 ? (
               <SessionErrorCard
+                sessionId={props.sessionId}
                 developerMode={props.developerMode}
                 error={error}
                 onDismiss={handleDismissError}
@@ -2774,6 +2786,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
               <div className="px-6 py-8">
                 {error ? (
                   <SessionErrorCard
+                    sessionId={props.sessionId}
                     developerMode={props.developerMode}
                     error={error}
                     onDismiss={handleDismissError}
@@ -2794,6 +2807,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
               </div>
             ) : renderedMessages.length === 0 && snapshot && snapshot.messages.length === 0 && error ? (
               <SessionErrorCard
+                sessionId={props.sessionId}
                 developerMode={props.developerMode}
                 error={error}
                 onDismiss={handleDismissError}

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -2,8 +2,9 @@ import type { UIMessage } from "ai";
 
 import { safeStringify } from "../../../../app/utils";
 import { normalizeErrorText } from "../../../../lib/error-text";
+import type { InferenceUpgradeReason } from "@/app/lib/inference-access";
 
-export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "free-model-limit" | "disk-full" | "database-error" | "generic";
+export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "free-model-limit" | "disk-full" | "database-error" | "inference-upgrade" | "generic";
 
 export type OpencodeSessionErrorPresentation = {
   kind: OpencodeSessionErrorKind;
@@ -11,7 +12,38 @@ export type OpencodeSessionErrorPresentation = {
   description: string | null;
   technicalDetails: string;
   recoveryPrompt: string | null;
+  inference?: { reason: InferenceUpgradeReason; resetsAt: string | null };
 };
+
+// Decode only structured engine envelopes, never codes mentioned in prose or
+// arbitrary provider payload fields. Bound both depth and JSON size.
+function errorRecords(value: unknown, depth = 0): unknown[] {
+  if (depth > 6) return [];
+  if (typeof value === "string") {
+    if (value.length > 65_536 || !value.trimStart().startsWith("{")) return [];
+    try { return errorRecords(JSON.parse(value), depth + 1); } catch { return []; }
+  }
+  if (!value || typeof value !== "object") return [];
+  return [value, ...["data", "cause", "error", "message"].flatMap((key) => errorRecords(recordValue(value, key), depth + 1))];
+}
+
+export function structuredInferenceError(error: unknown, providerID?: string): OpencodeSessionErrorPresentation["inference"] {
+  const records = errorRecords(error);
+  const provider = providerID ?? firstStringValue(records, ["providerID", "providerId", "provider"]);
+  if (provider !== "openwork" || firstNumberValue(records, ["statusCode", "status"]) !== 402) return undefined;
+  const body = records.flatMap((record) => errorRecords(recordValue(record, "responseBody")));
+  const reason = firstStringValue([...body, ...records], ["code", "errorCode"]);
+  if (reason !== "free_allowance_exhausted" && reason !== "managed_model_requires_upgrade") return undefined;
+  const reset = firstStringValue([...body, ...records], ["resetsAt"]);
+  return { reason, resetsAt: reset && Number.isFinite(Date.parse(reset)) ? new Date(reset).toISOString() : null };
+}
+
+export function latestAssistantProvider(messages: UIMessage[]): string | undefined {
+  const message = messages.findLast((item) => !item.id.startsWith("session-error:") && (item.role === "assistant" || item.role === "user"));
+  if (message?.role !== "assistant") return undefined;
+  const provider = recordValue(recordValue(message?.metadata, "opencode"), "providerID");
+  return typeof provider === "string" ? provider : undefined;
+}
 
 export const interruptedTaskRecoveryPrompt = [
   "Continue the interrupted task from the current state.",
@@ -192,7 +224,20 @@ function technicalErrorDetails(error: unknown, fallback: string, fields: ReturnT
   return normalizeErrorText(serialized && serialized !== "{}" ? serialized : fallback, { cap: 1_500 }).display;
 }
 
-export function presentOpencodeSessionError(error: unknown, fallback = "Session failed"): OpencodeSessionErrorPresentation {
+export function presentOpencodeSessionError(error: unknown, fallback = "Session failed", providerID?: string): OpencodeSessionErrorPresentation {
+  const inference = structuredInferenceError(error, providerID);
+  if (inference) return {
+    kind: "inference-upgrade",
+    title: inference.reason === "free_allowance_exhausted" ? "Your free Luna allowance is used up" : "This model requires OpenWork Models",
+    description: inference.reason === "free_allowance_exhausted"
+      ? "You've used this week's free allowance. Wait for the reset, upgrade, or choose another provider. Output already produced is kept."
+      : "Free access includes standard Luna. Upgrade to use this managed model, or choose another provider. Output already produced is kept.",
+    technicalDetails: `Status: 402\nProvider: openwork\nCode: ${inference.reason}`,
+    recoveryPrompt: null,
+    inference,
+  };
+  const structured = errorRecords(error)[0];
+  if (structured) error = structured;
   const fields = sessionErrorFields(error, fallback);
   const kind = sessionErrorKind(fields.name, fields.message, fields.code, fields.responseBody);
   const fallbackTitle = normalizeSessionError(fields.message ?? defaultErrorMessage(fields.name, fallback));
@@ -205,8 +250,8 @@ export function presentOpencodeSessionError(error: unknown, fallback = "Session 
   };
 }
 
-export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
-  const presentation = presentOpencodeSessionError(error, fallback);
+export function describeOpencodeSessionError(error: unknown, fallback = "Session failed", providerID?: string) {
+  const presentation = presentOpencodeSessionError(error, fallback, providerID);
   return presentation.description
     ? `${presentation.title}\n${presentation.description}`
     : presentation.title;
@@ -222,6 +267,10 @@ export function sessionErrorPresentationFromUIMessage(message: UIMessage): Openc
     : null;
   if (!sessionError || typeof sessionError !== "object") return null;
   const candidate = sessionError as Partial<OpencodeSessionErrorPresentation>;
+  const inference = candidate.inference;
+  if (inference !== undefined && (!inference || typeof inference !== "object"
+    || (inference.reason !== "free_allowance_exhausted" && inference.reason !== "managed_model_requires_upgrade")
+    || !(inference.resetsAt === null || typeof inference.resetsAt === "string"))) return null;
   if (
     typeof candidate.kind !== "string" ||
     typeof candidate.title !== "string" ||

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -6,6 +6,8 @@ import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
 import { observeModelsTaskEvent } from "@/app/lib/models-task-analytics";
+import { refreshInferenceAccess } from "@/app/lib/inference-access";
+import { getSessionModelSelection } from "../surface/session-model-store";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import { perfNow, recordPerfLog } from "@/app/lib/perf-log";
@@ -19,6 +21,7 @@ import {
 } from "./usechat-adapter";
 import {
   describeOpencodeSessionError,
+  latestAssistantProvider,
   presentOpencodeSessionError,
 } from "./session-error";
 import {
@@ -858,8 +861,11 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const sessionId = sessionIdFromProperties(event.properties);
     if (sessionId) {
       const sessionError = sessionErrorFromProperties(event.properties);
-      const errorPresentation = presentOpencodeSessionError(sessionError);
-      const errorText = describeOpencodeSessionError(sessionError);
+      const providerID = latestAssistantProvider(queryClient.getQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId)) ?? [])
+        ?? getSessionModelSelection(sessionId)?.model.providerID;
+      const errorPresentation = presentOpencodeSessionError(sessionError, "Session failed", providerID);
+      const errorText = describeOpencodeSessionError(sessionError, "Session failed", providerID);
+      refreshInferenceAccess();
       const runStartedAt = takeTaskRunStart(sessionId);
       if (runStartedAt !== null) {
         captureAnalyticsEvent("task_run_errored", {
@@ -1017,7 +1023,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
 
   if (event.type === "message.updated") {
     const props = (event.properties ?? {}) as {
-      info?: { id?: string; role?: UIMessage["role"] | string; sessionID?: string; time?: { created?: number; completed?: number } };
+      info?: { id?: string; role?: UIMessage["role"] | string; providerID?: string; sessionID?: string; time?: { created?: number; completed?: number } };
     };
     const info = props.info;
     if (!info?.id || !info.sessionID || (info.role !== "user" && info.role !== "assistant" && info.role !== "system")) {
@@ -1042,7 +1048,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       id: info.id,
       role: info.role,
       ...(typeof created === "number"
-        ? { metadata: { opencode: { created, ...(typeof completed === "number" ? { completed } : {}) } } }
+        ? { metadata: { opencode: { created, ...(typeof info.providerID === "string" ? { providerID: info.providerID } : {}), ...(typeof completed === "number" ? { completed } : {}) } } }
         : {}),
       parts: [],
     } satisfies UIMessage;
@@ -1353,6 +1359,7 @@ function applySessionRunStatus(
       });
     }
     if (shouldRecordTerminal) {
+      refreshInferenceAccess();
       const assistantCompletedAt = entry.assistantMessageCompletedAt.get(sessionId);
       const runActiveAt = entry.runActiveObservedAt.get(sessionId);
       recordSessionCompletionMark("run-terminal", {

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -150,7 +150,7 @@ export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessa
       id: message.info.id,
       role: message.info.role,
       ...(typeof created === "number"
-        ? { metadata: { opencode: { created, ...(typeof completed === "number" ? { completed } : {}) } } }
+        ? { metadata: { opencode: { created, ...(message.info.role === "assistant" ? { providerID: message.info.providerID } : {}), ...(typeof completed === "number" ? { completed } : {}) } } }
         : {}),
       parts: message.parts.flatMap<UIMessage["parts"][number]>((part) => {
         if (part.type === "text") {
@@ -200,7 +200,8 @@ export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessa
     const error = message.info.role === "assistant" && "error" in message.info ? message.info.error : undefined;
     if (!error) return [uiMessage];
 
-    const errorMessage = createSessionErrorUIMessage(message.info.id, presentOpencodeSessionError(error), { created });
+    const providerID = message.info.role === "assistant" ? message.info.providerID : undefined;
+    const errorMessage = createSessionErrorUIMessage(message.info.id, presentOpencodeSessionError(error, "Session failed", providerID), { created });
     return uiMessage.parts.length > 0 ? [uiMessage, errorMessage] : [errorMessage];
   });
 }

--- a/apps/app/src/react-app/kernel/model-config.ts
+++ b/apps/app/src/react-app/kernel/model-config.ts
@@ -12,8 +12,10 @@ import {
   parseModelRef,
 } from "../../app/utils";
 import { normalizeModelBehaviorValue } from "../../app/lib/model-behavior";
+import { LOCAL_PREFERENCES_KEY } from "./local-preferences-storage";
 
 export const storedDefaultModelChangedEvent = "openwork.defaultModelChanged";
+const MODEL_BEFORE_REPAIR_KEY = "openwork.defaultModel.beforeRepair.v1";
 
 export type SessionChoiceOverride = {
   model?: ModelRef | null;
@@ -157,11 +159,41 @@ export function readStoredDefaultModel(): ModelRef {
   }
 }
 
-export function writeStoredDefaultModel(model: ModelRef): void {
+export function readModelPreferenceBeforeRepair(current: { model: ModelRef | null; variant: string | null }) {
+  if (typeof window === "undefined") return current;
+  try {
+    const raw = window.localStorage.getItem(MODEL_BEFORE_REPAIR_KEY);
+    const snapshot: unknown = raw ? JSON.parse(raw) : null;
+    if (!snapshot || typeof snapshot !== "object" || !hasOwn(snapshot, "model") || !hasOwn(snapshot, "variant") || !hasOwn(snapshot, "repairedModel")) return current;
+    const repaired = parseStoredModel(snapshot.repairedModel);
+    const original = parseStoredModel(snapshot.model);
+    if (!original || !repaired || repaired.providerID !== current.model?.providerID || repaired.modelID !== current.model.modelID) return current;
+    if (snapshot.variant !== null && typeof snapshot.variant !== "string") return current;
+    return { model: original, variant: current.variant ?? snapshot.variant };
+  } catch { return current; }
+}
+
+export function writeStoredDefaultModel(model: ModelRef, options: { automaticRepair?: boolean } = {}): void {
   if (typeof window === "undefined") return;
   try {
     const value = formatModelRef(model);
     if (window.localStorage.getItem(MODEL_PREF_KEY) === value) return;
+    try {
+      if (options.automaticRepair) {
+        let variant: string | null = null;
+        try {
+          const raw = window.localStorage.getItem(LOCAL_PREFERENCES_KEY);
+          const prefs: unknown = raw ? JSON.parse(raw) : null;
+          if (prefs && typeof prefs === "object" && "modelVariant" in prefs && typeof prefs.modelVariant === "string") variant = prefs.modelVariant;
+        } catch { /* Invalid optional preferences must not block default repair. */ }
+        // Keep the pre-repair preference across reloads. Catalog repair can finish
+        // before member access loads, but it is not an explicit model choice.
+        const original = readModelPreferenceBeforeRepair({ model: readStoredDefaultModel(), variant });
+        window.localStorage.setItem(MODEL_BEFORE_REPAIR_KEY, JSON.stringify({ ...original, repairedModel: model }));
+      } else {
+        window.localStorage.removeItem(MODEL_BEFORE_REPAIR_KEY);
+      }
+    } catch { /* Optional provenance must not prevent the existing default repair. */ }
     window.localStorage.setItem(MODEL_PREF_KEY, value);
     window.dispatchEvent(new Event(storedDefaultModelChangedEvent));
   } catch {

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -8,6 +8,7 @@ import { hydrateOpenworkServerSettingsFromEnv } from "@/app/lib/openwork-server"
 import { isDesktopRuntime } from "@/app/utils";
 import { ConnectLinkProvider } from "@/react-app/domains/cloud/connect-link-provider";
 import { DenAuthProvider } from "@/react-app/domains/cloud/den-auth-provider";
+import { InferenceAccessProvider } from "@/react-app/domains/cloud/inference-access-provider";
 import { AutomationRunnerBridge } from "@/react-app/domains/automations/automation-runner-bridge";
 import { GlobalQueueDrainerBridge } from "@/react-app/domains/session/sync/global-queue-drainer-bridge";
 import { BrandThemeProvider } from "@/react-app/domains/cloud/brand-theme";
@@ -98,7 +99,9 @@ export function AppProviders({ children }: AppProvidersProps) {
       <ServerProvider defaultUrl={defaultUrl}>
         <ArchitectureMismatchGate>
           <DenAuthProvider>
-            <EnterpriseAwareAppProviders>{children}</EnterpriseAwareAppProviders>
+            <InferenceAccessProvider>
+              <EnterpriseAwareAppProviders>{children}</EnterpriseAwareAppProviders>
+            </InferenceAccessProvider>
           </DenAuthProvider>
         </ArchitectureMismatchGate>
       </ServerProvider>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -168,6 +168,8 @@ import { useRemoteAccessRestart } from "@/react-app/domains/workspace/remote-acc
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import { useInferenceAccess } from "@/react-app/domains/cloud/inference-access-provider";
+import { explicitModelChoiceKey, FREE_LUNA_MODEL, markExplicitModelChoice, modelSelectionUpgradeReason, shouldSelectInitialLuna } from "@/app/lib/inference-access";
 import {
   hasOpenWorkModelsAvailable,
   shouldShowOpenWorkModelsSyncing,
@@ -216,6 +218,7 @@ import { useBootOverlayVisible } from "./boot-state";
 import {
   createDenClient,
   isDenOrgAdminRole,
+  readDenBootstrapConfig,
   readDenSettings,
   type DenOrgRole,
 } from "@/app/lib/den";
@@ -253,7 +256,7 @@ import {
 import { WorkspaceProvider } from "./workspace-provider";
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 import { SettingsSurface } from "./settings-route";
-import { writeStoredDefaultModel } from "@/react-app/kernel/model-config";
+import { readModelPreferenceBeforeRepair, writeStoredDefaultModel } from "@/react-app/kernel/model-config";
 import {
   ensureProviderListQuery,
   getConnectedProviderItems,
@@ -370,6 +373,7 @@ export function SessionRoute() {
   const platform = usePlatform();
   const toggleSidebar = useUiStateStore((state) => state.toggleSidebar);
   const denAuth = useDenAuth();
+  const inference = useInferenceAccess();
   const { config: shellConfig } = useShellConfig();
   const local = useLocal();
   const automationDeploymentEnabled = useAutomationDeploymentEnabled();
@@ -900,6 +904,39 @@ export function SessionRoute() {
     providerConnectedIds,
     providers,
   });
+  const pendingLunaSetupKey = (() => {
+    if (denAuth.status !== "signed_in" || !denAuth.user || loading) return null;
+    if (workspaceSessionGroups.some((group) => group.status !== "ready")) return null;
+    // The parent owns installation cohort detection. Big Pickle is persisted
+    // during bootstrap, so an unset-preference check cannot identify setup.
+    const setupKey = `openwork.lunaSetup.v1:${JSON.stringify([readDenSettings().baseUrl, denAuth.user.id])}`;
+    try {
+      const emptyFirstTask = !selectedSessionId
+        && !Object.values(sessionsByWorkspaceId).some((sessions) => sessions.length > 0)
+        && Object.keys(useSessionModelStore.getState().bySessionId).length === 0;
+      const originalPreference = readModelPreferenceBeforeRepair({ model: local.prefs.defaultModel, variant: local.prefs.modelVariant });
+      return shouldSelectInitialLuna({
+        installationRequiresSignin: readDenBootstrapConfig().installationRequiresSignin === true,
+        signedIn: denAuth.status === "signed_in",
+        access: inference.access,
+        modelAvailable: openWorkModelsAvailable && entitledModelOptions.some((model) => model.providerID === FREE_LUNA_MODEL.providerID && model.modelID === FREE_LUNA_MODEL.modelID),
+        emptyFirstTask,
+        setupComplete: window.localStorage.getItem(setupKey) !== null,
+        explicitChoice: window.localStorage.getItem(explicitModelChoiceKey) !== null,
+        currentModel: originalPreference.model,
+        variant: originalPreference.variant,
+      }) ? setupKey : null;
+    } catch { return null; }
+  })();
+  useEffect(() => {
+    if (!pendingLunaSetupKey) return;
+    try {
+      if (window.localStorage.getItem(explicitModelChoiceKey) !== null) return;
+      // Persist before selection; storage failure must not repeatedly reset a preference.
+      window.localStorage.setItem(pendingLunaSetupKey, "complete");
+      local.setPrefs((previous) => ({ ...previous, defaultModel: FREE_LUNA_MODEL, modelVariant: null }));
+    } catch { /* Leave existing preferences alone when storage is unavailable. */ }
+  }, [local, pendingLunaSetupKey]);
   const openWorkModelsSyncing = shouldShowOpenWorkModelsSyncing({
     entitled: openWorkModelsEntitled,
     available: openWorkModelsAvailable,
@@ -935,6 +972,7 @@ export function SessionRoute() {
     return () => window.removeEventListener(openModelPickerEvent, handler);
   }, []);
   const entitledOrgDefaultModel = useMemo(() => {
+    if (pendingLunaSetupKey) return null;
     const runtimeOptions = providerListModelEntitlementOptions(
       cloudProviderList ?? providerListQuery.data,
     );
@@ -953,9 +991,10 @@ export function SessionRoute() {
     organizationAssignedModelOptions,
     providerListQuery.data,
     restrictToCloudProviders,
+    pendingLunaSetupKey,
   ]);
   useEffect(() => {
-    if (entitledOrgDefaultModel) writeStoredDefaultModel(entitledOrgDefaultModel);
+    if (entitledOrgDefaultModel) writeStoredDefaultModel(entitledOrgDefaultModel, { automaticRepair: true });
   }, [entitledOrgDefaultModel]);
   // Availability is resolved per effective model identity: the New Task
   // composer validates the global default while each conversation validates
@@ -1047,7 +1086,7 @@ export function SessionRoute() {
       autoOpenedUnavailableModelKey: autoOpenedUnavailableModelRef.current,
     })) return;
     if (!activeComposerTargetsSession && entitledOrgDefaultModel) {
-      writeStoredDefaultModel(entitledOrgDefaultModel);
+      writeStoredDefaultModel(entitledOrgDefaultModel, { automaticRepair: true });
       return;
     }
 
@@ -2284,8 +2323,10 @@ export function SessionRoute() {
       : selectedSessionId;
     const selection = activeSessionId ? getSessionModelSelection(activeSessionId) : null;
     const currentModel = selection?.model ?? local.prefs.defaultModel ?? null;
-    const next = nextFavoriteModel(useModelCollectionsStore.getState().favorites, currentModel);
+    const next = nextFavoriteModel(useModelCollectionsStore.getState().favorites.filter((model) => !modelSelectionUpgradeReason(inference.access, model)), currentModel);
     if (!next) return null;
+    if (!inference.checkSelection(next, activeSessionId ?? undefined)) return null;
+    markExplicitModelChoice();
 
     const providerModel = providerCatalog?.[next.providerID]?.[next.modelID];
     const summary = providerModel
@@ -2298,7 +2339,7 @@ export function SessionRoute() {
     useModelCollectionsStore.getState().recordRecent(next);
     local.setPrefs((previous) => ({ ...previous, defaultModel: next, modelVariant: variant }));
     return providerModel?.name ?? next.modelID;
-  }, [local, modelVariantValue, providerCatalog, selectedSessionId]);
+  }, [inference, local, modelVariantValue, providerCatalog, selectedSessionId]);
 
   const cycleFavoriteModelControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.favorite_model.cycle",
@@ -2620,6 +2661,8 @@ export function SessionRoute() {
     targetSessionId: string | null,
     behavior?: { value: string | null },
   ) => {
+    if (!inference.checkSelection(next, targetSessionId ?? undefined)) return;
+    markExplicitModelChoice();
     const explicitBehavior = behavior !== undefined;
     useModelCollectionsStore.getState().recordRecent(next);
     if (targetSessionId) {
@@ -2637,7 +2680,7 @@ export function SessionRoute() {
           : null,
     }));
     focusPromptSoon();
-  }, [local]);
+  }, [inference, local]);
 
   // Refresh the non-tab fields of the nav ref during render. The `options`
   // field is maintained by the `onSessionTabsChange` callback from SessionPage.
@@ -3674,6 +3717,7 @@ export function SessionRoute() {
       onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
     />
     <ModelPickerModal
+      sessionId={modelPickerSessionId ?? undefined}
       open={modelPicker.open}
       options={modelPicker.options}
       organizationModelsEmpty={organizationModelsEmpty}

--- a/apps/app/tests/model-picker-modal.test.ts
+++ b/apps/app/tests/model-picker-modal.test.ts
@@ -1,10 +1,28 @@
-import { describe, expect, test } from "bun:test";
-
-import {
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createElement } from "react";
+import type { InferenceAccess } from "@openwork/types/den/inference";
+import * as den from "../src/app/lib/den";
+import type { DenAuthStore } from "../src/react-app/domains/cloud/den-auth-provider";
+import { denSettingsChangedEvent } from "../src/app/lib/den-session-events";
+import { MODEL_PREF_KEY } from "../src/app/constants";
+import { explicitModelChoiceKey, FREE_LUNA_MODEL, markExplicitModelChoice, shouldSelectInitialLuna } from "../src/app/lib/inference-access";
+import { LOCAL_PREFERENCES_KEY } from "../src/react-app/kernel/local-preferences-storage";
+import { readModelPreferenceBeforeRepair, readStoredDefaultModel, writeStoredDefaultModel } from "../src/react-app/kernel/model-config";
+import { resolveEntitledOrgDefaultModel } from "../src/react-app/domains/connections/provider-auth/provider-policy";
+// Base UI detects DOM support when its module loads.
+GlobalRegistrator.register({ url: "http://localhost" });
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+afterAll(async () => { await GlobalRegistrator.unregister(); });
+const { createRoot } = await import("react-dom/client");
+const auth = await import("../src/react-app/domains/cloud/den-auth-provider");
+const { InferenceAccessProvider, InferenceAllowanceSummary, useInferenceAccess } = await import("../src/react-app/domains/cloud/inference-access-provider");
+const { createDefaultPlatform, PlatformProvider } = await import("../src/react-app/kernel/platform");
+const {
   MODEL_PICKER_DEFAULT_SUBTITLE,
   MODEL_PICKER_UNAVAILABLE_SUBTITLE,
   resolveModelPickerSubtitle,
-} from "../src/react-app/domains/session/modals/model-picker-modal";
+} = await import("../src/react-app/domains/session/modals/model-picker-modal");
 
 describe("model picker subtitle", () => {
   test("keeps the normal session subtitle by default", () => {
@@ -15,5 +33,203 @@ describe("model picker subtitle", () => {
     expect(resolveModelPickerSubtitle(MODEL_PICKER_UNAVAILABLE_SUBTITLE)).toBe(
       "The model you were using is no longer available, please select a different model for this session.",
     );
+  });
+});
+
+test("member access ignores stale organization reads and opens upgrades only on a managed selection", async () => {
+  const settings = { ...den.readDenSettings(), baseUrl: "https://den.example.com", activeOrgId: "org-a", authToken: "fixture-a" };
+  const authState: DenAuthStore = {
+    status: "signed_in", user: null, verifiedIdentity: { principalId: "person-a", organizationId: "org-a" },
+    isSignedIn: true, error: null, refresh: async () => undefined,
+  };
+  const pending: Array<{ orgId: string; resolve: (access: InferenceAccess & { canUpgrade: boolean }) => void }> = [];
+  const originalClient = den.createDenClient({ baseUrl: settings.baseUrl });
+  const settingsSpy = spyOn(den, "readDenSettings").mockImplementation(() => settings);
+  const authSpy = spyOn(auth, "useDenAuth").mockImplementation(() => authState);
+  const clientSpy = spyOn(den, "createDenClient").mockImplementation(() => ({
+    ...originalClient,
+    getInferenceAccess: (orgId) => new Promise((resolve) => { pending.push({ orgId, resolve }); }),
+  }));
+  const now = Date.now();
+  let clock = now;
+  const clockSpy = spyOn(Date, "now").mockImplementation(() => clock);
+  const opened: string[] = [];
+  const platform = { ...createDefaultPlatform(), openLink: (url: string) => { opened.push(url); } };
+  let inference: ReturnType<typeof useInferenceAccess> | undefined;
+  function Probe() {
+    inference = useInferenceAccess();
+    return createElement("div", null,
+      createElement("span", { "data-testid": "access" }, inference.access?.kind ?? "unknown"),
+      createElement(InferenceAllowanceSummary));
+  }
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const render = () => root.render(createElement(PlatformProvider, { value: platform, children:
+    createElement(InferenceAccessProvider, { children: createElement(Probe) }) }));
+  const free: InferenceAccess & { canUpgrade: boolean } = {
+    kind: "free", modelID: "openai/gpt-5.6-luna", weeklyLimitUsd: 1, usedUsd: 0.2, reservedUsd: 0.1,
+    remainingUsd: 0.8, resetsAt: "2026-09-14T00:00:00Z", reason: "free_request_in_progress", canUpgrade: false,
+  };
+  try {
+    await act(async () => { render(); });
+    expect(pending[0]?.orgId).toBe("org-a");
+    await act(async () => {
+      settings.activeOrgId = "org-b";
+      settings.authToken = "fixture-b";
+      authState.verifiedIdentity = { principalId: "person-b", organizationId: "org-b" };
+      window.dispatchEvent(new Event(denSettingsChangedEvent));
+      render();
+    });
+    expect(pending[1]?.orgId).toBe("org-b");
+    await act(async () => { pending[0]?.resolve({ ...free, canUpgrade: true }); });
+    expect(inference?.access).toBeNull();
+    await act(async () => { pending[1]?.resolve(free); });
+    expect(inference?.access?.canUpgrade).toBe(false);
+    expect(inference?.access?.kind).toBe("free");
+    expect(host.textContent).toContain("$0.80 of $1.00 left this week");
+    expect(host.textContent).toContain("Estimated pending cost: $0.10; the final charge may differ.");
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')).toBeNull();
+    expect(inference?.checkSelection({ providerID: "openwork", modelID: "openai/gpt-5.6-luna" })).toBe(true);
+    expect(inference?.checkSelection({ providerID: "lpr_managed", modelID: "minimax/minimax-m3" })).toBe(true);
+    await act(async () => {
+      expect(inference?.checkSelection({ providerID: "openwork", modelID: "minimax/minimax-m3" })).toBe(false);
+    });
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("Ask a workspace owner or admin");
+    expect(opened).toEqual([]);
+    await act(async () => {
+      clock += 60_000;
+      window.dispatchEvent(new Event("openwork.inference-access-refresh"));
+    });
+    expect(pending[2]?.orgId).toBe("org-b");
+    await act(async () => { pending[2]?.resolve({ ...free, kind: "exhausted", usedUsd: 1, reservedUsd: 0, remainingUsd: 0, reason: "free_allowance_exhausted", canUpgrade: true }); });
+    await act(async () => {
+      expect(inference?.checkSelection({ providerID: "openwork", modelID: "openai/gpt-5.6-luna" })).toBe(false);
+    });
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("Your free Luna allowance is used up");
+    const upgrade = Array.from(document.querySelectorAll("button")).find((button) => button.textContent === "Upgrade");
+    if (!upgrade) throw new Error("Expected the explicit Upgrade action");
+    await act(async () => upgrade.click());
+    expect(opened).toEqual(["https://den.example.com/dashboard/inference"]);
+    expect(document.body.textContent).not.toContain("fixture-b");
+    await act(async () => {
+      authState.status = "signed_out";
+      authState.verifiedIdentity = null;
+      settings.authToken = "";
+      window.dispatchEvent(new Event(denSettingsChangedEvent));
+      render();
+    });
+    expect(inference?.access).toBeNull();
+    expect(inference?.checkSelection({ providerID: "openwork", modelID: "minimax/minimax-m3" })).toBe(true);
+  } finally {
+    await act(async () => { root.unmount(); });
+    host.remove();
+    clientSpy.mockRestore();
+    settingsSpy.mockRestore();
+    authSpy.mockRestore();
+    clockSpy.mockRestore();
+  }
+});
+
+describe("initial Luna and automatic organization default repair", () => {
+  const starter = { providerID: "opencode", modelID: "big-pickle" };
+  const organizationModel = { providerID: "lpr_organization", modelID: "gpt-5.5" };
+  const free: InferenceAccess = {
+    kind: "free", modelID: FREE_LUNA_MODEL.modelID, weeklyLimitUsd: 1, usedUsd: 0,
+    reservedUsd: 0, remainingUsd: 1, resetsAt: "2026-09-14T00:00:00Z", reason: null,
+  };
+  const pendingLuna = (access: InferenceAccess | null, variant: string | null = null) => {
+    const original = readModelPreferenceBeforeRepair({ model: readStoredDefaultModel(), variant });
+    return shouldSelectInitialLuna({
+      installationRequiresSignin: true, signedIn: true, access, modelAvailable: true,
+      emptyFirstTask: true, setupComplete: false,
+      explicitChoice: localStorage.getItem(explicitModelChoiceKey) !== null,
+      currentModel: original.model, variant: original.variant,
+    });
+  };
+  const repair = (options = [organizationModel]) => {
+    const replacement = resolveEntitledOrgDefaultModel(options, {
+      currentDefault: readStoredDefaultModel(), restrictToCloud: true,
+      checkRestriction: (input) => input.restriction === "allowZenModel",
+    });
+    if (replacement) writeStoredDefaultModel(replacement, { automaticRepair: true });
+    return replacement;
+  };
+
+  test("paid, disabled and unavailable access leave ordinary organization repair enabled", () => {
+    const accessStates: Array<InferenceAccess | null> = [
+      { ...free, kind: "paid" }, { ...free, kind: "unavailable", reason: "free_disabled" },
+      { ...free, kind: "unavailable", reason: "not_eligible" }, null,
+    ];
+    for (const access of accessStates) {
+      localStorage.clear();
+      writeStoredDefaultModel(starter);
+      expect(pendingLuna(access)).toBe(false);
+      expect(repair()).toEqual(organizationModel);
+      expect(readStoredDefaultModel()).toEqual(organizationModel);
+      expect(pendingLuna(access)).toBe(false);
+      expect(localStorage.getItem(explicitModelChoiceKey)).toBeNull();
+    }
+  });
+
+  test("late free access can initialize Luna after automatic repair, including a preference echo", () => {
+    localStorage.clear();
+    writeStoredDefaultModel(starter);
+    expect(repair()).toEqual(organizationModel);
+    // LocalProvider mirrors the stored update; that is not a user selection.
+    writeStoredDefaultModel(organizationModel);
+    expect(readModelPreferenceBeforeRepair({ model: readStoredDefaultModel(), variant: null })).toEqual({ model: starter, variant: null });
+    expect(pendingLuna(free)).toBe(true);
+    expect(localStorage.getItem(explicitModelChoiceKey)).toBeNull();
+    writeStoredDefaultModel(FREE_LUNA_MODEL);
+    expect(repair()).toBeNull();
+    expect(readStoredDefaultModel()).toEqual(FREE_LUNA_MODEL);
+  });
+
+  test("existing paid and BYOK preferences are not reclassified as automatic starter choices", () => {
+    for (const chosen of [{ providerID: "openwork", modelID: "minimax/minimax-m3" }, organizationModel, { providerID: "openai", modelID: "gpt-5.5" }]) {
+      localStorage.clear();
+      writeStoredDefaultModel(chosen);
+      repair();
+      expect(readModelPreferenceBeforeRepair({ model: readStoredDefaultModel(), variant: null }).model).toEqual(chosen);
+      expect(pendingLuna(free)).toBe(false);
+      if (chosen.providerID !== "openai") expect(readStoredDefaultModel()).toEqual(chosen);
+    }
+  });
+
+  test("an explicit choice of the repaired model or starter prevents subsequent Luna initialization", () => {
+    for (const chosen of [organizationModel, starter]) {
+      localStorage.clear();
+      writeStoredDefaultModel(starter);
+      repair();
+      markExplicitModelChoice();
+      writeStoredDefaultModel(chosen);
+      expect(pendingLuna(free)).toBe(false);
+      expect(readStoredDefaultModel()).toEqual(chosen);
+    }
+  });
+
+  test("repair preserves the original effort preference and respects a newer effort choice", () => {
+    localStorage.clear();
+    writeStoredDefaultModel(starter);
+    localStorage.setItem(LOCAL_PREFERENCES_KEY, JSON.stringify({ modelVariant: "high" }));
+    repair();
+    expect(readModelPreferenceBeforeRepair({ model: readStoredDefaultModel(), variant: null }).variant).toBe("high");
+    expect(pendingLuna(free)).toBe(false);
+    expect(readModelPreferenceBeforeRepair({ model: readStoredDefaultModel(), variant: "medium" }).variant).toBe("medium");
+  });
+
+  test("optional snapshot storage failure does not block paid or BYOK default repair", () => {
+    localStorage.clear();
+    writeStoredDefaultModel(starter);
+    const setItem = localStorage.setItem.bind(localStorage);
+    const storageSpy = spyOn(localStorage, "setItem").mockImplementation((key, value) => {
+      if (key !== MODEL_PREF_KEY) throw new Error("No room for optional preference metadata");
+      setItem(key, value);
+    });
+    try {
+      expect(repair()).toEqual(organizationModel);
+      expect(readStoredDefaultModel()).toEqual(organizationModel);
+    } finally { storageSpy.mockRestore(); }
   });
 });

--- a/apps/app/tests/session-error-resilience.test.tsx
+++ b/apps/app/tests/session-error-resilience.test.tsx
@@ -13,6 +13,7 @@ import { createSessionErrorUIMessage } from "../src/react-app/domains/session/sy
 import {
   presentOpencodeSessionError,
   sessionErrorPresentationFromUIMessage,
+  structuredInferenceError,
 } from "../src/react-app/domains/session/sync/session-error"
 import {
   __applySessionSyncEventForTest,
@@ -26,6 +27,26 @@ afterEach(() => {
 })
 
 describe("session error resilience", () => {
+  test.each(["free_allowance_exhausted", "managed_model_requires_upgrade"])("recognizes structured 402 %s through engine wrappers without retry", (code) => {
+    const error = { name: "APIError", data: { statusCode: 402, providerID: "openwork", responseBody: JSON.stringify({ error: { code, resetsAt: "2026-09-14T00:00:00Z" } }) } }
+    for (const wrapped of [error, JSON.stringify(error), new Error(JSON.stringify(error)), { name: "UnknownError", data: { message: JSON.stringify(error) } }, { cause: error }]) {
+      const presentation = presentOpencodeSessionError(wrapped)
+      expect(presentation.kind).toBe("inference-upgrade")
+      expect(presentation.inference).toEqual({ reason: code, resetsAt: "2026-09-14T00:00:00.000Z" })
+      expect(presentation.recoveryPrompt).toBeNull()
+      expect(presentation.description).toContain("Output already produced is kept")
+      expect(sessionErrorPresentationFromUIMessage(createSessionErrorUIMessage("turn", presentation))).toEqual(presentation)
+    }
+    for (const providerID of ["lpr_managed", "openai", "opencode"]) {
+      expect(structuredInferenceError(error, providerID)).toBeUndefined()
+      expect(presentOpencodeSessionError(error, "Session failed", providerID).kind).not.toBe("inference-upgrade")
+    }
+    expect(structuredInferenceError({ ...error, data: { ...error.data, statusCode: 429 } })).toBeUndefined()
+    expect(structuredInferenceError({ ...error, data: { ...error.data, responseBody: `Please fix ${code}` } })).toBeUndefined()
+    expect(structuredInferenceError({ ...error, data: { ...error.data, providerID: undefined } })).toBeUndefined()
+    expect(structuredInferenceError({ ...error, data: { ...error.data, responseBody: '{"error":{"code":"rate_limit_error"}}' } })).toBeUndefined()
+  })
+
   const freeTierFailure = {
     name: "APIError",
     data: {

--- a/ee/apps/den-api/.env.example
+++ b/ee/apps/den-api/.env.example
@@ -145,6 +145,11 @@ SENTRY_DIST=
 
 OPENROUTER_MANAGEMENT_API_KEY=
 OPENROUTER_WORKSPACE_ID=
+# Mirror these non-secret settings in inference. The free upstream key belongs
+# only in inference, never in Den or a member/provider configuration.
+INFERENCE_FREE_ENABLED=false
+INFERENCE_FREE_WEEKLY_BUDGET_USD=1
+INFERENCE_FREE_MODEL_ID=openai/gpt-5.6-luna
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 STRIPE_INFERENCE_PRICE_ID=price_1TWsTW2Ytt5tm5rQTgrMhiP8

--- a/ee/apps/den-api/FREE_ALLOWANCE.md
+++ b/ee/apps/den-api/FREE_ALLOWANCE.md
@@ -1,0 +1,156 @@
+# Free Luna: Den Integration
+
+Den uses the shared exports in `@openwork/types/den/inference`. See
+`../inference/FREE_ALLOWANCE.md` for execution and accounting authority.
+
+## Desktop Contract
+
+`GET /v1/inference/access` accepts the existing authenticated session and active
+organization context (`x-openwork-org-id` when explicitly scoped). A joined,
+non-removed member is required. There is no client-supplied enrollment or user ID.
+The response is private and `Cache-Control: no-store`:
+
+```ts
+import type { InferenceAccess } from "@openwork/types/den/inference"
+
+type InferenceAccessResponse = {
+  access: InferenceAccess & { canUpgrade: boolean }
+  upgradePath: "/dashboard/billing" | null
+}
+```
+
+`access` contains `kind: paid | free | exhausted | unavailable`, `modelID`,
+`weeklyLimitUsd`, `usedUsd`, `reservedUsd`, `remainingUsd`, `resetsAt`, `reason`
+and `canUpgrade`. The numeric fields are USD, not internal accounting units.
+`resetsAt` is the next Monday at 00:00 UTC. Paid access has null free-allowance
+fields and does not fall through to free when a paid limit is reached.
+
+The allowance is **usage-metered**, not a strict USD spending cap. `usedUsd` is
+settled actual provider cost. `reservedUsd` is only an estimated pending cost,
+not actual spend or a guaranteed charge ceiling. `remainingUsd` is
+`max(0, weeklyLimitUsd - usedUsd)` and does not subtract the pending estimate.
+Admission checks actual weekly usage and limits request size, output and
+concurrency. The final admitted reply may cross the weekly limit; its full
+actual cost remains visible and subsequent requests are exhausted. The request
+caps do not establish a formal maximum USD overage.
+
+A pending current-week request returns `kind: free` with
+`reason: free_request_in_progress`. Keep the managed provider and its credentials;
+this is neither an upgrade requirement nor a provisioning failure. The proxy
+returns HTTP 423 for a busy person, with no automatic retry/Retry-After or upsell.
+An old-week pending request can still block admission even when this current-week
+status shows an unused balance. Status is not admission authorization.
+
+The route schema uses `z.enum(INFERENCE_ACCESS_REASONS)` from the shared inference
+module, so its reason values follow the backend contract without a second list.
+The generated OpenAPI operation ID is `getV1InferenceAccess`, with response
+component `InferenceAccessResponse`. The existing `pnpm sdk:generate` pipeline
+reads Den's current OpenAPI schema and updates `packages/sdk/src/gen`; run
+`pnpm sdk:check` afterward. No separate catalog registration or handwritten SDK
+method is needed. SDK regeneration belongs to the main integration handoff.
+
+`canUpgrade` follows the existing owner/admin role hierarchy. `upgradePath` is a
+fixed relative Den Web path for those roles, otherwise null; resolve it against
+the configured Den Web origin, never an inference/provider URL. Members should
+ask a workspace admin to upgrade. `GET/PATCH /v1/inference` remains admin-only.
+
+Status aggregates by the authenticated **user ID**, not member, organization or
+key: Den reads that person's current `InferenceFreeUsageBucketTable` row. No row
+means unused allowance. A failed bucket read returns `accounting_unavailable`
+with unknown usage/remaining fields, never an optimistic free balance.
+
+Provision through the existing lifecycle:
+
+- `GET /v1/llm-providers` (default `scope=usable`) enrolls/repairs the member's
+  ordinary `source: openwork`, `providerId: openwork` provider.
+- `GET /v1/llm-providers/:llmProviderId/connect` returns the existing connection
+  shape and ordinary member inference bearer key. It checks current eligibility
+  and repairs its own managed key. Ineligible callers with an existing grant get
+  200 with null credentials, preserving the published desktop sync contract.
+- Member-added hooks also provision free access after the joined membership is
+  persisted; member removal revokes its keys and managed provider.
+- Models remain discoverable through `GET /v1/llm-provider-catalog/openwork`,
+  including paid entries for contextual upgrade UI. Catalog presence is not
+  execution authority; the inference proxy rejects non-Luna free requests.
+
+Enrollment/repair never writes desktop preferences, default models or paid
+policies. Existing managed provider IDs, model rows and configuration survive
+key repair and billing downgrade. BYOK/custom/catalog `lpr_*` providers and their
+credentials are not modified. New-cohort default model selection belongs to
+Desktop, not Den.
+
+## Enrollment And Disablement
+
+New organizations currently start with limits metadata, not an inference deny.
+With rollout enabled, an active joined member in a never-subscribed organization
+with no inference/offer metadata causes Den to persist
+`inferenceFree: { offerAllowed: true }`. This is serialized with provider/key
+repair under organization and member row locks. The key, provider and member
+grant commit together, and repeated/concurrent repair reuses the valid key.
+
+Explicit `inference.enabled: false` or `inferenceFree.offerAllowed: false` denies
+free access. Malformed/unknown inference metadata does not enroll. Better Auth's
+raw organization-create hook strips client-submitted `inference` and
+`inferenceFree`; ordinary Den organization settings already allowlist fields.
+After raw creation, Den stores the remaining metadata as an object in its JSON
+column rather than Better Auth's text-column encoding, preserving unrelated
+fields when enrollment adds the offer.
+
+Admin `setInferenceEnabled(false)` persists `offerAllowed: false`, revokes all
+organization inference keys and deletes only managed OpenWork providers. These
+local changes commit before upstream paid-key deletion, so failure stays closed.
+
+Stripe callers pass `source: billing`. Stopping paid inference removes its tier,
+permits free fallback unless already administratively disabled, and revokes the
+old member keys without deleting model/configuration rows. The next member read
+repairs the key. Repeated downgrade events leave an already-free key alone.
+Billing activation never undoes an explicit admin disable; an admin must enable
+paid inference explicitly through the existing subscribed-only route.
+
+**Legacy limit:** before this change, disablement deleted inference metadata.
+For organizations with any inference subscription history and missing metadata,
+the intent cannot be recovered safely. They do not auto-enroll on reads. A new
+billing transition can record the offer, but old ambiguous records require an
+explicitly reviewed migration/opt-in; this change does not run one or add an
+opt-in UI.
+
+Organization-wide shared-worker materialization has no authenticated person, so
+it excludes free `source: openwork` keys rather than choosing a member's budget.
+Paid managed inference and BYOK retain their existing path. Person-scoped cloud
+worker support is deferred.
+
+## Rollout And Checks
+
+Mirror only these non-secret fields in Den and inference:
+
+```text
+INFERENCE_FREE_ENABLED=false
+INFERENCE_FREE_WEEKLY_BUDGET_USD=1
+INFERENCE_FREE_MODEL_ID=openai/gpt-5.6-luna
+```
+
+`INFERENCE_FREE_UPSTREAM_API_KEY` is never read or stored by Den. Den status is
+an entitlement/accounting projection, not a probe of inference-secret readiness
+or an admission guarantee. Deploy migration 0093 and configure inference before
+enabling the mirrored rollout flags; this integration does not deploy or change
+live settings.
+
+Focused checks from `ee/apps/den-api` (existing dependencies required):
+
+```sh
+bun test --conditions development test/llm-provider-access-parity.test.ts
+bun test --conditions development test/stripe-billing.test.ts
+bun test --conditions development test/cloud-provider-materialization.test.ts
+bun test --conditions development test/cloud-provider-materialization-read-retry.test.ts
+bun test --conditions development test/route-access-policy.test.ts -t 'member inference access'
+./node_modules/.bin/tsc --noEmit --pretty false
+```
+
+The provider-access test uses real local MySQL fixtures and mocks all external
+fetches; it requires the migrated test database. It covers concurrent repair,
+person-wide quota identity across two organizations, peer isolation, busy-provider
+continuity, metered overage/exhaustion and blocked states, preserved
+configuration/BYOK, billing fallback, admin and membership disablement, client
+metadata spoofing, catalog visibility and the generated OpenAPI reason enum.
+These focused checks are not final journey evidence. Integrated inference and
+Desktop proof remains with the covering free-allowance journey.

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -62,6 +62,7 @@ import {
   ORGANIZATION_SSO_JIT_ROLE,
 } from "./sso-jit.js";
 import { isScimDeprovisionedIdentity } from "./scim-deprovisioning.js";
+import { normalizeOrganizationMetadata } from "./organization-limits.js";
 import {
   ORGANIZATION_SAML_ALLOW_IDP_INITIATED,
   ORGANIZATION_SAML_DEPRECATED_ALGORITHM_BEHAVIOR,
@@ -1094,10 +1095,21 @@ export const auth = betterAuth({
         });
       },
       organizationHooks: {
+        beforeCreateOrganization: async ({ organization }) => {
+          // Entitlements are server-owned, including on Better Auth's raw route.
+          const { metadata } = normalizeOrganizationMetadata(organization.metadata);
+          delete metadata.inference;
+          delete metadata.inferenceFree;
+          return { data: { ...organization, metadata } };
+        },
         afterCreateOrganization: async ({ organization }) => {
-          await seedDefaultOrganizationRoles(
-            normalizeDenTypeId("organization", organization.id),
-          );
+          const organizationId = normalizeDenTypeId("organization", organization.id);
+          // Better Auth serializes metadata for text columns. Den's JSON column
+          // must hold an object so enrollment can preserve the remaining fields.
+          await db.update(schema.OrganizationTable)
+            .set({ metadata: normalizeOrganizationMetadata(organization.metadata).metadata })
+            .where(eq(schema.OrganizationTable.id, organizationId));
+          await seedDefaultOrganizationRoles(organizationId);
         },
         beforeAddMember: async ({ member }) => {
           const role = typeof member.role === "string" ? member.role : "";

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -2,6 +2,7 @@ import os from "node:os"
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import { denUrls } from "@openwork-ee/utils/den-urls"
+import { readFreeInferenceConfig } from "@openwork/types/den/inference"
 import { DEN_WORKER_POLL_INTERVAL_MS } from "./CONSTS.js"
 import { normalizeConfiguredPublicApiBaseUrl } from "./request-url.js"
 import { resolveDenServiceVersion } from "./service-version.js"
@@ -182,6 +183,9 @@ const EnvSchema = z.object({
   DEN_CKPT_INTERVAL_SECONDS: z.string().optional(),
   DEN_CKPT_KEEP: z.string().optional(),
   INFERENCE_PROXY_BASE_URL: z.string().optional(),
+  INFERENCE_FREE_ENABLED: z.string().optional(),
+  INFERENCE_FREE_WEEKLY_BUDGET_USD: z.string().optional(),
+  INFERENCE_FREE_MODEL_ID: z.string().optional(),
   OPENROUTER_MANAGEMENT_API_KEY: z.string().optional(),
   OPENROUTER_WORKSPACE_ID: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),
@@ -811,6 +815,7 @@ export const env = {
   corsHandledByEdge,
   openworkWebEnabled,
   inferenceProxyBaseUrl: optionalString(parsed.INFERENCE_PROXY_BASE_URL) ?? "http://127.0.0.1:8791",
+  inferenceFree: readFreeInferenceConfig(parsed),
   openRouterManagementApiKey: optionalString(parsed.OPENROUTER_MANAGEMENT_API_KEY),
   openRouterWorkspaceId: optionalString(parsed.OPENROUTER_WORKSPACE_ID),
   stripe: {

--- a/ee/apps/den-api/src/inference.ts
+++ b/ee/apps/den-api/src/inference.ts
@@ -1,6 +1,7 @@
-import { and, eq, inArray, isNull, sql } from "@openwork-ee/den-db/drizzle"
+import { and, eq, inArray, isNotNull, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   InferenceKeyTable,
+  InferenceFreeUsageBucketTable,
   InferenceOrgLimitPolicyTable,
   InferenceOrgUpstreamProviderKeyTable,
   InferenceOrgUsageBucketTable,
@@ -9,25 +10,31 @@ import {
   LlmProviderTable,
   MemberTable,
   OrganizationTable,
+  OrgSubscriptionTable,
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import {
   createInferenceBearerKey,
+  inferenceBearerKey,
+  inferenceBearerKeyLookupDigests,
   inferenceBearerKeyPrefix,
   inferenceBearerKeyStorageDigest,
-  type InferenceBearerKey,
 } from "@openwork-ee/utils/inference-bearer-key"
 import {
   INFERENCE_RESET_STRATEGY_BY_WINDOW_TYPE,
   INFERENCE_TIER_LIMITS,
   INFERENCE_WINDOW_DURATIONS_MS,
+  freeInferenceAccess,
+  freeInferenceWindow,
+  inferenceAccessMode,
 } from "@openwork/types/den/inference"
-import type { InferenceOrganizationMetadata, InferenceTier, InferenceWindowType } from "@openwork/types/den/inference"
+import type { InferenceAccess, InferenceOrganizationMetadata, InferenceTier, InferenceWindowType } from "@openwork/types/den/inference"
 import { db } from "./db.js"
 import { env } from "./env.js"
 
 type OrgId = typeof OrganizationTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
+type InferenceTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
 
 const OPENWORK_PROVIDER_ID = "openwork"
 const OPENROUTER_PROVIDER = "openrouter"
@@ -104,14 +111,14 @@ function buildOpenWorkProviderConfig() {
   }
 }
 
-async function revokeMemberInferenceKeys(memberId: MemberId) {
-  await db
+async function revokeMemberInferenceKeys(memberId: MemberId, tx: InferenceTransaction) {
+  await tx
     .update(InferenceKeyTable)
     .set({ status: "revoked", revoked_at: new Date() })
     .where(and(eq(InferenceKeyTable.org_membership_id, memberId), eq(InferenceKeyTable.status, "active")))
 }
 
-async function deleteOpenWorkProviders(where: { organizationId: OrgId; memberId?: MemberId }) {
+async function deleteOpenWorkProviders(where: { organizationId: OrgId; memberId?: MemberId }, tx: InferenceTransaction) {
   const providerWhere = where.memberId
     ? and(
         eq(LlmProviderTable.organizationId, where.organizationId),
@@ -125,138 +132,123 @@ async function deleteOpenWorkProviders(where: { organizationId: OrgId; memberId?
         eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
       )
 
-  const providers = await db.select({ id: LlmProviderTable.id }).from(LlmProviderTable).where(providerWhere)
+  const providers = await tx.select({ id: LlmProviderTable.id }).from(LlmProviderTable).where(providerWhere)
   if (providers.length === 0) {
     return
   }
 
   const providerIds = providers.map((provider) => provider.id)
-  await db.transaction(async (tx) => {
-    await tx.delete(LlmProviderAccessTable).where(inArray(LlmProviderAccessTable.llmProviderId, providerIds))
-    await tx.delete(LlmProviderModelTable).where(inArray(LlmProviderModelTable.llmProviderId, providerIds))
-    await tx.delete(LlmProviderTable).where(inArray(LlmProviderTable.id, providerIds))
-  })
-}
-
-async function createMemberInferenceKey(input: { organizationId: OrgId; memberId: MemberId }) {
-  const key = createInferenceBearerKey()
-  await db.insert(InferenceKeyTable).values({
-    id: createDenTypeId("inferenceKey"),
-    organization_id: input.organizationId,
-    org_membership_id: input.memberId,
-    name: "OpenWork Models",
-    key_hash: await inferenceBearerKeyStorageDigest(key),
-    key_prefix: inferenceBearerKeyPrefix(key),
-    status: "active",
-  })
-  return key
-}
-
-async function ensureOpenWorkLlmProviderForMember(input: { organizationId: OrgId; memberId: MemberId; inferenceKey: InferenceBearerKey }) {
-  const now = new Date()
-  const providerRows = await db
-    .select({ id: LlmProviderTable.id })
-    .from(LlmProviderTable)
-    .where(and(
-      eq(LlmProviderTable.organizationId, input.organizationId),
-      eq(LlmProviderTable.createdByOrgMembershipId, input.memberId),
-      eq(LlmProviderTable.source, "openwork"),
-      eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
-    ))
-    .limit(1)
-
-  const providerConfig = buildOpenWorkProviderConfig()
-  const providerId = providerRows[0]?.id ?? createDenTypeId("llmProvider")
-
-  await db.transaction(async (tx) => {
-    if (providerRows[0]) {
-      await tx
-        .update(LlmProviderTable)
-        .set({ name: "OpenWork Models", providerConfig, apiKey: input.inferenceKey.value, updatedAt: now })
-        .where(eq(LlmProviderTable.id, providerId))
-      await tx.delete(LlmProviderModelTable).where(eq(LlmProviderModelTable.llmProviderId, providerId))
-      await tx.delete(LlmProviderAccessTable).where(eq(LlmProviderAccessTable.llmProviderId, providerId))
-    } else {
-      await tx.insert(LlmProviderTable).values({
-        id: providerId,
-        organizationId: input.organizationId,
-        createdByOrgMembershipId: input.memberId,
-        source: "openwork",
-        providerId: OPENWORK_PROVIDER_ID,
-        name: "OpenWork Models",
-        providerConfig,
-        apiKey: input.inferenceKey.value,
-        createdAt: now,
-        updatedAt: now,
-      })
-    }
-
-    await tx.insert(LlmProviderAccessTable).values({
-      id: createDenTypeId("llmProviderAccess"),
-      llmProviderId: providerId,
-      orgMembershipId: input.memberId,
-      teamId: null,
-      createdAt: now,
-    })
-  })
-}
-
-async function ensureMemberInferenceAccess(input: { organizationId: OrgId; memberId: MemberId }) {
-  const key = await createMemberInferenceKey(input)
-  await ensureOpenWorkLlmProviderForMember({ ...input, inferenceKey: key })
-}
-
-async function memberHasOpenWorkInferenceAccess(input: { organizationId: OrgId; memberId: MemberId }) {
-  const [provider] = await db
-    .select({ id: LlmProviderTable.id })
-    .from(LlmProviderTable)
-    .where(and(
-      eq(LlmProviderTable.organizationId, input.organizationId),
-      eq(LlmProviderTable.createdByOrgMembershipId, input.memberId),
-      eq(LlmProviderTable.source, "openwork"),
-      eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
-    ))
-    .limit(1)
-  const [key] = await db
-    .select({ id: InferenceKeyTable.id })
-    .from(InferenceKeyTable)
-    .where(and(
-      eq(InferenceKeyTable.organization_id, input.organizationId),
-      eq(InferenceKeyTable.org_membership_id, input.memberId),
-      eq(InferenceKeyTable.status, "active"),
-    ))
-    .limit(1)
-
-  return Boolean(provider && key)
+  await tx.delete(LlmProviderAccessTable).where(inArray(LlmProviderAccessTable.llmProviderId, providerIds))
+  await tx.delete(LlmProviderModelTable).where(inArray(LlmProviderModelTable.llmProviderId, providerIds))
+  await tx.delete(LlmProviderTable).where(inArray(LlmProviderTable.id, providerIds))
 }
 
 /**
- * Re-provision this member's OpenWork Models key + LLM provider when the org
- * has inference enabled but the member row was deleted or never created.
- * Safe to call from member-facing list endpoints (self-heal).
+ * Enroll eligible joined members and repair only their managed OpenWork provider.
+ * The organization/member locks serialize enrollment, disablement and key repair.
+ * No upstream request or paid policy creation belongs in this path.
  */
 export async function repairMemberInferenceAccessIfNeeded(input: {
   organizationId: OrgId
   memberId: MemberId
 }): Promise<boolean> {
-  const [organization] = await db
-    .select({ metadata: OrganizationTable.metadata })
-    .from(OrganizationTable)
-    .where(eq(OrganizationTable.id, input.organizationId))
-    .limit(1)
+  return db.transaction(async (tx) => {
+    const [organization] = await tx.select({ metadata: OrganizationTable.metadata })
+      .from(OrganizationTable).where(eq(OrganizationTable.id, input.organizationId)).limit(1).for("update")
+    const [member] = await tx.select().from(MemberTable).where(and(
+      eq(MemberTable.id, input.memberId), eq(MemberTable.organizationId, input.organizationId),
+    )).limit(1).for("update")
+    if (!organization || !member?.userId || !member.joinedAt || member.removedAt) return false
 
-  const inference = readInferenceMetadata(organization?.metadata ?? null)
-  if (!inference) {
-    return false
+    let mode = inferenceAccessMode(organization.metadata)
+    if (env.inferenceFree.enabled && mode === "not_eligible"
+      && organization.metadata?.inference == null && organization.metadata?.inferenceFree == null) {
+      // The old paid disable path deleted metadata. Subscription history makes
+      // that absence ambiguous, so only never-subscribed orgs enroll by default.
+      const [subscription] = await tx.select({ id: OrgSubscriptionTable.id }).from(OrgSubscriptionTable).where(and(
+        eq(OrgSubscriptionTable.organization_id, input.organizationId), eq(OrgSubscriptionTable.type, "inference"),
+      )).limit(1)
+      if (subscription) return false
+      const metadata = { ...organization.metadata, inferenceFree: { offerAllowed: true } }
+      await tx.update(OrganizationTable).set({ metadata }).where(eq(OrganizationTable.id, input.organizationId))
+      mode = inferenceAccessMode(metadata)
+    }
+    if (mode !== "paid" && !(mode === "free" && env.inferenceFree.enabled)) return false
+
+    const [provider] = await tx.select().from(LlmProviderTable).where(and(
+      eq(LlmProviderTable.organizationId, input.organizationId),
+      eq(LlmProviderTable.createdByOrgMembershipId, input.memberId),
+      eq(LlmProviderTable.source, "openwork"),
+      eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
+    )).limit(1)
+    const activeKeys = await tx.select().from(InferenceKeyTable).where(and(
+      eq(InferenceKeyTable.organization_id, input.organizationId),
+      eq(InferenceKeyTable.org_membership_id, input.memberId),
+      eq(InferenceKeyTable.status, "active"),
+    ))
+    const digests = provider?.apiKey ? await inferenceBearerKeyLookupDigests(inferenceBearerKey(provider.apiKey)) : []
+    const matchingKey = activeKeys.find((key) => digests.includes(key.key_hash))
+    let changed = false
+    const staleKeys = activeKeys.filter((key) => key.id !== matchingKey?.id)
+    if (staleKeys.length) {
+      await tx.update(InferenceKeyTable).set({ status: "revoked", revoked_at: new Date() })
+        .where(inArray(InferenceKeyTable.id, staleKeys.map((key) => key.id)))
+      changed = true
+    }
+    const providerId = provider?.id ?? createDenTypeId("llmProvider")
+    if (!matchingKey) {
+      const key = createInferenceBearerKey()
+      await tx.insert(InferenceKeyTable).values({
+        id: createDenTypeId("inferenceKey"), organization_id: input.organizationId,
+        org_membership_id: input.memberId, name: "OpenWork Models",
+        key_hash: await inferenceBearerKeyStorageDigest(key), key_prefix: inferenceBearerKeyPrefix(key), status: "active",
+      })
+      if (provider) {
+        // Preserve provider identity, model selections and configuration on repair.
+        await tx.update(LlmProviderTable).set({ apiKey: key.value }).where(eq(LlmProviderTable.id, providerId))
+      } else {
+        await tx.insert(LlmProviderTable).values({
+          id: providerId, organizationId: input.organizationId, createdByOrgMembershipId: input.memberId,
+          source: "openwork", providerId: OPENWORK_PROVIDER_ID, name: "OpenWork Models",
+          providerConfig: buildOpenWorkProviderConfig(), apiKey: key.value,
+        })
+      }
+      changed = true
+    }
+    const [access] = await tx.select({ id: LlmProviderAccessTable.id }).from(LlmProviderAccessTable).where(and(
+      eq(LlmProviderAccessTable.llmProviderId, providerId), eq(LlmProviderAccessTable.orgMembershipId, input.memberId),
+    )).limit(1)
+    if (!access) {
+      await tx.insert(LlmProviderAccessTable).values({
+        id: createDenTypeId("llmProviderAccess"), llmProviderId: providerId, orgMembershipId: input.memberId, teamId: null,
+      })
+      changed = true
+    }
+    return changed
+  })
+}
+
+export async function getMemberInferenceAccess(input: {
+  organizationId: OrgId
+  memberId: MemberId
+  userId: DenTypeId<"user">
+}): Promise<InferenceAccess> {
+  const [row] = await db.select({ metadata: OrganizationTable.metadata })
+    .from(MemberTable).innerJoin(OrganizationTable, eq(OrganizationTable.id, MemberTable.organizationId))
+    .where(and(eq(MemberTable.id, input.memberId), eq(MemberTable.organizationId, input.organizationId),
+      eq(MemberTable.userId, input.userId), isNull(MemberTable.removedAt), isNotNull(MemberTable.joinedAt))).limit(1)
+  const mode = row ? inferenceAccessMode(row.metadata) : "not_eligible"
+  const now = new Date()
+  if (mode !== "free" || !env.inferenceFree.enabled) return freeInferenceAccess({ config: env.inferenceFree, mode, now })
+  try {
+    const [bucket] = await db.select().from(InferenceFreeUsageBucketTable).where(and(
+      eq(InferenceFreeUsageBucketTable.user_id, input.userId),
+      eq(InferenceFreeUsageBucketTable.window_start_at, freeInferenceWindow(now).start),
+    )).limit(1)
+    return freeInferenceAccess({ config: env.inferenceFree, mode, bucket, now })
+  } catch {
+    return { ...freeInferenceAccess({ config: env.inferenceFree, mode, now }), kind: "unavailable", reason: "accounting_unavailable", usedUsd: null, reservedUsd: null, remainingUsd: null }
   }
-
-  if (await memberHasOpenWorkInferenceAccess(input)) {
-    return false
-  }
-
-  await revokeMemberInferenceKeys(input.memberId)
-  await ensureMemberInferenceAccess(input)
-  return true
 }
 
 export async function syncInferenceForOrganizationMembers(input: { organizationId: OrgId }) {
@@ -267,12 +259,10 @@ export async function syncInferenceForOrganizationMembers(input: { organizationI
     .limit(1)
 
   const inference = readInferenceMetadata(organization?.metadata ?? null)
-  if (!inference) {
-    return
-  }
-
   const members = await listOrgMembers(input.organizationId)
-  await syncInferenceLimitPolicies({ organizationId: input.organizationId, tier: inference.tier, memberCount: members.length })
+  if (inference) {
+    await syncInferenceLimitPolicies({ organizationId: input.organizationId, tier: inference.tier, memberCount: members.length })
+  }
 
   for (const member of members) {
     await repairMemberInferenceAccessIfNeeded({
@@ -289,8 +279,12 @@ export async function syncInferenceAfterMemberChange(input: {
   change: "added" | "removed"
 }) {
   if (input.change === "removed") {
-    await revokeMemberInferenceKeys(input.memberId)
-    await deleteOpenWorkProviders({ organizationId: input.organizationId, memberId: input.memberId })
+    await db.transaction(async (tx) => {
+      await tx.select({ id: OrganizationTable.id }).from(OrganizationTable)
+        .where(eq(OrganizationTable.id, input.organizationId)).for("update")
+      await revokeMemberInferenceKeys(input.memberId, tx)
+      await deleteOpenWorkProviders({ organizationId: input.organizationId, memberId: input.memberId }, tx)
+    })
   }
 
   const [organization] = await db
@@ -299,14 +293,12 @@ export async function syncInferenceAfterMemberChange(input: {
     .where(eq(OrganizationTable.id, input.organizationId))
     .limit(1)
   const inference = readInferenceMetadata(organization?.metadata ?? null)
-  if (!inference) {
-    return
+  if (inference) {
+    await syncInferenceLimitPolicies({ organizationId: input.organizationId, tier: inference.tier, memberCount: input.memberCount })
   }
 
-  await syncInferenceLimitPolicies({ organizationId: input.organizationId, tier: inference.tier, memberCount: input.memberCount })
-
   if (input.change === "added") {
-    await ensureMemberInferenceAccess({ organizationId: input.organizationId, memberId: input.memberId })
+    await repairMemberInferenceAccessIfNeeded({ organizationId: input.organizationId, memberId: input.memberId })
   }
 }
 
@@ -586,7 +578,7 @@ export async function getInferenceStatus(organizationId: OrgId) {
   }
 }
 
-export async function setInferenceEnabled(input: { organizationId: OrgId; enabled: boolean; tier?: InferenceTier }) {
+export async function setInferenceEnabled(input: { organizationId: OrgId; enabled: boolean; tier?: InferenceTier; source?: "admin" | "billing" }) {
   const [organization] = await db
     .select({ metadata: OrganizationTable.metadata })
     .from(OrganizationTable)
@@ -597,28 +589,41 @@ export async function setInferenceEnabled(input: { organizationId: OrgId; enable
   }
 
   if (!input.enabled) {
-    const members = await listOrgMembers(input.organizationId)
+    await db.transaction(async (tx) => {
+      const [current] = await tx.select({ metadata: OrganizationTable.metadata }).from(OrganizationTable)
+        .where(eq(OrganizationTable.id, input.organizationId)).limit(1).for("update")
+      if (!current) return
+      if (input.source === "billing" && inferenceAccessMode(current.metadata) === "free") return
+      const metadata = setInferenceMetadata(current.metadata, null)
+      // Billing expiry is not an administrator's opt-out. Preserve an existing
+      // opt-out, even on a repeated or delayed subscription event.
+      const offerAllowed = input.source === "billing" && inferenceAccessMode(current.metadata) !== "admin_disabled"
+        && !(isRecord(current.metadata?.inferenceFree) && current.metadata.inferenceFree.offerAllowed === false)
+      metadata.inferenceFree = { offerAllowed }
+      await tx.update(OrganizationTable).set({ metadata }).where(eq(OrganizationTable.id, input.organizationId))
+      await tx.update(InferenceKeyTable).set({ status: "revoked", revoked_at: new Date() })
+        .where(eq(InferenceKeyTable.organization_id, input.organizationId))
+      if (!offerAllowed) await deleteOpenWorkProviders({ organizationId: input.organizationId }, tx)
+    })
+    // Revoke locally before contacting upstream so a failed deletion fails closed.
     await revokeOrgUpstreamProviderKeys(input.organizationId)
-    await db
-      .update(OrganizationTable)
-      .set({ metadata: setInferenceMetadata(organization.metadata, null) })
-      .where(eq(OrganizationTable.id, input.organizationId))
-    if (members.length > 0) {
-      await db
-        .update(InferenceKeyTable)
-        .set({ status: "revoked", revoked_at: new Date() })
-        .where(and(eq(InferenceKeyTable.organization_id, input.organizationId), inArray(InferenceKeyTable.org_membership_id, members.map((member) => member.id))))
-    }
-    await deleteOpenWorkProviders({ organizationId: input.organizationId })
     return getInferenceStatus(input.organizationId)
   }
 
+  if (input.source === "billing" && inferenceAccessMode(organization.metadata) === "admin_disabled") {
+    return getInferenceStatus(input.organizationId)
+  }
   const tier = input.tier ?? readInferenceMetadata(organization.metadata)?.tier ?? "tier1"
   await ensureOrgUpstreamProviderKey(input.organizationId)
-  await db
-    .update(OrganizationTable)
-    .set({ metadata: setInferenceMetadata(organization.metadata, { enabled: true, tier }) })
-    .where(eq(OrganizationTable.id, input.organizationId))
+  await db.transaction(async (tx) => {
+    const [current] = await tx.select({ metadata: OrganizationTable.metadata }).from(OrganizationTable)
+      .where(eq(OrganizationTable.id, input.organizationId)).limit(1).for("update")
+    if (!current || input.source === "billing" && inferenceAccessMode(current.metadata) === "admin_disabled") return
+    await tx.update(OrganizationTable).set({ metadata: {
+      ...setInferenceMetadata(current.metadata, { enabled: true, tier }),
+      inferenceFree: { offerAllowed: true },
+    } }).where(eq(OrganizationTable.id, input.organizationId))
+  })
   await syncInferenceForOrganizationMembers({ organizationId: input.organizationId })
   return getInferenceStatus(input.organizationId)
 }

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -3,9 +3,11 @@ import { and, asc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import {
   LlmProviderModelTable,
   LlmProviderTable,
+  OrganizationTable,
   WorkerTable,
   WorkerTokenTable,
 } from "@openwork-ee/den-db/schema"
+import { inferenceAccessMode } from "@openwork/types/den/inference"
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
@@ -183,7 +185,12 @@ const databaseMaterializationStore: CloudProviderMaterializationStore = {
       modelsByProvider.set(model.llmProviderId, existing)
     }
 
-    return providers.map((provider) => ({
+    const [organization] = await db.select({ metadata: OrganizationTable.metadata }).from(OrganizationTable)
+      .where(eq(OrganizationTable.id, organizationId)).limit(1)
+    // This org-wide path has no calling person. Never copy one member's free
+    // allowance key into a shared worker; paid inference and BYOK stay unchanged.
+    const paidInference = inferenceAccessMode(organization?.metadata ?? null) === "paid"
+    return providers.filter((provider) => provider.source !== "openwork" || paidInference).map((provider) => ({
       id: provider.id,
       source: provider.source,
       providerId: provider.providerId,

--- a/ee/apps/den-api/src/routes/org/inference.ts
+++ b/ee/apps/den-api/src/routes/org/inference.ts
@@ -1,12 +1,14 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
-import { getInferenceStatus, setInferenceEnabled } from "../../inference.js"
+import { INFERENCE_ACCESS_REASONS } from "@openwork/types/den/inference"
+import { getInferenceStatus, getMemberInferenceAccess, repairMemberInferenceAccessIfNeeded, setInferenceEnabled } from "../../inference.js"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { organizationHasActiveInferenceSubscription } from "../../stripe-billing.js"
-import { jsonValidator, orgRoleRoute } from "../../middleware/index.js"
+import { jsonValidator, orgMemberRoute, orgRoleRoute } from "../../middleware/index.js"
 import { forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { ensureOrganizationAdmin, orgAccessFailureStatus } from "./shared.js"
+import { ensureOrganizationAdmin, ensureOrganizationAdminRole, orgAccessFailureStatus } from "./shared.js"
 
 const inferenceSettingsSchema = z.object({
   enabled: z.boolean(),
@@ -40,7 +42,50 @@ const inferenceProviderMissingSchema = z.object({
   message: z.string(),
 }).meta({ ref: "InferenceProviderMissingError" })
 
+const inferenceAccessResponseSchema = z.object({
+  access: z.object({
+    kind: z.enum(["paid", "free", "exhausted", "unavailable"]),
+    modelID: z.string().nullable(),
+    weeklyLimitUsd: z.number().nullable(),
+    usedUsd: z.number().nullable(),
+    reservedUsd: z.number().nullable(),
+    remainingUsd: z.number().nullable(),
+    resetsAt: z.string().nullable(),
+    reason: z.enum(INFERENCE_ACCESS_REASONS).nullable(),
+    canUpgrade: z.boolean(),
+  }),
+  upgradePath: z.literal("/dashboard/billing").nullable(),
+}).meta({ ref: "InferenceAccessResponse" })
+
 export function registerOrgInferenceRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
+  app.get(
+    "/v1/inference/access",
+    describeRoute({
+      tags: ["Inference"],
+      summary: "Get my managed inference access",
+      description: "Returns the signed-in joined member's access and person-wide weekly free allowance, without credentials or administrative settings.",
+      responses: {
+        200: jsonResponse("Managed inference access returned successfully.", inferenceAccessResponseSchema),
+        401: jsonResponse("Sign in to read inference access.", unauthorizedSchema),
+        403: jsonResponse("Join the organization before using inference.", forbiddenSchema),
+      },
+    }),
+    orgMemberRoute(),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!payload.currentMember.joinedAt) return c.json({ error: "forbidden" }, 403)
+      const user = c.get("user")
+      if (!user) return c.json({ error: "unauthorized" }, 401)
+      await repairMemberInferenceAccessIfNeeded({ organizationId: payload.organization.id, memberId: payload.currentMember.id })
+      const access = await getMemberInferenceAccess({
+        organizationId: payload.organization.id, memberId: payload.currentMember.id, userId: normalizeDenTypeId("user", user.id),
+      })
+      const canUpgrade = ensureOrganizationAdminRole(c, "Only workspace owners and admins can upgrade.").ok
+      c.header("Cache-Control", "no-store")
+      return c.json({ access: { ...access, canUpgrade }, upgradePath: canUpgrade ? "/dashboard/billing" : null })
+    },
+  )
+
   app.get(
     "/v1/inference",
     describeRoute({

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -37,7 +37,7 @@ import {
 import { getModelsDevProvider, listModelsDevProviders } from "../../llm/models-dev.js"
 import type { MemberTeamsContext } from "../../middleware/member-teams.js"
 import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
-import { repairMemberInferenceAccessIfNeeded } from "../../inference.js"
+import { getMemberInferenceAccess, repairMemberInferenceAccessIfNeeded } from "../../inference.js"
 import { listAccessibleLlmProviderAccess, listGrantedLlmProviderMemberIds } from "./llm-provider-access.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationAdmin, ensureOrganizationAdminRole, idParamSchema, memberHasRole, orgAccessFailureStatus } from "./shared.js"
@@ -1309,9 +1309,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       const payload = c.get("organizationContext")
       const memberTeams = c.get("memberTeams") ?? []
 
-      // Desktop entitlement is based on this list. If org inference is enabled
-      // but this member's OpenWork provider/key was deleted, re-provision before
-      // listing so Subscribe CTAs don't lie about an already-enabled org.
+      // Enroll eligible members and repair managed inference without touching BYOK.
       if (query.scope === "usable") {
         try {
           await repairMemberInferenceAccessIfNeeded({
@@ -1331,8 +1329,11 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
         scope: query.scope,
       })
 
+      const inferenceAccess = query.scope === "usable" && providers.some((provider) => provider.source === "openwork")
+        ? await getMemberInferenceAccess({ organizationId: payload.organization.id, memberId: payload.currentMember.id, userId: normalizeDenTypeId("user", c.get("user").id) })
+        : null
       return c.json({
-        llmProviders: providers.map((provider) => ({
+        llmProviders: providers.filter((provider) => provider.source !== "openwork" || inferenceAccess?.kind !== "unavailable").map((provider) => ({
           ...provider,
           apiKey: undefined,
           canManage: canManageLlmProvider(payload, provider),
@@ -1403,7 +1404,27 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
 
       let credential = decodeProviderCredential(provider.apiKey)
       let memberCredential: z.infer<typeof memberCredentialConnectionSchema> | null = null
-      if (provider.credentialMode === "per_member") {
+      if (provider.source === "openwork") {
+        credential = { apiKey: null, apiKeys: null }
+        if (provider.createdByOrgMembershipId === payload.currentMember.id) {
+          try {
+            await repairMemberInferenceAccessIfNeeded({ organizationId: payload.organization.id, memberId: payload.currentMember.id })
+            const access = await getMemberInferenceAccess({
+              organizationId: payload.organization.id,
+              memberId: payload.currentMember.id,
+              userId: normalizeDenTypeId("user", c.get("user").id),
+            })
+            if (access.kind !== "unavailable") {
+              const [repaired] = await db.select({ apiKey: LlmProviderTable.apiKey }).from(LlmProviderTable)
+                .where(eq(LlmProviderTable.id, llmProviderId)).limit(1)
+              credential = decodeProviderCredential(repaired?.apiKey ?? null)
+            }
+          } catch {
+            // Fail only this provider closed; retain the published 200 contract.
+          }
+        }
+      }
+      if (provider.source !== "openwork" && provider.credentialMode === "per_member") {
         const bindingRows = await db
           .select()
           .from(LlmProviderMemberCredentialTable)
@@ -1429,7 +1450,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       // return `apiKeys` with `apiKey: null` so old clients fail with their
       // missing-credential error instead of applying a JSON blob as the key.
       // Catalog providers leave Den under provider-scoped env names (see
-      // toRuntimeProviderEnv); the stored row keeps the catalog's names.
+      // toRuntimeProviderEnv); the stored row keeps the original catalog names.
       const runtime = toRuntimeProviderEnv({ ...provider, apiKeys: credential.apiKeys })
       return c.json({
         llmProvider: {

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -537,7 +537,7 @@ export async function upsertOrgSubscriptionFromStripe(subscription: Stripe.Subsc
   })
 
   if (subscriptionType === INFERENCE_SUBSCRIPTION_TYPE && EXPIRED_STATUSES.has(status)) {
-    await setInferenceEnabled({ organizationId: metadata.organizationId as OrgId, enabled: false })
+    await setInferenceEnabled({ organizationId: metadata.organizationId as OrgId, enabled: false, source: "billing" })
   }
 
   return findOrgSubscriptionByStripeId(subscription.id)
@@ -1172,7 +1172,7 @@ export async function syncStripeCheckoutSession(input: { organizationId: OrgId; 
     })
   }
   if (row?.type === INFERENCE_SUBSCRIPTION_TYPE && ACTIVE_STATUSES.has(subscriptionStatus(subscription.status))) {
-    await setInferenceEnabled({ organizationId: row.organization_id, enabled: true })
+    await setInferenceEnabled({ organizationId: row.organization_id, enabled: true, source: "billing" })
   }
   return row
 }
@@ -1246,7 +1246,7 @@ async function expireNonWebSubscriptionAfterPaymentFailure(
     .set({ status: "expired", last_event_id: eventId, updated_at: new Date() })
     .where(eq(OrgSubscriptionTable.id, row.id))
   if (row.type === INFERENCE_SUBSCRIPTION_TYPE) {
-    await setInferenceEnabled({ organizationId: row.organization_id, enabled: false })
+    await setInferenceEnabled({ organizationId: row.organization_id, enabled: false, source: "billing" })
   }
 }
 
@@ -1352,7 +1352,7 @@ export async function handleStripeWebhook(input: { payload: string; signature: s
           })
         }
         if (row?.type === INFERENCE_SUBSCRIPTION_TYPE && ACTIVE_STATUSES.has(subscriptionStatus(subscription.status))) {
-          await setInferenceEnabled({ organizationId: row.organization_id, enabled: true })
+          await setInferenceEnabled({ organizationId: row.organization_id, enabled: true, source: "billing" })
         }
         if (row?.type === WEB_SUBSCRIPTION_TYPE && isEligibleOpenWorkWebSubscriptionStatus(subscription.status)) {
           await syncWebSubscriptionQuantityAfterMemberChange({

--- a/ee/apps/den-api/test/llm-provider-access-parity.test.ts
+++ b/ee/apps/den-api/test/llm-provider-access-parity.test.ts
@@ -1,6 +1,7 @@
-import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { afterAll, beforeAll, expect, mock, spyOn, test } from "bun:test"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { serializeSignedCookie } from "better-call"
+import { freeInferenceWindow, INFERENCE_ACCESS_REASONS, INFERENCE_FREE_MODEL_ID } from "@openwork/types/den/inference"
 
 const API_ORIGIN = "http://127.0.0.1:8790"
 
@@ -10,6 +11,10 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "z".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? API_ORIGIN
   process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? API_ORIGIN
+  process.env.DEN_ORG_MODE = "multi_org"
+  process.env.INFERENCE_FREE_ENABLED = "false"
+  process.env.STRIPE_SECRET_KEY = ""
+  process.env.OPENROUTER_MANAGEMENT_API_KEY = ""
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -54,12 +59,18 @@ let app: typeof import("../src/app.js").default
 let db: typeof import("../src/db.js").db
 let schema: typeof import("@openwork-ee/den-db/schema")
 let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let inference: typeof import("../src/inference.js")
+let env: typeof import("../src/env.js").env
+let fetchWitness: ReturnType<typeof spyOn<typeof globalThis, "fetch">>
 
 const ownerUserId = createDenTypeId("user")
 const memberUserId = createDenTypeId("user")
 const organizationId = createDenTypeId("organization")
 const ownerMemberId = createDenTypeId("member")
 const memberId = createDenTypeId("member")
+const secondOrganizationId = createDenTypeId("organization")
+const secondMemberId = createDenTypeId("member")
+const ownedOrganizationIds = [organizationId, secondOrganizationId]
 const ownerSessionId = createDenTypeId("session")
 const memberSessionId = createDenTypeId("session")
 const ownerSessionToken = `provider-parity-owner-${ownerSessionId}`
@@ -70,6 +81,9 @@ let memberCookie = ""
 beforeAll(async () => {
   seedRequiredEnv()
   mock.restore()
+  fetchWitness = spyOn(globalThis, "fetch").mockImplementation(Object.assign(async () => {
+    throw new Error("External requests are forbidden in provider access tests")
+  }, { preconnect: globalThis.fetch.preconnect }))
 
   const realDb = (await import("@openwork-ee/den-db")).createDenDb({
     databaseUrl: process.env.DATABASE_URL,
@@ -87,6 +101,8 @@ beforeAll(async () => {
   db = dbModule.db
   schema = schemaModule
   drizzle = drizzleModule
+  inference = await import("../src/inference.js")
+  env = (await import("../src/env.js")).env
 
   await db.insert(schema.AuthUserTable).values([
     {
@@ -121,20 +137,26 @@ beforeAll(async () => {
       role: "member",
     },
   ])
+  await db.insert(schema.OrganizationTable).values({
+    id: secondOrganizationId, name: "Second Allowance Workspace", slug: `allowance-second-${secondOrganizationId}`,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: secondMemberId, organizationId: secondOrganizationId, userId: memberUserId, role: "member",
+  })
   await db.insert(schema.AuthSessionTable).values([
     {
       id: ownerSessionId,
       userId: ownerUserId,
       activeOrganizationId: organizationId,
       token: ownerSessionToken,
-      expiresAt: new Date(Date.now() + 60_000),
+      expiresAt: new Date(Date.now() + 300_000),
     },
     {
       id: memberSessionId,
       userId: memberUserId,
       activeOrganizationId: organizationId,
       token: memberSessionToken,
-      expiresAt: new Date(Date.now() + 60_000),
+      expiresAt: new Date(Date.now() + 300_000),
     },
   ])
 
@@ -142,8 +164,8 @@ beforeAll(async () => {
   if (!betterAuthSecret) {
     throw new Error("BETTER_AUTH_SECRET is required")
   }
-  ownerCookie = await serializeSignedCookie("better-auth.session_token", ownerSessionToken, betterAuthSecret)
-  memberCookie = await serializeSignedCookie("better-auth.session_token", memberSessionToken, betterAuthSecret)
+  ownerCookie = await serializeSignedCookie("openwork-den.session_token", ownerSessionToken, betterAuthSecret)
+  memberCookie = await serializeSignedCookie("openwork-den.session_token", memberSessionToken, betterAuthSecret)
 })
 
 afterAll(async () => {
@@ -158,7 +180,7 @@ afterAll(async () => {
       db
         .select({ id: schema.LlmProviderTable.id })
         .from(schema.LlmProviderTable)
-        .where(drizzle.eq(schema.LlmProviderTable.organizationId, organizationId)),
+        .where(drizzle.inArray(schema.LlmProviderTable.organizationId, ownedOrganizationIds)),
     ),
   )
   await db.delete(schema.LlmProviderModelTable).where(
@@ -167,21 +189,33 @@ afterAll(async () => {
       db
         .select({ id: schema.LlmProviderTable.id })
         .from(schema.LlmProviderTable)
-        .where(drizzle.eq(schema.LlmProviderTable.organizationId, organizationId)),
+        .where(drizzle.inArray(schema.LlmProviderTable.organizationId, ownedOrganizationIds)),
     ),
   )
-  await db.delete(schema.LlmProviderTable).where(drizzle.eq(schema.LlmProviderTable.organizationId, organizationId))
+  await db.delete(schema.LlmProviderTable).where(drizzle.inArray(schema.LlmProviderTable.organizationId, ownedOrganizationIds))
+  await db.delete(schema.InferenceKeyTable).where(drizzle.inArray(schema.InferenceKeyTable.organization_id, ownedOrganizationIds))
+  await db.delete(schema.InferenceFreeUsageBucketTable).where(drizzle.inArray(schema.InferenceFreeUsageBucketTable.user_id, [ownerUserId, memberUserId]))
+  await db.delete(schema.OrgSubscriptionTable).where(drizzle.inArray(schema.OrgSubscriptionTable.organization_id, ownedOrganizationIds))
   await db.delete(schema.AuthSessionTable).where(
     drizzle.inArray(schema.AuthSessionTable.id, [ownerSessionId, memberSessionId]),
   )
-  await db.delete(schema.OrganizationRoleTable).where(drizzle.eq(schema.OrganizationRoleTable.organizationId, organizationId))
-  await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
-  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.OrganizationRoleTable).where(drizzle.inArray(schema.OrganizationRoleTable.organizationId, ownedOrganizationIds))
+  await db.delete(schema.MemberTable).where(drizzle.inArray(schema.MemberTable.organizationId, ownedOrganizationIds))
+  await db.delete(schema.OrganizationTable).where(drizzle.inArray(schema.OrganizationTable.id, ownedOrganizationIds))
   await db.delete(schema.AuthUserTable).where(
     drizzle.inArray(schema.AuthUserTable.id, [ownerUserId, memberUserId]),
   )
   mock.restore()
 })
+
+function request(cookie: string, path: string, init: RequestInit = {}, orgId = organizationId) {
+  const headers = new Headers(init.headers)
+  headers.set("cookie", cookie)
+  headers.set("origin", API_ORIGIN)
+  headers.set("x-openwork-org-id", orgId)
+  if (init.body) headers.set("content-type", "application/json")
+  return app.fetch(new Request(`${API_ORIGIN}${path}`, { ...init, headers }))
+}
 
 test("org-wide provider grants have list, connect, and resource snapshot parity", async () => {
   const createResponse = await app.fetch(new Request(`${API_ORIGIN}/v1/llm-providers`, {
@@ -230,4 +264,194 @@ test("org-wide provider grants have list, connect, and resource snapshot parity"
   const resourcesPayload: unknown = await resourcesResponse.json()
   expect(resourcesResponse.status).toBe(200)
   expect(resourceProviderIds(resourcesPayload)).toContain(llmProviderId)
+})
+
+test("joined members enroll once and read a person-wide allowance without paid provisioning", async () => {
+  const { and, eq } = drizzle
+  const accessPath = "/v1/inference/access"
+  const disabled = await request(memberCookie, accessPath)
+  expect(disabled.status).toBe(200)
+  expect(await disabled.json()).toMatchObject({ access: { kind: "unavailable", canUpgrade: false }, upgradePath: null })
+  expect(await db.select().from(schema.InferenceKeyTable).where(eq(schema.InferenceKeyTable.organization_id, organizationId))).toHaveLength(0)
+  expect((await request("", accessPath)).status).toBe(401)
+  expect((await request(memberCookie, "/v1/inference")).status).toBe(403)
+
+  env.inferenceFree.enabled = true
+  fetchWitness.mockClear()
+  await inference.syncInferenceAfterMemberChange({ organizationId: secondOrganizationId, memberId: secondMemberId, memberCount: 1, change: "added" })
+  const responses = await Promise.all(Array.from({ length: 8 }, () => request(memberCookie, "/v1/llm-providers")))
+  for (const response of responses) expect(response.status).toBe(200)
+  const providerWhere = and(eq(schema.LlmProviderTable.organizationId, organizationId), eq(schema.LlmProviderTable.createdByOrgMembershipId, memberId), eq(schema.LlmProviderTable.source, "openwork"))
+  const providers = await db.select().from(schema.LlmProviderTable).where(providerWhere)
+  expect(providers).toHaveLength(1)
+  const provider = providers[0]
+  if (!provider) throw new Error("Missing free provider")
+  expect(provider.providerId).toBe("openwork")
+  const activeKeys = () => db.select().from(schema.InferenceKeyTable).where(and(eq(schema.InferenceKeyTable.org_membership_id, memberId), eq(schema.InferenceKeyTable.status, "active")))
+  expect(await activeKeys()).toHaveLength(1)
+  expect(await db.select().from(schema.LlmProviderAccessTable).where(eq(schema.LlmProviderAccessTable.llmProviderId, provider.id))).toHaveLength(1)
+  const [org] = await db.select().from(schema.OrganizationTable).where(eq(schema.OrganizationTable.id, organizationId))
+  expect(org?.metadata?.inferenceFree).toEqual({ offerAllowed: true })
+  expect(org?.metadata?.inference).toBeUndefined()
+  for (const table of [schema.InferenceOrgLimitPolicyTable, schema.InferenceOrgUsageBucketTable, schema.InferenceOrgUpstreamProviderKeyTable, schema.OrgSubscriptionTable]) {
+    expect(await db.select().from(table).where(eq(table.organization_id, organizationId))).toHaveLength(0)
+  }
+
+  const access = await request(memberCookie, `${accessPath}?userId=${ownerUserId}`)
+  expect(access.headers.get("cache-control")).toBe("no-store")
+  const accessText = await access.text()
+  expect(JSON.parse(accessText)).toEqual({
+    access: { kind: "free", modelID: INFERENCE_FREE_MODEL_ID, weeklyLimitUsd: 1, usedUsd: 0, reservedUsd: 0, remainingUsd: 1, resetsAt: freeInferenceWindow().end.toISOString(), reason: null, canUpgrade: false },
+    upgradePath: null,
+  })
+  expect(accessText).not.toContain(provider.apiKey)
+  expect(accessText).not.toContain("key_hash")
+  expect(accessText).not.toContain("upstreamProviderConfigured")
+  expect(await (await request(ownerCookie, accessPath)).json()).toMatchObject({ access: { canUpgrade: true }, upgradePath: "/dashboard/billing" })
+
+  const connectPath = `/v1/llm-providers/${provider.id}/connect`
+  expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: provider.apiKey, source: "openwork" } })
+  expect((await request(ownerCookie, connectPath)).status).toBe(403)
+  const window = freeInferenceWindow()
+  await db.insert(schema.InferenceFreeUsageBucketTable).values({
+    user_id: memberUserId, window_start_at: window.start, window_end_at: window.end,
+    limit_amount: 100_000_000, used_amount: 25_000_000, reserved_amount: 10_000_000,
+  })
+  for (const orgId of [organizationId, secondOrganizationId]) {
+    expect(await (await request(memberCookie, accessPath, {}, orgId)).json()).toMatchObject({
+      access: { kind: "free", reason: "free_request_in_progress", usedUsd: 0.25, reservedUsd: 0.1, remainingUsd: 0.75 },
+    })
+  }
+  expect(providerIds(await (await request(memberCookie, "/v1/llm-providers")).json())).toContain(provider.id)
+  expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: provider.apiKey } })
+  const { materializeCloudWorkerProviders } = await import("../src/llm/cloud-provider-materialization.js")
+  const workerReads: string[] = []
+  const sharedWorker = await materializeCloudWorkerProviders({
+    organizationId: secondOrganizationId, workerId: createDenTypeId("worker"), instanceUrl: "https://worker.example.test",
+    hostToken: "test-host", clientToken: "test-client",
+    fetchImpl: async (url, init) => {
+      workerReads.push(`${init?.method ?? "GET"} ${new URL(url).pathname}`)
+      if (workerReads.at(-1) !== "GET /opencode/config") throw new Error("Must not write a person's free key into a shared worker")
+      return Response.json({ provider: {} })
+    },
+  })
+  expect(sharedWorker).toMatchObject({ ok: true, providers: 0 })
+  expect(workerReads).toEqual(["GET /opencode/config"])
+  expect(await (await request(ownerCookie, accessPath)).json()).toMatchObject({ access: { usedUsd: 0, reservedUsd: 0, remainingUsd: 1 } })
+  await db.update(schema.InferenceFreeUsageBucketTable).set({ used_amount: 101_000_000, reserved_amount: 0 }).where(eq(schema.InferenceFreeUsageBucketTable.user_id, memberUserId))
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "exhausted", reason: "free_allowance_exhausted", usedUsd: 1.01, reservedUsd: 0, remainingUsd: 0 } })
+  await db.update(schema.InferenceFreeUsageBucketTable).set({ blocked: true }).where(eq(schema.InferenceFreeUsageBucketTable.user_id, memberUserId))
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "unavailable", reason: "accounting_unavailable" } })
+  expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: null } })
+  await db.delete(schema.InferenceFreeUsageBucketTable).where(eq(schema.InferenceFreeUsageBucketTable.user_id, memberUserId))
+
+  const modelId = createDenTypeId("llmProviderModel")
+  const customConfig = { ...provider.providerConfig, name: "Keep my managed settings" }
+  await db.update(schema.LlmProviderTable).set({ providerConfig: customConfig }).where(eq(schema.LlmProviderTable.id, provider.id))
+  await db.insert(schema.LlmProviderModelTable).values({ id: modelId, llmProviderId: provider.id, modelId: INFERENCE_FREE_MODEL_ID, name: "Keep Luna", modelConfig: { id: INFERENCE_FREE_MODEL_ID } })
+  await db.update(schema.InferenceKeyTable).set({ status: "revoked" }).where(eq(schema.InferenceKeyTable.org_membership_id, memberId))
+  await Promise.all(Array.from({ length: 4 }, () => request(memberCookie, connectPath)))
+  const [repaired] = await db.select().from(schema.LlmProviderTable).where(providerWhere)
+  expect(repaired?.id).toBe(provider.id)
+  expect(repaired?.apiKey).not.toBe(provider.apiKey)
+  expect(repaired?.providerConfig).toEqual(customConfig)
+  expect(await db.select().from(schema.LlmProviderModelTable).where(eq(schema.LlmProviderModelTable.id, modelId))).toHaveLength(1)
+  expect(await activeKeys()).toHaveLength(1)
+  expect(fetchWitness).not.toHaveBeenCalled()
+})
+
+test("rollout, paid precedence, billing fallback and explicit admin disable preserve boundaries", async () => {
+  const { and, eq } = drizzle
+  const byokBefore = await db.select().from(schema.LlmProviderTable).where(and(eq(schema.LlmProviderTable.organizationId, organizationId), eq(schema.LlmProviderTable.source, "custom")))
+  const memberProviders = await db.select().from(schema.LlmProviderTable).where(and(eq(schema.LlmProviderTable.organizationId, organizationId), eq(schema.LlmProviderTable.createdByOrgMembershipId, memberId), eq(schema.LlmProviderTable.source, "openwork")))
+  const provider = memberProviders[0]
+  if (!provider) throw new Error("Missing managed provider")
+  const connectPath = `/v1/llm-providers/${provider.id}/connect`
+  const accessPath = "/v1/inference/access"
+
+  env.inferenceFree.enabled = false
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { reason: "free_disabled" } })
+  expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: null } })
+  expect(providerIds(await (await request(memberCookie, "/v1/llm-providers")).json())).not.toContain(provider.id)
+  await db.update(schema.OrganizationTable).set({ metadata: { inference: { enabled: true, tier: "tier2" }, inferenceFree: { offerAllowed: true } } }).where(eq(schema.OrganizationTable.id, organizationId))
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "paid", modelID: null, weeklyLimitUsd: null, remainingUsd: null } })
+  expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: provider.apiKey } })
+  env.inferenceFree.enabled = true
+  await inference.setInferenceEnabled({ organizationId, enabled: false, source: "billing" })
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "free" } })
+  const [downgraded] = await db.select().from(schema.LlmProviderTable).where(eq(schema.LlmProviderTable.id, provider.id))
+  expect(downgraded?.providerConfig).toEqual(provider.providerConfig)
+  expect(await db.select().from(schema.LlmProviderModelTable).where(eq(schema.LlmProviderModelTable.llmProviderId, provider.id))).toHaveLength(1)
+  await inference.setInferenceEnabled({ organizationId, enabled: false, source: "billing" })
+  expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: downgraded?.apiKey } })
+
+  const disable = await request(ownerCookie, "/v1/inference", { method: "PATCH", body: JSON.stringify({ enabled: false, inferenceFree: { offerAllowed: true }, source: "billing" }) })
+  expect(disable.status).toBe(200)
+  await inference.setInferenceEnabled({ organizationId, enabled: false, source: "billing" })
+  await inference.setInferenceEnabled({ organizationId, enabled: true, source: "billing" })
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "unavailable", reason: "admin_disabled" } })
+  expect(await db.select().from(schema.InferenceKeyTable).where(and(eq(schema.InferenceKeyTable.organization_id, organizationId), eq(schema.InferenceKeyTable.status, "active")))).toHaveLength(0)
+  expect((await request(memberCookie, connectPath)).status).toBe(404)
+  expect(await db.select().from(schema.LlmProviderTable).where(and(eq(schema.LlmProviderTable.organizationId, organizationId), eq(schema.LlmProviderTable.source, "custom")))).toEqual(byokBefore)
+  expect((await request(memberCookie, "/v1/inference", { method: "PATCH", body: JSON.stringify({ enabled: false }) })).status).toBe(403)
+
+  await db.update(schema.OrganizationTable).set({ metadata: { inference: { enabled: false }, inferenceFree: { offerAllowed: true } } }).where(eq(schema.OrganizationTable.id, organizationId))
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { reason: "admin_disabled" } })
+  await db.update(schema.OrganizationTable).set({ metadata: null }).where(eq(schema.OrganizationTable.id, organizationId))
+  await db.insert(schema.OrgSubscriptionTable).values({ id: createDenTypeId("orgSubscription"), organization_id: organizationId, type: "inference", status: "canceled", stripe_customer_id: "cus_allowance_test", stripe_subscription_id: `sub_${organizationId}` })
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "unavailable", reason: "not_eligible" } })
+  expect(await db.select().from(schema.InferenceOrgLimitPolicyTable).where(eq(schema.InferenceOrgLimitPolicyTable.organization_id, organizationId))).toHaveLength(0)
+
+  await db.update(schema.MemberTable).set({ joinedAt: null }).where(eq(schema.MemberTable.id, secondMemberId))
+  expect((await request(memberCookie, accessPath, {}, secondOrganizationId)).status).toBe(403)
+  expect(await inference.repairMemberInferenceAccessIfNeeded({ organizationId: secondOrganizationId, memberId: secondMemberId })).toBe(false)
+  await db.update(schema.MemberTable).set({ joinedAt: new Date(), removedAt: new Date() }).where(eq(schema.MemberTable.id, secondMemberId))
+  await inference.syncInferenceAfterMemberChange({ organizationId: secondOrganizationId, memberId: secondMemberId, memberCount: 0, change: "removed" })
+  expect((await request(memberCookie, accessPath, {}, secondOrganizationId)).status).toBe(404)
+  expect(await db.select().from(schema.InferenceKeyTable).where(and(eq(schema.InferenceKeyTable.org_membership_id, secondMemberId), eq(schema.InferenceKeyTable.status, "active")))).toHaveLength(0)
+  expect(fetchWitness).not.toHaveBeenCalled()
+})
+
+test("raw organization creation cannot spoof free or paid entitlements", async () => {
+  const slug = `allowance-spoof-${createDenTypeId("organization")}`
+  const response = await request(ownerCookie, "/api/auth/organization/create", {
+    method: "POST", body: JSON.stringify({ name: "Allowance Metadata Boundary", slug, metadata: { inference: { enabled: true, tier: "tier2" }, inferenceFree: { offerAllowed: true }, retained: "yes" } }),
+  })
+  expect(response.status).toBe(200)
+  const [created] = await db.select().from(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.slug, slug))
+  if (!created) throw new Error("Missing created organization")
+  ownedOrganizationIds.push(created.id)
+  expect(created.metadata?.inference).toBeUndefined()
+  expect(created.metadata?.inferenceFree).toBeUndefined()
+  expect(created.metadata?.retained).toBe("yes")
+  expect(await (await request(ownerCookie, "/v1/inference/access", {}, created.id)).json()).toMatchObject({ access: { kind: "free" } })
+  const [enrolled] = await db.select().from(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, created.id))
+  expect(enrolled?.metadata).toMatchObject({ retained: "yes", inferenceFree: { offerAllowed: true } })
+  expect(fetchWitness).not.toHaveBeenCalled()
+})
+
+test("model catalog retains paid entries for contextual upgrade discovery", async () => {
+  fetchWitness.mockImplementation(Object.assign(async (input: Parameters<typeof fetch>[0]) => {
+    if (String(input) !== "https://models.openworklabs.com/api.json") throw new Error("Unexpected external request")
+    return Response.json({ openwork: { id: "openwork", name: "OpenWork", models: {
+      [INFERENCE_FREE_MODEL_ID]: { id: INFERENCE_FREE_MODEL_ID, name: "Luna" },
+      "z-ai/glm-5.2": { id: "z-ai/glm-5.2", name: "Paid model" },
+    } } })
+  }, { preconnect: globalThis.fetch.preconnect }))
+  const response = await request(memberCookie, "/v1/llm-provider-catalog/openwork")
+  expect(response.status).toBe(200)
+  expect(await response.json()).toMatchObject({ provider: { models: expect.arrayContaining([
+    expect.objectContaining({ id: INFERENCE_FREE_MODEL_ID }), expect.objectContaining({ id: "z-ai/glm-5.2" }),
+  ]) } })
+  expect(fetchWitness).toHaveBeenCalledTimes(1)
+})
+
+test("member access OpenAPI exposes the shared metered reason contract", async () => {
+  const response = await request("", "/openapi.json")
+  expect(response.status).toBe(200)
+  const document: unknown = await response.json()
+  expect(document).toHaveProperty(["paths", "/v1/inference/access", "get", "operationId"], "getV1InferenceAccess")
+  expect(document).toHaveProperty(["components", "schemas", "InferenceAccessResponse", "properties", "access", "properties", "reason"], {
+    anyOf: [{ type: "string", enum: [...INFERENCE_ACCESS_REASONS] }, { type: "null" }],
+  })
 })

--- a/ee/apps/den-api/test/route-access-policy.test.ts
+++ b/ee/apps/den-api/test/route-access-policy.test.ts
@@ -111,6 +111,15 @@ function findRouteCalls(filePath: string): RouteCall[] {
 }
 
 describe("Den API route access policies", () => {
+  test("member inference access is separate from admin inference settings", () => {
+    const routes = findRouteCalls(join(srcRoot, "routes/org/inference.ts"))
+    const access = routes.find((route) => route.call.includes('"/v1/inference/access"'))
+    expect(access?.call).toContain("orgMemberRoute()")
+    const settings = routes.filter((route) => route.call.includes('"/v1/inference"'))
+    expect(settings).toHaveLength(2)
+    for (const route of settings) expect(route.call).toContain('orgRoleRoute(["admin"])')
+  })
+
   test("every route declares an explicit access policy", () => {
     const missingPolicy = listTypeScriptFiles(srcRoot)
       .flatMap(findRouteCalls)

--- a/ee/apps/den-api/test/stripe-billing.test.ts
+++ b/ee/apps/den-api/test/stripe-billing.test.ts
@@ -725,7 +725,7 @@ test("an asynchronous Checkout failure expires inference without enabling access
     status: "expired",
     last_event_id: "evt_inference_checkout_async_failed",
   })
-  expect(inferenceEnableCalls).toEqual([{ organizationId: "org_test", enabled: false }])
+  expect(inferenceEnableCalls).toEqual([{ organizationId: "org_test", enabled: false, source: "billing" }])
 })
 
 test("an asynchronous Checkout success clears payment failure and reconciles Web quantity", async () => {

--- a/ee/apps/den-web/app/(den)/_lib/inference-status.ts
+++ b/ee/apps/den-web/app/(den)/_lib/inference-status.ts
@@ -1,3 +1,33 @@
+import { INFERENCE_ACCESS_REASONS, type InferenceAccess } from "@openwork/types/den/inference";
+import { z } from "zod";
+
+const usd = z.number().finite().nonnegative().nullable();
+const accessSchema: z.ZodType<InferenceAccess & { canUpgrade: boolean }> = z.object({
+  kind: z.enum(["paid", "free", "exhausted", "unavailable"]),
+  modelID: z.string().nullable(),
+  weeklyLimitUsd: usd, usedUsd: usd, reservedUsd: usd, remainingUsd: usd,
+  resetsAt: z.iso.datetime().nullable(),
+  reason: z.enum(INFERENCE_ACCESS_REASONS).nullable(),
+  canUpgrade: z.boolean(),
+});
+
+export function parseInferenceAccessPayload(payload: unknown) {
+  const parsed = z.object({ access: accessSchema }).safeParse(payload);
+  return parsed.success ? parsed.data.access : null;
+}
+
+export function freeAllowanceDescription(access: InferenceAccess | null) {
+  if (!access || (access.kind !== "free" && access.kind !== "exhausted")) return null;
+  const usd = (value: number) => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+  const balance = access.remainingUsd !== null && access.weeklyLimitUsd !== null
+    ? `${usd(access.remainingUsd)} of ${usd(access.weeklyLimitUsd)} remaining per person this week.` : "Weekly allowance status is unavailable.";
+  const reset = access.resetsAt && Number.isFinite(Date.parse(access.resetsAt))
+    ? ` Resets ${new Date(access.resetsAt).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short" })}.` : "";
+  const pending = access.reason === "free_request_in_progress"
+    ? ` A Luna request is running or awaiting final usage.${access.reservedUsd !== null ? ` Estimated pending cost: ${usd(access.reservedUsd)}; the final charge may differ.` : ""} Wait for it to settle before starting another free request.` : "";
+  return `Free standard Luna. ${balance}${reset}${pending}`;
+}
+
 type InferenceWindowType = "five_hour" | "weekly" | "monthly";
 
 export type InferenceUsageBucket = {
@@ -70,4 +100,3 @@ export function parseInferencePayload(payload: unknown): InferenceStatus | null 
     buckets: parseUsageBuckets(value.buckets),
   };
 }
-

--- a/ee/apps/den-web/app/(den)/_lib/use-inference-access.ts
+++ b/ee/apps/den-web/app/(den)/_lib/use-inference-access.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useDenFlow } from "../_providers/den-flow-provider";
+import { requestJson } from "./den-flow";
+import { parseInferenceAccessPayload } from "./inference-status";
+
+export function useInferenceAccess(orgId: string | null) {
+  const { user } = useDenFlow();
+  return useQuery({
+    queryKey: ["inference-access", user?.id, orgId],
+    enabled: Boolean(user && orgId),
+    queryFn: async ({ signal }) => {
+      if (!orgId) return null;
+      const controller = new AbortController();
+      const cancel = () => controller.abort();
+      signal.addEventListener("abort", cancel, { once: true });
+      if (signal.aborted) cancel();
+      const timeout = setTimeout(cancel, 12_000);
+      try {
+        const { response, payload } = await requestJson("/v1/inference/access", {
+          method: "GET", signal: controller.signal, headers: { "x-openwork-org-id": orgId },
+        }, 12_000);
+        // Older deployments and disabled offers must not advertise free access.
+        return response.ok ? parseInferenceAccessPayload(payload) : null;
+      } catch { return null; }
+      finally { clearTimeout(timeout); signal.removeEventListener("abort", cancel); }
+    },
+    gcTime: 0,
+    staleTime: 0,
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: "always",
+    retry: false,
+  });
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
@@ -8,7 +9,8 @@ import { DenButton } from "../../_components/ui/button";
 import { DenPageHeader } from "../../_components/ui/page-header";
 import { DenCard } from "../../_components/ui/card";
 import { DenNotice } from "../../_components/ui/notice";
-import { parseInferencePayload, type InferenceStatus } from "../../_lib/inference-status";
+import { freeAllowanceDescription, parseInferencePayload } from "../../_lib/inference-status";
+import { useInferenceAccess } from "../../_lib/use-inference-access";
 import { DenSectionHeader } from "../../_components/ui/section-header";
 import { DenTable, type DenTableColumn } from "../../_components/ui/table";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
@@ -22,6 +24,7 @@ import { useOrgDashboard } from "../_providers/org-dashboard-provider";
  * unmapped models still render with sane defaults.
  */
 const MODEL_DETAILS: Record<string, { bestFor: string; monogram: string } | undefined> = {
+  "openai/gpt-5.6-luna": { bestFor: "Everyday knowledge work", monogram: "OA" },
   "moonshotai/kimi-k3": { bestFor: "Research & synthesis", monogram: "MS" },
   "z-ai/glm-5.2": { bestFor: "Multi-step tasks", monogram: "ZA" },
   "moonshotai/kimi-k2.7-code": { bestFor: "Spreadsheets & scripts", monogram: "MS" },
@@ -82,7 +85,7 @@ const MODEL_COLUMNS: readonly DenTableColumn<LineupModel>[] = [
   },
 ];
 
-function ModelsLineup({ subscribed }: { subscribed: boolean }) {
+function ModelsLineup({ subscribed, free }: { subscribed: boolean; free: boolean }) {
   return (
     <section className="grid gap-3.5">
       <DenSectionHeader
@@ -90,6 +93,7 @@ function ModelsLineup({ subscribed }: { subscribed: boolean }) {
         description={
           subscribed
             ? `Every member of your workspace can use all ${MODEL_LINEUP.length} models.`
+            : free ? "Standard Luna is included in the free weekly allowance. Upgrade to use every managed model below."
             : `Every member of your workspace can use all ${MODEL_LINEUP.length} models, the moment you subscribe.`
         }
       />
@@ -102,10 +106,8 @@ function ModelsLineup({ subscribed }: { subscribed: boolean }) {
 
 export function InferenceScreen() {
   const router = useRouter();
-  const { runtimeConfig, runtimeConfigLoaded } = useDenFlow();
+  const { runtimeConfig, runtimeConfigLoaded, user } = useDenFlow();
   const { activeOrg, orgContext, refreshOrgData, runReauthableAction } = useOrgDashboard();
-  const [status, setStatus] = useState<InferenceStatus | null>(null);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [subscribeBusy, setSubscribeBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -120,41 +122,32 @@ export function InferenceScreen() {
   // (single-org) deployments manage their own LLM providers instead.
   const isSelfHosted = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
   const activeOrgSlug = activeOrg?.slug ?? null;
+  const orgId = orgContext?.organization.id ?? null;
+  const { data: memberAccess = null } = useInferenceAccess(orgId);
+  const canStartCheckout = canManageModels && memberAccess?.canUpgrade !== false;
+  const { data: status = null, isPending: loading, error: statusError, refetch: refreshStatus } = useQuery({
+    queryKey: ["inference-settings", user?.id, orgId],
+    enabled: Boolean(user && orgId && canManageModels && !isSelfHosted),
+    queryFn: async ({ signal }) => {
+      if (!orgId) return null;
+      const { response, payload } = await requestJson("/v1/inference", { method: "GET", signal, headers: { "x-openwork-org-id": orgId } }, 12000);
+      if (!response.ok) throw new Error(getErrorMessage(payload, `Failed to load inference settings (${response.status}).`));
+      return parseInferencePayload(payload);
+    },
+    gcTime: 0,
+    refetchOnWindowFocus: "always",
+  });
 
   useEffect(() => {
     if (!isSelfHosted) return;
     router.replace(getCustomLlmProvidersRoute(activeOrgSlug));
   }, [isSelfHosted, activeOrgSlug, router]);
 
-  async function loadStatus() {
-    setLoading(true);
-    setError(null);
-    try {
-      const { response, payload } = await requestJson("/v1/inference", { method: "GET" }, 12000);
-      if (!response.ok) {
-        throw new Error(getErrorMessage(payload, `Failed to load inference settings (${response.status}).`));
-      }
-      const parsed = parseInferencePayload(payload);
-      if (!parsed) {
-        throw new Error("Inference settings response was incomplete.");
-      }
-      setStatus(parsed);
-    } catch (loadError) {
-      setError(loadError instanceof Error ? loadError.message : "Failed to load inference settings.");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    void loadStatus();
-  }, [orgContext?.organization.id]);
-
   // Subscribe at the point of value: start the Stripe checkout right here
   // instead of bouncing the user to the billing page. Billing stays the
   // status/portal view.
   async function startSubscribeCheckout() {
-    if (!canManageModels) {
+    if (!canStartCheckout) {
       setError("Only workspace admins can start OpenWork Models checkout.");
       return;
     }
@@ -213,7 +206,7 @@ export function InferenceScreen() {
           if (!parsed) {
             throw new Error("Inference settings response was incomplete.");
           }
-          setStatus(parsed);
+          await refreshStatus();
           await refreshOrgData();
         } finally {
           setSaving(false);
@@ -230,9 +223,10 @@ export function InferenceScreen() {
 
   const enabled = status?.enabled === true;
   const subscribed = status?.subscribed === true;
-  const showGettingStarted = !loading && status !== null && !subscribed;
+  const allowance = freeAllowanceDescription(memberAccess);
+  const showGettingStarted = !loading && status !== null && !subscribed && !allowance;
   const memberCount = status?.memberCount ?? 0;
-  const actionLabel = subscribed ? (enabled ? "Manage subscription" : "Enable") : "Subscribe";
+  const actionLabel = subscribed ? (enabled ? "Manage subscription" : "Enable") : allowance ? "Upgrade" : "Subscribe";
   const memberCaption = memberCount > 0
     ? `${memberCount} active member${memberCount === 1 ? "" : "s"}`
     : "billed per active member";
@@ -242,12 +236,21 @@ export function InferenceScreen() {
       <DenPageHeader title="OpenWork Models"
         description="Reliable, hand-picked models for knowledge work. No API keys to manage."
         caption={`$10 / user / month · ${memberCaption}`}
-        action={<DenButton type="button" onClick={subscribed ? toggleEnabled : () => void startSubscribeCheckout()}
-          loading={loading || saving || subscribeBusy} disabled={!canManageModels} variant={enabled ? "secondary" : "primary"}>
-          {actionLabel}
+        action={<DenButton type="button" onClick={!canStartCheckout ? () => setError("Ask a workspace owner or admin to upgrade OpenWork Models.") : subscribed ? toggleEnabled : () => void startSubscribeCheckout()}
+          loading={(canManageModels && loading) || saving || subscribeBusy} variant={enabled ? "secondary" : "primary"}>
+          {canStartCheckout ? actionLabel : "Ask admin"}
         </DenButton>} />
 
-      {error ? <DenNotice message={error} tone="error" /> : null}
+      {error || statusError ? <DenNotice message={error ?? statusError?.message ?? "Could not load model status."} tone="error" /> : null}
+
+      {allowance ? <DenCard>
+        <div className="grid gap-2" data-testid="inference-free-allowance">
+          <h2 className="text-base font-semibold">{memberAccess?.kind === "exhausted" ? "Your weekly Luna allowance is used up" : "Luna is included"}</h2>
+          <p className="text-sm leading-6 text-[#637291]">{allowance}</p>
+          <p className="text-sm leading-6 text-[#637291]">The allowance is shared across your workspaces, not multiplied by them. Bring your Own Keys keeps its own billing.</p>
+          {memberAccess?.kind === "exhausted" ? <p className="text-sm">Wait for the reset, upgrade, or choose your own provider.</p> : null}
+        </div>
+      </DenCard> : null}
 
       {canManageModels ? null : (
         <DenNotice
@@ -260,7 +263,7 @@ export function InferenceScreen() {
         <p className="text-sm leading-6 text-[#637291]">One subscription activates models for everyone in your workspace. After subscribing, choose a model from the OpenWork group in the app and start a task.</p>
       </DenCard> : null}
 
-      <ModelsLineup subscribed={subscribed} />
+      <ModelsLineup subscribed={subscribed} free={Boolean(allowance)} />
 
       <p className="text-[13px] text-gray-400">
         Prefer your own provider accounts?{" "}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -3,13 +3,14 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { Check, KeyRound, ArrowUpRight, ArrowRight } from "lucide-react";
 import { DenBadge } from "../../_components/ui/badge";
 import { DesktopHandoffAction } from "../../_components/auth-panel";
 import { SetupFrame } from "../../_components/setup-frame";
 import { getCustomLlmProvidersRoute, getInferenceRoute, getOrgDashboardRoute } from "../../_lib/den-org";
-import { getErrorMessage, normalizeAuthIntentParam, PENDING_AUTH_INTENT_STORAGE_KEY, requestJson } from "../../_lib/den-flow";
+import { normalizeAuthIntentParam, PENDING_AUTH_INTENT_STORAGE_KEY } from "../../_lib/den-flow";
+import { freeAllowanceDescription } from "../../_lib/inference-status";
+import { useInferenceAccess } from "../../_lib/use-inference-access";
 import { getDesktopGrant } from "../../_lib/desktop-handoff";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
@@ -25,19 +26,9 @@ export function MarketplaceOnboardingScreen() {
       modelsHeading.current?.focus();
     }
   }, [desktopAuthRequested]);
-  const { data: modelsEnabled, isPending: modelsLoading, error: modelsError } = useQuery({
-    queryKey: ["onboarding", "inference", orgId],
-    enabled: Boolean(orgId),
-    queryFn: async () => {
-      if (!orgId) throw new Error("Choose a workspace to check OpenWork Models.");
-      const { response, payload } = await requestJson("/v1/inference", { method: "GET", headers: { "x-openwork-org-id": orgId } }, 12000);
-      if (!response.ok) throw new Error(getErrorMessage(payload, "Could not check OpenWork Models."));
-      return typeof payload === "object" && payload !== null && "inference" in payload
-        && typeof payload.inference === "object" && payload.inference !== null
-        && "enabled" in payload.inference && payload.inference.enabled === true;
-    },
-    staleTime: 0,
-  });
+  const { data: modelAccess = null, isPending: modelsLoading, error: modelsError } = useInferenceAccess(orgId);
+  const modelsEnabled = modelAccess?.kind === "paid";
+  const allowance = freeAllowanceDescription(modelAccess);
 
   async function finish() {
     if (!orgId || completing) return;
@@ -57,9 +48,10 @@ export function MarketplaceOnboardingScreen() {
             <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-400">Optional · Models</p>
             <h2 id="setup-models-heading" ref={modelsHeading} tabIndex={-1} className="mt-2 text-xl font-semibold tracking-[-0.03em]">Your choice of model.</h2>
             <p className="mt-2 text-sm leading-6 text-[var(--dls-text-secondary)]" role="status">
-              {modelsLoading ? "Checking OpenWork Models..." : modelsError ? "Model status is unavailable. You can still complete setup." : modelsEnabled ? "OpenWork Models are on for this workspace." : "Signing in does not enable models. Keep your existing provider, or choose one when you are ready."}
+              {modelsLoading ? "Checking OpenWork Models..." : modelsError || !modelAccess ? "Model status is unavailable. You can still complete setup." : allowance ?? (modelsEnabled ? "OpenWork Models are on for this workspace." : "Keep your existing provider, or choose one when you are ready.")}
             </p>
             {modelsEnabled ? <DenBadge icon={Check}>Models on</DenBadge> : null}
+            {modelAccess?.kind === "free" ? <DenBadge icon={Check}>Free Luna included</DenBadge> : null}
           </div>
           <div className="divide-y divide-[var(--dls-border)] overflow-hidden rounded-2xl border border-[var(--dls-border)]">
             <div className="flex items-start gap-3 p-4 sm:p-5" data-testid="onboarding-choice-openwork-models">
@@ -68,7 +60,7 @@ export function MarketplaceOnboardingScreen() {
               </div>
               <div className="min-w-0 flex-1">
                 <h3 className="text-sm font-semibold">OpenWork Models</h3>
-                <p className="mt-1 text-[13px] leading-5 text-[var(--dls-text-secondary)]">Managed models, billed per member. No API keys to look after.</p>
+                <p className="mt-1 text-[13px] leading-5 text-[var(--dls-text-secondary)]">{allowance ? "Standard Luna with a free weekly allowance. Upgrade for other managed models." : "Managed models, billed per member. No API keys to look after."}</p>
                 <Link href={getInferenceRoute(orgSlug)} className="mt-3 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-neutral-950">
                   {modelsEnabled ? "Manage models" : "Explore models"}<ArrowUpRight className="size-3.5" aria-hidden />
                 </Link>

--- a/ee/apps/den-web/tests/onboarding-page.test.ts
+++ b/ee/apps/den-web/tests/onboarding-page.test.ts
@@ -31,10 +31,12 @@ describe("Marketplace onboarding page", () => {
   });
 
   test("checks model status without enabling models", () => {
-    expect(screen).toContain("/v1/inference");
-    expect(screen).toContain('headers: { "x-openwork-org-id": orgId }');
+    const memberAccess = read("_lib", "use-inference-access.ts");
+    expect(memberAccess).toContain("/v1/inference/access");
+    expect(memberAccess).toContain('headers: { "x-openwork-org-id": orgId }');
     expect(screen).not.toContain('method: "POST"');
-    expect(screen).toContain("Signing in does not enable models.");
+    expect(screen).toContain("Free Luna included");
+    expect(screen).toContain('modelAccess?.kind === "paid"');
     expect(screen).toContain("No model selection is required");
   });
 

--- a/ee/apps/den-web/tests/openwork-models-page.test.ts
+++ b/ee/apps/den-web/tests/openwork-models-page.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
+import { INFERENCE_ACCESS_REASONS, INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
+import { freeAllowanceDescription, parseInferenceAccessPayload } from "../app/(den)/_lib/inference-status";
 
 const screen = readFileSync(
   join(import.meta.dir, "..", "app", "(den)", "dashboard", "_components", "inference-screen.tsx"),
@@ -42,5 +43,44 @@ describe("OpenWork Models page", () => {
   test("cross-links to bring your own keys", () => {
     expect(screen).toContain("getCustomLlmProvidersRoute");
     expect(screen).toContain("Set up Bring your Own Keys.");
+  });
+
+  test("renders the configured free budget without claiming paid enablement", () => {
+    const access = parseInferenceAccessPayload({ access: {
+      kind: "free", modelID: "openai/gpt-5.6-luna", weeklyLimitUsd: 2,
+      usedUsd: 0.2, reservedUsd: 0, remainingUsd: 1.8, resetsAt: "2026-09-14T00:00:00Z", reason: null, canUpgrade: false,
+      token: "not-rendered",
+    } });
+    expect(access).not.toBeNull();
+    expect(access?.canUpgrade).toBe(false);
+    expect(access && "token" in access).toBe(false);
+    expect(freeAllowanceDescription(access)).toContain("Free standard Luna.");
+    expect(freeAllowanceDescription(access)).toContain("$1.80 of $2.00");
+    expect(freeAllowanceDescription(access)).toContain("Resets");
+    if (!access) throw new Error("Expected member access");
+    expect(freeAllowanceDescription({ ...access, kind: "paid" })).toBeNull();
+    expect(freeAllowanceDescription({ ...access, kind: "unavailable", reason: "free_disabled" })).toBeNull();
+    expect(parseInferenceAccessPayload({ access: { ...access, canUpgrade: undefined } })).toBeNull();
+    expect(screen).toContain('memberAccess?.canUpgrade !== false');
+    expect(screen).toContain('"Ask admin"');
+  });
+
+  test("keeps free access while awaiting usage and never subtracts the pending estimate", () => {
+    const busy = {
+      kind: "free", modelID: "openai/gpt-5.6-luna", weeklyLimitUsd: 1, usedUsd: 0.2,
+      reservedUsd: 0.1, remainingUsd: 0.8, resetsAt: "2026-09-14T00:00:00Z", reason: "free_request_in_progress", canUpgrade: false,
+    };
+    const access = parseInferenceAccessPayload({ access: busy });
+    expect(access?.kind).toBe("free");
+    expect(access?.reason).toBe("free_request_in_progress");
+    expect(access?.remainingUsd).toBe(0.8);
+    expect(freeAllowanceDescription(access)).toContain("Free standard Luna.");
+    expect(freeAllowanceDescription(access)).toContain("$0.80 of $1.00");
+    expect(freeAllowanceDescription(access)).toContain("awaiting final usage");
+    expect(freeAllowanceDescription(access)).toContain("Estimated pending cost: $0.10; the final charge may differ.");
+    for (const reason of INFERENCE_ACCESS_REASONS) {
+      expect(parseInferenceAccessPayload({ access: { ...busy, reason } })).not.toBeNull();
+    }
+    expect(parseInferenceAccessPayload({ access: { ...busy, reason: "insufficient_request_budget" } })).toBeNull();
   });
 });

--- a/ee/apps/inference/.env.example
+++ b/ee/apps/inference/.env.example
@@ -11,6 +11,14 @@ OPENROUTER_UPSTREAM_URL=https://openrouter.ai/api/v1
 INFERENCE_ADMIN_TOKEN=local-dev-admin-token
 INFERENCE_WEBHOOK_SECRET=local-dev-webhook-secret
 INFERENCE_CREDITS_PER_DOLLAR=1000000
+# Mirror these three non-secret settings in Den. Fixed Monday-UTC weeks;
+# an existing person's weekly bucket keeps its original limit until next week.
+# Usage-metered allowance: the last admitted reply may exceed the weekly amount.
+INFERENCE_FREE_ENABLED=false
+INFERENCE_FREE_WEEKLY_BUDGET_USD=1
+INFERENCE_FREE_MODEL_ID=openai/gpt-5.6-luna
+# Inference only. Never provision organization upstream keys for free users.
+INFERENCE_FREE_UPSTREAM_API_KEY=
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.01
 SENTRY_LOG_LEVEL=warn

--- a/ee/apps/inference/FREE_ALLOWANCE.md
+++ b/ee/apps/inference/FREE_ALLOWANCE.md
@@ -1,0 +1,181 @@
+# Free Standard Luna
+
+Approved policy: **"Usage-metered allowance (Recommended)"**. Check server weekly
+actual usage before a request, cap request size/output and concurrency, and settle
+actual cost. The final in-flight reply can exceed USD 1. This is not a mathematically
+strict USD 1 spending cap; no formal maximum overage is promised.
+
+Free access is an entitlement, not a model discount. The managed alias/upstream
+is `openai/gpt-5.6-luna`, with the original catalog prices and usage factor 1.
+Paid organization limits, paid provider credentials and BYOK are unchanged.
+
+## Server Configuration
+
+Mirror these non-secret settings in Den and inference:
+
+```text
+INFERENCE_FREE_ENABLED=false
+INFERENCE_FREE_WEEKLY_BUDGET_USD=1
+INFERENCE_FREE_MODEL_ID=openai/gpt-5.6-luna
+```
+
+Enable the flag when configuring the offer. The default remains off for an
+unconfigured installation; there is no permanent pricing-unavailable gate.
+The enabled flag accepts `true`/`false` or `1`/`0`. The budget is finite,
+nonnegative, and safely representable in integer inference units. Zero disables
+admission through exhaustion. Only the reviewed standard Luna alias is accepted.
+
+Set `INFERENCE_FREE_UPSTREAM_API_KEY` only in inference's server environment.
+No organization upstream key or paid subscription is provisioned for free users.
+Free requests use that credential only at
+`https://openrouter.ai/api/v1/chat/completions`; redirects and provider fallbacks
+are disabled. Missing credentials never fall through to a paid organization key.
+
+Configure OpenRouter usage export to `/webhooks/openrouter`, authenticated by
+`INFERENCE_WEBHOOK_SECRET`, as the fallback when response usage is missing or
+cannot be settled. Neither secret belongs in status responses or client config.
+Apply the additive `0093_free_inference_allowance` migration before enablement.
+
+## Den Contract
+
+Shared exports are in `@openwork/types/den/inference`:
+
+- `readFreeInferenceConfig(process.env)` returns validated non-secret settings.
+- `inferenceAccessMode(metadata)` gives paid tiers precedence. Den explicitly
+  writes `metadata.inferenceFree = { offerAllowed: true }` for eligibility and
+  preserves `{ offerAllowed: false }` on administrative disable. An absent paid
+  subscription does not itself authorize the free server key.
+- `freeInferenceWindow(now)` selects Monday 00:00 UTC through the next Monday,
+  exclusive, without rollover. SQL's clock selects the admission window.
+- `freeInferenceAccess({ config, mode, bucket, now })` returns `InferenceAccess`.
+  Den reads `InferenceFreeUsageBucketTable` for the authenticated `user_id` and
+  current `window_start_at`, retaining its ordinary active-membership checks.
+  Den adds role-based `canUpgrade`; it does not import inference app source.
+
+`usedUsd` is settled actual cost. `reservedUsd` is an **estimated pending cost**,
+not money already spent, a cost ceiling, or extra available budget.
+`remainingUsd = max(0, weeklyLimitUsd - usedUsd)` deliberately does not subtract
+that estimate. `usedUsd >= weeklyLimitUsd` is `exhausted`, not an accounting error.
+A current-week hold returns `kind: free, reason: free_request_in_progress`, so a
+busy request does not remove the provider or revoke the person's entitlement.
+
+The current-week status projection cannot discover an old-week pending request.
+The proxy's SQL admission checks all weeks and returns `free_request_in_progress`
+for that case. Status is a read-only projection, not admission authorization.
+The new week can show its untouched balance while an earlier receipt is awaited.
+
+Issue ordinary active member keys and the existing `openwork` provider without
+setting a paid tier. The proxy rechecks active key, membership organization,
+removal status, user identity and offer eligibility inside admission. Maintain
+all canonical Den authentication and membership checks.
+
+## Admission And Settlement
+
+`free-allowance.ts` uses the existing `user` row as a transaction-scoped person
+lock. Different keys, memberships, organizations, devices and weeks share that
+lock. Admission checks for any `held` or `invalid` reservation across that person's
+history; at most one unsettled request is permitted, even at a weekly boundary.
+
+For an eligible person with no pending request, admission conditionally updates
+the current bucket only when `used_amount < limit_amount`, `reserved_amount = 0`
+and the bucket is not blocked. It inserts the matching immutable request record
+in the same transaction, before sending upstream. A positive estimate is stored
+as `min(estimatedCost, limit - used)`, with at least one integer unit. Even one
+unit of actual balance admits the normal capped reply; there is no minimum prompt
+cost floor and no output reduction based on that tiny remaining balance.
+
+All amounts use `INFERENCE_USAGE_CONVERSION_FACTOR = 100000000`. Each reservation
+pins person, original week, organization, membership, key, model, output cap and
+estimated prices. The existing `input_token_cap` database column stores the input
+token **estimate** under this policy; it is not a provider-enforced input cap.
+Weekly limits are snapshotted on first admission; budget changes apply to newly
+created windows, not already-open ones.
+
+`free-response.ts` observes only the authenticated OpenRouter response on the free
+path. A non-streaming completion needs a matching model, generation ID, terminal
+choice and finite nonnegative `usage.cost`. For SSE, it also requires a complete
+final usage event and `[DONE]`. It parses fragmented UTF-8/SSE incrementally with
+bounded buffering, forwards original bytes, and settles before forwarding the
+completed DONE event so the next engine tool turn can acquire the person slot.
+
+Response usage and authenticated webhook usage share `settleFreeInference`.
+Settlement locks the same person, request and original bucket, then atomically
+clears the estimated hold and adds actual provider cost. Actual cost may exceed
+both the estimate and the weekly limit. The next request then receives exhausted
+status. Request/generation deduplication prevents response/webhook races from
+charging twice. Invalid identities, model mismatches, missing/negative/non-finite
+costs and conflicting receipts never release a held request or mint a refund.
+Counter corruption or unsafe integer totals block accounting for investigation.
+
+Cancellation, upstream errors, malformed/truncated responses, missing costs and
+failed settlement retain the hold. There is no timeout or weekly-reset refund.
+A valid late receipt can settle after key revocation or a paid upgrade and charges
+only the original window. It does not consume the new week's money. Until that
+receipt arrives, new free admissions remain blocked across all keys/orgs/weeks.
+Paid usage never enters these free tables, and free usage never enters paid buckets.
+
+## Request Limits And Estimates
+
+- Actual wire body: at most **131072 bytes**, enforced before parsing JSON without
+  trusting Content-Length.
+- Supplied messages, tool schemas and structured-output schema: at most **32768
+  UTF-8 bytes** of compact JSON. Oversized input is rejected, never silently trimmed.
+- Total output: at most **4096 tokens**, including reasoning, or the caller's
+  smaller requested maximum. One completion; standard model only.
+- Ordinary text, function tools, parameterless functions, null/empty tool lists,
+  structured output and typed reasoning history are supported. Non-text inputs,
+  plugins, server tools, arbitrary model/routing selectors, pro mode and unsupported
+  per-call features are rejected before admission.
+
+The display estimate uses supplied input bytes plus 1024 framing tokens, 64 per
+message and 256 per tool. It uses the highest checked-in input/cache-write and
+output rates across context tiers: currently USD 0.50 and USD 1.80 per million.
+For a simple `Hello` request this is approximately 0.8 cents including the full
+4096-token output allowance. This is an estimate, not a guarantee or actual charge.
+Input framing, schema expansion and restored reasoning may differ. The final
+admitted reply can cross the weekly limit; its measured cost is retained in full.
+Request and output caps constrain ordinary requests, but do not establish a formal
+USD overage bound. Token-rate routing ceilings and zero per-request routing price
+remain defensive preferences, not a strict total-spend guarantee.
+
+The input contract was checked against OpenCode `v1.18.18` and its pinned
+`@openrouter/ai-sdk-provider@2.9.0`, including a fresh serializer request sent only
+to a deterministic fetch fixture. `reasoningEffort`, `textVerbosity`, canonical
+`reasoning.effort`, `usage.include`, array-form system content and function/tool
+history survive. The estimate is not used to alter those messages or reasoning.
+
+## Errors And Checks
+
+| HTTP | Code | Meaning |
+| --- | --- | --- |
+| 402 | `managed_model_requires_upgrade` | A different known managed model was selected. |
+| 402 | `free_allowance_exhausted` | Actual weekly usage reached/exceeded the allowance. |
+| 423 | `free_request_in_progress` | Another free request is running or awaiting usage; wait and retry manually. `retryable: false`, no Retry-After, no upsell. |
+| 400 | `unsupported_free_inference_input` | Invalid/unsupported input, not an upgrade request. |
+| 413 | `free_inference_input_too_large` / `free_inference_request_too_large` | Explicitly shorten input; nothing was trimmed/sent. |
+| 503 | `free_inference_unavailable` | Missing configuration or unavailable accounting, not a tokenizer gate. |
+
+Fast checks using existing dependencies, without triggering an install:
+
+```sh
+node --conditions=development --import ./ee/apps/inference/node_modules/tsx/dist/loader.mjs --test ee/apps/inference/test/*.test.ts
+node ee/apps/inference/node_modules/typescript/bin/tsc -p ee/apps/inference/tsconfig.json --noEmit
+```
+
+The main integration journey should use the real inference service, isolated
+MySQL and a deterministic upstream fixture. Seed a real `AuthUserTable` row plus
+two active memberships/keys for that same person and another person's identity.
+Assert one winner under concurrent admissions, same-person cross-org exclusion,
+independent second-person access, a final over-budget reply, exhausted retries
+without upstream calls, missing-cost holds across rollover, late original-week
+charging, and response/webhook duplicate settlement. The existing schema suffices;
+no additional migration or live provider call is required. Colocated tests are
+fast checks, not a substitute for that real database journey.
+
+For the fixture, register the real `registerProxyRoutes` and
+`registerWebhookRoutes` handlers on the test HTTP server, supply the real key,
+admission and settlement functions backed by the isolated database, and inject
+only the upstream `fetch`. The free credential destination remains pinned in
+production; do not relax that allowlist to run the journey. Return a matching
+`id`/`model`, terminal choice and `usage.cost`; streaming fixtures also send the
+final `[DONE]`. Omit cost deliberately for the awaiting-usage/rollover case.

--- a/ee/apps/inference/src/env.ts
+++ b/ee/apps/inference/src/env.ts
@@ -1,6 +1,7 @@
 import "./load-env.js";
 import type { DenDbMode, PlanetScaleCredentials } from "@openwork-ee/den-db";
 import { z } from "zod";
+import { INFERENCE_FREE_ENV, readFreeInferenceConfig } from "@openwork/types/den/inference";
 
 const EnvSchema = z
   .object({
@@ -111,6 +112,8 @@ const planetscale: PlanetScaleCredentials | null =
     : null;
 
 export const env = {
+  freeInference: readFreeInferenceConfig(process.env),
+  freeUpstreamApiKey: optionalString(process.env[INFERENCE_FREE_ENV.upstreamApiKey]),
   port: parsePort(parsed.PORT),
   corsOrigins: splitCsv(parsed.CORS_ORIGINS),
   databaseUrl: parsed.DATABASE_URL,

--- a/ee/apps/inference/src/free-allowance.ts
+++ b/ee/apps/inference/src/free-allowance.ts
@@ -1,0 +1,162 @@
+import { and, eq, isNull, sql } from "@openwork-ee/den-db/drizzle"
+import { AuthUserTable, InferenceFreeReservationTable as Reservation, InferenceFreeUsageBucketTable as Bucket, InferenceKeyTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db"
+import { freeInferenceAccess, freeInferenceWindow, inferenceAccessMode, INFERENCE_USAGE_CONVERSION_FACTOR } from "@openwork/types/den/inference"
+import type { FreeInferenceConfig, InferenceAccess } from "@openwork/types/den/inference"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { db } from "./db.js"
+import { freeRequestReservation } from "./free-request.js"
+import type { FreeRequestPricing } from "./free-request.js"
+
+function changedOne(result: unknown): boolean {
+  if (Array.isArray(result)) return changedOne(result[0])
+  if (typeof result !== "object" || result === null) return false
+  if ("rowsAffected" in result) return result.rowsAffected === 1
+  if ("affectedRows" in result) return result.affectedRows === 1
+  return false
+}
+
+export type FreeReservationResult = { ok: true; maxOutputTokens: number; access: InferenceAccess } | { ok: false; access: InferenceAccess }
+
+export async function reserveFreeInference(input: {
+  keyId: string
+  requestId: string
+  config: FreeInferenceConfig
+  pricing: FreeRequestPricing
+}, database = db): Promise<FreeReservationResult> {
+  if (!input.requestId.startsWith("free_")) throw new Error("Free reservation requires a free request ID")
+  return database.transaction(async (tx) => {
+    // Recheck canonical key/membership inside the reservation transaction. A
+    // client user ID, org switch or newly issued key cannot choose the bucket.
+    const [identity] = await tx.select({
+      key: InferenceKeyTable,
+      userId: MemberTable.userId,
+      metadata: OrganizationTable.metadata,
+      nowMs: sql<number>`unix_timestamp(current_timestamp(3)) * 1000`,
+    }).from(InferenceKeyTable)
+      .innerJoin(MemberTable, eq(InferenceKeyTable.org_membership_id, MemberTable.id))
+      .innerJoin(OrganizationTable, eq(InferenceKeyTable.organization_id, OrganizationTable.id))
+      .where(and(
+        eq(InferenceKeyTable.id, normalizeDenTypeId("inferenceKey", input.keyId)),
+        eq(InferenceKeyTable.status, "active"),
+        eq(MemberTable.organizationId, InferenceKeyTable.organization_id),
+        isNull(MemberTable.removedAt),
+      )).limit(1).for("update")
+    const mode = identity ? inferenceAccessMode(identity.metadata) : "not_eligible"
+    if (!identity?.userId || mode !== "free" || !input.config.enabled) {
+      return { ok: false, access: freeInferenceAccess({ config: input.config, mode: mode === "paid" ? "not_eligible" : mode }) }
+    }
+    // A stable PERSON lock serializes different memberships, keys and weeks.
+    // Bucket uniqueness alone cannot prevent two outstanding requests at rollover.
+    const [person] = await tx.select({ id: AuthUserTable.id }).from(AuthUserTable)
+      .where(eq(AuthUserTable.id, identity.userId)).limit(1).for("update")
+    if (!person) return { ok: false, access: freeInferenceAccess({ config: input.config, mode: "not_eligible" }) }
+    const now = new Date(Number(identity.nowMs))
+    const window = freeInferenceWindow(now)
+    const where = and(eq(Bucket.user_id, identity.userId), eq(Bucket.window_start_at, window.start))
+    // The unique person/week key serializes concurrent first use as well as
+    // existing buckets. Never refresh a limit or reset counters on duplicate.
+    await tx.insert(Bucket).values({ user_id: identity.userId, window_start_at: window.start, window_end_at: window.end, limit_amount: input.config.weeklyLimitAmount })
+      .onDuplicateKeyUpdate({ set: { user_id: sql`${Bucket.user_id}` } })
+    const [bucket] = await tx.select().from(Bucket).where(where).limit(1).for("update")
+    if (!bucket) throw new Error("Free allowance bucket unavailable")
+    const access = freeInferenceAccess({ config: input.config, mode, bucket, now })
+    if (access.kind !== "free") return { ok: false, access }
+    // The person lock serializes this first nonlocking read. Do not gap-lock
+    // a missing reservation range shared with another person's first insert.
+    const [pending] = await tx.select({ status: Reservation.status }).from(Reservation)
+      .where(and(eq(Reservation.user_id, identity.userId), sql`${Reservation.status} <> 'settled'`)).limit(1)
+    if (pending?.status === "invalid") return { ok: false, access: { ...access, kind: "unavailable", reason: "accounting_unavailable" } }
+    if (pending || bucket.reserved_amount > 0) return { ok: false, access: { ...access, reason: "free_request_in_progress" } }
+    const reservation = freeRequestReservation(input.pricing, bucket.limit_amount - bucket.used_amount)
+    if (!reservation) throw new Error("Invalid free request estimate")
+    const updated = await tx.update(Bucket).set({ reserved_amount: reservation.amount }).where(and(
+      where, eq(Bucket.blocked, false),
+      eq(Bucket.reserved_amount, 0), sql`${Bucket.used_amount} < ${Bucket.limit_amount}`,
+    ))
+    if (!changedOne(updated)) throw new Error("Free allowance reservation failed closed")
+    // Duplicate request IDs roll back the bucket increment. An uncertain commit
+    // must not be retried as another upstream request with this reservation.
+    await tx.insert(Reservation).values({
+      request_id: input.requestId,
+      user_id: identity.userId,
+      window_start_at: window.start,
+      organization_id: identity.key.organization_id,
+      org_membership_id: identity.key.org_membership_id,
+      inference_key_id: identity.key.id,
+      model_id: input.config.modelID,
+      upstream_model: input.config.modelID,
+      reserved_amount: reservation.amount,
+      // Kept in the existing column: this is now an estimate, not an input cap.
+      input_token_cap: input.pricing.inputTokenEstimate,
+      max_output_tokens: reservation.maxOutputTokens,
+      input_token_price: input.pricing.inputTokenPrice,
+      output_token_price: input.pricing.outputTokenPrice,
+    })
+    return { ok: true, maxOutputTokens: reservation.maxOutputTokens, access: freeInferenceAccess({ config: input.config, mode, bucket: { ...bucket, reserved_amount: bucket.reserved_amount + reservation.amount }, now }) }
+  }, { isolationLevel: "read committed" })
+}
+
+export type FreeSettlement = {
+  requestId: string
+  inferenceKeyId: string
+  orgMembershipId: string
+  requestModel: string | null
+  responseModel: string | null
+  currency: string | null
+  eventId: string | null
+} & ({ costUsd: number } | { inputCost: number; outputCost: number })
+
+export function freeSettlementAmount(input: FreeSettlement, reservation: Pick<typeof Reservation.$inferSelect, "inference_key_id" | "org_membership_id" | "upstream_model">) {
+  const components = "costUsd" in input ? [input.costUsd] : [input.inputCost, input.outputCost]
+  const cost = Math.ceil(components.reduce((sum, value) => sum + value, 0) * INFERENCE_USAGE_CONVERSION_FACTOR)
+  if (input.inferenceKeyId !== reservation.inference_key_id || input.orgMembershipId !== reservation.org_membership_id
+    || input.requestModel !== reservation.upstream_model || input.responseModel !== reservation.upstream_model
+    || input.currency !== "USD" || !input.eventId
+    || !components.every((value) => Number.isFinite(value) && value >= 0)
+    || !Number.isSafeInteger(cost) || cost < 0) return null
+  return cost
+}
+
+export async function settleFreeInference(input: FreeSettlement, database = db): Promise<boolean> {
+  const [owner] = await database.select({ userId: Reservation.user_id }).from(Reservation)
+    .where(eq(Reservation.request_id, input.requestId)).limit(1)
+  if (!owner) return false
+  return database.transaction(async (tx) => {
+    // Same lock order as admission, before request and bucket locks. A deleted
+    // user cannot admit new work, but their immutable usage can still settle.
+    await tx.select({ id: AuthUserTable.id }).from(AuthUserTable)
+      .where(eq(AuthUserTable.id, owner.userId)).limit(1).for("update")
+    const [reservation] = await tx.select().from(Reservation).where(eq(Reservation.request_id, input.requestId)).limit(1).for("update")
+    if (!reservation) return false
+    const where = and(eq(Bucket.user_id, reservation.user_id), eq(Bucket.window_start_at, reservation.window_start_at))
+    const [bucket] = await tx.select().from(Bucket).where(where).limit(1).for("update")
+    if (!bucket) throw new Error("Free settlement bucket unavailable")
+    const amount = freeSettlementAmount(input, reservation)
+    if (reservation.status === "invalid") return false
+    if (amount === null) {
+      console.error("[free-inference] rejected usage receipt; hold retained", { requestId: input.requestId })
+      return false
+    }
+    if (reservation.status === "settled") {
+      if (input.eventId !== reservation.external_event_id || amount !== reservation.actual_amount) {
+        console.error("[free-inference] conflicting duplicate usage receipt", { requestId: input.requestId })
+      }
+      return false
+    }
+    if (reservation.status !== "held" || bucket.reserved_amount !== reservation.reserved_amount
+      || !Number.isSafeInteger(bucket.used_amount) || bucket.used_amount < 0 || !Number.isSafeInteger(bucket.used_amount + amount)) {
+      await tx.update(Bucket).set({ blocked: true }).where(where)
+      await tx.update(Reservation).set({ status: "invalid" }).where(eq(Reservation.request_id, input.requestId))
+      console.error("[free-inference] accounting invariant violation", { requestId: input.requestId })
+      return false
+    }
+    const updated = await tx.update(Bucket).set({
+      reserved_amount: 0,
+      used_amount: sql`${Bucket.used_amount} + ${amount}`,
+    }).where(and(where, eq(Bucket.reserved_amount, reservation.reserved_amount)))
+    if (!changedOne(updated)) throw new Error("Free settlement failed closed")
+    await tx.update(Reservation).set({ status: "settled", actual_amount: amount, external_event_id: input.eventId, settled_at: new Date() })
+      .where(eq(Reservation.request_id, input.requestId))
+    return true
+  })
+}

--- a/ee/apps/inference/src/free-request.ts
+++ b/ee/apps/inference/src/free-request.ts
@@ -1,0 +1,162 @@
+import { INFERENCE_FREE_MODEL_ID, INFERENCE_USAGE_CONVERSION_FACTOR } from "@openwork/types/den/inference"
+import { z } from "zod"
+import models from "./models/openwork-models.json" with { type: "json" }
+
+export const FREE_REQUEST_MAX_BYTES = 128 * 1024
+export const FREE_INPUT_CONTENT_MAX_BYTES = 32 * 1024
+export const FREE_MAX_OUTPUT_TOKENS = 4096
+const effort = z.enum(["none", "low", "medium", "high", "xhigh", "max"])
+const functionName = z.string().regex(/^[a-zA-Z0-9_-]{1,64}$/)
+const functionCall = z.strictObject({ name: functionName, arguments: z.string() })
+const reasoningDetailFields = { id: z.string().nullish(), format: z.string().optional(), index: z.number().int().nonnegative().optional() }
+const reasoningDetail = z.union([
+  z.strictObject({ ...reasoningDetailFields, type: z.literal("reasoning.text"), text: z.string(), signature: z.string().nullish() }),
+  z.strictObject({ ...reasoningDetailFields, type: z.literal("reasoning.summary"), summary: z.string() }),
+  z.strictObject({ ...reasoningDetailFields, type: z.literal("reasoning.encrypted"), data: z.string() }),
+])
+const requestSchema = z.strictObject({
+  model: z.string(),
+  messages: z.array(z.strictObject({
+    role: z.enum(["system", "developer", "user", "assistant", "tool"]),
+    content: z.union([z.string(), z.array(z.strictObject({ type: z.literal("text"), text: z.string() }))]).nullable().optional(),
+    name: z.string().optional(),
+    tool_call_id: z.string().optional(),
+    tool_calls: z.array(z.strictObject({ id: z.string().min(1), type: z.literal("function"), function: functionCall })).nullish(),
+    reasoning: z.string().nullish(),
+    reasoning_content: z.string().nullish(),
+    // Preserve ordinary engine reasoning history. Its supplied bytes contribute
+    // to the size limit; restored input is charged from actual provider usage.
+    reasoning_details: z.array(reasoningDetail).nullish(),
+    annotations: z.array(z.never()).nullish(),
+  })).min(1),
+  tools: z.array(z.strictObject({
+    type: z.literal("function"),
+    function: z.strictObject({ name: functionName, description: z.string().nullish(), parameters: z.record(z.string(), z.unknown()).nullish(), strict: z.boolean().nullish() }),
+  })).nullish(),
+  tool_choice: z.union([z.enum(["auto", "none", "required"]), z.strictObject({ type: z.literal("function"), function: z.strictObject({ name: functionName }) })]).nullish(),
+  parallel_tool_calls: z.boolean().nullish(),
+  n: z.literal(1).nullish(),
+  max_tokens: z.number().int().positive().max(128_000).nullish(),
+  max_completion_tokens: z.number().int().positive().max(128_000).nullish(),
+  stream: z.boolean().optional(),
+  stream_options: z.strictObject({ include_usage: z.boolean().optional() }).nullish(),
+  usage: z.strictObject({ include: z.boolean() }).nullish(),
+  reasoning: z.strictObject({ effort: effort.nullish(), enabled: z.boolean().optional(), exclude: z.boolean().optional(), summary: z.enum(["auto", "concise", "detailed"]).optional() }).nullish(),
+  reasoning_effort: effort.nullish(),
+  // OpenCode 1.18.18 passes these adapter options through OpenRouter SDK 2.9.0
+  // verbatim, alongside usage.include and an optional canonical reasoning.effort.
+  reasoningEffort: effort.optional(),
+  textVerbosity: z.enum(["low", "medium", "high"]).optional(),
+  verbosity: z.enum(["low", "medium", "high"]).nullish(),
+  temperature: z.number().finite().nullish(),
+  top_p: z.number().finite().nullish(),
+  top_k: z.number().int().nonnegative().nullish(),
+  frequency_penalty: z.number().finite().nullish(),
+  presence_penalty: z.number().finite().nullish(),
+  seed: z.number().int().nullish(),
+  stop: z.union([z.string(), z.array(z.string()).max(4)]).nullish(),
+  transforms: z.array(z.never()).optional(),
+  provider: z.strictObject({ allow_fallbacks: z.literal(false).optional(), require_parameters: z.literal(true).optional() }).optional(),
+  response_format: z.union([
+    z.strictObject({ type: z.enum(["text", "json_object"]) }),
+    z.strictObject({ type: z.literal("json_schema"), json_schema: z.strictObject({ name: z.string(), description: z.string().optional(), schema: z.record(z.string(), z.unknown()), strict: z.boolean().optional() }) }),
+  ]).nullish(),
+})
+
+export type FreeRequestError = { ok: false; status: 400 | 413 | 503; code: string; message: string }
+export type FreeRequestInspection = { ok: true; inputContentBytes: number; request: z.infer<typeof requestSchema> } | FreeRequestError
+
+export function inspectFreeRequest(value: unknown): FreeRequestInspection {
+  const parsed = requestSchema.safeParse(value)
+  if (!parsed.success) return { ok: false, status: 400, code: "unsupported_free_inference_input", message: "Free Luna accepts text and ordinary function tools. This input contains an invalid or unsupported parameter, attachment, server feature, or stored reasoning block. Nothing was trimmed or sent; this is not an allowance or upgrade error." }
+  const request = parsed.data
+  if (![INFERENCE_FREE_MODEL_ID, `openwork/${INFERENCE_FREE_MODEL_ID}`].includes(request.model)) {
+    return { ok: false, status: 400, code: "unsupported_free_inference_input", message: "The free request must select standard Luna." }
+  }
+  // A byte-level BPE starts with UTF-8 bytes and only merges them. This bounds
+  // tokens in THIS serialized supplied input, including names, JSON schemas,
+  // system messages and tool history. It DOES NOT bound provider-added framing,
+  // schema expansion or restored reasoning. See FREE_ALLOWANCE.md for sources.
+  const inputContentBytes = Buffer.byteLength(JSON.stringify({ messages: request.messages, tools: request.tools, response_format: request.response_format }), "utf8")
+  if (inputContentBytes > FREE_INPUT_CONTENT_MAX_BYTES) {
+    return { ok: false, status: 413, code: "free_inference_input_too_large", message: `Free Luna input is limited to ${FREE_INPUT_CONTENT_MAX_BYTES} UTF-8 bytes including messages, tool schemas and structured-output schemas. Shorten the input explicitly; nothing was trimmed or sent.` }
+  }
+  return { ok: true, inputContentBytes, request }
+}
+
+export async function readFreeRequest(request: Request): Promise<{ ok: true; value: unknown } | FreeRequestError> {
+  const reader = request.body?.getReader()
+  if (!reader) return { ok: false, status: 400, code: "invalid_json", message: "A JSON request body is required." }
+  const decoder = new TextDecoder("utf-8", { fatal: true })
+  let bytes = 0
+  let text = ""
+  try {
+    for (;;) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+      bytes += chunk.value.byteLength
+      if (bytes > FREE_REQUEST_MAX_BYTES) {
+        void reader.cancel().catch(() => {})
+        return { ok: false, status: 413, code: "free_inference_request_too_large", message: `Free inference requests are limited to ${FREE_REQUEST_MAX_BYTES} bytes. Nothing was trimmed or sent.` }
+      }
+      text += decoder.decode(chunk.value, { stream: true })
+    }
+    text += decoder.decode()
+    return { ok: true, value: JSON.parse(text) }
+  } catch {
+    void reader.cancel().catch(() => {})
+    return { ok: false, status: 400, code: "invalid_json", message: "The request must contain valid UTF-8 JSON." }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+export type FreeRequestPricing = {
+  inputTokenEstimate: number
+  inputTokenPrice: number
+  outputTokenPrice: number
+  maxOutputTokens: number
+  provider: {
+    allow_fallbacks: false
+    require_parameters: true
+    max_price: { prompt: number; completion: number; request: 0 }
+  }
+}
+
+export type FreeRequestPreparation = { ok: true; pricing: FreeRequestPricing } | FreeRequestError
+
+export function prepareFreeRequest(value: unknown): FreeRequestPreparation {
+  const inspection = inspectFreeRequest(value)
+  if (!inspection.ok) return inspection
+  const { request, inputContentBytes } = inspection
+  const model = models[INFERENCE_FREE_MODEL_ID]
+  const costs = [model.cost, ...model.cost.tiers, model.cost.context_over_200k]
+  const inputPrice = Math.max(...costs.flatMap((cost) => [cost.input, cost.cache_read, cost.cache_write]))
+  const outputPrice = Math.max(...costs.map((cost) => cost.output))
+  if (![inputPrice, outputPrice].every((price) => Number.isFinite(price) && price > 0)) {
+    return { ok: false, status: 503, code: "free_inference_unavailable", message: "Free Luna pricing is temporarily unavailable. No request was sent." }
+  }
+  // Deliberately conservative DISPLAY estimate, not a tokenizer or cost bound.
+  // Admission uses actual weekly usage, not this amount. Provider framing and
+  // restored reasoning can differ; the final admitted reply may exceed budget.
+  const inputTokenEstimate = inputContentBytes + 1024 + request.messages.length * 64 + (request.tools?.length ?? 0) * 256
+  return { ok: true, pricing: {
+    inputTokenEstimate,
+    inputTokenPrice: Math.ceil(inputPrice * INFERENCE_USAGE_CONVERSION_FACTOR / 1_000_000),
+    outputTokenPrice: Math.ceil(outputPrice * INFERENCE_USAGE_CONVERSION_FACTOR / 1_000_000),
+    maxOutputTokens: Math.min(request.max_tokens ?? model.limit.output, request.max_completion_tokens ?? model.limit.output, FREE_MAX_OUTPUT_TOKENS),
+    provider: { allow_fallbacks: false, require_parameters: true, max_price: { prompt: inputPrice, completion: outputPrice, request: 0 } },
+  } }
+}
+
+export function freeRequestReservation(pricing: FreeRequestPricing, remaining: number) {
+  if (![pricing.inputTokenEstimate, pricing.inputTokenPrice, pricing.outputTokenPrice, pricing.maxOutputTokens].every((value) => Number.isSafeInteger(value) && value > 0)
+    || !Number.isSafeInteger(remaining) || remaining < 0) return null
+  const maxOutputTokens = Math.min(pricing.maxOutputTokens, FREE_MAX_OUTPUT_TOKENS)
+  const estimate = pricing.inputTokenEstimate * pricing.inputTokenPrice + maxOutputTokens * pricing.outputTokenPrice
+  if (!Number.isSafeInteger(estimate) || estimate <= 0 || remaining === 0) return null
+  // A positive marker occupies the one-request slot even with one unit left.
+  // The estimate cannot prevent admission or shorten the last admitted reply.
+  const amount = Math.min(estimate, remaining)
+  return { amount, maxOutputTokens }
+}

--- a/ee/apps/inference/src/free-response.ts
+++ b/ee/apps/inference/src/free-response.ts
@@ -1,0 +1,120 @@
+import type { FreeSettlement } from "./free-allowance.js"
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+// Observe only the free path's authenticated upstream response. Forward its
+// original bytes; never derive cost from token counts, text or an estimate.
+export function meterFreeResponse(body: ReadableStream<Uint8Array> | null, input: {
+  streaming: boolean
+  identity: Pick<FreeSettlement, "requestId" | "inferenceKeyId" | "orgMembershipId" | "requestModel">
+  settle: (receipt: FreeSettlement) => Promise<boolean>
+}) {
+  if (!body) return body
+  const reader = body.getReader()
+  const decoder = new TextDecoder("utf-8", { fatal: true })
+  const maxBufferedCharacters = 1_048_576
+  let pending = ""
+  let dataLines = ""
+  let valid = true
+  let terminal = false
+  let done = false
+  let attempted = false
+  let generationId: string | null = null
+  let model: string | null = null
+  let cost: number | null = null
+
+  function accept(text: string) {
+    if (done) { valid = false; return }
+    if (text.trim() === "[DONE]") { done = true; return }
+    const payload: unknown = JSON.parse(text)
+    if (!record(payload) || payload.error) { valid = false; return }
+    if (payload.id !== undefined) {
+      if (typeof payload.id !== "string" || !payload.id || payload.id.length > 255 || generationId !== null && generationId !== payload.id) { valid = false; return }
+      generationId = payload.id
+    }
+    if (payload.model !== undefined) {
+      if (typeof payload.model !== "string" || payload.model !== input.identity.requestModel || model !== null && model !== payload.model) { valid = false; return }
+      model = payload.model
+    }
+    if (payload.choices !== undefined) {
+      if (!Array.isArray(payload.choices) || payload.choices.length > 1) { valid = false; return }
+      for (const choice of payload.choices) {
+        if (!record(choice) || choice.index !== 0) { valid = false; return }
+        if (choice.finish_reason != null) {
+          if (!["stop", "length", "tool_calls", "function_call", "content_filter"].includes(String(choice.finish_reason))) { valid = false; return }
+          terminal = true
+        }
+      }
+    }
+    if (record(payload.usage) && payload.usage.cost !== undefined) {
+      const value = payload.usage.cost
+      if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || cost !== null && cost !== value) { valid = false; return }
+      cost = value
+    }
+  }
+
+  function observe(bytes: Uint8Array) {
+    if (!valid || attempted) return
+    try {
+      pending += decoder.decode(bytes, { stream: true })
+      if (pending.length + dataLines.length > maxBufferedCharacters) throw new Error("Accounting frame too large")
+      if (!input.streaming) return
+      let newline: number
+      while ((newline = pending.indexOf("\n")) >= 0) {
+        const line = pending.slice(0, newline).replace(/\r$/, "")
+        pending = pending.slice(newline + 1)
+        if (!line) {
+          if (dataLines) accept(dataLines)
+          dataLines = ""
+        } else if (line.startsWith("data:")) {
+          const data = line.slice(5).replace(/^ /, "")
+          dataLines += `${dataLines ? "\n" : ""}${data}`
+        } else if (line.startsWith("event:") && line.slice(6).trim() === "error") {
+          valid = false
+        }
+      }
+    } catch {
+      valid = false
+      pending = ""
+      dataLines = ""
+    }
+  }
+
+  async function settle() {
+    if (attempted || !valid || !terminal || !generationId || !model || cost === null || input.streaming && !done) return
+    attempted = true
+    try {
+      await input.settle({ ...input.identity, responseModel: model, currency: "USD", eventId: generationId, costUsd: cost })
+    } catch {
+      // Failed/missing settlement leaves the SQL hold for the authenticated
+      // webhook. Do not truncate a valid reply or free the slot speculatively.
+      console.error("[free-inference] response settlement deferred", { requestId: input.identity.requestId })
+    }
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read()
+        if (chunk.done) {
+          if (!input.streaming && valid) {
+            try { pending += decoder.decode(); accept(pending) } catch { valid = false }
+            await settle()
+          }
+          controller.close()
+          return
+        }
+        observe(chunk.value)
+        // A complete final usage + DONE receipt settles before DONE reaches the
+        // engine, so its next function-tool turn can acquire the person slot.
+        if (input.streaming && done) await settle()
+        controller.enqueue(chunk.value)
+      } catch (error) {
+        controller.error(error)
+      }
+    },
+    async cancel(reason) { await reader.cancel(reason) },
+  })
+}

--- a/ee/apps/inference/src/keys.ts
+++ b/ee/apps/inference/src/keys.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto"
 import { and, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
-import { InferenceKeyTable, InferenceOrgUpstreamProviderKeyTable, MemberTable } from "@openwork-ee/den-db"
+import { InferenceKeyTable, InferenceOrgUpstreamProviderKeyTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db"
+import { inferenceAccessMode } from "@openwork/types/den/inference"
 import {
   inferenceBearerKeyLookupDigests,
   type InferenceBearerKey,
@@ -17,9 +18,10 @@ export function constantTimeEquals(a: string, b: string) {
 export async function findActiveInferenceKey(key: InferenceBearerKey) {
   const keyHashes = await inferenceBearerKeyLookupDigests(key)
   const [row] = await db
-    .select({ inferenceKey: InferenceKeyTable })
+    .select({ inferenceKey: InferenceKeyTable, userId: MemberTable.userId, metadata: OrganizationTable.metadata })
     .from(InferenceKeyTable)
     .innerJoin(MemberTable, eq(InferenceKeyTable.org_membership_id, MemberTable.id))
+    .innerJoin(OrganizationTable, eq(InferenceKeyTable.organization_id, OrganizationTable.id))
     .where(and(
       inArray(InferenceKeyTable.key_hash, keyHashes),
       eq(InferenceKeyTable.status, "active"),
@@ -30,7 +32,7 @@ export async function findActiveInferenceKey(key: InferenceBearerKey) {
   if (!row) {
     return null
   }
-  return row.inferenceKey
+  return { ...row.inferenceKey, user_id: row.userId, accessMode: inferenceAccessMode(row.metadata) }
 }
 
 export async function getOpenRouterProviderKey(organizationId: string) {

--- a/ee/apps/inference/src/models/openwork-models.json
+++ b/ee/apps/inference/src/models/openwork-models.json
@@ -297,5 +297,72 @@
       "output": 15,
       "cache_read": 0.3
     }
+  },
+  "openai/gpt-5.6-luna": {
+    "id": "openai/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+    "family": "gpt-luna",
+    "attachment": true,
+    "reasoning": true,
+    "reasoning_options": [
+      {
+        "type": "effort",
+        "values": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    ],
+    "tool_call": true,
+    "structured_output": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 1050000,
+      "input": 922000,
+      "output": 128000
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 1.2,
+      "cache_read": 0.02,
+      "cache_write": 0.25,
+      "tiers": [
+        {
+          "input": 0.4,
+          "output": 1.8,
+          "cache_read": 0.04,
+          "cache_write": 0.5,
+          "tier": {
+            "type": "context",
+            "size": 272000
+          }
+        }
+      ],
+      "context_over_200k": {
+        "input": 0.4,
+        "output": 1.8,
+        "cache_read": 0.04,
+        "cache_write": 0.5
+      }
+    }
   }
 }

--- a/ee/apps/inference/src/proxy.ts
+++ b/ee/apps/inference/src/proxy.ts
@@ -13,10 +13,17 @@ import {
 import type { InferenceReporter } from "./inference-reporting.js"
 import { listModelCatalog, resolveModelAlias } from "./model-catalog.js"
 import type { AnalyticsObserver, beginModelAnalytics } from "./task-analytics.js"
+import { freeInferenceAccess } from "@openwork/types/den/inference"
+import type { FreeInferenceConfig, InferenceAccess } from "@openwork/types/den/inference"
+import { prepareFreeRequest, readFreeRequest } from "./free-request.js"
+import type { FreeRequestPricing } from "./free-request.js"
+import type { reserveFreeInference, settleFreeInference } from "./free-allowance.js"
+import { meterFreeResponse } from "./free-response.js"
 
 type JsonObject = Record<string, unknown>
 type PreparedBody = {
   body: BodyInit | null
+  json: JsonObject
   incomingModel: string
   modelAlias: string
   upstreamModel: string | null
@@ -52,6 +59,14 @@ const defaultProxyDependencies: ProxyDependencies = {
     const limits = await import("./limits.js")
     return limits.ensureUsableBuckets(organizationId)
   },
+  async reserveFreeInference(input) {
+    const allowance = await import("./free-allowance.js")
+    return allowance.reserveFreeInference(input)
+  },
+  async settleFreeInference(input) {
+    const allowance = await import("./free-allowance.js")
+    return allowance.settleFreeInference(input)
+  },
   fetch,
   async analytics(input) {
     const { beginModelAnalytics } = await import("./task-analytics.js")
@@ -66,6 +81,10 @@ type ProxyDependencies = {
   fetch: typeof fetch
   reporter?: InferenceReporter
   analytics?: typeof beginModelAnalytics
+  freeConfig?: FreeInferenceConfig
+  freeUpstreamApiKey?: string
+  reserveFreeInference?: typeof reserveFreeInference
+  settleFreeInference?: typeof settleFreeInference
 }
 
 function readInferenceBearerKey(request: Request) {
@@ -174,6 +193,12 @@ function sanitizeHeaders(request: Request, apiKey: string, openworkRequestId: st
 
 function openAiError(status: number, code: string, message: string) {
   return Response.json({ error: { message, type: "invalid_request_error", code } }, { status })
+}
+
+function freeError(status: number, code: string, message: string, access: InferenceAccess, hasAccountingSnapshot = false) {
+  // Pre-admission errors know eligibility/reset, but have not read this person's
+  // bucket. Never present the configured default as their remaining balance.
+  return Response.json({ error: { message, type: "invalid_request_error", code, resetsAt: access.resetsAt, reason: access.reason, ...(code === "free_request_in_progress" ? { retryable: false } : {}), ...(hasAccountingSnapshot ? { access } : {}) } }, { status })
 }
 
 function logProxyError(message: string, details: Record<string, unknown>) {
@@ -470,7 +495,7 @@ async function prepareBody(request: Request, input: {
   body.user = input.orgMembershipId
   body.session_id = input.openworkRequestId
   body.trace = {
-    trace_id: input.openworkRequestId,
+    trace_id: input.openworkRequestId.replace(/^free_/, ""),
     trace_name: "OpenWork Inference",
     generation_name: model.alias,
     org_membership_id: input.orgMembershipId,
@@ -480,6 +505,7 @@ async function prepareBody(request: Request, input: {
 
   return {
     body: JSON.stringify(body),
+    json: body,
     incomingModel: requestedModel,
     modelAlias: model.alias,
     upstreamModel: model.upstreamModel,
@@ -532,7 +558,14 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
       return localRouteRejection(c.req.path, c.req.method)
     }
 
-    const openworkRequestId = buildRequestId()
+    const freeConfig = dependencies.freeConfig ?? env.freeInference
+    const isFree = inferenceKey.accessMode === "free"
+    let freeAccess = freeInferenceAccess({ config: freeConfig, mode: inferenceKey.accessMode })
+    if (inferenceKey.accessMode !== "paid" && (!isFree || !inferenceKey.user_id || !freeConfig.enabled)) {
+      if (!inferenceKey.user_id) freeAccess = { ...freeAccess, kind: "unavailable", reason: "not_eligible" }
+      return freeError(403, "managed_inference_unavailable", "Managed inference is unavailable for this account.", freeAccess)
+    }
+    const openworkRequestId = `${isFree ? "free_" : ""}${buildRequestId()}`
     const incomingHeaders = sanitizeIncomingHeaders(c.req.raw.headers)
 
     if (new URL(c.req.url).search) {
@@ -566,6 +599,21 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
       return openAiError(400, "unsupported_query_parameters", "OpenWork chat completions does not accept query parameters.")
     }
 
+    let freePricing: FreeRequestPricing | null = null
+    if (isFree) {
+      if (!isJsonRequest(c.req.raw)) return openAiError(415, "unsupported_media_type", "Inference requests must use a JSON Content-Type.")
+      const parsed = await readFreeRequest(c.req.raw.clone())
+      if (!parsed.ok) return freeError(parsed.status, parsed.code, parsed.message, freeAccess)
+      const json = parsed.value
+      const selectedModel = isJsonObject(json) && typeof json.model === "string" ? resolveModelAlias(json.model) : null
+      if (selectedModel && selectedModel.alias !== freeConfig.modelID) {
+        return freeError(402, "managed_model_requires_upgrade", "This managed model requires an upgrade. Free access includes standard Luna only.", freeAccess)
+      }
+      const preparation = prepareFreeRequest(json)
+      if (!preparation.ok) return freeError(preparation.status, preparation.code, preparation.message, freeAccess)
+      freePricing = preparation.pricing
+    }
+
     const prepared = await prepareBody(c.req.raw, {
       organizationId: inferenceKey.organization_id,
       orgMembershipId: inferenceKey.org_membership_id,
@@ -586,55 +634,83 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
       return prepared.error
     }
 
-    const limits = await dependencies.ensureUsableBuckets(inferenceKey.organization_id)
-    if (!limits.ok) {
-      c.header("x-openwork-limit-bucket-id", limits.limitedBy)
-      c.header("x-openwork-limit-window-type", limits.windowType)
-      const limitedBucket = "limitedBucket" in limits ? limits.limitedBucket : null
-      if (limitedBucket) {
-        const retryAfter = secondsUntil(limitedBucket.windowEndAt)
-        c.header("retry-after", String(retryAfter))
-        c.header("x-ratelimit-limit-tokens", String(limitedBucket.limitAmount))
-        c.header("x-ratelimit-remaining-tokens", "0")
-        c.header("x-ratelimit-reset-tokens", `${retryAfter}s`)
+    let upstreamApiKey: string
+    if (isFree) {
+      const key = dependencies.freeUpstreamApiKey ?? env.freeUpstreamApiKey
+      if (!key || !freePricing || !dependencies.reserveFreeInference) {
+        return freeError(503, "free_inference_unavailable", "Free inference is temporarily unavailable.", { ...freeAccess, kind: "unavailable", reason: "upstream_unavailable" })
       }
-      return c.json({
-        error: {
-          message: `Rate limit reached for organization ${inferenceKey.organization_id}.`,
-          type: "tokens",
-          param: null,
-          code: "rate_limit_exceeded",
-        },
-      }, 429)
-    }
+      try {
+        const reservation = await dependencies.reserveFreeInference({ keyId: inferenceKey.id, requestId: openworkRequestId, config: freeConfig, pricing: freePricing })
+        freeAccess = reservation.access
+        if (!reservation.ok) {
+          if (freeAccess.reason === "free_request_in_progress") return freeError(423, "free_request_in_progress", "Another free Luna request is running or awaiting confirmed usage. Wait, then retry manually. This is not a request to upgrade.", freeAccess, true)
+          return freeError(freeAccess.kind === "exhausted" ? 402 : 503, freeAccess.kind === "exhausted" ? "free_allowance_exhausted" : "free_inference_unavailable",
+            freeAccess.kind === "exhausted" ? "Your weekly free Luna usage has reached its allowance. Upgrade or wait for the weekly reset." : "Free inference is temporarily unavailable.", freeAccess, true)
+        }
+        delete prepared.json.max_completion_tokens
+        prepared.json.max_tokens = reservation.maxOutputTokens
+        prepared.json.n = 1
+        prepared.json.provider = freePricing.provider
+        prepared.json.transforms = []
+        prepared.body = JSON.stringify(prepared.json)
+        upstreamApiKey = key
+      } catch {
+        return freeError(503, "free_inference_unavailable", "Free inference accounting is temporarily unavailable. No upstream request was sent.", { ...freeAccess, kind: "unavailable", reason: "accounting_unavailable" })
+      }
+    } else {
+      const limits = await dependencies.ensureUsableBuckets(inferenceKey.organization_id)
+      if (!limits.ok) {
+        c.header("x-openwork-limit-bucket-id", limits.limitedBy)
+        c.header("x-openwork-limit-window-type", limits.windowType)
+        const limitedBucket = "limitedBucket" in limits ? limits.limitedBucket : null
+        if (limitedBucket) {
+          const retryAfter = secondsUntil(limitedBucket.windowEndAt)
+          c.header("retry-after", String(retryAfter))
+          c.header("x-ratelimit-limit-tokens", String(limitedBucket.limitAmount))
+          c.header("x-ratelimit-remaining-tokens", "0")
+          c.header("x-ratelimit-reset-tokens", `${retryAfter}s`)
+        }
+        return c.json({
+          error: {
+            message: `Rate limit reached for organization ${inferenceKey.organization_id}.`,
+            type: "tokens",
+            param: null,
+            code: "rate_limit_exceeded",
+          },
+        }, 429)
+      }
 
-    const providerKey = await dependencies.getOpenRouterProviderKey(inferenceKey.organization_id)
-    if (!providerKey) {
-      logProxyError("Missing active OpenRouter provider key", {
-        path: c.req.path,
-        organizationId: inferenceKey.organization_id,
-        orgMembershipId: inferenceKey.org_membership_id,
-        inferenceKeyId: inferenceKey.id,
-        openworkRequestId,
-      })
-      reporter.handledError({
-        reason: "missing_provider_key",
-        organizationId: inferenceKey.organization_id,
-        orgMembershipId: inferenceKey.org_membership_id,
-        inferenceKeyId: inferenceKey.id,
-        openworkRequestId,
-        route: c.req.path,
-        method: c.req.method,
-        headers: incomingHeaders,
-        incomingModel: prepared.incomingModel,
-        resolvedUpstreamModel: prepared.upstreamModel,
-        status: 400,
-      })
-      return c.json({ error: { message: "No active OpenRouter provider key configured for organization.", type: "invalid_request_error", code: "missing_provider_key" } }, 400)
+      const providerKey = await dependencies.getOpenRouterProviderKey(inferenceKey.organization_id)
+      if (!providerKey) {
+        logProxyError("Missing active OpenRouter provider key", {
+          path: c.req.path,
+          organizationId: inferenceKey.organization_id,
+          orgMembershipId: inferenceKey.org_membership_id,
+          inferenceKeyId: inferenceKey.id,
+          openworkRequestId,
+        })
+        reporter.handledError({
+          reason: "missing_provider_key",
+          organizationId: inferenceKey.organization_id,
+          orgMembershipId: inferenceKey.org_membership_id,
+          inferenceKeyId: inferenceKey.id,
+          openworkRequestId,
+          route: c.req.path,
+          method: c.req.method,
+          headers: incomingHeaders,
+          incomingModel: prepared.incomingModel,
+          resolvedUpstreamModel: prepared.upstreamModel,
+          status: 400,
+        })
+        return c.json({ error: { message: "No active OpenRouter provider key configured for organization.", type: "invalid_request_error", code: "missing_provider_key" } }, 400)
+      }
+      upstreamApiKey = providerKey.encrypted_api_key
     }
 
     const upstreamPath = c.req.path.replace(/^\/api\/v1/, "")
-    const upstreamUrl = new URL(`${env.openRouterUpstreamUrl}${upstreamPath}`)
+    // A server-owned free credential is never sent to a configurable host or a redirect.
+    const upstreamUrl = new URL(`${isFree ? "https://openrouter.ai/api/v1" : env.openRouterUpstreamUrl}${upstreamPath}`)
     const startedAt = Date.now()
     // Fail closed and bound the optional analytics check; it cannot hold up
     // inference when the analytics store is unavailable.
@@ -647,13 +723,15 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
     try {
       const upstreamInit: ProxyRequestInit = {
         method: c.req.method,
-        headers: sanitizeHeaders(c.req.raw, providerKey.encrypted_api_key, openworkRequestId),
+        headers: sanitizeHeaders(c.req.raw, upstreamApiKey, openworkRequestId),
         body: prepared.body,
         duplex: "half",
+        ...(isFree ? { redirect: "error", signal: c.req.raw.signal } : {}),
       }
       upstream = await dependencies.fetch(upstreamUrl, upstreamInit)
     } catch (error) {
       analytics?.(false).finish("failed")
+      if (isFree) return freeError(502, "free_inference_upstream_error", "The request did not finish. Its estimated allowance reservation remains held while usage is unconfirmed; retry manually after confirmation.", freeAccess, true)
       logProxyError("Failed to reach OpenRouter upstream", {
         openworkRequestId,
         organizationId: inferenceKey.organization_id,
@@ -684,6 +762,11 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
     }
 
     if (!upstream.ok) {
+      if (isFree) {
+        analytics?.(false).finish("failed")
+        await upstream.body?.cancel()
+        return freeError(502, "free_inference_upstream_error", "The request did not finish. Its estimated allowance reservation remains held while usage is unconfirmed; retry manually after confirmation.", freeAccess, true)
+      }
       await logUpstreamError({
         upstream,
         upstreamUrl,
@@ -701,9 +784,15 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
       })
     }
 
-    const headers = new Headers(upstream.headers)
+    const headers = isFree ? new Headers({ "content-type": upstream.headers.get("content-type") ?? "application/json" }) : new Headers(upstream.headers)
     headers.set("x-openwork-request-id", openworkRequestId)
-    return new Response(trackStream(upstream.body, analytics?.(upstream.headers.get("content-type")?.includes("text/event-stream") === true) ?? null, upstream.ok),
+    const streaming = upstream.headers.get("content-type")?.includes("text/event-stream") === true
+    const body = isFree && dependencies.settleFreeInference ? meterFreeResponse(upstream.body, {
+      streaming,
+      identity: { requestId: openworkRequestId, inferenceKeyId: inferenceKey.id, orgMembershipId: inferenceKey.org_membership_id, requestModel: freeConfig.modelID },
+      settle: dependencies.settleFreeInference,
+    }) : upstream.body
+    return new Response(trackStream(body, analytics?.(streaming) ?? null, upstream.ok),
       { status: upstream.status, statusText: upstream.statusText, headers })
   }
 

--- a/ee/apps/inference/src/webhooks.ts
+++ b/ee/apps/inference/src/webhooks.ts
@@ -11,6 +11,7 @@ import { constantTimeEquals } from "./keys.js"
 import { ensureUsableBuckets as ensureUsageBuckets } from "./limits.js"
 import type { BucketLimitMetadata, BucketMetadata } from "./limits.js"
 import { resolveModelByUpstreamModel } from "./model-catalog.js"
+import type { settleFreeInference } from "./free-allowance.js"
 
 type JsonRecord = Record<string, unknown>
 
@@ -91,6 +92,7 @@ type ChargeBucketsInput = {
 }
 
 type WebhookDependencies = {
+  settleFreeInference?: typeof settleFreeInference
   reporter: OpenRouterUsageWebhookReporter
   findInferenceKey(inferenceKeyId: string): Promise<WebhookInferenceKey | null>
   ensureUsableBuckets(organizationId: string, occurredAt: Date): Promise<UsageBucketSettlement>
@@ -274,6 +276,10 @@ const sentryWebhookReporter: OpenRouterUsageWebhookReporter = {
 }
 
 const defaultWebhookDependencies: WebhookDependencies = {
+  async settleFreeInference(input) {
+    const allowance = await import("./free-allowance.js")
+    return allowance.settleFreeInference(input)
+  },
   reporter: sentryWebhookReporter,
   async findInferenceKey(inferenceKeyId) {
     const [inferenceKey] = await db.select().from(InferenceKeyTable)
@@ -367,6 +373,22 @@ function reportUnknownPricedModel(input: { span: ParsedSpan; inferenceKey: Webho
 }
 
 async function ingestSpan(span: ParsedSpan, dependencies: WebhookDependencies) {
+  // Admission pins free identity/model/window before execution. Settle that
+  // immutable reservation even after revocation, upgrade or a weekly reset;
+  // an unknown free request never falls through into the paid ledger.
+  if (span.openworkRequestId.startsWith("free_")) {
+    return dependencies.settleFreeInference?.({
+      requestId: span.openworkRequestId,
+      inferenceKeyId: span.inferenceKeyId,
+      orgMembershipId: span.orgMembershipId,
+      requestModel: span.requestModel,
+      responseModel: span.responseModel,
+      inputCost: span.inputCost,
+      outputCost: span.outputCost,
+      currency: span.usageMetadata.currency,
+      eventId: span.generationId ?? span.externalEventId,
+    }) ?? false
+  }
   const inferenceKey = await dependencies.findInferenceKey(span.inferenceKeyId)
   if (!inferenceKey || inferenceKey.status !== "active") {
     logWebhookError("skipped span for missing or inactive inference key", { inferenceKeyId: span.inferenceKeyId })

--- a/ee/apps/inference/test/proxy.test.ts
+++ b/ee/apps/inference/test/proxy.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 import { Hono } from "hono"
 import type { InferenceHandledErrorReport, InferenceReporter, InferenceRequestReport } from "../src/inference-reporting.js"
+import { freeInferenceAccess, freeInferenceWindow, inferenceAccessMode, INFERENCE_ACCESS_REASONS, INFERENCE_FREE_MODEL_ID, readFreeInferenceConfig } from "@openwork/types/den/inference"
+import { FREE_INPUT_CONTENT_MAX_BYTES, FREE_MAX_OUTPUT_TOKENS, FREE_REQUEST_MAX_BYTES, freeRequestReservation, inspectFreeRequest, prepareFreeRequest, readFreeRequest } from "../src/free-request.js"
+import { meterFreeResponse } from "../src/free-response.js"
+import type { FreeSettlement } from "../src/free-allowance.js"
 
 process.env.OPENWORK_DEV_MODE = "1"
 process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_den"
@@ -29,6 +33,11 @@ type CapturedReports = {
 }
 
 type TestServerOptions = {
+  settleFreeInference?: typeof import("../src/free-allowance.js").settleFreeInference
+  accessMode?: ReturnType<typeof inferenceAccessMode>
+  missingUser?: boolean
+  freeConfig?: ReturnType<typeof readFreeInferenceConfig>
+  reserveFreeInference?: typeof import("../src/free-allowance.js").reserveFreeInference
   analytics?: typeof import("../src/task-analytics.js").beginModelAnalytics
   organizationId?: string
   providerKey?: { encrypted_api_key: string } | null
@@ -143,6 +152,8 @@ function createTestServer(options: TestServerOptions = {}) {
         id: "inference_key_123",
         organization_id: options.organizationId ?? "organization_123",
         org_membership_id: "member_123",
+        accessMode: options.accessMode ?? "paid",
+        user_id: options.missingUser ? null : "user_123",
       }
     },
     async getOpenRouterProviderKey(_organizationId: string) {
@@ -177,6 +188,10 @@ function createTestServer(options: TestServerOptions = {}) {
     fetch: upstreamFetch,
     analytics: options.analytics,
     reporter,
+    freeConfig: options.freeConfig ?? readFreeInferenceConfig({ INFERENCE_FREE_ENABLED: "true" }),
+    freeUpstreamApiKey: "free-provider-key",
+    reserveFreeInference: options.reserveFreeInference,
+    settleFreeInference: options.settleFreeInference,
   })
 
   return { app, upstreamRequests, calls, reports }
@@ -800,4 +815,437 @@ test("authenticates before rejecting unsupported routes", async () => {
   assert.equal(calls.ensureUsableBuckets, 0)
   assert.equal(calls.getOpenRouterProviderKey, 0)
   assert.equal(upstreamRequests.length, 0)
+})
+
+const freeConfig = readFreeInferenceConfig({ INFERENCE_FREE_ENABLED: "true" })
+const lunaBody = { model: INFERENCE_FREE_MODEL_ID, messages: [{ role: "user", content: "Hello" }] }
+function freeChat(app: Hono, body: Record<string, unknown> = lunaBody) {
+  return app.fetch(inferenceRequest({ method: "POST", headers: authHeaders("application/json"), body: JSON.stringify(body) }))
+}
+
+test("ordinary free Luna reserves before forwarding and never uses paid credentials or buckets", async () => {
+  let reserved = false
+  const { app, calls } = createTestServer({
+    accessMode: "free",
+    reserveFreeInference: async (input) => {
+      assert.ok(input.requestId.startsWith("free_"))
+      assert.equal(input.keyId, "inference_key_123")
+      assert.equal(input.config.modelID, INFERENCE_FREE_MODEL_ID)
+      reserved = true
+      return { ok: true, maxOutputTokens: 17, access: freeInferenceAccess({ config: freeConfig, mode: "free" }) }
+    },
+    fetch: async (input, init) => {
+      assert.equal(reserved, true)
+      assert.equal(requestUrl(input), "https://openrouter.ai/api/v1/chat/completions")
+      assert.equal(new Headers(init?.headers).get("authorization"), "Bearer free-provider-key")
+      assert.equal(init?.redirect, "error")
+      const body = parseJsonObject(requireBodyText(readInitBody(init?.body)))
+      assert.equal(body.model, INFERENCE_FREE_MODEL_ID)
+      assert.equal(body.max_tokens, 17)
+      assert.equal(body.max_completion_tokens, undefined)
+      assert.ok(isRecord(body.trace))
+      assert.match(String(body.trace.trace_id), /^[a-f0-9]{32}$/)
+      assert.match(String(body.trace.openwork_request_id), /^free_[a-f0-9]{32}$/)
+      assert.deepEqual(body.provider, { allow_fallbacks: false, require_parameters: true, max_price: { prompt: 0.5, completion: 1.8, request: 0 } })
+      assert.deepEqual(body.transforms, [])
+      return Response.json({ ok: true }, { headers: { "x-api-key": "must-not-leak" } })
+    },
+  })
+  const response = await freeChat(app, { ...lunaBody, max_completion_tokens: 4000, reasoning: { effort: "high" } })
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get("x-api-key"), null)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+})
+
+test("free discovery can show upsell models but paid model execution is a non-retryable upgrade error", async () => {
+  const { app, upstreamRequests, calls } = createTestServer({ accessMode: "free" })
+  assert.equal((await app.fetch(inferenceRequest({ method: "GET", path: "/api/v1/models", headers: authHeaders() }))).status, 200)
+  const response = await freeChat(app, { ...lunaBody, model: "z-ai/glm-5.2" })
+  assert.equal(response.status, 402)
+  assert.equal(await readErrorCode(response), "managed_model_requires_upgrade")
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("reservation exhaustion returns reset and sanitized state without retry-after or upstream calls", async () => {
+  const now = new Date("2026-09-08T12:00:00Z")
+  const window = freeInferenceWindow(now)
+  const access = freeInferenceAccess({ config: freeConfig, mode: "free", now, bucket: { window_start_at: window.start, window_end_at: window.end, limit_amount: 100_000_000, used_amount: 100_000_000, reserved_amount: 0, blocked: false } })
+  const { app, upstreamRequests } = createTestServer({ accessMode: "free", reserveFreeInference: async () => ({ ok: false, access }) })
+  const response = await freeChat(app)
+  assert.equal(response.status, 402)
+  assert.equal(response.headers.get("retry-after"), null)
+  const body = parseJsonObject(await response.text())
+  assert.ok(isRecord(body.error))
+  assert.equal(body.error.code, "free_allowance_exhausted")
+  assert.equal(body.error.resetsAt, "2026-09-14T00:00:00.000Z")
+  assert.deepEqual(body.error.access, access)
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("paid exhaustion never falls through to the free allowance", async () => {
+  const { app, upstreamRequests } = createTestServer({ usageLimited: true, reserveFreeInference: async () => { throw new Error("must not reserve free usage") } })
+  const response = await freeChat(app)
+  assert.equal(response.status, 429)
+  assert.equal(await readErrorCode(response), "rate_limit_exceeded")
+  assert.equal(upstreamRequests.length, 0)
+})
+
+for (const options of [
+  { accessMode: "admin_disabled" }, { accessMode: "not_eligible" },
+  { accessMode: "free", missingUser: true },
+  { accessMode: "free", freeConfig: readFreeInferenceConfig({}) },
+] satisfies TestServerOptions[]) {
+  test(`free eligibility fails closed: ${JSON.stringify(options)}`, async () => {
+    const { app, upstreamRequests } = createTestServer(options)
+    assert.equal((await freeChat(app)).status, 403)
+    assert.equal(upstreamRequests.length, 0)
+  })
+}
+
+test("uncertain accounting sends nothing upstream; provider failures retain the committed hold", async () => {
+  const unavailable = createTestServer({ accessMode: "free", reserveFreeInference: async () => { throw new Error("uncertain database commit") } })
+  assert.equal((await freeChat(unavailable.app)).status, 503)
+  assert.equal(unavailable.upstreamRequests.length, 0)
+  let reservations = 0
+  const failure = createTestServer({
+    accessMode: "free",
+    reserveFreeInference: async () => {
+      reservations++
+      return { ok: true, maxOutputTokens: 1, access: freeInferenceAccess({ config: freeConfig, mode: "free" }) }
+    },
+    fetch: async () => new Response("provider-secret-error", { status: 500 }),
+  })
+  const response = await freeChat(failure.app)
+  assert.equal(response.status, 502)
+  const text = await response.text()
+  assert.ok(text.includes("reservation remains held"))
+  assert.ok(!text.includes("provider-secret-error"))
+  assert.equal(reservations, 1)
+})
+
+test("the display hold fits remaining money but one unit left still admits the full capped reply", () => {
+  const prepared = prepareFreeRequest({ ...lunaBody, max_tokens: 16384, reasoning: { effort: "max" } })
+  assert.ok(prepared.ok)
+  const pricing = prepared.pricing
+  assert.equal(pricing.maxOutputTokens, FREE_MAX_OUTPUT_TOKENS)
+  assert.equal(pricing.inputTokenPrice, 50)
+  assert.equal(pricing.outputTokenPrice, 180)
+  assert.deepEqual(freeRequestReservation(pricing, 1), { amount: 1, maxOutputTokens: FREE_MAX_OUTPUT_TOKENS })
+  assert.deepEqual(freeRequestReservation(pricing, 100), { amount: 100, maxOutputTokens: FREE_MAX_OUTPUT_TOKENS })
+  assert.equal(freeRequestReservation(pricing, 0), null)
+  assert.equal(freeRequestReservation({ ...pricing, inputTokenEstimate: NaN }, 100_000_000), null)
+  assert.equal(freeRequestReservation({ ...pricing, inputTokenEstimate: 0 }, 100_000_000), null)
+  assert.equal(freeRequestReservation({ ...pricing, outputTokenPrice: -1 }, 100_000_000), null)
+  const short = prepareFreeRequest({ ...lunaBody, max_completion_tokens: 17 })
+  assert.ok(short.ok)
+  assert.equal(short.pricing.maxOutputTokens, 17)
+})
+
+for (const unsupported of [
+  { n: 2 }, { plugins: [{ id: "web" }] }, { models: [INFERENCE_FREE_MODEL_ID] },
+  { provider: { max_price: { prompt: 999 } } }, { service_tier: "priority" },
+  { tools: [{ type: "openrouter:image_generation" }] }, { prediction: { content: "x" } },
+  { messages: [{ role: "user", content: [{ type: "image_url", image_url: { url: "https://image.invalid/test.png" } }] }] },
+  { max_tokens: 0 }, { reasoning: { max_tokens: 999_999 } }, { unknown_future_feature: true },
+  { reasoning: { mode: "pro" } },
+  { messages: [{ role: "assistant", content: "", reasoning_details: [{ type: "unknown", data: "opaque" }] }] },
+]) {
+  test(`free requests reject unbounded or per-call features: ${JSON.stringify(unsupported)}`, () => {
+    const result = prepareFreeRequest({ ...lunaBody, ...unsupported })
+    assert.equal(result.ok, false)
+    if (!result.ok) assert.equal(result.code, "unsupported_free_inference_input")
+  })
+}
+
+test("shared config and metadata separate explicit opt-out, paid precedence and free eligibility", () => {
+  assert.ok(INFERENCE_ACCESS_REASONS.includes("free_request_in_progress"))
+  assert.equal(new Set<string>(INFERENCE_ACCESS_REASONS).has("insufficient_request_budget"), false)
+  assert.equal(readFreeInferenceConfig({}).weeklyBudgetUsd, 1)
+  assert.equal(readFreeInferenceConfig({ INFERENCE_FREE_WEEKLY_BUDGET_USD: "0" }).weeklyLimitAmount, 0)
+  for (const budget of ["-1", "NaN", "Infinity", "", "1e20"]) assert.throws(() => readFreeInferenceConfig({ INFERENCE_FREE_WEEKLY_BUDGET_USD: budget }))
+  assert.throws(() => readFreeInferenceConfig({ INFERENCE_FREE_ENABLED: "yes" }))
+  assert.throws(() => readFreeInferenceConfig({ INFERENCE_FREE_MODEL_ID: "openai/gpt-5.6-luna-pro" }))
+  assert.equal(inferenceAccessMode(null), "not_eligible")
+  assert.equal(inferenceAccessMode({ inferenceFree: { offerAllowed: true } }), "free")
+  assert.equal(inferenceAccessMode({ inferenceFree: { offerAllowed: false } }), "admin_disabled")
+  assert.equal(inferenceAccessMode({ inference: { enabled: false }, inferenceFree: { offerAllowed: true } }), "admin_disabled")
+  assert.equal(inferenceAccessMode({ inference: { enabled: true, tier: "tier1" }, inferenceFree: { offerAllowed: true } }), "paid")
+})
+
+test("weekly status is Monday UTC with no rollover and never reuses a previous window's balance", () => {
+  const sunday = new Date("2026-09-13T23:59:59.999Z")
+  const monday = new Date("2026-09-14T00:00:00.000Z")
+  const oldWindow = freeInferenceWindow(sunday)
+  assert.equal(oldWindow.start.toISOString(), "2026-09-07T00:00:00.000Z")
+  assert.equal(oldWindow.end.getTime(), monday.getTime())
+  assert.equal(freeInferenceWindow(monday).start.getTime(), monday.getTime())
+  const bucket = { window_start_at: oldWindow.start, window_end_at: oldWindow.end, limit_amount: 100_000_000, used_amount: 100_500_000, reserved_amount: 0, blocked: false }
+  assert.equal(freeInferenceAccess({ config: freeConfig, mode: "free", bucket, now: sunday }).kind, "exhausted")
+  assert.equal(freeInferenceAccess({ config: freeConfig, mode: "free", bucket, now: monday }).reason, "accounting_unavailable")
+  const newWeek = freeInferenceAccess({ config: freeConfig, mode: "free", bucket: null, now: monday })
+  assert.equal(newWeek.remainingUsd, 1)
+  assert.equal(newWeek.usedUsd, 0)
+  assert.equal(newWeek.reservedUsd, 0)
+})
+
+test("invalid and blocked accounting never exposes spendable free balance", () => {
+  const now = new Date("2026-09-08T12:00:00Z")
+  const window = freeInferenceWindow(now)
+  const bucket = { window_start_at: window.start, window_end_at: window.end, limit_amount: 100_000_000, used_amount: 10, reserved_amount: 10, blocked: false }
+  for (const invalid of [{ used_amount: -1 }, { used_amount: NaN }, { reserved_amount: -1 }, { blocked: true }]) {
+    const access = freeInferenceAccess({ config: freeConfig, mode: "free", bucket: { ...bucket, ...invalid }, now })
+    assert.equal(access.kind, "unavailable")
+    assert.equal(access.reason, "accounting_unavailable")
+  }
+})
+
+test("cancelling a free stream cannot release its reservation", async () => {
+  let held = 0
+  let cancelled = false
+  const { app } = createTestServer({
+    accessMode: "free",
+    reserveFreeInference: async () => { held++; return { ok: true, maxOutputTokens: 1, access: freeInferenceAccess({ config: freeConfig, mode: "free" }) } },
+    fetch: async () => new Response(new ReadableStream({ cancel() { cancelled = true } }), { headers: { "content-type": "text/event-stream" } }),
+  })
+  const response = await freeChat(app, { ...lunaBody, stream: true })
+  assert.equal(response.status, 200)
+  await response.body?.cancel()
+  assert.equal(cancelled, true)
+  assert.equal(held, 1)
+})
+
+test("a final admitted reply can exceed the weekly limit and subsequent retries are exhausted without upstream calls", async () => {
+  const now = new Date()
+  const window = freeInferenceWindow(now)
+  const bucket = { window_start_at: window.start, window_end_at: window.end, limit_amount: 100_000_000, used_amount: 99_999_999, reserved_amount: 0, blocked: false }
+  let upstreamCalls = 0
+  let settlements = 0
+  const access = () => freeInferenceAccess({ config: freeConfig, mode: "free", bucket, now })
+  const { app, calls } = createTestServer({
+    accessMode: "free",
+    reserveFreeInference: async ({ pricing }) => {
+      const state = access()
+      if (state.kind !== "free" || state.reason === "free_request_in_progress") return { ok: false, access: state }
+      const reservation = freeRequestReservation(pricing, bucket.limit_amount - bucket.used_amount)
+      assert.ok(reservation)
+      assert.equal(reservation.amount, 1)
+      bucket.reserved_amount = reservation.amount
+      return { ok: true, maxOutputTokens: reservation.maxOutputTokens, access: access() }
+    },
+    fetch: async (_input, init) => {
+      upstreamCalls++
+      const body = parseJsonObject(requireBodyText(readInitBody(init?.body)))
+      assert.equal(body.max_tokens, FREE_MAX_OUTPUT_TOKENS)
+      assert.equal(body.n, 1)
+      return Response.json({ id: "gen_last", model: INFERENCE_FREE_MODEL_ID, choices: [{ index: 0, finish_reason: "stop", message: { role: "assistant", content: "Reply" } }], usage: { cost: 0.008 } })
+    },
+    settleFreeInference: async (receipt) => {
+      assert.ok("costUsd" in receipt)
+      assert.equal(receipt.costUsd, 0.008)
+      assert.equal(receipt.eventId, "gen_last")
+      settlements++
+      bucket.used_amount += Math.ceil(receipt.costUsd * 100_000_000)
+      bucket.reserved_amount = 0
+      return true
+    },
+  })
+  const response = await freeChat(app)
+  assert.equal(response.status, 200)
+  await response.json()
+  assert.equal(settlements, 1)
+  assert.equal(access().kind, "exhausted")
+  assert.equal(access().reason, "free_allowance_exhausted")
+  assert.equal(access().remainingUsd, 0)
+  assert.ok(bucket.used_amount > bucket.limit_amount)
+  for (let retry = 0; retry < 2; retry++) {
+    const denied = await freeChat(app)
+    assert.equal(denied.status, 402)
+    assert.equal(await readErrorCode(denied), "free_allowance_exhausted")
+  }
+  assert.equal(upstreamCalls, 1)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+})
+
+test("unknown model selectors and unpriced attachments produce input errors rather than an upsell", async () => {
+  const { app, upstreamRequests } = createTestServer({ accessMode: "free" })
+  for (const body of [{ ...lunaBody, model: "unknown/unpriced" }, { ...lunaBody, messages: [{ role: "user", content: [{ type: "image_url", image_url: { url: "https://image.invalid/test" } }] }] }]) {
+    const response = await freeChat(app, body)
+    assert.equal(response.status, 400)
+    assert.equal(await readErrorCode(response), "unsupported_free_inference_input")
+  }
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("OpenCode OpenRouter wire shapes, parameterless functions and null/empty tools pass input validation unchanged", () => {
+  const body = {
+    model: INFERENCE_FREE_MODEL_ID,
+    max_tokens: 16384,
+    messages: [
+      { role: "system", content: [{ type: "text", text: "Use the supplied tools." }] },
+      { role: "user", content: "Check status." },
+      { role: "assistant", content: "", tool_calls: [{ id: "call_status", type: "function", function: { name: "status", arguments: "{}" } }], reasoning_details: [] },
+      { role: "tool", name: "status", tool_call_id: "call_status", content: "ready" },
+    ],
+    tools: [{ type: "function", function: { name: "status" } }],
+    tool_choice: "auto",
+    usage: { include: true },
+    reasoningEffort: "medium",
+    textVerbosity: "low",
+    reasoning: { effort: "high" },
+    stream: true,
+    stream_options: { include_usage: true },
+  }
+  const original = JSON.stringify(body)
+  assert.equal(inspectFreeRequest(body).ok, true)
+  assert.equal(JSON.stringify(body), original)
+  for (const tools of [null, [], [{ type: "function", function: { name: "status", parameters: {} } }]]) {
+    assert.equal(inspectFreeRequest({ ...body, tools }).ok, true)
+  }
+  assert.equal(inspectFreeRequest({ ...lunaBody, messages: [{ role: "assistant", content: null, tool_calls: null }], temperature: null, top_p: null, stop: null }).ok, true)
+  assert.equal(prepareFreeRequest({ ...body, messages: [{ role: "assistant", content: "", reasoning_details: [{ type: "reasoning.encrypted", data: "opaque", id: "rs_test", format: "openai-responses-v1" }] }] }).ok, true)
+})
+
+test("UTF-8 byte measurement includes Unicode, system and tool/schema structure, never a characters/4 heuristic", () => {
+  for (const content of ["ascii", "\u00e9", "\u304a\u8a95\u751f\u65e5", "\u{1f680}", "e\u0301", "\ud800", "\u0000"]) {
+    const body = { ...lunaBody, messages: [{ role: "system", content: "System rules" }, { role: "user", content }], tools: [{ type: "function", function: { name: "status", description: content, parameters: { type: "object", properties: { detail: { type: "string", description: content } } } } }], response_format: { type: "json_schema", json_schema: { name: "status", schema: { type: "object", properties: { result: { type: "string" } } } } } }
+    const inspected = inspectFreeRequest(body)
+    assert.ok(inspected.ok)
+    assert.equal(inspected.inputContentBytes, Buffer.byteLength(JSON.stringify({ messages: body.messages, tools: body.tools, response_format: body.response_format }), "utf8"))
+    assert.ok(inspected.inputContentBytes > Buffer.byteLength(content, "utf8"))
+    // Bytes only bound supplied content, never a complete upstream prompt.
+    const preparation = prepareFreeRequest(body)
+    assert.ok(preparation.ok)
+    assert.ok(preparation.pricing.inputTokenEstimate > inspected.inputContentBytes)
+    assert.equal(preparation.pricing.maxOutputTokens, FREE_MAX_OUTPUT_TOKENS)
+  }
+})
+
+test("free input rejects oversized content and schema overhead instead of silently trimming", async () => {
+  const overhead = Buffer.byteLength(JSON.stringify({ messages: [{ role: "user", content: "" }] }), "utf8")
+  const fitting = { ...lunaBody, messages: [{ role: "user", content: "x".repeat(FREE_INPUT_CONTENT_MAX_BYTES - overhead) }] }
+  const before = JSON.stringify(fitting)
+  const fit = inspectFreeRequest(fitting)
+  assert.ok(fit.ok)
+  assert.equal(fit.inputContentBytes, FREE_INPUT_CONTENT_MAX_BYTES)
+  const tooLarge = { ...fitting, tools: [{ type: "function", function: { name: "status" } }] }
+  const inspected = inspectFreeRequest(tooLarge)
+  assert.equal(inspected.ok, false)
+  if (!inspected.ok) assert.equal(inspected.code, "free_inference_input_too_large")
+  assert.equal(JSON.stringify(fitting), before)
+  const { app, upstreamRequests } = createTestServer({ accessMode: "free" })
+  const response = await freeChat(app, tooLarge)
+  assert.equal(response.status, 413)
+  assert.equal(await readErrorCode(response), "free_inference_input_too_large")
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("raw request limits count actual UTF-8 bytes regardless of content-length, including fragmented Unicode", async () => {
+  const text = JSON.stringify({ ...lunaBody, messages: [{ role: "user", content: "\u{1f680}\u00e9" }] })
+  const bytes = new TextEncoder().encode(text)
+  const request = new Request("https://inference.invalid", { method: "POST", body: new ReadableStream({ start(controller) { for (const byte of bytes) controller.enqueue(new Uint8Array([byte])); controller.close() } }), duplex: "half" })
+  assert.deepEqual(await readFreeRequest(request), { ok: true, value: JSON.parse(text) })
+  const tooLarge = new Request("https://inference.invalid", { method: "POST", headers: { "content-length": "1" }, body: " ".repeat(FREE_REQUEST_MAX_BYTES + 1) })
+  const result = await readFreeRequest(tooLarge)
+  assert.equal(result.ok, false)
+  if (!result.ok) assert.equal(result.code, "free_inference_request_too_large")
+  const invalid = await readFreeRequest(new Request("https://inference.invalid", { method: "POST", body: new Uint8Array([0xff]) }))
+  assert.equal(invalid.ok, false)
+  if (!invalid.ok) assert.equal(invalid.code, "invalid_json")
+})
+
+test("an estimated hold preserves entitlement and actual remaining money, and concurrent requests require manual retry", async () => {
+  const now = new Date()
+  const window = freeInferenceWindow(now)
+  const bucket = { window_start_at: window.start, window_end_at: window.end, limit_amount: 100_000_000, used_amount: 0, reserved_amount: 100_000_000, blocked: false }
+  const access = freeInferenceAccess({ config: freeConfig, mode: "free", bucket, now })
+  assert.equal(access.kind, "free")
+  assert.equal(access.reason, "free_request_in_progress")
+  assert.equal(access.remainingUsd, 1)
+  assert.equal(access.usedUsd, 0)
+  const { app, upstreamRequests, calls } = createTestServer({ accessMode: "free", reserveFreeInference: async () => ({ ok: false, access }) })
+  for (let retry = 0; retry < 2; retry++) {
+    const response = await freeChat(app)
+    assert.equal(response.status, 423)
+    assert.equal(response.headers.get("retry-after"), null)
+    const payload = parseJsonObject(await response.text())
+    assert.ok(isRecord(payload.error))
+    assert.equal(payload.error.code, "free_request_in_progress")
+    assert.equal(payload.error.retryable, false)
+    assert.ok(String(payload.error.message).includes("retry manually"))
+    assert.ok(String(payload.error.message).includes("not a request to upgrade"))
+  }
+  assert.equal(upstreamRequests.length, 0)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+})
+
+const responseIdentity = { requestId: "free_response", inferenceKeyId: "key", orgMembershipId: "member", requestModel: INFERENCE_FREE_MODEL_ID }
+const terminalFrame = { id: "gen_response", model: INFERENCE_FREE_MODEL_ID, choices: [{ index: 0, finish_reason: "tool_calls", delta: {} }] }
+const usageFrame = { id: "gen_response", model: INFERENCE_FREE_MODEL_ID, choices: [], usage: { cost: 0.0042 } }
+
+test("fragmented free SSE settles final actual cost exactly once before DONE, preserving original bytes", async () => {
+  const text = `data: ${JSON.stringify({ id: "gen_response", model: INFERENCE_FREE_MODEL_ID, choices: [{ index: 0, delta: { content: "\u{1f680}" }, finish_reason: null }] })}\r\n\r\ndata: ${JSON.stringify(terminalFrame)}\r\n\r\ndata: ${JSON.stringify(usageFrame)}\r\n\r\ndata: ${JSON.stringify(usageFrame)}\r\n\r\ndata: [DONE]\r\n\r\n`
+  const receipts: FreeSettlement[] = []
+  const bytes = new TextEncoder().encode(text)
+  const stream = meterFreeResponse(new ReadableStream({ start(controller) { for (const byte of bytes) controller.enqueue(new Uint8Array([byte])); controller.close() } }), {
+    streaming: true,
+    identity: responseIdentity,
+    settle: async (receipt) => { receipts.push(receipt); return true },
+  })
+  assert.ok(stream)
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let received = ""
+  for (;;) {
+    const result = await reader.read()
+    if (result.done) break
+    received += decoder.decode(result.value, { stream: true })
+    if (received.endsWith("[DONE]\r\n\r\n")) assert.equal(receipts.length, 1)
+  }
+  received += decoder.decode()
+  assert.equal(received, text)
+  assert.deepEqual(receipts, [{ ...responseIdentity, responseModel: INFERENCE_FREE_MODEL_ID, currency: "USD", eventId: "gen_response", costUsd: 0.0042 }])
+})
+
+test("free JSON settlement requires a terminal matching model and actual cost, never a token-based estimate", async () => {
+  for (const usage of [{ cost: 0 }, { prompt_tokens: 12, completion_tokens: 3 }]) {
+    const receipts: FreeSettlement[] = []
+    const text = JSON.stringify({ ...terminalFrame, usage })
+    const stream = meterFreeResponse(new Response(text).body, { streaming: false, identity: responseIdentity, settle: async (receipt) => { receipts.push(receipt); return true } })
+    assert.equal(await new Response(stream).text(), text)
+    assert.equal(receipts.length, "cost" in usage ? 1 : 0)
+  }
+})
+
+for (const text of [
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: ${JSON.stringify(usageFrame)}\n\n`,
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: [DONE]\n\n`,
+  `data: ${JSON.stringify(usageFrame)}\n\ndata: [DONE]\n\n`,
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: ${JSON.stringify({ ...usageFrame, model: "other/model" })}\n\ndata: [DONE]\n\n`,
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: ${JSON.stringify({ ...usageFrame, id: "other_generation" })}\n\ndata: [DONE]\n\n`,
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: ${JSON.stringify({ ...usageFrame, usage: { cost: -1 } })}\n\ndata: [DONE]\n\n`,
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: ${JSON.stringify(usageFrame)}\n\ndata: {"error":{"message":"incomplete"}}\n\ndata: [DONE]\n\n`,
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: not-json\n\ndata: [DONE]\n\n`,
+  `data: ${JSON.stringify(terminalFrame)}\n\ndata: ${JSON.stringify(usageFrame)}\n\nevent: error\ndata: {"message":"incomplete"}\n\ndata: [DONE]\n\n`,
+]) {
+  test(`missing or invalid final free accounting retains the hold (${text.length} bytes, ${text.slice(-24)})`, async () => {
+    let settlements = 0
+    const stream = meterFreeResponse(new Response(text).body, { streaming: true, identity: responseIdentity, settle: async () => { settlements++; return true } })
+    assert.equal(await new Response(stream).text(), text)
+    assert.equal(settlements, 0)
+  })
+}
+
+test("cancelled free accounting and unavailable settlement retain holds without corrupting replies", async () => {
+  let settlements = 0
+  const cancelled = meterFreeResponse(new ReadableStream(), { streaming: true, identity: responseIdentity, settle: async () => { settlements++; return true } })
+  await cancelled?.cancel()
+  assert.equal(settlements, 0)
+  const text = `data: ${JSON.stringify(terminalFrame)}\n\ndata: ${JSON.stringify(usageFrame)}\n\ndata: [DONE]\n\n`
+  const failed = meterFreeResponse(new Response(text).body, { streaming: true, identity: responseIdentity, settle: async () => { settlements++; throw new Error("store unavailable") } })
+  assert.equal(await new Response(failed).text(), text)
+  assert.equal(settlements, 1)
 })

--- a/ee/apps/inference/test/webhooks.test.ts
+++ b/ee/apps/inference/test/webhooks.test.ts
@@ -39,7 +39,7 @@ async function responseJson(response: Response) {
   return payload
 }
 
-function createWebhookTestServer() {
+function createWebhookTestServer(options: { settleFreeInference?: typeof import("../src/free-allowance.js").settleFreeInference } = {}) {
   const app = new Hono()
   const organizationId = createDenTypeId("organization")
   const orgMembershipId = createDenTypeId("member")
@@ -67,6 +67,7 @@ function createWebhookTestServer() {
   }
 
   registerWebhookRoutes(app, {
+    settleFreeInference: options.settleFreeInference,
     reporter: {
       unknownModel(report) {
         reports.push(report)
@@ -236,4 +237,48 @@ test("deducts usage without Sentry diagnostics when OpenRouter usage reports a k
     totalTokens: 24,
   }])
   assert.deepEqual(bucketCharges, [{ amount: 1 }])
+})
+
+test("authenticated free usage goes only to the original reservation, not current paid buckets", async () => {
+  const settlements: import("../src/free-allowance.js").FreeSettlement[] = []
+  const server = createWebhookTestServer({ settleFreeInference: async (input) => { settlements.push(input); return settlements.length === 1 } })
+  const payload = server.usagePayload({ requestId: "free_original-week", eventId: "event", generationId: "generation", requestModel: "openai/gpt-5.6-luna", responseModel: "openai/gpt-5.6-luna" })
+  const unauthorized = new Request(webhookRequest(payload), { headers: { "content-type": "application/json" } })
+  assert.equal((await server.app.fetch(unauthorized)).status, 401)
+  assert.equal(settlements.length, 0)
+  assert.equal((await responseJson(await server.app.fetch(webhookRequest(payload)))).ingested, 1)
+  assert.equal((await responseJson(await server.app.fetch(webhookRequest(payload)))).ingested, 0)
+  assert.equal(settlements[0].requestId, "free_original-week")
+  assert.equal(settlements[0].eventId, "generation")
+  assert.equal(settlements[0].currency, "USD")
+  assert.equal(server.calls.ensureUsableBuckets, 0)
+  assert.equal(server.insertedEntries.length, 0)
+  assert.equal(server.bucketCharges.length, 0)
+})
+
+test("missing free reservations and missing costs cannot become paid charges or free refunds", async () => {
+  const server = createWebhookTestServer({ settleFreeInference: async () => false })
+  const payload = server.usagePayload({ requestId: "free_unknown", eventId: "event", generationId: "generation", requestModel: "openai/gpt-5.6-luna", responseModel: "openai/gpt-5.6-luna" })
+  assert.equal((await responseJson(await server.app.fetch(webhookRequest(payload)))).ingested, 0)
+  payload.resourceSpans[0].scopeSpans[0].spans[0].attributes = payload.resourceSpans[0].scopeSpans[0].spans[0].attributes.filter((attr) => !attr.key.endsWith("_cost"))
+  assert.equal((await responseJson(await server.app.fetch(webhookRequest(payload)))).ingested, 0)
+  assert.equal(server.calls.ensureUsableBuckets, 0)
+  assert.equal(server.bucketCharges.length, 0)
+})
+
+test("free settlement accepts actual cost above its estimate and rejects invalid identity, model or currency", async () => {
+  const { freeSettlementAmount } = await import("../src/free-allowance.js")
+  const keyId = createDenTypeId("inferenceKey")
+  const memberId = createDenTypeId("member")
+  const reservation = { inference_key_id: keyId, org_membership_id: memberId, upstream_model: "openai/gpt-5.6-luna", reserved_amount: 50_000_000 }
+  const receipt = { requestId: "free_cost", inferenceKeyId: keyId, orgMembershipId: memberId, requestModel: reservation.upstream_model, responseModel: reservation.upstream_model, inputCost: 0.01, outputCost: 0.02, currency: "USD", eventId: "generation" }
+  assert.equal(freeSettlementAmount(receipt, reservation), 3_000_000)
+  assert.equal(freeSettlementAmount({ ...receipt, inputCost: 0, outputCost: 0 }, reservation), 0)
+  assert.equal(freeSettlementAmount({ ...receipt, inputCost: 0, outputCost: 1.01 }, reservation), 101_000_000)
+  assert.equal(freeSettlementAmount({ requestId: receipt.requestId, inferenceKeyId: keyId, orgMembershipId: memberId, requestModel: reservation.upstream_model, responseModel: reservation.upstream_model, currency: "USD", eventId: "generation", costUsd: 1.01 }, reservation), 101_000_000)
+  for (const invalid of [
+    { inputCost: -1 }, { outputCost: Infinity }, { outputCost: NaN }, { outputCost: Number.MAX_VALUE },
+    { inferenceKeyId: createDenTypeId("inferenceKey") }, { orgMembershipId: createDenTypeId("member") },
+    { requestModel: null }, { responseModel: "openai/gpt-5.6-luna-pro" }, { currency: null }, { currency: "EUR" }, { eventId: null },
+  ]) assert.equal(freeSettlementAmount({ ...receipt, ...invalid }, reservation), null)
 })

--- a/ee/packages/den-db/drizzle/0093_free_inference_allowance.sql
+++ b/ee/packages/den-db/drizzle/0093_free_inference_allowance.sql
@@ -1,0 +1,37 @@
+CREATE TABLE `inference_free_reservations` (
+	`request_id` varchar(64) NOT NULL,
+	`user_id` varchar(64) NOT NULL,
+	`window_start_at` timestamp(3) NOT NULL,
+	`organization_id` varchar(64) NOT NULL,
+	`org_membership_id` varchar(64) NOT NULL,
+	`inference_key_id` varchar(64) NOT NULL,
+	`model_id` varchar(255) NOT NULL,
+	`upstream_model` varchar(255) NOT NULL,
+	`reserved_amount` bigint NOT NULL,
+	`input_token_cap` int NOT NULL,
+	`max_output_tokens` int NOT NULL,
+	`input_token_price` bigint NOT NULL,
+	`output_token_price` bigint NOT NULL,
+	`actual_amount` bigint,
+	`external_event_id` varchar(255),
+	`status` enum('held','settled','invalid') NOT NULL DEFAULT 'held',
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	`settled_at` timestamp(3),
+	CONSTRAINT `inference_free_reservations_request_id` PRIMARY KEY(`request_id`),
+	CONSTRAINT `inference_free_reservations_external_event` UNIQUE(`external_event_id`)
+);
+
+--> statement-breakpoint
+CREATE TABLE `inference_free_usage_buckets` (
+	`user_id` varchar(64) NOT NULL,
+	`window_start_at` timestamp(3) NOT NULL,
+	`window_end_at` timestamp(3) NOT NULL,
+	`limit_amount` bigint NOT NULL,
+	`used_amount` bigint NOT NULL DEFAULT 0,
+	`reserved_amount` bigint NOT NULL DEFAULT 0,
+	`blocked` boolean NOT NULL DEFAULT false,
+	CONSTRAINT `inference_free_usage_buckets_user_id_window_start_at_pk` PRIMARY KEY(`user_id`,`window_start_at`)
+);
+
+--> statement-breakpoint
+CREATE INDEX `inference_free_reservations_user_window` ON `inference_free_reservations` (`user_id`,`window_start_at`);

--- a/ee/packages/den-db/drizzle/meta/0093_snapshot.json
+++ b/ee/packages/den-db/drizzle/meta/0093_snapshot.json
@@ -1,0 +1,12458 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f85c748a-3109-4bca-b746-e79cda4f2d34",
+  "prevId": "96cd2f65-1938-4864-879b-d6a91e781c2c",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_account_id_provider_id": {
+          "name": "account_account_id_provider_id",
+          "columns": [
+            "`account_id`(191)",
+            "`provider_id`(191)"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "account_id": {
+          "name": "account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id": {
+          "name": "apikey_config_id",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id": {
+          "name": "apikey_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key": {
+          "name": "apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apikey_id": {
+          "name": "apikey_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jwks_id": {
+          "name": "jwks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "session_token": {
+          "name": "session_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id": {
+          "name": "session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_id": {
+          "name": "session_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "user_email": {
+          "name": "user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_created_at_id": {
+          "name": "user_created_at_id",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "verification_identifier": {
+          "name": "verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_id": {
+          "name": "verification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_identity": {
+      "name": "external_identity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_json": {
+          "name": "name_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emails_json": {
+          "name": "emails_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_scim_sync_at": {
+          "name": "last_scim_sync_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sso_login_at": {
+          "name": "last_sso_login_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_identity_org_user": {
+          "name": "external_identity_org_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_sso_remote": {
+          "name": "external_identity_org_sso_remote",
+          "columns": [
+            "organization_id",
+            "sso_provider_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_scim_external": {
+          "name": "external_identity_org_scim_external",
+          "columns": [
+            "organization_id",
+            "scim_provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_email": {
+          "name": "external_identity_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        },
+        "external_identity_sso_provider": {
+          "name": "external_identity_sso_provider",
+          "columns": [
+            "sso_provider_id"
+          ],
+          "isUnique": false
+        },
+        "external_identity_scim_provider": {
+          "name": "external_identity_scim_provider",
+          "columns": [
+            "scim_provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token": {
+          "name": "oauth_access_token_token",
+          "columns": [
+            "`token`(191)"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_client_id": {
+          "name": "oauth_access_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_session_id": {
+          "name": "oauth_access_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_user_id": {
+          "name": "oauth_access_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_reference_id": {
+          "name": "oauth_access_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_refresh_id": {
+          "name": "oauth_access_token_refresh_id",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthAccessToken_id": {
+          "name": "oauthAccessToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClientAssertion": {
+      "name": "oauthClientAssertion",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClientAssertion_id": {
+          "name": "oauthClientAssertion_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClientResource": {
+      "name": "oauthClientResource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "oauth_client_resource_client_id": {
+          "name": "oauth_client_resource_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_resource_resource_id": {
+          "name": "oauth_client_resource_resource_id",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClientResource_id": {
+          "name": "oauthClientResource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClient": {
+      "name": "oauthClient",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backchannel_logout_uri": {
+          "name": "backchannel_logout_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backchannel_logout_session_required": {
+          "name": "backchannel_logout_session_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jwks": {
+          "name": "jwks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jwks_uri": {
+          "name": "jwks_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dpop_bound_access_tokens": {
+          "name": "dpop_bound_access_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id": {
+          "name": "oauth_client_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_client_user_id": {
+          "name": "oauth_client_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_reference_id": {
+          "name": "oauth_client_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClient_id": {
+          "name": "oauthClient_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthConsent": {
+      "name": "oauthConsent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id": {
+          "name": "oauth_consent_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_user_id": {
+          "name": "oauth_consent_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_reference_id": {
+          "name": "oauth_consent_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthConsent_id": {
+          "name": "oauthConsent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthRefreshToken": {
+      "name": "oauthRefreshToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_replay_response": {
+          "name": "rotation_replay_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_replay_expires_at": {
+          "name": "rotation_replay_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token": {
+          "name": "oauth_refresh_token_token",
+          "columns": [
+            "`token`(191)"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_client_id": {
+          "name": "oauth_refresh_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_session_id": {
+          "name": "oauth_refresh_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_user_id": {
+          "name": "oauth_refresh_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_reference_id": {
+          "name": "oauth_refresh_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthRefreshToken_id": {
+          "name": "oauthRefreshToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthResource": {
+      "name": "oauthResource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_ttl": {
+          "name": "access_token_ttl",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_ttl": {
+          "name": "refresh_token_ttl",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signing_algorithm": {
+          "name": "signing_algorithm",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_claims": {
+          "name": "custom_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dpop_bound_access_tokens_required": {
+          "name": "dpop_bound_access_tokens_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_resource_identifier": {
+          "name": "oauth_resource_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthResource_id": {
+          "name": "oauthResource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_provider": {
+      "name": "scim_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_token": {
+          "name": "scim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mapping_mode": {
+          "name": "group_mapping_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'metadata_only'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_provider_provider_id": {
+          "name": "scim_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "scim_provider_organization_id": {
+          "name": "scim_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_sync_event": {
+      "name": "scim_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_sync_event_org_status": {
+          "name": "scim_sync_event_org_status",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_provider_status": {
+          "name": "scim_sync_event_provider_status",
+          "columns": [
+            "provider_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_next_retry": {
+          "name": "scim_sync_event_next_retry",
+          "columns": [
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_user": {
+          "name": "scim_sync_event_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_sync_event_id": {
+          "name": "scim_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_connection": {
+      "name": "sso_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'disabled'"
+        },
+        "sign_in_path": {
+          "name": "sign_in_path",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_revision": {
+          "name": "config_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "test_status": {
+          "name": "test_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tested_revision": {
+          "name": "last_tested_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verification_token": {
+          "name": "domain_verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_intent_id": {
+          "name": "active_test_intent_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_user_id": {
+          "name": "active_test_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_provider_id": {
+          "name": "active_test_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_config_revision": {
+          "name": "active_test_config_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_expires_at": {
+          "name": "active_test_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_started_at": {
+          "name": "active_test_started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id": {
+          "name": "sso_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_provider_id": {
+          "name": "sso_connection_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_domain": {
+          "name": "sso_connection_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_connection_id": {
+          "name": "sso_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_provider": {
+      "name": "sso_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_provider_provider_id": {
+          "name": "sso_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_provider_domain": {
+          "name": "sso_provider_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_organization_id": {
+          "name": "sso_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_user_id": {
+          "name": "sso_provider_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard_access_grant": {
+      "name": "dashboard_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_access_grant_organization_id": {
+          "name": "dashboard_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_org_membership_id": {
+          "name": "dashboard_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_team_id": {
+          "name": "dashboard_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_org_wide": {
+          "name": "dashboard_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_dashboard_org_membership": {
+          "name": "dashboard_access_grant_dashboard_org_membership",
+          "columns": [
+            "dashboard_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "dashboard_access_grant_dashboard_team": {
+          "name": "dashboard_access_grant_dashboard_team",
+          "columns": [
+            "dashboard_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_access_grant_id": {
+          "name": "dashboard_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard": {
+      "name": "dashboard",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elements_json": {
+          "name": "elements_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_organization_id": {
+          "name": "dashboard_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_created_by_org_membership_id": {
+          "name": "dashboard_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_name": {
+          "name": "dashboard_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy_member": {
+      "name": "desktop_policy_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_policy_member_organization_id": {
+          "name": "desktop_policy_member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_org_member_id": {
+          "name": "desktop_policy_member_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_team_id": {
+          "name": "desktop_policy_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_policy_org_member": {
+          "name": "desktop_policy_member_policy_org_member",
+          "columns": [
+            "desktop_policy_id",
+            "org_member_id"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_member_policy_team": {
+          "name": "desktop_policy_member_policy_team",
+          "columns": [
+            "desktop_policy_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_member_id": {
+          "name": "desktop_policy_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy": {
+      "name": "desktop_policy",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_name": {
+          "name": "policy_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "policy": {
+          "name": "policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "created_by_org_member_id": {
+          "name": "created_by_org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "desktop_policy_org_external_key": {
+          "name": "desktop_policy_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_created_by_member_id": {
+          "name": "desktop_policy_created_by_member_id",
+          "columns": [
+            "created_by_org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_is_enabled": {
+          "name": "desktop_policy_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_priority": {
+          "name": "desktop_policy_priority",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_deleted_at": {
+          "name": "desktop_policy_deleted_at",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_org_default": {
+          "name": "desktop_policy_org_default",
+          "columns": [
+            "organization_id",
+            "is_default"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_diagnostic_credential": {
+      "name": "organization_diagnostic_credential",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_diagnostic_credential_organization_id": {
+          "name": "organization_diagnostic_credential_organization_id",
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_keys": {
+      "name": "inference_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_keys_key_hash": {
+          "name": "inference_keys_key_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "inference_keys_organization_id": {
+          "name": "inference_keys_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_org_membership_id": {
+          "name": "inference_keys_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_status": {
+          "name": "inference_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_keys_id": {
+          "name": "inference_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_limit_policies": {
+      "name": "inference_org_limit_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "enum('five_hour','weekly','monthly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_strategy": {
+          "name": "reset_strategy",
+          "type": "enum('anchored','activity_based')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_at": {
+          "name": "anchor_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_bucket_id": {
+          "name": "current_bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_limit_policies_org_window_type": {
+          "name": "inference_org_limit_policies_org_window_type",
+          "columns": [
+            "organization_id",
+            "window_type"
+          ],
+          "isUnique": true
+        },
+        "inference_org_limit_policies_current_bucket_id": {
+          "name": "inference_org_limit_policies_current_bucket_id",
+          "columns": [
+            "current_bucket_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_limit_policies_id": {
+          "name": "inference_org_limit_policies_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_upstream_provider_keys": {
+      "name": "inference_org_upstream_provider_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openrouter'"
+        },
+        "external_key_hash": {
+          "name": "external_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_workspace_id": {
+          "name": "external_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_upstream_provider_keys_external_key_hash": {
+          "name": "inference_org_upstream_provider_keys_external_key_hash",
+          "columns": [
+            "external_key_hash"
+          ],
+          "isUnique": false
+        },
+        "inference_org_upstream_provider_keys_org_provider": {
+          "name": "inference_org_upstream_provider_keys_org_provider",
+          "columns": [
+            "organization_id",
+            "provider"
+          ],
+          "isUnique": true
+        },
+        "inference_org_upstream_provider_keys_status": {
+          "name": "inference_org_upstream_provider_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_upstream_provider_keys_id": {
+          "name": "inference_org_upstream_provider_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_usage_buckets": {
+      "name": "inference_org_usage_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_usage_buckets_org_window": {
+          "name": "inference_org_usage_buckets_org_window",
+          "columns": [
+            "organization_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        },
+        "inference_org_usage_buckets_policy_window": {
+          "name": "inference_org_usage_buckets_policy_window",
+          "columns": [
+            "policy_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_usage_buckets_id": {
+          "name": "inference_org_usage_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_bucket_charges": {
+      "name": "inference_usage_ledger_bucket_charges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ledger_entry_id": {
+          "name": "ledger_entry_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_bucket_charges_bucket_id": {
+          "name": "inference_usage_ledger_bucket_charges_bucket_id",
+          "columns": [
+            "bucket_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_bucket_charges_entry_bucket": {
+          "name": "inference_usage_ledger_bucket_charges_entry_bucket",
+          "columns": [
+            "ledger_entry_id",
+            "bucket_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_bucket_charges_id": {
+          "name": "inference_usage_ledger_bucket_charges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_entries": {
+      "name": "inference_usage_ledger_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inference_key_id": {
+          "name": "inference_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_entries_organization_id": {
+          "name": "inference_usage_ledger_entries_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_org_membership_id": {
+          "name": "inference_usage_ledger_entries_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_inference_key_id": {
+          "name": "inference_usage_ledger_entries_inference_key_id",
+          "columns": [
+            "inference_key_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_external_event_id": {
+          "name": "inference_usage_ledger_entries_external_event_id",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        },
+        "inference_usage_ledger_entries_job_event_type": {
+          "name": "inference_usage_ledger_entries_job_event_type",
+          "columns": [
+            "external_job_id",
+            "event_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_entries_id": {
+          "name": "inference_usage_ledger_entries_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_connect_grant": {
+      "name": "desktop_connect_grant",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "install_link_id": {
+          "name": "install_link_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claims": {
+          "name": "claims",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_nonce": {
+          "name": "consumed_nonce",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_connect_grant_install_link_id": {
+          "name": "desktop_connect_grant_install_link_id",
+          "columns": [
+            "install_link_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_connect_grant_expires_at": {
+          "name": "desktop_connect_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_connect_grant_code_hash": {
+          "name": "desktop_connect_grant_code_hash",
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_handoff_grant": {
+      "name": "desktop_handoff_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_handoff_grant_user_id": {
+          "name": "desktop_handoff_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_handoff_grant_expires_at": {
+          "name": "desktop_handoff_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_handoff_grant_id": {
+          "name": "desktop_handoff_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "install_link": {
+      "name": "install_link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "install_link_token_hash": {
+          "name": "install_link_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "install_link_organization_id": {
+          "name": "install_link_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "install_link_created_by_user_id": {
+          "name": "install_link_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "install_link_revoked_at": {
+          "name": "install_link_revoked_at",
+          "columns": [
+            "revoked_at"
+          ],
+          "isUnique": false
+        },
+        "install_link_expires_at": {
+          "name": "install_link_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "install_link_id": {
+          "name": "install_link_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id": {
+          "name": "invitation_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email": {
+          "name": "invitation_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_status": {
+          "name": "invitation_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "invitation_team_id": {
+          "name": "invitation_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_inviter_id": {
+          "name": "invitation_inviter_id",
+          "columns": [
+            "inviter_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_member_id": {
+          "name": "invitation_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_invite_token": {
+          "name": "invitation_invite_token",
+          "columns": [
+            "invite_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_id": {
+          "name": "invitation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_by_org_member": {
+          "name": "invited_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by_org_member": {
+          "name": "removed_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "member_user_id": {
+          "name": "member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_invite_id": {
+          "name": "member_invite_id",
+          "columns": [
+            "invite_id"
+          ],
+          "isUnique": false
+        },
+        "member_invited_by_org_member": {
+          "name": "member_invited_by_org_member",
+          "columns": [
+            "invited_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_removed_at": {
+          "name": "member_removed_at",
+          "columns": [
+            "removed_at"
+          ],
+          "isUnique": false
+        },
+        "member_removed_by_org_member": {
+          "name": "member_removed_by_org_member",
+          "columns": [
+            "removed_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_organization_user": {
+          "name": "member_organization_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "member_id": {
+          "name": "member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_brand_asset": {
+      "name": "organization_brand_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "mediumblob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "organization_brand_asset_version": {
+          "name": "organization_brand_asset_version",
+          "columns": [
+            "organization_id",
+            "kind",
+            "version",
+            "extension"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_brand_asset_id": {
+          "name": "organization_brand_asset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_role": {
+      "name": "organization_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_role_name": {
+          "name": "organization_role_name",
+          "columns": [
+            "organization_id",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_role_id": {
+          "name": "organization_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_app_restrictions": {
+          "name": "desktop_app_restrictions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_slug": {
+          "name": "organization_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_created_at_id": {
+          "name": "organization_created_at_id",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_id": {
+          "name": "organization_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_bootstrap": {
+      "name": "workspace_bootstrap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "setup_member_id": {
+          "name": "setup_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_public_key": {
+          "name": "device_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_key_fingerprint": {
+          "name": "device_key_fingerprint",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisional'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_bootstrap_organization_id": {
+          "name": "workspace_bootstrap_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_status": {
+          "name": "workspace_bootstrap_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_expires_at": {
+          "name": "workspace_bootstrap_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_bootstrap_id": {
+          "name": "workspace_bootstrap_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_claim": {
+      "name": "workspace_claim",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bootstrap_id": {
+          "name": "bootstrap_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_claim_token_hash": {
+          "name": "workspace_claim_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "workspace_claim_bootstrap_id": {
+          "name": "workspace_claim_bootstrap_id",
+          "columns": [
+            "bootstrap_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_organization_id": {
+          "name": "workspace_claim_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_status": {
+          "name": "workspace_claim_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_expires_at": {
+          "name": "workspace_claim_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_claim_id": {
+          "name": "workspace_claim_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "remote_mcp_app": {
+      "name": "remote_mcp_app",
+      "columns": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_source_url": {
+          "name": "resolved_source_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','retired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_mcp_app_organization_id": {
+          "name": "remote_mcp_app_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "remote_mcp_app_plugin_id": {
+          "name": "remote_mcp_app_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": true
+        },
+        "remote_mcp_app_active_version_id": {
+          "name": "remote_mcp_app_active_version_id",
+          "columns": [
+            "active_version_id"
+          ],
+          "isUnique": false
+        },
+        "remote_mcp_app_status": {
+          "name": "remote_mcp_app_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "remote_mcp_app_config_object_id": {
+          "name": "remote_mcp_app_config_object_id",
+          "columns": [
+            "config_object_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "remote_session_command": {
+      "name": "remote_session_command",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','claimed','delivered','failed','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_model_id": {
+          "name": "model_model_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_runner_id": {
+          "name": "claimed_by_runner_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "remote_session_command_idempotency_key": {
+          "name": "remote_session_command_idempotency_key",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "remote_session_command_owner_status": {
+          "name": "remote_session_command_owner_status",
+          "columns": [
+            "org_id",
+            "owner_member_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "remote_session_command_status_expires": {
+          "name": "remote_session_command_status_expires",
+          "columns": [
+            "status",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "remote_session_command_id": {
+          "name": "remote_session_command_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_member": {
+      "name": "scim_group_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_user_id": {
+          "name": "remote_user_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_member_group_remote_user": {
+          "name": "scim_group_member_group_remote_user",
+          "columns": [
+            "group_id",
+            "remote_user_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_member_membership_key": {
+          "name": "scim_group_member_membership_key",
+          "columns": [
+            "membership_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_member_user_id": {
+          "name": "scim_group_member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_org_membership_id": {
+          "name": "scim_group_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_team_member_id": {
+          "name": "scim_group_member_team_member_id",
+          "columns": [
+            "team_member_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_provider_org": {
+          "name": "scim_group_member_provider_org",
+          "columns": [
+            "provider_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_member_id": {
+          "name": "scim_group_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_role_grant": {
+      "name": "scim_group_role_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_grant_key": {
+          "name": "role_grant_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_role_projected": {
+          "name": "is_role_projected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_role_grant_role_grant_key": {
+          "name": "scim_group_role_grant_role_grant_key",
+          "columns": [
+            "role_grant_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_role_grant_group_id": {
+          "name": "scim_group_role_grant_group_id",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_role_grant_provider_org": {
+          "name": "scim_group_role_grant_provider_org",
+          "columns": [
+            "provider_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_role_grant_user_id": {
+          "name": "scim_group_role_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_role_grant_id": {
+          "name": "scim_group_role_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_role": {
+      "name": "scim_group_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_key": {
+          "name": "role_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_role_role_key": {
+          "name": "scim_group_role_role_key",
+          "columns": [
+            "role_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_role_group_id": {
+          "name": "scim_group_role_group_id",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_role_id": {
+          "name": "scim_group_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group": {
+      "name": "scim_group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_group_id": {
+          "name": "scim_group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id_key": {
+          "name": "external_id_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_scim_group_id": {
+          "name": "scim_group_scim_group_id",
+          "columns": [
+            "scim_group_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_provider_external_id": {
+          "name": "scim_group_provider_external_id",
+          "columns": [
+            "provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_external_id_key": {
+          "name": "scim_group_external_id_key",
+          "columns": [
+            "external_id_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_team_id": {
+          "name": "scim_group_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_organization_id": {
+          "name": "scim_group_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_id": {
+          "name": "scim_group_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_user_tombstone": {
+      "name": "scim_user_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deprovisioned_user_id": {
+          "name": "deprovisioned_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deprovisioned_at": {
+          "name": "deprovisioned_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_user_tombstone_org_user": {
+          "name": "scim_user_tombstone_org_user",
+          "columns": [
+            "organization_id",
+            "deprovisioned_user_id"
+          ],
+          "isUnique": true
+        },
+        "scim_user_tombstone_org_external_id": {
+          "name": "scim_user_tombstone_org_external_id",
+          "columns": [
+            "organization_id",
+            "external_id"
+          ],
+          "isUnique": false
+        },
+        "scim_user_tombstone_org_email": {
+          "name": "scim_user_tombstone_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_user_tombstone_id": {
+          "name": "scim_user_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_revision": {
+      "name": "automation_revision",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "enum('once','daily','weekly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "enum('desktop','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "maximum_runtime_ms": {
+          "name": "maximum_runtime_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "digest": {
+          "name": "digest",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_revision_version": {
+          "name": "automation_revision_version",
+          "columns": [
+            "automation_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_revision_id": {
+          "name": "automation_revision_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_run_event": {
+      "name": "automation_run_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engine_event_id": {
+          "name": "engine_event_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_idempotency_key": {
+          "name": "engine_idempotency_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_execution_id": {
+          "name": "engine_execution_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('user','assistant','capability_search','capability_execution','usage','warning','terminal')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_run_event_sequence": {
+          "name": "automation_run_event_sequence",
+          "columns": [
+            "run_id",
+            "attempt",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "automation_run_engine_event": {
+          "name": "automation_run_engine_event",
+          "columns": [
+            "run_id",
+            "engine_idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "automation_run_event_created": {
+          "name": "automation_run_event_created",
+          "columns": [
+            "run_id",
+            "attempt",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_run_event_id": {
+          "name": "automation_run_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_run": {
+      "name": "automation_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "enum('scheduled','recovery','manual')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('queued','claimed','running','succeeded','failed','cancelled','skipped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "enum('desktop','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "claim_deadline_at": {
+          "name": "claim_deadline_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_thread_id": {
+          "name": "cloud_thread_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engine_kind": {
+          "name": "engine_kind",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_receipt": {
+          "name": "engine_receipt",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_sequence": {
+          "name": "engine_sequence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "engine_admitted_at": {
+          "name": "engine_admitted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codemode_receipt_id": {
+          "name": "codemode_receipt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_result": {
+          "name": "validated_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_token_hash": {
+          "name": "mcp_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_token_expires_at": {
+          "name": "mcp_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_run_occurrence": {
+          "name": "automation_run_occurrence",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "automation_run_cloud_thread": {
+          "name": "automation_run_cloud_thread",
+          "columns": [
+            "cloud_thread_id"
+          ],
+          "isUnique": true
+        },
+        "automation_run_claimable": {
+          "name": "automation_run_claimable",
+          "columns": [
+            "status",
+            "lease_expires_at"
+          ],
+          "isUnique": false
+        },
+        "automation_run_history": {
+          "name": "automation_run_history",
+          "columns": [
+            "automation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_runner_notification": {
+      "name": "automation_runner_notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('work_available','cancellation')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_runner_notification_owner_cursor": {
+          "name": "automation_runner_notification_owner_cursor",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_runner_notification_id": {
+          "name": "automation_runner_notification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_runner": {
+      "name": "automation_runner",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supported_execution_targets": {
+          "name": "supported_execution_targets",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "enum('darwin','win32','linux')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concurrency": {
+          "name": "concurrency",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_runner_owner_seen": {
+          "name": "automation_runner_owner_seen",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_runner_id": {
+          "name": "automation_runner_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation": {
+      "name": "automation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('active','inactive','needs_attention','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_run_at": {
+          "name": "latest_run_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "needs_attention_reason": {
+          "name": "needs_attention_reason",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_successful_run_id": {
+          "name": "latest_successful_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_successful_result": {
+          "name": "latest_successful_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_org_owner_state": {
+          "name": "automation_org_owner_state",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "automation_due": {
+          "name": "automation_due",
+          "columns": [
+            "state",
+            "next_due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_id": {
+          "name": "automation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "artifact_view_revision": {
+      "name": "artifact_view_revision",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_member_id": {
+          "name": "created_by_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "react_source": {
+          "name": "react_source",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "css_source": {
+          "name": "css_source",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiled_html": {
+          "name": "compiled_html",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "build_diagnostics": {
+          "name": "build_diagnostics",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "build_status": {
+          "name": "build_status",
+          "type": "enum('ready','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_digest": {
+          "name": "source_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_digest": {
+          "name": "resource_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema_digest": {
+          "name": "output_schema_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csp": {
+          "name": "csp",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiler_name": {
+          "name": "compiler_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiler_version": {
+          "name": "compiler_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "react_version": {
+          "name": "react_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiled_html_bytes": {
+          "name": "compiled_html_bytes",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "artifact_view_revision_view_created": {
+          "name": "artifact_view_revision_view_created",
+          "columns": [
+            "artifact_view_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_revision_org_status": {
+          "name": "artifact_view_revision_org_status",
+          "columns": [
+            "organization_id",
+            "build_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "artifact_view_revision_id": {
+          "name": "artifact_view_revision_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "artifact_view": {
+      "name": "artifact_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','retired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "active_revision_id": {
+          "name": "active_revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_in_workflow": {
+          "name": "use_in_workflow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "artifact_view_org_script": {
+          "name": "artifact_view_org_script",
+          "columns": [
+            "organization_id",
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_org_owner": {
+          "name": "artifact_view_org_owner",
+          "columns": [
+            "organization_id",
+            "owner_member_id"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_active_revision": {
+          "name": "artifact_view_active_revision",
+          "columns": [
+            "active_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard_app": {
+      "name": "dashboard_app",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_app_organization_id_member_id_artifact_view_id_pk": {
+          "name": "dashboard_app_organization_id_member_id_artifact_view_id_pk",
+          "columns": [
+            "organization_id",
+            "member_id",
+            "artifact_view_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workflow_run": {
+      "name": "workflow_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('succeeded','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "script_input": {
+          "name": "script_input",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "script_input_digest": {
+          "name": "script_input_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_schema_digest": {
+          "name": "input_schema_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_result": {
+          "name": "validated_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_markdown": {
+          "name": "result_markdown",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_digest": {
+          "name": "result_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema_digest": {
+          "name": "output_schema_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "renderer_version": {
+          "name": "renderer_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_content_deleted_at": {
+          "name": "artifact_content_deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workflow_run_org_created": {
+          "name": "workflow_run_org_created",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "workflow_run_automation": {
+          "name": "workflow_run_automation",
+          "columns": [
+            "automation_run_id"
+          ],
+          "isUnique": false
+        },
+        "workflow_run_artifact_history": {
+          "name": "workflow_run_artifact_history",
+          "columns": [
+            "config_object_id",
+            "finished_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connected_account": {
+      "name": "connected_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_code_verifier": {
+          "name": "pending_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_health": {
+          "name": "credential_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connected_account_organization_id": {
+          "name": "connected_account_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connected_account_member_provider": {
+          "name": "connected_account_member_provider",
+          "columns": [
+            "org_membership_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_mcp_connection_access_grant": {
+      "name": "external_mcp_connection_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_mcp_requirement_binding_id": {
+          "name": "plugin_mcp_requirement_binding_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "emc_access_grant_organization_id": {
+          "name": "emc_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_connection_id": {
+          "name": "emc_access_grant_connection_id",
+          "columns": [
+            "external_mcp_connection_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_plugin_mcp_binding_id": {
+          "name": "emc_access_grant_plugin_mcp_binding_id",
+          "columns": [
+            "plugin_mcp_requirement_binding_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_org_membership_id": {
+          "name": "emc_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_team_id": {
+          "name": "emc_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_connection_member": {
+          "name": "emc_access_grant_connection_member",
+          "columns": [
+            "external_mcp_connection_id",
+            "org_membership_id",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "emc_access_grant_connection_team": {
+          "name": "emc_access_grant_connection_team",
+          "columns": [
+            "external_mcp_connection_id",
+            "team_id",
+            "source_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_mcp_connection_access_grant_id": {
+          "name": "external_mcp_connection_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_mcp_connection": {
+      "name": "external_mcp_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "enum('oauth','apikey','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum('external_mcp','native_provider')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'external_mcp'"
+        },
+        "native_provider_key": {
+          "name": "native_provider_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_configuration": {
+          "name": "oauth_configuration",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_policy": {
+          "name": "tool_policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_directly": {
+          "name": "expose_directly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "enum('shared','per_member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_code_verifier": {
+          "name": "pending_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_health": {
+          "name": "credential_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_issuer_review_required_at": {
+          "name": "oauth_issuer_review_required_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_mcp_connection_organization_id": {
+          "name": "external_mcp_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "external_mcp_connection_org_external_key": {
+          "name": "external_mcp_connection_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_oauth_client": {
+      "name": "org_oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_oauth_client_org_provider": {
+          "name": "org_oauth_client_org_provider",
+          "columns": [
+            "organization_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_oauth_client_id": {
+          "name": "org_oauth_client_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_mcp_requirement_binding": {
+      "name": "plugin_mcp_requirement_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "required_auth_type": {
+          "name": "required_auth_type",
+          "type": "enum('oauth','apikey','none')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connection_owned_by_plugin": {
+          "name": "connection_owned_by_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "plugin_mcp_req_binding_plugin_id": {
+          "name": "plugin_mcp_req_binding_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_config_object_id": {
+          "name": "plugin_mcp_req_binding_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_connection_id": {
+          "name": "plugin_mcp_req_binding_connection_id",
+          "columns": [
+            "external_mcp_connection_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_org_plugin_object_server": {
+          "name": "plugin_mcp_req_binding_org_plugin_object_server",
+          "columns": [
+            "organization_id",
+            "plugin_id",
+            "config_object_id",
+            "server_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_mcp_requirement_binding_id": {
+          "name": "plugin_mcp_requirement_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_access": {
+      "name": "llm_provider_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_access_org_membership_id": {
+          "name": "llm_provider_access_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_team_id": {
+          "name": "llm_provider_access_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_provider_org_membership": {
+          "name": "llm_provider_access_provider_org_membership",
+          "columns": [
+            "llm_provider_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_access_provider_team": {
+          "name": "llm_provider_access_provider_team",
+          "columns": [
+            "llm_provider_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_access_id": {
+          "name": "llm_provider_access_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_member_credential": {
+      "name": "llm_provider_member_credential",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_principal_id": {
+          "name": "external_principal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_credential_id": {
+          "name": "external_credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('active','blocked','stale','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "enum('member','admin','provisioner')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_member_credential_organization_id": {
+          "name": "llm_provider_member_credential_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_member_credential_member_provider": {
+          "name": "llm_provider_member_credential_member_provider",
+          "columns": [
+            "org_membership_id",
+            "llm_provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_member_credential_id": {
+          "name": "llm_provider_member_credential_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_model": {
+      "name": "llm_provider_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_model_model_id": {
+          "name": "llm_provider_model_model_id",
+          "columns": [
+            "model_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_model_provider_model": {
+          "name": "llm_provider_model_provider_model",
+          "columns": [
+            "llm_provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_model_id": {
+          "name": "llm_provider_model_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider": {
+      "name": "llm_provider",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum('models_dev','custom','openwork')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "enum('shared','per_member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_org_external_key": {
+          "name": "llm_provider_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_organization_id": {
+          "name": "llm_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_created_by_org_membership_id": {
+          "name": "llm_provider_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_source": {
+          "name": "llm_provider_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_provider_id": {
+          "name": "llm_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_access_grant": {
+      "name": "config_object_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_access_grant_organization_id": {
+          "name": "config_object_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_membership_id": {
+          "name": "config_object_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_team_id": {
+          "name": "config_object_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_wide": {
+          "name": "config_object_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_object_org_membership": {
+          "name": "config_object_access_grant_object_org_membership",
+          "columns": [
+            "config_object_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "config_object_access_grant_object_team": {
+          "name": "config_object_access_grant_object_team",
+          "columns": [
+            "config_object_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_access_grant_id": {
+          "name": "config_object_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object": {
+      "name": "config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom','script','workflow','app')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_mode": {
+          "name": "source_mode",
+          "type": "enum('cloud','import','connector')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_name": {
+          "name": "current_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_extension": {
+          "name": "current_file_extension",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_relative_path": {
+          "name": "current_relative_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_organization_id": {
+          "name": "config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_type": {
+          "name": "config_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "config_object_source_mode": {
+          "name": "config_object_source_mode",
+          "columns": [
+            "source_mode"
+          ],
+          "isUnique": false
+        },
+        "config_object_status": {
+          "name": "config_object_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "config_object_created_by_org_membership_id": {
+          "name": "config_object_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_connector_instance_id": {
+          "name": "config_object_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_current_relative_path": {
+          "name": "config_object_current_relative_path",
+          "columns": [
+            "current_relative_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_version": {
+      "name": "config_object_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_payload_json": {
+          "name": "normalized_payload_json",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_source_text": {
+          "name": "raw_source_text",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "enum('cloud','import','connector','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deleted_version": {
+          "name": "is_deleted_version",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "config_object_version_organization_id": {
+          "name": "config_object_version_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_created_by_org_membership_id": {
+          "name": "config_object_version_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_connector_sync_event_id": {
+          "name": "config_object_version_connector_sync_event_id",
+          "columns": [
+            "connector_sync_event_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_source_revision_ref": {
+          "name": "config_object_version_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_lookup_latest": {
+          "name": "config_object_version_lookup_latest",
+          "columns": [
+            "config_object_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_account": {
+      "name": "connector_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_ref": {
+          "name": "external_account_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','disconnected','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_account_created_by_org_membership_id": {
+          "name": "connector_account_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_connector_type": {
+          "name": "connector_account_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "idx_connector_account_on_remote_id": {
+          "name": "idx_connector_account_on_remote_id",
+          "columns": [
+            "remote_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_status": {
+          "name": "connector_account_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_account_org_type_remote_id": {
+          "name": "connector_account_org_type_remote_id",
+          "columns": [
+            "organization_id",
+            "connector_type",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance_access_grant": {
+      "name": "connector_instance_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instance_access_grant_organization_id": {
+          "name": "connector_instance_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_membership_id": {
+          "name": "connector_instance_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_team_id": {
+          "name": "connector_instance_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_wide": {
+          "name": "connector_instance_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_instance_org_membership": {
+          "name": "connector_instance_access_grant_instance_org_membership",
+          "columns": [
+            "connector_instance_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "connector_instance_access_grant_instance_team": {
+          "name": "connector_instance_access_grant_instance_team",
+          "columns": [
+            "connector_instance_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_access_grant_id": {
+          "name": "connector_instance_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance": {
+      "name": "connector_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','disabled','archived','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "instance_config_json": {
+          "name": "instance_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_cursor": {
+          "name": "last_sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_instance_connector_account_id": {
+          "name": "connector_instance_connector_account_id",
+          "columns": [
+            "connector_account_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_created_by_org_membership_id": {
+          "name": "connector_instance_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_connector_type": {
+          "name": "connector_instance_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_status": {
+          "name": "connector_instance_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_org_name": {
+          "name": "connector_instance_org_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_mapping": {
+      "name": "connector_mapping",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mapping_kind": {
+          "name": "mapping_kind",
+          "type": "enum('path','api','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom','script','workflow','app')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_add_to_plugin": {
+          "name": "auto_add_to_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mapping_config_json": {
+          "name": "mapping_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_mapping_organization_id": {
+          "name": "connector_mapping_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_connector_instance_id": {
+          "name": "connector_mapping_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_object_type": {
+          "name": "connector_mapping_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_plugin_id": {
+          "name": "connector_mapping_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_target_selector_object_type": {
+          "name": "connector_mapping_target_selector_object_type",
+          "columns": [
+            "connector_target_id",
+            "selector",
+            "object_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_binding": {
+      "name": "connector_source_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_stable_ref": {
+          "name": "external_stable_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_source_revision_ref": {
+          "name": "last_seen_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_source_binding_organization_id": {
+          "name": "connector_source_binding_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_instance_id": {
+          "name": "connector_source_binding_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_target_id": {
+          "name": "connector_source_binding_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_mapping_id": {
+          "name": "connector_source_binding_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_external_locator": {
+          "name": "connector_source_binding_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_config_object": {
+          "name": "connector_source_binding_config_object",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_binding_id": {
+          "name": "connector_source_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_tombstone": {
+      "name": "connector_source_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "former_config_object_id": {
+          "name": "former_config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_in_sync_event_id": {
+          "name": "deleted_in_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_source_revision_ref": {
+          "name": "deleted_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "connector_source_tombstone_organization_id": {
+          "name": "connector_source_tombstone_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_instance_id": {
+          "name": "connector_source_tombstone_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_target_id": {
+          "name": "connector_source_tombstone_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_mapping_id": {
+          "name": "connector_source_tombstone_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_external_locator": {
+          "name": "connector_source_tombstone_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_former_config_object_id": {
+          "name": "connector_source_tombstone_former_config_object_id",
+          "columns": [
+            "former_config_object_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_tombstone_id": {
+          "name": "connector_source_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_sync_event": {
+      "name": "connector_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('push','installation','installation_repositories','repository','manual_resync')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_ref": {
+          "name": "external_event_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_sync_event_organization_id": {
+          "name": "connector_sync_event_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_instance_id": {
+          "name": "connector_sync_event_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_target_id": {
+          "name": "connector_sync_event_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_target_status": {
+          "name": "connector_sync_event_target_status",
+          "columns": [
+            "connector_target_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_event_type": {
+          "name": "connector_sync_event_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status": {
+          "name": "connector_sync_event_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status_next_attempt_at": {
+          "name": "connector_sync_event_status_next_attempt_at",
+          "columns": [
+            "status",
+            "next_attempt_at"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_source_revision_ref": {
+          "name": "connector_sync_event_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_external_event_ref": {
+          "name": "connector_sync_event_external_event_ref",
+          "columns": [
+            "external_event_ref"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_target": {
+      "name": "connector_target",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "enum('repository_branch')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_target_ref": {
+          "name": "external_target_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_config_json": {
+          "name": "target_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_target_organization_id": {
+          "name": "connector_target_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_connector_type": {
+          "name": "connector_target_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_target_type_created_id": {
+          "name": "connector_target_type_created_id",
+          "columns": [
+            "connector_type",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_target_kind": {
+          "name": "connector_target_target_kind",
+          "columns": [
+            "target_kind"
+          ],
+          "isUnique": false
+        },
+        "connector_target_instance_remote_id": {
+          "name": "connector_target_instance_remote_id",
+          "columns": [
+            "connector_instance_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_access_grant": {
+      "name": "marketplace_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_access_grant_organization_id": {
+          "name": "marketplace_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_membership_id": {
+          "name": "marketplace_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_team_id": {
+          "name": "marketplace_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_wide": {
+          "name": "marketplace_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_marketplace_org_membership": {
+          "name": "marketplace_access_grant_marketplace_org_membership",
+          "columns": [
+            "marketplace_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "marketplace_access_grant_marketplace_team": {
+          "name": "marketplace_access_grant_marketplace_team",
+          "columns": [
+            "marketplace_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_access_grant_id": {
+          "name": "marketplace_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_plugin": {
+      "name": "marketplace_plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_plugin_organization_id": {
+          "name": "marketplace_plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_plugin_id": {
+          "name": "marketplace_plugin_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_marketplace_plugin": {
+          "name": "marketplace_plugin_marketplace_plugin",
+          "columns": [
+            "marketplace_id",
+            "plugin_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_plugin_id": {
+          "name": "marketplace_plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace": {
+      "name": "marketplace",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_org_external_key": {
+          "name": "marketplace_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "marketplace_organization_id": {
+          "name": "marketplace_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_created_by_org_membership_id": {
+          "name": "marketplace_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_status": {
+          "name": "marketplace_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_access_grant": {
+      "name": "plugin_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_access_grant_organization_id": {
+          "name": "plugin_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_membership_id": {
+          "name": "plugin_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_team_id": {
+          "name": "plugin_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_wide": {
+          "name": "plugin_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_plugin_org_membership": {
+          "name": "plugin_access_grant_plugin_org_membership",
+          "columns": [
+            "plugin_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "plugin_access_grant_plugin_team": {
+          "name": "plugin_access_grant_plugin_team",
+          "columns": [
+            "plugin_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_access_grant_id": {
+          "name": "plugin_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_config_object": {
+      "name": "plugin_config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_config_object_organization_id": {
+          "name": "plugin_config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_config_object_id": {
+          "name": "plugin_config_object_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_connector_mapping_id": {
+          "name": "plugin_config_object_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_plugin_config_object": {
+          "name": "plugin_config_object_plugin_config_object",
+          "columns": [
+            "plugin_id",
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_config_object_id": {
+          "name": "plugin_config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin": {
+      "name": "plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_repository_url": {
+          "name": "source_repository_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_format": {
+          "name": "source_format",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_schema_version": {
+          "name": "source_schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_organization_id": {
+          "name": "plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_created_by_org_membership_id": {
+          "name": "plugin_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_status": {
+          "name": "plugin_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_subscriptions": {
+      "name": "org_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('inference','seat','web')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('incomplete','incomplete_expired','trialing','active','past_due','canceled','unpaid','paused','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'incomplete'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "payment_failed": {
+          "name": "payment_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_customer_id": {
+          "name": "org_subscriptions_customer_id",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": false
+        },
+        "org_subscriptions_subscription_id": {
+          "name": "org_subscriptions_subscription_id",
+          "columns": [
+            "stripe_subscription_id"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_org_type": {
+          "name": "org_subscriptions_org_type",
+          "columns": [
+            "organization_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_status": {
+          "name": "org_subscriptions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_subscriptions_id": {
+          "name": "org_subscriptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_member": {
+      "name": "team_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_member_org_membership_id": {
+          "name": "team_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_user_id": {
+          "name": "team_member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_membership_key": {
+          "name": "team_member_membership_key",
+          "columns": [
+            "membership_key"
+          ],
+          "isUnique": true
+        },
+        "team_member_team_org_membership": {
+          "name": "team_member_team_org_membership",
+          "columns": [
+            "team_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_member_id": {
+          "name": "team_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "team_org_external_key": {
+          "name": "team_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "team_organization_name": {
+          "name": "team_organization_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_id": {
+          "name": "team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "temp_file": {
+      "name": "temp_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upload_token_hash": {
+          "name": "upload_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_token_hash": {
+          "name": "download_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'application/octet-stream'"
+        },
+        "max_bytes": {
+          "name": "max_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "enum('volume','s3')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','uploaded')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expected_sha256": {
+          "name": "expected_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "temp_file_upload_token_hash": {
+          "name": "temp_file_upload_token_hash",
+          "columns": [
+            "upload_token_hash"
+          ],
+          "isUnique": true
+        },
+        "temp_file_download_token_hash": {
+          "name": "temp_file_download_token_hash",
+          "columns": [
+            "download_token_hash"
+          ],
+          "isUnique": true
+        },
+        "temp_file_organization_id": {
+          "name": "temp_file_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "temp_file_expires_at": {
+          "name": "temp_file_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "temp_file_id": {
+          "name": "temp_file_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_event": {
+      "name": "audit_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_event_org_id": {
+          "name": "audit_event_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "audit_event_worker_id": {
+          "name": "audit_event_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "daytona_sandbox": {
+      "name": "daytona_sandbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_volume_id": {
+          "name": "workspace_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_volume_id": {
+          "name": "data_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url": {
+          "name": "signed_preview_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url_expires_at": {
+          "name": "signed_preview_url_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "daytona_sandbox_worker_id": {
+          "name": "daytona_sandbox_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": true
+        },
+        "daytona_sandbox_sandbox_id": {
+          "name": "daytona_sandbox_sandbox_id",
+          "columns": [
+            "sandbox_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daytona_sandbox_id": {
+          "name": "daytona_sandbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_bundle": {
+      "name": "worker_bundle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "worker_bundle_worker_id": {
+          "name": "worker_bundle_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_bundle_id": {
+          "name": "worker_bundle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_instance": {
+      "name": "worker_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_instance_worker_id": {
+          "name": "worker_instance_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker": {
+      "name": "worker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "enum('local','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_version": {
+          "name": "image_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_backend": {
+          "name": "sandbox_backend",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_code": {
+          "name": "cloud_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_stage": {
+          "name": "cloud_failure_stage",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_reference": {
+          "name": "cloud_failure_reference",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_at": {
+          "name": "cloud_failure_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_org_id": {
+          "name": "worker_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "worker_created_by_user_id": {
+          "name": "worker_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "worker_status": {
+          "name": "worker_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "worker_last_heartbeat_at": {
+          "name": "worker_last_heartbeat_at",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        },
+        "worker_last_active_at": {
+          "name": "worker_last_active_at",
+          "columns": [
+            "last_active_at"
+          ],
+          "isUnique": false
+        },
+        "worker_claimable_updated": {
+          "name": "worker_claimable_updated",
+          "columns": [
+            "destination",
+            "sandbox_backend",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_id": {
+          "name": "worker_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_token": {
+      "name": "worker_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('client','host','activity')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worker_token_worker_id": {
+          "name": "worker_token_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        },
+        "worker_token_token": {
+          "name": "worker_token_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_token_id": {
+          "name": "worker_token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_allowlist": {
+      "name": "admin_allowlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "admin_allowlist_email": {
+          "name": "admin_allowlist_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_allowlist_id": {
+          "name": "admin_allowlist_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit": {
+      "name": "rate_limit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limit_key": {
+          "name": "rate_limit_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_id": {
+          "name": "rate_limit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_event": {
+      "name": "telemetry_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_event_org_id_type_ts": {
+          "name": "telemetry_event_org_id_type_ts",
+          "columns": [
+            "org_id",
+            "event_type",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_id_member_id": {
+          "name": "telemetry_event_org_id_member_id",
+          "columns": [
+            "org_id",
+            "member_id"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_member_ts": {
+          "name": "telemetry_event_member_ts",
+          "columns": [
+            "member_id",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_session_ts": {
+          "name": "telemetry_event_org_session_ts",
+          "columns": [
+            "org_id",
+            "session_id",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_event_id": {
+          "name": "telemetry_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_session_dimension": {
+      "name": "telemetry_session_dimension",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_type": {
+          "name": "dimension_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_value": {
+          "name": "dimension_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_label": {
+          "name": "dimension_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_session_dimension_org_source_session_type": {
+          "name": "telemetry_session_dimension_org_source_session_type",
+          "columns": [
+            "org_id",
+            "source",
+            "session_id",
+            "dimension_type"
+          ],
+          "isUnique": true
+        },
+        "telemetry_session_dimension_filter": {
+          "name": "telemetry_session_dimension_filter",
+          "columns": [
+            "org_id",
+            "dimension_type",
+            "dimension_value",
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_session_dimension_id": {
+          "name": "telemetry_session_dimension_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "models_analytics_event": {
+      "name": "models_analytics_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_complete": {
+          "name": "usage_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "models_analytics_dedup": {
+          "name": "models_analytics_dedup",
+          "columns": [
+            "org_id",
+            "member_id",
+            "source",
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "models_analytics_activity": {
+          "name": "models_analytics_activity",
+          "columns": [
+            "org_id",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_task": {
+          "name": "models_analytics_task",
+          "columns": [
+            "org_id",
+            "member_id",
+            "session_id",
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_consumption": {
+          "name": "models_analytics_consumption",
+          "columns": [
+            "org_id",
+            "type",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_export": {
+          "name": "models_analytics_export",
+          "columns": [
+            "org_id",
+            "exported_at",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "models_analytics_event_id": {
+          "name": "models_analytics_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "models_analytics_settings": {
+      "name": "models_analytics_settings",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consented_by": {
+          "name": "consented_by",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "export_enabled": {
+          "name": "export_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "export_enabled_at": {
+          "name": "export_enabled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_host": {
+          "name": "langfuse_host",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_public_key": {
+          "name": "langfuse_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_secret_key": {
+          "name": "langfuse_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "models_analytics_settings_org_id": {
+          "name": "models_analytics_settings_org_id",
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_free_reservations": {
+      "name": "inference_free_reservations",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inference_key_id": {
+          "name": "inference_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reserved_amount": {
+          "name": "reserved_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_token_cap": {
+          "name": "input_token_cap",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actual_amount": {
+          "name": "actual_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('held','settled','invalid')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'held'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inference_free_reservations_user_window": {
+          "name": "inference_free_reservations_user_window",
+          "columns": [
+            "user_id",
+            "window_start_at"
+          ],
+          "isUnique": false
+        },
+        "inference_free_reservations_external_event": {
+          "name": "inference_free_reservations_external_event",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_free_reservations_request_id": {
+          "name": "inference_free_reservations_request_id",
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_free_usage_buckets": {
+      "name": "inference_free_usage_buckets",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reserved_amount": {
+          "name": "reserved_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_free_usage_buckets_user_id_window_start_at_pk": {
+          "name": "inference_free_usage_buckets_user_id_window_start_at_pk",
+          "columns": [
+            "user_id",
+            "window_start_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "account_account_id_provider_id": {
+        "columns": {
+          "`account_id`(191)": {
+            "isExpression": true
+          },
+          "`provider_id`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "oauth_access_token_token": {
+        "columns": {
+          "`token`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "oauth_refresh_token_token": {
+        "columns": {
+          "`token`(191)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -645,6 +645,13 @@
       "when": 1788675287930,
       "tag": "0092_models_task_analytics",
       "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "5",
+      "when": 1788825600000,
+      "tag": "0093_free_inference_allowance",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/inference.ts
+++ b/ee/packages/den-db/src/schema/inference.ts
@@ -1,10 +1,12 @@
 import { relations } from "drizzle-orm"
 import {
   bigint,
+  boolean,
   index,
   int,
   mysqlEnum,
   mysqlTable,
+  primaryKey,
   timestamp,
   uniqueIndex,
   varchar,
@@ -15,6 +17,42 @@ import { MemberTable, OrganizationTable } from "./org"
 
 export const InferenceKeyStatus = ["active", "revoked"] as const
 export const InferenceOrgUpstreamProviderKeyStatus = ["active", "revoked"] as const
+
+// Person-scoped, immutable UTC weeks. This is deliberately separate from paid
+// organization usage: changing memberships or issuing another key adds no budget.
+export const InferenceFreeUsageBucketTable = mysqlTable("inference_free_usage_buckets", {
+  user_id: denTypeIdColumn("user", "user_id").notNull(),
+  window_start_at: timestamp("window_start_at", { fsp: 3 }).notNull(),
+  window_end_at: timestamp("window_end_at", { fsp: 3 }).notNull(),
+  limit_amount: bigint("limit_amount", { mode: "number" }).notNull(),
+  used_amount: bigint("used_amount", { mode: "number" }).notNull().default(0),
+  reserved_amount: bigint("reserved_amount", { mode: "number" }).notNull().default(0),
+  blocked: boolean("blocked").notNull().default(false),
+}, (table) => [primaryKey({ columns: [table.user_id, table.window_start_at] })])
+
+export const InferenceFreeReservationTable = mysqlTable("inference_free_reservations", {
+  request_id: varchar("request_id", { length: 64 }).notNull().primaryKey(),
+  user_id: denTypeIdColumn("user", "user_id").notNull(),
+  window_start_at: timestamp("window_start_at", { fsp: 3 }).notNull(),
+  organization_id: denTypeIdColumn("organization", "organization_id").notNull(),
+  org_membership_id: denTypeIdColumn("member", "org_membership_id").notNull(),
+  inference_key_id: denTypeIdColumn("inferenceKey", "inference_key_id").notNull(),
+  model_id: varchar("model_id", { length: 255 }).notNull(),
+  upstream_model: varchar("upstream_model", { length: 255 }).notNull(),
+  reserved_amount: bigint("reserved_amount", { mode: "number" }).notNull(),
+  input_token_cap: int("input_token_cap").notNull(),
+  max_output_tokens: int("max_output_tokens").notNull(),
+  input_token_price: bigint("input_token_price", { mode: "number" }).notNull(),
+  output_token_price: bigint("output_token_price", { mode: "number" }).notNull(),
+  actual_amount: bigint("actual_amount", { mode: "number" }),
+  external_event_id: varchar("external_event_id", { length: 255 }),
+  status: mysqlEnum("status", ["held", "settled", "invalid"]).notNull().default("held"),
+  created_at: timestamps.created_at,
+  settled_at: timestamp("settled_at", { fsp: 3 }),
+}, (table) => [
+  index("inference_free_reservations_user_window").on(table.user_id, table.window_start_at),
+  uniqueIndex("inference_free_reservations_external_event").on(table.external_event_id),
+])
 
 export const InferenceKeyTable = mysqlTable(
   "inference_keys",

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -272,7 +272,7 @@ async function waitForAuthProbe(ref: DenRef, service: SpawnedService): Promise<v
   throw new Error(`Den auth behavioral probe failed at ${url}; expected a non-403 response. Last: ${last}. Log:\n${await logTail(service.logPath)}`);
 }
 
-async function runDbPush(databaseUrl: string): Promise<void> {
+export async function runDbPush(databaseUrl: string): Promise<void> {
   try {
     const commands = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1"
       ? [

--- a/evals/packages/env/src/free-inference-service.ts
+++ b/evals/packages/env/src/free-inference-service.ts
@@ -1,0 +1,135 @@
+import { createServer } from "node:http";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+
+export interface UpstreamPlan {
+  cost: number | null;
+  hold?: boolean;
+}
+
+export interface UpstreamCall {
+  prompt: string;
+  url: string;
+  authorization: string | null;
+  redirect: RequestRedirect | undefined;
+  requestId: string;
+  generationId: string;
+  body: Record<string, unknown>;
+}
+
+export function record(value: unknown): Record<string, unknown> {
+  const isRecord = (input: unknown): input is Record<string, unknown> => Boolean(input) && typeof input === "object" && !Array.isArray(input);
+  if (!isRecord(value)) throw new Error("Expected a JSON object");
+  return value;
+}
+
+export async function bootFreeInferenceService() {
+  const plans = new Map<string, UpstreamPlan>();
+  const gates = new Map<string, Array<() => void>>();
+  const calls: UpstreamCall[] = [];
+
+  // Install before importing the app: its default proxy dependency captures fetch.
+  // There is deliberately no network fallback, even for an unexpected URL.
+  globalThis.fetch = async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url !== "https://openrouter.ai/api/v1/chat/completions") throw new Error(`Unexpected upstream: ${url}`);
+    if (typeof init?.body !== "string") throw new Error("Expected a serialized completion");
+    const body = record(JSON.parse(init.body));
+    const messages = body.messages;
+    if (!Array.isArray(messages)) throw new Error("Expected messages");
+    const prompt = record(messages[0]).content;
+    if (typeof prompt !== "string") throw new Error("Expected a text prompt");
+    const plan = plans.get(prompt);
+    if (!plan) throw new Error("Unplanned upstream request");
+    const headers = new Headers(init.headers);
+    const requestId = headers.get("x-openwork-request-id");
+    if (!requestId) throw new Error("Missing request identity");
+    const generationId = `gen-${requestId}`;
+    calls.push({ prompt, url, authorization: headers.get("authorization"), redirect: init.redirect, requestId, generationId, body });
+    if (plan.hold) {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("Unreleased upstream fixture")), 20_000);
+        const release = () => { clearTimeout(timer); resolve(); };
+        gates.set(prompt, [...(gates.get(prompt) ?? []), release]);
+      });
+    }
+    const usage = { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16, ...(plan.cost === null ? {} : { cost: plan.cost }) };
+    const identity = { id: generationId, model: body.model };
+    if (!body.stream) {
+      return Response.json({ ...identity, choices: [{ index: 0, message: { role: "assistant", content: "Fixture reply: caf\u00e9" }, finish_reason: "stop" }], usage });
+    }
+    const wire = [
+      { ...identity, choices: [{ index: 0, delta: { content: "Fixture reply: caf\u00e9" }, finish_reason: null }] },
+      { ...identity, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+      { ...identity, choices: [], usage },
+      "[DONE]",
+    ].map((event) => `data: ${typeof event === "string" ? event : JSON.stringify(event)}\r\n\r\n`).join("");
+    const bytes = new TextEncoder().encode(wire);
+    let offset = 0;
+    return new Response(new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (offset === bytes.length) return controller.close();
+        // Split inside UTF-8, JSON and SSE delimiters, not just between events.
+        controller.enqueue(bytes.slice(offset, ++offset));
+      },
+    }), { headers: { "content-type": "text/event-stream" } });
+  };
+
+  const { default: app } = await import("../../../../ee/apps/inference/src/app.ts");
+  app.get("/__fixture/upstream", (c) => c.json(calls));
+  app.post("/__fixture/plan", async (c) => {
+    const body = record(await c.req.json());
+    if (typeof body.prompt !== "string" || (body.cost !== null && typeof body.cost !== "number")) return c.body(null, 400);
+    plans.set(body.prompt, { cost: body.cost, hold: body.hold === true });
+    return c.body(null, 204);
+  });
+  app.post("/__fixture/release", async (c) => {
+    const body = record(await c.req.json());
+    if (typeof body.prompt !== "string") return c.body(null, 400);
+    for (const release of gates.get(body.prompt) ?? []) release();
+    gates.delete(body.prompt);
+    return c.body(null, 204);
+  });
+
+  const server = createServer(async (request, response) => {
+    try {
+      const headers = new Headers();
+      for (const [name, value] of Object.entries(request.headers)) {
+        if (value !== undefined) headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+      }
+      const reader = Readable.toWeb(request).getReader();
+      const init = {
+        method: request.method,
+        headers,
+        body: request.method === "GET" || request.method === "HEAD" ? undefined : new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            const chunk = await reader.read();
+            if (chunk.done) controller.close();
+            else controller.enqueue(chunk.value);
+          },
+          cancel: (reason) => reader.cancel(reason),
+        }),
+        duplex: "half",
+      };
+      const result = await app.fetch(new Request(`http://127.0.0.1${request.url}`, init));
+      response.writeHead(result.status, Object.fromEntries(result.headers));
+      const output = result.body?.getReader();
+      if (output) for (;;) {
+        const chunk = await output.read();
+        if (chunk.done) break;
+        response.write(chunk.value);
+      }
+      response.end();
+    } catch (error) {
+      console.error(error);
+      response.writeHead(500).end();
+    }
+  });
+  server.listen(0, "127.0.0.1", () => {
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Missing fixture address");
+    process.send?.({ url: `http://127.0.0.1:${address.port}` });
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await bootFreeInferenceService();

--- a/evals/packages/env/src/free-inference.ts
+++ b/evals/packages/env/src/free-inference.ts
@@ -1,0 +1,161 @@
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+import { createConnection } from "mysql2/promise";
+import type { RowDataPacket } from "mysql2";
+import type { Place } from "./place.ts";
+import { SkipError } from "./needs.ts";
+import { DEFAULT_MYSQL_URL, ephemeralDatabaseName, localMysqlIsRunning } from "./place.ts";
+import { runDbPush } from "./den.ts";
+import { record } from "./free-inference-service.ts";
+import type { UpstreamCall, UpstreamPlan } from "./free-inference-service.ts";
+
+export const freeModel = "openai/gpt-5.6-luna";
+export const freeCredential = "fixture-free-upstream-not-a-real-key";
+const webhookSecret = "fixture-webhook-not-a-real-secret";
+const root = fileURLToPath(new URL("../../../..", import.meta.url));
+const id = (prefix: string) => `${prefix}_0${randomBytes(13).toString("hex").slice(0, 25)}`;
+
+export interface MemberKey { userId: string; orgId: string; memberId: string; keyId: string; key: string }
+interface Bucket extends RowDataPacket {
+  user_id: string; window_start_at: Date; window_end_at: Date;
+  limit_amount: number; used_amount: number; reserved_amount: number; blocked: number;
+}
+interface Reservation extends RowDataPacket {
+  request_id: string; user_id: string; window_start_at: Date;
+  organization_id: string; org_membership_id: string; inference_key_id: string;
+  model_id: string; upstream_model: string; max_output_tokens: number;
+  reserved_amount: number; actual_amount: number | null; external_event_id: string | null;
+  status: "held" | "settled" | "invalid";
+}
+
+/** Real app + real schema, isolated DB only. No Den, Redis, provider secrets or UI. */
+export async function freeInferenceWorld(stack: AsyncDisposableStack, place: Place) {
+  if (place.kind !== "local") throw new SkipError("free inference fixture requires local MySQL; no remote fallback is implemented");
+  const mysql = new URL(process.env.OPENWORK_EVAL_MYSQL_URL?.trim() || DEFAULT_MYSQL_URL);
+  if (!["127.0.0.1", "localhost", "[::1]"].includes(mysql.hostname)) throw new Error("Free inference proof refuses non-loopback MySQL");
+  if (!await localMysqlIsRunning()) throw new SkipError("local MySQL; run pnpm dev:den:mysql");
+  const database = stack.use(await place.db(ephemeralDatabaseName("free_inference")));
+  await runDbPush(database.url);
+  const sql = await createConnection({ uri: database.url, timezone: "Z" });
+  stack.defer(() => sql.end());
+  await sql.query("SET time_zone = '+00:00'");
+
+  const child = spawn(process.execPath, [
+    "--conditions=development", "--import", `${root}/ee/apps/inference/node_modules/tsx/dist/loader.mjs`,
+    `${root}/evals/packages/env/src/free-inference-service.ts`,
+  ], {
+    cwd: root,
+    // Do not inherit credentials, Node preload hooks or production DB settings.
+    env: {
+      PATH: process.env.PATH, HOME: process.env.HOME, TZ: "UTC", NODE_ENV: "test",
+      DATABASE_URL: database.url, DB_MODE: "mysql",
+      DEN_DB_ENCRYPTION_KEY: "fixture-db-encryption-placeholder-1234567890",
+      INFERENCE_FREE_ENABLED: "true", INFERENCE_FREE_WEEKLY_BUDGET_USD: "1",
+      INFERENCE_FREE_MODEL_ID: freeModel, INFERENCE_FREE_UPSTREAM_API_KEY: freeCredential,
+      INFERENCE_WEBHOOK_SECRET: webhookSecret, INFERENCE_ADMIN_TOKEN: "fixture-admin",
+      OPENAI_API_KEY: "", OPENAI_REALTIME_API_KEY: "", SENTRY_DSN: "", SENTRY_LOG_LEVEL: "off",
+      OPENROUTER_UPSTREAM_URL: "https://openrouter.ai/api/v1", OPENWORK_DEV_MODE: "0",
+    },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  let log = "";
+  child.stdout?.on("data", (chunk: Buffer) => { log = (log + chunk.toString()).slice(-8_000); });
+  child.stderr?.on("data", (chunk: Buffer) => { log = (log + chunk.toString()).slice(-8_000); });
+  stack.defer(async () => {
+    if (!child.pid || child.exitCode !== null || child.signalCode !== null) return;
+    const exited = once(child, "exit");
+    child.kill("SIGTERM");
+    const timer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+    try { await exited; } finally { clearTimeout(timer); }
+  });
+  const url = await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Inference fixture did not boot: ${log}`)), 30_000);
+    child.once("error", (error) => { clearTimeout(timer); reject(error); });
+    child.once("exit", (code) => { clearTimeout(timer); reject(new Error(`Inference fixture exited (${code}): ${log}`)); });
+    child.once("message", (message) => {
+      clearTimeout(timer);
+      const value = record(message).url;
+      if (typeof value === "string") resolve(value);
+      else reject(new Error("Invalid inference fixture address"));
+    });
+  });
+  const http = (path: string, init?: RequestInit) => fetch(`${url}${path}`, { ...init, signal: AbortSignal.timeout(25_000) });
+  const ready = await http("/ready");
+  if (!ready.ok) throw new Error(`Inference database readiness failed: ${await ready.text()} ${log}`);
+  const control = async (path: string, body: unknown) => {
+    const result = await http(`/__fixture/${path}`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    if (!result.ok) throw new Error(`Fixture control failed: ${path} ${result.status}`);
+  };
+  const orgs = [id("org"), id("org")];
+  for (const org of orgs) {
+    await sql.execute("INSERT INTO organization (id, name, slug, metadata) VALUES (?, ?, ?, ?)",
+      [org, "Allowance fixture", org, JSON.stringify({ inferenceFree: { offerAllowed: true } })]);
+  }
+
+  return {
+    url, database, http,
+    plan: (prompt: string, plan: UpstreamPlan) => control("plan", { prompt, ...plan }),
+    release: (prompt: string) => control("release", { prompt }),
+    async calls(): Promise<UpstreamCall[]> {
+      const response = await http("/__fixture/upstream");
+      if (!response.ok) throw new Error("Cannot read upstream witness");
+      return response.json();
+    },
+    async seedPerson(): Promise<[MemberKey, MemberKey, MemberKey]> {
+      const userId = id("usr");
+      await sql.execute("INSERT INTO `user` (id, name, email, email_verified) VALUES (?, ?, ?, true)", [userId, "Allowance person", `${userId}@openwork.test`]);
+      const members: MemberKey[] = [];
+      for (const orgId of orgs) {
+        const memberId = id("om");
+        await sql.execute("INSERT INTO member (id, organization_id, user_id) VALUES (?, ?, ?)", [memberId, orgId, userId]);
+        for (let i = 0; i < (orgId === orgs[0] ? 2 : 1); i++) {
+          const keyId = id("ink"), key = `ow_inf_${randomBytes(32).toString("base64url")}`;
+          await sql.execute("INSERT INTO inference_keys (id, organization_id, org_membership_id, key_hash, status) VALUES (?, ?, ?, ?, 'active')",
+            [keyId, orgId, memberId, createHash("sha256").update(key).digest("hex")]);
+          members.push({ userId, orgId, memberId, keyId, key });
+        }
+      }
+      const [a, b, c] = members;
+      if (!a || !b || !c) throw new Error("Missing fixture keys");
+      return [a, b, c];
+    },
+    async snapshot(userId: string) {
+      const [buckets] = await sql.execute<Bucket[]>("SELECT * FROM inference_free_usage_buckets WHERE user_id = ? ORDER BY window_start_at", [userId]);
+      const [reservations] = await sql.execute<Reservation[]>("SELECT * FROM inference_free_reservations WHERE user_id = ? ORDER BY created_at, request_id", [userId]);
+      const [paid] = await sql.query<RowDataPacket[]>("SELECT (SELECT COUNT(*) FROM inference_org_usage_buckets) AS buckets, (SELECT COUNT(*) FROM inference_usage_ledger_entries) AS ledger");
+      return { buckets, reservations, paid };
+    },
+    // Explicit rollover arrangement: move only this person's existing history,
+    // atomically, not the SQL server's shared clock or any accounting function.
+    async seedPreviousWeek(userId: string) {
+      await sql.beginTransaction();
+      try {
+        await sql.execute("UPDATE inference_free_usage_buckets SET window_start_at = DATE_SUB(window_start_at, INTERVAL 7 DAY), window_end_at = DATE_SUB(window_end_at, INTERVAL 7 DAY) WHERE user_id = ?", [userId]);
+        await sql.execute("UPDATE inference_free_reservations SET window_start_at = DATE_SUB(window_start_at, INTERVAL 7 DAY) WHERE user_id = ?", [userId]);
+        await sql.commit();
+      } catch (error) { await sql.rollback(); throw error; }
+    },
+    async seedRevokedKey(keyId: string) {
+      await sql.execute("UPDATE inference_keys SET status = 'revoked', revoked_at = CURRENT_TIMESTAMP(3) WHERE id = ?", [keyId]);
+    },
+    webhook(call: UpstreamCall, cost: number, overrides: Record<string, string | number> = {}, signature = webhookSecret) {
+      const trace = record(call.body.trace);
+      const attrs = {
+        "trace.metadata.openwork_request_id": call.requestId,
+        "trace.metadata.inference_key_id": trace.inference_key_id,
+        "trace.metadata.org_membership_id": trace.org_membership_id,
+        "gen_ai.request.model": call.body.model, "gen_ai.response.model": call.body.model,
+        "gen_ai.response.id": call.generationId, "gen_ai.usage.input_cost": 0,
+        "gen_ai.usage.output_cost": cost, "gen_ai.usage.currency": "USD", ...overrides,
+      };
+      return http("/webhooks/openrouter", {
+        method: "POST", headers: { "content-type": "application/json", "x-webhook-signature": signature },
+        body: JSON.stringify({ resourceSpans: [{ scopeSpans: [{ spans: [{
+          attributes: Object.entries(attrs).map(([key, value]) => ({ key, value: typeof value === "number" ? { doubleValue: value } : { stringValue: value } })),
+        }] }] }] }),
+      });
+    },
+  };
+}

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -4,6 +4,7 @@ import { modelPicker } from "../worlds/chat.ts";
 const test = spec.world(modelPicker);
 
 test("the composer model pickers keep their controls without the OpenWork Models subscribe promo", async ({ user, step }) => {
+  await user.type("composer", "Keep this model-picker draft.");
   await user.click({ role: "button", label: "Change model" });
   await user.click({ role: "button", label: /^Model\s+Big Pickle/ });
 
@@ -11,6 +12,8 @@ test("the composer model pickers keep their controls without the OpenWork Models
     await user.see({ placeholder: "Search models..." });
     await user.see({ role: "button", label: "All models" });
     await user.see({ role: "button", label: "Connect more providers" });
+    await user.notSee({ testId: "inference-upgrade-dialog" });
+    await user.see("composer", { text: "Keep this model-picker draft." });
     for (const removed of [
       "Your API keys",
       "Add your keys",
@@ -32,5 +35,8 @@ test("the composer model pickers keep their controls without the OpenWork Models
     await user.notSee({ text: "Subscribe to use hosted frontier models in this workspace." });
     await user.notSee({ text: "Sign in to unlock hosted frontier models for your team." });
     await user.notSee({ role: "button", label: "Subscribe" });
+    await user.notSee({ testId: "inference-upgrade-dialog" });
   });
+  await user.click({ role: "button", label: "Done" });
+  await user.see("composer", { text: "Keep this model-picker draft." });
 });

--- a/evals/specs/free-inference-allowance.test.ts
+++ b/evals/specs/free-inference-allowance.test.ts
@@ -1,0 +1,229 @@
+import { expect } from "vitest";
+import { eventually, needs, test } from "@openwork/testkit";
+import { freeCredential, freeInferenceWorld, freeModel } from "../worlds/free-inference.ts";
+import type { MemberKey } from "../worlds/free-inference.ts";
+
+// New person-metered journey: real inference HTTP routes and SQL accounting,
+// not Den enrollment, paid managed-inference provisioning, or a UI journey.
+test("free Luna meters a person's actual weekly usage across keys, organizations and late receipts", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["pnpm"], placement: "local" });
+  await using stack = new AsyncDisposableStack();
+  const world = await freeInferenceWorld(stack, place);
+  const [primary, extraKey, otherOrg] = await world.seedPerson();
+  const [independent] = await world.seedPerson();
+  const [pending, , pendingOtherOrg] = await world.seedPerson();
+  const [racing] = await world.seedPerson();
+  const body = (prompt: string, options: Record<string, unknown> = {}) => ({ model: freeModel, messages: [{ role: "user", content: prompt }], ...options });
+  const complete = async (member: MemberKey, prompt: string, options: Record<string, unknown> = {}) => {
+    const response = await world.http("/api/v1/chat/completions", {
+      method: "POST", headers: { authorization: `Bearer ${member.key}`, "content-type": "application/json" },
+      body: JSON.stringify(body(prompt, options)),
+    });
+    return { status: response.status, headers: response.headers, text: await response.text() };
+  };
+  const rejected = async (member: MemberKey, prompt: string, status: number, code: string, options: Record<string, unknown> = {}) => {
+    const before = await world.calls();
+    const result = await complete(member, prompt, options);
+    expect(result.status, result.text).toBe(status);
+    expect(JSON.parse(result.text)).toMatchObject({ error: { code } });
+    expect(await world.calls(), "denied calls never reach the provider").toEqual(before);
+    if (status === 423) {
+      expect(JSON.parse(result.text)).toMatchObject({ error: { retryable: false, reason: "free_request_in_progress", access: { kind: "free" } } });
+      expect(result.headers.has("retry-after")).toBe(false);
+      expect(JSON.parse(result.text).error.upgradePath).toBeUndefined();
+    }
+    return result;
+  };
+  const callFor = async (prompt: string) => {
+    const calls = await eventually(() => world.calls(), {
+      within: 10_000, intervalMs: 25, label: `upstream receives ${prompt.slice(0, 50)}`,
+      until: (calls) => calls.some((call) => call.prompt === prompt),
+    });
+    const call = calls.find((call) => call.prompt === prompt);
+    if (!call) throw new Error("Upstream witness disappeared");
+    return call;
+  };
+  const settled = (member: MemberKey, count: number) => eventually(() => world.snapshot(member.userId), {
+    within: 10_000, intervalMs: 25, label: "SQL settlement commits",
+    until: (state) => state.reservations.length === count && state.reservations.every((row) => row.status === "settled"),
+  });
+
+  expect(primary.userId).toBe(otherOrg.userId);
+  expect(primary.memberId).not.toBe(otherOrg.memberId);
+  expect(primary.orgId).not.toBe(otherOrg.orgId);
+  expect(primary.memberId).toBe(extraKey.memberId);
+  expect(primary.keyId).not.toBe(extraKey.keyId);
+  expect(independent.userId).not.toBe(primary.userId);
+  const untouched = await world.snapshot(independent.userId);
+  expect(untouched).toMatchObject({ buckets: [], reservations: [], paid: [{ buckets: 0, ledger: 0 }] });
+
+  const modelsResponse = await world.http("/api/v1/models", { headers: { authorization: `Bearer ${primary.key}` } });
+  expect(modelsResponse.status).toBe(200);
+  const catalog: { data: Array<{ id: string }> } = await modelsResponse.json();
+  expect(catalog.data.some((entry) => entry.id === freeModel)).toBe(true);
+  const paidModel = catalog.data.find((entry) => entry.id !== freeModel)?.id;
+  expect(paidModel, "a known paid model, not an unknown-model rejection").toBeTruthy();
+  await rejected(primary, "paid selection", 402, "managed_model_requires_upgrade", { model: paidModel });
+  await rejected(primary, "x".repeat(32_768), 413, "free_inference_input_too_large");
+  await rejected(primary, "unsupported image", 400, "unsupported_free_inference_input", {
+    messages: [{ role: "user", content: [{ type: "image_url", image_url: { url: "https://invalid.test/image" } }] }],
+  });
+  expect((await world.snapshot(primary.userId)).buckets).toEqual([]);
+
+  // The positive input boundary is the full compact envelope, not string length.
+  const inputAtLimit = "x".repeat(32_768 - new TextEncoder().encode(JSON.stringify({ messages: [{ role: "user", content: "" }] })).length);
+  await world.plan(inputAtLimit, { cost: 0.25 });
+  const first = await complete(primary, inputAtLimit, { max_tokens: 128_000 });
+  expect(first.status, first.text).toBe(200);
+  expect(JSON.parse(first.text)).toMatchObject({ model: freeModel, usage: { cost: 0.25 }, choices: [{ message: { content: "Fixture reply: caf\u00e9" } }] });
+  const firstCall = await callFor(inputAtLimit);
+  expect(first.headers.get("x-openwork-request-id")).toBe(firstCall.requestId);
+  expect(firstCall).toMatchObject({ url: "https://openrouter.ai/api/v1/chat/completions", authorization: `Bearer ${freeCredential}`, redirect: "error" });
+  expect(firstCall.body).toMatchObject({ model: freeModel, max_tokens: 4096, n: 1, messages: body(inputAtLimit).messages, provider: { allow_fallbacks: false, require_parameters: true } });
+  let state = await settled(primary, 1);
+  expect(state.buckets).toHaveLength(1);
+  expect(state.buckets[0]).toMatchObject({ limit_amount: 100_000_000, used_amount: 25_000_000, reserved_amount: 0, blocked: 0 });
+  expect(state.reservations[0]).toMatchObject({ request_id: firstCall.requestId, user_id: primary.userId, organization_id: primary.orgId, org_membership_id: primary.memberId, inference_key_id: primary.keyId, actual_amount: 25_000_000, external_event_id: firstCall.generationId, max_output_tokens: 4096 });
+  expect(state.reservations[0].actual_amount).toBeGreaterThan(state.reservations[0].reserved_amount);
+  const week = state.buckets[0];
+  expect(week.window_start_at.getUTCDay()).toBe(1);
+  expect(week.window_start_at.toISOString()).toMatch(/T00:00:00\.000Z$/);
+  expect(week.window_end_at.getTime() - week.window_start_at.getTime()).toBe(7 * 86_400_000);
+  expect(await world.snapshot(independent.userId)).toEqual(untouched);
+
+  await world.plan("another organization", { cost: 0.5 });
+  const second = await complete(otherOrg, "another organization", { stream: true, max_completion_tokens: 32 });
+  expect(second.status, second.text).toBe(200);
+  expect(second.text).toContain("Fixture reply: caf\u00e9");
+  expect(second.text).toContain('"cost":0.5');
+  expect(second.text).toContain("data: [DONE]");
+  expect((await callFor("another organization")).body).toMatchObject({ max_tokens: 32 });
+  state = await settled(primary, 2);
+  expect(state.buckets).toHaveLength(1);
+  expect(state.buckets[0]).toMatchObject({ used_amount: 75_000_000, reserved_amount: 0 });
+
+  await world.plan("final capped reply", { cost: 0.5, hold: true });
+  const finalRequest = complete(extraKey, "final capped reply");
+  await callFor("final capped reply");
+  const held = (await world.snapshot(primary.userId)).reservations.find((row) => row.status === "held");
+  expect(held?.max_output_tokens).toBe(4096);
+  expect(held?.reserved_amount).toBeGreaterThan(0);
+  expect(held?.reserved_amount).toBeLessThan(50_000_000);
+  await world.release("final capped reply");
+  expect((await finalRequest).status).toBe(200);
+  state = await settled(primary, 3);
+  expect(state.buckets[0]).toMatchObject({ used_amount: 125_000_000, reserved_amount: 0 });
+  for (const member of [primary, extraKey, otherOrg]) {
+    const denial = await rejected(member, "exhausted retry", 402, "free_allowance_exhausted");
+    expect(JSON.parse(denial.text)).toMatchObject({ error: { access: { kind: "exhausted", usedUsd: 1.25, remainingUsd: 0, weeklyLimitUsd: 1 } } });
+  }
+  expect(await world.snapshot(primary.userId)).toEqual(state);
+  expect(await world.snapshot(independent.userId)).toEqual(untouched);
+  evidence.recordAssertionEvidence("Actual usage, not estimates, consumes one USD per person per Monday UTC week", "HTTP 200 replies reached the fixture; SQL settled 0.25 + 0.50 + 0.50 USD. All three keys then received 402 without upstream; the second person and paid ledger stayed unchanged.", true);
+
+  // Simultaneous first admissions for DIFFERENT people must both make progress.
+  // Use memberships in the same organization to expose over-broad/deadlocking locks.
+  await world.plan("independent admission", { cost: 0.125, hold: true });
+  await world.plan("parallel admission", { cost: 0.125, hold: true });
+  const independentRequest = complete(independent, "independent admission");
+  const parallelRequest = complete(racing, "parallel admission");
+  await Promise.all([callFor("independent admission"), callFor("parallel admission")]);
+  for (const member of [independent, racing]) {
+    const snapshot = await world.snapshot(member.userId);
+    expect(snapshot.reservations.filter((row) => row.status === "held")).toHaveLength(1);
+    expect(snapshot.buckets[0].used_amount).toBe(0);
+  }
+  await Promise.all([world.release("independent admission"), world.release("parallel admission")]);
+  expect((await Promise.all([independentRequest, parallelRequest])).map((reply) => reply.status)).toEqual([200, 200]);
+  expect((await settled(independent, 1)).buckets[0].used_amount).toBe(12_500_000);
+  expect((await settled(racing, 1)).buckets[0].used_amount).toBe(12_500_000);
+
+  // Fresh person/week, different memberships: exactly one first admission wins.
+  await world.plan("same person race", { cost: null, hold: true });
+  const competitors = [complete(pending, "same person race", { stream: true }), complete(pendingOtherOrg, "same person race", { stream: true })];
+  const losingReply = await Promise.race(competitors);
+  expect(losingReply.status, losingReply.text).toBe(423);
+  expect(JSON.parse(losingReply.text)).toMatchObject({ error: { code: "free_request_in_progress", retryable: false } });
+  expect(losingReply.headers.has("retry-after")).toBe(false);
+  const missingCostCall = await callFor("same person race");
+  const winningKey = missingCostCall.body.user === pending.memberId ? pending : pendingOtherOrg;
+  const survivingKey = winningKey === pending ? pendingOtherOrg : pending;
+  expect((await world.calls()).filter((call) => call.prompt === "same person race")).toHaveLength(1);
+  expect((await world.snapshot(pending.userId)).reservations).toHaveLength(1);
+  await world.release("same person race");
+  const replies = await Promise.all(competitors);
+  expect(replies.map((reply) => reply.status).sort()).toEqual([200, 423]);
+  expect(replies.find((reply) => reply.status === 200)?.text).toContain("data: [DONE]");
+  const awaitingUsage = await world.snapshot(pending.userId);
+  expect(awaitingUsage.reservations[0]).toMatchObject({ status: "held", actual_amount: null });
+  expect(awaitingUsage.buckets[0].reserved_amount).toBeGreaterThan(0);
+  expect(awaitingUsage.buckets[0].used_amount).toBe(0);
+  await rejected(pendingOtherOrg, "missing usage manual retry", 423, "free_request_in_progress");
+  evidence.recordAssertionEvidence("Person locking neither deadlocks independent first use nor admits two requests for one person", "Two independent first admissions completed concurrently; two cross-organization keys for a fresh person produced exactly one upstream call and HTTP 200/423, with a retained SQL hold when usage.cost was missing.", true);
+
+  await world.seedPreviousWeek(pending.userId);
+  const oldState = await world.snapshot(pending.userId);
+  const oldWeek = oldState.buckets[0].window_start_at;
+  expect(oldWeek.getTime()).toBe(week.window_start_at.getTime() - 7 * 86_400_000);
+  await rejected(pending, "new week still pending", 423, "free_request_in_progress");
+  const rollover = await world.snapshot(pending.userId);
+  expect(rollover.buckets[0]).toEqual(oldState.buckets[0]);
+  // Admission may materialize the untouched new bucket before denying the hold.
+  expect(rollover.buckets.length).toBeLessThanOrEqual(2);
+  for (const bucket of rollover.buckets.slice(1)) {
+    expect(bucket).toMatchObject({ limit_amount: 100_000_000, used_amount: 0, reserved_amount: 0 });
+  }
+
+  expect((await world.webhook(missingCostCall, 0.25, {}, "incorrect-signature")).status).toBe(401);
+  const wrongIdentity = await world.webhook(missingCostCall, 0.25, { "trace.metadata.org_membership_id": independent.memberId });
+  expect(wrongIdentity.status).toBe(200);
+  expect(await wrongIdentity.json()).toMatchObject({ ingested: 0, skipped: 1 });
+  expect(await world.snapshot(pending.userId)).toEqual(rollover);
+  await world.seedRevokedKey(winningKey.keyId);
+  await rejected(winningKey, "revoked key", 401, "invalid_api_key");
+  const late = await world.webhook(missingCostCall, 0.25);
+  expect(late.status).toBe(200);
+  expect(await late.json()).toMatchObject({ ingested: 1, skipped: 0 });
+  const lateState = await settled(pending, 1);
+  expect(lateState.buckets[0]).toMatchObject({ window_start_at: oldWeek, used_amount: 25_000_000, reserved_amount: 0 });
+  expect(lateState.buckets.slice(1)).toEqual(rollover.buckets.slice(1));
+  for (const cost of [0.25, 0.75]) {
+    const replay = await world.webhook(missingCostCall, cost);
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({ ingested: 0, skipped: 1 });
+    expect(await world.snapshot(pending.userId)).toEqual(lateState);
+  }
+  await world.plan("fresh week after receipt", { cost: 0.125 });
+  expect((await complete(survivingKey, "fresh week after receipt")).status).toBe(200);
+  const fresh = await settled(pending, 2);
+  expect(fresh.buckets).toHaveLength(2);
+  expect(fresh.buckets[0]).toEqual(lateState.buckets[0]);
+  expect(fresh.buckets[1]).toMatchObject({ limit_amount: 100_000_000, used_amount: 12_500_000, reserved_amount: 0 });
+  await rejected(winningKey, "revoked key stays revoked", 401, "invalid_api_key");
+  evidence.recordAssertionEvidence("Old-week missing usage blocks new admission until an authenticated original-week receipt settles once", "423 survived explicit rollover seeding; invalid signature and wrong identity did not release the hold. Late and replayed receipts charged only the old week. An active key then used the fresh one-USD week; the revoked key remained denied.", true);
+
+  const independentBeforeRace = await world.snapshot(independent.userId);
+  await world.plan("response webhook race", { cost: 0.25, hold: true });
+  const responseRace = complete(racing, "response webhook race", { stream: true });
+  const raceCall = await callFor("response webhook race");
+  const [, fallback] = await Promise.all([world.release("response webhook race"), world.webhook(raceCall, 0.25)]);
+  expect(fallback.status).toBe(200);
+  const fallbackBody = await fallback.json();
+  expect([0, 1]).toContain(fallbackBody.ingested);
+  expect(fallbackBody.ingested + fallbackBody.skipped).toBe(1);
+  expect((await responseRace).status).toBe(200);
+  const raced = await settled(racing, 2);
+  expect(raced.buckets[0]).toMatchObject({ used_amount: 37_500_000, reserved_amount: 0 });
+  expect(raced.reservations.filter((row) => row.external_event_id === raceCall.generationId)).toHaveLength(1);
+  const duplicate = await world.webhook(raceCall, 0.25);
+  expect(duplicate.status).toBe(200);
+  expect(await duplicate.json()).toMatchObject({ ingested: 0, skipped: 1 });
+  expect(await world.snapshot(racing.userId)).toEqual(raced);
+  expect(await world.snapshot(independent.userId)).toEqual(independentBeforeRace);
+  expect(raced.paid).toEqual([{ buckets: 0, ledger: 0 }]);
+  evidence.recordAssertionEvidence("Response usage and signed webhook fallback cannot double-charge", "Racing the final SSE usage against the authenticated webhook settled exactly 0.25 USD once; replay left SQL unchanged, the independent person unchanged, and paid accounting empty.", true);
+
+  // Stop the owned child and connection before dropping only this random DB.
+  await stack.disposeAsync();
+  expect(await world.database.exists(), "the proof leaves no owned database").toBe(false);
+});

--- a/evals/specs/session-error-technical-details.e2e.test.ts
+++ b/evals/specs/session-error-technical-details.e2e.test.ts
@@ -71,7 +71,7 @@ test("session error cards expose provider diagnostics only in Developer mode", a
   const storageErrors: Array<"disk-full" | "database-error"> = ["disk-full", "database-error"];
   for (const kind of storageErrors) {
     await step(`${kind} shows recovery guidance and keeps the stack trace in Developer mode`, async () => {
-      await world.seedStorageError(kind);
+      await world.seedError(kind);
       const title = kind === "disk-full" ? "Not enough disk space" : "OpenWork couldn’t access its saved data";
       await user.see({ text: title });
       await user.see({ text: kind === "disk-full" ? /Free up some disk space/ : /check the available disk space/ });
@@ -90,7 +90,7 @@ test("session error cards expose provider diagnostics only in Developer mode", a
       await user.notSee({ text: /at runLoop/ });
     });
     await step(`${kind} banner hides the stack trace outside Developer mode`, async () => {
-      await world.seedStorageError(kind, "banner");
+      await world.seedError(kind, "banner");
       const title = kind === "disk-full" ? "Not enough disk space" : "OpenWork couldn’t access its saved data";
       await user.see({ testId: "session-error-card" });
       await user.see({ text: title });
@@ -103,5 +103,28 @@ test("session error cards expose provider diagnostics only in Developer mode", a
       await user.notSee({ text: /at runLoop/ });
     });
   }
+
+  await user.type("composer", "Keep this unsent draft.");
+  for (const kind of ["free_allowance_exhausted", "managed_model_requires_upgrade"] as const) {
+    for (const surface of ["transcript", "banner"] as const) {
+      await step(`${kind} ${surface} explains the managed limit without retrying or discarding work`, async () => {
+        await world.seedError(kind, surface);
+        await user.see({ text: kind === "free_allowance_exhausted" ? "Your free Luna allowance is used up" : "This model requires OpenWork Models" });
+        await user.see({ testId: "inference-error-actions" });
+        await user.see({ role: "button", label: "Choose another provider" });
+        await user.notSee({ testId: "session-error-resume" });
+        await user.notSee({ testId: "inference-upgrade-dialog" });
+        await user.see("composer", { text: "Keep this unsent draft." });
+        if (surface === "transcript") await user.see({ text: "Looking at the repository now." });
+      });
+    }
+  }
+  await step("an organization BYOK 402 never becomes an OpenWork paywall", async () => {
+    await world.seedError("byok-allowance");
+    await user.see({ text: "The model request was declined." });
+    await user.notSee({ testId: "inference-error-actions" });
+    await user.notSee({ text: "Your free Luna allowance is used up" });
+    await user.see("composer", { text: "Keep this unsent draft." });
+  });
 
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1288,7 +1288,7 @@ export async function sessionErrorCard(seed: Seed) {
   await arrangeControl(seed, app, "eval.session_error.seed");
   return {
     app, workspace, session,
-    seedStorageError: (kind: "disk-full" | "database-error", surface: "transcript" | "banner" = "transcript") => arrangeControl(seed, app, "eval.session_error.seed", { kind, surface }),
+    seedError: (kind: "disk-full" | "database-error" | "free_allowance_exhausted" | "managed_model_requires_upgrade" | "byok-allowance", surface: "transcript" | "banner" = "transcript") => arrangeControl(seed, app, "eval.session_error.seed", { kind, surface }),
   };
 }
 

--- a/evals/worlds/free-inference.ts
+++ b/evals/worlds/free-inference.ts
@@ -1,0 +1,2 @@
+export { freeInferenceWorld, freeModel, freeCredential } from "../packages/env/src/free-inference.ts";
+export type { MemberKey } from "../packages/env/src/free-inference.ts";

--- a/packages/sdk/src/gen/sdk.gen.ts
+++ b/packages/sdk/src/gen/sdk.gen.ts
@@ -214,6 +214,8 @@ import type {
   GetV1DevEmailsResponses,
   GetV1DiagnosticsEgressErrors,
   GetV1DiagnosticsEgressResponses,
+  GetV1InferenceAccessErrors,
+  GetV1InferenceAccessResponses,
   GetV1InferenceAnalyticsActivityResponses,
   GetV1InferenceAnalyticsConsumptionResponses,
   GetV1InferenceAnalyticsSettingsResponses,
@@ -3820,6 +3822,19 @@ export class DenClient extends HeyApiClient {
       PutV1DiagnosticsEgressTokenErrors,
       ThrowOnError
     >({ url: "/v1/diagnostics/egress/token", ...options });
+  }
+
+  /**
+   * Get my managed inference access
+   *
+   * Returns the signed-in joined member's access and person-wide weekly free allowance, without credentials or administrative settings.
+   */
+  public getV1InferenceAccess<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<
+      GetV1InferenceAccessResponses,
+      GetV1InferenceAccessErrors,
+      ThrowOnError
+    >({ url: "/v1/inference/access", ...options });
   }
 
   /**

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -897,6 +897,29 @@ export type DesktopPolicyListResponse = {
   }>;
 };
 
+export type InferenceAccessResponse = {
+  access: {
+    kind: "paid" | "free" | "exhausted" | "unavailable";
+    modelID: string | null;
+    weeklyLimitUsd: number | null;
+    usedUsd: number | null;
+    reservedUsd: number | null;
+    remainingUsd: number | null;
+    resetsAt: string | null;
+    reason:
+      | "admin_disabled"
+      | "not_eligible"
+      | "free_disabled"
+      | "accounting_unavailable"
+      | "free_allowance_exhausted"
+      | "free_request_in_progress"
+      | "upstream_unavailable"
+      | null;
+    canUpgrade: boolean;
+  };
+  upgradePath: "/dashboard/billing" | null;
+};
+
 export type InferenceStatus = {
   enabled: boolean;
   tier: "tier1" | "tier2";
@@ -10404,6 +10427,35 @@ export type PutV1DiagnosticsEgressTokenResponses = {
 
 export type PutV1DiagnosticsEgressTokenResponse =
   PutV1DiagnosticsEgressTokenResponses[keyof PutV1DiagnosticsEgressTokenResponses];
+
+export type GetV1InferenceAccessData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/v1/inference/access";
+};
+
+export type GetV1InferenceAccessErrors = {
+  /**
+   * Sign in to read inference access.
+   */
+  401: UnauthorizedError;
+  /**
+   * Join the organization before using inference.
+   */
+  403: ForbiddenError;
+};
+
+export type GetV1InferenceAccessError = GetV1InferenceAccessErrors[keyof GetV1InferenceAccessErrors];
+
+export type GetV1InferenceAccessResponses = {
+  /**
+   * Managed inference access returned successfully.
+   */
+  200: InferenceAccessResponse;
+};
+
+export type GetV1InferenceAccessResponse = GetV1InferenceAccessResponses[keyof GetV1InferenceAccessResponses];
 
 export type GetV1InferenceData = {
   body?: never;

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -108,6 +108,12 @@ export const INFERENCE_MODEL_ALIASES = {
     enabled: true,
     usageFactor: 1,
   },
+  "openai/gpt-5.6-luna": {
+    upstreamModel: "openai/gpt-5.6-luna",
+    displayName: "OpenWork: GPT-5.6 Luna",
+    enabled: true,
+    usageFactor: 1,
+  },
 } as const;
 
 export type InferenceModelAlias = keyof typeof INFERENCE_MODEL_ALIASES;
@@ -116,3 +122,127 @@ export type InferenceOrganizationMetadata = {
   enabled: true;
   tier: InferenceTier;
 };
+
+export const INFERENCE_FREE_MODEL_ID = "openai/gpt-5.6-luna";
+export const INFERENCE_FREE_ENV = {
+  enabled: "INFERENCE_FREE_ENABLED",
+  weeklyBudgetUsd: "INFERENCE_FREE_WEEKLY_BUDGET_USD",
+  modelID: "INFERENCE_FREE_MODEL_ID",
+  upstreamApiKey: "INFERENCE_FREE_UPSTREAM_API_KEY",
+} as const;
+
+export type FreeInferenceConfig = {
+  enabled: boolean;
+  weeklyBudgetUsd: number;
+  weeklyLimitAmount: number;
+  modelID: typeof INFERENCE_FREE_MODEL_ID;
+};
+
+// Both Den and inference pass their server environment. Never include credentials
+// in this return value. New models require a reviewed reservation pricing policy.
+export function readFreeInferenceConfig(environment: Record<string, string | undefined>): FreeInferenceConfig {
+  const enabled = environment[INFERENCE_FREE_ENV.enabled] ?? "false";
+  if (!["true", "false", "1", "0"].includes(enabled)) {
+    throw new Error(`${INFERENCE_FREE_ENV.enabled} must be true, false, 1, or 0`);
+  }
+  const budget = environment[INFERENCE_FREE_ENV.weeklyBudgetUsd] ?? "1";
+  const weeklyBudgetUsd = Number(budget);
+  const weeklyLimitAmount = Math.floor(weeklyBudgetUsd * INFERENCE_USAGE_CONVERSION_FACTOR);
+  if (!budget.trim() || !Number.isFinite(weeklyBudgetUsd) || weeklyBudgetUsd < 0 || !Number.isSafeInteger(weeklyLimitAmount)) {
+    throw new Error(`${INFERENCE_FREE_ENV.weeklyBudgetUsd} must be finite, nonnegative, and representable in inference units`);
+  }
+  const modelID = environment[INFERENCE_FREE_ENV.modelID] ?? INFERENCE_FREE_MODEL_ID;
+  if (modelID !== INFERENCE_FREE_MODEL_ID) {
+    throw new Error(`${INFERENCE_FREE_ENV.modelID} must be an approved free model alias`);
+  }
+  return { enabled: enabled === "true" || enabled === "1", weeklyBudgetUsd: weeklyLimitAmount / INFERENCE_USAGE_CONVERSION_FACTOR, weeklyLimitAmount, modelID };
+}
+
+// UTC Monday 00:00 inclusive to the next Monday exclusive; no rollover.
+export function freeInferenceWindow(now = new Date()) {
+  const start = new Date(now);
+  start.setUTCHours(0, 0, 0, 0);
+  start.setUTCDate(start.getUTCDate() - (start.getUTCDay() + 6) % 7);
+  return { start, end: new Date(start.getTime() + INFERENCE_WINDOW_DURATIONS_MS.weekly) };
+}
+
+export const INFERENCE_ACCESS_REASONS = [
+  "admin_disabled",
+  "not_eligible",
+  "free_disabled",
+  "accounting_unavailable",
+  "free_allowance_exhausted",
+  "free_request_in_progress",
+  "upstream_unavailable",
+] as const;
+export type InferenceAccessReason = (typeof INFERENCE_ACCESS_REASONS)[number];
+export type InferenceAccess = {
+  kind: "paid" | "free" | "exhausted" | "unavailable";
+  modelID: string | null;
+  weeklyLimitUsd: number | null;
+  usedUsd: number | null;
+  // Estimated pending cost, not settled usage or a guaranteed maximum charge.
+  reservedUsd: number | null;
+  remainingUsd: number | null;
+  resetsAt: string | null;
+  reason: InferenceAccessReason | null;
+  canUpgrade?: boolean;
+};
+
+// Den writes inferenceFree.offerAllowed explicitly, including false on admin
+// disable. Missing paid metadata alone never authorizes the free upstream key.
+export function inferenceAccessMode(metadata: Record<string, unknown> | null): "paid" | "free" | "admin_disabled" | "not_eligible" {
+  const inference = metadata?.inference;
+  const offer = metadata?.inferenceFree;
+  if (typeof inference === "object" && inference !== null && "enabled" in inference && inference.enabled === false) return "admin_disabled";
+  if (typeof inference === "object" && inference !== null && "tier" in inference) {
+    if (inference.tier === "tier1" || inference.tier === "tier2") return "paid";
+    return "not_eligible";
+  }
+  if (typeof offer === "object" && offer !== null && "offerAllowed" in offer) {
+    if (offer.offerAllowed === false) return "admin_disabled";
+    if (offer.offerAllowed === true) return "free";
+  }
+  return "not_eligible";
+}
+
+// Structural projection of InferenceFreeUsageBucketTable. Den reads the row for
+// the authenticated person's user_id and this week's window_start_at.
+export type FreeInferenceBucketState = {
+  window_start_at: Date;
+  window_end_at: Date;
+  limit_amount: number;
+  used_amount: number;
+  reserved_amount: number;
+  blocked: boolean;
+};
+
+export function freeInferenceAccess(input: {
+  config: FreeInferenceConfig;
+  mode: ReturnType<typeof inferenceAccessMode>;
+  bucket?: FreeInferenceBucketState | null;
+  now?: Date;
+}): InferenceAccess {
+  if (input.mode === "paid") return { kind: "paid", modelID: null, weeklyLimitUsd: null, usedUsd: null, reservedUsd: null, remainingUsd: null, resetsAt: null, reason: null };
+  const window = freeInferenceWindow(input.now);
+  const bucket = input.bucket;
+  const limit = bucket?.limit_amount ?? input.config.weeklyLimitAmount;
+  const used = bucket?.used_amount ?? 0;
+  const reserved = bucket?.reserved_amount ?? 0;
+  const valid = [limit, used, reserved].every((value) => Number.isSafeInteger(value) && value >= 0)
+    && (!bucket || bucket.window_start_at.getTime() === window.start.getTime() && bucket.window_end_at.getTime() === window.end.getTime());
+  const remaining = valid ? Math.max(0, limit - used) : 0;
+  const reason = input.mode !== "free" ? input.mode : !input.config.enabled ? "free_disabled" : !valid || bucket?.blocked ? "accounting_unavailable" : remaining === 0 ? "free_allowance_exhausted" : reserved > 0 ? "free_request_in_progress" : null;
+  return {
+    // A busy account retains its provider/entitlement; it is not an upgrade or
+    // provisioning failure. Admission checks the reason as well as the kind.
+    kind: reason === null || reason === "free_request_in_progress" ? "free" : reason === "free_allowance_exhausted" ? "exhausted" : "unavailable",
+    modelID: input.config.modelID,
+    weeklyLimitUsd: valid ? limit / INFERENCE_USAGE_CONVERSION_FACTOR : null,
+    usedUsd: valid ? used / INFERENCE_USAGE_CONVERSION_FACTOR : null,
+    reservedUsd: valid ? reserved / INFERENCE_USAGE_CONVERSION_FACTOR : null,
+    remainingUsd: remaining / INFERENCE_USAGE_CONVERSION_FACTOR,
+    resetsAt: window.end.toISOString(),
+    reason,
+  };
+}


### PR DESCRIPTION
## Stack

Parent: #4619 (`feature/new-install-signin`), above #4608. This PR adds the free managed-model offer; it does not repeat the installation gate or change legacy sign-in policy.

## Experience

- Offer standard `openai/gpt-5.6-luna` through OpenWork inference without a paid subscription.
- Default allowance: **USD 1 of actual inference usage per person per week**, configurable server-side. Monday 00:00 UTC reset, no rollover, one allowance across devices, keys and organizations.
- Initialize Luna once for the new-install cohort after verified sign-in and provider readiness. Preserve explicit selections, existing conversations and legacy defaults; paid/BYOK repair stays available.
- Selecting another OpenWork-managed model offers the existing Models upgrade path and retains the current model/draft. Exhaustion shows the reset and upgrade guidance. Non-admins get administrator guidance. Local/OpenCode and organization BYOK are not paywalled by these prompts.
- Account/org-scoped status is exposed through member-readable `GET /v1/inference/access`; the SDK and both clients use the shared reason contract. In-flight usage remains free access, not lost entitlement.

## Metered allowance, not a strict pre-reserved dollar ceiling

Admission checks actual weekly usage before generation and permits one unsettled request per person. Requests are limited to 32 KiB supplied input, 128 KiB wire size and 4,096 output tokens, including reasoning. **The final admitted reply may exceed the weekly dollar amount.** Future calls are then blocked. This is the intended usage-metered policy, not a guarantee of zero overage.

Actual provider cost settles transactionally from the terminal response or authenticated webhook. Missing receipts retain the hold and request manual retry rather than granting fresh capacity. Late/repeated receipts charge only the original person/week once. `reservedUsd` is an estimate, not billed cost. Another managed model and exhausted usage return explicit 402 upgrade errors; a request already running returns a non-upsell 423.

Paid policies, paid upstream keys and BYOK remain separate. Admin disablement cannot be silently overridden. Free keys are not distributed to organization-wide shared workers.

## Configuration and migration

- Apply additive migration `0093_free_inference_allowance` before enabling. The large generated snapshot is schema metadata.
- Mirror non-secret `INFERENCE_FREE_ENABLED`, `INFERENCE_FREE_WEEKLY_BUDGET_USD` and `INFERENCE_FREE_MODEL_ID` in Den and inference. Defaults are **disabled**, USD 1, standard Luna.
- Configure `INFERENCE_FREE_UPSTREAM_API_KEY` only in inference and retain authenticated usage export. No shared upstream key is delivered to clients.
- Production flags, credentials, billing and subscriptions were **not changed**. No paid upstream calls were made.
- Details: `ee/apps/inference/FREE_ALLOWANCE.md` and `ee/apps/den-api/FREE_ALLOWANCE.md`.

## Verification — Incomplete

Exact head: `00b1b9b77bd750ce5996712ba21666dc0319d873`.

### Passed

- `pnpm evals:pr specs/free-inference-allowance.test.ts` — exit 0, **1 passed, 0 failed, 0 skipped**, on this exact head. The PR lane used the existing local MySQL prerequisite with an isolated disposable database; it does not print the E2E placement banner. Real inference HTTP service and SQL accounting; only upstream generation is synthetic.
- Journey assertions cover successful JSON/fragmented-SSE responses, request caps, paid-model denial before upstream, final overage followed by denial, person-wide accounting across memberships/keys, independent-person concurrency, single-person serialization, rollover with held usage, revoked keys, invalid/late/replayed receipts, response/webhook races and database cleanup. Paid ledger and other people are checked unchanged.
- App and Den Web typechecks after inheriting the sign-in parent; inference/Den source types; `pnpm sdk:check`; catalog validation.
- Focused implementation checks: 94 inference tests, 71 UI/access tests, 38 Stripe tests; real-DB provider/access coverage and member-credential regression. These supplement the journey, not replace UI evidence.

### Deferred / Incomplete

- Full end-to-end **new installation → sign-in → free Luna response → paid-model selection/exhaustion upsell** is not yet proven. The picker/error journeys were extended, but their positive free-access runtime path has not been executed.
- No real Luna generation, live upstream usage export, live checkout, production migration or rollout. Missing provider receipts intentionally block more free requests until reconciled; no timeout refunds.
- Non-text/unsupported free-input formats and organization-wide worker credentials remain outside the initial free offer.
- Parent #4619 has its own exact-head four-test desktop proof; it is not substituted for this child's missing integrated UI proof.

## Overlap and deployment boundary

#4471 changes overlapping paid managed-inference accounting and capability surfaces. This free ledger/entitlement is isolated, paid behavior is retained, and #4471 is untouched; reconcile both diffs before integration.

Both stack branch names are disabled in all four Vercel Git deployment configs before publication. GitHub reports no deployment records for either branch. No Vercel deployment command, merge or release is included. Merge bottom-up only after separate approval and fresh exact-head checks.
