### PR TITLE
feat(models): add no-sign-in Luna with bounded free usage

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -19,8 +19,8 @@ export { LANGUAGE_PREF_KEY } from "../i18n";
 export const HIDE_TITLEBAR_PREF_KEY = "openwork.hideTitlebar";
 
 export const DEFAULT_MODEL: ModelRef = {
-  providerID: "opencode",
-  modelID: "big-pickle",
+  providerID: "openwork-free",
+  modelID: "openai/gpt-5.6-luna",
 };
 
 export const SUGGESTED_PLUGINS: SuggestedPlugin[] = [];

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -1086,6 +1086,16 @@ const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
     : `Retrying · attempt ${status.attempt}`
   const action = status.action
   const freeModelLimit = action?.reason === "free_tier_limit"
+  const retryText = `${status.message} ${action?.title ?? ""} ${action?.message ?? ""}`
+  const anonymousLimit = /anonymous_limit_exceeded/i.test(retryText)
+  const anonymousCapacity = /anonymous_capacity_exceeded/i.test(retryText)
+  const anonymousUnavailable = /anonymous_unavailable/i.test(retryText)
+  const anonymousFailure = anonymousLimit || anonymousCapacity || anonymousUnavailable
+  const anonymousTitle = anonymousLimit
+    ? "OpenWork Models free limit reached"
+    : anonymousCapacity
+      ? "OpenWork Models are busy right now"
+      : "OpenWork Models are temporarily unavailable"
 
   return (
     <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
@@ -1095,7 +1105,7 @@ const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
             <LoaderCircle size={16} className="mt-0.5 shrink-0 animate-spin text-amber-700" />
             <div className="min-w-0 space-y-1">
               <p className="whitespace-pre-wrap text-sm font-medium text-amber-900">
-                {freeModelLimit ? "The free starter model is busy right now" : status.message}
+                {anonymousFailure ? anonymousTitle : freeModelLimit ? "The free starter model is busy right now" : status.message}
               </p>
               <p className="text-xs text-amber-800">{info}</p>
             </div>
@@ -1103,10 +1113,12 @@ const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
           {action ? (
             <div className="ml-6 space-y-1 border-t border-amber-400/60 pt-2">
               <p className="text-xs font-medium text-amber-950">
-                {freeModelLimit ? "Free model limit reached" : action.title}
+                {anonymousFailure ? "Try again later" : freeModelLimit ? "Free model limit reached" : action.title}
               </p>
               <p className="text-xs text-amber-900">
-                {freeModelLimit
+                {anonymousFailure
+                  ? "Wait a moment and retry, or choose another model provider to keep working."
+                  : freeModelLimit
                   ? "OpenWork will keep retrying. To keep working now, connect your own model provider."
                   : action.message}
               </p>

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -11,9 +11,13 @@ import {
 import { isDefaultControlPlaneUrl } from "../settings/cloud/control-plane-url";
 import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
 import { useSyncExternalStore } from "react";
+import { readDesktopDistributionInfo } from "../../../app/lib/desktop";
+import { isDesktopRuntime } from "../../../app/utils";
 
 export const OPENWORK_MODELS_PROVIDER_ID = "openwork";
 export const OPENWORK_MODELS_PROVIDER_NAME = "OpenWork Models";
+export const OPENWORK_FREE_MODELS_PROVIDER_ID = "openwork-free";
+export const OPENWORK_FREE_MODELS_PROVIDER_NAME = "OpenWork Models (Free)";
 export const OPENWORK_MODELS_PROMO_HIDDEN_KEY = "openwork.openworkModelsPromo.hidden";
 export const OPENWORK_MODELS_PROMO_LAST_SHOWN_KEY = "openwork.openworkModelsPromo.lastShownAt";
 export const OPENWORK_MODELS_STARTUP_PROMO_SHOWN_KEY = "openwork.openworkModelsPromo.startupShown";
@@ -37,6 +41,28 @@ export function isOpenWorkModelsPromoEligibleForDenBaseUrl(baseUrl: string) {
 
 export function isOpenWorkModelsPromoEligible() {
   return isOpenWorkModelsPromoEligibleForDenBaseUrl(readDenSettings().baseUrl);
+}
+
+export function isOpenWorkModelsFreeEligible() {
+  const bootstrap = readDenBootstrapConfig();
+  const distribution = readDesktopDistributionInfo();
+  return isDesktopRuntime()
+    && distribution.flavor === "public"
+    && bootstrap.requireSignin !== true
+    && bootstrap.requireActivation !== true
+    && isOpenWorkModelsPromoEligibleForDenBaseUrl(readDenSettings().baseUrl);
+}
+
+export function useOpenWorkModelsFreeEligibility() {
+  return useSyncExternalStore(
+    (notify) => {
+      if (typeof window === "undefined") return () => undefined;
+      window.addEventListener(denSettingsChangedEvent, notify);
+      return () => window.removeEventListener(denSettingsChangedEvent, notify);
+    },
+    isOpenWorkModelsFreeEligible,
+    isOpenWorkModelsFreeEligible,
+  );
 }
 
 export function useOpenWorkModelsPromoEligibility() {

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -219,6 +219,11 @@ function configsAreSemanticallyEqual(left: string, right: string): boolean {
   return leftCanonical !== null && leftCanonical === rightCanonical;
 }
 
+function isDefaultDisabledOpenCodeProvider(providerId: string): boolean {
+  const normalized = providerId.trim().toLowerCase();
+  return normalized === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID || normalized === "opencode-go";
+}
+
 export type ProviderAuthMethod = {
   type: "oauth" | "api" | "cloud";
   label: string;
@@ -1582,7 +1587,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     };
 
     try {
-      if (resolved.toLowerCase() === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
+      if (isDefaultDisabledOpenCodeProvider(resolved)) {
         await ensureProjectProviderDisabledState(resolved, false);
       }
       const trimmedCode = code?.trim();
@@ -1635,7 +1640,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     setStateField("providerAuthBusy", true);
     try {
-      if (providerId.trim().toLowerCase() === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
+      if (isDefaultDisabledOpenCodeProvider(providerId)) {
         await ensureProjectProviderDisabledState(providerId, false);
       }
       await c.auth.set({ providerID: providerId, auth: { type: "api", key: trimmed } });
@@ -2165,9 +2170,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
 
     try {
-      // OpenCode Zen is built-in / env-backed. Credential removal alone leaves
-      // it connected — disable it via runtime OPENCODE_CONFIG injection.
-      if (resolved.toLowerCase() === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
+      // OpenCode's built-in providers can be env-backed. Credential removal
+      // alone leaves them connected, so disable them in the managed runtime.
+      if (isDefaultDisabledOpenCodeProvider(resolved)) {
         try {
           await removeProviderAuthCredentials(resolved);
         } catch {
@@ -2345,7 +2350,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         } else {
           const logoutProviderIds = detail?.status === "signed_out"
             ? [...new Set(options.providerConnectedIds())].filter(
-              (providerId) => providerId.trim().toLowerCase() !== DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
+              (providerId) => isCloudManagedProviderKey(providerId),
             )
             : [];
           // Account-scoped catalog state must disappear synchronously. Config

--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -32,7 +32,9 @@ export function ProviderSelectionStep({
         <PageHeader className="mb-8 text-center">
           <PageTitle>Power your first task</PageTitle>
           <PageDescription>
-            Connect a model, then try a real task in chat so you can see OpenWork work.
+            {showOpenWorkModels
+              ? "Start with OpenWork Models for free, or connect your own provider."
+              : "Connect your own model provider when you’re ready to run a task."}
           </PageDescription>
         </PageHeader>
 
@@ -40,6 +42,7 @@ export function ProviderSelectionStep({
           {showOpenWorkModels ? (
             <button
               type="button"
+              aria-label="Use OpenWork Models"
               className="flex w-full items-start gap-4 rounded-xl border border-blue-7/50 bg-blue-2/30 p-4 text-left transition-colors hover:bg-blue-3/40"
               onClick={onOpenWorkModels}
             >
@@ -49,7 +52,7 @@ export function ProviderSelectionStep({
                   Use OpenWork Models
                 </div>
                 <div className="mt-0.5 text-xs text-muted-foreground">
-                  Pay through OpenWork Cloud and skip API key setup.
+                  Continue without an account or API key. Free usage has limits.
                 </div>
               </div>
             </button>
@@ -57,6 +60,7 @@ export function ProviderSelectionStep({
 
           <button
             type="button"
+            aria-label="Bring your own API key"
             className="flex w-full items-start gap-4 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:bg-accent"
             onClick={onBringYourOwn}
           >
@@ -74,7 +78,7 @@ export function ProviderSelectionStep({
           <div className="pt-1 text-center">
             <Button variant="ghost" size="sm" onClick={onSkip}>
               <SkipForwardIcon className="mr-1.5 size-3.5" />
-              Skip and use the free model
+              {showOpenWorkModels ? "Skip for now" : "Skip model setup for now"}
             </Button>
           </div>
         </div>

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -79,9 +79,8 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
   }, []);
 
-  // Quiet inline lead to OpenWork Models: replaces the old startup dialog
-  // interrupt. Shown only while the session runs on the free starter model
-  // (the built-in `opencode` provider) and the hosted offering applies.
+  // Quiet status for the anonymous OpenWork Models provider. It confirms that
+  // the first task is ready without making sign-in or an upgrade mandatory.
   const onFreeStarterModel = props.composer?.selectedModel.providerID === DEFAULT_MODEL.providerID;
   const showModelsHint =
     openWorkModelsPromoEligible &&
@@ -134,13 +133,13 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
           className="flex items-center justify-center gap-2 text-[12px] text-muted-foreground"
           data-testid="openwork-models-hint"
         >
-          <span>Using the free starter model.</span>
+          <span>Using OpenWork Models (Free). Free usage has limits.</span>
           <button
             type="button"
             className="flex items-center gap-1 font-medium text-blue-10 transition-colors hover:text-blue-11"
             onClick={() => platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn, "sign-up"))}
           >
-            Get frontier models with no API keys
+            See more OpenWork Models
             <ArrowRight className="size-3" />
           </button>
           <button

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -3,7 +3,7 @@ import type { UIMessage } from "ai";
 import { safeStringify } from "../../../../app/utils";
 import { normalizeErrorText } from "../../../../lib/error-text";
 
-export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "free-model-limit" | "disk-full" | "database-error" | "generic";
+export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "free-model-limit" | "anonymous-limit" | "anonymous-capacity" | "anonymous-unavailable" | "disk-full" | "database-error" | "generic";
 
 export type OpencodeSessionErrorPresentation = {
   kind: OpencodeSessionErrorKind;
@@ -83,6 +83,9 @@ function sessionErrorKind(
   if (responseBody?.includes("FreeUsageLimitError") || message?.includes("FreeUsageLimitError")) {
     return "free-model-limit";
   }
+  if (/anonymous_limit_exceeded/i.test(searchable)) return "anonymous-limit";
+  if (/anonymous_capacity_exceeded/i.test(searchable)) return "anonymous-capacity";
+  if (/anonymous_unavailable/i.test(searchable)) return "anonymous-unavailable";
   return "generic";
 }
 
@@ -92,6 +95,9 @@ function errorTitle(kind: OpencodeSessionErrorKind, fallback: string) {
   if (kind === "aborted") return "Task interrupted";
   if (kind === "provider-timeout") return "Provider did not respond in time";
   if (kind === "free-model-limit") return "The free starter model is busy right now";
+  if (kind === "anonymous-limit") return "OpenWork Models free limit reached";
+  if (kind === "anonymous-capacity") return "OpenWork Models are busy right now";
+  if (kind === "anonymous-unavailable") return "OpenWork Models are temporarily unavailable";
   return fallback;
 }
 
@@ -110,6 +116,15 @@ function errorDescription(kind: OpencodeSessionErrorKind) {
   }
   if (kind === "free-model-limit") {
     return "Too many people are using the free model at once. Wait a few minutes and try again, or connect your own model provider in Settings → AI Providers to keep working.";
+  }
+  if (kind === "anonymous-limit") {
+    return "Wait for your free usage to reset, then try again. You can also connect your own provider in Settings → AI Providers.";
+  }
+  if (kind === "anonymous-capacity") {
+    return "Capacity is full right now. Wait a few minutes and retry. You can use an existing signed-in plan or your own provider in the meantime.";
+  }
+  if (kind === "anonymous-unavailable") {
+    return "Try again later. You can use an existing signed-in plan or connect your own provider in Settings → AI Providers.";
   }
   return null;
 }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2342,7 +2342,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               }
             }}
             canDisconnectProvider={(provider) =>
-              provider.id.trim().toLowerCase() === "opencode" || provider.source !== "env"
+              ["opencode", "opencode-go"].includes(provider.id.trim().toLowerCase()) || provider.source !== "env"
             }
             canAddProviders={!providerAuthStore.isProviderAddRestricted()}
             organizationName={cloudSession.activeOrgName}

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -23,9 +23,8 @@ import { AttributionStep, type AttributionSource } from "../domains/onboarding/a
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
 import type { CreateWorkspaceOptions } from "../domains/workspace/types";
 import {
-  getOpenWorkModelsActionUrl,
   hideOpenWorkModelsPromo,
-  useOpenWorkModelsPromoEligibility,
+  useOpenWorkModelsFreeEligibility,
   markOpenWorkModelsStartupPromoShown,
 } from "../domains/cloud/openwork-models-promo";
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
@@ -142,7 +141,7 @@ export function WelcomeRoute() {
   const [state, dispatch] = useReducer(welcomeReducer, initialWelcomeState);
   const [manualFolder, setManualFolder] = useState("");
   const [joinOrganizationOpen, setJoinOrganizationOpen] = useState(false);
-  const showOpenWorkModelsPromo = useOpenWorkModelsPromoEligibility();
+  const showOpenWorkModelsPromo = useOpenWorkModelsFreeEligibility();
   const denAuthTokenSnapshot = useSyncExternalStore(
     subscribeToDenSettings,
     readDenAuthTokenSnapshot,
@@ -435,10 +434,10 @@ export function WelcomeRoute() {
         <ProviderSelectionStep
           showOpenWorkModels={showOpenWorkModelsPromo}
           onOpenWorkModels={() => {
-            // Land on the OpenWork Models value-prop page when already
-            // signed in to Den; otherwise start sign-up. Previously this
-            // always opened a bare sign-up page — payment before value.
-            platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn, "sign-up"));
+            // The public desktop provisions its free model lazily through the
+            // local server. No Cloud account, checkout, or browser handoff is
+            // required before the first task.
+            markOpenWorkModelsStartupPromoShown();
             const route = state.pendingWorkspaceId
               ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
               : "/session";

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1010,6 +1010,15 @@ function envFlagEnabled(name) {
   return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
+function isHostedOpenWorkBootstrap(config) {
+  try {
+    const origin = new URL(String(config?.baseUrl ?? "").trim()).origin;
+    return origin === "https://app.openworklabs.com" || origin === "https://api.openworklabs.com";
+  } catch {
+    return false;
+  }
+}
+
 const IDLE_ENGINE_INFO = Object.freeze({
   running: false,
   runtime: "direct",
@@ -1301,6 +1310,13 @@ const runtimeManager = createRuntimeManager({
         filePath: path.join(app.getPath("userData"), "local-managed-mcp-vault-key.bin"),
         loadSafeStorage: () => require("electron").safeStorage,
       }),
+  anonymousInferenceEligible: async () => {
+    const bootstrap = await workspaceStore.getDesktopBootstrapConfig();
+    return DESKTOP_DISTRIBUTION.flavor === "public"
+      && bootstrap.requireSignin !== true
+      && bootstrap.requireActivation !== true
+      && isHostedOpenWorkBootstrap(bootstrap);
+  },
 });
 const initialRunnerBootstrap = workspaceStore.readDesktopBootstrapConfigSync();
 const legacyRunnerBaseUrls = [

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1375,6 +1375,7 @@ export function createRuntimeManager({
   desktopRoot,
   listLocalWorkspacePaths,
   localManagedMcpVaultKey,
+  anonymousInferenceEligible = async () => false,
   workspaceMkdir = mkdir,
   workspacePlatform = process.platform,
 }) {
@@ -1974,6 +1975,7 @@ export function createRuntimeManager({
       opencodeBin: managedOpencode?.path ?? undefined,
       opencodeCwd: managedOpencodeWorkdir(),
       localManagedMcpVaultKey,
+      anonymousInferenceEligible: await anonymousInferenceEligible(),
     });
     inProcessServer = handle;
     openworkServerState.managedOpencodeExecution = handle.managedOpencodeExecution ?? null;

--- a/apps/server/src/anonymous-inference.ts
+++ b/apps/server/src/anonymous-inference.ts
@@ -1,0 +1,696 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import type { ServerConfig } from "./types.js";
+import { externalFetch } from "./server-fetch.js";
+import { runtimeStorageDir } from "./runtime-db.js";
+import {
+  mergeRuntimeProviderUpdate,
+  readGlobalRuntimeOpencodeConfig,
+  runtimeDisabledProviderList,
+  runtimeProviderMap,
+  writeGlobalRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
+
+export const ANONYMOUS_INFERENCE_PROVIDER_ID = "openwork-free";
+export const ANONYMOUS_INFERENCE_PROVIDER_NAME = "OpenWork Models (Free)";
+export const ANONYMOUS_INFERENCE_MODEL_ID = "openai/gpt-5.6-luna";
+
+const PREVIOUS_ANONYMOUS_INFERENCE_MODEL_ID = "deepseek/deepseek-v4-flash";
+
+const DEFAULT_ANONYMOUS_INFERENCE_ORIGIN = "https://inference.openworklabs.com";
+const LOCAL_ROUTE_PREFIX = "/anonymous-inference/v1";
+const LOCAL_TOKEN_PREFIX = "owf_local_";
+const REQUEST_BODY_LIMIT_BYTES = 2 * 1024 * 1024;
+const ERROR_BODY_LIMIT_BYTES = 64 * 1024;
+const SESSION_TIMEOUT_MS = 10_000;
+const RESPONSE_HEADER_TIMEOUT_MS = 30_000;
+const REQUEST_BODY_TIMEOUT_MS = 15_000;
+const REQUEST_LIFETIME_MS = 5 * 60_000;
+const TOKEN_EXPIRY_SKEW_MS = 30_000;
+const REMOTE_FAILURE_CACHE_DEFAULT_MS = 30_000;
+const REMOTE_FAILURE_CACHE_MAX_MS = 60_000;
+const MAX_REMOTE_FAILURE_CACHE_ENTRIES = 64;
+
+type AnonymousInferenceLogger = {
+  log: (level: "info" | "warn" | "error", message: string, attributes?: Record<string, unknown>) => void;
+};
+
+type AnonymousSession = {
+  token: string;
+  expiresAt: number;
+};
+
+type CachedFailure = {
+  expiresAt: number;
+  status: number;
+  statusText: string;
+  headers: [string, string][];
+  body: Uint8Array;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function enabledFlag(value: string | undefined): boolean {
+  return /^(?:1|true|yes|on)$/i.test(value?.trim() ?? "");
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+}
+
+export function resolveAnonymousInferenceOrigin(environment: NodeJS.ProcessEnv = process.env): string {
+  const configured = environment.OPENWORK_FREE_INFERENCE_ORIGIN?.trim();
+  const raw = configured || DEFAULT_ANONYMOUS_INFERENCE_ORIGIN;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("OPENWORK_FREE_INFERENCE_ORIGIN must be a valid URL");
+  }
+  if (url.username || url.password || url.search || url.hash || (url.pathname && url.pathname !== "/")) {
+    throw new Error("OPENWORK_FREE_INFERENCE_ORIGIN must contain only an origin");
+  }
+  const localDevelopment = environment.OPENWORK_DEV_MODE === "1" || environment.NODE_ENV === "test";
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && localDevelopment && isLoopbackHostname(url.hostname))) {
+    throw new Error("OPENWORK_FREE_INFERENCE_ORIGIN must use HTTPS (localhost HTTP is allowed only in development and tests)");
+  }
+  return url.origin;
+}
+
+function anonymousInferenceDisabled(environment: NodeJS.ProcessEnv): boolean {
+  return enabledFlag(environment.OPENWORK_DISABLE_FREE_INFERENCE)
+    || enabledFlag(environment.OPENWORK_DISABLE_HOSTED_MODELS)
+    || enabledFlag(environment.VITE_DISABLE_OPENWORK_MODELS);
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: string[]): boolean {
+  const keys = Object.keys(value);
+  return keys.length === expected.length && expected.every((key) => Object.hasOwn(value, key));
+}
+
+function isGeneratedModel(value: unknown, id: string, name: string, temperature: boolean): boolean {
+  if (!isRecord(value)) return false;
+  const generatedKeys = ["id", "name", "attachment", "reasoning", "temperature", "tool_call", "limit", "modalities"];
+  const hasFixedOptions = hasExactKeys(value, [...generatedKeys, "options"]);
+  if (!hasExactKeys(value, generatedKeys) && !hasFixedOptions) {
+    return false;
+  }
+  if (value.id !== id
+    || value.name !== name
+    || value.attachment !== false
+    || value.reasoning !== false
+    || value.temperature !== temperature
+    || value.tool_call !== true
+    || !isRecord(value.limit)
+    || !hasExactKeys(value.limit, ["context", "input", "output"])
+    || value.limit.context !== 135_168
+    || value.limit.input !== 131_072
+    || value.limit.output !== 4_096
+    || !isRecord(value.modalities)
+    || !hasExactKeys(value.modalities, ["input", "output"])) {
+    return false;
+  }
+  const input = value.modalities.input;
+  const output = value.modalities.output;
+  if (!Array.isArray(input) || input.length !== 1 || input[0] !== "text"
+    || !Array.isArray(output) || output.length !== 1 || output[0] !== "text") return false;
+  if (!hasFixedOptions) return true;
+  return id === ANONYMOUS_INFERENCE_MODEL_ID
+    && isRecord(value.options)
+    && hasExactKeys(value.options, ["reasoningEffort"])
+    && value.options.reasoningEffort === "none";
+}
+
+function isOwnedProvider(value: unknown): boolean {
+  if (!isRecord(value)
+    || !hasExactKeys(value, ["name", "npm", "options", "models"])
+    || value.name !== ANONYMOUS_INFERENCE_PROVIDER_NAME
+    || value.npm !== "@openrouter/ai-sdk-provider") {
+    return false;
+  }
+  const options = value.options;
+  const models = value.models;
+  if (!isRecord(options)
+    || !hasExactKeys(options, ["apiKey", "baseURL"])
+    || !isRecord(models)
+    || Object.keys(models).length !== 1) return false;
+  if (typeof options.baseURL !== "string" || !/^http:\/\/127\.0\.0\.1:\d+\/anonymous-inference\/v1$/.test(options.baseURL)) {
+    return false;
+  }
+  if (typeof options.apiKey !== "string" || !/^owf_local_[A-Za-z0-9_-]{43}$/.test(options.apiKey)) return false;
+  return isGeneratedModel(models[ANONYMOUS_INFERENCE_MODEL_ID], ANONYMOUS_INFERENCE_MODEL_ID, "GPT-5.6 Luna", false)
+    || isGeneratedModel(models[PREVIOUS_ANONYMOUS_INFERENCE_MODEL_ID], PREVIOUS_ANONYMOUS_INFERENCE_MODEL_ID, "DeepSeek V4 Flash", true);
+}
+
+function jsonError(status: number, code: string, message: string, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify({ error: { message, type: "openwork_anonymous_error", code } }), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function errorCode(body: Uint8Array): string | null {
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(body));
+    if (!isRecord(parsed) || !isRecord(parsed.error)) return null;
+    return typeof parsed.error.code === "string" ? parsed.error.code : null;
+  } catch {
+    return null;
+  }
+}
+
+function forwardedHeaders(headers: Headers): [string, string][] {
+  return ["content-type", "retry-after", "x-request-id"].flatMap((name) => {
+    const value = headers.get(name);
+    return value ? [[name, value] as [string, string]] : [];
+  });
+}
+
+function responseFromCachedFailure(failure: CachedFailure): Response {
+  return new Response(failure.body.slice(), {
+    status: failure.status,
+    statusText: failure.statusText,
+    headers: failure.headers,
+  });
+}
+
+class BodyReadDeadlineError extends Error {}
+
+async function readBoundedBody(
+  stream: ReadableStream<Uint8Array> | null,
+  limit: number,
+  signal: AbortSignal,
+  deadlineAt: number,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  if (!stream) return new Uint8Array();
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  while (true) {
+    if (signal.aborted) {
+      await reader.cancel(signal.reason).catch(() => undefined);
+      signal.throwIfAborted();
+    }
+    if (Date.now() >= deadlineAt) {
+      await reader.cancel(new BodyReadDeadlineError()).catch(() => undefined);
+      throw new BodyReadDeadlineError();
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let abortListener: (() => void) | undefined;
+    let chunk: { result: Awaited<ReturnType<typeof reader.read>> } | { deadline: true } | { aborted: true };
+    try {
+      chunk = await Promise.race([
+        reader.read().then((result) => ({ result })),
+        new Promise<{ deadline: true }>((resolve) => {
+          timeout = setTimeout(() => resolve({ deadline: true }), Math.max(1, deadlineAt - Date.now()));
+        }),
+        new Promise<{ aborted: true }>((resolve) => {
+          abortListener = () => resolve({ aborted: true });
+          if (signal.aborted) resolve({ aborted: true });
+          else signal.addEventListener("abort", abortListener, { once: true });
+        }),
+      ]);
+    } catch (error) {
+      await reader.cancel(error).catch(() => undefined);
+      throw error;
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      if (abortListener) signal.removeEventListener("abort", abortListener);
+    }
+    if ("aborted" in chunk) {
+      await reader.cancel(signal.reason).catch(() => undefined);
+      throw signal.reason instanceof Error ? signal.reason : new Error("Body read was aborted");
+    }
+    if ("deadline" in chunk) {
+      await reader.cancel(new BodyReadDeadlineError()).catch(() => undefined);
+      throw new BodyReadDeadlineError();
+    }
+    const { result } = chunk;
+    if (result.done) break;
+    length += result.value.byteLength;
+    if (length > limit) {
+      await reader.cancel(new Error("Body exceeded OpenWork anonymous inference limit")).catch(() => undefined);
+      return null;
+    }
+    chunks.push(result.value);
+  }
+  const body: Uint8Array<ArrayBuffer> = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+function boundedStreamResponse(
+  response: Response,
+  controller: AbortController,
+  cleanup: () => void,
+): Response {
+  if (!response.body) {
+    cleanup();
+    return new Response(null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: forwardedHeaders(response.headers),
+    });
+  }
+  const reader = response.body.getReader();
+  let finished = false;
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    controller.signal.removeEventListener("abort", abortUpstream);
+    cleanup();
+  };
+  const abortUpstream = () => {
+    void reader.cancel(controller.signal.reason).catch(() => undefined);
+    finish();
+  };
+  controller.signal.addEventListener("abort", abortUpstream, { once: true });
+  const body = new ReadableStream<Uint8Array>({
+    async pull(streamController) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          finish();
+          streamController.close();
+          return;
+        }
+        streamController.enqueue(chunk.value);
+      } catch (error) {
+        finish();
+        streamController.error(error);
+      }
+    },
+    async cancel(reason) {
+      controller.abort(reason);
+      finish();
+      await reader.cancel(reason).catch(() => undefined);
+    },
+  });
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: forwardedHeaders(response.headers),
+  });
+}
+
+function failureCacheDuration(headers: Headers): number {
+  const retryAfter = headers.get("retry-after")?.trim();
+  if (!retryAfter) return REMOTE_FAILURE_CACHE_DEFAULT_MS;
+  const seconds = Number(retryAfter);
+  const duration = Number.isFinite(seconds)
+    ? seconds * 1_000
+    : Date.parse(retryAfter) - Date.now();
+  if (!Number.isFinite(duration) || duration <= 0) return REMOTE_FAILURE_CACHE_DEFAULT_MS;
+  return Math.max(REMOTE_FAILURE_CACHE_DEFAULT_MS, Math.min(duration, REMOTE_FAILURE_CACHE_MAX_MS));
+}
+
+export class AnonymousInferenceService {
+  private readonly origin: string;
+  private readonly localAccessToken = `${LOCAL_TOKEN_PREFIX}${randomBytes(32).toString("base64url")}`;
+  private readonly installationPath: string;
+  private installationIdPromise: Promise<string> | null = null;
+  private session: AnonymousSession | null = null;
+  private sessionPromise: Promise<AnonymousSession> | null = null;
+  private activeControllers = new Set<AbortController>();
+  private failures = new Map<string, CachedFailure>();
+  private readonly eligible: boolean;
+  private cloudSessionActive = false;
+  private available = false;
+  private stopped = false;
+
+  constructor(
+    private readonly config: ServerConfig,
+    private readonly logger: AnonymousInferenceLogger,
+    environment: NodeJS.ProcessEnv = process.env,
+  ) {
+    this.origin = resolveAnonymousInferenceOrigin(environment);
+    this.installationPath = join(runtimeStorageDir(config), "anonymous-inference-installation.json");
+    this.eligible = config.anonymousInferenceEligible === true
+      && !config.readOnly
+      && !anonymousInferenceDisabled(environment);
+    this.available = this.eligible;
+  }
+
+  async initialize(boundPort: number): Promise<boolean> {
+    if (this.stopped) return false;
+    if (this.config.readOnly) {
+      this.available = false;
+      return false;
+    }
+    const runtime = await readGlobalRuntimeOpencodeConfig(this.config);
+    const providers = runtimeProviderMap(runtime);
+    const current = providers[ANONYMOUS_INFERENCE_PROVIDER_ID];
+    const permitted = this.eligible
+      && !this.cloudSessionActive
+      && runtime.managedPolicy?.allowCustomProviders !== false
+      && !runtimeDisabledProviderList(runtime).includes(ANONYMOUS_INFERENCE_PROVIDER_ID);
+
+    if (!permitted) {
+      this.disable();
+      if (current && isOwnedProvider(current)) {
+        await writeGlobalRuntimeOpencodeConfig(this.config, (snapshot) => ({
+          ...snapshot,
+          provider: mergeRuntimeProviderUpdate(snapshot.provider, { [ANONYMOUS_INFERENCE_PROVIDER_ID]: null }),
+        }));
+      }
+      return false;
+    }
+
+    if (current && !isOwnedProvider(current)) {
+      this.disable();
+      this.logger.log("warn", "Reserved anonymous inference provider id is already user-configured; leaving it unchanged.", {
+        provider_id: ANONYMOUS_INFERENCE_PROVIDER_ID,
+      });
+      return false;
+    }
+
+    this.available = true;
+
+    const provider = {
+      name: ANONYMOUS_INFERENCE_PROVIDER_NAME,
+      npm: "@openrouter/ai-sdk-provider",
+      options: {
+        apiKey: this.localAccessToken,
+        baseURL: `http://127.0.0.1:${boundPort}${LOCAL_ROUTE_PREFIX}`,
+      },
+      models: {
+        [ANONYMOUS_INFERENCE_MODEL_ID]: {
+          id: ANONYMOUS_INFERENCE_MODEL_ID,
+          name: "GPT-5.6 Luna",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          options: { reasoningEffort: "none" },
+          limit: { context: 135_168, input: 131_072, output: 4_096 },
+          modalities: { input: ["text"], output: ["text"] },
+        },
+      },
+    };
+    await writeGlobalRuntimeOpencodeConfig(this.config, (snapshot) => ({
+      ...snapshot,
+      provider: mergeRuntimeProviderUpdate(snapshot.provider, { [ANONYMOUS_INFERENCE_PROVIDER_ID]: provider }),
+    }));
+    return true;
+  }
+
+  async setCloudSessionActive(active: boolean, boundPort: number): Promise<boolean> {
+    this.cloudSessionActive = active;
+    return await this.initialize(boundPort);
+  }
+
+  async handle(request: Request, endpoint: "models" | "chat/completions"): Promise<Response> {
+    request.signal.throwIfAborted();
+    if (!this.available || this.stopped) {
+      return jsonError(503, "anonymous_unavailable", "OpenWork Models (Free) are unavailable for this installation.");
+    }
+    if (!this.authenticates(request)) {
+      return jsonError(401, "invalid_local_anonymous_token", "The local OpenWork Models credential is invalid.");
+    }
+    if (endpoint === "models") {
+      if (request.method !== "GET") {
+        return jsonError(405, "method_not_allowed", "This OpenWork Models route requires GET.", { allow: "GET" });
+      }
+      return Response.json({
+        object: "list",
+        data: [{ id: ANONYMOUS_INFERENCE_MODEL_ID, object: "model", owned_by: "openwork" }],
+      });
+    }
+    if (endpoint === "chat/completions" && request.method !== "POST") {
+      return jsonError(405, "method_not_allowed", "This OpenWork Models route requires POST.", { allow: "POST" });
+    }
+
+    const declaredLength = Number(request.headers.get("content-length") ?? "0");
+    if (Number.isFinite(declaredLength) && declaredLength > REQUEST_BODY_LIMIT_BYTES) {
+      await request.body?.cancel(new Error("Anonymous inference request was too large")).catch(() => undefined);
+      return jsonError(413, "anonymous_request_too_large", "The OpenWork Models request is too large.");
+    }
+    const deadlineAt = Date.now() + REQUEST_LIFETIME_MS;
+    let boundedBody: Uint8Array<ArrayBuffer> | null;
+    try {
+      boundedBody = await readBoundedBody(
+        request.body,
+        REQUEST_BODY_LIMIT_BYTES,
+        request.signal,
+        Math.min(deadlineAt, Date.now() + REQUEST_BODY_TIMEOUT_MS),
+      );
+    } catch (error) {
+      if (request.signal.aborted) throw error;
+      return jsonError(503, "anonymous_unavailable", "OpenWork Models could not read the request in time. Try again.");
+    }
+    if (!boundedBody) {
+      return jsonError(413, "anonymous_request_too_large", "The OpenWork Models request is too large.");
+    }
+    const body = request.method === "GET" ? undefined : boundedBody.buffer;
+    const requestKey = createHash("sha256")
+      .update(endpoint)
+      .update("\0")
+      .update(body ? new Uint8Array(body) : new Uint8Array())
+      .digest("hex");
+    const cached = this.cachedFailure(requestKey);
+    if (cached) return responseFromCachedFailure(cached);
+
+    try {
+      return await this.proxy(request, endpoint, body, requestKey, true, false, deadlineAt);
+    } catch (error) {
+      if (request.signal.aborted) throw error;
+      this.logger.log("warn", "Anonymous inference request failed before a response began.", {
+        error: error instanceof Error ? error.message : "anonymous_inference_request_failed",
+      });
+      return jsonError(503, "anonymous_unavailable", "OpenWork Models (Free) are temporarily unavailable. Try again later or use your own provider.");
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.disable();
+    this.failures.clear();
+    this.session = null;
+  }
+
+  private disable(): void {
+    this.available = false;
+    for (const controller of this.activeControllers) controller.abort(new Error("OpenWork anonymous inference was disabled"));
+    this.activeControllers.clear();
+  }
+
+  private async assertDispatchAllowed(request: Request, signal: AbortSignal): Promise<void> {
+    request.signal.throwIfAborted();
+    signal.throwIfAborted();
+    if (this.stopped || !this.available) throw new Error("OpenWork anonymous inference is unavailable");
+    const runtime = await readGlobalRuntimeOpencodeConfig(this.config);
+    request.signal.throwIfAborted();
+    signal.throwIfAborted();
+    if (this.cloudSessionActive
+      || runtime.managedPolicy?.allowCustomProviders === false
+      || runtimeDisabledProviderList(runtime).includes(ANONYMOUS_INFERENCE_PROVIDER_ID)) {
+      this.disable();
+      throw new Error("OpenWork anonymous inference is disabled by local policy");
+    }
+  }
+
+  private authenticates(request: Request): boolean {
+    const supplied = request.headers.get("authorization")?.match(/^Bearer\s+(.+)$/i)?.[1];
+    if (!supplied) return false;
+    const actual = Buffer.from(supplied);
+    const expected = Buffer.from(this.localAccessToken);
+    return actual.length === expected.length && timingSafeEqual(actual, expected);
+  }
+
+  private async installationId(): Promise<string> {
+    this.installationIdPromise ??= this.loadOrCreateInstallationId();
+    return await this.installationIdPromise;
+  }
+
+  private async loadOrCreateInstallationId(): Promise<string> {
+    try {
+      const parsed: unknown = JSON.parse(await readFile(this.installationPath, "utf8"));
+      if (isRecord(parsed) && typeof parsed.installationId === "string" && isUuid(parsed.installationId)) {
+        return parsed.installationId;
+      }
+    } catch {
+      // A missing or invalid file is repaired with a new stable installation id.
+    }
+    const installationId = randomUUID();
+    await mkdir(dirname(this.installationPath), { recursive: true });
+    const temporaryPath = `${this.installationPath}.${process.pid}.${randomUUID()}.tmp`;
+    await writeFile(temporaryPath, `${JSON.stringify({ installationId })}\n`, { flag: "wx", mode: 0o600 });
+    try {
+      await chmod(temporaryPath, 0o600);
+      await rename(temporaryPath, this.installationPath);
+      await chmod(this.installationPath, 0o600);
+    } catch (error) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+    return installationId;
+  }
+
+  private async guestSession(force = false): Promise<AnonymousSession> {
+    if (!force && this.session && this.session.expiresAt - TOKEN_EXPIRY_SKEW_MS > Date.now()) return this.session;
+    if (this.sessionPromise) return await this.sessionPromise;
+    const mint = this.mintGuestSession();
+    this.sessionPromise = mint;
+    try {
+      this.session = await mint;
+      return this.session;
+    } finally {
+      if (this.sessionPromise === mint) this.sessionPromise = null;
+    }
+  }
+
+  private async mintGuestSession(): Promise<AnonymousSession> {
+    const response = await externalFetch(`${this.origin}/api/anonymous/session`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ installationId: await this.installationId() }),
+      signal: AbortSignal.timeout(SESSION_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`Anonymous session request was rejected (${response.status})`);
+    const payload: unknown = await response.json();
+    if (
+      !isRecord(payload)
+      || typeof payload.token !== "string"
+      || !payload.token.trim()
+      || typeof payload.expiresAt !== "number"
+      || !Number.isFinite(payload.expiresAt)
+      || payload.expiresAt <= Date.now()
+      || payload.model !== ANONYMOUS_INFERENCE_MODEL_ID
+    ) {
+      throw new Error("Anonymous session response was invalid");
+    }
+    return { token: payload.token, expiresAt: payload.expiresAt };
+  }
+
+  private async proxy(
+    request: Request,
+    endpoint: "models" | "chat/completions",
+    body: ArrayBuffer | undefined,
+    requestKey: string,
+    allowAuthRetry: boolean,
+    forceSessionRefresh: boolean,
+    deadlineAt: number,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    this.activeControllers.add(controller);
+    const abortFromCaller = () => controller.abort(request.signal.reason);
+    if (request.signal.aborted) controller.abort(request.signal.reason);
+    else request.signal.addEventListener("abort", abortFromCaller, { once: true });
+    const lifetimeTimeout = setTimeout(
+      () => controller.abort(new Error("Anonymous inference request lifetime expired")),
+      Math.max(1, deadlineAt - Date.now()),
+    );
+    let headerTimeout: ReturnType<typeof setTimeout> | undefined;
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      clearTimeout(lifetimeTimeout);
+      if (headerTimeout) clearTimeout(headerTimeout);
+      request.signal.removeEventListener("abort", abortFromCaller);
+      this.activeControllers.delete(controller);
+    };
+
+    let session: AnonymousSession;
+    try {
+      await this.assertDispatchAllowed(request, controller.signal);
+      session = await this.guestSession(forceSessionRefresh);
+      await this.assertDispatchAllowed(request, controller.signal);
+    } catch (error) {
+      cleanup();
+      throw error;
+    }
+
+    let response: Response;
+    try {
+      await this.assertDispatchAllowed(request, controller.signal);
+      headerTimeout = setTimeout(
+        () => controller.abort(new Error("Anonymous inference response headers timed out")),
+        Math.min(RESPONSE_HEADER_TIMEOUT_MS, Math.max(1, deadlineAt - Date.now())),
+      );
+      response = await externalFetch(`${this.origin}/api/anonymous/v1/${endpoint}`, {
+        method: request.method,
+        headers: {
+          authorization: `Bearer ${session.token}`,
+          ...(body ? { "content-type": request.headers.get("content-type") ?? "application/json" } : {}),
+          ...(request.headers.get("accept") ? { accept: request.headers.get("accept") ?? "*/*" } : {}),
+        },
+        body,
+        signal: controller.signal,
+      });
+      clearTimeout(headerTimeout);
+      headerTimeout = undefined;
+    } catch (error) {
+      cleanup();
+      throw error;
+    }
+
+    if (!response.ok) {
+      const declaredErrorLength = Number(response.headers.get("content-length") ?? "0");
+      let bytes: Uint8Array<ArrayBuffer> | null = null;
+      try {
+        if (Number.isFinite(declaredErrorLength) && declaredErrorLength > ERROR_BODY_LIMIT_BYTES) {
+          await response.body?.cancel(new Error("Anonymous inference error body was too large")).catch(() => undefined);
+        } else {
+          bytes = await readBoundedBody(response.body, ERROR_BODY_LIMIT_BYTES, controller.signal, deadlineAt);
+        }
+      } finally {
+        cleanup();
+      }
+      if (!bytes) {
+        return jsonError(503, "anonymous_unavailable", "OpenWork Models (Free) returned an invalid error response.");
+      }
+      const code = errorCode(bytes);
+      if (allowAuthRetry && response.status === 401 && code === "invalid_anonymous_token") {
+        const rejectedCurrentSession = this.session?.token === session.token;
+        if (rejectedCurrentSession) this.session = null;
+        request.signal.throwIfAborted();
+        if (this.stopped || !this.available) {
+          return jsonError(503, "anonymous_unavailable", "OpenWork Models (Free) are unavailable for this installation.");
+        }
+        return await this.proxy(request, endpoint, body, requestKey, false, rejectedCurrentSession, deadlineAt);
+      }
+      const failure: CachedFailure = {
+        expiresAt: Date.now() + failureCacheDuration(response.headers),
+        status: response.status,
+        statusText: response.statusText,
+        headers: forwardedHeaders(response.headers),
+        body: bytes,
+      };
+      if (["anonymous_limit_exceeded", "anonymous_capacity_exceeded", "anonymous_unavailable"].includes(code ?? "")) {
+        failure.headers.push(["x-openwork-anonymous-no-upstream-retry", "1"]);
+        this.rememberFailure(requestKey, failure);
+      }
+      return responseFromCachedFailure(failure);
+    }
+    return boundedStreamResponse(response, controller, cleanup);
+  }
+
+  private cachedFailure(key: string): CachedFailure | null {
+    const now = Date.now();
+    for (const [candidate, failure] of this.failures) {
+      if (failure.expiresAt <= now) this.failures.delete(candidate);
+    }
+    return this.failures.get(key) ?? null;
+  }
+
+  private rememberFailure(key: string, failure: CachedFailure): void {
+    if (this.failures.size >= MAX_REMOTE_FAILURE_CACHE_ENTRIES) {
+      const oldest = this.failures.keys().next().value;
+      if (oldest) this.failures.delete(oldest);
+    }
+    this.failures.set(key, failure);
+  }
+}

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -49,6 +49,8 @@ export type EmbeddedServerOptions = CliArgs & {
   opencodeCwd?: string;
   /** Secure key custody for the local managed MCP credential vault. */
   localManagedMcpVaultKey?: LocalManagedMcpVaultKeyProvider;
+  /** Trusted desktop-distribution eligibility for the anonymous hosted model. */
+  anonymousInferenceEligible?: boolean;
 };
 
 export type EmbeddedServerHandle = {
@@ -71,6 +73,7 @@ export type EmbeddedServerHandle = {
 export async function startEmbeddedServer(options: EmbeddedServerOptions): Promise<EmbeddedServerHandle> {
   const config = await resolveServerConfig(options);
   config.localManagedMcpVaultKey = options.localManagedMcpVaultKey;
+  config.anonymousInferenceEligible = options.anonymousInferenceEligible === true;
   const logger = createServerLogger(config);
 
   // Spawn managed OpenCode if requested and no explicit base URL was provided.

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -39,6 +39,7 @@ import {
   runtimeProviderMap,
   runtimePluginList,
   type RuntimeOpencodeConfig,
+  withEngineGlobalRuntimeDefaults,
 } from "./runtime-opencode-config-store.js";
 import { CONNECT_MCP_SERVER_NAME_PREFIX } from "./connect-mcp-server-catalog.js";
 import { OPENWORK_AGENT_PROMPT } from "./openwork-agent-prompt.js";
@@ -58,18 +59,19 @@ export async function buildOpenworkRuntimeConfigObject(
 export function buildOpenworkRuntimeConfigObjectFromSnapshot(
   runtimeConfig: RuntimeOpencodeConfig,
 ): Record<string, unknown> {
-  const disabledProviders = runtimeDisabledProviderList(runtimeConfig);
-  const permissions = legacyExecutionPermissions(runtimeConfig.managedPolicy?.execution);
-  const { managedPolicy: _managedPolicy, ...engineConfig } = runtimeConfig;
-  const provider = runtimeProviderMap(runtimeConfig);
+  const globalRuntimeConfig = withEngineGlobalRuntimeDefaults(runtimeConfig);
+  const disabledProviders = runtimeDisabledProviderList(globalRuntimeConfig);
+  const permissions = legacyExecutionPermissions(globalRuntimeConfig.managedPolicy?.execution);
+  const { managedPolicy: _managedPolicy, ...engineConfig } = globalRuntimeConfig;
+  const provider = runtimeProviderMap(globalRuntimeConfig);
   return {
     ...engineConfig,
-    ...(runtimeConfig.managedPolicy?.allowCustomProviders === false ? { enabled_providers: [
+    ...(globalRuntimeConfig.managedPolicy?.allowCustomProviders === false ? { enabled_providers: [
       ...Object.keys(provider).filter((id) => /^(?:lpr_|openwork$)/i.test(id)),
-      ...(runtimeConfig.managedPolicy.allowZenModel !== false ? ["opencode"] : []),
+      ...(globalRuntimeConfig.managedPolicy.allowZenModel !== false ? ["opencode"] : []),
     ] } : {}),
     permission: { ...engineConfig.permission, ...permissions },
-    default_agent: runtimeConfig.default_agent ?? "openwork",
+    default_agent: globalRuntimeConfig.default_agent ?? "openwork",
     agent: {
       openwork: {
         description: "OpenWork default agent",
@@ -105,10 +107,10 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
       openworkAnthropicAdaptiveThinkingPluginPath(),
       openworkAnthropicToolSchemaPluginPath(),
       openworkTitleRecoveryPluginPath(),
-      ...runtimePluginList(runtimeConfig),
+      ...runtimePluginList(globalRuntimeConfig),
     ],
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),
-    mcp: Object.fromEntries(Object.entries(runtimeMcpMap(runtimeConfig))
+    mcp: Object.fromEntries(Object.entries(runtimeMcpMap(globalRuntimeConfig))
       .filter(([name]) => !name.startsWith(CONNECT_MCP_SERVER_NAME_PREFIX))),
     ...(Object.keys(provider).length ? { provider } : {}),
   };

--- a/apps/server/src/runtime-config-disabled-providers.test.ts
+++ b/apps/server/src/runtime-config-disabled-providers.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { startServer } from "./server.js";
+import { buildOpenworkRuntimeConfigObjectFromSnapshot } from "./openwork-runtime-config.js";
 import {
+  DEFAULT_ENGINE_DISABLED_PROVIDERS,
   readGlobalRuntimeOpencodeConfig,
   readRuntimeOpencodeConfig,
   writeRuntimeOpencodeConfig,
@@ -62,6 +64,26 @@ afterEach(async () => {
 });
 
 describe("runtime-config disabled providers route", () => {
+  test("defaults only an absent engine-global list and preserves an explicit empty list", async () => {
+    const root = await createTempRoot();
+    const { base, config } = await startOpenworkServer(root);
+
+    expect((await readGlobalRuntimeOpencodeConfig(config)).disabled_providers).toEqual([...DEFAULT_ENGINE_DISABLED_PROVIDERS]);
+    expect(buildOpenworkRuntimeConfigObjectFromSnapshot({}).disabled_providers).toEqual([...DEFAULT_ENGINE_DISABLED_PROVIDERS]);
+
+    const response = await fetch(`${base}/workspace/ws_1/runtime-config/disabled-providers`, {
+      method: "POST",
+      headers: clientAuth(),
+      body: JSON.stringify({ providers: [] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ disabledProviders: [] });
+    expect((await readGlobalRuntimeOpencodeConfig(config)).disabled_providers).toEqual([]);
+    expect(buildOpenworkRuntimeConfigObjectFromSnapshot({ disabled_providers: [] }).disabled_providers).toEqual([]);
+    expect((await readRuntimeOpencodeConfig(config, "ws_1")).disabled_providers).toBeUndefined();
+  });
+
   test("writes disabled providers into the runtime store", async () => {
     const root = await createTempRoot();
     const { base, config } = await startOpenworkServer(root);

--- a/apps/server/src/runtime-opencode-config-store.test.ts
+++ b/apps/server/src/runtime-opencode-config-store.test.ts
@@ -264,7 +264,7 @@ describe("runtime OpenCode config store", () => {
 
       const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
       expect(globalRuntime.plugin).toEqual(["plugin-global", "plugin-a", "plugin-shared", "plugin-b"]);
-      expect(globalRuntime.disabled_providers).toEqual(["anthropic", "openai"]);
+      expect(globalRuntime.disabled_providers).toEqual(["opencode", "opencode-go", "anthropic", "openai"]);
       expect(globalRuntime.permission?.external_directory).toEqual({
         "/folders/a": "allow",
         "/folders/b": "allow",

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -19,6 +19,7 @@ export type RuntimeOpencodeConfig = {
 };
 
 export const ENGINE_GLOBAL_RUNTIME_CONFIG_ID = "__openwork_engine_global__";
+export const DEFAULT_ENGINE_DISABLED_PROVIDERS = ["opencode", "opencode-go"] as const;
 
 /** Reserved Connect MCP name; kept in sync with OPENWORK_CLOUD_MCP_NAME in cloud-mcp-health.ts. */
 const OPENWORK_CLOUD_MCP_RESERVED_NAME = "openwork-cloud";
@@ -47,6 +48,14 @@ function normalizeRuntimeOpencodeConfig(value: unknown): RuntimeOpencodeConfig {
     ...(externalDirectory ? { permission: { external_directory: externalDirectory } } : {}),
     ...(provider ? { provider } : {}),
   };
+}
+
+export function withEngineGlobalRuntimeDefaults(
+  config: RuntimeOpencodeConfig,
+): RuntimeOpencodeConfig {
+  return Array.isArray(config.disabled_providers)
+    ? config
+    : { ...config, disabled_providers: [...DEFAULT_ENGINE_DISABLED_PROVIDERS] };
 }
 
 function parseRuntimeOpencodeConfig(configJson: string): RuntimeOpencodeConfig {
@@ -149,7 +158,9 @@ export async function readRuntimeOpencodeConfig(config: ServerConfig, workspaceI
 }
 
 export async function readGlobalRuntimeOpencodeConfig(config: ServerConfig): Promise<RuntimeOpencodeConfig> {
-  return await readRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID);
+  return withEngineGlobalRuntimeDefaults(
+    await readRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID),
+  );
 }
 
 export type RuntimeOpencodeConfigRow = {
@@ -273,7 +284,7 @@ export async function readEffectiveRuntimeOpencodeConfig(
   workspaceId: string,
 ): Promise<RuntimeOpencodeConfig> {
   if (isEngineGlobalRuntimeConfigId(workspaceId)) {
-    return await readRuntimeOpencodeConfig(config, workspaceId);
+    return await readGlobalRuntimeOpencodeConfig(config);
   }
   const [globalRuntime, workspaceRuntime] = await Promise.all([
     readGlobalRuntimeOpencodeConfig(config),
@@ -528,7 +539,13 @@ function updateRuntimeConfig(
   const pending = runtimeWrites.get(config) ?? Promise.resolve();
   const result = pending.catch(() => undefined).then(async () => {
     const row = await runtimeOpencodeConfigStore.getRow(config, workspaceId);
-    const next = normalizeRuntimeOpencodeConfig(updater(row?.value ?? {}));
+    const current = isEngineGlobalRuntimeConfigId(workspaceId)
+      ? withEngineGlobalRuntimeDefaults(row?.value ?? {})
+      : row?.value ?? {};
+    const updated = normalizeRuntimeOpencodeConfig(updater(current));
+    const next = isEngineGlobalRuntimeConfigId(workspaceId)
+      ? withEngineGlobalRuntimeDefaults(updated)
+      : updated;
     const configJson = runtimeOpencodeConfigStore.serialize(next);
     if (row?.valueJson === configJson) return { config: next, changed: false };
     await runtimeOpencodeConfigStore.setSerialized(config, workspaceId, configJson, Date.now());

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -90,6 +90,7 @@ import {
 import { serve, type ServeResult } from "./serve-node.js";
 import { serveStaticUi } from "./static-ui.js";
 import { externalFetch, loopbackFetch } from "./server-fetch.js";
+import { AnonymousInferenceService } from "./anonymous-inference.js";
 import { registerCoreRoutes } from "./routes/core.js";
 import { registerFileRoutes } from "./routes/files.js";
 import { registerOperationRoutes } from "./routes/operations.js";
@@ -767,10 +768,14 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     },
     logger: toManagedProviderAuthLogger(logger),
   });
+  const anonymousInference = new AnonymousInferenceService(config, logger);
   managedDesktopPolicy(config).onChange = () => {
     // Sign-in can precede the first workspace. Its future engine reads the
     // persisted policy at startup; there is no running workspace to reload.
     if (config.workspaces.length > 0) cloudProviderSync.markReloadPending();
+    void anonymousInference.initialize(config.port).then((changed) => {
+      if (changed && config.workspaces.length > 0) cloudProviderSync.markReloadPending();
+    }).catch(() => undefined);
   };
   const engineV2Preview = createEngineV2Preview({ config, env, deferStart: true });
   const routes = createRoutes(
@@ -783,6 +788,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     logger,
     cloudProviderSync,
     engineV2Preview,
+    anonymousInference,
   );
 
   const serverOptions: {
@@ -1039,6 +1045,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   } catch (error) {
     captureServerException(error, { method: "START", route: "startServer" });
     cloudProviderSync.stop();
+    anonymousInference.stop();
     await engineV2Preview.stop().catch(() => undefined);
     engineInstanceReaper.close();
     clearEngineInstanceReaperForConfig(config);
@@ -1057,6 +1064,20 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
         error: error instanceof Error ? error.message : "unknown",
       });
     }
+  }
+  try {
+    await anonymousInference.initialize(server.port);
+  } catch (error) {
+    anonymousInference.stop();
+    cloudProviderSync.stop();
+    await engineV2Preview.stop().catch(() => undefined);
+    engineInstanceReaper.close();
+    clearEngineInstanceReaperForConfig(config);
+    invalidateEngineMcpServerState(config, engineMcpServerState);
+    watcherHandle.close();
+    reloadBaselineRefreshers.delete(config);
+    await Promise.resolve().then(() => server.stop()).catch(() => undefined);
+    throw error;
   }
   // Policy hooks must receive the listener that actually bound, including
   // ephemeral ports and retries after a port collision.
@@ -1084,6 +1105,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     stop: async () => {
       managedDesktopPolicy(config).onChange = undefined;
       cloudProviderSync.stop();
+      anonymousInference.stop();
       await engineV2Preview.stop().catch(() => undefined);
       engineInstanceReaper.close();
       clearEngineInstanceReaperForConfig(config);
@@ -2241,8 +2263,15 @@ function createRoutes(
   logger: ServerLogger,
   cloudProviderSync: CloudProviderSync,
   engineV2Preview: EngineV2Preview,
+  anonymousInference: AnonymousInferenceService,
 ): Route[] {
   const routes: Route[] = [];
+  addRoute(routes, "GET", "/anonymous-inference/v1/models", "none", (ctx) =>
+    anonymousInference.handle(ctx.request, "models"));
+  addRoute(routes, "POST", "/anonymous-inference/v1/models", "none", (ctx) =>
+    anonymousInference.handle(ctx.request, "models"));
+  addRoute(routes, "POST", "/anonymous-inference/v1/chat/completions", "none", (ctx) =>
+    anonymousInference.handle(ctx.request, "chat/completions"));
   // A rollover-capable pool can apply this immediately without disposing
   // the generation that owns live sessions. Legacy/external engines keep
   // the established busy deferral.
@@ -2872,6 +2901,7 @@ function createRoutes(
     ensureWritable(config);
     const session = parseCloudProviderDenSession(await readJsonBody(ctx.request));
     if (!session) throw new ApiError(400, "invalid_payload", "baseUrl, token, and orgId are required");
+    await anonymousInference.setCloudSessionActive(true, config.port);
     await managedDesktopPolicy(config).setSession(session);
     await cloudProviderSync.setSession(session);
     return new Response(null, { status: 204 });
@@ -2881,6 +2911,7 @@ function createRoutes(
     ensureWritable(config);
     await managedDesktopPolicy(config).clearSession();
     await cloudProviderSync.clearSession();
+    await anonymousInference.setCloudSessionActive(false, config.port);
     return new Response(null, { status: 204 });
   });
 

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -105,6 +105,8 @@ export interface ServerConfig {
   logRequests: boolean;
   /** In-memory secure key custody supplied by an embedding host such as OpenWork Desktop. */
   localManagedMcpVaultKey?: LocalManagedMcpVaultKeyProvider;
+  /** Trusted embedding-host decision; standalone/self-hosted servers never opt in implicitly. */
+  anonymousInferenceEligible?: boolean;
 }
 
 export interface Capabilities {

--- a/ee/apps/inference/.env.example
+++ b/ee/apps/inference/.env.example
@@ -11,6 +11,61 @@ OPENROUTER_UPSTREAM_URL=https://openrouter.ai/api/v1
 INFERENCE_ADMIN_TOKEN=local-dev-admin-token
 INFERENCE_WEBHOOK_SECRET=local-dev-webhook-secret
 INFERENCE_CREDITS_PER_DOLLAR=1000000
+
+# Anonymous Models rollout is fail-closed and off by default. Enable only after
+# applying the anonymous inference migration and configuring a dedicated key.
+# On OpenRouter, restrict this API key to the selected provider/BYOK key, choose
+# "Never use shared capacity for any model", and cap workspace/guardrail daily
+# and monthly budgets no higher than the globals below with "Include BYOK spend".
+# Verify those external settings, then set the attestation and enable flags and
+# restart the inference service. This file does not configure OpenRouter.
+ANONYMOUS_INFERENCE_ENABLED=false
+ANONYMOUS_OPENROUTER_API_KEY=
+ANONYMOUS_TOKEN_SECRET=
+# Stable across ANONYMOUS_TOKEN_SECRET rotation and required to be a different
+# value. Never rotate this accounting key without migrating persisted identity
+# hashes; changing it starts new quota namespaces.
+ANONYMOUS_ACCOUNTING_IDENTITY_KEY=
+ANONYMOUS_OPENROUTER_PROVIDER=
+ANONYMOUS_OPENROUTER_BYOK_ONLY_VERIFIED=false
+
+# Conservative micro-USD budgets ($1 = 1,000,000 micro-USD), UTC calendar windows.
+ANONYMOUS_INSTALL_DAILY_MICRO_USD=50000
+ANONYMOUS_INSTALL_MONTHLY_MICRO_USD=1000000
+ANONYMOUS_IP_DAILY_MICRO_USD=250000
+ANONYMOUS_GLOBAL_DAILY_MICRO_USD=100000000
+ANONYMOUS_GLOBAL_MONTHLY_MICRO_USD=3000000000
+ANONYMOUS_GLOBAL_INFLIGHT=20
+ANONYMOUS_TOKEN_TTL_SECONDS=3600
+ANONYMOUS_SESSION_INSTALL_HOURLY=12
+ANONYMOUS_SESSION_IP_HOURLY=30
+ANONYMOUS_SESSION_GLOBAL_HOURLY=10000
+ANONYMOUS_REQUEST_INSTALL_HOURLY=60
+ANONYMOUS_REQUEST_IP_HOURLY=300
+ANONYMOUS_REQUEST_GLOBAL_HOURLY=10000
+ANONYMOUS_MAX_BODY_BYTES=262144
+ANONYMOUS_MAX_INPUT_TOKENS=131072
+# Reserved inside the input-token ceiling for provider chat-message and tool
+# template tokens that are not represented by the canonical forwarded JSON.
+ANONYMOUS_CHAT_WRAPPING_TOKEN_ALLOWANCE=2048
+ANONYMOUS_MAX_COMPLETION_TOKENS=4096
+# The dedicated standard GPT-5.6 Luna endpoint must support these limits at or
+# below these fail-closed price ceilings. Luna input is $0.20/M, but the $0.25/M
+# input-class bound conservatively covers cache writes ($0.25/M; reads $0.02/M).
+# With $1.20/M output and the fixed 10% safety margin, the maximum request
+# reservation is 41,452 micro-USD, below the $0.05 installation daily allowance.
+ANONYMOUS_MAX_INPUT_PRICE_MICRO_USD_PER_MILLION=250000
+ANONYMOUS_MAX_COMPLETION_PRICE_MICRO_USD_PER_MILLION=1200000
+ANONYMOUS_REQUEST_TIMEOUT_MS=60000
+ANONYMOUS_MAX_RESPONSE_BYTES=2097152
+
+# Default identity uses the socket peer. For a trusted ingress, set an exact
+# number of X-Forwarded-For proxy hops and list every permitted proxy IP. The
+# service rejects mismatched chains. Never enable hops without this allowlist.
+# Installation UUIDs can be reset and IPs can be shared/change; hashed /64 IPv6
+# plus installation, IP, and global limits reduce but cannot eliminate Sybil use.
+ANONYMOUS_TRUST_PROXY_HOPS=0
+ANONYMOUS_TRUSTED_PROXY_IPS=
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.01
 SENTRY_LOG_LEVEL=warn

--- a/ee/apps/inference/src/anonymous-identity.ts
+++ b/ee/apps/inference/src/anonymous-identity.ts
@@ -1,0 +1,209 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto"
+import { isIP } from "node:net"
+import { getConnInfo } from "@hono/node-server/conninfo"
+import type { Context } from "hono"
+import { env } from "./env.js"
+
+export type AnonymousIdentities = {
+  installationHash: string
+  ipHash: string
+  globalHash: string
+}
+
+type AnonymousTokenPayload = AnonymousIdentities & {
+  expiresAt: number
+  issuedAt: number
+}
+
+function anonymousSecret() {
+  if (!env.anonymous.tokenSecret) throw new Error("Anonymous inference token secret is unavailable")
+  return env.anonymous.tokenSecret
+}
+
+function accountingIdentityKey() {
+  if (!env.anonymous.accountingIdentityKey) throw new Error("Anonymous inference accounting identity key is unavailable")
+  return env.anonymous.accountingIdentityKey
+}
+
+function hashIdentity(kind: "installation" | "ip" | "global", value: string) {
+  return createHmac("sha256", accountingIdentityKey()).update(`${kind}:${value}`, "utf8").digest("hex")
+}
+
+function normalizeIpv4(value: string) {
+  const parts = value.split(".")
+  if (parts.length !== 4) return null
+  const numbers = parts.map(Number)
+  if (numbers.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return null
+  return numbers.join(".")
+}
+
+function ipv4TailGroups(value: string) {
+  const ipv4 = normalizeIpv4(value)
+  if (!ipv4) return null
+  const parts = ipv4.split(".").map(Number)
+  return [((parts[0] ?? 0) << 8) + (parts[1] ?? 0), ((parts[2] ?? 0) << 8) + (parts[3] ?? 0)]
+}
+
+function expandIpv6(value: string) {
+  const [leftValue, rightValue, ...extra] = value.split("::")
+  if (extra.length > 0) return null
+  const readSide = (side: string) => {
+    if (!side) return []
+    const groups: number[] = []
+    for (const part of side.split(":")) {
+      if (part.includes(".")) {
+        const tail = ipv4TailGroups(part)
+        if (!tail) return null
+        groups.push(...tail)
+        continue
+      }
+      const parsed = Number.parseInt(part, 16)
+      if (!part || part.length > 4 || !Number.isInteger(parsed) || parsed < 0 || parsed > 0xffff) return null
+      groups.push(parsed)
+    }
+    return groups
+  }
+  const left = readSide(leftValue ?? "")
+  const right = readSide(rightValue ?? "")
+  if (!left || !right) return null
+  if (!value.includes("::")) return left.length === 8 ? left : null
+  const missing = 8 - left.length - right.length
+  if (missing < 1) return null
+  return [...left, ...Array.from({ length: missing }, () => 0), ...right]
+}
+
+export function canonicalizeAnonymousAddress(input: string) {
+  let value = input.trim().toLowerCase()
+  if (value.startsWith("[") && value.endsWith("]")) value = value.slice(1, -1)
+  value = value.split("%", 1)[0] ?? ""
+  if (value.startsWith("::ffff:") && isIP(value.slice(7)) === 4) return normalizeIpv4(value.slice(7))
+  const version = isIP(value)
+  if (version === 4) return normalizeIpv4(value)
+  if (version !== 6) return null
+  const groups = expandIpv6(value)
+  if (!groups) return null
+  return groups.map((group) => group.toString(16).padStart(4, "0")).join(":")
+}
+
+function anonymousQuotaAddress(canonicalAddress: string) {
+  if (!canonicalAddress.includes(":")) return canonicalAddress
+  return `${canonicalAddress.split(":").slice(0, 4).join(":")}::/64`
+}
+
+export function resolveAnonymousClientAddress(c: Context) {
+  const socketAddress = canonicalizeAnonymousAddress(getConnInfo(c).remote.address ?? "")
+  if (!socketAddress) return null
+  if (env.anonymous.trustProxyHops === 0) return anonymousQuotaAddress(socketAddress)
+
+  // Trust is decided with canonical full addresses. IPv6 /64 aggregation is
+  // applied only after every configured proxy hop passed exact comparison.
+  const trusted = new Set(env.anonymous.trustedProxyIps.map(canonicalizeAnonymousAddress))
+  if (trusted.has(null) || trusted.size === 0) return null
+  const forwarded = c.req.raw.headers.get("x-forwarded-for")
+  if (!forwarded) return null
+  const chain = forwarded.split(",").map(canonicalizeAnonymousAddress)
+  if (chain.some((address) => address === null)) return null
+  const addresses = chain.filter((address) => address !== null)
+  addresses.push(socketAddress)
+  const clientIndex = addresses.length - 1 - env.anonymous.trustProxyHops
+  if (clientIndex < 0) return null
+  for (let offset = 0; offset < env.anonymous.trustProxyHops; offset += 1) {
+    const proxy = addresses[addresses.length - 1 - offset]
+    if (!proxy || !trusted.has(proxy)) return null
+  }
+  const clientAddress = addresses[clientIndex]
+  return clientAddress ? anonymousQuotaAddress(clientAddress) : null
+}
+
+export function createAnonymousIdentities(installationId: string, normalizedAddress: string): AnonymousIdentities {
+  return {
+    installationHash: hashIdentity("installation", installationId.toLowerCase()),
+    ipHash: hashIdentity("ip", normalizedAddress),
+    globalHash: hashIdentity("global", "openwork-free-allowance"),
+  }
+}
+
+function tokenKey() {
+  return Uint8Array.from(createHash("sha256").update(anonymousSecret(), "utf8").digest())
+}
+
+function concatBytes(values: Uint8Array[]) {
+  const output = new Uint8Array(values.reduce((total, value) => total + value.byteLength, 0))
+  let offset = 0
+  for (const value of values) {
+    output.set(value, offset)
+    offset += value.byteLength
+  }
+  return output
+}
+
+export function issueAnonymousToken(identities: AnonymousIdentities, now = Date.now()) {
+  const expiresAt = now + env.anonymous.tokenTtlSeconds * 1000
+  const payload = JSON.stringify({
+    version: 1,
+    installationHash: identities.installationHash,
+    ipHash: identities.ipHash,
+    globalHash: identities.globalHash,
+    issuedAt: now,
+    expiresAt,
+  })
+  const iv = Uint8Array.from(randomBytes(12))
+  const cipher = createCipheriv("aes-256-gcm", tokenKey(), iv)
+  const encrypted = concatBytes([Uint8Array.from(cipher.update(payload, "utf8")), Uint8Array.from(cipher.final())])
+  const packed = concatBytes([iv, Uint8Array.from(cipher.getAuthTag()), encrypted])
+  const token = Buffer.from(packed).toString("base64url")
+  return { token: `ow_guest_v1.${token}`, expiresAt }
+}
+
+function readTokenPayload(value: unknown): AnonymousTokenPayload | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null
+  if (!("version" in value) || value.version !== 1) return null
+  if (!("installationHash" in value) || typeof value.installationHash !== "string" || !/^[a-f0-9]{64}$/.test(value.installationHash)) return null
+  if (!("ipHash" in value) || typeof value.ipHash !== "string" || !/^[a-f0-9]{64}$/.test(value.ipHash)) return null
+  if (!("globalHash" in value) || typeof value.globalHash !== "string" || !/^[a-f0-9]{64}$/.test(value.globalHash)) return null
+  if (!("issuedAt" in value) || typeof value.issuedAt !== "number" || !Number.isSafeInteger(value.issuedAt)) return null
+  if (!("expiresAt" in value) || typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt)) return null
+  return {
+    installationHash: value.installationHash,
+    ipHash: value.ipHash,
+    globalHash: value.globalHash,
+    issuedAt: value.issuedAt,
+    expiresAt: value.expiresAt,
+  }
+}
+
+function constantTimeHashEqual(left: string, right: string) {
+  const leftBytes = Uint8Array.from(Buffer.from(left, "hex"))
+  const rightBytes = Uint8Array.from(Buffer.from(right, "hex"))
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes)
+}
+
+export function verifyAnonymousToken(token: string, normalizedAddress: string, now = Date.now()) {
+  if (!token.startsWith("ow_guest_v1.")) return null
+  try {
+    const packed = Uint8Array.from(Buffer.from(token.slice("ow_guest_v1.".length), "base64url"))
+    if (packed.length <= 28) return null
+    const iv = packed.subarray(0, 12)
+    const tag = packed.subarray(12, 28)
+    const encrypted = packed.subarray(28)
+    const decipher = createDecipheriv("aes-256-gcm", tokenKey(), iv)
+    decipher.setAuthTag(tag)
+    const decrypted = concatBytes([Uint8Array.from(decipher.update(encrypted)), Uint8Array.from(decipher.final())])
+    const text = new TextDecoder().decode(decrypted)
+    const payload = readTokenPayload(JSON.parse(text))
+    if (!payload || payload.expiresAt <= now || payload.issuedAt > now + 30_000) return null
+    const currentIpHash = hashIdentity("ip", normalizedAddress)
+    const currentGlobalHash = hashIdentity("global", "openwork-free-allowance")
+    if (!constantTimeHashEqual(payload.ipHash, currentIpHash) || !constantTimeHashEqual(payload.globalHash, currentGlobalHash)) return null
+    return payload
+  } catch {
+    return null
+  }
+}

--- a/ee/apps/inference/src/anonymous-limits.ts
+++ b/ee/apps/inference/src/anonymous-limits.ts
@@ -1,0 +1,398 @@
+import { createHash } from "node:crypto"
+import { and, count, eq, lte, sql } from "@openwork-ee/den-db/drizzle"
+import {
+  AnonymousInferenceControlTable,
+  AnonymousInferenceRateBucketTable,
+  AnonymousInferenceReservationChargeTable,
+  AnonymousInferenceReservationTable,
+  AnonymousInferenceUsageBucketTable,
+} from "@openwork-ee/den-db"
+import { db } from "./db.js"
+import { env } from "./env.js"
+import type { AnonymousIdentities } from "./anonymous-identity.js"
+
+const controlId = "anonymous-inference-global"
+const upstreamCostSafetyNumerator = 11
+const upstreamCostSafetyDenominator = 10
+
+type AdmissionFailure = {
+  ok: false
+  reason: "limit" | "capacity" | "unavailable"
+  retryAfterSeconds?: number
+}
+
+type RateSpec = {
+  id: string
+  kind: "session" | "request"
+  scope: "installation" | "ip" | "global"
+  identityHash: string
+  start: Date
+  end: Date
+  limit: number
+}
+
+type UsageSpec = {
+  id: string
+  scope: "installation" | "ip" | "global"
+  identityHash: string
+  windowType: "daily" | "monthly"
+  start: Date
+  end: Date
+  limitMicroUsd: number
+}
+
+type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
+
+function stableId(parts: string[]) {
+  return createHash("sha256").update(parts.join(":"), "utf8").digest("hex")
+}
+
+function hourlyWindow(now: Date) {
+  const start = new Date(now)
+  start.setUTCMinutes(0, 0, 0)
+  return { start, end: new Date(start.getTime() + 60 * 60 * 1000) }
+}
+
+function dailyWindow(now: Date) {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  return { start, end: new Date(start.getTime() + 24 * 60 * 60 * 1000) }
+}
+
+function monthlyWindow(now: Date) {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1))
+  return { start, end }
+}
+
+function retryAfterSeconds(end: Date, now: Date) {
+  return Math.max(1, Math.ceil((end.getTime() - now.getTime()) / 1000))
+}
+
+async function lockControl(tx: Transaction) {
+  const [control] = await tx.select().from(AnonymousInferenceControlTable)
+    .where(eq(AnonymousInferenceControlTable.id, controlId)).limit(1).for("update")
+  if (!control) throw new Error("Anonymous inference control row is unavailable")
+  return control
+}
+
+async function reapExpiredReservations(tx: Transaction, now: Date) {
+  await tx.update(AnonymousInferenceReservationTable).set({
+    status: "retained",
+    released_at: now,
+  }).where(and(
+    eq(AnonymousInferenceReservationTable.status, "active"),
+    lte(AnonymousInferenceReservationTable.lease_expires_at, now),
+  ))
+}
+
+function rateSpecs(kind: "session" | "request", identities: AnonymousIdentities, now: Date): RateSpec[] {
+  const window = hourlyWindow(now)
+  const limits = kind === "session"
+    ? {
+        installation: env.anonymous.sessionInstallHourly,
+        ip: env.anonymous.sessionIpHourly,
+        global: env.anonymous.sessionGlobalHourly,
+      }
+    : {
+        installation: env.anonymous.requestInstallHourly,
+        ip: env.anonymous.requestIpHourly,
+        global: env.anonymous.requestGlobalHourly,
+      }
+  const values: Array<{ scope: RateSpec["scope"]; identityHash: string }> = [
+    { scope: "installation", identityHash: identities.installationHash },
+    { scope: "ip", identityHash: identities.ipHash },
+    { scope: "global", identityHash: identities.globalHash },
+  ]
+  return values.map(({ scope, identityHash }) => ({
+    id: stableId(["rate", kind, scope, identityHash, window.start.toISOString()]),
+    kind,
+    scope,
+    identityHash,
+    start: window.start,
+    end: window.end,
+    limit: limits[scope],
+  })).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function usageSpecs(identities: AnonymousIdentities, now: Date): UsageSpec[] {
+  const daily = dailyWindow(now)
+  const monthly = monthlyWindow(now)
+  const values: Array<Omit<UsageSpec, "id">> = [
+    { scope: "installation", identityHash: identities.installationHash, windowType: "daily", ...daily, limitMicroUsd: env.anonymous.installDailyMicroUsd },
+    { scope: "installation", identityHash: identities.installationHash, windowType: "monthly", ...monthly, limitMicroUsd: env.anonymous.installMonthlyMicroUsd },
+    { scope: "ip", identityHash: identities.ipHash, windowType: "daily", ...daily, limitMicroUsd: env.anonymous.ipDailyMicroUsd },
+    { scope: "global", identityHash: identities.globalHash, windowType: "daily", ...daily, limitMicroUsd: env.anonymous.globalDailyMicroUsd },
+    { scope: "global", identityHash: identities.globalHash, windowType: "monthly", ...monthly, limitMicroUsd: env.anonymous.globalMonthlyMicroUsd },
+  ]
+  return values.map((value) => ({
+    ...value,
+    id: stableId(["usage", value.scope, value.identityHash, value.windowType, value.start.toISOString()]),
+  })).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+async function prepareRateBuckets(tx: Transaction, specs: RateSpec[]) {
+  for (const spec of specs) {
+    await tx.insert(AnonymousInferenceRateBucketTable).values({
+      id: spec.id,
+      kind: spec.kind,
+      scope: spec.scope,
+      identity_hash: spec.identityHash,
+      window_start_at: spec.start,
+      window_end_at: spec.end,
+      limit_amount: spec.limit,
+      used_amount: 0,
+    }).onDuplicateKeyUpdate({ set: { limit_amount: spec.limit } })
+  }
+  const rows = []
+  for (const spec of specs) {
+    const [row] = await tx.select().from(AnonymousInferenceRateBucketTable)
+      .where(eq(AnonymousInferenceRateBucketTable.id, spec.id)).limit(1).for("update")
+    if (!row) throw new Error("Anonymous inference rate bucket is unavailable")
+    rows.push(row)
+  }
+  return rows
+}
+
+async function prepareUsageBuckets(tx: Transaction, specs: UsageSpec[]) {
+  for (const spec of specs) {
+    await tx.insert(AnonymousInferenceUsageBucketTable).values({
+      id: spec.id,
+      scope: spec.scope,
+      identity_hash: spec.identityHash,
+      window_type: spec.windowType,
+      window_start_at: spec.start,
+      window_end_at: spec.end,
+      limit_micro_usd: spec.limitMicroUsd,
+      used_micro_usd: 0,
+    }).onDuplicateKeyUpdate({ set: { limit_micro_usd: spec.limitMicroUsd } })
+  }
+  const rows = []
+  for (const spec of specs) {
+    const [row] = await tx.select().from(AnonymousInferenceUsageBucketTable)
+      .where(eq(AnonymousInferenceUsageBucketTable.id, spec.id)).limit(1).for("update")
+    if (!row) throw new Error("Anonymous inference usage bucket is unavailable")
+    rows.push(row)
+  }
+  return rows
+}
+
+function firstRateLimit(rows: Awaited<ReturnType<typeof prepareRateBuckets>>, now: Date) {
+  const limited = rows.find((row) => row.used_amount >= row.limit_amount)
+  if (!limited) return null
+  return {
+    ok: false as const,
+    reason: limited.scope === "global" ? "capacity" as const : "limit" as const,
+    retryAfterSeconds: retryAfterSeconds(limited.window_end_at, now),
+  }
+}
+
+async function incrementRateBuckets(tx: Transaction, rows: Awaited<ReturnType<typeof prepareRateBuckets>>) {
+  for (const row of rows) {
+    await tx.update(AnonymousInferenceRateBucketTable).set({
+      used_amount: sql`${AnonymousInferenceRateBucketTable.used_amount} + 1`,
+    }).where(eq(AnonymousInferenceRateBucketTable.id, row.id))
+  }
+}
+
+export function anonymousReservationMicroUsd() {
+  const input = env.anonymous.maxInputTokens * env.anonymous.maxInputPriceMicroUsdPerMillion
+  const output = env.anonymous.maxCompletionTokens * env.anonymous.maxCompletionPriceMicroUsdPerMillion
+  // OpenRouter BYOK currently adds a 5% fee. Keep a fixed 10% reserve margin
+  // for that fee, rounding, and accounting drift; operators cannot lower it.
+  return Math.ceil(((input + output) * upstreamCostSafetyNumerator) / (1_000_000 * upstreamCostSafetyDenominator))
+}
+
+export async function consumeAnonymousSessionIssuance(
+  identities: AnonymousIdentities,
+  request: { deadlineAt: number; signal: AbortSignal },
+): Promise<{ ok: true } | AdmissionFailure> {
+  return db.transaction(async (tx) => {
+    const control = await lockControl(tx)
+    if (control.blocked) return { ok: false, reason: "unavailable" }
+    const now = new Date()
+    if (request.signal.aborted || now.getTime() >= request.deadlineAt) return { ok: false, reason: "unavailable" }
+    await reapExpiredReservations(tx, now)
+    const specs = rateSpecs("session", identities, now)
+    // Check fixed-cardinality shared identities before inserting an
+    // attacker-selected installation row. Rejected UUID churn stays O(1).
+    const sharedRows = await prepareRateBuckets(tx, specs.filter((spec) => spec.scope !== "installation"))
+    const sharedLimit = firstRateLimit(sharedRows, now)
+    if (sharedLimit) return sharedLimit
+    if (request.signal.aborted || Date.now() >= request.deadlineAt) return { ok: false, reason: "unavailable" }
+    const installationRows = await prepareRateBuckets(tx, specs.filter((spec) => spec.scope === "installation"))
+    const installationLimit = firstRateLimit(installationRows, now)
+    if (installationLimit) return installationLimit
+    if (request.signal.aborted || Date.now() >= request.deadlineAt) return { ok: false, reason: "unavailable" }
+    await incrementRateBuckets(tx, [...sharedRows, ...installationRows])
+    return { ok: true }
+  })
+}
+
+export async function reserveAnonymousInference(input: {
+  id: string
+  identities: AnonymousIdentities
+  deadlineAt: number
+  signal: AbortSignal
+}): Promise<{ ok: true; reservationId: string; dispatchDeadline: number } | AdmissionFailure> {
+  const reserveMicroUsd = anonymousReservationMicroUsd()
+  return db.transaction(async (tx) => {
+    const control = await lockControl(tx)
+    if (control.blocked) return { ok: false, reason: "unavailable" }
+    // The lease starts after this process owns the global admission lock; time
+    // spent waiting for that lock never becomes dispatch time.
+    const now = new Date()
+    const dispatchDeadline = Math.min(
+      input.deadlineAt,
+      now.getTime() + env.anonymous.requestTimeoutMs,
+    )
+    if (input.signal.aborted || dispatchDeadline <= now.getTime()) return { ok: false, reason: "unavailable" }
+    await reapExpiredReservations(tx, now)
+
+    const [installInflight] = await tx.select({ amount: count() }).from(AnonymousInferenceReservationTable).where(and(
+      eq(AnonymousInferenceReservationTable.status, "active"),
+      eq(AnonymousInferenceReservationTable.installation_hash, input.identities.installationHash),
+    ))
+    const [globalInflight] = await tx.select({ amount: count() }).from(AnonymousInferenceReservationTable)
+      .where(eq(AnonymousInferenceReservationTable.status, "active"))
+    if (Number(installInflight?.amount ?? 0) >= 1 || Number(globalInflight?.amount ?? 0) >= env.anonymous.globalInflight) {
+      return { ok: false, reason: "capacity", retryAfterSeconds: Math.ceil((env.anonymous.requestTimeoutMs + 30_000) / 1000) }
+    }
+
+    const rateRows = await prepareRateBuckets(tx, rateSpecs("request", input.identities, now))
+    const rateLimited = firstRateLimit(rateRows, now)
+    if (rateLimited) return rateLimited
+
+    const usageRows = await prepareUsageBuckets(tx, usageSpecs(input.identities, now))
+    const usageLimited = usageRows.find((row) => row.used_micro_usd + reserveMicroUsd > row.limit_micro_usd)
+    if (usageLimited) {
+      return { ok: false, reason: "limit", retryAfterSeconds: retryAfterSeconds(usageLimited.window_end_at, now) }
+    }
+    // Bucket preparation can wait on row locks. Recheck the original request
+    // lifetime before consuming rate/spend or creating a lease.
+    if (input.signal.aborted || Date.now() >= dispatchDeadline) return { ok: false, reason: "unavailable" }
+
+    await incrementRateBuckets(tx, rateRows)
+    for (const row of usageRows) {
+      await tx.update(AnonymousInferenceUsageBucketTable).set({
+        used_micro_usd: sql`${AnonymousInferenceUsageBucketTable.used_micro_usd} + ${reserveMicroUsd}`,
+      }).where(eq(AnonymousInferenceUsageBucketTable.id, row.id))
+    }
+    await tx.insert(AnonymousInferenceReservationTable).values({
+      id: input.id,
+      installation_hash: input.identities.installationHash,
+      ip_hash: input.identities.ipHash,
+      reserved_micro_usd: reserveMicroUsd,
+      lease_expires_at: new Date(dispatchDeadline + 30_000),
+    })
+    await tx.insert(AnonymousInferenceReservationChargeTable).values(usageRows.map((row) => ({
+      id: stableId(["charge", input.id, row.id]),
+      reservation_id: input.id,
+      bucket_id: row.id,
+      reserved_micro_usd: reserveMicroUsd,
+    })))
+    return { ok: true, reservationId: input.id, dispatchDeadline }
+  })
+}
+
+export async function validateAnonymousDispatch(reservationId: string, dispatchDeadline: number, signal: AbortSignal) {
+  return db.transaction(async (tx) => {
+    const control = await lockControl(tx)
+    // Read time only after acquiring the same lock used by admission. A stale
+    // pre-lock timestamp must never authorize dispatch after its deadline.
+    const now = new Date()
+    await reapExpiredReservations(tx, now)
+    const [reservation] = await tx.select().from(AnonymousInferenceReservationTable)
+      .where(eq(AnonymousInferenceReservationTable.id, reservationId)).limit(1).for("update")
+    const valid = !control.blocked
+      && !signal.aborted
+      && reservation?.status === "active"
+      && reservation.lease_expires_at > now
+      && dispatchDeadline > now.getTime()
+    if (reservation?.status === "active" && !valid) {
+      await tx.update(AnonymousInferenceReservationTable).set({ status: "retained", released_at: now })
+        .where(eq(AnonymousInferenceReservationTable.id, reservationId))
+    }
+    return valid
+  })
+}
+
+export type TrustedAnonymousUsage = {
+  costMicroUsd: number
+  inputTokens: number
+  billableCompletionTokens: number
+}
+
+function unsafeUsageForReservation(usage: TrustedAnonymousUsage | null, reservedMicroUsd: number) {
+  return usage !== null && (
+    !Number.isSafeInteger(usage.costMicroUsd)
+    || usage.costMicroUsd < 0
+    || usage.costMicroUsd > reservedMicroUsd
+    || !Number.isSafeInteger(usage.inputTokens)
+    || usage.inputTokens < 0
+    || usage.inputTokens > env.anonymous.maxInputTokens
+    || !Number.isSafeInteger(usage.billableCompletionTokens)
+    || usage.billableCompletionTokens < 0
+    || usage.billableCompletionTokens > env.anonymous.maxCompletionTokens
+  )
+}
+
+async function blockAnonymousInference(tx: Transaction, now: Date) {
+  await tx.update(AnonymousInferenceControlTable).set({
+    blocked: true,
+    blocked_at: now,
+    block_reason: "reservation_safety_fault",
+  }).where(eq(AnonymousInferenceControlTable.id, controlId))
+}
+
+export async function settleAnonymousInference(reservationId: string, usage: TrustedAnonymousUsage | null) {
+  return db.transaction(async (tx) => {
+    await lockControl(tx)
+    const now = new Date()
+    const [reservation] = await tx.select().from(AnonymousInferenceReservationTable)
+      .where(eq(AnonymousInferenceReservationTable.id, reservationId)).limit(1).for("update")
+    if (!reservation) return "missing"
+    const unsafeUsage = unsafeUsageForReservation(usage, reservation.reserved_micro_usd)
+    if (reservation.status === "active" && reservation.lease_expires_at <= now) {
+      if (unsafeUsage) await blockAnonymousInference(tx, now)
+      await tx.update(AnonymousInferenceReservationTable).set({ status: "retained", released_at: now })
+        .where(eq(AnonymousInferenceReservationTable.id, reservationId))
+      return unsafeUsage ? "blocked" : "retained"
+    }
+    // A timeout/reaper may have retained this charge before the final trusted
+    // usage frame arrived. Never refund it, but still trip the durable kill
+    // switch if that late usage proves the reservation was insufficient.
+    if (reservation.status !== "active") {
+      if (unsafeUsage) await blockAnonymousInference(tx, now)
+      return unsafeUsage ? "blocked" : reservation.status
+    }
+    if (!usage || unsafeUsage) {
+      if (unsafeUsage) await blockAnonymousInference(tx, now)
+      await tx.update(AnonymousInferenceReservationTable).set({
+        status: "retained",
+        released_at: now,
+      }).where(eq(AnonymousInferenceReservationTable.id, reservationId))
+      return unsafeUsage ? "blocked" : "retained"
+    }
+
+    const refundMicroUsd = reservation.reserved_micro_usd - usage.costMicroUsd
+    const charges = await tx.select().from(AnonymousInferenceReservationChargeTable)
+      .where(eq(AnonymousInferenceReservationChargeTable.reservation_id, reservationId))
+    charges.sort((left, right) => left.bucket_id.localeCompare(right.bucket_id))
+    for (const charge of charges) {
+      if (refundMicroUsd > 0) {
+        await tx.update(AnonymousInferenceUsageBucketTable).set({
+          used_micro_usd: sql`${AnonymousInferenceUsageBucketTable.used_micro_usd} - ${refundMicroUsd}`,
+        }).where(eq(AnonymousInferenceUsageBucketTable.id, charge.bucket_id))
+      }
+      await tx.update(AnonymousInferenceReservationChargeTable).set({
+        settled_micro_usd: usage.costMicroUsd,
+      }).where(eq(AnonymousInferenceReservationChargeTable.id, charge.id))
+    }
+    await tx.update(AnonymousInferenceReservationTable).set({
+      status: "settled",
+      settled_micro_usd: usage.costMicroUsd,
+      released_at: now,
+    }).where(eq(AnonymousInferenceReservationTable.id, reservationId))
+    return "settled"
+  })
+}

--- a/ee/apps/inference/src/anonymous.ts
+++ b/ee/apps/inference/src/anonymous.ts
@@ -1,0 +1,727 @@
+import { createHash, randomUUID } from "node:crypto"
+import type { Context, Hono } from "hono"
+import { z } from "zod"
+import {
+  consumeAnonymousSessionIssuance,
+  reserveAnonymousInference,
+  settleAnonymousInference,
+  validateAnonymousDispatch,
+  type TrustedAnonymousUsage,
+} from "./anonymous-limits.js"
+import {
+  createAnonymousIdentities,
+  issueAnonymousToken,
+  resolveAnonymousClientAddress,
+  verifyAnonymousToken,
+} from "./anonymous-identity.js"
+import { env } from "./env.js"
+
+const anonymousModel = "openai/gpt-5.6-luna"
+const sessionPath = "/api/anonymous/session"
+const modelsPath = "/api/anonymous/v1/models"
+const chatPath = "/api/anonymous/v1/chat/completions"
+const sessionSchema = z.object({ installationId: z.string().uuid() }).strict()
+const policyFields = new Set([
+  "models", "fallbacks", "preset", "route", "provider", "plugins", "transforms", "reasoning",
+  "web_search_options", "user", "session_id", "trace", "service_tier",
+])
+const allowedTopLevelFields = new Set([
+  "model", "messages", "stream", "max_tokens", "max_completion_tokens", "temperature", "top_p",
+  "frequency_penalty", "presence_penalty", "stop", "seed", "n", "tools", "tool_choice",
+  "response_format", "parallel_tool_calls", "usage", "reasoningEffort", "textVerbosity",
+])
+const sdkTextVerbosityValues = new Set(["low", "medium", "high"])
+
+type JsonObject = Record<string, unknown>
+type PreparedAnonymousRequest = {
+  body: string
+  stream: boolean
+}
+
+type AnonymousRouteDependencies = {
+  fetch: typeof fetch
+  clientAddress: (context: Context) => string | null
+  consumeSessionIssuance: typeof consumeAnonymousSessionIssuance
+  reserve: typeof reserveAnonymousInference
+  settle: typeof settleAnonymousInference
+  validateDispatch: typeof validateAnonymousDispatch
+}
+
+const defaultDependencies: AnonymousRouteDependencies = {
+  fetch,
+  clientAddress: resolveAnonymousClientAddress,
+  consumeSessionIssuance: consumeAnonymousSessionIssuance,
+  reserve: reserveAnonymousInference,
+  settle: settleAnonymousInference,
+  validateDispatch: validateAnonymousDispatch,
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function openAiError(status: number, code: string, message: string, type = "invalid_request_error") {
+  return Response.json({ error: { code, message, type } }, { status })
+}
+
+function unavailable() {
+  return openAiError(503, "anonymous_unavailable", "OpenWork's free allowance is temporarily unavailable. Please try again later.", "api_error")
+}
+
+function invalidToken() {
+  return openAiError(401, "invalid_anonymous_token", "This OpenWork free allowance token is invalid or expired.", "authentication_error")
+}
+
+function modelNotAllowed(message = "OpenWork's free allowance only supports GPT-5.6 Luna and does not allow alternate routing.") {
+  return openAiError(403, "anonymous_model_not_allowed", message)
+}
+
+function admissionError(result: { reason: "limit" | "capacity" | "unavailable"; retryAfterSeconds?: number }) {
+  if (result.reason === "unavailable") return unavailable()
+  const capacity = result.reason === "capacity"
+  const response = openAiError(
+    429,
+    capacity ? "anonymous_capacity_exceeded" : "anonymous_limit_exceeded",
+    capacity
+      ? "OpenWork's free allowance is at capacity. Please try again later."
+      : "You have reached the OpenWork free allowance. Please try again after it resets.",
+    "rate_limit_error",
+  )
+  if (result.retryAfterSeconds) response.headers.set("retry-after", String(result.retryAfterSeconds))
+  return response
+}
+
+async function readBoundedJson(request: Request, maxBytes: number, deadlineAt: number) {
+  const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
+  if (contentType !== "application/json" || request.headers.get("content-encoding")) {
+    return { error: openAiError(400, "invalid_request", "OpenWork's free allowance accepts uncompressed JSON requests only.") }
+  }
+  const declared = Number(request.headers.get("content-length") ?? "0")
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    return { error: openAiError(400, "invalid_request", "The request is too large for the OpenWork free allowance.") }
+  }
+  if (!request.body) return { error: openAiError(400, "invalid_request", "A JSON request body is required for the OpenWork free allowance.") }
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let size = 0
+  while (true) {
+    if (request.signal.aborted || Date.now() >= deadlineAt) {
+      await reader.cancel().catch(() => undefined)
+      return { error: unavailable() }
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    let abortListener: (() => void) | undefined
+    const chunk = await Promise.race([
+      reader.read().then((result) => ({ result })),
+      new Promise<{ timedOut: true }>((resolve) => {
+        timeout = setTimeout(() => resolve({ timedOut: true }), Math.max(1, deadlineAt - Date.now()))
+      }),
+      new Promise<{ aborted: true }>((resolve) => {
+        abortListener = () => resolve({ aborted: true })
+        if (request.signal.aborted) {
+          resolve({ aborted: true })
+          return
+        }
+        request.signal.addEventListener("abort", abortListener, { once: true })
+      }),
+    ]).finally(() => {
+      if (timeout) clearTimeout(timeout)
+      if (abortListener) request.signal.removeEventListener("abort", abortListener)
+    })
+    if ("timedOut" in chunk || "aborted" in chunk) {
+      await reader.cancel().catch(() => undefined)
+      return { error: unavailable() }
+    }
+    const { result } = chunk
+    if (result.done) break
+    size += result.value.byteLength
+    if (size > maxBytes) {
+      await reader.cancel().catch(() => undefined)
+      return { error: openAiError(400, "invalid_request", "The request is too large for the OpenWork free allowance.") }
+    }
+    chunks.push(result.value)
+  }
+  const bytes = new Uint8Array(size)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  try {
+    return { value: JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)), size }
+  } catch {
+    return { error: openAiError(400, "invalid_request", "The JSON request is invalid for the OpenWork free allowance.") }
+  }
+}
+
+function hasOnlyFields(value: JsonObject, fields: Set<string>) {
+  return Object.keys(value).every((field) => fields.has(field))
+}
+
+function isBoundedString(value: unknown, max = 65_536): value is string {
+  return typeof value === "string" && Buffer.byteLength(value, "utf8") <= max
+}
+
+function isJsonValue(value: unknown, depth = 0): boolean {
+  if (depth > 24) return false
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true
+  if (typeof value === "number") return Number.isFinite(value)
+  if (Array.isArray(value)) return value.every((entry) => isJsonValue(entry, depth + 1))
+  if (!isObject(value)) return false
+  if (Object.prototype.hasOwnProperty.call(value, "$ref")) return false
+  return Object.values(value).every((entry) => isJsonValue(entry, depth + 1))
+}
+
+function validContent(value: unknown) {
+  if (typeof value === "string" || value === null) return true
+  if (!Array.isArray(value)) return false
+  return value.every((part) => isObject(part)
+    && hasOnlyFields(part, new Set(["type", "text"]))
+    && (part.type === "text" || part.type === "input_text")
+    && isBoundedString(part.text))
+}
+
+function validToolCalls(value: unknown) {
+  if (value === undefined) return true
+  if (!Array.isArray(value) || value.length > 64) return false
+  return value.every((call) => isObject(call)
+    && hasOnlyFields(call, new Set(["id", "type", "function", "index"]))
+    && isBoundedString(call.id, 256)
+    && call.type === "function"
+    && (call.index === undefined || (Number.isInteger(call.index) && Number(call.index) >= 0))
+    && isObject(call.function)
+    && hasOnlyFields(call.function, new Set(["name", "arguments"]))
+    && isBoundedString(call.function.name, 256)
+    && isBoundedString(call.function.arguments))
+}
+
+function validMessages(value: unknown) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 256) return false
+  const roles = new Set(["system", "developer", "user", "assistant", "tool"])
+  const fields = new Set(["role", "content", "name", "tool_call_id", "tool_calls", "refusal"])
+  return value.every((message) => isObject(message)
+    && hasOnlyFields(message, fields)
+    && typeof message.role === "string"
+    && roles.has(message.role)
+    && validContent(message.content)
+    && (message.name === undefined || isBoundedString(message.name, 256))
+    && (message.tool_call_id === undefined || isBoundedString(message.tool_call_id, 256))
+    && (message.refusal === undefined || isBoundedString(message.refusal))
+    && validToolCalls(message.tool_calls))
+}
+
+function validTools(value: unknown) {
+  if (value === undefined) return true
+  if (!Array.isArray(value) || value.length > 64) return false
+  return value.every((tool) => isObject(tool)
+    && hasOnlyFields(tool, new Set(["type", "function"]))
+    && tool.type === "function"
+    && isObject(tool.function)
+    && hasOnlyFields(tool.function, new Set(["name", "description", "parameters", "strict"]))
+    && isBoundedString(tool.function.name, 256)
+    && (tool.function.description === undefined || isBoundedString(tool.function.description, 8_192))
+    && (tool.function.parameters === undefined || (isObject(tool.function.parameters) && isJsonValue(tool.function.parameters)))
+    && (tool.function.strict === undefined || typeof tool.function.strict === "boolean"))
+}
+
+function validToolChoice(value: unknown) {
+  if (value === undefined || value === "none" || value === "auto" || value === "required") return true
+  return isObject(value)
+    && hasOnlyFields(value, new Set(["type", "function"]))
+    && value.type === "function"
+    && isObject(value.function)
+    && hasOnlyFields(value.function, new Set(["name"]))
+    && isBoundedString(value.function.name, 256)
+}
+
+function validUsage(value: unknown) {
+  return value === undefined
+    || (isObject(value) && hasOnlyFields(value, new Set(["include"])) && value.include === true)
+}
+
+function validResponseFormat(value: unknown) {
+  if (value === undefined) return true
+  if (!isObject(value) || !hasOnlyFields(value, new Set(["type", "json_schema"]))) return false
+  if (value.type === "text" || value.type === "json_object") return value.json_schema === undefined
+  if (value.type !== "json_schema" || !isObject(value.json_schema)) return false
+  return hasOnlyFields(value.json_schema, new Set(["name", "description", "schema", "strict"]))
+    && isBoundedString(value.json_schema.name, 256)
+    && (value.json_schema.description === undefined || isBoundedString(value.json_schema.description, 8_192))
+    && isObject(value.json_schema.schema)
+    && isJsonValue(value.json_schema.schema)
+    && (value.json_schema.strict === undefined || typeof value.json_schema.strict === "boolean")
+}
+
+function optionalInteger(value: unknown, min: number, max: number) {
+  return value === undefined || (Number.isSafeInteger(value) && Number(value) >= min && Number(value) <= max)
+}
+
+function prepareAnonymousBody(value: unknown): PreparedAnonymousRequest | Response {
+  if (!isObject(value)) return openAiError(400, "invalid_request", "The OpenWork free allowance request must be a JSON object.")
+  const policyField = Object.keys(value).find((field) => policyFields.has(field))
+  if (policyField) return modelNotAllowed(`OpenWork's free allowance does not allow ${policyField} overrides.`)
+  const unknownField = Object.keys(value).find((field) => !allowedTopLevelFields.has(field))
+  if (unknownField) return openAiError(400, "invalid_request", `The field ${unknownField} is not supported by the OpenWork free allowance.`)
+  if (value.model !== anonymousModel) return modelNotAllowed()
+  if (!validMessages(value.messages)) return openAiError(400, "invalid_request", "Messages must contain bounded text-only content for the OpenWork free allowance.")
+  if (!validTools(value.tools)) return modelNotAllowed("OpenWork's free allowance permits client-side function tools only; server tools and remote media are not allowed.")
+  if (!validToolChoice(value.tool_choice) || !validResponseFormat(value.response_format)) {
+    return openAiError(400, "invalid_request", "The requested response or tool format is invalid for the OpenWork free allowance.")
+  }
+  if (!validUsage(value.usage)) return openAiError(400, "invalid_request", "The requested usage format is invalid for the OpenWork free allowance.")
+  if (value.stream !== undefined && typeof value.stream !== "boolean") return openAiError(400, "invalid_request", "stream must be a boolean.")
+  if (value.n !== undefined && value.n !== 1) return modelNotAllowed("OpenWork's free allowance supports exactly one completion per request.")
+  if (!optionalInteger(value.max_tokens, 1, env.anonymous.maxCompletionTokens)
+    || !optionalInteger(value.max_completion_tokens, 1, env.anonymous.maxCompletionTokens)
+    || (value.max_tokens !== undefined && value.max_completion_tokens !== undefined)) {
+    return openAiError(400, "invalid_request", `OpenWork's free allowance allows at most ${env.anonymous.maxCompletionTokens} billable completion tokens.`)
+  }
+  if (value.reasoningEffort !== undefined && typeof value.reasoningEffort !== "string") {
+    return openAiError(400, "invalid_request", "reasoningEffort must be the fixed none compatibility value.")
+  }
+  if (value.reasoningEffort !== undefined && value.reasoningEffort !== "none") {
+    return modelNotAllowed("OpenWork's free allowance fixes reasoning effort to none and mode to standard.")
+  }
+  if (value.textVerbosity !== undefined
+    && (typeof value.textVerbosity !== "string" || !sdkTextVerbosityValues.has(value.textVerbosity))) {
+    return openAiError(400, "invalid_request", "textVerbosity must be low, medium, or high.")
+  }
+  const unsupportedGenerationField = [
+    "temperature", "top_p", "frequency_penalty", "presence_penalty", "stop", "parallel_tool_calls",
+  ].find((field) => value[field] !== undefined)
+  if (unsupportedGenerationField) {
+    return openAiError(400, "invalid_request", `The field ${unsupportedGenerationField} is not supported by GPT-5.6 Luna.`)
+  }
+  if (!optionalInteger(value.seed, -2_147_483_648, 2_147_483_647)) {
+    return openAiError(400, "invalid_request", "A numeric generation setting is outside the OpenWork free allowance bounds.")
+  }
+
+  const stream = value.stream === true
+  const maxTokens = typeof value.max_tokens === "number"
+    ? value.max_tokens
+    : typeof value.max_completion_tokens === "number"
+      ? value.max_completion_tokens
+      : env.anonymous.maxCompletionTokens
+  const forwarded: JsonObject = {
+    model: anonymousModel,
+    messages: value.messages,
+    stream,
+    max_tokens: maxTokens,
+    reasoning: { effort: "none", mode: "standard", exclude: true },
+    usage: { include: true },
+    provider: {
+      order: [env.anonymous.provider],
+      only: [env.anonymous.provider],
+      allow_fallbacks: false,
+      require_parameters: true,
+      data_collection: "deny",
+      zdr: true,
+      max_price: {
+        prompt: env.anonymous.maxInputPriceMicroUsdPerMillion / 1_000_000,
+        completion: env.anonymous.maxCompletionPriceMicroUsdPerMillion / 1_000_000,
+        request: 0,
+        image: 0,
+      },
+    },
+  }
+  // Luna does not advertise n as a supported parameter. Omitting its default
+  // value preserves one completion while n !== 1 is rejected above.
+  for (const field of [
+    "seed", "tool_choice", "response_format",
+  ]) {
+    if (value[field] !== undefined) forwarded[field] = value[field]
+  }
+  // OpenCode and the AI SDK use camelCase provider options. OpenRouter's
+  // documented Chat API accepts the bounded equivalent as verbosity.
+  if (value.textVerbosity !== undefined) forwarded.verbosity = value.textVerbosity
+  if (stream) forwarded.stream_options = { include_usage: true }
+  // A byte-level canonical payload cap is enforced after JSON parsing and all
+  // server-owned fields are added. Keeping it below the priced input-token cap
+  // leaves an explicit allowance for provider chat/tool framing. Upstream usage
+  // remains authoritative and any reservation overrun trips the kill switch.
+  const canonicalPayloadLimit = env.anonymous.maxInputTokens - env.anonymous.chatWrappingTokenAllowance
+  if (value.tools !== undefined) forwarded.tools = value.tools
+  const body = JSON.stringify(forwarded)
+  const canonicalPayloadBytes = Buffer.byteLength(body, "utf8")
+  if (canonicalPayloadLimit <= 0 || canonicalPayloadBytes > canonicalPayloadLimit) {
+    return openAiError(400, "invalid_request", "The canonical chat and tool context is too large for the OpenWork free allowance.")
+  }
+  return { body, stream }
+}
+
+function readTrustedUsage(value: unknown): TrustedAnonymousUsage | null {
+  if (!isObject(value) || !isObject(value.usage)) return null
+  const usage = value.usage
+  if (typeof usage.cost !== "number" || !Number.isFinite(usage.cost) || usage.cost < 0) return null
+  if (typeof usage.is_byok !== "boolean") return null
+  if (!Number.isSafeInteger(usage.prompt_tokens) || Number(usage.prompt_tokens) < 0) return null
+  if (!Number.isSafeInteger(usage.completion_tokens) || Number(usage.completion_tokens) < 0) return null
+  const completionTokens = Number(usage.completion_tokens)
+  let reasoningTokens = 0
+  if (isObject(usage.completion_tokens_details) && usage.completion_tokens_details.reasoning_tokens !== undefined) {
+    if (!Number.isSafeInteger(usage.completion_tokens_details.reasoning_tokens)
+      || Number(usage.completion_tokens_details.reasoning_tokens) < 0) return null
+    reasoningTokens = Number(usage.completion_tokens_details.reasoning_tokens)
+  }
+  if (reasoningTokens > completionTokens) return null
+  // This route is enabled only after the key is attested as BYOK-only. Treat a
+  // shared-routing marker or missing provider principal as unknown accounting;
+  // either case retains the full reservation rather than refunding from the fee.
+  if (!usage.is_byok
+    || !isObject(usage.cost_details)
+    || typeof usage.cost_details.upstream_inference_cost !== "number"
+    || !Number.isFinite(usage.cost_details.upstream_inference_cost)
+    || usage.cost_details.upstream_inference_cost < 0) return null
+  const totalCost = usage.cost + usage.cost_details.upstream_inference_cost
+  if (!Number.isFinite(totalCost)) return null
+  const costMicroUsd = Math.ceil(totalCost * 1_000_000)
+  if (!Number.isSafeInteger(costMicroUsd)) return null
+  return {
+    costMicroUsd,
+    inputTokens: Number(usage.prompt_tokens),
+    // OpenAI reports reasoning_tokens as an inclusive subset of completion_tokens.
+    billableCompletionTokens: completionTokens,
+  }
+}
+
+async function readBoundedResponseJson(response: Response) {
+  const reader = response.body?.getReader()
+  if (!reader) return null
+  const chunks: Uint8Array[] = []
+  let bytes = 0
+  while (true) {
+    const chunk = await reader.read()
+    if (chunk.done) break
+    bytes += chunk.value.byteLength
+    if (bytes > env.anonymous.maxResponseBytes) {
+      await reader.cancel()
+      return null
+    }
+    chunks.push(chunk.value)
+  }
+  const body = new Uint8Array(bytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body))
+    if (!isObject(parsed)) return null
+    const usage = readTrustedUsage(parsed)
+    const publicBody = new TextEncoder().encode(JSON.stringify(publicAnonymousResponse(parsed)))
+    if (publicBody.byteLength > env.anonymous.maxResponseBytes) return null
+    return { body: publicBody, usage }
+  } catch {
+    return null
+  }
+}
+
+function publicAnonymousUsage(value: unknown) {
+  if (!isObject(value)) return null
+  const usage: JsonObject = {}
+  for (const field of ["prompt_tokens", "completion_tokens", "total_tokens"]) {
+    if (Number.isSafeInteger(value[field]) && Number(value[field]) >= 0) usage[field] = value[field]
+  }
+  if (isObject(value.prompt_tokens_details) && Number.isSafeInteger(value.prompt_tokens_details.cached_tokens)
+    && Number(value.prompt_tokens_details.cached_tokens) >= 0) {
+    usage.prompt_tokens_details = { cached_tokens: value.prompt_tokens_details.cached_tokens }
+  }
+  if (isObject(value.completion_tokens_details) && Number.isSafeInteger(value.completion_tokens_details.reasoning_tokens)
+    && Number(value.completion_tokens_details.reasoning_tokens) >= 0) {
+    usage.completion_tokens_details = { reasoning_tokens: value.completion_tokens_details.reasoning_tokens }
+  }
+  return usage
+}
+
+function publicAnonymousResponse(value: JsonObject) {
+  const usage = publicAnonymousUsage(value.usage)
+  return usage ? { ...value, usage } : value
+}
+
+function trackAnonymousStream(input: {
+  body: ReadableStream<Uint8Array>
+  controller: AbortController
+  finalize: (usage: TrustedAnonymousUsage | null) => Promise<void>
+}) {
+  const reader = input.body.getReader()
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ""
+  let bytes = 0
+  let usage: TrustedAnonymousUsage | null = null
+  const transform = (text: string) => {
+    buffer += text.replaceAll("\r\n", "\n")
+    let output = ""
+    while (true) {
+      const boundary = buffer.indexOf("\n\n")
+      if (boundary < 0) break
+      const frame = buffer.slice(0, boundary).replaceAll("\r", "")
+      buffer = buffer.slice(boundary + 2)
+      const data = frame.split("\n").filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trim()).join("\n")
+      if (!data || data === "[DONE]") {
+        output += `${frame}\n\n`
+        continue
+      }
+      try {
+        const parsed: unknown = JSON.parse(data)
+        const found = readTrustedUsage(parsed)
+        if (found) usage = found
+        output += isObject(parsed) && publicAnonymousUsage(parsed.usage)
+          ? `data: ${JSON.stringify(publicAnonymousResponse(parsed))}\n\n`
+          : `${frame}\n\n`
+      } catch {
+        output += `${frame}\n\n`
+      }
+    }
+    if (Buffer.byteLength(buffer, "utf8") > 262_144) buffer = ""
+    return output
+  }
+  return new ReadableStream<Uint8Array>({
+    async pull(stream) {
+      try {
+        while (true) {
+          const chunk = await reader.read()
+          if (chunk.done) {
+            const output = transform(decoder.decode()) + buffer
+            buffer = ""
+            if (output) stream.enqueue(encoder.encode(output))
+            await input.finalize(usage)
+            stream.close()
+            return
+          }
+          bytes += chunk.value.byteLength
+          if (bytes > env.anonymous.maxResponseBytes) {
+            input.controller.abort()
+            await input.finalize(null)
+            stream.error(new Error("Anonymous inference response exceeded its safety bound"))
+            return
+          }
+          const output = transform(decoder.decode(chunk.value, { stream: true }))
+          if (output) {
+            stream.enqueue(encoder.encode(output))
+            return
+          }
+        }
+      } catch (error) {
+        await input.finalize(null)
+        stream.error(error)
+      }
+    },
+    async cancel(reason) {
+      input.controller.abort()
+      await input.finalize(null)
+      await reader.cancel(reason)
+    },
+  })
+}
+
+function requestId() {
+  return createHash("sha256").update(`${Date.now()}:${randomUUID()}`, "utf8").digest("hex")
+}
+
+function readBearer(request: Request) {
+  const header = request.headers.get("authorization")
+  if (!header?.toLowerCase().startsWith("bearer ")) return null
+  return header.slice(7).trim() || null
+}
+
+function anonymousModels() {
+  return { object: "list", data: [{ id: anonymousModel, object: "model", created: 0, owned_by: "openwork" }] }
+}
+
+export function registerAnonymousInferenceRoutes(app: Hono, dependencies: AnonymousRouteDependencies = defaultDependencies) {
+  app.post(sessionPath, async (c) => {
+    const requestDeadline = Date.now() + env.anonymous.requestTimeoutMs
+    if (!env.anonymous.enabled) return unavailable()
+    const address = dependencies.clientAddress(c)
+    if (!address) return unavailable()
+    const parsedBody = await readBoundedJson(c.req.raw, 4_096, requestDeadline)
+    if ("error" in parsedBody) return parsedBody.error
+    const parsed = sessionSchema.safeParse(parsedBody.value)
+    if (!parsed.success) return openAiError(400, "invalid_request", "A valid installationId UUID is required for the OpenWork free allowance.")
+    const identities = createAnonymousIdentities(parsed.data.installationId, address)
+    if (c.req.raw.signal.aborted || Date.now() >= requestDeadline) return unavailable()
+    try {
+      const admitted = await dependencies.consumeSessionIssuance(identities, {
+        deadlineAt: requestDeadline,
+        signal: c.req.raw.signal,
+      })
+      if (!admitted.ok) return admissionError(admitted)
+      if (c.req.raw.signal.aborted || Date.now() >= requestDeadline) return unavailable()
+      const token = issueAnonymousToken(identities)
+      return c.json({ ...token, model: anonymousModel })
+    } catch {
+      return unavailable()
+    }
+  })
+
+  async function authenticate(c: Context) {
+    if (!env.anonymous.enabled) return { error: unavailable() }
+    const address = dependencies.clientAddress(c)
+    const bearer = readBearer(c.req.raw)
+    if (!address || !bearer) return { error: invalidToken() }
+    const token = verifyAnonymousToken(bearer, address)
+    return token ? { identities: token } : { error: invalidToken() }
+  }
+
+  app.get(modelsPath, async (c) => {
+    const authentication = await authenticate(c)
+    if ("error" in authentication) return authentication.error
+    if (new URL(c.req.url).search) return modelNotAllowed("OpenWork's free allowance does not allow model query overrides.")
+    return c.json(anonymousModels())
+  })
+
+  app.post(chatPath, async (c) => {
+    const requestDeadline = Date.now() + env.anonymous.requestTimeoutMs
+    const authentication = await authenticate(c)
+    if ("error" in authentication) return authentication.error
+    if (new URL(c.req.url).search) return modelNotAllowed("OpenWork's free allowance does not allow routing query parameters.")
+    const parsedBody = await readBoundedJson(c.req.raw, env.anonymous.maxBodyBytes, requestDeadline)
+    if ("error" in parsedBody) return parsedBody.error
+    const prepared = prepareAnonymousBody(parsedBody.value)
+    if (prepared instanceof Response) return prepared
+    if (c.req.raw.signal.aborted || Date.now() >= requestDeadline) return unavailable()
+
+    const id = requestId()
+    let admitted: Awaited<ReturnType<typeof dependencies.reserve>>
+    try {
+      admitted = await dependencies.reserve({
+        id,
+        identities: authentication.identities,
+        deadlineAt: requestDeadline,
+        signal: c.req.raw.signal,
+      })
+    } catch {
+      return unavailable()
+    }
+    if (!admitted.ok) return admissionError(admitted)
+
+    const controller = new AbortController()
+    let retainedSettlement: Promise<void> | null = null
+    let usageSettlement: Promise<void> | null = null
+    const finalize = (usage: TrustedAnonymousUsage | null) => {
+      if (usage) {
+        usageSettlement ??= dependencies.settle(admitted.reservationId, usage).then(() => undefined).catch(() => undefined)
+        return usageSettlement
+      }
+      if (usageSettlement) return usageSettlement
+      retainedSettlement ??= dependencies.settle(admitted.reservationId, null).then(() => undefined).catch(() => undefined)
+      return retainedSettlement
+    }
+    const abort = () => {
+      controller.abort()
+      void finalize(null)
+    }
+    c.req.raw.signal.addEventListener("abort", abort, { once: true })
+    if (c.req.raw.signal.aborted) abort()
+    let dispatchable = false
+    try {
+      dispatchable = !controller.signal.aborted
+        && await dependencies.validateDispatch(admitted.reservationId, admitted.dispatchDeadline, controller.signal)
+        && !controller.signal.aborted
+        && Date.now() < admitted.dispatchDeadline
+    } catch {
+      dispatchable = false
+    }
+    if (!dispatchable) {
+      c.req.raw.signal.removeEventListener("abort", abort)
+      await finalize(null)
+      return unavailable()
+    }
+    const timeoutMs = admitted.dispatchDeadline - Date.now()
+    if (timeoutMs <= 0) {
+      c.req.raw.signal.removeEventListener("abort", abort)
+      await finalize(null)
+      return unavailable()
+    }
+    const timeout = setTimeout(() => {
+      controller.abort()
+      void finalize(null)
+    }, timeoutMs)
+    if (controller.signal.aborted || Date.now() >= admitted.dispatchDeadline) {
+      clearTimeout(timeout)
+      c.req.raw.signal.removeEventListener("abort", abort)
+      await finalize(null)
+      return unavailable()
+    }
+
+    let upstream: Response
+    try {
+      upstream = await dependencies.fetch(`${env.openRouterUpstreamUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          accept: prepared.stream ? "text/event-stream" : "application/json",
+          authorization: `Bearer ${env.anonymous.apiKey}`,
+          "content-type": "application/json",
+          "x-openwork-request-id": id,
+          ...(env.proxyBaseUrl ? { "http-referer": env.proxyBaseUrl } : {}),
+          "x-title": "OpenWork Free Allowance",
+        },
+        body: prepared.body,
+        signal: controller.signal,
+      })
+    } catch {
+      clearTimeout(timeout)
+      c.req.raw.signal.removeEventListener("abort", abort)
+      await finalize(null)
+      return unavailable()
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      clearTimeout(timeout)
+      c.req.raw.signal.removeEventListener("abort", abort)
+      await upstream.body?.cancel().catch(() => undefined)
+      await finalize(null)
+      return unavailable()
+    }
+
+    const upstreamContentType = upstream.headers.get("content-type")?.toLowerCase() ?? ""
+    if ((prepared.stream && !upstreamContentType.startsWith("text/event-stream"))
+      || (!prepared.stream && !upstreamContentType.startsWith("application/json"))) {
+      clearTimeout(timeout)
+      c.req.raw.signal.removeEventListener("abort", abort)
+      controller.abort()
+      await upstream.body.cancel().catch(() => undefined)
+      await finalize(null)
+      return unavailable()
+    }
+
+    const headers = new Headers({
+      "cache-control": "no-store",
+      "content-type": upstream.headers.get("content-type") ?? (prepared.stream ? "text/event-stream" : "application/json"),
+      "x-openwork-request-id": id,
+    })
+    if (!prepared.stream) {
+      let result: Awaited<ReturnType<typeof readBoundedResponseJson>> = null
+      try {
+        result = await readBoundedResponseJson(upstream)
+      } catch {
+        // Unknown/partial usage retains the reservation.
+      }
+      clearTimeout(timeout)
+      c.req.raw.signal.removeEventListener("abort", abort)
+      if (!result) {
+        controller.abort()
+        await finalize(null)
+        return unavailable()
+      }
+      await finalize(result.usage)
+      return new Response(result.body, { status: upstream.status, headers })
+    }
+
+    const body = trackAnonymousStream({
+      body: upstream.body,
+      controller,
+      finalize: async (usage) => {
+        clearTimeout(timeout)
+        c.req.raw.signal.removeEventListener("abort", abort)
+        await finalize(usage)
+      },
+    })
+    return new Response(body, { status: upstream.status, headers })
+  })
+
+  app.all("/api/anonymous", (c) => modelNotAllowed(`OpenWork's free allowance does not support ${c.req.method} ${c.req.path}.`))
+  app.all("/api/anonymous/*", (c) => modelNotAllowed(`OpenWork's free allowance does not support ${c.req.method} ${c.req.path}.`))
+}

--- a/ee/apps/inference/src/app.ts
+++ b/ee/apps/inference/src/app.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { db } from "./db.js";
 import { env } from "./env.js";
 import { isSentryEnabled } from "./instrumentation.js";
+import { registerAnonymousInferenceRoutes } from "./anonymous.js";
 import { registerProxyRoutes } from "./proxy.js";
 import { registerWebhookRoutes } from "./webhooks.js";
 
@@ -97,6 +98,7 @@ if (shouldServeLocalModelCatalog) {
 }
 
 registerProxyRoutes(app);
+registerAnonymousInferenceRoutes(app);
 registerWebhookRoutes(app);
 
 app.onError((error, c) => {

--- a/ee/apps/inference/src/env.ts
+++ b/ee/apps/inference/src/env.ts
@@ -19,6 +19,35 @@ const EnvSchema = z
     INFERENCE_ADMIN_TOKEN: z.string().optional(),
     INFERENCE_WEBHOOK_SECRET: z.string().optional(),
     INFERENCE_CREDITS_PER_DOLLAR: z.string().optional(),
+    ANONYMOUS_INFERENCE_ENABLED: z.string().optional(),
+    ANONYMOUS_OPENROUTER_API_KEY: z.string().optional(),
+    ANONYMOUS_TOKEN_SECRET: z.string().optional(),
+    ANONYMOUS_ACCOUNTING_IDENTITY_KEY: z.string().optional(),
+    ANONYMOUS_OPENROUTER_PROVIDER: z.string().optional(),
+    ANONYMOUS_OPENROUTER_BYOK_ONLY_VERIFIED: z.string().optional(),
+    ANONYMOUS_TOKEN_TTL_SECONDS: z.string().optional(),
+    ANONYMOUS_INSTALL_DAILY_MICRO_USD: z.string().optional(),
+    ANONYMOUS_INSTALL_MONTHLY_MICRO_USD: z.string().optional(),
+    ANONYMOUS_IP_DAILY_MICRO_USD: z.string().optional(),
+    ANONYMOUS_GLOBAL_DAILY_MICRO_USD: z.string().optional(),
+    ANONYMOUS_GLOBAL_MONTHLY_MICRO_USD: z.string().optional(),
+    ANONYMOUS_GLOBAL_INFLIGHT: z.string().optional(),
+    ANONYMOUS_SESSION_INSTALL_HOURLY: z.string().optional(),
+    ANONYMOUS_SESSION_IP_HOURLY: z.string().optional(),
+    ANONYMOUS_SESSION_GLOBAL_HOURLY: z.string().optional(),
+    ANONYMOUS_REQUEST_INSTALL_HOURLY: z.string().optional(),
+    ANONYMOUS_REQUEST_IP_HOURLY: z.string().optional(),
+    ANONYMOUS_REQUEST_GLOBAL_HOURLY: z.string().optional(),
+    ANONYMOUS_MAX_BODY_BYTES: z.string().optional(),
+    ANONYMOUS_MAX_INPUT_TOKENS: z.string().optional(),
+    ANONYMOUS_CHAT_WRAPPING_TOKEN_ALLOWANCE: z.string().optional(),
+    ANONYMOUS_MAX_COMPLETION_TOKENS: z.string().optional(),
+    ANONYMOUS_MAX_INPUT_PRICE_MICRO_USD_PER_MILLION: z.string().optional(),
+    ANONYMOUS_MAX_COMPLETION_PRICE_MICRO_USD_PER_MILLION: z.string().optional(),
+    ANONYMOUS_REQUEST_TIMEOUT_MS: z.string().optional(),
+    ANONYMOUS_MAX_RESPONSE_BYTES: z.string().optional(),
+    ANONYMOUS_TRUST_PROXY_HOPS: z.string().optional(),
+    ANONYMOUS_TRUSTED_PROXY_IPS: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     const mode =
@@ -99,6 +128,22 @@ function parseCreditsPerDollar(value: string | undefined) {
   return credits;
 }
 
+function parseBoolean(name: string, value: string | undefined, fallback: boolean) {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  throw new Error(`${name} must be true or false`);
+}
+
+function parseInteger(name: string, value: string | undefined, fallback: number, min: number, max: number) {
+  const parsedValue = Number(value ?? fallback);
+  if (!Number.isSafeInteger(parsedValue) || parsedValue < min || parsedValue > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return parsedValue;
+}
+
 const planetscale: PlanetScaleCredentials | null =
   parsed.DATABASE_HOST &&
   parsed.DATABASE_USERNAME &&
@@ -109,6 +154,28 @@ const planetscale: PlanetScaleCredentials | null =
         password: parsed.DATABASE_PASSWORD,
       }
     : null;
+
+const anonymousRequestedEnabled = parseBoolean("ANONYMOUS_INFERENCE_ENABLED", parsed.ANONYMOUS_INFERENCE_ENABLED, false);
+const anonymousByokOnlyVerified = parseBoolean(
+  "ANONYMOUS_OPENROUTER_BYOK_ONLY_VERIFIED",
+  parsed.ANONYMOUS_OPENROUTER_BYOK_ONLY_VERIFIED,
+  false,
+);
+const anonymousApiKey = optionalString(parsed.ANONYMOUS_OPENROUTER_API_KEY);
+const anonymousTokenSecret = optionalString(parsed.ANONYMOUS_TOKEN_SECRET);
+const anonymousAccountingIdentityKey = optionalString(parsed.ANONYMOUS_ACCOUNTING_IDENTITY_KEY);
+const anonymousProvider = optionalString(parsed.ANONYMOUS_OPENROUTER_PROVIDER);
+const anonymousConfigurationReady = Boolean(
+  anonymousApiKey
+  && anonymousTokenSecret
+  && anonymousTokenSecret.length >= 32
+  && anonymousAccountingIdentityKey
+  && anonymousAccountingIdentityKey.length >= 32
+  && anonymousAccountingIdentityKey !== anonymousTokenSecret
+  && anonymousProvider
+  && anonymousByokOnlyVerified
+  && (isDevMode || normalizeUrl(parsed.OPENROUTER_UPSTREAM_URL ?? "https://openrouter.ai/api/v1").startsWith("https://")),
+);
 
 export const env = {
   port: parsePort(parsed.PORT),
@@ -126,4 +193,55 @@ export const env = {
   adminToken: optionalString(parsed.INFERENCE_ADMIN_TOKEN),
   webhookSecret: optionalString(parsed.INFERENCE_WEBHOOK_SECRET),
   creditsPerDollar: parseCreditsPerDollar(parsed.INFERENCE_CREDITS_PER_DOLLAR),
+  anonymous: {
+    requestedEnabled: anonymousRequestedEnabled,
+    enabled: anonymousRequestedEnabled && anonymousConfigurationReady,
+    configurationReady: anonymousConfigurationReady,
+    apiKey: anonymousApiKey,
+    tokenSecret: anonymousTokenSecret,
+    accountingIdentityKey: anonymousAccountingIdentityKey,
+    provider: anonymousProvider,
+    byokOnlyVerified: anonymousByokOnlyVerified,
+    tokenTtlSeconds: parseInteger("ANONYMOUS_TOKEN_TTL_SECONDS", parsed.ANONYMOUS_TOKEN_TTL_SECONDS, 3600, 1, 86_400),
+    installDailyMicroUsd: parseInteger("ANONYMOUS_INSTALL_DAILY_MICRO_USD", parsed.ANONYMOUS_INSTALL_DAILY_MICRO_USD, 50_000, 1, 100_000_000),
+    installMonthlyMicroUsd: parseInteger("ANONYMOUS_INSTALL_MONTHLY_MICRO_USD", parsed.ANONYMOUS_INSTALL_MONTHLY_MICRO_USD, 1_000_000, 1, 3_000_000_000),
+    ipDailyMicroUsd: parseInteger("ANONYMOUS_IP_DAILY_MICRO_USD", parsed.ANONYMOUS_IP_DAILY_MICRO_USD, 250_000, 1, 100_000_000),
+    globalDailyMicroUsd: parseInteger("ANONYMOUS_GLOBAL_DAILY_MICRO_USD", parsed.ANONYMOUS_GLOBAL_DAILY_MICRO_USD, 100_000_000, 1, 1_000_000_000),
+    globalMonthlyMicroUsd: parseInteger("ANONYMOUS_GLOBAL_MONTHLY_MICRO_USD", parsed.ANONYMOUS_GLOBAL_MONTHLY_MICRO_USD, 3_000_000_000, 1, 10_000_000_000),
+    globalInflight: parseInteger("ANONYMOUS_GLOBAL_INFLIGHT", parsed.ANONYMOUS_GLOBAL_INFLIGHT, 20, 1, 1_000),
+    sessionInstallHourly: parseInteger("ANONYMOUS_SESSION_INSTALL_HOURLY", parsed.ANONYMOUS_SESSION_INSTALL_HOURLY, 12, 1, 10_000),
+    sessionIpHourly: parseInteger("ANONYMOUS_SESSION_IP_HOURLY", parsed.ANONYMOUS_SESSION_IP_HOURLY, 30, 1, 100_000),
+    sessionGlobalHourly: parseInteger("ANONYMOUS_SESSION_GLOBAL_HOURLY", parsed.ANONYMOUS_SESSION_GLOBAL_HOURLY, 10_000, 1, 1_000_000),
+    requestInstallHourly: parseInteger("ANONYMOUS_REQUEST_INSTALL_HOURLY", parsed.ANONYMOUS_REQUEST_INSTALL_HOURLY, 60, 1, 100_000),
+    requestIpHourly: parseInteger("ANONYMOUS_REQUEST_IP_HOURLY", parsed.ANONYMOUS_REQUEST_IP_HOURLY, 300, 1, 1_000_000),
+    requestGlobalHourly: parseInteger("ANONYMOUS_REQUEST_GLOBAL_HOURLY", parsed.ANONYMOUS_REQUEST_GLOBAL_HOURLY, 10_000, 1, 10_000_000),
+    maxBodyBytes: parseInteger("ANONYMOUS_MAX_BODY_BYTES", parsed.ANONYMOUS_MAX_BODY_BYTES, 262_144, 1_024, 1_048_576),
+    maxInputTokens: parseInteger("ANONYMOUS_MAX_INPUT_TOKENS", parsed.ANONYMOUS_MAX_INPUT_TOKENS, 131_072, 256, 131_072),
+    chatWrappingTokenAllowance: parseInteger(
+      "ANONYMOUS_CHAT_WRAPPING_TOKEN_ALLOWANCE",
+      parsed.ANONYMOUS_CHAT_WRAPPING_TOKEN_ALLOWANCE,
+      2_048,
+      2_048,
+      32_768,
+    ),
+    maxCompletionTokens: parseInteger("ANONYMOUS_MAX_COMPLETION_TOKENS", parsed.ANONYMOUS_MAX_COMPLETION_TOKENS, 4_096, 1, 16_384),
+    maxInputPriceMicroUsdPerMillion: parseInteger(
+      "ANONYMOUS_MAX_INPUT_PRICE_MICRO_USD_PER_MILLION",
+      parsed.ANONYMOUS_MAX_INPUT_PRICE_MICRO_USD_PER_MILLION,
+      250_000,
+      1,
+      100_000_000,
+    ),
+    maxCompletionPriceMicroUsdPerMillion: parseInteger(
+      "ANONYMOUS_MAX_COMPLETION_PRICE_MICRO_USD_PER_MILLION",
+      parsed.ANONYMOUS_MAX_COMPLETION_PRICE_MICRO_USD_PER_MILLION,
+      1_200_000,
+      1,
+      100_000_000,
+    ),
+    requestTimeoutMs: parseInteger("ANONYMOUS_REQUEST_TIMEOUT_MS", parsed.ANONYMOUS_REQUEST_TIMEOUT_MS, 60_000, 1_000, 300_000),
+    maxResponseBytes: parseInteger("ANONYMOUS_MAX_RESPONSE_BYTES", parsed.ANONYMOUS_MAX_RESPONSE_BYTES, 2_097_152, 16_384, 16_777_216),
+    trustProxyHops: parseInteger("ANONYMOUS_TRUST_PROXY_HOPS", parsed.ANONYMOUS_TRUST_PROXY_HOPS, 0, 0, 8),
+    trustedProxyIps: splitCsv(parsed.ANONYMOUS_TRUSTED_PROXY_IPS),
+  },
 };

--- a/ee/packages/den-db/drizzle/0094_anonymous_inference.sql
+++ b/ee/packages/den-db/drizzle/0094_anonymous_inference.sql
@@ -1,0 +1,71 @@
+CREATE TABLE `anonymous_inference_control` (
+	`id` varchar(64) NOT NULL,
+	`blocked` boolean NOT NULL DEFAULT false,
+	`blocked_at` timestamp(3),
+	`block_reason` varchar(64),
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+	CONSTRAINT `anonymous_inference_control_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `anonymous_inference_rate_buckets` (
+	`id` varchar(64) NOT NULL,
+	`kind` enum('session','request') NOT NULL,
+	`scope` enum('installation','ip','global') NOT NULL,
+	`identity_hash` varchar(64) NOT NULL,
+	`window_start_at` timestamp(3) NOT NULL,
+	`window_end_at` timestamp(3) NOT NULL,
+	`limit_amount` bigint NOT NULL,
+	`used_amount` bigint NOT NULL DEFAULT 0,
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+	CONSTRAINT `anonymous_inference_rate_buckets_id` PRIMARY KEY(`id`),
+	CONSTRAINT `anonymous_inference_rate_bucket_identity_window` UNIQUE(`kind`,`scope`,`identity_hash`,`window_start_at`)
+);
+--> statement-breakpoint
+CREATE TABLE `anonymous_inference_reservation_charges` (
+	`id` varchar(64) NOT NULL,
+	`reservation_id` varchar(64) NOT NULL,
+	`bucket_id` varchar(64) NOT NULL,
+	`reserved_micro_usd` bigint NOT NULL,
+	`settled_micro_usd` bigint,
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	CONSTRAINT `anonymous_inference_reservation_charges_id` PRIMARY KEY(`id`),
+	CONSTRAINT `anonymous_inference_reservation_charge_bucket` UNIQUE(`reservation_id`,`bucket_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `anonymous_inference_reservations` (
+	`id` varchar(64) NOT NULL,
+	`installation_hash` varchar(64) NOT NULL,
+	`ip_hash` varchar(64) NOT NULL,
+	`status` enum('active','settled','retained') NOT NULL DEFAULT 'active',
+	`reserved_micro_usd` bigint NOT NULL,
+	`settled_micro_usd` bigint,
+	`lease_expires_at` timestamp(3) NOT NULL,
+	`released_at` timestamp(3),
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+	CONSTRAINT `anonymous_inference_reservations_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `anonymous_inference_usage_buckets` (
+	`id` varchar(64) NOT NULL,
+	`scope` enum('installation','ip','global') NOT NULL,
+	`identity_hash` varchar(64) NOT NULL,
+	`window_type` enum('daily','monthly') NOT NULL,
+	`window_start_at` timestamp(3) NOT NULL,
+	`window_end_at` timestamp(3) NOT NULL,
+	`limit_micro_usd` bigint NOT NULL,
+	`used_micro_usd` bigint NOT NULL DEFAULT 0,
+	`created_at` timestamp(3) NOT NULL DEFAULT (now()),
+	`updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+	CONSTRAINT `anonymous_inference_usage_buckets_id` PRIMARY KEY(`id`),
+	CONSTRAINT `anonymous_inference_usage_bucket_identity_window` UNIQUE(`scope`,`identity_hash`,`window_type`,`window_start_at`)
+);
+--> statement-breakpoint
+CREATE INDEX `anonymous_inference_rate_bucket_window_end` ON `anonymous_inference_rate_buckets` (`window_end_at`);--> statement-breakpoint
+CREATE INDEX `anonymous_inference_reservation_charge_bucket_id` ON `anonymous_inference_reservation_charges` (`bucket_id`);--> statement-breakpoint
+CREATE INDEX `anonymous_inference_reservation_active_installation` ON `anonymous_inference_reservations` (`status`,`installation_hash`,`lease_expires_at`);--> statement-breakpoint
+CREATE INDEX `anonymous_inference_reservation_active_lease` ON `anonymous_inference_reservations` (`status`,`lease_expires_at`);--> statement-breakpoint
+CREATE INDEX `anonymous_inference_usage_bucket_window_end` ON `anonymous_inference_usage_buckets` (`window_end_at`);--> statement-breakpoint
+INSERT INTO `anonymous_inference_control` (`id`, `blocked`) VALUES ('anonymous-inference-global', false);

--- a/ee/packages/den-db/drizzle/meta/0094_snapshot.json
+++ b/ee/packages/den-db/drizzle/meta/0094_snapshot.json
@@ -1,0 +1,12697 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "cc905be1-46df-4909-9c90-c2ae463e3718",
+  "prevId": "9ec171b4-1026-4c3e-8498-b43afccb8a19",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_account_id_provider_id": {
+          "name": "account_account_id_provider_id",
+          "columns": [
+            "`account_id`(191)",
+            "`provider_id`(191)"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "account_id": {
+          "name": "account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id": {
+          "name": "apikey_config_id",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id": {
+          "name": "apikey_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key": {
+          "name": "apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apikey_id": {
+          "name": "apikey_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jwks_id": {
+          "name": "jwks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "session_token": {
+          "name": "session_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id": {
+          "name": "session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_id": {
+          "name": "session_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "user_email": {
+          "name": "user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_created_at_id": {
+          "name": "user_created_at_id",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "verification_identifier": {
+          "name": "verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_id": {
+          "name": "verification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_identity": {
+      "name": "external_identity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_json": {
+          "name": "name_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emails_json": {
+          "name": "emails_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_scim_sync_at": {
+          "name": "last_scim_sync_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sso_login_at": {
+          "name": "last_sso_login_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_identity_org_user": {
+          "name": "external_identity_org_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_sso_remote": {
+          "name": "external_identity_org_sso_remote",
+          "columns": [
+            "organization_id",
+            "sso_provider_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_scim_external": {
+          "name": "external_identity_org_scim_external",
+          "columns": [
+            "organization_id",
+            "scim_provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_email": {
+          "name": "external_identity_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        },
+        "external_identity_sso_provider": {
+          "name": "external_identity_sso_provider",
+          "columns": [
+            "sso_provider_id"
+          ],
+          "isUnique": false
+        },
+        "external_identity_scim_provider": {
+          "name": "external_identity_scim_provider",
+          "columns": [
+            "scim_provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token": {
+          "name": "oauth_access_token_token",
+          "columns": [
+            "`token`(191)"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_client_id": {
+          "name": "oauth_access_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_session_id": {
+          "name": "oauth_access_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_user_id": {
+          "name": "oauth_access_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_reference_id": {
+          "name": "oauth_access_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_refresh_id": {
+          "name": "oauth_access_token_refresh_id",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthAccessToken_id": {
+          "name": "oauthAccessToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClientAssertion": {
+      "name": "oauthClientAssertion",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClientAssertion_id": {
+          "name": "oauthClientAssertion_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClientResource": {
+      "name": "oauthClientResource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "oauth_client_resource_client_id": {
+          "name": "oauth_client_resource_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_resource_resource_id": {
+          "name": "oauth_client_resource_resource_id",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClientResource_id": {
+          "name": "oauthClientResource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClient": {
+      "name": "oauthClient",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backchannel_logout_uri": {
+          "name": "backchannel_logout_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backchannel_logout_session_required": {
+          "name": "backchannel_logout_session_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jwks": {
+          "name": "jwks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jwks_uri": {
+          "name": "jwks_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dpop_bound_access_tokens": {
+          "name": "dpop_bound_access_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id": {
+          "name": "oauth_client_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_client_user_id": {
+          "name": "oauth_client_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_reference_id": {
+          "name": "oauth_client_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClient_id": {
+          "name": "oauthClient_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthConsent": {
+      "name": "oauthConsent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id": {
+          "name": "oauth_consent_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_user_id": {
+          "name": "oauth_consent_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_reference_id": {
+          "name": "oauth_consent_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthConsent_id": {
+          "name": "oauthConsent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthRefreshToken": {
+      "name": "oauthRefreshToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_replay_response": {
+          "name": "rotation_replay_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_replay_expires_at": {
+          "name": "rotation_replay_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token": {
+          "name": "oauth_refresh_token_token",
+          "columns": [
+            "`token`(191)"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_client_id": {
+          "name": "oauth_refresh_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_session_id": {
+          "name": "oauth_refresh_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_user_id": {
+          "name": "oauth_refresh_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_reference_id": {
+          "name": "oauth_refresh_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthRefreshToken_id": {
+          "name": "oauthRefreshToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthResource": {
+      "name": "oauthResource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_ttl": {
+          "name": "access_token_ttl",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_ttl": {
+          "name": "refresh_token_ttl",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signing_algorithm": {
+          "name": "signing_algorithm",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_claims": {
+          "name": "custom_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dpop_bound_access_tokens_required": {
+          "name": "dpop_bound_access_tokens_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_resource_identifier": {
+          "name": "oauth_resource_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthResource_id": {
+          "name": "oauthResource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_provider": {
+      "name": "scim_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_token": {
+          "name": "scim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mapping_mode": {
+          "name": "group_mapping_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'metadata_only'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_provider_provider_id": {
+          "name": "scim_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "scim_provider_organization_id": {
+          "name": "scim_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_sync_event": {
+      "name": "scim_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_sync_event_org_status": {
+          "name": "scim_sync_event_org_status",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_provider_status": {
+          "name": "scim_sync_event_provider_status",
+          "columns": [
+            "provider_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_next_retry": {
+          "name": "scim_sync_event_next_retry",
+          "columns": [
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_user": {
+          "name": "scim_sync_event_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_sync_event_id": {
+          "name": "scim_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_connection": {
+      "name": "sso_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'disabled'"
+        },
+        "sign_in_path": {
+          "name": "sign_in_path",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_revision": {
+          "name": "config_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "test_status": {
+          "name": "test_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tested_revision": {
+          "name": "last_tested_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verification_token": {
+          "name": "domain_verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_intent_id": {
+          "name": "active_test_intent_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_user_id": {
+          "name": "active_test_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_provider_id": {
+          "name": "active_test_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_config_revision": {
+          "name": "active_test_config_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_expires_at": {
+          "name": "active_test_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_started_at": {
+          "name": "active_test_started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id": {
+          "name": "sso_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_provider_id": {
+          "name": "sso_connection_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_domain": {
+          "name": "sso_connection_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_connection_id": {
+          "name": "sso_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_provider": {
+      "name": "sso_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_provider_provider_id": {
+          "name": "sso_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_provider_domain": {
+          "name": "sso_provider_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_organization_id": {
+          "name": "sso_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_user_id": {
+          "name": "sso_provider_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard_access_grant": {
+      "name": "dashboard_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_access_grant_organization_id": {
+          "name": "dashboard_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_org_membership_id": {
+          "name": "dashboard_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_team_id": {
+          "name": "dashboard_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_org_wide": {
+          "name": "dashboard_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_dashboard_org_membership": {
+          "name": "dashboard_access_grant_dashboard_org_membership",
+          "columns": [
+            "dashboard_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "dashboard_access_grant_dashboard_team": {
+          "name": "dashboard_access_grant_dashboard_team",
+          "columns": [
+            "dashboard_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_access_grant_id": {
+          "name": "dashboard_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard": {
+      "name": "dashboard",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elements_json": {
+          "name": "elements_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_organization_id": {
+          "name": "dashboard_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_created_by_org_membership_id": {
+          "name": "dashboard_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_name": {
+          "name": "dashboard_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy_member": {
+      "name": "desktop_policy_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_policy_member_organization_id": {
+          "name": "desktop_policy_member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_org_member_id": {
+          "name": "desktop_policy_member_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_team_id": {
+          "name": "desktop_policy_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_policy_org_member": {
+          "name": "desktop_policy_member_policy_org_member",
+          "columns": [
+            "desktop_policy_id",
+            "org_member_id"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_member_policy_team": {
+          "name": "desktop_policy_member_policy_team",
+          "columns": [
+            "desktop_policy_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_member_id": {
+          "name": "desktop_policy_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy": {
+      "name": "desktop_policy",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_name": {
+          "name": "policy_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "policy": {
+          "name": "policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "created_by_org_member_id": {
+          "name": "created_by_org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "desktop_policy_org_external_key": {
+          "name": "desktop_policy_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_created_by_member_id": {
+          "name": "desktop_policy_created_by_member_id",
+          "columns": [
+            "created_by_org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_is_enabled": {
+          "name": "desktop_policy_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_priority": {
+          "name": "desktop_policy_priority",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_deleted_at": {
+          "name": "desktop_policy_deleted_at",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_org_default": {
+          "name": "desktop_policy_org_default",
+          "columns": [
+            "organization_id",
+            "is_default"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_diagnostic_credential": {
+      "name": "organization_diagnostic_credential",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_diagnostic_credential_organization_id": {
+          "name": "organization_diagnostic_credential_organization_id",
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "anonymous_inference_control": {
+      "name": "anonymous_inference_control",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_reason": {
+          "name": "block_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anonymous_inference_control_id": {
+          "name": "anonymous_inference_control_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "anonymous_inference_rate_buckets": {
+      "name": "anonymous_inference_rate_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum('session','request')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('installation','ip','global')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_hash": {
+          "name": "identity_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "anonymous_inference_rate_bucket_identity_window": {
+          "name": "anonymous_inference_rate_bucket_identity_window",
+          "columns": [
+            "kind",
+            "scope",
+            "identity_hash",
+            "window_start_at"
+          ],
+          "isUnique": true
+        },
+        "anonymous_inference_rate_bucket_window_end": {
+          "name": "anonymous_inference_rate_bucket_window_end",
+          "columns": [
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anonymous_inference_rate_buckets_id": {
+          "name": "anonymous_inference_rate_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "anonymous_inference_reservation_charges": {
+      "name": "anonymous_inference_reservation_charges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reserved_micro_usd": {
+          "name": "reserved_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settled_micro_usd": {
+          "name": "settled_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "anonymous_inference_reservation_charge_bucket": {
+          "name": "anonymous_inference_reservation_charge_bucket",
+          "columns": [
+            "reservation_id",
+            "bucket_id"
+          ],
+          "isUnique": true
+        },
+        "anonymous_inference_reservation_charge_bucket_id": {
+          "name": "anonymous_inference_reservation_charge_bucket_id",
+          "columns": [
+            "bucket_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anonymous_inference_reservation_charges_id": {
+          "name": "anonymous_inference_reservation_charges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "anonymous_inference_reservations": {
+      "name": "anonymous_inference_reservations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_hash": {
+          "name": "installation_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','settled','retained')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "reserved_micro_usd": {
+          "name": "reserved_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settled_micro_usd": {
+          "name": "settled_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "anonymous_inference_reservation_active_installation": {
+          "name": "anonymous_inference_reservation_active_installation",
+          "columns": [
+            "status",
+            "installation_hash",
+            "lease_expires_at"
+          ],
+          "isUnique": false
+        },
+        "anonymous_inference_reservation_active_lease": {
+          "name": "anonymous_inference_reservation_active_lease",
+          "columns": [
+            "status",
+            "lease_expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anonymous_inference_reservations_id": {
+          "name": "anonymous_inference_reservations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "anonymous_inference_usage_buckets": {
+      "name": "anonymous_inference_usage_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('installation','ip','global')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_hash": {
+          "name": "identity_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "enum('daily','monthly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_micro_usd": {
+          "name": "limit_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_micro_usd": {
+          "name": "used_micro_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "anonymous_inference_usage_bucket_identity_window": {
+          "name": "anonymous_inference_usage_bucket_identity_window",
+          "columns": [
+            "scope",
+            "identity_hash",
+            "window_type",
+            "window_start_at"
+          ],
+          "isUnique": true
+        },
+        "anonymous_inference_usage_bucket_window_end": {
+          "name": "anonymous_inference_usage_bucket_window_end",
+          "columns": [
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anonymous_inference_usage_buckets_id": {
+          "name": "anonymous_inference_usage_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_keys": {
+      "name": "inference_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_keys_key_hash": {
+          "name": "inference_keys_key_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "inference_keys_organization_id": {
+          "name": "inference_keys_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_org_membership_id": {
+          "name": "inference_keys_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_status": {
+          "name": "inference_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_keys_id": {
+          "name": "inference_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_limit_policies": {
+      "name": "inference_org_limit_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "enum('five_hour','weekly','monthly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_strategy": {
+          "name": "reset_strategy",
+          "type": "enum('anchored','activity_based')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_at": {
+          "name": "anchor_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_bucket_id": {
+          "name": "current_bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_limit_policies_org_window_type": {
+          "name": "inference_org_limit_policies_org_window_type",
+          "columns": [
+            "organization_id",
+            "window_type"
+          ],
+          "isUnique": true
+        },
+        "inference_org_limit_policies_current_bucket_id": {
+          "name": "inference_org_limit_policies_current_bucket_id",
+          "columns": [
+            "current_bucket_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_limit_policies_id": {
+          "name": "inference_org_limit_policies_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_upstream_provider_keys": {
+      "name": "inference_org_upstream_provider_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openrouter'"
+        },
+        "external_key_hash": {
+          "name": "external_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_workspace_id": {
+          "name": "external_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_upstream_provider_keys_external_key_hash": {
+          "name": "inference_org_upstream_provider_keys_external_key_hash",
+          "columns": [
+            "external_key_hash"
+          ],
+          "isUnique": false
+        },
+        "inference_org_upstream_provider_keys_org_provider": {
+          "name": "inference_org_upstream_provider_keys_org_provider",
+          "columns": [
+            "organization_id",
+            "provider"
+          ],
+          "isUnique": true
+        },
+        "inference_org_upstream_provider_keys_status": {
+          "name": "inference_org_upstream_provider_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_upstream_provider_keys_id": {
+          "name": "inference_org_upstream_provider_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_usage_buckets": {
+      "name": "inference_org_usage_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_usage_buckets_org_window": {
+          "name": "inference_org_usage_buckets_org_window",
+          "columns": [
+            "organization_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        },
+        "inference_org_usage_buckets_policy_window": {
+          "name": "inference_org_usage_buckets_policy_window",
+          "columns": [
+            "policy_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_usage_buckets_id": {
+          "name": "inference_org_usage_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_bucket_charges": {
+      "name": "inference_usage_ledger_bucket_charges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ledger_entry_id": {
+          "name": "ledger_entry_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_bucket_charges_bucket_id": {
+          "name": "inference_usage_ledger_bucket_charges_bucket_id",
+          "columns": [
+            "bucket_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_bucket_charges_entry_bucket": {
+          "name": "inference_usage_ledger_bucket_charges_entry_bucket",
+          "columns": [
+            "ledger_entry_id",
+            "bucket_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_bucket_charges_id": {
+          "name": "inference_usage_ledger_bucket_charges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_entries": {
+      "name": "inference_usage_ledger_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inference_key_id": {
+          "name": "inference_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_entries_organization_id": {
+          "name": "inference_usage_ledger_entries_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_org_membership_id": {
+          "name": "inference_usage_ledger_entries_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_inference_key_id": {
+          "name": "inference_usage_ledger_entries_inference_key_id",
+          "columns": [
+            "inference_key_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_external_event_id": {
+          "name": "inference_usage_ledger_entries_external_event_id",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        },
+        "inference_usage_ledger_entries_job_event_type": {
+          "name": "inference_usage_ledger_entries_job_event_type",
+          "columns": [
+            "external_job_id",
+            "event_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_entries_id": {
+          "name": "inference_usage_ledger_entries_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_connect_grant": {
+      "name": "desktop_connect_grant",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "install_link_id": {
+          "name": "install_link_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claims": {
+          "name": "claims",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_nonce": {
+          "name": "consumed_nonce",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_connect_grant_install_link_id": {
+          "name": "desktop_connect_grant_install_link_id",
+          "columns": [
+            "install_link_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_connect_grant_expires_at": {
+          "name": "desktop_connect_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_connect_grant_code_hash": {
+          "name": "desktop_connect_grant_code_hash",
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_handoff_grant": {
+      "name": "desktop_handoff_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_handoff_grant_user_id": {
+          "name": "desktop_handoff_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_handoff_grant_expires_at": {
+          "name": "desktop_handoff_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_handoff_grant_id": {
+          "name": "desktop_handoff_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "install_link": {
+      "name": "install_link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "install_link_token_hash": {
+          "name": "install_link_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "install_link_organization_id": {
+          "name": "install_link_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "install_link_created_by_user_id": {
+          "name": "install_link_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "install_link_revoked_at": {
+          "name": "install_link_revoked_at",
+          "columns": [
+            "revoked_at"
+          ],
+          "isUnique": false
+        },
+        "install_link_expires_at": {
+          "name": "install_link_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "install_link_id": {
+          "name": "install_link_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id": {
+          "name": "invitation_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email": {
+          "name": "invitation_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_status": {
+          "name": "invitation_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "invitation_team_id": {
+          "name": "invitation_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_inviter_id": {
+          "name": "invitation_inviter_id",
+          "columns": [
+            "inviter_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_member_id": {
+          "name": "invitation_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_invite_token": {
+          "name": "invitation_invite_token",
+          "columns": [
+            "invite_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_id": {
+          "name": "invitation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_by_org_member": {
+          "name": "invited_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by_org_member": {
+          "name": "removed_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "member_user_id": {
+          "name": "member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_invite_id": {
+          "name": "member_invite_id",
+          "columns": [
+            "invite_id"
+          ],
+          "isUnique": false
+        },
+        "member_invited_by_org_member": {
+          "name": "member_invited_by_org_member",
+          "columns": [
+            "invited_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_removed_at": {
+          "name": "member_removed_at",
+          "columns": [
+            "removed_at"
+          ],
+          "isUnique": false
+        },
+        "member_removed_by_org_member": {
+          "name": "member_removed_by_org_member",
+          "columns": [
+            "removed_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_organization_user": {
+          "name": "member_organization_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "member_id": {
+          "name": "member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_brand_asset": {
+      "name": "organization_brand_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "mediumblob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "organization_brand_asset_version": {
+          "name": "organization_brand_asset_version",
+          "columns": [
+            "organization_id",
+            "kind",
+            "version",
+            "extension"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_brand_asset_id": {
+          "name": "organization_brand_asset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_role": {
+      "name": "organization_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_role_name": {
+          "name": "organization_role_name",
+          "columns": [
+            "organization_id",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_role_id": {
+          "name": "organization_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_app_restrictions": {
+          "name": "desktop_app_restrictions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_slug": {
+          "name": "organization_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_created_at_id": {
+          "name": "organization_created_at_id",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_id": {
+          "name": "organization_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_bootstrap": {
+      "name": "workspace_bootstrap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "setup_member_id": {
+          "name": "setup_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_public_key": {
+          "name": "device_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_key_fingerprint": {
+          "name": "device_key_fingerprint",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisional'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_bootstrap_organization_id": {
+          "name": "workspace_bootstrap_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_status": {
+          "name": "workspace_bootstrap_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_expires_at": {
+          "name": "workspace_bootstrap_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_bootstrap_id": {
+          "name": "workspace_bootstrap_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_claim": {
+      "name": "workspace_claim",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bootstrap_id": {
+          "name": "bootstrap_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_claim_token_hash": {
+          "name": "workspace_claim_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "workspace_claim_bootstrap_id": {
+          "name": "workspace_claim_bootstrap_id",
+          "columns": [
+            "bootstrap_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_organization_id": {
+          "name": "workspace_claim_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_status": {
+          "name": "workspace_claim_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_expires_at": {
+          "name": "workspace_claim_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_claim_id": {
+          "name": "workspace_claim_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "remote_mcp_app": {
+      "name": "remote_mcp_app",
+      "columns": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_source_url": {
+          "name": "resolved_source_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','retired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_mcp_app_organization_id": {
+          "name": "remote_mcp_app_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "remote_mcp_app_plugin_id": {
+          "name": "remote_mcp_app_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": true
+        },
+        "remote_mcp_app_active_version_id": {
+          "name": "remote_mcp_app_active_version_id",
+          "columns": [
+            "active_version_id"
+          ],
+          "isUnique": false
+        },
+        "remote_mcp_app_status": {
+          "name": "remote_mcp_app_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "remote_mcp_app_config_object_id": {
+          "name": "remote_mcp_app_config_object_id",
+          "columns": [
+            "config_object_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "remote_session_command": {
+      "name": "remote_session_command",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','claimed','delivered','failed','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_model_id": {
+          "name": "model_model_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_runner_id": {
+          "name": "claimed_by_runner_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "remote_session_command_idempotency_key": {
+          "name": "remote_session_command_idempotency_key",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "remote_session_command_owner_status": {
+          "name": "remote_session_command_owner_status",
+          "columns": [
+            "org_id",
+            "owner_member_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "remote_session_command_status_expires": {
+          "name": "remote_session_command_status_expires",
+          "columns": [
+            "status",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "remote_session_command_id": {
+          "name": "remote_session_command_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_member": {
+      "name": "scim_group_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_user_id": {
+          "name": "remote_user_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_member_group_remote_user": {
+          "name": "scim_group_member_group_remote_user",
+          "columns": [
+            "group_id",
+            "remote_user_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_member_membership_key": {
+          "name": "scim_group_member_membership_key",
+          "columns": [
+            "membership_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_member_user_id": {
+          "name": "scim_group_member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_org_membership_id": {
+          "name": "scim_group_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_team_member_id": {
+          "name": "scim_group_member_team_member_id",
+          "columns": [
+            "team_member_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_provider_org": {
+          "name": "scim_group_member_provider_org",
+          "columns": [
+            "provider_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_member_id": {
+          "name": "scim_group_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_role_grant": {
+      "name": "scim_group_role_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_grant_key": {
+          "name": "role_grant_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_role_projected": {
+          "name": "is_role_projected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_role_grant_role_grant_key": {
+          "name": "scim_group_role_grant_role_grant_key",
+          "columns": [
+            "role_grant_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_role_grant_group_id": {
+          "name": "scim_group_role_grant_group_id",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_role_grant_provider_org": {
+          "name": "scim_group_role_grant_provider_org",
+          "columns": [
+            "provider_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_role_grant_user_id": {
+          "name": "scim_group_role_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_role_grant_id": {
+          "name": "scim_group_role_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_role": {
+      "name": "scim_group_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_key": {
+          "name": "role_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_role_role_key": {
+          "name": "scim_group_role_role_key",
+          "columns": [
+            "role_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_role_group_id": {
+          "name": "scim_group_role_group_id",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_role_id": {
+          "name": "scim_group_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group": {
+      "name": "scim_group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_group_id": {
+          "name": "scim_group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id_key": {
+          "name": "external_id_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_scim_group_id": {
+          "name": "scim_group_scim_group_id",
+          "columns": [
+            "scim_group_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_provider_external_id": {
+          "name": "scim_group_provider_external_id",
+          "columns": [
+            "provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_external_id_key": {
+          "name": "scim_group_external_id_key",
+          "columns": [
+            "external_id_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_team_id": {
+          "name": "scim_group_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_organization_id": {
+          "name": "scim_group_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_id": {
+          "name": "scim_group_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_user_tombstone": {
+      "name": "scim_user_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deprovisioned_user_id": {
+          "name": "deprovisioned_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deprovisioned_at": {
+          "name": "deprovisioned_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_user_tombstone_org_user": {
+          "name": "scim_user_tombstone_org_user",
+          "columns": [
+            "organization_id",
+            "deprovisioned_user_id"
+          ],
+          "isUnique": true
+        },
+        "scim_user_tombstone_org_external_id": {
+          "name": "scim_user_tombstone_org_external_id",
+          "columns": [
+            "organization_id",
+            "external_id"
+          ],
+          "isUnique": false
+        },
+        "scim_user_tombstone_org_email": {
+          "name": "scim_user_tombstone_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_user_tombstone_id": {
+          "name": "scim_user_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_revision": {
+      "name": "automation_revision",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "enum('once','daily','weekly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "enum('desktop','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "maximum_runtime_ms": {
+          "name": "maximum_runtime_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "digest": {
+          "name": "digest",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_revision_version": {
+          "name": "automation_revision_version",
+          "columns": [
+            "automation_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_revision_id": {
+          "name": "automation_revision_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_run_event": {
+      "name": "automation_run_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engine_event_id": {
+          "name": "engine_event_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_idempotency_key": {
+          "name": "engine_idempotency_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_execution_id": {
+          "name": "engine_execution_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('user','assistant','capability_search','capability_execution','usage','warning','terminal')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_run_event_sequence": {
+          "name": "automation_run_event_sequence",
+          "columns": [
+            "run_id",
+            "attempt",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "automation_run_engine_event": {
+          "name": "automation_run_engine_event",
+          "columns": [
+            "run_id",
+            "engine_idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "automation_run_event_created": {
+          "name": "automation_run_event_created",
+          "columns": [
+            "run_id",
+            "attempt",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_run_event_id": {
+          "name": "automation_run_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_run": {
+      "name": "automation_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "enum('scheduled','recovery','manual')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('queued','claimed','running','succeeded','failed','cancelled','skipped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "enum('desktop','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "claim_deadline_at": {
+          "name": "claim_deadline_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_thread_id": {
+          "name": "cloud_thread_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engine_kind": {
+          "name": "engine_kind",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_receipt": {
+          "name": "engine_receipt",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_sequence": {
+          "name": "engine_sequence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "engine_admitted_at": {
+          "name": "engine_admitted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codemode_receipt_id": {
+          "name": "codemode_receipt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_result": {
+          "name": "validated_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_token_hash": {
+          "name": "mcp_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_token_expires_at": {
+          "name": "mcp_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_run_occurrence": {
+          "name": "automation_run_occurrence",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "automation_run_cloud_thread": {
+          "name": "automation_run_cloud_thread",
+          "columns": [
+            "cloud_thread_id"
+          ],
+          "isUnique": true
+        },
+        "automation_run_claimable": {
+          "name": "automation_run_claimable",
+          "columns": [
+            "status",
+            "lease_expires_at"
+          ],
+          "isUnique": false
+        },
+        "automation_run_history": {
+          "name": "automation_run_history",
+          "columns": [
+            "automation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_runner_notification": {
+      "name": "automation_runner_notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('work_available','cancellation')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_runner_notification_owner_cursor": {
+          "name": "automation_runner_notification_owner_cursor",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_runner_notification_id": {
+          "name": "automation_runner_notification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_runner": {
+      "name": "automation_runner",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supported_execution_targets": {
+          "name": "supported_execution_targets",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "enum('darwin','win32','linux')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concurrency": {
+          "name": "concurrency",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_runner_owner_seen": {
+          "name": "automation_runner_owner_seen",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_runner_id": {
+          "name": "automation_runner_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation": {
+      "name": "automation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('active','inactive','needs_attention','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_run_at": {
+          "name": "latest_run_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "needs_attention_reason": {
+          "name": "needs_attention_reason",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_successful_run_id": {
+          "name": "latest_successful_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_successful_result": {
+          "name": "latest_successful_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_org_owner_state": {
+          "name": "automation_org_owner_state",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "automation_due": {
+          "name": "automation_due",
+          "columns": [
+            "state",
+            "next_due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_id": {
+          "name": "automation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "artifact_view_revision": {
+      "name": "artifact_view_revision",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_member_id": {
+          "name": "created_by_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "react_source": {
+          "name": "react_source",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "css_source": {
+          "name": "css_source",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiled_html": {
+          "name": "compiled_html",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "build_diagnostics": {
+          "name": "build_diagnostics",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "build_status": {
+          "name": "build_status",
+          "type": "enum('ready','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_digest": {
+          "name": "source_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_digest": {
+          "name": "resource_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema_digest": {
+          "name": "output_schema_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csp": {
+          "name": "csp",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiler_name": {
+          "name": "compiler_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiler_version": {
+          "name": "compiler_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "react_version": {
+          "name": "react_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiled_html_bytes": {
+          "name": "compiled_html_bytes",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "artifact_view_revision_view_created": {
+          "name": "artifact_view_revision_view_created",
+          "columns": [
+            "artifact_view_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_revision_org_status": {
+          "name": "artifact_view_revision_org_status",
+          "columns": [
+            "organization_id",
+            "build_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "artifact_view_revision_id": {
+          "name": "artifact_view_revision_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "artifact_view": {
+      "name": "artifact_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','retired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "active_revision_id": {
+          "name": "active_revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_in_workflow": {
+          "name": "use_in_workflow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "artifact_view_org_script": {
+          "name": "artifact_view_org_script",
+          "columns": [
+            "organization_id",
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_org_owner": {
+          "name": "artifact_view_org_owner",
+          "columns": [
+            "organization_id",
+            "owner_member_id"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_active_revision": {
+          "name": "artifact_view_active_revision",
+          "columns": [
+            "active_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard_app": {
+      "name": "dashboard_app",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_app_organization_id_member_id_artifact_view_id_pk": {
+          "name": "dashboard_app_organization_id_member_id_artifact_view_id_pk",
+          "columns": [
+            "organization_id",
+            "member_id",
+            "artifact_view_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workflow_run": {
+      "name": "workflow_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('succeeded','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "script_input": {
+          "name": "script_input",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "script_input_digest": {
+          "name": "script_input_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_schema_digest": {
+          "name": "input_schema_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_result": {
+          "name": "validated_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_markdown": {
+          "name": "result_markdown",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_digest": {
+          "name": "result_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema_digest": {
+          "name": "output_schema_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "renderer_version": {
+          "name": "renderer_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_content_deleted_at": {
+          "name": "artifact_content_deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workflow_run_org_created": {
+          "name": "workflow_run_org_created",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "workflow_run_automation": {
+          "name": "workflow_run_automation",
+          "columns": [
+            "automation_run_id"
+          ],
+          "isUnique": false
+        },
+        "workflow_run_artifact_history": {
+          "name": "workflow_run_artifact_history",
+          "columns": [
+            "config_object_id",
+            "finished_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connected_account": {
+      "name": "connected_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_code_verifier": {
+          "name": "pending_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_health": {
+          "name": "credential_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connected_account_organization_id": {
+          "name": "connected_account_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connected_account_member_provider": {
+          "name": "connected_account_member_provider",
+          "columns": [
+            "org_membership_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_mcp_connection_access_grant": {
+      "name": "external_mcp_connection_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_mcp_requirement_binding_id": {
+          "name": "plugin_mcp_requirement_binding_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "emc_access_grant_organization_id": {
+          "name": "emc_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_connection_id": {
+          "name": "emc_access_grant_connection_id",
+          "columns": [
+            "external_mcp_connection_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_plugin_mcp_binding_id": {
+          "name": "emc_access_grant_plugin_mcp_binding_id",
+          "columns": [
+            "plugin_mcp_requirement_binding_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_org_membership_id": {
+          "name": "emc_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_team_id": {
+          "name": "emc_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_connection_member": {
+          "name": "emc_access_grant_connection_member",
+          "columns": [
+            "external_mcp_connection_id",
+            "org_membership_id",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "emc_access_grant_connection_team": {
+          "name": "emc_access_grant_connection_team",
+          "columns": [
+            "external_mcp_connection_id",
+            "team_id",
+            "source_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_mcp_connection_access_grant_id": {
+          "name": "external_mcp_connection_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_mcp_connection": {
+      "name": "external_mcp_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "enum('oauth','apikey','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum('external_mcp','native_provider')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'external_mcp'"
+        },
+        "native_provider_key": {
+          "name": "native_provider_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_configuration": {
+          "name": "oauth_configuration",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_policy": {
+          "name": "tool_policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_directly": {
+          "name": "expose_directly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "enum('shared','per_member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_code_verifier": {
+          "name": "pending_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_health": {
+          "name": "credential_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_issuer_review_required_at": {
+          "name": "oauth_issuer_review_required_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_mcp_connection_organization_id": {
+          "name": "external_mcp_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "external_mcp_connection_org_external_key": {
+          "name": "external_mcp_connection_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_oauth_client": {
+      "name": "org_oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_oauth_client_org_provider": {
+          "name": "org_oauth_client_org_provider",
+          "columns": [
+            "organization_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_oauth_client_id": {
+          "name": "org_oauth_client_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_mcp_requirement_binding": {
+      "name": "plugin_mcp_requirement_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "required_auth_type": {
+          "name": "required_auth_type",
+          "type": "enum('oauth','apikey','none')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connection_owned_by_plugin": {
+          "name": "connection_owned_by_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "plugin_mcp_req_binding_plugin_id": {
+          "name": "plugin_mcp_req_binding_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_config_object_id": {
+          "name": "plugin_mcp_req_binding_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_connection_id": {
+          "name": "plugin_mcp_req_binding_connection_id",
+          "columns": [
+            "external_mcp_connection_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_org_plugin_object_server": {
+          "name": "plugin_mcp_req_binding_org_plugin_object_server",
+          "columns": [
+            "organization_id",
+            "plugin_id",
+            "config_object_id",
+            "server_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_mcp_requirement_binding_id": {
+          "name": "plugin_mcp_requirement_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_access": {
+      "name": "llm_provider_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_access_org_membership_id": {
+          "name": "llm_provider_access_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_team_id": {
+          "name": "llm_provider_access_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_provider_org_membership": {
+          "name": "llm_provider_access_provider_org_membership",
+          "columns": [
+            "llm_provider_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_access_provider_team": {
+          "name": "llm_provider_access_provider_team",
+          "columns": [
+            "llm_provider_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_access_id": {
+          "name": "llm_provider_access_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_member_credential": {
+      "name": "llm_provider_member_credential",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_principal_id": {
+          "name": "external_principal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_credential_id": {
+          "name": "external_credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('active','blocked','stale','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "enum('member','admin','provisioner')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_member_credential_organization_id": {
+          "name": "llm_provider_member_credential_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_member_credential_member_provider": {
+          "name": "llm_provider_member_credential_member_provider",
+          "columns": [
+            "org_membership_id",
+            "llm_provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_member_credential_id": {
+          "name": "llm_provider_member_credential_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_model": {
+      "name": "llm_provider_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_model_model_id": {
+          "name": "llm_provider_model_model_id",
+          "columns": [
+            "model_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_model_provider_model": {
+          "name": "llm_provider_model_provider_model",
+          "columns": [
+            "llm_provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_model_id": {
+          "name": "llm_provider_model_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider": {
+      "name": "llm_provider",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum('models_dev','custom','openwork')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "enum('shared','per_member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_org_external_key": {
+          "name": "llm_provider_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_organization_id": {
+          "name": "llm_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_created_by_org_membership_id": {
+          "name": "llm_provider_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_source": {
+          "name": "llm_provider_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_provider_id": {
+          "name": "llm_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_access_grant": {
+      "name": "config_object_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_access_grant_organization_id": {
+          "name": "config_object_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_membership_id": {
+          "name": "config_object_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_team_id": {
+          "name": "config_object_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_wide": {
+          "name": "config_object_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_object_org_membership": {
+          "name": "config_object_access_grant_object_org_membership",
+          "columns": [
+            "config_object_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "config_object_access_grant_object_team": {
+          "name": "config_object_access_grant_object_team",
+          "columns": [
+            "config_object_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_access_grant_id": {
+          "name": "config_object_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object": {
+      "name": "config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom','script','workflow','app')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_mode": {
+          "name": "source_mode",
+          "type": "enum('cloud','import','connector')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_name": {
+          "name": "current_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_extension": {
+          "name": "current_file_extension",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_relative_path": {
+          "name": "current_relative_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_organization_id": {
+          "name": "config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_type": {
+          "name": "config_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "config_object_source_mode": {
+          "name": "config_object_source_mode",
+          "columns": [
+            "source_mode"
+          ],
+          "isUnique": false
+        },
+        "config_object_status": {
+          "name": "config_object_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "config_object_created_by_org_membership_id": {
+          "name": "config_object_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_connector_instance_id": {
+          "name": "config_object_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_current_relative_path": {
+          "name": "config_object_current_relative_path",
+          "columns": [
+            "current_relative_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_version": {
+      "name": "config_object_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_payload_json": {
+          "name": "normalized_payload_json",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_source_text": {
+          "name": "raw_source_text",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "enum('cloud','import','connector','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deleted_version": {
+          "name": "is_deleted_version",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "config_object_version_organization_id": {
+          "name": "config_object_version_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_created_by_org_membership_id": {
+          "name": "config_object_version_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_connector_sync_event_id": {
+          "name": "config_object_version_connector_sync_event_id",
+          "columns": [
+            "connector_sync_event_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_source_revision_ref": {
+          "name": "config_object_version_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_lookup_latest": {
+          "name": "config_object_version_lookup_latest",
+          "columns": [
+            "config_object_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_account": {
+      "name": "connector_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_ref": {
+          "name": "external_account_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','disconnected','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_account_created_by_org_membership_id": {
+          "name": "connector_account_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_connector_type": {
+          "name": "connector_account_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "idx_connector_account_on_remote_id": {
+          "name": "idx_connector_account_on_remote_id",
+          "columns": [
+            "remote_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_status": {
+          "name": "connector_account_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_account_org_type_remote_id": {
+          "name": "connector_account_org_type_remote_id",
+          "columns": [
+            "organization_id",
+            "connector_type",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance_access_grant": {
+      "name": "connector_instance_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instance_access_grant_organization_id": {
+          "name": "connector_instance_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_membership_id": {
+          "name": "connector_instance_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_team_id": {
+          "name": "connector_instance_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_wide": {
+          "name": "connector_instance_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_instance_org_membership": {
+          "name": "connector_instance_access_grant_instance_org_membership",
+          "columns": [
+            "connector_instance_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "connector_instance_access_grant_instance_team": {
+          "name": "connector_instance_access_grant_instance_team",
+          "columns": [
+            "connector_instance_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_access_grant_id": {
+          "name": "connector_instance_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance": {
+      "name": "connector_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','disabled','archived','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "instance_config_json": {
+          "name": "instance_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_cursor": {
+          "name": "last_sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_instance_connector_account_id": {
+          "name": "connector_instance_connector_account_id",
+          "columns": [
+            "connector_account_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_created_by_org_membership_id": {
+          "name": "connector_instance_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_connector_type": {
+          "name": "connector_instance_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_status": {
+          "name": "connector_instance_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_org_name": {
+          "name": "connector_instance_org_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_mapping": {
+      "name": "connector_mapping",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mapping_kind": {
+          "name": "mapping_kind",
+          "type": "enum('path','api','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom','script','workflow','app')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_add_to_plugin": {
+          "name": "auto_add_to_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mapping_config_json": {
+          "name": "mapping_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_mapping_organization_id": {
+          "name": "connector_mapping_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_connector_instance_id": {
+          "name": "connector_mapping_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_object_type": {
+          "name": "connector_mapping_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_plugin_id": {
+          "name": "connector_mapping_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_target_selector_object_type": {
+          "name": "connector_mapping_target_selector_object_type",
+          "columns": [
+            "connector_target_id",
+            "selector",
+            "object_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_binding": {
+      "name": "connector_source_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_stable_ref": {
+          "name": "external_stable_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_source_revision_ref": {
+          "name": "last_seen_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_source_binding_organization_id": {
+          "name": "connector_source_binding_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_instance_id": {
+          "name": "connector_source_binding_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_target_id": {
+          "name": "connector_source_binding_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_mapping_id": {
+          "name": "connector_source_binding_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_external_locator": {
+          "name": "connector_source_binding_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_config_object": {
+          "name": "connector_source_binding_config_object",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_binding_id": {
+          "name": "connector_source_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_tombstone": {
+      "name": "connector_source_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "former_config_object_id": {
+          "name": "former_config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_in_sync_event_id": {
+          "name": "deleted_in_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_source_revision_ref": {
+          "name": "deleted_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "connector_source_tombstone_organization_id": {
+          "name": "connector_source_tombstone_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_instance_id": {
+          "name": "connector_source_tombstone_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_target_id": {
+          "name": "connector_source_tombstone_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_mapping_id": {
+          "name": "connector_source_tombstone_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_external_locator": {
+          "name": "connector_source_tombstone_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_former_config_object_id": {
+          "name": "connector_source_tombstone_former_config_object_id",
+          "columns": [
+            "former_config_object_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_tombstone_id": {
+          "name": "connector_source_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_sync_event": {
+      "name": "connector_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('push','installation','installation_repositories','repository','manual_resync')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_ref": {
+          "name": "external_event_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_sync_event_organization_id": {
+          "name": "connector_sync_event_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_instance_id": {
+          "name": "connector_sync_event_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_target_id": {
+          "name": "connector_sync_event_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_target_status": {
+          "name": "connector_sync_event_target_status",
+          "columns": [
+            "connector_target_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_event_type": {
+          "name": "connector_sync_event_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status": {
+          "name": "connector_sync_event_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status_next_attempt_at": {
+          "name": "connector_sync_event_status_next_attempt_at",
+          "columns": [
+            "status",
+            "next_attempt_at"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_source_revision_ref": {
+          "name": "connector_sync_event_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_external_event_ref": {
+          "name": "connector_sync_event_external_event_ref",
+          "columns": [
+            "external_event_ref"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_target": {
+      "name": "connector_target",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "enum('repository_branch')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_target_ref": {
+          "name": "external_target_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_config_json": {
+          "name": "target_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_target_organization_id": {
+          "name": "connector_target_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_connector_type": {
+          "name": "connector_target_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_target_type_created_id": {
+          "name": "connector_target_type_created_id",
+          "columns": [
+            "connector_type",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_target_kind": {
+          "name": "connector_target_target_kind",
+          "columns": [
+            "target_kind"
+          ],
+          "isUnique": false
+        },
+        "connector_target_instance_remote_id": {
+          "name": "connector_target_instance_remote_id",
+          "columns": [
+            "connector_instance_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_access_grant": {
+      "name": "marketplace_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_access_grant_organization_id": {
+          "name": "marketplace_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_membership_id": {
+          "name": "marketplace_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_team_id": {
+          "name": "marketplace_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_wide": {
+          "name": "marketplace_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_marketplace_org_membership": {
+          "name": "marketplace_access_grant_marketplace_org_membership",
+          "columns": [
+            "marketplace_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "marketplace_access_grant_marketplace_team": {
+          "name": "marketplace_access_grant_marketplace_team",
+          "columns": [
+            "marketplace_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_access_grant_id": {
+          "name": "marketplace_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_plugin": {
+      "name": "marketplace_plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_plugin_organization_id": {
+          "name": "marketplace_plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_plugin_id": {
+          "name": "marketplace_plugin_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_marketplace_plugin": {
+          "name": "marketplace_plugin_marketplace_plugin",
+          "columns": [
+            "marketplace_id",
+            "plugin_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_plugin_id": {
+          "name": "marketplace_plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace": {
+      "name": "marketplace",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_org_external_key": {
+          "name": "marketplace_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "marketplace_organization_id": {
+          "name": "marketplace_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_created_by_org_membership_id": {
+          "name": "marketplace_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_status": {
+          "name": "marketplace_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_access_grant": {
+      "name": "plugin_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_access_grant_organization_id": {
+          "name": "plugin_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_membership_id": {
+          "name": "plugin_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_team_id": {
+          "name": "plugin_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_wide": {
+          "name": "plugin_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_plugin_org_membership": {
+          "name": "plugin_access_grant_plugin_org_membership",
+          "columns": [
+            "plugin_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "plugin_access_grant_plugin_team": {
+          "name": "plugin_access_grant_plugin_team",
+          "columns": [
+            "plugin_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_access_grant_id": {
+          "name": "plugin_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_config_object": {
+      "name": "plugin_config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_config_object_organization_id": {
+          "name": "plugin_config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_config_object_id": {
+          "name": "plugin_config_object_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_connector_mapping_id": {
+          "name": "plugin_config_object_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_plugin_config_object": {
+          "name": "plugin_config_object_plugin_config_object",
+          "columns": [
+            "plugin_id",
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_config_object_id": {
+          "name": "plugin_config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin": {
+      "name": "plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_repository_url": {
+          "name": "source_repository_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_format": {
+          "name": "source_format",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_schema_version": {
+          "name": "source_schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_organization_id": {
+          "name": "plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_created_by_org_membership_id": {
+          "name": "plugin_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_status": {
+          "name": "plugin_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_subscriptions": {
+      "name": "org_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('inference','seat','web')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('incomplete','incomplete_expired','trialing','active','past_due','canceled','unpaid','paused','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'incomplete'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "payment_failed": {
+          "name": "payment_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_customer_id": {
+          "name": "org_subscriptions_customer_id",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": false
+        },
+        "org_subscriptions_subscription_id": {
+          "name": "org_subscriptions_subscription_id",
+          "columns": [
+            "stripe_subscription_id"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_org_type": {
+          "name": "org_subscriptions_org_type",
+          "columns": [
+            "organization_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_status": {
+          "name": "org_subscriptions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_subscriptions_id": {
+          "name": "org_subscriptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_member": {
+      "name": "team_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_member_org_membership_id": {
+          "name": "team_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_user_id": {
+          "name": "team_member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_membership_key": {
+          "name": "team_member_membership_key",
+          "columns": [
+            "membership_key"
+          ],
+          "isUnique": true
+        },
+        "team_member_team_org_membership": {
+          "name": "team_member_team_org_membership",
+          "columns": [
+            "team_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_member_id": {
+          "name": "team_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grants_organization_admin": {
+          "name": "grants_organization_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "team_org_external_key": {
+          "name": "team_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "team_organization_name": {
+          "name": "team_organization_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_id": {
+          "name": "team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "temp_file": {
+      "name": "temp_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upload_token_hash": {
+          "name": "upload_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_token_hash": {
+          "name": "download_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'application/octet-stream'"
+        },
+        "max_bytes": {
+          "name": "max_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "enum('volume','s3')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','uploaded')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expected_sha256": {
+          "name": "expected_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "temp_file_upload_token_hash": {
+          "name": "temp_file_upload_token_hash",
+          "columns": [
+            "upload_token_hash"
+          ],
+          "isUnique": true
+        },
+        "temp_file_download_token_hash": {
+          "name": "temp_file_download_token_hash",
+          "columns": [
+            "download_token_hash"
+          ],
+          "isUnique": true
+        },
+        "temp_file_organization_id": {
+          "name": "temp_file_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "temp_file_expires_at": {
+          "name": "temp_file_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "temp_file_id": {
+          "name": "temp_file_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_event": {
+      "name": "audit_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_event_org_id": {
+          "name": "audit_event_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "audit_event_worker_id": {
+          "name": "audit_event_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "daytona_sandbox": {
+      "name": "daytona_sandbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_volume_id": {
+          "name": "workspace_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_volume_id": {
+          "name": "data_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url": {
+          "name": "signed_preview_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url_expires_at": {
+          "name": "signed_preview_url_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "daytona_sandbox_worker_id": {
+          "name": "daytona_sandbox_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": true
+        },
+        "daytona_sandbox_sandbox_id": {
+          "name": "daytona_sandbox_sandbox_id",
+          "columns": [
+            "sandbox_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daytona_sandbox_id": {
+          "name": "daytona_sandbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_bundle": {
+      "name": "worker_bundle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "worker_bundle_worker_id": {
+          "name": "worker_bundle_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_bundle_id": {
+          "name": "worker_bundle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_instance": {
+      "name": "worker_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_instance_worker_id": {
+          "name": "worker_instance_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker": {
+      "name": "worker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "enum('local','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_version": {
+          "name": "image_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_backend": {
+          "name": "sandbox_backend",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_code": {
+          "name": "cloud_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_stage": {
+          "name": "cloud_failure_stage",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_reference": {
+          "name": "cloud_failure_reference",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_at": {
+          "name": "cloud_failure_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_org_id": {
+          "name": "worker_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "worker_created_by_user_id": {
+          "name": "worker_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "worker_status": {
+          "name": "worker_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "worker_last_heartbeat_at": {
+          "name": "worker_last_heartbeat_at",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        },
+        "worker_last_active_at": {
+          "name": "worker_last_active_at",
+          "columns": [
+            "last_active_at"
+          ],
+          "isUnique": false
+        },
+        "worker_claimable_updated": {
+          "name": "worker_claimable_updated",
+          "columns": [
+            "destination",
+            "sandbox_backend",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_id": {
+          "name": "worker_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_token": {
+      "name": "worker_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('client','host','activity')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worker_token_worker_id": {
+          "name": "worker_token_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        },
+        "worker_token_token": {
+          "name": "worker_token_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_token_id": {
+          "name": "worker_token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_allowlist": {
+      "name": "admin_allowlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "admin_allowlist_email": {
+          "name": "admin_allowlist_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_allowlist_id": {
+          "name": "admin_allowlist_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit": {
+      "name": "rate_limit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limit_key": {
+          "name": "rate_limit_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_id": {
+          "name": "rate_limit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_event": {
+      "name": "telemetry_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_event_org_id_type_ts": {
+          "name": "telemetry_event_org_id_type_ts",
+          "columns": [
+            "org_id",
+            "event_type",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_id_member_id": {
+          "name": "telemetry_event_org_id_member_id",
+          "columns": [
+            "org_id",
+            "member_id"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_member_ts": {
+          "name": "telemetry_event_member_ts",
+          "columns": [
+            "member_id",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_session_ts": {
+          "name": "telemetry_event_org_session_ts",
+          "columns": [
+            "org_id",
+            "session_id",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_event_id": {
+          "name": "telemetry_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_session_dimension": {
+      "name": "telemetry_session_dimension",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_type": {
+          "name": "dimension_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_value": {
+          "name": "dimension_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_label": {
+          "name": "dimension_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_session_dimension_org_source_session_type": {
+          "name": "telemetry_session_dimension_org_source_session_type",
+          "columns": [
+            "org_id",
+            "source",
+            "session_id",
+            "dimension_type"
+          ],
+          "isUnique": true
+        },
+        "telemetry_session_dimension_filter": {
+          "name": "telemetry_session_dimension_filter",
+          "columns": [
+            "org_id",
+            "dimension_type",
+            "dimension_value",
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_session_dimension_id": {
+          "name": "telemetry_session_dimension_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "models_analytics_event": {
+      "name": "models_analytics_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_complete": {
+          "name": "usage_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "models_analytics_dedup": {
+          "name": "models_analytics_dedup",
+          "columns": [
+            "org_id",
+            "member_id",
+            "source",
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "models_analytics_activity": {
+          "name": "models_analytics_activity",
+          "columns": [
+            "org_id",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_task": {
+          "name": "models_analytics_task",
+          "columns": [
+            "org_id",
+            "member_id",
+            "session_id",
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_consumption": {
+          "name": "models_analytics_consumption",
+          "columns": [
+            "org_id",
+            "type",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_export": {
+          "name": "models_analytics_export",
+          "columns": [
+            "org_id",
+            "exported_at",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "models_analytics_event_id": {
+          "name": "models_analytics_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "models_analytics_settings": {
+      "name": "models_analytics_settings",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consented_by": {
+          "name": "consented_by",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "export_enabled": {
+          "name": "export_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "export_enabled_at": {
+          "name": "export_enabled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_host": {
+          "name": "langfuse_host",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_public_key": {
+          "name": "langfuse_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_secret_key": {
+          "name": "langfuse_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "models_analytics_settings_org_id": {
+          "name": "models_analytics_settings_org_id",
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "account_account_id_provider_id": {
+        "columns": {
+          "`account_id`(191)": {
+            "isExpression": true
+          },
+          "`provider_id`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "oauth_access_token_token": {
+        "columns": {
+          "`token`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "oauth_refresh_token_token": {
+        "columns": {
+          "`token`(191)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -652,6 +652,13 @@
       "when": 1788863483979,
       "tag": "0093_team_organization_admin",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "5",
+      "when": 1788875223075,
+      "tag": "0094_anonymous_inference",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/inference.ts
+++ b/ee/packages/den-db/src/schema/inference.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm"
 import {
   bigint,
+  boolean,
   index,
   int,
   mysqlEnum,
@@ -15,6 +16,10 @@ import { MemberTable, OrganizationTable } from "./org"
 
 export const InferenceKeyStatus = ["active", "revoked"] as const
 export const InferenceOrgUpstreamProviderKeyStatus = ["active", "revoked"] as const
+export const AnonymousInferenceScopes = ["installation", "ip", "global"] as const
+export const AnonymousInferenceUsageWindows = ["daily", "monthly"] as const
+export const AnonymousInferenceRateKinds = ["session", "request"] as const
+export const AnonymousInferenceReservationStatuses = ["active", "settled", "retained"] as const
 
 export const InferenceKeyTable = mysqlTable(
   "inference_keys",
@@ -105,6 +110,107 @@ export const InferenceOrgUpstreamProviderKeyTable = mysqlTable(
       table.provider,
     ),
     index("inference_org_upstream_provider_keys_status").on(table.status),
+  ],
+)
+
+// Anonymous inference identities are one-way hashes. A single control row is
+// locked before every admission/settlement so limits remain atomic across all
+// inference service instances.
+export const AnonymousInferenceControlTable = mysqlTable(
+  "anonymous_inference_control",
+  {
+    id: varchar("id", { length: 64 }).notNull().primaryKey(),
+    blocked: boolean("blocked").notNull().default(false),
+    blocked_at: timestamp("blocked_at", { fsp: 3 }),
+    block_reason: varchar("block_reason", { length: 64 }),
+    ...timestamps,
+  },
+)
+
+export const AnonymousInferenceUsageBucketTable = mysqlTable(
+  "anonymous_inference_usage_buckets",
+  {
+    id: varchar("id", { length: 64 }).notNull().primaryKey(),
+    scope: mysqlEnum("scope", AnonymousInferenceScopes).notNull(),
+    identity_hash: varchar("identity_hash", { length: 64 }).notNull(),
+    window_type: mysqlEnum("window_type", AnonymousInferenceUsageWindows).notNull(),
+    window_start_at: timestamp("window_start_at", { fsp: 3 }).notNull(),
+    window_end_at: timestamp("window_end_at", { fsp: 3 }).notNull(),
+    limit_micro_usd: bigint("limit_micro_usd", { mode: "number" }).notNull(),
+    used_micro_usd: bigint("used_micro_usd", { mode: "number" }).notNull().default(0),
+    ...timestamps,
+  },
+  (table) => [
+    uniqueIndex("anonymous_inference_usage_bucket_identity_window").on(
+      table.scope,
+      table.identity_hash,
+      table.window_type,
+      table.window_start_at,
+    ),
+    index("anonymous_inference_usage_bucket_window_end").on(table.window_end_at),
+  ],
+)
+
+export const AnonymousInferenceRateBucketTable = mysqlTable(
+  "anonymous_inference_rate_buckets",
+  {
+    id: varchar("id", { length: 64 }).notNull().primaryKey(),
+    kind: mysqlEnum("kind", AnonymousInferenceRateKinds).notNull(),
+    scope: mysqlEnum("scope", AnonymousInferenceScopes).notNull(),
+    identity_hash: varchar("identity_hash", { length: 64 }).notNull(),
+    window_start_at: timestamp("window_start_at", { fsp: 3 }).notNull(),
+    window_end_at: timestamp("window_end_at", { fsp: 3 }).notNull(),
+    limit_amount: bigint("limit_amount", { mode: "number" }).notNull(),
+    used_amount: bigint("used_amount", { mode: "number" }).notNull().default(0),
+    ...timestamps,
+  },
+  (table) => [
+    uniqueIndex("anonymous_inference_rate_bucket_identity_window").on(
+      table.kind,
+      table.scope,
+      table.identity_hash,
+      table.window_start_at,
+    ),
+    index("anonymous_inference_rate_bucket_window_end").on(table.window_end_at),
+  ],
+)
+
+export const AnonymousInferenceReservationTable = mysqlTable(
+  "anonymous_inference_reservations",
+  {
+    id: varchar("id", { length: 64 }).notNull().primaryKey(),
+    installation_hash: varchar("installation_hash", { length: 64 }).notNull(),
+    ip_hash: varchar("ip_hash", { length: 64 }).notNull(),
+    status: mysqlEnum("status", AnonymousInferenceReservationStatuses).notNull().default("active"),
+    reserved_micro_usd: bigint("reserved_micro_usd", { mode: "number" }).notNull(),
+    settled_micro_usd: bigint("settled_micro_usd", { mode: "number" }),
+    lease_expires_at: timestamp("lease_expires_at", { fsp: 3 }).notNull(),
+    released_at: timestamp("released_at", { fsp: 3 }),
+    ...timestamps,
+  },
+  (table) => [
+    index("anonymous_inference_reservation_active_installation").on(
+      table.status,
+      table.installation_hash,
+      table.lease_expires_at,
+    ),
+    index("anonymous_inference_reservation_active_lease").on(table.status, table.lease_expires_at),
+  ],
+)
+
+export const AnonymousInferenceReservationChargeTable = mysqlTable(
+  "anonymous_inference_reservation_charges",
+  {
+    id: varchar("id", { length: 64 }).notNull().primaryKey(),
+    reservation_id: varchar("reservation_id", { length: 64 }).notNull(),
+    bucket_id: varchar("bucket_id", { length: 64 }).notNull(),
+    reserved_micro_usd: bigint("reserved_micro_usd", { mode: "number" }).notNull(),
+    settled_micro_usd: bigint("settled_micro_usd", { mode: "number" }),
+    created_at: timestamps.created_at,
+  },
+  (table) => [
+    uniqueIndex("anonymous_inference_reservation_charge_bucket").on(table.reservation_id, table.bucket_id),
+    index("anonymous_inference_reservation_charge_bucket_id").on(table.bucket_id),
   ],
 )
 
@@ -244,3 +350,8 @@ export const inferenceOrgUsageBucket = InferenceOrgUsageBucketTable
 export const inferenceOrgUpstreamProviderKey = InferenceOrgUpstreamProviderKeyTable
 export const inferenceUsageLedgerEntry = InferenceUsageLedgerEntryTable
 export const inferenceUsageLedgerBucketCharge = InferenceUsageLedgerBucketChargeTable
+export const anonymousInferenceControl = AnonymousInferenceControlTable
+export const anonymousInferenceUsageBucket = AnonymousInferenceUsageBucketTable
+export const anonymousInferenceRateBucket = AnonymousInferenceRateBucketTable
+export const anonymousInferenceReservation = AnonymousInferenceReservationTable
+export const anonymousInferenceReservationCharge = AnonymousInferenceReservationChargeTable

--- a/evals/packages/labs/src/anonymous-inference-fixture.mjs
+++ b/evals/packages/labs/src/anonymous-inference-fixture.mjs
@@ -1,0 +1,408 @@
+/** Deterministic OpenRouter witness and disposable-DB arrangement for the anonymous inference journey. */
+import { createHash, randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { Readable } from "node:stream";
+import { pathToFileURL } from "node:url";
+
+const anonymousUpstreamKey = "anonymous-inference-fixture-upstream";
+const paidUpstreamKey = "anonymous-inference-fixture-paid-upstream";
+export function paidFixtureKey(memberId) { return `ow_inf_anonymous-fixture-${memberId}`; }
+
+async function database() {
+  const { createDenDb } = await import("../../../../ee/packages/den-db/src/client.ts");
+  const { db } = createDenDb({ databaseUrl: process.env.DATABASE_URL, mode: "mysql" });
+  return db;
+}
+
+async function arrange(command, orgId, memberId) {
+  if (command === "migrate-anonymous") {
+    const { createConnection } = await import("../../../../ee/packages/den-db/node_modules/mysql2/promise.js");
+    const connection = await createConnection(process.env.DATABASE_URL);
+    try {
+      const [tables] = await connection.query("SHOW TABLES LIKE 'anonymous_inference_control'");
+      if (Array.isArray(tables) && tables.length === 0) {
+        const migration = await readFile(new URL("../../../../ee/packages/den-db/drizzle/0094_anonymous_inference.sql", import.meta.url), "utf8");
+        for (const statement of migration.split("--> statement-breakpoint").map((value) => value.trim()).filter(Boolean)) {
+          await connection.query(statement);
+        }
+      }
+    } finally {
+      await connection.end();
+    }
+    console.log("Anonymous inference schema ready");
+    return;
+  }
+  const db = await database();
+  const schema = await import("../../../../ee/packages/den-db/src/schema.ts");
+  const { and, eq, sql } = await import("../../../../ee/packages/den-db/src/drizzle.ts");
+  const { createDenTypeId, normalizeDenTypeId } = await import("../../../../ee/packages/utils/src/typeid.ts");
+  if (command === "subscription") {
+    const id = normalizeDenTypeId("organization", orgId);
+    await db.insert(schema.OrgSubscriptionTable).values({
+      id: createDenTypeId("orgSubscription"), organization_id: id, type: "inference", status: "active",
+      stripe_customer_id: `cus_anonymous_fixture_${orgId}`, stripe_subscription_id: `sub_anonymous_fixture_${orgId}`, quantity: 1,
+    });
+    await db.insert(schema.InferenceOrgUpstreamProviderKeyTable).values({
+      id: createDenTypeId("inferenceOrgProviderKey"), organization_id: id, provider: "openrouter",
+      encrypted_api_key: paidUpstreamKey, status: "active",
+    });
+  } else if (command === "ensure-control") {
+    await db.insert(schema.AnonymousInferenceControlTable).values({ id: "anonymous-inference-global" })
+      .onDuplicateKeyUpdate({ set: { id: "anonymous-inference-global" } });
+  } else if (command === "configure-paid") {
+    const key = paidFixtureKey(memberId);
+    await db.update(schema.InferenceKeyTable).set({ key_hash: createHash("sha256").update(key).digest("hex") }).where(and(
+      eq(schema.InferenceKeyTable.organization_id, normalizeDenTypeId("organization", orgId)),
+      eq(schema.InferenceKeyTable.org_membership_id, normalizeDenTypeId("member", memberId)),
+      eq(schema.InferenceKeyTable.status, "active"),
+    ));
+  } else if (command === "reset-anonymous") {
+    await db.delete(schema.AnonymousInferenceReservationChargeTable);
+    await db.delete(schema.AnonymousInferenceReservationTable);
+    await db.delete(schema.AnonymousInferenceUsageBucketTable);
+    await db.delete(schema.AnonymousInferenceRateBucketTable);
+    await db.update(schema.AnonymousInferenceControlTable).set({ blocked: false, blocked_at: null, block_reason: null });
+  } else if (command === "pause-anonymous") {
+    await db.execute(sql.raw("RENAME TABLE anonymous_inference_usage_buckets TO anonymous_inference_usage_buckets_unavailable"));
+  } else if (command === "resume-anonymous") {
+    await db.execute(sql.raw("RENAME TABLE anonymous_inference_usage_buckets_unavailable TO anonymous_inference_usage_buckets"));
+  } else if (command === "accounting") {
+    const reservations = await db.select({
+      status: schema.AnonymousInferenceReservationTable.status,
+      reservedMicroUsd: schema.AnonymousInferenceReservationTable.reserved_micro_usd,
+      settledMicroUsd: schema.AnonymousInferenceReservationTable.settled_micro_usd,
+    }).from(schema.AnonymousInferenceReservationTable);
+    const buckets = await db.select({
+      scope: schema.AnonymousInferenceUsageBucketTable.scope,
+      windowType: schema.AnonymousInferenceUsageBucketTable.window_type,
+      usedMicroUsd: schema.AnonymousInferenceUsageBucketTable.used_micro_usd,
+    }).from(schema.AnonymousInferenceUsageBucketTable);
+    const rateBuckets = await db.select({
+      kind: schema.AnonymousInferenceRateBucketTable.kind,
+      scope: schema.AnonymousInferenceRateBucketTable.scope,
+      usedAmount: schema.AnonymousInferenceRateBucketTable.used_amount,
+    }).from(schema.AnonymousInferenceRateBucketTable);
+    const [control] = await db.select({ blocked: schema.AnonymousInferenceControlTable.blocked }).from(schema.AnonymousInferenceControlTable).limit(1);
+    console.log(JSON.stringify({ reservations, buckets, rateBuckets, blocked: control?.blocked ?? null }));
+    return;
+  } else {
+    throw new Error(`Unknown anonymous inference fixture command: ${command}`);
+  }
+  console.log("Anonymous inference fixture ready");
+}
+
+async function serveWitness() {
+  const calls = [];
+  const waiting = new Set();
+  let errorBodiesClosed = 0;
+  const server = createServer(async (request, response) => {
+    if (request.url === "/health") { response.end("ok"); return; }
+    if (request.url === "/fixture/requests") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ calls, waiting: waiting.size, errorBodiesClosed }));
+      return;
+    }
+    if (request.url === "/fixture/release") {
+      for (const release of waiting) release();
+      response.end("{}");
+      return;
+    }
+    if (request.url?.startsWith("/fixture/control-lock")) {
+      const delayMs = Math.min(5_000, Math.max(1, Number(new URL(request.url, "http://fixture").searchParams.get("ms") ?? "1000")));
+      const db = await database();
+      const schema = await import("../../../../ee/packages/den-db/src/schema.ts");
+      const { eq } = await import("../../../../ee/packages/den-db/src/drizzle.ts");
+      await db.transaction(async (tx) => {
+        await tx.select().from(schema.AnonymousInferenceControlTable)
+          .where(eq(schema.AnonymousInferenceControlTable.id, "anonymous-inference-global")).limit(1).for("update");
+        response.writeHead(200, { "content-type": "text/plain" });
+        response.write("locked");
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      });
+      response.end(" released");
+      return;
+    }
+    let text = "";
+    for await (const chunk of request) {
+      text += chunk.toString();
+      if (text.length > 1_048_576) { response.writeHead(413).end(); return; }
+    }
+    let payload;
+    try { payload = JSON.parse(text); }
+    catch { response.writeHead(400).end(); return; }
+    const prompt = JSON.stringify(payload.messages ?? []);
+    const marker = prompt.includes("fixture:cancellation")
+      ? "cancellation"
+      : prompt.includes("fixture:provisioning")
+        ? "provisioning"
+        : null;
+    const missingUsage = prompt.includes("fixture:missing-usage");
+    const hold = prompt.includes("fixture:hold");
+    const outage = prompt.includes("fixture:outage");
+    const authorization = request.headers.authorization;
+    const availableTools = Array.isArray(payload.tools) ? payload.tools.map((tool) => tool?.function?.name).filter((name) => typeof name === "string") : [];
+    const hasAssistantMessage = Array.isArray(payload.messages) && payload.messages.some((message) => message?.role === "assistant");
+    const useFixtureTool = !hasAssistantMessage && availableTools.includes("glob");
+    calls.push({
+      authenticated: authorization === `Bearer ${anonymousUpstreamKey}` ? "anonymous" : authorization === `Bearer ${paidUpstreamKey}` ? "paid" : "unknown",
+      model: payload.model,
+      provider: payload.provider,
+      maxTokens: payload.max_tokens,
+      n: payload.n,
+      reasoning: payload.reasoning,
+      reasoningEffort: payload.reasoningEffort,
+      textVerbosity: payload.textVerbosity,
+      verbosity: payload.verbosity,
+      stream: payload.stream === true,
+      streamOptions: payload.stream_options,
+      usage: payload.usage,
+      toolChoice: payload.tool_choice,
+      toolCount: Array.isArray(payload.tools) ? payload.tools.length : 0,
+      tools: payload.tools,
+      toolNames: Array.isArray(payload.tools) ? payload.tools.map((tool) => tool?.function?.name).filter((name) => typeof name === "string") : [],
+      messageRoles: Array.isArray(payload.messages) ? payload.messages.map((message) => message?.role) : [],
+      canonicalBytes: Buffer.byteLength(text, "utf8"),
+      hasPlugins: Object.prototype.hasOwnProperty.call(payload, "plugins"),
+      marker,
+    });
+    if (outage) {
+      response.writeHead(503, { "content-type": "application/json" });
+      response.write(JSON.stringify({ error: { message: "private fixture outage detail" } }));
+      const timer = setTimeout(() => response.end(), 5_000);
+      response.once("close", () => { clearTimeout(timer); errorBodiesClosed += 1; });
+      return;
+    }
+    const id = `chatcmpl-${randomUUID()}`;
+    const byokMissingPrincipal = prompt.includes("fixture:byok-missing-principal");
+    const byokZeroFee = prompt.includes("fixture:byok-zero-fee");
+    const byokFlagMismatch = prompt.includes("fixture:byok-flag-mismatch");
+    const inclusiveReasoning = prompt.includes("fixture:reasoning-inclusive");
+    const reasoningOverTotal = prompt.includes("fixture:reasoning-over-total");
+    const completionTokens = inclusiveReasoning ? 4_096 : 20;
+    const usage = {
+      prompt_tokens: 100, completion_tokens: completionTokens, total_tokens: 100 + completionTokens,
+      completion_tokens_details: { reasoning_tokens: inclusiveReasoning ? 2_048 : reasoningOverTotal ? 21 : 0 },
+      is_byok: !byokFlagMismatch,
+      cost: prompt.includes("fixture:over-cost") ? 0.05 : byokZeroFee ? 0 : byokFlagMismatch ? 0.0001 : 0.000005,
+      ...(byokFlagMismatch ? { cost_details: { upstream_inference_cost: 0.0001 } }
+        : byokMissingPrincipal ? {}
+          : { cost_details: { upstream_inference_cost: prompt.includes("fixture:over-cost") || prompt.includes("fixture:late-over-cost") ? 1 : 0.0001 } }),
+    };
+    if (prompt.includes("fixture:late-over-cost")) {
+      const db = await database();
+      const schema = await import("../../../../ee/packages/den-db/src/schema.ts");
+      const { eq } = await import("../../../../ee/packages/den-db/src/drizzle.ts");
+      await db.transaction(async (tx) => {
+        await tx.select().from(schema.AnonymousInferenceControlTable)
+          .where(eq(schema.AnonymousInferenceControlTable.id, "anonymous-inference-global")).limit(1).for("update");
+        await tx.update(schema.AnonymousInferenceReservationTable).set({ status: "retained", released_at: new Date() })
+          .where(eq(schema.AnonymousInferenceReservationTable.status, "active"));
+      });
+    }
+    if (!payload.stream) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        id, model: payload.model, provider: "fixture-provider", choices: [{
+          index: 0,
+          message: useFixtureTool
+            ? { role: "assistant", content: null, tool_calls: [{ id: "anonymous-fixture-glob", type: "function", function: { name: "glob", arguments: JSON.stringify({ pattern: "*", path: "." }) } }] }
+            : { role: "assistant", content: "Anonymous Models are working." },
+          finish_reason: useFixtureTool ? "tool_calls" : "stop",
+        }],
+        ...(missingUsage ? {} : { usage }),
+      }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    if (useFixtureTool) {
+      response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", model: payload.model, provider: "fixture-provider", choices: [{ index: 0, delta: { role: "assistant", tool_calls: [{ index: 0, id: "anonymous-fixture-glob", type: "function", function: { name: "glob", arguments: JSON.stringify({ pattern: "*", path: "." }) } }] }, finish_reason: "tool_calls" }] })}\n\n`);
+      if (!missingUsage) response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", model: payload.model, provider: "fixture-provider", choices: [], usage })}\n\n`);
+      response.end("data: [DONE]\n\n");
+      return;
+    }
+    response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", model: payload.model, provider: "fixture-provider", choices: [{ index: 0, delta: { role: "assistant", content: "Anonymous " }, finish_reason: null }] })}\n\n`);
+    if (hold) {
+      await new Promise((resolve) => {
+        const release = () => { waiting.delete(release); resolve(); };
+        waiting.add(release);
+        response.once("close", release);
+      });
+      if (response.destroyed) return;
+    }
+    response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", model: payload.model, choices: [{ index: 0, delta: { content: "Models are working." }, finish_reason: "stop" }] })}\n\n`);
+    if (!missingUsage) response.write(`data: ${JSON.stringify({ id, object: "chat.completion.chunk", model: payload.model, provider: "fixture-provider", choices: [], usage })}\n\n`);
+    response.end("data: [DONE]\n\n");
+  });
+  await new Promise((resolve) => server.listen(Number(process.env.ANONYMOUS_WITNESS_PORT ?? 8792), "0.0.0.0", resolve));
+}
+
+async function serveClientProxy() {
+  const upstream = new URL(process.env.ANONYMOUS_CLIENT_UPSTREAM_URL ?? "http://127.0.0.1:8791");
+  const mints = [];
+  const inference = [];
+  const unexpected = [];
+  let currentToken = null;
+  let rejectedToken = null;
+  let failure = null;
+  let nextSessionDelayMs = 0;
+  let failNextSession = false;
+
+  function json(response, status, value, headers = {}) {
+    response.writeHead(status, { "content-type": "application/json", ...headers });
+    response.end(JSON.stringify(value));
+  }
+
+  async function body(request) {
+    const chunks = [];
+    let size = 0;
+    for await (const chunk of request) {
+      size += chunk.length;
+      if (size > 2 * 1024 * 1024) throw new Error("Client proxy request exceeded fixture limit");
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  function error(response, status, code, message) {
+    json(response, status, { error: { code, message, type: status === 429 ? "rate_limit_error" : "api_error" } }, { "retry-after": "1" });
+  }
+
+  function responseHeaders(headers) {
+    const output = {};
+    for (const name of ["content-type", "cache-control", "retry-after", "x-request-id"]) {
+      const value = headers.get(name);
+      if (value) output[name] = value;
+    }
+    return output;
+  }
+
+  const server = createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", "http://fixture");
+      if (url.pathname === "/health") return json(response, 200, { ok: true });
+      if (request.method === "GET" && url.pathname === "/fixture/client/state") {
+        return json(response, 200, { mints, inference, unexpected, failure, currentToken: Boolean(currentToken), rejectedToken: Boolean(rejectedToken) });
+      }
+      if (request.method === "POST" && url.pathname === "/fixture/client/expire") {
+        rejectedToken = currentToken;
+        return json(response, 200, { expired: Boolean(rejectedToken) });
+      }
+      const bytes = await body(request);
+      let payload = {};
+      try { payload = bytes.length ? JSON.parse(bytes.toString("utf8")) : {}; }
+      catch { return json(response, 400, { error: "invalid fixture JSON" }); }
+      if (request.method === "POST" && url.pathname === "/fixture/client/failure") {
+        failure = ["limit", "capacity", "unavailable"].includes(payload.failure) ? payload.failure : null;
+        return json(response, 200, { failure });
+      }
+      if (request.method === "POST" && url.pathname === "/fixture/client/session") {
+        nextSessionDelayMs = Math.min(5_000, Math.max(0, Number(payload.delayMs) || 0));
+        failNextSession = payload.fail === true;
+        return json(response, 200, { nextSessionDelayMs, failNextSession });
+      }
+
+      const isSession = request.method === "POST" && url.pathname === "/api/anonymous/session";
+      const isChat = request.method === "POST" && url.pathname === "/api/anonymous/v1/chat/completions";
+      if (!isSession && !isChat) unexpected.push(`${request.method ?? "GET"} ${url.pathname}`);
+      const authorization = request.headers.authorization ?? null;
+      const bodyHash = createHash("sha256").update(bytes).digest("hex");
+      if (isChat && rejectedToken && authorization === `Bearer ${rejectedToken}`) {
+        inference.push({ status: 401, bodyHash, faulted: true });
+        return error(response, 401, "invalid_anonymous_token", "The guest token is invalid");
+      }
+      if (isChat && failure) {
+        const status = failure === "unavailable" ? 503 : 429;
+        const code = failure === "limit" ? "anonymous_limit_exceeded" : failure === "capacity" ? "anonymous_capacity_exceeded" : "anonymous_unavailable";
+        inference.push({ status, bodyHash, faulted: true });
+        return error(response, status, code, "Injected anonymous client failure");
+      }
+      if (isSession && nextSessionDelayMs > 0) {
+        const delayMs = nextSessionDelayMs;
+        nextSessionDelayMs = 0;
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+      if (isSession && failNextSession) {
+        failNextSession = false;
+        return error(response, 503, "anonymous_unavailable", "Injected anonymous session failure");
+      }
+
+      const target = new URL(`${url.pathname}${url.search}`, upstream);
+      const controller = new AbortController();
+      request.once("aborted", () => controller.abort());
+      const upstreamResponse = await fetch(target, {
+        method: request.method,
+        headers: {
+          ...(authorization ? { authorization } : {}),
+          ...(request.headers["content-type"] ? { "content-type": request.headers["content-type"] } : {}),
+          ...(request.headers.accept ? { accept: request.headers.accept } : {}),
+        },
+        body: bytes.length ? bytes : undefined,
+        signal: controller.signal,
+      });
+      if (isSession) {
+        const responseBytes = Buffer.from(await upstreamResponse.arrayBuffer());
+        let result = {};
+        try { result = JSON.parse(responseBytes.toString("utf8")); } catch {}
+        if (upstreamResponse.ok && typeof result.token === "string") {
+          currentToken = result.token;
+          mints.push({
+            installationId: String(payload.installationId ?? ""),
+            tokenHash: createHash("sha256").update(result.token).digest("hex"),
+          });
+        }
+        response.writeHead(upstreamResponse.status, responseHeaders(upstreamResponse.headers));
+        response.end(responseBytes);
+        return;
+      }
+      if (isChat) {
+        let code = null;
+        let message = null;
+        if (!upstreamResponse.ok) {
+          try {
+            const result = await upstreamResponse.clone().json();
+            code = typeof result?.error?.code === "string" ? result.error.code : typeof result?.error === "string" ? result.error : null;
+            message = typeof result?.error?.message === "string" ? result.error.message : null;
+          } catch {}
+        }
+        const tools = Array.isArray(payload.tools) ? payload.tools : [];
+        const messages = Array.isArray(payload.messages) ? payload.messages : [];
+        inference.push({
+          status: upstreamResponse.status,
+          bodyHash,
+          faulted: false,
+          code,
+          message,
+          model: payload.model,
+          maxTokens: payload.max_tokens,
+          stream: payload.stream === true,
+          toolChoice: payload.tool_choice,
+          toolCount: tools.length,
+          requestedToolNames: tools.map((tool) => tool?.function?.name).filter((name) => typeof name === "string"),
+          canonicalBytes: bytes.length,
+          topLevelFields: Object.keys(payload).sort(),
+          toolFieldSets: [...new Set(tools.map((tool) => tool && typeof tool === "object" ? Object.keys(tool).sort().join(",") : typeof tool))],
+          functionFieldSets: [...new Set(tools.map((tool) => tool?.function && typeof tool.function === "object" ? Object.keys(tool.function).sort().join(",") : typeof tool?.function))],
+          messageFieldSets: [...new Set(messages.map((entry) => entry && typeof entry === "object" ? Object.keys(entry).sort().join(",") : typeof entry))],
+        });
+      }
+      response.writeHead(upstreamResponse.status, responseHeaders(upstreamResponse.headers));
+      if (!upstreamResponse.body) return response.end();
+      Readable.fromWeb(upstreamResponse.body).pipe(response);
+    })().catch((caught) => {
+      unexpected.push(caught instanceof Error ? caught.message : String(caught));
+      if (!response.headersSent) error(response, 502, "anonymous_unavailable", "Client proxy failed");
+      else response.destroy(caught instanceof Error ? caught : undefined);
+    });
+  });
+  await new Promise((resolve) => server.listen(Number(process.env.ANONYMOUS_CLIENT_PROXY_PORT ?? 8800), "0.0.0.0", resolve));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (process.argv[2] === "witness") await serveWitness();
+  else if (process.argv[2] === "client-proxy") await serveClientProxy();
+  else {
+    await arrange(process.argv[2], process.argv[3], process.argv[4]);
+    process.exit(0);
+  }
+}

--- a/evals/specs/anonymous-inference.test.ts
+++ b/evals/specs/anonymous-inference.test.ts
@@ -1,0 +1,391 @@
+import { randomUUID } from "node:crypto";
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { anonymousInferenceWorld } from "../worlds/anonymous-inference.ts";
+
+const test = spec.world(anonymousInferenceWorld, { timeout: 300_000, needs: {} });
+const freeModel = "openai/gpt-5.6-luna";
+
+function object(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected an object");
+  return Object.fromEntries(Object.entries(value));
+}
+
+function list(value: unknown) { return Array.isArray(value) ? value.map(object) : []; }
+
+async function json(response: Response) { return object(await response.json()); }
+
+async function errorCode(response: Response) {
+  const error = object((await json(response)).error);
+  return String(error.code);
+}
+
+async function issueResponse(url: string, installationId = randomUUID()) {
+  return fetch(`${url}/api/anonymous/session`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ installationId }),
+    signal: AbortSignal.timeout(10_000),
+  });
+}
+
+async function issue(url: string, installationId = randomUUID()) {
+  const response = await issueResponse(url, installationId);
+  const body = await json(response);
+  if (!response.ok || typeof body.token !== "string") throw new Error(`Anonymous session failed: HTTP ${response.status} ${JSON.stringify(body)}`);
+  return { token: body.token, installationId, expiresAt: body.expiresAt, model: body.model };
+}
+
+function auth(token: string) { return { authorization: `Bearer ${token}`, "content-type": "application/json" }; }
+
+async function complete(url: string, token: string, input: Record<string, unknown> = {}, signal: AbortSignal = AbortSignal.timeout(15_000)) {
+  return fetch(`${url}/api/anonymous/v1/chat/completions`, {
+    method: "POST", headers: auth(token),
+    body: JSON.stringify({ model: freeModel, messages: [{ role: "user", content: "Prove the free model boundary." }], ...input }),
+    signal,
+  });
+}
+
+async function witness(url: string) { return json(await fetch(`${url}/fixture/requests`, { signal: AbortSignal.timeout(5_000) })); }
+
+test("anonymous managed inference is separately authorized and financially bounded", { timeout: 300_000 }, async ({ world, probe, evidence }) => {
+  const missing = await fetch(`${world.primaryUrl}/api/anonymous/v1/models`, { signal: AbortSignal.timeout(5_000) });
+  expect(missing.status).toBe(401);
+  expect(await errorCode(missing)).toBe("invalid_anonymous_token");
+
+  const session = await issue(world.primaryUrl);
+  expect(session.expiresAt).toEqual(expect.any(Number));
+  expect(session.model).toBe(freeModel);
+  const modelsResponse = await fetch(`${world.primaryUrl}/api/anonymous/v1/models`, {
+    headers: { authorization: `Bearer ${session.token}` }, signal: AbortSignal.timeout(5_000),
+  });
+  expect(modelsResponse.status).toBe(200);
+  const models = list((await json(modelsResponse)).data);
+  expect(models.map((model) => model.id)).toEqual([freeModel]);
+  expect(JSON.stringify(models)).not.toContain("deepseek");
+
+  const plain = await complete(world.primaryUrl, session.token, { stream: false });
+  expect(plain.status).toBe(200);
+  expect(object(list((await json(plain)).choices)[0]?.message).content).toBe("Anonymous Models are working.");
+  const allowedTools = [
+    { type: "function", function: { name: "alpha", description: "First allowed tool", parameters: { type: "object", properties: {} } } },
+    { type: "function", function: { name: "omega", description: "Last allowed tool", parameters: { type: "object", properties: {} } } },
+  ];
+  const streamed = await complete(world.primaryUrl, session.token, {
+    stream: true,
+    tools: allowedTools,
+    tool_choice: "auto",
+    reasoningEffort: "none",
+    textVerbosity: "low",
+  });
+  expect(streamed.status).toBe(200);
+  expect(await streamed.text()).toContain("data: [DONE]");
+  const observed = list((await witness(world.witnessUrl)).calls);
+  expect(observed).toHaveLength(2);
+  expect(observed.every((call) => call.authenticated === "anonymous" && call.model === freeModel)).toBe(true);
+  expect(observed.every((call) => call.n === undefined && call.maxTokens === 4096 && call.hasPlugins === false)).toBe(true);
+  expect(observed.every((call) => {
+    const reasoning = object(call.reasoning);
+    return reasoning.effort === "none" && reasoning.mode === "standard" && reasoning.exclude === true;
+  })).toBe(true);
+  expect(observed.every((call) => call.reasoningEffort === undefined && call.textVerbosity === undefined)).toBe(true);
+  expect(observed[1]?.verbosity).toBe("low");
+  expect(observed.every((call) => object(call.usage).include === true)).toBe(true);
+  expect(object(observed[1]?.streamOptions).include_usage).toBe(true);
+  expect(observed[1]?.tools).toEqual(allowedTools);
+  expect(observed[1]?.toolNames).toEqual(["alpha", "omega"]);
+  expect(observed.every((call) => {
+    const provider = object(call.provider);
+    return provider.allow_fallbacks === false && provider.require_parameters === true
+      && provider.data_collection === "deny" && provider.zdr === true
+      && JSON.stringify(provider.order) === '["fixture-provider"]' && JSON.stringify(provider.only) === '["fixture-provider"]'
+      && object(provider.max_price).prompt === 0.25 && object(provider.max_price).completion === 1.2
+      && object(provider.max_price).request === 0 && object(provider.max_price).image === 0;
+  })).toBe(true);
+  evidence.recordAssertionEvidence("A no-sign-in session exposes and serves only the fixed free model", "The session and HTTP models list contained only GPT-5.6 Luna; JSON and SSE chats reached the independently authenticated witness with exact tools and server-owned standard/no-reasoning, provider-only, no-fallback, ZDR/data, $0.25/M conservative input-class, $1.20/M output, n and token bounds. The genuine SDK none/low hints were accepted, camelCase controls were not forwarded, and textVerbosity became bounded OpenRouter verbosity.", true);
+
+  const forged = await fetch(`${world.primaryUrl}/api/anonymous/v1/models`, { headers: { authorization: `Bearer ${session.token}x` } });
+  expect(forged.status).toBe(401); expect(await errorCode(forged)).toBe("invalid_anonymous_token");
+  const expiring = await issue(world.expiringUrl);
+  await new Promise((resolve) => setTimeout(resolve, 1_100));
+  const expired = await fetch(`${world.primaryUrl}/api/anonymous/v1/models`, { headers: { authorization: `Bearer ${expiring.token}` } });
+  expect(expired.status).toBe(401); expect(await errorCode(expired)).toBe("invalid_anonymous_token");
+
+  const beforePolicy = list((await witness(world.witnessUrl)).calls).length;
+  for (const forbiddenModel of ["deepseek/deepseek-v4-flash", "z-ai/glm-5.2", "openai/gpt-5.6-luna-pro"]) {
+    const forbidden = await complete(world.primaryUrl, session.token, { model: forbiddenModel });
+    expect(forbidden.status).toBe(403); expect(await errorCode(forbidden)).toBe("anonymous_model_not_allowed");
+  }
+  for (const override of [
+    { provider: { order: ["attacker"] } },
+    { reasoning: { effort: "high", mode: "pro" } },
+    { reasoningEffort: "medium" },
+    { reasoningEffort: "pro" },
+    { reasoningEffort: { effort: "none" } },
+    { textVerbosity: "max" },
+    { textVerbosity: null },
+    { plugins: [{ id: "web" }] },
+    { tools: [{ type: "openrouter:advisor" }] },
+    { messages: [{ role: "user", content: [{ type: "image_url", image_url: { url: "https://example.invalid/private" } }] }] },
+    { n: 2 },
+    { temperature: 0 },
+    { max_tokens: 4_097 },
+  ]) {
+    const rejected = await complete(world.primaryUrl, session.token, override);
+    expect([400, 403]).toContain(rejected.status);
+  }
+  const queryOverride = await fetch(`${world.primaryUrl}/api/anonymous/v1/chat/completions?model=z-ai/glm-5.2`, {
+    method: "POST", headers: auth(session.token), body: JSON.stringify({ model: freeModel, messages: [{ role: "user", content: "hello" }] }),
+  });
+  expect(queryOverride.status).toBe(403); expect(await errorCode(queryOverride)).toBe("anonymous_model_not_allowed");
+  const oversizedBody = JSON.stringify({
+    model: freeModel,
+    messages: Array.from({ length: 3 }, (_, index) => ({ role: "user", content: `${index}:${"x".repeat(44_000)}` })),
+  });
+  expect(Buffer.byteLength(oversizedBody, "utf8")).toBeLessThan(262_144);
+  const oversized = await fetch(`${world.primaryUrl}/api/anonymous/v1/chat/completions`, {
+    method: "POST", headers: auth(session.token), body: oversizedBody, signal: AbortSignal.timeout(10_000),
+  });
+  expect(oversized.status).toBe(400); expect(await errorCode(oversized)).toBe("invalid_request");
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(beforePolicy);
+  const expandingNumbers = Array.from({ length: 30_000 }, () => "1e20").join(",");
+  const expansionBody = `{"model":"${freeModel}","messages":[{"role":"user","content":"bounded"}],"tools":[{"type":"function","function":{"name":"expanded","parameters":{"type":"object","examples":[${expandingNumbers}]}}}]}`;
+  expect(Buffer.byteLength(expansionBody, "utf8")).toBeLessThan(262_144);
+  const expanded = await fetch(`${world.primaryUrl}/api/anonymous/v1/chat/completions`, {
+    method: "POST", headers: auth(session.token), body: expansionBody, signal: AbortSignal.timeout(10_000),
+  });
+  expect(expanded.status).toBe(400);
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(beforePolicy);
+  const neighboringProxy = await fetch(`${world.trustedNeighborUrl}/api/anonymous/session`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": "203.0.113.10" },
+    body: JSON.stringify({ installationId: randomUUID() }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  expect(neighboringProxy.status).toBe(503); expect(await errorCode(neighboringProxy)).toBe("anonymous_unavailable");
+
+  const paid = await fetch(`${world.primaryUrl}/api/v1/chat/completions`, {
+    method: "POST", headers: auth(world.paidKey),
+    body: JSON.stringify({ model: "z-ai/glm-5.2", messages: [{ role: "user", content: "Paid Models remains separate." }], stream: false }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  expect(paid.status).toBe(200);
+  expect(list((await witness(world.witnessUrl)).calls).at(-1)).toMatchObject({ authenticated: "paid", model: "z-ai/glm-5.2" });
+  evidence.recordAssertionEvidence("Guest authorization and canonical payload boundaries prevent alternate spending paths", "Missing, forged and expired tokens, prior DeepSeek/other/premium/pro model IDs, alternate/pro/malformed reasoningEffort and malformed textVerbosity hints, reasoning/routing/plugin/server-tool/media/n/sampling/token/query overrides, oversized valid messages, a raw-small but canonical-expanded tool schema, and an IPv6-neighbor trusted-hop forgery made zero upstream attempts; the membership-backed paid route still returned 200.", true);
+
+  await world.reset();
+  const concurrent = await issue(world.primaryUrl);
+  const sameInstallRace = await Promise.all([
+    complete(world.primaryUrl, concurrent.token, { stream: true, messages: [{ role: "user", content: "fixture:hold install-a" }] }),
+    complete(world.secondaryUrl, concurrent.token, { stream: true, messages: [{ role: "user", content: "fixture:hold install-b" }] }),
+  ]);
+  expect(sameInstallRace.map((response) => response.status).sort()).toEqual([200, 429]);
+  const sameInstallDenied = sameInstallRace.find((response) => response.status === 429);
+  expect(sameInstallDenied && await errorCode(sameInstallDenied)).toBe("anonymous_capacity_exceeded");
+  await probe.eventually(() => witness(world.witnessUrl), { within: 10_000, label: "one same-install upstream winner", until: (snapshot) => snapshot.waiting === 1 });
+  await fetch(`${world.witnessUrl}/fixture/release`, { method: "POST" });
+  const sameInstallWinner = sameInstallRace.find((response) => response.status === 200);
+  expect(sameInstallWinner && await sameInstallWinner.text()).toContain("[DONE]");
+
+  await world.reset();
+  const globalTokens = await Promise.all([issue(world.primaryUrl), issue(world.primaryUrl), issue(world.primaryUrl)]);
+  const [globalTokenA, globalTokenB, globalTokenC] = globalTokens;
+  if (!globalTokenA || !globalTokenB || !globalTokenC) throw new Error("Expected three global concurrency tokens");
+  const callsBeforeGlobalRace = list((await witness(world.witnessUrl)).calls).length;
+  const globalRace = await Promise.all([
+    complete(world.primaryUrl, globalTokenA.token, { stream: true, messages: [{ role: "user", content: "fixture:hold global-a" }] }),
+    complete(world.secondaryUrl, globalTokenB.token, { stream: true, messages: [{ role: "user", content: "fixture:hold global-b" }] }),
+  ]);
+  expect(globalRace.every((response) => response.status === 200)).toBe(true);
+  await probe.eventually(() => witness(world.witnessUrl), { within: 10_000, label: "two cross-instance global winners", until: (snapshot) => snapshot.waiting === 2 });
+  const globalDenied = await complete(world.secondaryUrl, globalTokenC.token);
+  expect(globalDenied.status).toBe(429); expect(await errorCode(globalDenied)).toBe("anonymous_capacity_exceeded");
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(callsBeforeGlobalRace + 2);
+  await fetch(`${world.witnessUrl}/fixture/release`, { method: "POST" });
+  for (const response of globalRace) expect(await response.text()).toContain("[DONE]");
+  const recovered = await complete(world.secondaryUrl, globalTokenC.token);
+  expect(recovered.status).toBe(200); await recovered.text();
+  evidence.recordAssertionEvidence("Atomic durable admission enforces distinct installation and global concurrency across service instances", "Two simultaneous same-installation requests with global capacity two produced one upstream winner and one local 429; two different installations then won a simultaneous cross-instance race, the third was denied without upstream, and release restored capacity.", true);
+
+  await world.reset();
+  const accountingToken = await issue(world.primaryUrl);
+  const zeroFeeByok = await complete(world.primaryUrl, accountingToken.token, { messages: [{ role: "user", content: "fixture:byok-zero-fee" }] });
+  expect(zeroFeeByok.status).toBe(200); await zeroFeeByok.text();
+  const zeroFeeAccounting = await world.accounting();
+  expect(list(zeroFeeAccounting.reservations)).toEqual([expect.objectContaining({ status: "settled", settledMicroUsd: 100 })]);
+  expect(list(zeroFeeAccounting.buckets).find((row) => row.scope === "installation" && row.windowType === "daily")?.usedMicroUsd).toBe(100);
+  for (const marker of ["fixture:byok-fee-principal", "fixture:byok-flag-mismatch", "fixture:byok-missing-principal"]) {
+    const response = await complete(world.primaryUrl, accountingToken.token, { messages: [{ role: "user", content: marker }] });
+    expect(response.status).toBe(200); await response.text();
+  }
+  const costAccounting = await world.accounting();
+  expect(list(costAccounting.reservations).filter((row) => row.status === "settled").map((row) => row.settledMicroUsd).sort((left, right) => Number(left) - Number(right))).toEqual([100, 105]);
+  expect(list(costAccounting.reservations).filter((row) => row.status === "retained")).toEqual([
+    expect.objectContaining({ reservedMicroUsd: 41_452, settledMicroUsd: null }),
+    expect.objectContaining({ reservedMicroUsd: 41_452, settledMicroUsd: null }),
+  ]);
+  evidence.recordAssertionEvidence("Trusted OpenRouter BYOK accounting includes provider principal exactly once", "A zero-fee BYOK response independently settled and consumed 100 micro-USD of budget from its positive provider principal; fee plus principal settled to 105; a non-BYOK marker and missing BYOK principal each retained the full 41,452-micro-USD reservation derived from 131,072 input tokens at the conservative $0.25/M cache-write bound plus 4,096 output tokens at $1.20/M and the fixed 10% margin.", true);
+
+  await world.reset();
+  const reasoningToken = await issue(world.primaryUrl);
+  const inclusiveReasoning = await complete(world.primaryUrl, reasoningToken.token, { messages: [{ role: "user", content: "fixture:reasoning-inclusive" }] });
+  expect(inclusiveReasoning.status).toBe(200); await inclusiveReasoning.text();
+  const inclusiveReasoningAccounting = await world.accounting();
+  expect(inclusiveReasoningAccounting.blocked).toBe(false);
+  expect(list(inclusiveReasoningAccounting.reservations)).toEqual([expect.objectContaining({ status: "settled", settledMicroUsd: 105 })]);
+  const reasoningOverTotal = await complete(world.primaryUrl, reasoningToken.token, { messages: [{ role: "user", content: "fixture:reasoning-over-total" }] });
+  expect(reasoningOverTotal.status).toBe(200); await reasoningOverTotal.text();
+  const inconsistentReasoningAccounting = await world.accounting();
+  expect(inconsistentReasoningAccounting.blocked).toBe(false);
+  expect(list(inconsistentReasoningAccounting.reservations).find((row) => row.status === "retained")).toEqual(
+    expect.objectContaining({ reservedMicroUsd: 41_452, settledMicroUsd: null }),
+  );
+  const afterInconsistentReasoning = await complete(world.secondaryUrl, reasoningToken.token);
+  expect(afterInconsistentReasoning.status).toBe(200); await afterInconsistentReasoning.text();
+  expect((await world.accounting()).blocked).toBe(false);
+  evidence.recordAssertionEvidence("Inclusive reasoning usage is normalized without double-counting", "A 4,096-token completion containing 2,048 reasoning tokens settled normally because OpenAI completion_tokens already includes reasoning_tokens; a reasoning count above the completion total retained the 41,452-micro-USD reservation as unknown usage without tripping the kill switch, and a later request still succeeded.", true);
+
+  await world.reset();
+  const rotationInstallation = randomUUID();
+  const beforeRotation = await issue(world.primaryUrl, rotationInstallation);
+  const beforeRotationCall = await complete(world.primaryUrl, beforeRotation.token);
+  expect(beforeRotationCall.status).toBe(200); await beforeRotationCall.text();
+  const rejectedByRotatedCipher = await fetch(`${world.rotatedUrl}/api/anonymous/v1/models`, { headers: { authorization: `Bearer ${beforeRotation.token}` } });
+  expect(rejectedByRotatedCipher.status).toBe(401);
+  const afterRotation = await issue(world.rotatedUrl, rotationInstallation);
+  const afterRotationCall = await complete(world.rotatedUrl, afterRotation.token);
+  expect(afterRotationCall.status).toBe(200); await afterRotationCall.text();
+  const rotationAccounting = await world.accounting();
+  const globalDailyAfterRotation = list(rotationAccounting.buckets).filter((row) => row.scope === "global" && row.windowType === "daily");
+  expect(globalDailyAfterRotation).toHaveLength(1);
+  expect(globalDailyAfterRotation[0]?.usedMicroUsd).toBe(210);
+  evidence.recordAssertionEvidence("Token encryption rotation does not rotate durable accounting identities", "The old token failed on the rotated cipher service, a newly minted token for the same installation succeeded, and both calls accumulated 210 micro-USD in one global daily bucket keyed by the separate stable accounting secret.", true);
+
+  await world.reset();
+  const cancellation = await issue(world.primaryUrl);
+  const cancelled = await complete(world.primaryUrl, cancellation.token, { stream: true, messages: [{ role: "user", content: "fixture:hold cancellation" }] });
+  expect(cancelled.status).toBe(200);
+  await cancelled.body?.cancel();
+  const retainedAfterCancel = await probe.eventually(() => world.accounting(), {
+    within: 10_000, label: "cancelled reservation retained", until: (accounting) => list(accounting.reservations).some((row) => row.status === "retained"),
+  });
+  expect(list(retainedAfterCancel.reservations).find((row) => row.status === "retained")?.reservedMicroUsd).toBe(41_452);
+  const afterCancel = await complete(world.secondaryUrl, cancellation.token);
+  expect(afterCancel.status).toBe(200); await afterCancel.text();
+
+  await world.reset();
+  const incomplete = await issue(world.primaryUrl);
+  const noUsage = await complete(world.primaryUrl, incomplete.token, { stream: false, messages: [{ role: "user", content: "fixture:missing-usage" }] });
+  expect(noUsage.status).toBe(200); await noUsage.text();
+  const afterMissing = await complete(world.secondaryUrl, incomplete.token);
+  expect(afterMissing.status).toBe(200); await afterMissing.text();
+  const incompleteAccounting = await world.accounting();
+  expect(list(incompleteAccounting.reservations).map((row) => row.status).sort()).toEqual(["retained", "settled"]);
+  expect(list(incompleteAccounting.buckets).find((row) => row.scope === "installation" && row.windowType === "daily")?.usedMicroUsd).toBe(41_557);
+  evidence.recordAssertionEvidence("Unknown usage retains reserved spend but releases capacity", "Cancellation and missing usage each became retained reservations of 41,452 micro-USD; a subsequent request through the other instance recovered capacity and a complete 5-micro-USD fee plus 100-micro-USD provider principal settled to 105 micro-USD.", true);
+
+  await world.reset();
+  for (const installationId of [randomUUID(), randomUUID()]) {
+    const identity = await issue(world.primaryUrl, installationId);
+    const response = await complete(world.primaryUrl, identity.token, { messages: [{ role: "user", content: "fixture:missing-usage" }] });
+    expect(response.status).toBe(200); await response.text();
+  }
+  const resetIdentity = await issue(world.primaryUrl);
+  const ipLimited = await complete(world.secondaryUrl, resetIdentity.token);
+  expect(ipLimited.status).toBe(429); expect(await errorCode(ipLimited)).toBe("anonymous_limit_exceeded");
+
+  await world.reset();
+  const globalSpendTokens = await Promise.all([issue(world.globalSpendUrl), issue(world.globalSpendUrl), issue(world.globalSpendUrl)]);
+  const [globalSpendA, globalSpendB, globalSpendC] = globalSpendTokens;
+  if (!globalSpendA || !globalSpendB || !globalSpendC) throw new Error("Expected three global spend tokens");
+  for (const identity of [globalSpendA, globalSpendB]) {
+    const response = await complete(world.globalSpendUrl, identity.token);
+    expect(response.status).toBe(200); await response.text();
+  }
+  const settledGlobal = await world.accounting();
+  expect(list(settledGlobal.reservations).every((row) => row.status === "settled")).toBe(true);
+  expect(list(settledGlobal.buckets).find((row) => row.scope === "global" && row.windowType === "daily")?.usedMicroUsd).toBe(210);
+  const callsBeforeGlobalSpendLimit = list((await witness(world.witnessUrl)).calls).length;
+  const globallyLimited = await complete(world.globalSpendUrl, globalSpendC.token);
+  expect(globallyLimited.status).toBe(429); expect(await errorCode(globallyLimited)).toBe("anonymous_limit_exceeded");
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(callsBeforeGlobalSpendLimit);
+
+  await world.reset();
+  for (let index = 0; index < 4; index += 1) await issue(world.primaryUrl);
+  const rateRowsBeforeDenial = list((await world.accounting()).rateBuckets).filter((row) => row.kind === "session" && row.scope === "installation");
+  expect(rateRowsBeforeDenial).toHaveLength(4);
+  for (let index = 0; index < 5; index += 1) {
+    const denied = await issueResponse(world.primaryUrl);
+    expect(denied.status).toBe(429); expect(await errorCode(denied)).toBe("anonymous_limit_exceeded");
+  }
+  const rateRowsAfterDenial = list((await world.accounting()).rateBuckets).filter((row) => row.kind === "session" && row.scope === "installation");
+  expect(rateRowsAfterDenial).toHaveLength(4);
+  evidence.recordAssertionEvidence("Renewal and random installation identities cannot reset shared spend or grow denied rate state", "Different UUIDs exhausted the IP budget; two settled calls accumulated 210 micro-USD until the global budget denied a fresh UUID without upstream; five UUIDs denied by the shared issuance limit persisted no new installation buckets.", true);
+
+  await world.reset();
+  const slowSession = await issue(world.slowUrl);
+  const callsBeforeSlowBody = list((await witness(world.witnessUrl)).calls).length;
+  const slowBody = JSON.stringify({ model: freeModel, messages: [{ role: "user", content: "slow body" }] });
+  const slowResult = await world.slowChat(slowSession.token, slowBody, 1_500);
+  expect(slowResult.status).toBe(503);
+  expect(object(object(JSON.parse(slowResult.body)).error).code).toBe("anonymous_unavailable");
+  expect(list((await world.accounting()).reservations)).toHaveLength(0);
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(callsBeforeSlowBody);
+
+  await world.reset();
+  const admissionCancellation = await issue(world.primaryUrl);
+  const callsBeforeAdmissionCancellation = list((await witness(world.witnessUrl)).calls).length;
+  const controlLock = await fetch(`${world.witnessUrl}/fixture/control-lock?ms=1500`, { method: "POST" });
+  expect(controlLock.status).toBe(200);
+  const cancellationController = new AbortController();
+  const cancelledDuringAdmission = complete(world.primaryUrl, admissionCancellation.token, {}, cancellationController.signal);
+  setTimeout(() => cancellationController.abort(), 100);
+  await expect(cancelledDuringAdmission).rejects.toThrow();
+  await controlLock.text();
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(callsBeforeAdmissionCancellation);
+  const afterAdmissionCancellation = await complete(world.secondaryUrl, admissionCancellation.token);
+  expect(afterAdmissionCancellation.status).toBe(200); await afterAdmissionCancellation.text();
+  await probe.eventually(() => world.accounting(), {
+    within: 10_000,
+    label: "cancelled admission created no reservation",
+    until: (accounting) => list(accounting.reservations).length === 1 && list(accounting.reservations)[0]?.status === "settled",
+  });
+  evidence.recordAssertionEvidence("Request lifetime begins before body consumption and dispatch revalidates cancellation", "A body slower than the one-second request lifetime returned 503 with zero reservations/upstream calls; a request cancelled while admission waited on the durable lock created no reservation or upstream attempt, and the next request recovered normally.", true);
+
+  await world.reset();
+  const outageToken = await issue(world.primaryUrl);
+  const callsBeforeOutage = list((await witness(world.witnessUrl)).calls).length;
+  await world.outage(true);
+  const dbOutage = await complete(world.primaryUrl, outageToken.token);
+  expect(dbOutage.status).toBe(503); expect(await errorCode(dbOutage)).toBe("anonymous_unavailable");
+  await world.outage(false);
+  const unset = await fetch(`${world.unconfiguredUrl}/api/anonymous/session`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ installationId: randomUUID() }),
+  });
+  expect(unset.status).toBe(503); expect(await errorCode(unset)).toBe("anonymous_unavailable");
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(callsBeforeOutage);
+
+  const errorBodiesBefore = Number((await witness(world.witnessUrl)).errorBodiesClosed);
+  const upstreamOutage = await complete(world.primaryUrl, outageToken.token, { messages: [{ role: "user", content: "fixture:outage" }] });
+  const upstreamOutageText = await upstreamOutage.text();
+  expect(upstreamOutage.status).toBe(503);
+  expect(object(object(JSON.parse(upstreamOutageText)).error).code).toBe("anonymous_unavailable");
+  expect(upstreamOutageText).not.toContain("private fixture outage detail");
+  await probe.eventually(() => witness(world.witnessUrl), {
+    within: 5_000,
+    label: "unused upstream error body closed",
+    until: (snapshot) => Number(snapshot.errorBodiesClosed) > errorBodiesBefore,
+  });
+
+  await world.reset();
+  const safetyToken = await issue(world.primaryUrl);
+  const overCost = await complete(world.primaryUrl, safetyToken.token, { messages: [{ role: "user", content: "fixture:late-over-cost" }] });
+  expect(overCost.status).toBe(200); await overCost.text();
+  const lateAccounting = await world.accounting();
+  expect(lateAccounting.blocked).toBe(true);
+  expect(list(lateAccounting.reservations)).toEqual([expect.objectContaining({ status: "retained", settledMicroUsd: null })]);
+  expect(list(lateAccounting.buckets).find((row) => row.scope === "installation" && row.windowType === "daily")?.usedMicroUsd).toBe(41_452);
+  const callsBeforeBlock = list((await witness(world.witnessUrl)).calls).length;
+  const blocked = await complete(world.secondaryUrl, safetyToken.token);
+  expect(blocked.status).toBe(503); expect(await errorCode(blocked)).toBe("anonymous_unavailable");
+  expect(list((await witness(world.witnessUrl)).calls)).toHaveLength(callsBeforeBlock);
+  evidence.recordAssertionEvidence("Configuration, storage, upstream failure and late reservation overrun fail closed", "Unset rollout configuration and a quota-table outage returned anonymous_unavailable without spending; the upstream error body was cancelled and hidden; trusted over-reserve usage arriving after retention triggered the durable block without refund or another upstream attempt.", true);
+});

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -5,7 +5,7 @@ const test = spec.world(modelPicker);
 
 test("the composer model pickers keep their controls without the OpenWork Models subscribe promo", async ({ user, step }) => {
   await user.click({ role: "button", label: "Change model" });
-  await user.click({ role: "button", label: /^Model\s+Big Pickle/ });
+  await user.click({ role: "button", label: /^Model\s+/ });
 
   await step("the compact picker keeps controls without subscribe promotion", async () => {
     await user.see({ placeholder: "Search models..." });

--- a/evals/specs/first-run-local.e2e.test.ts
+++ b/evals/specs/first-run-local.e2e.test.ts
@@ -5,7 +5,20 @@ import { bareFirstRunWorld } from "../worlds/first-run.ts";
 const test = spec.world(bareFirstRunWorld);
 const prompt = "Create a short welcome checklist for this OpenWork workspace. Use exactly three bullets and mention one thing I can do next.";
 
-test("first use without an invite or cloud reaches local task UI with honest model setup", async ({ world, user, probe, step }) => {
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry))
+    : [];
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+const chatRequests = (snapshot: Record<string, unknown>) => records(snapshot.inference);
+const toolNameSet = (value: unknown) => [...new Set(strings(value))].sort();
+
+test("first use without an invite runs through anonymous OpenWork Models with safe renewal and honest limits", async ({ world, user, probe, step, evidence }) => {
   await step("Welcome", async () => {
     await user.see({ text: "Welcome to OpenWork" });
     await user.see("Use Without Cloud");
@@ -20,7 +33,7 @@ test("first use without an invite or cloud reaches local task UI with honest mod
   });
 
   await step("Finish onboarding", async () => {
-    await user.click("Skip and use the free model");
+    await user.click("Use OpenWork Models");
     await user.see({ text: "How did you hear about OpenWork?" }, { timeoutMs: 90_000 });
     await user.click("Skip");
     await user.see({ text: /What do you need done\?/ }, { timeoutMs: 180_000 });
@@ -30,34 +43,254 @@ test("first use without an invite or cloud reaches local task UI with honest mod
   const composer = await probe.composer();
   expect(composer.route).toContain("/workspace/");
   expect(composer.route).toContain("/session");
-  expect(composer.runTaskVisible).toBe(true);
   await user.notSee({ text: /Something went wrong/ });
-  await user.see({ text: /Using the free starter model/ });
-  await user.type("composer", prompt);
+  await user.see({ text: /Using OpenWork Models \(Free\)/ });
 
-  if (!(await probe.composer()).runTaskEnabled) {
-    await user.see("Connect a model provider");
-    return;
-  }
+  const configured = await world.providerState();
+  expect(configured).toMatchObject({
+    status: 200,
+    exists: true,
+    name: "OpenWork Models (Free)",
+    model: true,
+    localRoute: true,
+    localToken: true,
+  });
+  expect(records((await world.guestWitness()).mints)).toHaveLength(0);
+  expect(await world.openedUrls()).toEqual([]);
 
-  await step("Run the first task or hear honestly why the free model can't", async () => {
+  await step("Keep OpenCode's built-in providers opt-in", async () => {
+    const fresh = await probe.eventually(
+      () => world.runtimeProviderState(),
+      {
+        within: 60_000,
+        label: "fresh runtime provider defaults",
+        until: (state) => state.configStatus === 200 && state.providersStatus === 200 && state.selectableProviders.includes("openwork-free"),
+      },
+    );
+    expect(fresh.disabledProviders).toEqual(["opencode", "opencode-go"]);
+    expect(fresh.connectedProviders).toContain("openwork-free");
+    expect(fresh.selectableProviders).toContain("openwork-free");
+    expect(fresh.connectedProviders).not.toContain("opencode");
+    expect(fresh.connectedProviders).not.toContain("opencode-go");
+    expect(fresh.selectableProviders).not.toContain("opencode");
+    expect(fresh.selectableProviders).not.toContain("opencode-go");
+    expect(fresh.defaultModel).toBe("openwork-free/openai/gpt-5.6-luna");
+    evidence.recordAssertionEvidence(
+      "A new public desktop defaults to Luna without silently enabling OpenCode's built-in providers",
+      JSON.stringify(fresh),
+      true,
+    );
+
+    const enabledWrite = await world.setRuntimeDisabledProviders(["opencode-go"]);
+    expect(enabledWrite).toEqual({ status: 200, disabledProviders: ["opencode-go"] });
+    await world.restartEngine();
+    const enabled = await probe.eventually(
+      () => world.runtimeProviderState(),
+      {
+        within: 120_000,
+        label: "explicit OpenCode opt-in after engine restart",
+        until: (state) => state.disabledProviders.length === 1 && state.disabledProviders[0] === "opencode-go" && state.selectableProviders.includes("opencode"),
+      },
+    );
+    expect(enabled.connectedProviders).toContain("opencode");
+    expect(enabled.selectableProviders).toContain("opencode");
+    expect(enabled.selectableProviders).toContain("openwork-free");
+    expect(enabled.connectedProviders).not.toContain("opencode-go");
+    expect(enabled.defaultModel).toBe("openwork-free/openai/gpt-5.6-luna");
+
+    const disabledWrite = await world.setRuntimeDisabledProviders(["opencode", "opencode-go"]);
+    expect(disabledWrite).toEqual({ status: 200, disabledProviders: ["opencode", "opencode-go"] });
+    await world.restartEngine();
+    const disabledAgain = await probe.eventually(
+      () => world.runtimeProviderState(),
+      {
+        within: 120_000,
+        label: "OpenCode re-disabled after engine restart",
+        until: (state) => state.disabledProviders.length === 2 && !state.connectedProviders.includes("opencode") && !state.selectableProviders.includes("opencode"),
+      },
+    );
+    expect(disabledAgain.disabledProviders).toEqual(["opencode", "opencode-go"]);
+    expect(disabledAgain.selectableProviders).toContain("openwork-free");
+    expect(disabledAgain.connectedProviders).not.toContain("opencode-go");
+    expect(disabledAgain.selectableProviders).not.toContain("opencode-go");
+    expect(disabledAgain.defaultModel).toBe("openwork-free/openai/gpt-5.6-luna");
+    evidence.recordAssertionEvidence(
+      "Explicit built-in provider opt-in survives restart and re-disable restores only the requested runtime entries",
+      JSON.stringify({ enabledWrite, enabled, disabledWrite, disabledAgain }),
+      true,
+    );
+  });
+
+  await step("Run the first task without cloud sign-in", async () => {
+    await user.type("composer", prompt);
+    expect((await probe.composer()).runTaskEnabled).toBe(true);
     await user.click("Run task");
     await user.see({ text: prompt }, { timeoutMs: 30_000 });
-    const outcome = await probe.eventually(
-      async () => {
-        const composer = await probe.composer();
-        if (composer.assistantMessageCount > 0) return "replied";
-        const busy = await probe.has("The free starter model is busy right now");
-        return busy ? "free-model-busy" : null;
-      },
-      { within: 180_000, label: "assistant reply or honest free-model notice", until: (value) => value !== null },
+    const completion = await probe.eventually(async () => {
+      const composer = await probe.composer();
+      const client = chatRequests(await world.guestWitness());
+      return {
+        assistantMessageCount: composer.assistantMessageCount,
+        failed: client.find((request) => typeof request.status === "number" && request.status >= 400) ?? null,
+      };
+    }, {
+      within: 180_000,
+      label: "first anonymous assistant reply or boundary rejection",
+      until: (state) => state.assistantMessageCount > 0 || state.failed !== null,
+    });
+    if (completion.assistantMessageCount === 0) throw new Error(`Anonymous task boundary rejected the SDK request: ${JSON.stringify(completion.failed)}`);
+    await user.see({ text: "Anonymous Models are working." }, { timeoutMs: 180_000 });
+    await probe.eventually(
+      () => probe.composer(),
+      { within: 180_000, label: "first anonymous task becomes idle", until: (state) => state.runTaskVisible },
     );
-    expect(outcome === "replied" || outcome === "free-model-busy").toBe(true);
-    if (outcome === "free-model-busy") {
-      await user.see({ text: "The free starter model is busy right now" });
-    }
+    const witness = await world.guestWitness();
+    const mints = records(witness.mints);
+    const accepted = chatRequests(witness).filter((request) => request.status === 200 && request.faulted === false);
+    expect(mints).toHaveLength(1);
+    expect(accepted.length).toBeGreaterThan(0);
+    expect(strings(witness.unexpected)).toEqual([]);
+    const upstream = records((await world.upstreamWitness()).calls);
+    expect(upstream).toHaveLength(accepted.length);
+    expect(upstream.every((request) => request.authenticated === "anonymous" && request.model === "openai/gpt-5.6-luna")).toBe(true);
+    expect(upstream.every((request) => typeof request.maxTokens === "number" && request.maxTokens <= 4_096 && request.hasPlugins === false)).toBe(true);
+    expect(upstream.some((request) => typeof request.toolCount === "number" && request.toolCount > 0)).toBe(true);
+    expect(accepted.map((request) => toolNameSet(request.requestedToolNames))).toEqual(upstream.map((request) => toolNameSet(request.toolNames)));
+    expect(upstream.every((request) => typeof request.canonicalBytes === "number" && request.canonicalBytes <= 129_024)).toBe(true);
+    expect(upstream.filter((request) => request.stream === true).every((request) => JSON.stringify(request.streamOptions) === '{"include_usage":true}')).toBe(true);
+    expect(upstream.every((request) => JSON.stringify(request.usage) === '{"include":true}')).toBe(true);
     await user.notSee({ text: /subscribe to Go/i });
     await user.notSee({ text: /Error from provider/ });
     await user.notSee({ text: /Something went wrong/ });
+    evidence.recordAssertionEvidence(
+      "Luna completes the first real SDK request through the anonymous gateway with the engine's tools intact",
+      JSON.stringify({ accepted, upstream }),
+      true,
+    );
+  });
+
+  await step("Renew a rejected guest token with the same installation", async () => {
+    const before = await world.guestWitness();
+    const successfulBefore = chatRequests(before).filter((request) => request.status === 200).length;
+    const assistantBefore = (await probe.composer()).assistantMessageCount;
+    await world.expireGuestToken();
+    const renewalPrompt = "Confirm the free model still works after renewal.";
+    await user.type("composer", renewalPrompt);
+    await user.click("Run task");
+    await user.see({ text: renewalPrompt }, { timeoutMs: 30_000 });
+    await probe.eventually(
+      async () => (await probe.composer()).assistantMessageCount,
+      { within: 180_000, label: "second assistant reply after guest renewal", until: (count) => count > assistantBefore },
+    );
+    await probe.eventually(
+      () => probe.composer(),
+      { within: 180_000, label: "renewed anonymous task becomes idle", until: (state) => state.runTaskVisible },
+    );
+    const witness = await world.guestWitness();
+    const mints = records(witness.mints);
+    expect(mints).toHaveLength(2);
+    expect(new Set(mints.map((mint) => mint.installationId)).size).toBe(1);
+    const rejected = chatRequests(witness).filter((request) => request.status === 401);
+    expect(rejected.length).toBeGreaterThan(0);
+    expect(new Set(rejected.map((request) => request.bodyHash)).size).toBe(rejected.length);
+    expect(chatRequests(witness).filter((request) => request.status === 200).length).toBeGreaterThan(successfulBefore);
+    const provider = await world.providerState();
+    const serializedProvider = "serialized" in provider && typeof provider.serialized === "string" ? provider.serialized : "";
+    expect(serializedProvider).not.toBe("");
+    expect(mints.every((mint) => typeof mint.tokenHash === "string")).toBe(true);
+    expect(serializedProvider).not.toContain("ow_guest_v1.");
+    evidence.recordAssertionEvidence(
+      "Anonymous renewal keeps one installation and does not expose guest credentials in provider config",
+      JSON.stringify({ mints, rejected, successfulRequests: chatRequests(witness).filter((request) => request.status === 200).length }),
+      true,
+    );
+  });
+
+  await step("Cancel during shared renewal without starting generation", async () => {
+    const upstreamBefore = records((await world.upstreamWitness()).calls).filter((request) => request.marker === "cancellation").length;
+    const mintsBefore = records((await world.guestWitness()).mints).length;
+    await world.nextGuestSession({ delayMs: 2_000 });
+    await world.expireGuestToken();
+    expect(await world.requestAnonymous({ abortAfterMs: 300, prompt: "fixture:cancellation" })).toMatchObject({ aborted: true, status: 0 });
+    await probe.eventually(
+      async () => records((await world.guestWitness()).mints).length,
+      { within: 10_000, label: "shared guest mint finishes after caller cancellation", until: (count) => count > mintsBefore },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    const cancellationCalls = records((await world.upstreamWitness()).calls).filter((request) => request.marker === "cancellation");
+    expect(cancellationCalls).toHaveLength(upstreamBefore);
+    evidence.recordAssertionEvidence(
+      "Cancellation during shared renewal never reaches generation",
+      JSON.stringify({ upstreamBefore, upstreamAfter: cancellationCalls.length }),
+      true,
+    );
+  });
+
+  await step("Fail guest provisioning without starting generation", async () => {
+    const upstreamBefore = records((await world.upstreamWitness()).calls).filter((request) => request.marker === "provisioning").length;
+    await world.nextGuestSession({ fail: true });
+    await world.expireGuestToken();
+    expect(await world.requestAnonymous({ prompt: "fixture:provisioning" })).toEqual({ aborted: false, status: 503, code: "anonymous_unavailable" });
+    const provisioningCalls = records((await world.upstreamWitness()).calls).filter((request) => request.marker === "provisioning");
+    expect(provisioningCalls).toHaveLength(upstreamBefore);
+    evidence.recordAssertionEvidence(
+      "Failed guest provisioning stops before generation",
+      JSON.stringify({ upstreamBefore, upstreamAfter: provisioningCalls.length }),
+      true,
+    );
+  });
+
+  await step("Show quota limits without retrying the hosted model", async () => {
+    await world.failGuestRequestsWith("limit");
+    const quotaPrompt = "Trigger the deterministic free quota witness.";
+    await user.type("composer", quotaPrompt);
+    await user.click("Run task");
+    await user.see({ text: "OpenWork Models free limit reached" }, { timeoutMs: 180_000 });
+    await user.see({ text: /Wait for your free usage to reset/ });
+    const limited = chatRequests(await world.guestWitness()).filter((request) => request.status === 429 && request.faulted === true);
+    expect(limited.length).toBeGreaterThan(0);
+    expect(new Set(limited.map((request) => request.bodyHash)).size).toBe(limited.length);
+    evidence.recordAssertionEvidence("The free limit is shown without replaying a request", JSON.stringify(limited), true);
+  });
+
+  await step("Distinguish temporary service unavailability", async () => {
+    await world.failGuestRequestsWith("unavailable");
+    const unavailablePrompt = "Trigger the deterministic unavailable witness.";
+    await user.type("composer", unavailablePrompt);
+    await user.click("Run task");
+    await user.see({ text: "OpenWork Models are temporarily unavailable" }, { timeoutMs: 180_000 });
+    await user.see({ text: /use an existing signed-in plan/i });
+    const unavailable = chatRequests(await world.guestWitness()).filter((request) => request.status === 503 && request.faulted === true);
+    expect(unavailable.length).toBeGreaterThan(0);
+    expect(new Set(unavailable.map((request) => request.bodyHash)).size).toBe(unavailable.length);
+    evidence.recordAssertionEvidence("Temporary anonymous service failure remains distinct and single-attempt", JSON.stringify(unavailable), true);
+  });
+
+  await step("Preserve an explicit local provider through real sign-out", async () => {
+    await world.failGuestRequestsWith(null);
+    await world.prepareExplicitByokAndSignIn();
+    await user.see({ role: "button", label: "Sign out" }, { timeoutMs: 60_000 });
+    await user.click({ role: "button", label: "Sign out" });
+    await user.notSee({ role: "button", label: "Sign out" }, { timeoutMs: 60_000 });
+    const explicit = await probe.eventually(
+      () => world.explicitByokState(),
+      { within: 60_000, label: "local providers restored after sign-out", until: (state) => state.providerPreserved && state.freeProviderPreserved && state.defaultPreserved && state.disabledProviders.length === 2 },
+    );
+    expect(explicit).toEqual({
+      providerPreserved: true,
+      freeProviderPreserved: true,
+      defaultPreserved: true,
+      disabledProviders: ["opencode", "opencode-go"],
+    });
+    evidence.recordAssertionEvidence("Explicit BYOK choice survives cloud sign-in and sign-out without enabling built-in providers", JSON.stringify(explicit), true);
+  });
+
+  await step("Suppress managed installs with a live server and no guest contact", async () => {
+    const managed = await world.managedProviderSuppressed();
+    expect(managed).toMatchObject({
+      provider: { status: 200, exists: false },
+      contacts: 0,
+    });
+    evidence.recordAssertionEvidence("Managed desktop suppression stays live without anonymous outbound contact", JSON.stringify(managed), true);
   });
 });

--- a/evals/worlds/anonymous-inference.ts
+++ b/evals/worlds/anonymous-inference.ts
@@ -1,0 +1,242 @@
+import { spawn } from "node:child_process";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+import { allocateFreePort } from "@openwork/cdp";
+import { createDaytonaHost, defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
+import type { Seed } from "@openwork/env";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const fixture = "evals/packages/labs/src/anonymous-inference-fixture.mjs";
+const loader = "./ee/apps/den-api/node_modules/tsx/dist/loader.mjs";
+const encryptionKey = "anonymous-inference-fixture-encryption-key-not-production";
+const tokenSecret = "anonymous-inference-fixture-token-secret-not-production";
+const accountingIdentityKey = "anonymous-inference-fixture-accounting-key-not-production";
+const anonymousUpstreamKey = "anonymous-inference-fixture-upstream";
+const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+const remoteSourcePaths = [
+  "apps/app/src/app/constants.ts",
+  "apps/app/src/components/chat/message-list.tsx",
+  "apps/app/src/react-app/domains/cloud/openwork-models-promo.ts",
+  "apps/app/src/react-app/domains/connections/provider-auth/store.ts",
+  "apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx",
+  "apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx",
+  "apps/app/src/react-app/domains/session/sync/session-error.ts",
+  "apps/app/src/react-app/kernel/model-config.ts",
+  "apps/app/src/react-app/shell/settings-route.tsx",
+  "apps/app/src/react-app/shell/welcome-route.tsx",
+  "apps/desktop/electron/main.mjs",
+  "apps/desktop/electron/runtime.mjs",
+  "apps/server/src/anonymous-inference.ts",
+  "apps/server/src/embedded.ts",
+  "apps/server/src/openwork-runtime-config.ts",
+  "apps/server/src/runtime-opencode-config-store.ts",
+  "apps/server/src/server.ts",
+  "apps/server/src/types.ts",
+  "ee/apps/inference/src/anonymous-identity.ts",
+  "ee/apps/inference/src/anonymous-limits.ts",
+  "ee/apps/inference/src/anonymous.ts",
+  "ee/apps/inference/src/app.ts",
+  "ee/apps/inference/src/env.ts",
+  "ee/packages/den-db/drizzle/0094_anonymous_inference.sql",
+  "ee/packages/den-db/src/schema/inference.ts",
+  fixture,
+];
+
+function object(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected an object");
+  return Object.fromEntries(Object.entries(value));
+}
+
+export async function anonymousInferenceWorld(seed: Seed) {
+  const den = await seed.den({
+    org: { name: "Anonymous Inference Boundary", admin: { name: "Models Admin" } },
+    env: { DEN_DB_ENCRYPTION_KEY: encryptionKey, DEN_ORG_MODE: "multi_org", DEN_PLAN_GATING_ENABLED: "true" },
+  });
+  const context = object((await seed.api(den.admin, "/v1/org")).body);
+  const orgId = String(object(context.organization).id);
+  const memberId = String(object(context.currentMember).id);
+  const remote = den.placement?.kind === "daytona" ? den.placement.sandboxId : null;
+  const ports = remote
+    ? { primary: 8791, secondary: 8793, expiring: 8794, unconfigured: 8795, rotated: 8796, trustedNeighbor: 8797, slow: 8798, globalSpend: 8799, witness: 8792, clientProxy: 8800 }
+    : {
+        primary: await allocateFreePort(), secondary: await allocateFreePort(), expiring: await allocateFreePort(),
+        unconfigured: await allocateFreePort(), rotated: await allocateFreePort(), trustedNeighbor: await allocateFreePort(),
+        slow: await allocateFreePort(), globalSpend: await allocateFreePort(), witness: await allocateFreePort(), clientProxy: await allocateFreePort(),
+      };
+  const host = remote ? createDaytonaHost({ sandboxId: remote, repoRoot: root, log: () => {} }) : null;
+  const url = async (port: number) => host ? host.previewUrl(port) : `http://127.0.0.1:${port}`;
+  const [primaryUrl, secondaryUrl, expiringUrl, unconfiguredUrl, rotatedUrl, slowUrl, globalSpendUrl, witnessUrl, clientUrl] = await Promise.all([
+    url(ports.primary), url(ports.secondary), url(ports.expiring), url(ports.unconfigured), url(ports.rotated),
+    url(ports.slow), url(ports.globalSpend), url(ports.witness), url(ports.clientProxy),
+  ]);
+  const trustedNeighborUrl = remote ? await url(ports.trustedNeighbor) : `http://[::1]:${ports.trustedNeighbor}`;
+  const databaseUrlCandidate = remote ? "mysql://root:password@127.0.0.1:3306/openwork_den" : den.database?.url;
+  if (!databaseUrlCandidate) throw new Error("Anonymous inference proof requires an isolated Den database");
+  const databaseUrl = databaseUrlCandidate;
+  const baseEnv: Record<string, string> = {
+    OPENWORK_DEV_MODE: "1", DATABASE_URL: databaseUrl, DB_MODE: "mysql", DEN_DB_ENCRYPTION_KEY: encryptionKey,
+    SENTRY_DSN: "", OPENROUTER_UPSTREAM_URL: `http://127.0.0.1:${ports.witness}`,
+    ANONYMOUS_INFERENCE_ENABLED: "true", ANONYMOUS_OPENROUTER_API_KEY: anonymousUpstreamKey,
+    ANONYMOUS_TOKEN_SECRET: tokenSecret, ANONYMOUS_ACCOUNTING_IDENTITY_KEY: accountingIdentityKey,
+    ANONYMOUS_OPENROUTER_PROVIDER: "fixture-provider",
+    ANONYMOUS_OPENROUTER_BYOK_ONLY_VERIFIED: "true", ANONYMOUS_TOKEN_TTL_SECONDS: "300",
+    ANONYMOUS_INSTALL_DAILY_MICRO_USD: "1000000", ANONYMOUS_INSTALL_MONTHLY_MICRO_USD: "10000000",
+    ANONYMOUS_IP_DAILY_MICRO_USD: "83200", ANONYMOUS_GLOBAL_DAILY_MICRO_USD: "10000000",
+    ANONYMOUS_GLOBAL_MONTHLY_MICRO_USD: "100000000", ANONYMOUS_GLOBAL_INFLIGHT: "2",
+    ANONYMOUS_SESSION_INSTALL_HOURLY: "4", ANONYMOUS_SESSION_IP_HOURLY: "4",
+    ANONYMOUS_SESSION_GLOBAL_HOURLY: "1000", ANONYMOUS_REQUEST_INSTALL_HOURLY: "100",
+    ANONYMOUS_REQUEST_IP_HOURLY: "100", ANONYMOUS_REQUEST_GLOBAL_HOURLY: "1000",
+    ANONYMOUS_REQUEST_TIMEOUT_MS: "10000",
+  };
+  const children: ReturnType<typeof spawn>[] = [];
+  const diagnostics: string[] = [];
+  async function sandboxExec(sandbox: string, script: string, label: string, timeoutMs = 60_000) {
+    const encoded = Buffer.from(script).toString("base64");
+    const result = await execInSandbox(defaultDaytonaExec, sandbox, `printf %s ${encoded} | base64 -d | bash`, { timeoutMs, context: label });
+    if (result.code !== 0) throw new Error(`${label} failed: ${(result.stderr || result.stdout).slice(-1000)}`);
+    return result.stdout;
+  }
+  async function remoteExec(script: string, label: string, timeoutMs = 60_000) {
+    if (!remote) throw new Error("Missing remote sandbox");
+    return sandboxExec(remote, script, label, timeoutMs);
+  }
+  async function syncRemoteSources(sandbox: string) {
+    const sources = await Promise.all(remoteSourcePaths.map(async (path) => ({ path, content: await readFile(`${root}/${path}`, "utf8") })));
+    const archive = gzipSync(Buffer.from(JSON.stringify(sources))).toString("base64");
+    const archivePath = "/tmp/openwork-anonymous-sources.json.gz.b64";
+    await sandboxExec(sandbox, `: > ${archivePath}`, "Prepare anonymous source upload");
+    for (let offset = 0; offset < archive.length; offset += 6_000) {
+      await sandboxExec(sandbox, `printf %s ${archive.slice(offset, offset + 6_000)} >> ${archivePath}`, "Upload anonymous sources");
+    }
+    await sandboxExec(sandbox, `python3 - <<'PY'
+import base64,gzip,json,os
+archive='${archivePath}'
+sources=json.loads(gzip.decompress(base64.b64decode(open(archive,'rb').read())).decode())
+for source in sources:
+ target=os.path.join('/workspace',source['path'])
+ os.makedirs(os.path.dirname(target),exist_ok=True)
+ with open(target,'w',encoding='utf-8') as output: output.write(source['content'])
+os.remove(archive)
+PY`, "Install anonymous sources");
+  }
+  function processEnv(env: Record<string, string>) { return { ...process.env, ...env }; }
+  async function start(args: string[], env: Record<string, string>, label: string) {
+    if (remote) {
+      const config = Buffer.from(JSON.stringify(env)).toString("base64");
+      const command = Buffer.from(JSON.stringify(args)).toString("base64");
+      await remoteExec(`python3 - <<'PY'\nimport os,json,base64,subprocess\ne=dict(os.environ);e.update(json.loads(base64.b64decode('${config}')))\na=json.loads(base64.b64decode('${command}'))\nwith open('/tmp/${label}.log','ab',buffering=0) as log:\n subprocess.Popen(a,cwd='/workspace',env=e,stdin=subprocess.DEVNULL,stdout=log,stderr=log,start_new_session=True)\nPY`, `Start ${label}`);
+      return;
+    }
+    const child = spawn(args[0] ?? "node", args.slice(1), { cwd: root, env: processEnv(env), stdio: ["ignore", "pipe", "pipe"] });
+    const collect = (chunk: Buffer) => { diagnostics.push(`${label}: ${chunk.toString()}`); if (diagnostics.length > 200) diagnostics.shift(); };
+    child.stdout?.on("data", collect); child.stderr?.on("data", collect);
+    children.push(child);
+  }
+  async function fixtureCommand(command: string, ...args: string[]) {
+    const commandArgs = ["node", "--conditions=development", "--import", loader, fixture, command, ...args];
+    if (remote) {
+      const shell = `cd /workspace && env ${Object.entries(baseEnv).map(([key, value]) => `${key}=${quote(value)}`).join(" ")} ${commandArgs.map(quote).join(" ")}`;
+      return remoteExec(shell, `Anonymous fixture ${command}`);
+    }
+    return new Promise<string>((resolve, reject) => {
+      const child = spawn(commandArgs[0] ?? "node", commandArgs.slice(1), { cwd: root, env: processEnv(baseEnv), stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = ""; let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+      child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+      child.once("exit", (code) => code === 0 ? resolve(stdout) : reject(new Error(`Fixture ${command} failed: ${stderr.slice(-1000)}`)));
+    });
+  }
+
+  if (remote) await syncRemoteSources(remote);
+  await fixtureCommand("migrate-anonymous");
+  await fixtureCommand("subscription", orgId, memberId);
+  await fixtureCommand("ensure-control");
+  const enabled = await seed.api(den.admin, "/v1/inference", { method: "PATCH", body: JSON.stringify({ enabled: true, tier: "tier1" }) });
+  if (!enabled.response.ok) throw new Error(`Paid Models setup failed: HTTP ${enabled.response.status}`);
+  await fixtureCommand("configure-paid", orgId, memberId);
+  await start(["node", "--conditions=development", "--import", loader, fixture, "witness"], { ...baseEnv, ANONYMOUS_WITNESS_PORT: String(ports.witness) }, "anonymous-witness");
+  const serverArgs = ["node", "--conditions=development", "--import", loader, "ee/apps/inference/src/server.ts"];
+  await start(serverArgs, { ...baseEnv, PORT: String(ports.primary) }, "anonymous-primary");
+  await start(serverArgs, { ...baseEnv, PORT: String(ports.secondary) }, "anonymous-secondary");
+  await start(serverArgs, { ...baseEnv, PORT: String(ports.expiring), ANONYMOUS_TOKEN_TTL_SECONDS: "1" }, "anonymous-expiring");
+  await start(serverArgs, { ...baseEnv, PORT: String(ports.rotated), ANONYMOUS_TOKEN_SECRET: `${tokenSecret}-rotated` }, "anonymous-rotated");
+  await start(serverArgs, {
+    ...baseEnv, PORT: String(ports.trustedNeighbor), ANONYMOUS_TRUST_PROXY_HOPS: "1", ANONYMOUS_TRUSTED_PROXY_IPS: "::2",
+  }, "anonymous-trusted-neighbor");
+  await start(serverArgs, { ...baseEnv, PORT: String(ports.slow), ANONYMOUS_REQUEST_TIMEOUT_MS: "1000" }, "anonymous-slow");
+  await start(serverArgs, { ...baseEnv, PORT: String(ports.globalSpend), ANONYMOUS_GLOBAL_DAILY_MICRO_USD: "41600" }, "anonymous-global-spend");
+  await start(serverArgs, {
+    ...baseEnv, PORT: String(ports.unconfigured), ANONYMOUS_OPENROUTER_API_KEY: "", ANONYMOUS_INFERENCE_ENABLED: "true",
+  }, "anonymous-unconfigured");
+  await start(["node", "--conditions=development", "--import", loader, fixture, "client-proxy"], {
+    ...baseEnv,
+    ANONYMOUS_CLIENT_PROXY_PORT: String(ports.clientProxy),
+    ANONYMOUS_CLIENT_UPSTREAM_URL: `http://127.0.0.1:${ports.primary}`,
+  }, "anonymous-client-proxy");
+  for (const serviceUrl of [witnessUrl, primaryUrl, secondaryUrl, expiringUrl, unconfiguredUrl, rotatedUrl, trustedNeighborUrl, slowUrl, globalSpendUrl, clientUrl]) {
+    const deadline = Date.now() + 60_000;
+    let ready = false;
+    while (Date.now() < deadline) {
+      ready = await fetch(`${serviceUrl}/health`, { signal: AbortSignal.timeout(2_000) }).then((response) => response.ok).catch(() => false);
+      if (ready) break;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    if (!ready) throw new Error(`Anonymous inference service did not start: ${serviceUrl}\n${diagnostics.slice(-20).join("")}`);
+  }
+
+  return {
+    primaryUrl, secondaryUrl, expiringUrl, unconfiguredUrl, rotatedUrl, trustedNeighborUrl, slowUrl, globalSpendUrl,
+    witnessUrl, clientUrl, orgId, memberId, den,
+    syncRemoteSources,
+    paidKey: `ow_inf_anonymous-fixture-${memberId}`,
+    async reset() { await fixtureCommand("reset-anonymous"); },
+    async outage(unavailable: boolean) { await fixtureCommand(unavailable ? "pause-anonymous" : "resume-anonymous"); },
+    async accounting() {
+      const output = await fixtureCommand("accounting");
+      const line = output.trim().split(/\r?\n/).findLast((entry) => entry.startsWith("{"));
+      if (!line) throw new Error(`Accounting fixture returned no JSON: ${output.slice(-500)}`);
+      return object(JSON.parse(line));
+    },
+    async clientSnapshot() {
+      return object(await (await fetch(`${clientUrl}/fixture/client/state`, { signal: AbortSignal.timeout(5_000) })).json());
+    },
+    async expireClientToken() {
+      await fetch(`${clientUrl}/fixture/client/expire`, { method: "POST", signal: AbortSignal.timeout(5_000) });
+    },
+    async failClientWith(failure: "limit" | "capacity" | "unavailable" | null) {
+      await fetch(`${clientUrl}/fixture/client/failure`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ failure }), signal: AbortSignal.timeout(5_000),
+      });
+    },
+    async nextClientSession(input: { delayMs?: number; fail?: boolean }) {
+      await fetch(`${clientUrl}/fixture/client/session`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(input), signal: AbortSignal.timeout(5_000),
+      });
+    },
+    async upstreamSnapshot() {
+      return object(await (await fetch(`${witnessUrl}/fixture/requests`, { signal: AbortSignal.timeout(5_000) })).json());
+    },
+    async slowChat(token: string, body: string, delayMs: number) {
+      const target = new URL(`${slowUrl}/api/anonymous/v1/chat/completions`);
+      const send = target.protocol === "https:" ? httpsRequest : httpRequest;
+      return new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const request = send(target, {
+          method: "POST",
+          headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        }, (response) => {
+          let responseBody = "";
+          response.on("data", (chunk) => { responseBody += chunk.toString(); });
+          response.once("end", () => resolve({ status: response.statusCode ?? 0, body: responseBody }));
+        });
+        request.once("error", reject);
+        const split = Math.max(1, Math.floor(body.length / 2));
+        request.write(body.slice(0, split));
+        setTimeout(() => request.end(body.slice(split)), delayMs);
+      });
+    },
+    async [Symbol.asyncDispose]() { for (const child of children) child.kill("SIGTERM"); },
+  };
+}

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -34,8 +34,10 @@ import {
   readHandoffDeepLink,
   readResolvedMarketplace,
   signIn,
+  signInDesktopAs,
   signInInBrowser,
 } from "@openwork/behaviors";
+import { anonymousInferenceWorld } from "./anonymous-inference.ts";
 
 // Transitional helpers for journeys whose product-specific mechanics do not yet
 // have spec primitives. Specs still import through their owned world module.
@@ -112,15 +114,317 @@ export async function appSmokeWorld(seed: Seed) {
 }
 
 export async function bareFirstRunWorld(seed: Seed, { place }: { place: Place }) {
+  const inference = await anonymousInferenceWorld(seed);
   const capture = process.platform === "linux" && place.kind === "local" ? await captureOpenedUrls() : null;
-  const app = capture
-    ? await desktop({ name: "first-run", host: place.host(), env: { PATH: `${capture.binDir}:${process.env.PATH ?? ""}` } })
-    : await seed.desktop({ name: "first-run", signIn: false });
+  const env = {
+    OPENWORK_FREE_INFERENCE_ORIGIN: inference.clientUrl,
+    VITE_DISABLE_OPENWORK_MODELS: "0",
+  };
+  let remoteDesktop: Awaited<ReturnType<typeof provisionDesktopSandbox>> | null = null;
+  try {
+    remoteDesktop = place.kind === "daytona"
+      ? await provisionDesktopSandbox({
+        ref: process.env.OPENWORK_EVAL_REF?.trim() || process.env.GITHUB_SHA?.trim() || "dev",
+        name: "first-run",
+        log: (line) => console.error(`[openwork/testkit] ${line}`),
+      })
+      : null;
+    if (remoteDesktop) await inference.syncRemoteSources(remoteDesktop.sandbox);
+  } catch (error) {
+    if (remoteDesktop?.created) await deleteSandboxes([remoteDesktop.sandbox]);
+    await inference[Symbol.asyncDispose]();
+    throw error;
+  }
+  const desktopHost = remoteDesktop ? daytonaSandbox(remoteDesktop.sandbox) : place.host();
+  let app: Awaited<ReturnType<Seed["desktop"]>>;
+  try {
+    app = capture
+      ? await desktop({ name: "first-run", host: place.host(), env: { ...env, PATH: `${capture.binDir}:${process.env.PATH ?? ""}` } })
+      : desktopHost
+        ? await desktop({ name: "first-run", host: desktopHost, env })
+        : await seed.desktop({ name: "first-run", signIn: false, env });
+  } catch (error) {
+    if (remoteDesktop?.created) await deleteSandboxes([remoteDesktop.sandbox]);
+    await inference[Symbol.asyncDispose]();
+    throw error;
+  }
+
+  const providerState = (surface = app) => seed.evalIn(surface, browserScript(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__;
+    if (typeof bridge?.invokeDesktop !== "function") return { status: 0, exists: false, name: null, model: false, localRoute: false, localToken: false, serialized: "" };
+    const info = await bridge.invokeDesktop("openworkServerInfo");
+    if (!info.baseUrl || !info.hostToken) return { status: 0, exists: false, name: null, model: false, localRoute: false, localToken: false, serialized: "" };
+    const response = await fetch(info.baseUrl + "/runtime-config/providers", {
+      headers: { "X-OpenWork-Host-Token": info.hostToken },
+    });
+    const body: unknown = await response.json();
+    const providerMap = body && typeof body === "object" && !Array.isArray(body) && "provider" in body
+      ? body.provider
+      : null;
+    const provider = providerMap && typeof providerMap === "object" && !Array.isArray(providerMap) && "openwork-free" in providerMap
+      ? providerMap["openwork-free"]
+      : null;
+    const options = provider && typeof provider === "object" && !Array.isArray(provider) && "options" in provider
+      ? provider.options
+      : null;
+    const models = provider && typeof provider === "object" && !Array.isArray(provider) && "models" in provider
+      ? provider.models
+      : null;
+    const baseURL = options && typeof options === "object" && !Array.isArray(options) && "baseURL" in options
+      ? options.baseURL
+      : null;
+    const apiKey = options && typeof options === "object" && !Array.isArray(options) && "apiKey" in options
+      ? options.apiKey
+      : null;
+    return {
+      status: response.status,
+      exists: Boolean(provider),
+      name: provider && typeof provider === "object" && !Array.isArray(provider) && "name" in provider && typeof provider.name === "string" ? provider.name : null,
+      model: Boolean(models && typeof models === "object" && !Array.isArray(models) && "openai/gpt-5.6-luna" in models),
+      localRoute: typeof baseURL === "string" && /^http:\/\/127\.0\.0\.1:\d+\/anonymous-inference\/v1$/.test(baseURL),
+      localToken: typeof apiKey === "string" && apiKey.startsWith("owf_local_"),
+      serialized: JSON.stringify(body),
+    };
+  }, []), { awaitPromise: true });
+
+  const runtimeProviderState = () => seed.evalIn(app, browserScript(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__;
+    if (typeof bridge?.invokeDesktop !== "function") throw new Error("Desktop bridge unavailable");
+    const info = await bridge.invokeDesktop("openworkServerInfo");
+    if (!info.baseUrl || !info.ownerToken) throw new Error("OpenWork server unavailable");
+    const headers = { Authorization: "Bearer " + info.ownerToken };
+    const workspacesResponse = await fetch(info.baseUrl + "/workspaces", { headers });
+    const workspaces: unknown = await workspacesResponse.json();
+    const workspaceId = workspaces && typeof workspaces === "object" && !Array.isArray(workspaces) && "activeId" in workspaces && typeof workspaces.activeId === "string"
+      ? workspaces.activeId
+      : "";
+    if (!workspaceId) throw new Error("No active workspace");
+    const [configResponse, providersResponse] = await Promise.all([
+      fetch(info.baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/config", { headers }),
+      fetch(info.baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/opencode/provider", { headers }),
+    ]);
+    const configBody: unknown = await configResponse.json();
+    const providersBody: unknown = await providersResponse.json();
+    const opencode = configBody && typeof configBody === "object" && !Array.isArray(configBody) && "opencode" in configBody && configBody.opencode && typeof configBody.opencode === "object" && !Array.isArray(configBody.opencode)
+      ? configBody.opencode
+      : null;
+    const disabledProviders = opencode && "disabled_providers" in opencode && Array.isArray(opencode.disabled_providers)
+      ? opencode.disabled_providers.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    const providerList = providersBody && typeof providersBody === "object" && !Array.isArray(providersBody) && "data" in providersBody
+      ? providersBody.data
+      : providersBody;
+    const all = providerList && typeof providerList === "object" && !Array.isArray(providerList) && "all" in providerList && Array.isArray(providerList.all)
+      ? providerList.all
+      : [];
+    const connectedProviders = providerList && typeof providerList === "object" && !Array.isArray(providerList) && "connected" in providerList && Array.isArray(providerList.connected)
+      ? providerList.connected.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    const connected = new Set(connectedProviders);
+    const selectableProviders = all.flatMap((entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry) || !("id" in entry) || typeof entry.id !== "string") return [];
+      const models = "models" in entry && entry.models && typeof entry.models === "object" && !Array.isArray(entry.models)
+        ? entry.models
+        : null;
+      return connected.has(entry.id) && models && Object.keys(models).length > 0 ? [entry.id] : [];
+    });
+    return {
+      configStatus: configResponse.status,
+      providersStatus: providersResponse.status,
+      disabledProviders,
+      connectedProviders,
+      selectableProviders,
+      defaultModel: localStorage.getItem("openwork.defaultModel"),
+    };
+  }, []), { awaitPromise: true, timeoutMs: 60_000 });
+
+  const setRuntimeDisabledProviders = (providers: string[]) => seed.evalIn(app, browserScript(async (value) => {
+    const bridge = window.__OPENWORK_ELECTRON__;
+    if (typeof bridge?.invokeDesktop !== "function") throw new Error("Desktop bridge unavailable");
+    const info = await bridge.invokeDesktop("openworkServerInfo");
+    if (!info.baseUrl || !info.ownerToken) throw new Error("OpenWork server unavailable");
+    const headers = { Authorization: "Bearer " + info.ownerToken, "Content-Type": "application/json" };
+    const workspacesResponse = await fetch(info.baseUrl + "/workspaces", { headers });
+    const workspaces: unknown = await workspacesResponse.json();
+    const workspaceId = workspaces && typeof workspaces === "object" && !Array.isArray(workspaces) && "activeId" in workspaces && typeof workspaces.activeId === "string"
+      ? workspaces.activeId
+      : "";
+    if (!workspaceId) throw new Error("No active workspace");
+    const response = await fetch(info.baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/runtime-config/disabled-providers", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ providers: value }),
+    });
+    const body: unknown = await response.json();
+    const disabledProviders = body && typeof body === "object" && !Array.isArray(body) && "disabledProviders" in body && Array.isArray(body.disabledProviders)
+      ? body.disabledProviders.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    return { status: response.status, disabledProviders };
+  }, [providers]), { awaitPromise: true, timeoutMs: 60_000 });
+
   return {
     app,
     capture,
-    workspacePath: seed.tmpPath("first-run-workspace"),
-    async [Symbol.asyncDispose]() { await app[Symbol.asyncDispose](); },
+    guestWitness: () => inference.clientSnapshot(),
+    upstreamWitness: () => inference.upstreamSnapshot(),
+    providerState: () => providerState(),
+    runtimeProviderState,
+    setRuntimeDisabledProviders,
+    restartEngine: () => seed.evalIn(app, browserScript(async () => {
+      const bridge = window.__OPENWORK_ELECTRON__;
+      if (typeof bridge?.invokeDesktop !== "function") throw new Error("Desktop bridge unavailable");
+      await bridge.invokeDesktop("engineRestart", {});
+      return true;
+    }, []), { awaitPromise: true, timeoutMs: 120_000 }),
+    expireGuestToken: () => inference.expireClientToken(),
+    failGuestRequestsWith: (failure: "limit" | "capacity" | "unavailable" | null) => inference.failClientWith(failure),
+    nextGuestSession: (input: { delayMs?: number; fail?: boolean }) => inference.nextClientSession(input),
+    openedUrls: () => capture?.opened() ?? Promise.resolve([]),
+    async requestAnonymous(options: { abortAfterMs?: number; prompt?: string } = {}) {
+      return seed.evalIn(app, browserScript(async (input) => {
+        const bridge = window.__OPENWORK_ELECTRON__;
+        if (typeof bridge?.invokeDesktop !== "function") throw new Error("Desktop bridge unavailable");
+        const info = await bridge.invokeDesktop("openworkServerInfo");
+        if (!info.baseUrl || !info.hostToken) throw new Error("OpenWork server unavailable");
+        const providers = await fetch(info.baseUrl + "/runtime-config/providers", {
+          headers: { "X-OpenWork-Host-Token": info.hostToken },
+        });
+        const providerBody: unknown = await providers.json();
+        const providerMap = providerBody && typeof providerBody === "object" && !Array.isArray(providerBody) && "provider" in providerBody
+          ? providerBody.provider
+          : null;
+        const provider = providerMap && typeof providerMap === "object" && !Array.isArray(providerMap) && "openwork-free" in providerMap
+          ? providerMap["openwork-free"]
+          : null;
+        const providerOptions = provider && typeof provider === "object" && !Array.isArray(provider) && "options" in provider
+          ? provider.options
+          : null;
+        const baseURL = providerOptions && typeof providerOptions === "object" && !Array.isArray(providerOptions) && "baseURL" in providerOptions && typeof providerOptions.baseURL === "string"
+          ? providerOptions.baseURL
+          : "";
+        const apiKey = providerOptions && typeof providerOptions === "object" && !Array.isArray(providerOptions) && "apiKey" in providerOptions && typeof providerOptions.apiKey === "string"
+          ? providerOptions.apiKey
+          : "";
+        if (!baseURL || !apiKey) throw new Error("Anonymous provider unavailable");
+        const controller = new AbortController();
+        const timer = input.abortAfterMs === undefined ? null : window.setTimeout(() => controller.abort(), input.abortAfterMs);
+        try {
+          const response = await fetch(baseURL + "/chat/completions", {
+            method: "POST",
+            headers: { authorization: "Bearer " + apiKey, "content-type": "application/json" },
+            body: JSON.stringify({
+              model: "openai/gpt-5.6-luna",
+              messages: [{ role: "user", content: input.prompt ?? "Validate anonymous generation." }],
+              stream: false,
+              max_tokens: 16,
+            }),
+            signal: controller.signal,
+          });
+          const body: unknown = await response.json();
+          const error = body && typeof body === "object" && !Array.isArray(body) && "error" in body ? body.error : null;
+          const code = error && typeof error === "object" && !Array.isArray(error) && "code" in error && typeof error.code === "string" ? error.code : null;
+          return { aborted: false, status: response.status, code };
+        } catch (error) {
+          return { aborted: controller.signal.aborted, status: 0, code: error instanceof Error ? error.name : "request_failed" };
+        } finally {
+          if (timer !== null) window.clearTimeout(timer);
+        }
+      }, [options]), { awaitPromise: true });
+    },
+    async prepareExplicitByokAndSignIn() {
+      await seed.evalIn(app, browserScript(async () => {
+        const bridge = window.__OPENWORK_ELECTRON__;
+        if (typeof bridge?.invokeDesktop !== "function") throw new Error("Desktop bridge unavailable");
+        const info = await bridge.invokeDesktop("openworkServerInfo");
+        if (!info.baseUrl || !info.ownerToken) throw new Error("OpenWork server unavailable");
+        const auth = { Authorization: "Bearer " + info.ownerToken, "Content-Type": "application/json" };
+        const workspaces = await fetch(info.baseUrl + "/workspaces", { headers: auth });
+        const workspaceBody: unknown = await workspaces.json();
+        const workspaceId = workspaceBody && typeof workspaceBody === "object" && !Array.isArray(workspaceBody) && "activeId" in workspaceBody && typeof workspaceBody.activeId === "string" ? workspaceBody.activeId : "";
+        if (!workspaceId) throw new Error("No active workspace");
+        const patch = await fetch(info.baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+          method: "PATCH", headers: auth,
+          body: JSON.stringify({ opencode: { provider: { "byok-witness": {
+            name: "Explicit BYOK Witness", npm: "@ai-sdk/openai-compatible",
+            options: { apiKey: "byok-owned-key", baseURL: "http://127.0.0.1:9/v1" },
+            models: { "explicit/byok": { id: "explicit/byok", name: "Explicit BYOK" } },
+          } } } }),
+        });
+        if (!patch.ok) throw new Error("BYOK provider patch failed: " + patch.status);
+        localStorage.setItem("openwork.defaultModel", "byok-witness/explicit/byok");
+        window.dispatchEvent(new Event("openwork.defaultModelChanged"));
+      }, []), { awaitPromise: true });
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      await signInDesktopAs(app, inference.den.ref, inference.den.admin);
+      await go(app, "/settings/cloud-account");
+    },
+    async explicitByokState() {
+      return seed.evalIn(app, browserScript(async () => {
+        const bridge = window.__OPENWORK_ELECTRON__;
+        if (typeof bridge?.invokeDesktop !== "function") throw new Error("Desktop bridge unavailable");
+        const info = await bridge.invokeDesktop("openworkServerInfo");
+        if (!info.baseUrl || !info.hostToken || !info.ownerToken) throw new Error("OpenWork server unavailable");
+        const providers = await fetch(info.baseUrl + "/runtime-config/providers", {
+          headers: { "X-OpenWork-Host-Token": info.hostToken },
+        });
+        const providersBody: unknown = await providers.json();
+        const providerMap = providersBody && typeof providersBody === "object" && !Array.isArray(providersBody) && "provider" in providersBody
+          ? providersBody.provider
+          : null;
+        const workspacesResponse = await fetch(info.baseUrl + "/workspaces", {
+          headers: { Authorization: "Bearer " + info.ownerToken },
+        });
+        const workspacesBody: unknown = await workspacesResponse.json();
+        const workspaceId = workspacesBody && typeof workspacesBody === "object" && !Array.isArray(workspacesBody) && "activeId" in workspacesBody && typeof workspacesBody.activeId === "string"
+          ? workspacesBody.activeId
+          : "";
+        const configResponse = await fetch(info.baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+          headers: { Authorization: "Bearer " + info.ownerToken },
+        });
+        const configBody: unknown = await configResponse.json();
+        const opencode = configBody && typeof configBody === "object" && !Array.isArray(configBody) && "opencode" in configBody && configBody.opencode && typeof configBody.opencode === "object" && !Array.isArray(configBody.opencode)
+          ? configBody.opencode
+          : null;
+        const disabledProviders = opencode && "disabled_providers" in opencode && Array.isArray(opencode.disabled_providers)
+          ? opencode.disabled_providers.filter((entry): entry is string => typeof entry === "string")
+          : [];
+        return {
+          providerPreserved: Boolean(providerMap && typeof providerMap === "object" && !Array.isArray(providerMap) && "byok-witness" in providerMap),
+          freeProviderPreserved: Boolean(providerMap && typeof providerMap === "object" && !Array.isArray(providerMap) && "openwork-free" in providerMap),
+          defaultPreserved: localStorage.getItem("openwork.defaultModel") === "byok-witness/explicit/byok",
+          disabledProviders,
+        };
+      }, []), { awaitPromise: true });
+    },
+    async managedProviderSuppressed() {
+      const before = await inference.clientSnapshot();
+      const managed = desktopHost
+        ? await desktop({ name: "first-run-managed-suppression", host: desktopHost, env: { ...env, OPENWORK_DESKTOP_DISTRIBUTION: "cloud" } })
+        : await seed.desktop({ name: "first-run-managed-suppression", signIn: false, env: { ...env, OPENWORK_DESKTOP_DISTRIBUTION: "cloud" } });
+      try {
+        const provider = await providerState(managed);
+        const after = await inference.clientSnapshot();
+        const beforeMints = Array.isArray(before.mints) ? before.mints.length : -1;
+        const afterMints = Array.isArray(after.mints) ? after.mints.length : -1;
+        const beforeInference = Array.isArray(before.inference) ? before.inference.length : -1;
+        const afterInference = Array.isArray(after.inference) ? after.inference.length : -1;
+        return { provider, contacts: (afterMints - beforeMints) + (afterInference - beforeInference) };
+      } finally {
+        if (desktopHost) await managed[Symbol.asyncDispose]();
+      }
+    },
+    workspacePath: place.kind === "daytona" ? "/workspace/first-run-workspace" : seed.tmpPath("first-run-workspace"),
+    async [Symbol.asyncDispose]() {
+      try {
+        await app[Symbol.asyncDispose]();
+      } finally {
+        try {
+          if (remoteDesktop?.created) await deleteSandboxes([remoteDesktop.sandbox]);
+        } finally {
+          await inference[Symbol.asyncDispose]();
+        }
+      }
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Make OpenWork Models (Free), backed only by GPT-5.6 Luna, the default for new eligible public-desktop profiles without sign-in or provider-key setup.
- Disable OpenCode Zen and OpenCode Go by default while preserving explicit opt-ins, BYOK configurations, and managed-install restrictions.
- Add separate anonymous tokens and durable atomic spend/concurrency reservations, server-owned routing and model allowlists, bounded requests, conservative BYOK accounting, and fail-closed safety controls. Paid model access remains separate.
- Add migration `0094_anonymous_inference` after the latest base migration.

## Default limits
- Installation: $0.05/day and $1/month; shared IP: $0.25/day.
- Global: $100/day and $3,000/month; one in-flight request per installation.
- Luna only; no premium/pro-model or alternate-routing fallback. Maximum conservative request reservation is 41,452 micro-USD.

## Verification — Passed on 95985a6452b239f2261d1633ceb92d3a656bd51b
Both journey tests ran against the exact committed SHA on isolated Daytona environments, with zero skips. Evidence is attached in the PR comments.

```sh
OPENWORK_EVAL_REF=95985a6452b239f2261d1633ceb92d3a656bd51b OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/anonymous-inference.test.ts
OPENWORK_EVAL_REF=95985a6452b239f2261d1633ceb92d3a656bd51b pnpm evals:e2e first-run-local
```

- Anonymous inference boundary: 1 passed; authorization, Luna-only routing, BYOK fee plus provider-cost accounting, inclusive reasoning usage, concurrency, budget exhaustion, cancellation, key rotation, and outage negatives.
- First run: 1 passed; real desktop/local proxy/gateway/provider-witness flow, all requested tools preserved, Zen/Go default disable and explicit opt-in across restart, renewal, honest errors, BYOK preservation, and managed suppression.
- Server, app, and inference TypeScript checks passed; 13 targeted runtime-config tests and 45 inference tests passed.

## Rollout / limitations
**This PR does not enable production spending.** `ANONYMOUS_INFERENCE_ENABLED` remains false until the migration, dedicated OpenRouter BYOK key, provider restrictions, separate secrets, and trusted-ingress configuration are deployed and verified.

Configure OpenRouter to never use shared capacity and include BYOK spend in its workspace/guardrail budgets; see `ee/apps/inference/.env.example`. Provider pricing/token-limit behavior is an external rollout prerequisite, not something the deterministic witness proves. Anonymous installation IDs can be reset and IPs shared or rotated; global admission limits are the financial backstop. No production model calls or credentials were used in verification.
