### PR TITLE
fix(app): keep storage failures scoped to the task that failed

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1092,7 +1092,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const sessionModelUnavailable = props.resolveModelAvailability
     ? props.resolveModelAvailability(sessionModel.selectedModel).status === "unavailable"
     : Boolean(props.modelUnavailable);
-  const [error, setError] = useState<SessionError | null>(null);
+  // This surface is retained across navigation. Async completions must keep
+  // their original owner, including when different servers reuse session IDs.
+  const sessionOwner = JSON.stringify([props.opencodeBaseUrl, props.workspaceId, props.sessionId]);
+  const activeSessionOwnerRef = useRef(sessionOwner);
+  activeSessionOwnerRef.current = sessionOwner;
+  const [ownedError, setOwnedError] = useState<{ owner: string; error: SessionError } | null>(null);
+  const error = ownedError?.owner === sessionOwner ? ownedError.error : null;
+  const setError = useCallback((nextError: SessionError | null) => {
+    if (activeSessionOwnerRef.current !== sessionOwner) return;
+    setOwnedError(nextError ? { owner: sessionOwner, error: nextError } : null);
+  }, [sessionOwner]);
   const [restoringRevertedMessages, setRestoringRevertedMessages] = useState(false);
   const [delayedLoadingTarget, setDelayedLoadingTarget] = useState<{ workspaceId: string; sessionId: string } | null>(null);
   const showDelayedLoading = delayedLoadingTarget?.workspaceId === props.workspaceId &&
@@ -1123,7 +1133,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [cloudQueueRetryVersion, setCloudQueueRetryVersion] = useState(0);
   const [pendingSendSessions, setPendingSendSessions] = useState<string[]>([]);
   const pendingSendsRef = useRef(new Map<symbol, string>());
-  const sending = pendingSendSessions.includes(props.sessionId);
+  const sending = pendingSendSessions.includes(sessionOwner);
   const cloudQueueBlockedRef = useRef(false);
   const evalSnapshotFailureRef = useRef(false);
   // Shared with promote-to-send so a manual send-now cannot race the idle drain.
@@ -1209,7 +1219,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     autoOpenedTargetRef.current = null;
     initializedAutoOpenSessionRef.current = null;
     setVerifiedOpenTargets([]);
-  }, [props.sessionId]);
+  }, [sessionOwner, setError]);
 
   useEffect(() => () => {
     clearComposerRevertTarget(props.sessionId);
@@ -1458,7 +1468,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         return { ok: true };
       },
     };
-  }, [props.sessionId]);
+  }, [props.sessionId, setError]);
   useControlAction(props.isControlTarget ? seedSessionErrorControlAction : null);
   const seedSessionLifecycleControlAction = useMemo<OpenworkControlAction | null>(() => {
     if (!import.meta.env.DEV) return null;
@@ -1800,7 +1810,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // up the new message — so this is safe to call while the agent is busy.
   const sendDraft = useCallback(async (nextDraft: ComposerDraft) => {
     const submissionId = Symbol();
-    pendingSendsRef.current.set(submissionId, props.sessionId);
+    pendingSendsRef.current.set(submissionId, sessionOwner);
     setPendingSendSessions([...pendingSendsRef.current.values()]);
     setError(null);
     try {
@@ -1810,20 +1820,24 @@ export function SessionSurface(props: SessionSurfaceProps) {
       // submission and the route accepted or sent it.
       appendComposerHistory(props.sessionId, nextDraft.text);
       useSessionActivityStore.getState().setRunStatus(props.workspaceId, props.sessionId, { type: "busy" });
-      setAwaitingAssistantBaseline(renderedMessages.length);
+      if (activeSessionOwnerRef.current === sessionOwner) {
+        setAwaitingAssistantBaseline(renderedMessages.length);
+      }
       return result;
     } catch (nextError) {
       const parsed = parseSessionError(nextError);
       captureAnalyticsEvent("task_send_failed", {});
       setError(parsed);
       useSessionActivityStore.getState().setError(props.workspaceId, props.sessionId, parsed.message);
-      setAwaitingAssistantBaseline(null);
+      if (activeSessionOwnerRef.current === sessionOwner) {
+        setAwaitingAssistantBaseline(null);
+      }
       throw nextError;
     } finally {
       pendingSendsRef.current.delete(submissionId);
       setPendingSendSessions([...pendingSendsRef.current.values()]);
     }
-  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length]);
+  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length, sessionOwner, setError]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);
@@ -1833,7 +1847,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Initial send (agent idle) and explicit "Steer" follow-up (agent busy)
   // share the same immediate path.
   const handleSend = useCallback(async () => {
-    if ([...pendingSendsRef.current.values()].includes(props.sessionId)) return;
+    if ([...pendingSendsRef.current.values()].includes(sessionOwner)) return;
     const originalDraft = draft;
     const text = originalDraft.trim();
     if (!text && attachments.length === 0) return;
@@ -1859,7 +1873,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     } finally {
       setAttachmentsUploading(false);
     }
-  }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft]);
+  }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft, sessionOwner]);
 
   // One-step run from the empty-state hero: the route seeds this session's
   // draft and marks it for auto-send. Fire the same send path as the send
@@ -1974,12 +1988,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
     captureAnalyticsEvent("task_run_stopped", {});
     await snapshotQuery.refetch();
-  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, queuedItems, snapshotQuery.refetch]);
+  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, queuedItems, snapshotQuery.refetch, setError]);
 
   const handleDismissError = useCallback(() => {
     setError(null);
     useSessionActivityStore.getState().clearError(props.workspaceId, props.sessionId);
-  }, [props.sessionId, props.workspaceId]);
+  }, [props.sessionId, props.workspaceId, setError]);
 
   // Drain one queued follow-up each time the session goes idle, so prompts
   // run as separate turns instead of one merged message. Progress is grounded

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2794,7 +2794,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   </div>
                 )}
               </div>
-            ) : renderedMessages.length === 0 && effectiveActivityStatus !== "idle" ? (
+            ) : renderedMessages.length === 0 && effectiveActivityStatus !== "idle" && !error ? (
               <div className="px-6 py-12">
                 <AssistantWaitingCard label={getSessionActivityStatusLabel(effectiveActivityStatus)} />
               </div>

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -87,7 +87,7 @@ function sessionErrorKind(
 }
 
 function errorTitle(kind: OpencodeSessionErrorKind, fallback: string) {
-  if (kind === "disk-full") return "Not enough disk space";
+  if (kind === "disk-full") return "Storage error reported";
   if (kind === "database-error") return "OpenWork couldn’t access its saved data";
   if (kind === "aborted") return "Task interrupted";
   if (kind === "provider-timeout") return "Provider did not respond in time";
@@ -97,7 +97,7 @@ function errorTitle(kind: OpencodeSessionErrorKind, fallback: string) {
 
 function errorDescription(kind: OpencodeSessionErrorKind) {
   if (kind === "disk-full") {
-    return "The device running this task has run out of storage. Free up some disk space, then try again. If this is a cloud workspace, ask its administrator to check the storage.";
+    return "A storage limit was reported by the task runtime or a connected service. This does not necessarily mean your computer is full. Check the affected service or workspace before freeing local disk space.";
   }
   if (kind === "database-error") {
     return "Try again. If this keeps happening, check the available disk space on the device running this task and restart OpenWork. For a cloud workspace, contact its administrator.";

--- a/apps/app/tests/session-error-resilience.test.tsx
+++ b/apps/app/tests/session-error-resilience.test.tsx
@@ -51,9 +51,8 @@ describe("session error resilience", () => {
     const raw = `effect/sql/SqlError: Failed to execute statement\n at runLoop (/$bunfs/root/chunk.js:25:2045)\n${code}`
     const presentation = presentOpencodeSessionError({ name: "SqlError", data: { message: raw } })
     expect(presentation.kind).toBe("disk-full")
-    expect(presentation.title).toBe("Not enough disk space")
-    expect(presentation.description).toContain("Free up some disk space")
-    expect(presentation.description).toContain("cloud workspace")
+    expect(presentation.title).toBe("Storage error reported")
+    expect(presentation.description).toBe("A storage limit was reported by the task runtime or a connected service. This does not necessarily mean your computer is full. Check the affected service or workspace before freeing local disk space.")
     expect(presentation.technicalDetails).toContain(code)
     expect(presentation.technicalDetails).toContain("at runLoop")
     expect(presentation.recoveryPrompt).toBeNull()
@@ -66,6 +65,22 @@ describe("session error resilience", () => {
     ]) {
       expect(presentOpencodeSessionError(error).kind).toBe("disk-full")
     }
+  })
+
+  test("an upstream response-body storage code does not diagnose the local computer", () => {
+    const presentation = presentOpencodeSessionError({
+      name: "APIError",
+      data: {
+        message: "Connected service could not save the task output",
+        statusCode: 507,
+        responseBody: JSON.stringify({ error: { code: "EDQUOT", message: "Connected service storage quota exceeded" } }),
+      },
+    })
+    expect(presentation.kind).toBe("disk-full")
+    expect(presentation.title).toBe("Storage error reported")
+    expect(presentation.description).toContain("does not necessarily mean your computer is full")
+    expect(presentation.technicalDetails).toContain("EDQUOT")
+    expect(presentation.technicalDetails).toContain("507")
   })
 
   test("does not diagnose a generic database failure as a full disk", () => {
@@ -450,8 +465,8 @@ describe("session error technical details", () => {
   test("storage errors show guidance without technical codes outside developer mode", () => {
     const raw = "effect/sql/SqlError: Failed to execute statement\n at runLoop (/$bunfs/root/chunk.js:25:2045)\nENOSPC: no space left on device"
     const html = renderErrorTranscript(raw, false)
-    expect(html).toContain("Not enough disk space")
-    expect(html).toContain("Free up some disk space")
+    expect(html).toContain("Storage error reported")
+    expect(html).toContain("does not necessarily mean your computer is full")
     expect(html).not.toContain("SqlError")
     expect(html).not.toContain("runLoop")
     expect(html).not.toContain("ENOSPC")

--- a/evals/specs/session-error-technical-details.e2e.test.ts
+++ b/evals/specs/session-error-technical-details.e2e.test.ts
@@ -1,8 +1,11 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
-import { sessionErrorCard } from "../worlds/chat.ts";
+import { sessionErrorCard, sessionSubmitErrorIsolation } from "../worlds/chat.ts";
 
 const test = spec.world(sessionErrorCard);
+const submitTest = spec.world(sessionSubmitErrorIsolation, { timeout: 600_000 });
+const STORAGE_TITLE = "Storage error reported";
+const STORAGE_DESCRIPTION = "A storage limit was reported by the task runtime or a connected service. This does not necessarily mean your computer is full. Check the affected service or workspace before freeing local disk space.";
 
 // Values from the seeded payload (eval.session_error.seed): an Anthropic 429
 // with a JSON response body. None of these appear in the plain card text.
@@ -72,13 +75,14 @@ test("session error cards expose provider diagnostics only in Developer mode", a
   for (const kind of storageErrors) {
     await step(`${kind} shows recovery guidance and keeps the stack trace in Developer mode`, async () => {
       await world.seedStorageError(kind);
-      const title = kind === "disk-full" ? "Not enough disk space" : "OpenWork couldn’t access its saved data";
+      const title = kind === "disk-full" ? STORAGE_TITLE : "OpenWork couldn’t access its saved data";
       await user.see({ text: title });
-      await user.see({ text: kind === "disk-full" ? /Free up some disk space/ : /check the available disk space/ });
+      await user.see({ text: kind === "disk-full" ? STORAGE_DESCRIPTION : /check the available disk space/ });
       await user.notSee({ text: /effect\/sql\/SqlError/ });
       await user.notSee({ text: /at runLoop/ });
       await user.notSee(detailsToggle);
-      if (kind === "database-error") await user.notSee({ text: "Not enough disk space" });
+      await user.notSee({ text: "Not enough disk space" });
+      if (kind === "database-error") await user.notSee({ text: STORAGE_TITLE });
       await toggleDeveloperMode("on");
       await user.click(detailsToggle);
       await user.see({ text: /effect\/sql\/SqlError/ });
@@ -91,7 +95,7 @@ test("session error cards expose provider diagnostics only in Developer mode", a
     });
     await step(`${kind} banner hides the stack trace outside Developer mode`, async () => {
       await world.seedStorageError(kind, "banner");
-      const title = kind === "disk-full" ? "Not enough disk space" : "OpenWork couldn’t access its saved data";
+      const title = kind === "disk-full" ? STORAGE_TITLE : "OpenWork couldn’t access its saved data";
       await user.see({ testId: "session-error-card" });
       await user.see({ text: title });
       await user.notSee({ text: /at runLoop/ });
@@ -104,4 +108,73 @@ test("session error cards expose provider diagnostics only in Developer mode", a
     });
   }
 
+});
+
+submitTest("a delayed submit error stays with its owner while another retained task remains sendable", async ({ user, probe, step, world }) => {
+  const a = world.sessionA.sessionId;
+  const b = world.sessionB.sessionId;
+  const banner = { testId: "session-error-card" };
+  const select = async (title: string, sessionId: string) => {
+    await user.click({ text: title });
+    await probe.eventually(() => world.selectedSurface(), {
+      within: 15_000, label: "the selected task owns the visible surface", until: value => value.sessionId === sessionId,
+    });
+  };
+  const readyToSend = (sessionId: string) => probe.eventually(() => world.selectedSurface(), {
+    within: 15_000, label: "the selected task can send", until: value => value.sessionId === sessionId && value.runEnabled,
+  });
+  const releaseFailure = async (count: number) => {
+    await world.failHeldSubmissions();
+    await probe.eventually(() => world.readSubmissions(), {
+      within: 15_000, label: "the held SDK error response finishes", until: value => value.finished === count,
+    });
+    await world.settleResponse();
+  };
+
+  await step("A's real submit stays pending while B is selected and editable", async () => {
+    await user.type("composer", "Save the first task output.", { verify: true });
+    await readyToSend(a);
+    await user.click({ role: "button", label: "Run task" });
+    await probe.eventually(() => world.readSubmissions(), {
+      within: 30_000, label: "A's actual submit is intercepted before its response", until: value => value.held === 1,
+    });
+    await select(world.sessionB.title, b);
+    await user.type("composer", world.promptB, { verify: true });
+    await readyToSend(b);
+    expect(world.readSubmissions().finished).toBe(0);
+  });
+
+  await step("A's late upstream storage failure neither shows a B banner nor blocks B's one send", async () => {
+    await releaseFailure(1);
+    await user.notSee(banner);
+    await user.notSee({ text: STORAGE_TITLE });
+    await user.see("composer", { editable: true, text: world.promptB });
+    // Do not poll past an incorrect disabled state after the response settled.
+    expect(await world.selectedSurface()).toEqual({ sessionId: b, runEnabled: true });
+    await user.click({ role: "button", label: "Run task" });
+    await user.see({ text: world.replyB }, { timeoutMs: 60_000 });
+    expect(world.readSubmissions().requests.filter(request => request.sessionId === b)).toHaveLength(1);
+    expect(world.readSubmissions().requests.find(request => request.sessionId === b)?.body).toContain(world.promptB);
+    await user.notSee(banner);
+  });
+
+  await step("a failure delivered while A owns the surface remains visible with neutral storage guidance", async () => {
+    await select(world.sessionA.title, a);
+    await user.type("composer", "Save the first task output again.", { replace: true, verify: true });
+    await readyToSend(a);
+    await user.click({ role: "button", label: "Run task" });
+    await probe.eventually(() => world.readSubmissions(), {
+      within: 30_000, label: "A's own second submit reaches the same HTTP boundary", until: value => value.held === 2,
+    });
+    await releaseFailure(2);
+    await user.see(banner);
+    await user.see({ text: STORAGE_TITLE });
+    await user.see({ text: STORAGE_DESCRIPTION });
+    await user.notSee({ text: /EDQUOT/ });
+    expect(await world.selectedSurface()).toEqual({ sessionId: a, runEnabled: false });
+    await select(world.sessionB.title, b);
+    await user.see({ text: world.replyB });
+    await user.notSee(banner);
+    expect(world.readSubmissions().requests.filter(request => request.sessionId === b)).toHaveLength(1);
+  });
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1362,6 +1362,121 @@ export async function sessionErrorCard(seed: Seed) {
   };
 }
 
+export async function sessionSubmitErrorIsolation(seed: Seed) {
+  const promptB = "Summarize the second task independently.";
+  const replyB = "The second task completed independently.";
+  const base = await splitPaneQuestions(seed, "session-submit-error-isolation", [
+    { promptMarker: promptB, latestUserTurn: true, finalReply: replyB, steps: [] },
+  ]);
+  const sessionB = await seedSessionRetry(seed, base.app, { title: "Independent task B" });
+  const sessionA = await seedSessionRetry(seed, base.app, { title: "Storage failure task A" });
+  const endpoint = base.app.client.webSocketDebuggerUrl;
+  if (!endpoint) throw new Error("Submit fault requires the desktop CDP endpoint");
+  const origin = await evalIn(base.app, () => "http://127.0.0.1:" + localStorage.getItem("openwork.server.port"));
+  const paths = (id: string) => ["workspace", "w"].flatMap(mount => ["opencode", "opencode2/api"].map(engine =>
+    `/${mount}/${encodeURIComponent(base.workspace.workspaceId)}/${engine}/session/${encodeURIComponent(id)}/prompt_async`));
+  const pathsA = paths(sessionA.sessionId);
+  const pathsB = paths(sessionB.sessionId);
+  const socket = new WebSocket(endpoint);
+  const ready = Promise.withResolvers<void>();
+  const commands = new Map<number, ReturnType<typeof Promise.withResolvers<void>>>();
+  const held = new Map<string, string>();
+  const finished = new Set<string>();
+  const requests: { sessionId: string; body: string }[] = [];
+  let nextId = 1;
+  let disposed = false;
+  let failure: Error | undefined;
+  const command = async (method: string, params = {}) => {
+    const id = nextId++;
+    const result = Promise.withResolvers<void>();
+    commands.set(id, result);
+    const timer = setTimeout(() => result.reject(new Error(`Submit fault timed out: ${method}`)), 15_000);
+    try { socket.send(JSON.stringify({ id, method, params })); await result.promise; }
+    finally { clearTimeout(timer); commands.delete(id); }
+  };
+  const fail = (error = new Error("Submit fault lost its CDP connection")) => {
+    if (disposed) return;
+    failure = error;
+    ready.reject(error);
+    for (const result of commands.values()) result.reject(error);
+  };
+  socket.addEventListener("open", () => ready.resolve());
+  socket.addEventListener("error", () => fail());
+  socket.addEventListener("close", () => fail());
+  socket.addEventListener("message", event => {
+    const message: unknown = JSON.parse(String(event.data));
+    if (!isRecord(message)) return;
+    if (typeof message.id === "number") {
+      const result = commands.get(message.id);
+      if (message.error) result?.reject(new Error("Submit fault CDP command failed"));
+      else result?.resolve();
+    }
+    const params = message.params;
+    if (!isRecord(params) || typeof params.requestId !== "string") return;
+    if (message.method === "Network.loadingFinished") finished.add(params.requestId);
+    if (message.method !== "Fetch.requestPaused") return;
+    const request = params.request;
+    const path = isRecord(request) && typeof request.url === "string" ? new URL(request.url).pathname : "";
+    if (isRecord(request) && request.method === "POST" && (pathsA.includes(path) || pathsB.includes(path))) {
+      requests.push({ sessionId: pathsA.includes(path) ? sessionA.sessionId : sessionB.sessionId,
+        body: typeof request.postData === "string" ? request.postData : "" });
+      if (pathsA.includes(path)) {
+        if (typeof params.networkId !== "string") { fail(new Error("Submit fault has no network request ID")); return; }
+        held.set(params.requestId, params.networkId);
+        return;
+      }
+    }
+    void command("Fetch.continueRequest", { requestId: params.requestId }).catch(fail);
+  });
+  const timer = setTimeout(() => ready.reject(new Error("Submit fault could not connect")), 15_000);
+  try {
+    await ready.promise;
+    await command("Network.enable");
+    await command("Fetch.enable", { patterns: [...pathsA, ...pathsB].map(path => ({ urlPattern: origin + path + "*", requestStage: "Request" })) });
+  } catch (error) { disposed = true; socket.close(); throw error; }
+  finally { clearTimeout(timer); }
+  return {
+    ...base, sessionA, sessionB, promptB, replyB,
+    readSubmissions() {
+      if (failure) throw failure;
+      return { requests: [...requests], held: held.size, finished: [...held.values()].filter(id => finished.has(id)).length };
+    },
+    async failHeldSubmissions() {
+      if (failure) throw failure;
+      const pending = [...held].filter(([, id]) => !finished.has(id));
+      if (!pending.length) throw new Error("No submit request is held");
+      // A real SDK response, not a seeded presentation: the storage code exists
+      // only in the upstream response body, not in the top-level message.
+      const body = Buffer.from(JSON.stringify({ name: "APIError", data: {
+        message: "Connected service could not save the task output", statusCode: 507,
+        responseBody: JSON.stringify({ error: { code: "EDQUOT", message: "Connected service storage quota exceeded" } }),
+      } })).toString("base64");
+      await Promise.all(pending.map(([requestId]) => command("Fetch.fulfillRequest", {
+        requestId, responseCode: 507, responseHeaders: [
+          { name: "content-type", value: "application/json" },
+          { name: "access-control-allow-origin", value: "*" },
+        ], body,
+      })));
+    },
+    async selectedSurface() {
+      return evalIn(base.app, () => {
+        const surface = document.querySelector<HTMLElement>('[data-workbench-pane="primary"] [data-session-surface-id]');
+        const run = surface?.querySelector<HTMLButtonElement>('button[aria-label="Run task"]');
+        return { sessionId: surface?.dataset.sessionSurfaceId ?? "", runEnabled: Boolean(run && !run.disabled) };
+      });
+    },
+    async settleResponse() {
+      // Network completion precedes the SDK promise chain and React's commit.
+      await evalIn(base.app, () => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+        { awaitPromise: true, timeoutMs: 5_000 });
+    },
+    async [Symbol.asyncDispose]() {
+      try { if (socket.readyState === WebSocket.OPEN) await command("Fetch.disable"); }
+      finally { disposed = true; socket.close(); }
+    },
+  };
+}
+
 export async function snapshotFailure(seed: Seed) {
   const app = await seed.desktop({ name: "composer-snapshot-failure" });
   const workspace = await seed.workspace(app, seed.tmpPath("composer-snapshot-failure"));


### PR DESCRIPTION
## Problem

A storage error reported by a connected service can be presented as a full disk on the task's device. Separately, a send that fails after navigation can write its error into another retained conversation and disable that conversation's composer. Failed first sends can also hide the recovery card behind a generic Error placeholder.

## Changes

- Scope transient errors and pending sends to endpoint, workspace, and session. Ignore stale surface updates while preserving the original task's activity error.
- Use origin-neutral storage guidance instead of claiming that the user's computer or task device is full. Keep technical diagnostics behind Developer mode.
- Show the first-send recovery card rather than an activity placeholder.
- Extend the existing error journey with a delayed HTTP 507 response: A fails after switching to B, B submits exactly once and completes, and a subsequent failure on A still shows its own recovery guidance.

No cloud quota enforcement, runtime routing, automatic retry, or snapshot-readiness policy changes. Investigation found no general cloud-storage preflight gate on local submissions. This fixes confirmed presentation and conversation-isolation defects; it does not establish the cause of any particular storage incident.

## Verification

**Verdict: Passed — both exact-head journey tests passed with no skips, and their evidence is published.**

- [Delayed failure isolation and first-send recovery evidence](https://github.com/different-ai/openwork/pull/4623#issuecomment-5589294742)
- [Storage guidance and Developer-mode diagnostics evidence](https://github.com/different-ai/openwork/pull/4623#issuecomment-5589305267)

Head: `78158623f7e5533c5e3d25e26fcfc29f61ea4da8`

- `OPENWORK_EVAL_REF=$(git rev-parse HEAD) pnpm evals:e2e session-error-technical-details` — exit 0, **2 passed / 0 failed / 0 skipped**. Cold-booted resources; checkout confirmed the exact head. Placement: `daytona (daytona CLI authenticated)`.
- `pnpm --dir apps/app exec bun test --isolate tests/session-error-resilience.test.tsx` — exit 0, **24 passed / 0 failed**, 101 assertions.
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `pnpm evals:check-browser` — exit 0, 728 browser callbacks checked.
- `git diff --check origin/dev...HEAD` — exit 0.

Earlier attempts included an unpinned checkout, a transport timeout, and a short-ref checkout rejection. These are not counted as proof. The first exact-head run exposed the hidden first-send recovery card; the follow-up commit fixes it and the final exact-head run passes both tests.

Deferred: cross-platform/v2 matrices and a production incident reproduction. No production storage or connected records were changed.
