### PR TITLE
fix(den): authenticate installed desktop handoff

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -25,7 +25,7 @@ type InstallConfig = {
   distribution: "cloud" | "enterprise";
 };
 
-const RETURN_TO_OPENWORK_URL = "openwork://open";
+const DESKTOP_SIGN_IN_PATH = "/?mode=sign-in&desktopAuth=1&desktopScheme=openwork";
 const INSTALL_PLATFORMS: InstallPlatform[] = ["mac-arm64", "mac-x64", "win-x64", "linux-x64", "linux-arm64"];
 
 
@@ -439,7 +439,8 @@ export function InstallScreen() {
             ) : (
               <div className="grid gap-5 text-left">
                 <DownloadPlatformGrid groups={downloadGroups} />
-                <a className="den-button-secondary w-fit" href={RETURN_TO_OPENWORK_URL}>
+                {/* Reload so the auth provider reads the desktop handoff parameters on mount. */}
+                <a className="den-button-secondary w-fit" href={token ? new URL(DESKTOP_SIGN_IN_PATH, config.webUrl).toString() : DESKTOP_SIGN_IN_PATH}>
                   I already installed OpenWork
                 </a>
               </div>

--- a/evals/specs/first-run-cloud-share.e2e.test.ts
+++ b/evals/specs/first-run-cloud-share.e2e.test.ts
@@ -1,10 +1,12 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
+import { addInitScript, browserScript } from "@openwork/cdp";
+import { clickText } from "@openwork/behaviors";
 import { firstRunCloudShareWorld } from "../worlds/first-run.ts";
 
 const test = spec.world(firstRunCloudShareWorld);
 
-test("first run signs in through the browser, then shares a skill with a colleague via a marketplace", async ({ world, user, agent, probe, step }) => {
+test("first run signs in through the browser, then shares a skill with a colleague via a marketplace", async ({ world, user, agent, probe, evidence, step }) => {
   const appUser = user.on(world.app);
   const webUser = user.on(world.web);
   const appProbe = probe.on(world.app);
@@ -45,6 +47,67 @@ test("first run signs in through the browser, then shares a skill with a colleag
     ]);
   });
 
+  await step("Already-installed Cloud users return through the same instance's auth route", async () => {
+    // Control installation metadata only. Session hydration, navigation and grant
+    // generation use the real Den, including its existing browser session.
+    await using configWitness = await addInitScript(world.web.client, browserScript((webUrl, apiUrl) => {
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = async (input, init) => {
+        const request = new Request(input, init);
+        const url = new URL(request.url);
+        if (url.pathname !== "/v1/install-config" && url.pathname !== "/v1/me/install-config") {
+          return originalFetch(input, init);
+        }
+        return Response.json({
+          appName: "OpenWork", clientName: "Install Journey", requireSignin: true,
+          logoUrl: null, iconUrl: null, desktopVersion: "0.18.0", distribution: "cloud",
+          // A session-backed local/preview install must not jump to a configured hosted default.
+          webUrl: url.searchParams.has("token") ? `${webUrl}/ignored-config-path` : "https://app.openworklabs.com",
+          apiUrl,
+        });
+      };
+    }, [world.den.ref.webUrl, world.den.ref.apiUrl]));
+    const origin = new URL(world.den.ref.webUrl).origin;
+    const authUrl = `${origin}/?mode=sign-in&desktopAuth=1&desktopScheme=openwork`;
+    const installSource = new URL(origin);
+    // Local Den trusts both aliases. A token-backed install on the other alias
+    // must return to the configured instance, not the install page's origin.
+    if (installSource.hostname === "127.0.0.1") installSource.hostname = "localhost";
+    const grants = new Set<string>();
+    for (const installUrl of [`${origin}/install`, `${installSource.origin}/install?token=synthetic-install-token&step=3`]) {
+      await webUser.navigate(installUrl);
+      await webUser.see({ role: "link", text: "I already installed OpenWork" }, { timeoutMs: 90_000 });
+      expect(await webProbe.eval(() => document.querySelector('a[href="openwork://open"]') === null)).toBe(true);
+      const href = await webProbe.eval(() => [...document.querySelectorAll<HTMLAnchorElement>("a")]
+        .find((link) => link.textContent?.trim() === "I already installed OpenWork")?.href);
+      expect(href).toBe(authUrl);
+      await webProbe.eval(() => { document.documentElement.dataset.installDocument = "before-handoff"; });
+      // Activate the real anchor default action without depending on OS focus
+      // after the preceding custom-protocol handoff.
+      await clickText(world.web, "I already installed OpenWork");
+      await webUser.see({ testId: "desktop-signed-in-handoff" }, { timeoutMs: 90_000 });
+      expect(await webProbe.eval(() => location.href)).toBe(authUrl);
+      expect(await webProbe.eval(() => document.documentElement.dataset.installDocument ?? null)).toBeNull();
+      await webUser.see({ text: world.den.admin.email });
+      await webUser.notSee({ role: "textbox", label: /password/i });
+      const deepLink = await probe.eventually(() => webProbe.eval(() =>
+        [...document.querySelectorAll("input")].find((input) => input.value.startsWith("openwork://den-auth?"))?.value ?? ""
+      ), { within: 60_000, label: "install-issued desktop grant", until: (value) => typeof value === "string" && value.includes("grant=") });
+      if (typeof deepLink !== "string") throw new Error("Missing install handoff URL");
+      const handoff = new URL(deepLink);
+      const grant = handoff.searchParams.get("grant");
+      expect(handoff.protocol).toBe("openwork:");
+      expect(handoff.hostname).toBe("den-auth");
+      expect(handoff.searchParams.get("denBaseUrl")).toBe(`${origin}/api/den`);
+      expect(handoff.searchParams.has("token")).toBe(false);
+      expect(grant).toBeTruthy();
+      if (!grant) throw new Error("Missing desktop grant");
+      expect(grants.has(grant)).toBe(false);
+      grants.add(grant);
+    }
+    evidence.recordAssertionEvidence("Cloud install reuses browser authentication on the correct instance", "Both session-backed and token-backed install links performed full-page navigation to the desktop sign-in route, retained the signed-in identity and produced distinct real den-auth grants with the destination's /api/den URL and no install token. Session-backed navigation ignored the hosted config default; token-backed navigation used the config's root.", true);
+  });
+
   await step("The browser-issued grant returns to the app", async () => {
     // TODO(primitive): read the browser-issued desktop handoff URL.
     const deepLink = await probe.eventually(
@@ -57,6 +120,8 @@ test("first run signs in through the browser, then shares a skill with a colleag
     );
     if (typeof deepLink !== "string") throw new Error("The browser-issued handoff URL was not a string.");
     const handoff = new URL(deepLink);
+    expect(handoff.hostname).toBe("den-auth");
+    expect(handoff.searchParams.get("denBaseUrl")).toBe(`${new URL(world.den.ref.webUrl).origin}/api/den`);
     const grant = handoff.searchParams.get("grant");
     expect(grant, `unexpected deep link: ${deepLink}`).toBeTruthy();
     await agent.on(world.app).run("auth.exchange-grant", { grant, baseUrl: world.den.ref.webUrl });


### PR DESCRIPTION
## Summary
- Route the Cloud install page’s already-installed link through the existing desktop sign-in route with a full document navigation, instead of a bare app-open URL.
- Keep session-backed navigation on the current origin and port; use the install config web origin for token-backed links. Do not forward the install token into authentication.
- Reuse existing browser sessions and Den-generated grants with denBaseUrl. Leave enterprise workspace-address instructions unchanged.

## Verification
Committed head: `53063f1bd2795f2fb2c63ecff0911c09900bf953`.
- `pnpm evals:e2e first-run-cloud-share --local`: runtime Passed, 1 passed / 0 failed / 0 skipped; placement: `local (--local)`; cold-booted isolated Den and desktop.
- Assertions cover the actual auth-route destination, full document reload, retained signed-in identity, distinct real grants with the destination API URL, absence of the install token, desktop grant exchange, and the existing marketplace-sharing flow.
- Only install metadata is controlled. Authentication and grant generation are real. The install anchor is activated with the existing DOM-click helper; OS protocol dispatch is not claimed as tested.
- `pnpm --filter @openwork-ee/den-web typecheck`: passed.
- `pnpm --dir evals run check:browser`: passed (725 callbacks).
- `git diff --check`: passed.

## Draft Blocker
Overall proof is **Incomplete**: the existing journey has 8 pending visual expectations across 4 screenshots. The evidence judge exits 2 because neither OPENAI_API_KEY nor ANTHROPIC_API_KEY is available. No judgments were fabricated and no secrets were retrieved. The matching test-evidence comment will retain these pending results rather than treating them as passed.

Source run: `evals/results/test-runs/2026-09-08T14-56-17-221Z-first-run-signs-in-through-the-browser-then-shares-a-skill-with-a-colleague-via/test-run.json`.

Local coverage used dynamic ports, not port 3005 specifically. The broader spec-layer typecheck previously reported Promise.withResolvers library errors in untouched world files; an ES2024 lib override passed, but no clean-control comparison was made.

To finish proof, judge and publish the exact committed-head run with a configured vision provider, then mark ready and enable squash auto-merge without bypassing repository checks. Screenshot attachment also requires gh 2.99 or later; this environment has gh 2.96.