### PR TITLE
fix(browser): bound retained tabs and release abandoned pages

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -259,6 +259,7 @@ declare global {
         createTab?: (url?: string, sessionId?: string | null) => Promise<{ tabId: string }>;
         closeTab?: (tabId: string) => Promise<string | null>;
         closeAllTabs?: () => Promise<string[]>;
+        closeSessionTabs?: (sessionId: string) => Promise<string[]>;
         selectTab?: (tabId: string) => Promise<string>;
         reorderTabs?: (tabIds: string[]) => Promise<BrowserPanelTab[]>;
         listTabs?: () => Promise<BrowserPanelTab[]>;
@@ -294,6 +295,15 @@ declare global {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+export async function closeSessionBrowserTabs(sessionId: string): Promise<void> {
+  if (typeof window === "undefined" || !sessionId.trim()) return;
+  try {
+    await window.__OPENWORK_ELECTRON__?.browser?.closeSessionTabs?.(sessionId);
+  } catch {
+    // Cleanup is idempotent and must not undo a confirmed session deletion.
+  }
+}
 
 async function invokeElectronHelper<C extends DesktopCommandName>(
   command: C,

--- a/apps/app/src/app/lib/opencode-session-native.ts
+++ b/apps/app/src/app/lib/opencode-session-native.ts
@@ -1,5 +1,6 @@
 import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
+import { closeSessionBrowserTabs } from "./desktop";
 import { createClient, unwrap, type FieldsResult } from "./opencode";
 import { createClientV2, isOpencodeV2BaseUrl } from "./opencode-v2-adapter";
 import type { OpenworkSessionSnapshot } from "./openwork-server";
@@ -101,5 +102,7 @@ export async function deleteNativeSession(
   dependencies?: NativeSessionDependencies,
 ) {
   const result = await sessionOperations(endpoint, dependencies).delete(sessionId, options);
-  return unwrapSessionResult(result, "session_not_found");
+  const deleted = unwrapSessionResult(result, "session_not_found");
+  if (deleted) void closeSessionBrowserTabs(sessionId);
+  return deleted;
 }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -81,6 +81,7 @@ import { resolveCollectibleOpenTarget } from "../artifacts/resolve-open-target";
 import type { OpenTargetOptions } from "@/lib/target-provider";
 import { SidePanel } from "../panel/side-panel";
 import { getSidePanelSessionKey } from "../panel/side-panel-session";
+import { useCreateTab } from "../panel/use-side-panel-tabs";
 import { TerminalDock } from "../terminal/terminal-dock";
 import { useActivePanelTab, usePanelTabStore, useSessionPanelState } from "../panel/panel-tab-store";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
@@ -651,6 +652,7 @@ export function SessionPage(props: SessionPageProps) {
     if (/^wss?:\/\//i.test(target.value)) return target.value.replace(/^ws:/i, "http:").replace(/^wss:/i, "https:");
     return target.value;
   }, []);
+  const createBrowserTab = useCreateTab();
   const openTargetForRuntime = useCallback((runtime: {
     client: OpenworkServerClient | null;
     runtimeWorkspaceId: string | null;
@@ -662,7 +664,7 @@ export function SessionPage(props: SessionPageProps) {
       if (isElectronRuntime()) {
         const ownerSessionId = sourceSessionId ?? props.selectedSessionId ?? null;
         openOwnerSidePanel(ownerSessionId);
-        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(url, ownerSessionId);
+        void createBrowserTab(url, ownerSessionId);
       } else {
         window.open(url, "_blank", "noopener,noreferrer");
       }
@@ -734,7 +736,7 @@ export function SessionPage(props: SessionPageProps) {
     }
 
     openFileTarget(target);
-  }, [activePanelTab?.id, browserUrlForTarget, openOwnerSidePanel, openTab, props.selectedSessionId, setCurrentSidePanel]);
+  }, [activePanelTab?.id, browserUrlForTarget, createBrowserTab, openOwnerSidePanel, openTab, props.selectedSessionId, setCurrentSidePanel]);
   const openTarget = useCallback((target: OpenTarget, options?: OpenTargetOptions, sourceSessionId?: string) => {
     openTargetForRuntime({
       client: props.openworkServerClient,

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -15,6 +15,7 @@ import { useDragControls } from "motion/react";
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
 import { PanelTab, PanelTabClose, PanelTabItem, PanelTabList } from "@/components/panel-tabs";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import {
   InputGroup,
   InputGroupAddon,
@@ -187,7 +188,9 @@ function BrowserPanelContent({
   }, [tab.id, tab.url]);
 
   const navigate = React.useCallback(() => {
-    void getElectronBrowser()?.navigate?.(urlInput);
+    void getElectronBrowser()?.navigate?.(urlInput).catch((error: unknown) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    });
   }, [urlInput]);
 
   const back = React.useCallback(() => {
@@ -274,7 +277,9 @@ function BrowserPanelContent({
         // Naming the conversation lets the native browser put that
         // conversation's tabs on screen and keep every other conversation's
         // tabs silently in the background.
-        browser.show?.(bounds, sessionId);
+        void browser.show?.(bounds, sessionId).catch((error: unknown) => {
+          toast.error(error instanceof Error ? error.message : String(error));
+        });
         shownRef.current = true;
         lastBoundsRef.current = bounds;
         return;

--- a/apps/app/src/react-app/domains/session/panel/use-side-panel-tabs.ts
+++ b/apps/app/src/react-app/domains/session/panel/use-side-panel-tabs.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { activeBrowserTabIdForSession, browserTabsForSession } from "@openwork/browser-tabs";
 
 import type { BrowserStatePayload } from "@/app/lib/desktop";
+import { toast } from "@/components/ui/sonner";
 
 import {
   type PanelTab,
@@ -56,8 +57,12 @@ export function useSidePanelTabs(sessionId: string) {
 }
 
 export function useCreateTab() {
-  return React.useCallback((url?: string, sessionId?: string | null) => {
-    void getElectronBrowser()?.createTab?.(url, sessionId);
+  return React.useCallback(async (url?: string, sessionId?: string | null) => {
+    try {
+      await getElectronBrowser()?.createTab?.(url, sessionId);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
+    }
   }, []);
 }
 

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -8,6 +8,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 
 import { t } from "../../../../i18n";
+import { closeSessionBrowserTabs } from "../../../../app/lib/desktop";
 import { unwrap } from "../../../../app/lib/opencode";
 import {
   abortSession as abortSessionTyped,
@@ -797,7 +798,8 @@ export function createSessionActionsStore(options: {
     const root = options.selectedWorkspaceRoot().trim();
     const directory = toSessionTransportDirectory(root);
     const params = directory ? { sessionID: trimmed, directory } : { sessionID: trimmed };
-    unwrap(await c.session.delete(params));
+    const deleted = unwrap(await c.session.delete(params));
+    if (deleted) void closeSessionBrowserTabs(trimmed);
     clearSessionDraft(LOCAL_SESSION_DRAFT_SCOPE, options.selectedWorkspaceId().trim(), trimmed);
 
     options.setSessions(options.sessions().filter((s) => s.id !== trimmed));

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import type { FilePart, Part, PermissionRequest, PermissionV2Request, QuestionRequest, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { getReactQueryClient } from "../../../infra/query-client";
+import { closeSessionBrowserTabs } from "@/app/lib/desktop";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
 import { observeModelsTaskEvent } from "@/app/lib/models-task-analytics";
@@ -844,6 +845,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.deleted") {
     const props = (event.properties ?? {}) as { sessionID?: string; info?: { id?: string } };
     const sessionId = props.sessionID ?? props.info?.id ?? "";
+    if (sessionId) void closeSessionBrowserTabs(sessionId);
     if (sessionId) entry.titleRecovery?.resolve(sessionId);
     if (sessionId) useSessionActivityStore.getState().removeSession(workspaceId, sessionId);
     if (sessionId) useWorkbenchStore.getState().closeTab({ workspaceId, sessionId });

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -20,6 +20,10 @@ const BROWSER_DEFAULT_URL = "about:blank";
 // URL a user-initiated new tab (the "+" button / opening the browser panel)
 // lands on. The agent's programmatic path keeps BROWSER_DEFAULT_URL.
 const BROWSER_NEW_TAB_URL = "https://www.google.com";
+// Bound native page allocation across conversations. Refuse new work rather
+// than evicting a live document (unsaved input and CDP handles cannot be restored
+// from a URL). This is a tab bound, not a Chromium process or memory limit.
+const MAX_BROWSER_TABS = 12;
 const BROWSER_TARGET_RESOLVE_TIMEOUT_MS = 2500;
 const BROWSER_TARGET_RESOLVE_INTERVAL_MS = 80;
 const MENU_OVERLAY_HTML = "overlay.html";
@@ -185,18 +189,25 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     // a queued about:blank navigation would abort this awaited load with
     // ERR_ABORTED and fail the agent's request before the page ever opens.
     const tab = createBrowserTab("about:blank", { select: true, initializeBlank: false, ownerSessionId });
-    await tab.view.webContents.loadURL(browserTargetMarkerUrl(tab.tabId));
-    const targetId = await resolveBrowserCdpTargetId(tab.tabId);
-    await tab.view.webContents.loadURL(url);
-    return {
-      provider: "builtin",
-      browser_url: cdpBrowserUrl(),
-      target_id: targetId,
-      tab_id: tab.tabId,
-      url,
-      owner_session_id: registry.ownerOf(tab.tabId),
-      visible: registry.surfacingFor(tab.tabId) === "foreground",
-    };
+    try {
+      await tab.view.webContents.loadURL(browserTargetMarkerUrl(tab.tabId));
+      const targetId = await resolveBrowserCdpTargetId(tab.tabId);
+      await tab.view.webContents.loadURL(url);
+      return {
+        provider: "builtin",
+        browser_url: cdpBrowserUrl(),
+        target_id: targetId,
+        tab_id: tab.tabId,
+        url,
+        owner_session_id: registry.ownerOf(tab.tabId),
+        visible: registry.surfacingFor(tab.tabId) === "foreground",
+      };
+    } catch (error) {
+      // No usable handle was returned. Retries must not retain unreachable
+      // pages after marker discovery or navigation fails.
+      closeBrowserTab(tab.tabId);
+      throw error;
+    }
   }
 
   function getBrowserTab(tabId = registry.onScreenTabId()) {
@@ -506,12 +517,12 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
             const browser = request.browsers.find(({ id }) => `browser:${id}` === payload.itemId);
             await browser.open(request.url);
           }
-        } catch {
+        } catch (error) {
           const mainWindow = window();
           if (mainWindow && !mainWindow.isDestroyed()) {
             await dialog.showMessageBox(mainWindow, {
               type: "error", message: "Could not open this link",
-              detail: "Your browser may be unavailable, or your organization may restrict this destination. You can copy the link address instead.",
+              detail: error instanceof Error ? error.message : "Your browser may be unavailable, or your organization may restrict this destination. You can copy the link address instead.",
             });
           }
         }
@@ -600,6 +611,11 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
   });
 
   function createBrowserTab(url = "about:blank", { select = true, initializeBlank = true, ownerSessionId = null } = {}) {
+    // Check synchronously before creating a WebContentsView, including pending
+    // opens, popups, transcript links and the tab-strip button.
+    if (browserTabs.size >= MAX_BROWSER_TABS) {
+      throw new Error(`OpenWork has ${MAX_BROWSER_TABS} browser tabs open. Close an unused browser tab in any conversation, then try again.`);
+    }
     installPolicyRequestHook();
     const tabId = createBrowserTabId();
     const view = new WebContentsView({
@@ -685,9 +701,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     view.webContents.on("did-stop-loading", () => sendBrowserState());
     view.webContents.on("focus", () => resetViewportEmulation(view));
     view.webContents.once("destroyed", () => {
-      browserTabs.delete(tabId);
-      registry.remove(tabId);
-      sendBrowserState();
+      // CDP Target.closeTarget and page-initiated close bypass our tab-strip
+      // handler; they must release the native parent and owner state too.
+      closeBrowserTab(tabId);
     });
     if (registry.surfacingFor(tabId) === "background") {
       // Silent: the owner is not on screen. Keep the page real while unseen.
@@ -742,6 +758,13 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     return backgroundWindow;
   }
 
+  function releaseEmptyBackgroundWindow() {
+    if (!backgroundWindow) return;
+    if (!backgroundWindow.isDestroyed() && backgroundWindow.contentView.children.length > 0) return;
+    if (!backgroundWindow.isDestroyed()) backgroundWindow.destroy();
+    backgroundWindow = null;
+  }
+
   // A tab whose conversation is not on screen must still behave like a real
   // page for the agent driving it: lay out at a real viewport, accept typing as
   // a focused page, and paint so CDP screenshots work. Park it in a never-shown
@@ -793,6 +816,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
       if (registry.surfacingFor(tab.tabId) === "background") enterBackgroundMode(tab);
       else exitBackgroundMode(tab);
     }
+    releaseEmptyBackgroundWindow();
   }
 
   function setVisibleSession(sessionId) {
@@ -926,30 +950,29 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     if (removed && !removed.ownerHasTabs) {
       sendToRenderer("openwork:browser:panel-closed", { ownerSessionId: removed.tab.ownerSessionId });
     }
-    try { tab.view.webContents.close(); } catch { /* already destroyed */ }
+    try {
+      if (!tab.view.webContents.isDestroyed()) tab.view.webContents.close({ waitForBeforeUnload: false });
+    } catch { /* already destroyed */ }
+    releaseEmptyBackgroundWindow();
     sendBrowserState();
     return tabId;
   }
 
   function closeAllBrowserTabs() {
     const closedTabIds = registry.list().map((tab) => tab.tabId);
-    if (closedTabIds.length === 0) return [];
-    hideMenuOverlay();
-    const tabsToClose = closedTabIds
-      .map((tabId) => browserTabs.get(tabId))
-      .filter(Boolean);
-    const owners = new Set(closedTabIds.map((tabId) => registry.ownerOf(tabId)));
-    for (const tab of tabsToClose) tab.background = false;
-    hideBrowserView();
-    browserTabs.clear();
-    registry.clear();
-    for (const tab of tabsToClose) {
-      try { tab.view.webContents.close(); } catch { /* already destroyed */ }
-    }
-    for (const ownerSessionId of owners) {
-      sendToRenderer("openwork:browser:panel-closed", { ownerSessionId });
-    }
-    sendBrowserState();
+    for (const tabId of closedTabIds) closeBrowserTab(tabId);
+    return closedTabIds;
+  }
+
+  function closeSessionBrowserTabs(sessionId) {
+    // Missing/malformed ownership must never become a request to close shared
+    // tabs or the currently visible conversation.
+    const ownerSessionId = normalizeSessionId(sessionId);
+    if (!ownerSessionId) return [];
+    const closedTabIds = registry.list()
+      .filter((tab) => tab.ownerSessionId === ownerSessionId)
+      .map((tab) => tab.tabId);
+    for (const tabId of closedTabIds) closeBrowserTab(tabId);
     return closedTabIds;
   }
 
@@ -1060,6 +1083,8 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     ipcMain.handle("openwork:browser:state", () => ({
       ...browserStatePayload(),
       nativeViews: browserNativeViews(),
+      tabLimit: MAX_BROWSER_TABS,
+      backgroundWindowCount: Number(Boolean(backgroundWindow && !backgroundWindow.isDestroyed())),
       backgroundWindowVisible: Boolean(backgroundWindow && !backgroundWindow.isDestroyed() && backgroundWindow.isVisible()),
       visibleWindowCount: BrowserWindow.getAllWindows().filter((host) => host.isVisible()).length,
     }));
@@ -1071,6 +1096,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     });
     ipcMain.handle("openwork:browser:closeTab", (_event, tabId) => closeBrowserTab(tabId == null ? undefined : String(tabId)));
     ipcMain.handle("openwork:browser:closeAllTabs", () => closeAllBrowserTabs());
+    ipcMain.handle("openwork:browser:closeSessionTabs", (_event, sessionId) => closeSessionBrowserTabs(sessionId));
     ipcMain.handle("openwork:browser:selectTab", (_event, tabId) => {
       const tab = selectBrowserTab(String(tabId ?? ""));
       resetViewportEmulation(tab.view);

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -49,7 +49,8 @@ export class WebContentsView {
       once(event, handler) { listeners.set(event, handler); },
       emit(event, ...args) { listeners.get(event)?.(null, ...args); },
       setWindowOpenHandler() {},
-      isDestroyed() { return false; },
+      destroyed: false,
+      isDestroyed() { return this.destroyed; },
       getURL() { return this.url; },
       getTitle() { return ""; },
       isLoading() { return false; },
@@ -57,7 +58,7 @@ export class WebContentsView {
       canGoForward() { return false; },
       loadURL(url) { this.url = url; return Promise.resolve(); },
       focus() {},
-      close() {},
+      close() { this.destroyed = true; this.emit("destroyed"); },
     };
   }
   setBounds(bounds) { this.bounds = bounds; }
@@ -334,6 +335,65 @@ test("closing a conversation's last tab tells only that conversation its panel i
   assert.equal(onScreen(), aView, "A keeps browsing");
   assert.deepEqual(messages("openwork:browser:panel-closed"), [{ ownerSessionId: "B" }]);
   assert.deepEqual(invoke("openwork:browser:state").tabs.map((tab) => tab.ownerSessionId), ["A"]);
+});
+
+test("capacity refuses allocation without replacing existing tabs and closing frees a slot", async () => {
+  const { invoke, views } = createPanel();
+  const limit = invoke("openwork:browser:state").tabLimit;
+  assert.equal(limit, 12);
+  for (let i = 0; i < limit; i++) invoke("openwork:browser:createTab", "about:blank", `owner-${i}`);
+  const before = invoke("openwork:browser:state");
+  assert.throws(() => invoke("openwork:browser:createTab", "about:blank", "overflow"), /12 browser tabs open.*Close.*try again/);
+  await assert.rejects(invoke("openwork:browser:openUrl", "https://example.com"), /12 browser tabs open/);
+  assert.equal(views().length, limit, "rejection allocates no native view");
+  assert.deepEqual(invoke("openwork:browser:state").tabs, before.tabs);
+  invoke("openwork:browser:closeTab", before.tabs[0].id);
+  assert.equal(views()[0].webContents.isDestroyed(), true);
+  invoke("openwork:browser:createTab", "about:blank", "retry");
+  assert.equal(invoke("openwork:browser:state").tabs.length, limit);
+});
+
+test("owner cleanup is exact and idempotent and releases only an empty background host", async () => {
+  const { invoke, views, messages } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  invoke("openwork:browser:createTab", "about:blank", "A");
+  invoke("openwork:browser:createTab", "about:blank", null);
+  const b = invoke("openwork:browser:createTab", "about:blank", "B");
+  const c = invoke("openwork:browser:createTab", "about:blank", "C");
+  await flush();
+  for (const invalid of [undefined, null, "", "   ", 1]) assert.deepEqual(invoke("openwork:browser:closeSessionTabs", invalid), []);
+  assert.deepEqual(invoke("openwork:browser:closeSessionTabs", "B"), [b.tabId]);
+  assert.deepEqual(invoke("openwork:browser:closeSessionTabs", "B"), []);
+  assert.equal(views()[2].webContents.isDestroyed(), true);
+  assert.equal(invoke("openwork:browser:state").backgroundWindowCount, 1, "C still uses the hidden host");
+  assert.deepEqual(invoke("openwork:browser:closeSessionTabs", "C"), [c.tabId]);
+  assert.equal(invoke("openwork:browser:state").backgroundWindowCount, 0);
+  assert.deepEqual(invoke("openwork:browser:state").tabs.map(tab => tab.ownerSessionId), ["A", null]);
+  assert.ok(views().slice(0, 2).every(view => !view.webContents.isDestroyed()));
+  assert.deepEqual(messages("openwork:browser:panel-closed"), [{ ownerSessionId: "B" }, { ownerSessionId: "C" }]);
+  invoke("openwork:browser:closeAllTabs");
+  assert.ok(views().every(view => view.webContents.isDestroyed()));
+});
+
+test("external target destruction releases owner state and the empty hidden host", async () => {
+  const { invoke, views } = createPanel();
+  invoke("openwork:browser:createTab", "about:blank", "B");
+  await flush();
+  views()[0].webContents.close();
+  assert.deepEqual(invoke("openwork:browser:state").tabs, []);
+  assert.equal(invoke("openwork:browser:state").backgroundWindowCount, 0);
+});
+
+test("failed target discovery rolls back its allocation while another owner's page survives", async () => {
+  const { invoke, views } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  invoke("openwork:browser:createTab", "about:blank", "A");
+  const before = invoke("openwork:browser:state");
+  await assert.rejects(invoke("openwork:browser:openUrl", "https://example.com", "builtin", { sessionId: "B" }), /Could not resolve/);
+  assert.deepEqual(invoke("openwork:browser:state").tabs, before.tabs);
+  assert.equal(invoke("openwork:browser:state").backgroundWindowCount, 0);
+  assert.equal(views()[1].webContents.isDestroyed(), true);
+  assert.equal(views()[0].webContents.isDestroyed(), false);
 });
 
 test("tabs created without a conversation stay shared and behave as before", async () => {

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -196,6 +196,7 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     createTab(url, sessionId) { return ipcRenderer.invoke("openwork:browser:createTab", url, sessionId); },
     closeTab(tabId) { return ipcRenderer.invoke("openwork:browser:closeTab", tabId); },
     closeAllTabs() { return ipcRenderer.invoke("openwork:browser:closeAllTabs"); },
+    closeSessionTabs(sessionId) { return ipcRenderer.invoke("openwork:browser:closeSessionTabs", sessionId); },
     selectTab(tabId) { return ipcRenderer.invoke("openwork:browser:selectTab", tabId); },
     reorderTabs(tabIds) { return ipcRenderer.invoke("openwork:browser:reorderTabs", tabIds); },
     listTabs() { return ipcRenderer.invoke("openwork:browser:listTabs"); },

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -20,6 +20,244 @@ const conversation = (title: string): Target => ({ text: title });
 // @openwork/browser-tabs) so the agent sees a desktop-sized page.
 const BACKGROUND_TAB_VIEWPORT = { width: 1280, height: 800 };
 
+test("the global tab limit rejects new pages without disturbing live tabs, and closing a tab makes room", async ({ world, user, agent, step }) => {
+  const reading = { ...world.session, title: "Reading at capacity" };
+  await world.renameSession(reading.sessionId, reading.title);
+  const researching = await world.openSession("Research at capacity");
+  await user.click(conversation(reading.title));
+  const initial = await world.readBrowserState();
+  expect(initial.tabs).toEqual([]);
+  expect(initial.tabLimit).toBe(12);
+  const readingTab = await world.openTabAs("capacity-reading", reading.sessionId);
+  await user.see(tabButton(readingTab.name), { timeoutMs: 30_000 });
+  const researchTab = await world.openTabAs("capacity-research", researching.sessionId);
+  await world.loadInputProbe(researchTab);
+  expect(await world.clickAndType(researchTab, "before")).toEqual({ clicks: 1, value: "before" });
+  for (let index = 2; index < initial.tabLimit; index += 1) {
+    await world.openTabAs(`capacity-${index}`, researching.sessionId);
+  }
+  const full = await world.readBrowserState();
+  expect(full.tabs).toHaveLength(12);
+  expect(full).toMatchObject({ activeTabId: readingTab.tabId, visibleSessionId: reading.sessionId,
+    backgroundWindowCount: 1, backgroundWindowVisible: false, visibleWindowCount: 1 });
+  const pages = await world.pageTargets();
+  const retryUrl = `${world.origin}/?viewport-probe=capacity-retry`;
+
+  await step("The new-tab button explains how to make room without allocating a page", async () => {
+    await user.click({ role: "button", label: "New tab" });
+    await user.see({ text: /OpenWork has 12 browser tabs open\. Close an unused browser tab in any conversation, then try again\./ });
+    const rejected = await world.readBrowserState();
+    expect(rejected.tabs).toEqual(full.tabs);
+    expect(rejected).toMatchObject({ activeTabId: readingTab.tabId, visibleSessionId: reading.sessionId,
+      backgroundWindowCount: 1, backgroundWindowVisible: false, visibleWindowCount: 1 });
+    expect(await world.pageTargets()).toEqual(pages);
+    expect(await world.readInputProbe(researchTab)).toEqual({ clicks: 1, value: "before" });
+    await user.see(tabButton(readingTab.name));
+  });
+
+  await step("Foreground and background opens hit the same limit without allocating or replacing a CDP page", async () => {
+    await expect(agent.run("browser.open_url", { url: retryUrl, provider: "builtin" }))
+      .rejects.toThrow(/12 browser tabs open.*Close.*try again/s);
+    await expect(world.openTabAs("capacity-overflow", researching.sessionId))
+      .rejects.toThrow(/12 browser tabs open.*Close.*try again/s);
+    const rejected = await world.readBrowserState();
+    expect(rejected.tabs).toEqual(full.tabs);
+    expect(rejected).toMatchObject({ activeTabId: readingTab.tabId, visibleSessionId: reading.sessionId,
+      backgroundWindowCount: 1, backgroundWindowVisible: false, visibleWindowCount: 1 });
+    expect(await world.pageTargets()).toEqual(pages);
+    expect(await world.readInputProbe(researchTab)).toEqual({ clicks: 1, value: "before" });
+    expect(await world.clickAndType(researchTab, "-limited")).toEqual({ clicks: 2, value: "before-limited" });
+    await user.see(tabButton(readingTab.name));
+    await user.notSee(tabButton("capacity-retry"));
+  });
+
+  await step("Closing a visible tab releases exactly one slot and the same request succeeds", async () => {
+    const readingState = full.tabs.find(tab => tab.id === readingTab.tabId);
+    if (!readingState) throw new Error("The reading tab is missing at capacity.");
+    await user.click({ role: "button", label: `Close tab: ${readingState.label}` });
+    await eventually(async () => {
+      expect((await world.readBrowserState()).tabs).toEqual(full.tabs.filter(tab => tab.id !== readingTab.tabId));
+      expect(await world.pageTargets()).toEqual(pages.filter(page => page.id !== readingTab.targetId));
+      return true;
+    }, { within: 15_000, label: "closing the tab removes its native page and releases one slot" });
+
+    const result = await agent.run("browser.open_url", { url: retryUrl, provider: "builtin" });
+    const retried = await eventually(() => world.readBrowserState(), {
+      within: 15_000,
+      until: state => state.tabs.some(tab => tab.url === retryUrl && tab.id === state.activeTabId),
+      label: "the capacity retry selects a new owned browser page",
+    });
+    const replacement = retried.tabs.find(tab => tab.url === retryUrl);
+    if (!replacement) throw new Error("The capacity retry did not create a tab.");
+    const handle = await world.tabHandle(replacement);
+    expect(result).toMatchObject({ tab_id: handle.tabId, target_id: handle.targetId, owner_session_id: reading.sessionId });
+    expect(retried.tabs).toHaveLength(12);
+    expect(retried.tabs.filter(tab => tab.id !== replacement.id)).toEqual(full.tabs.filter(tab => tab.id !== readingTab.tabId));
+    expect(await world.pageTargets()).toEqual([...pages.filter(page => page.id !== readingTab.targetId),
+      { id: handle.targetId, url: retryUrl }].sort((a, b) => a.id.localeCompare(b.id)));
+    expect(await world.clickAndType(researchTab, "-retry")).toEqual({ clicks: 3, value: "before-limited-retry" });
+    await user.see(tabButton("capacity-retry"));
+    await world.loadInputProbe(handle);
+    expect(await world.clickAndType(handle, "retry works")).toEqual({ clicks: 1, value: "retry works" });
+    expect(await world.readInputProbe(researchTab)).toEqual({ clicks: 3, value: "before-limited-retry" });
+  });
+});
+
+test("session deletion closes only its owned pages and preserves neighbor and shared tabs", async ({ world, user, agent, probe, step }) => {
+    const removed = { ...world.session, title: "Completed browser research" };
+    await world.renameSession(removed.sessionId, removed.title);
+    const neighbor = await world.openSession("Continuing browser research");
+    await user.see(conversation(neighbor.title));
+    const shared = await world.openTab("shared-survivor");
+    await world.loadInputProbe(shared);
+    expect(await world.clickAndType(shared, "shared")).toEqual({ clicks: 1, value: "shared" });
+    const neighborTab = await world.openTabAs("neighbor-survivor", neighbor.sessionId);
+    await world.loadInputProbe(neighborTab);
+    expect(await world.clickAndType(neighborTab, "neighbor")).toEqual({ clicks: 1, value: "neighbor" });
+    const baseline = await eventually(() => world.readBrowserState(), {
+      within: 15_000,
+      until: state => state.tabs.length === 2 && state.tabs.every(tab => tab.label === "input-probe")
+        && state.visibleSessionId === neighbor.sessionId && state.activeTabId === neighborTab.tabId,
+      label: "the shared and neighbor pages have settled before opening owned pages",
+    });
+    expect(baseline.tabs.find(tab => tab.id === shared.tabId)?.ownerSessionId).toBeNull();
+    expect(baseline.tabs.find(tab => tab.id === neighborTab.tabId)?.ownerSessionId).toBe(neighbor.sessionId);
+    expect(baseline.backgroundWindowCount).toBe(0);
+    const baselinePages = await world.pageTargets();
+    const owned = [
+      await world.openTabAs("completed-one", removed.sessionId),
+      await world.openTabAs("completed-two", removed.sessionId),
+    ];
+    const before = await world.readBrowserState();
+    expect(before.tabs.filter(tab => tab.ownerSessionId === removed.sessionId).map(tab => tab.id))
+      .toEqual(owned.map(tab => tab.tabId));
+    expect(before).toMatchObject({ activeTabId: neighborTab.tabId, visibleSessionId: neighbor.sessionId,
+      backgroundWindowCount: 1, backgroundWindowVisible: false, visibleWindowCount: 1 });
+    const pages = await world.pageTargets();
+    for (const tab of owned) expect(pages.some(page => page.id === tab.targetId)).toBe(true);
+
+    await step("A real session deletion destroys every owned page, but neither surviving document", async () => {
+      // Delete through the public server rail, not a renderer cleanup helper,
+      // so browser cleanup must arrive through the real session event.
+      expect((await agent.desktopApi(`${world.sessionApiBase}/${removed.sessionId}`, { method: "DELETE" })).status).toBe(200);
+      await eventually(async () => {
+        expect((await probe.desktopApi(`${world.sessionApiBase}/${removed.sessionId}`)).status).toBe(404);
+        expect((await probe.desktopApi(`${world.sessionApiBase}/${neighbor.sessionId}`)).status).toBe(200);
+        const sessions = await agent.list();
+        expect(sessions.some(session => session.sessionId === removed.sessionId)).toBe(false);
+        expect(sessions.some(session => session.sessionId === neighbor.sessionId)).toBe(true);
+        const state = await world.readBrowserState();
+        expect(state.tabs).toEqual(baseline.tabs);
+        expect(state.nativeViews.map(view => view.tabId).sort()).toEqual(baseline.nativeViews.map(view => view.tabId).sort());
+        expect(state).toMatchObject({ activeTabId: neighborTab.tabId, visibleSessionId: neighbor.sessionId,
+          backgroundWindowCount: 0, backgroundWindowVisible: false, visibleWindowCount: 1 });
+        expect(await world.pageTargets()).toEqual(baselinePages);
+        return true;
+      }, { within: 30_000, label: "the deleted session and its pages disappear, including their empty hidden host" });
+      await user.notSee(conversation(removed.title));
+      await user.see(conversation(neighbor.title));
+      expect(await world.readInputProbe(shared)).toEqual({ clicks: 1, value: "shared" });
+      expect(await world.readInputProbe(neighborTab)).toEqual({ clicks: 1, value: "neighbor" });
+      expect(await world.clickAndType(neighborTab, "-kept")).toEqual({ clicks: 2, value: "neighbor-kept" });
+      expect(await world.pageTargets()).toEqual(baselinePages);
+    });
+});
+
+test("repeated refused navigations leave no allocated page or hidden host and keep the existing input alive", async ({ world, user, step }) => {
+  const reading = { ...world.session, title: "Reading during failed opens" };
+  await world.renameSession(reading.sessionId, reading.title);
+  const researching = await world.openSession("Retrying browser research");
+  await user.click(conversation(reading.title));
+  const readingTab = await world.openTabAs("failed-open-survivor", reading.sessionId);
+  await world.loadInputProbe(readingTab);
+  expect(await world.clickAndType(readingTab, "kept")).toEqual({ clicks: 1, value: "kept" });
+  const baseline = await eventually(() => world.readBrowserState(), {
+    within: 15_000, until: state => state.tabs.length === 1 && state.tabs[0].label === "input-probe"
+      && state.visibleSessionId === reading.sessionId && state.activeTabId === readingTab.tabId,
+    label: "the existing input page settles before failed navigation attempts",
+  });
+  expect(baseline.backgroundWindowCount).toBe(0);
+  const pages = await world.pageTargets();
+
+  await step("Foreground and background unsafe-port failures release their otherwise unreachable native pages", async () => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      // Chromium refuses this loopback port without depending on DNS or a server.
+      const ownerSessionId = attempt === 1 ? reading.sessionId : researching.sessionId;
+      await expect(world.openTabAs(`refused-${attempt}`, ownerSessionId, "http://127.0.0.1:1"))
+        .rejects.toThrow(/ERR_UNSAFE_PORT/);
+      await eventually(async () => {
+        const state = await world.readBrowserState();
+        expect(state.tabs).toEqual(baseline.tabs);
+        expect(state.nativeViews.map(view => view.tabId)).toEqual([readingTab.tabId]);
+        expect(state).toMatchObject({ activeTabId: readingTab.tabId, visibleSessionId: reading.sessionId,
+          backgroundWindowCount: 0, backgroundWindowVisible: false, visibleWindowCount: 1 });
+        expect(await world.pageTargets()).toEqual(pages);
+        return true;
+      }, { within: 15_000, label: `failed navigation ${attempt + 1} returns pages and hosts to baseline` });
+      expect(await world.readInputProbe(readingTab)).toEqual({ clicks: 1, value: "kept" });
+    }
+    expect(await world.clickAndType(readingTab, "-after")).toEqual({ clicks: 2, value: "kept-after" });
+  });
+
+  await step("A valid retry still opens a usable background page after the failures", async () => {
+    const recovered = await world.openTabAs("navigation-recovered", researching.sessionId);
+    expect((await world.readBrowserState()).tabs).toHaveLength(2);
+    await world.loadInputProbe(recovered);
+    expect(await world.clickAndType(recovered, "recovered")).toEqual({ clicks: 1, value: "recovered" });
+    expect(await world.readInputProbe(readingTab)).toEqual({ clicks: 2, value: "kept-after" });
+  });
+});
+
+test("moving the last background page on screen releases its hidden host and repeated create-close cycles return to baseline", async ({ world, user, step }) => {
+  const reading = { ...world.session, title: "Conversation without browser tabs" };
+  await world.renameSession(reading.sessionId, reading.title);
+  const researching = await world.openSession("Temporary browser research");
+  await user.click(conversation(reading.title));
+  const baseline = await eventually(() => world.readBrowserState(), {
+    within: 15_000, until: state => state.visibleSessionId === reading.sessionId,
+    label: "the empty reading conversation is on screen before counting native resources",
+  });
+  expect(baseline).toMatchObject({ tabs: [], nativeViews: [], backgroundWindowCount: 0 });
+  const pages = await world.pageTargets();
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    await step(`Create-close cycle ${cycle + 1} releases the empty host without replacing the live page`, async () => {
+      const tab = await world.openTabAs(`temporary-${cycle}`, researching.sessionId);
+      const hidden = await world.readBrowserState();
+      expect(hidden).toMatchObject({ visibleSessionId: reading.sessionId, backgroundWindowCount: 1,
+        backgroundWindowVisible: false, visibleWindowCount: 1 });
+      expect(hidden.nativeViews).toHaveLength(1);
+      expect(hidden.nativeViews[0]).toMatchObject({ tabId: tab.tabId, attached: false, aboveApp: false });
+      await world.loadInputProbe(tab);
+      expect(await world.clickAndType(tab, "background")).toEqual({ clicks: 1, value: "background" });
+      await user.click(conversation(researching.title));
+      const shown = await eventually(() => world.readBrowserState(), {
+        within: 15_000,
+        until: state => state.backgroundWindowCount === 0 && state.activeTabId === tab.tabId
+          && state.nativeViews.some(view => view.tabId === tab.tabId && view.attached && view.aboveApp),
+        label: "moving the last child to the sidebar destroys the empty hidden host",
+      });
+      expect(shown.tabs).toHaveLength(1);
+      expect(shown).toMatchObject({ visibleSessionId: researching.sessionId, backgroundWindowVisible: false, visibleWindowCount: 1 });
+      await eventually(async () => {
+        expect((await world.pageTargets()).filter(page => !pages.some(previous => previous.id === page.id)))
+          .toEqual([{ id: tab.targetId, url: shown.tabs[0].url }]);
+        return true;
+      }, { within: 15_000, label: "the hidden host target disappears while the same browser page remains" });
+      expect(await world.clickAndType(tab, "-shown")).toEqual({ clicks: 2, value: "background-shown" });
+      await user.click({ role: "button", label: "Close tab: input-probe" });
+      await user.click(conversation(reading.title));
+      await eventually(async () => {
+        const state = await world.readBrowserState();
+        expect(state).toMatchObject({ tabs: [], nativeViews: [], activeTabId: null, visibleSessionId: reading.sessionId,
+          backgroundWindowCount: 0, backgroundWindowVisible: false, visibleWindowCount: 1 });
+        expect(await world.pageTargets()).toEqual(pages);
+        return true;
+      }, { within: 15_000, label: "closing the page returns native resources and CDP targets to baseline" });
+    });
+  }
+});
+
 test("a background conversation's agent browses silently and its page is waiting when the user switches to it", async ({ world, user, step }) => {
   const reading = { ...world.session, title: "Reading the news" };
   await world.renameSession(reading.sessionId, reading.title);

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -74,6 +74,7 @@ test("the global tab limit rejects new pages without disturbing live tabs, and c
   await step("Closing a visible tab releases exactly one slot and the same request succeeds", async () => {
     const readingState = full.tabs.find(tab => tab.id === readingTab.tabId);
     if (!readingState) throw new Error("The reading tab is missing at capacity.");
+    await user.hover({ role: "button", label: `Select tab: ${readingState.label}` });
     await user.click({ role: "button", label: `Close tab: ${readingState.label}` });
     await eventually(async () => {
       expect((await world.readBrowserState()).tabs).toEqual(full.tabs.filter(tab => tab.id !== readingTab.tabId));
@@ -245,6 +246,7 @@ test("moving the last background page on screen releases its hidden host and rep
         return true;
       }, { within: 15_000, label: "the hidden host target disappears while the same browser page remains" });
       expect(await world.clickAndType(tab, "-shown")).toEqual({ clicks: 2, value: "background-shown" });
+      await user.hover({ role: "button", label: "Select tab: input-probe" });
       await user.click({ role: "button", label: "Close tab: input-probe" });
       await user.click(conversation(reading.title));
       await eventually(async () => {

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -2,7 +2,7 @@ import { browserScript, browserSource } from "@openwork/cdp";
 import { control } from "@openwork/behaviors";
 import { captureScreenshot, connect, debuggerUrlFor, evaluate, listTargets, navigate } from "@openwork/cdp";
 import type { AttachedSurface, CdpClient, Surface } from "@openwork/cdp";
-import type { Seed } from "@openwork/env";
+import { resolveEvalEngine, type Seed } from "@openwork/env";
 
 export interface BuiltinBrowserTab {
   tabId: string;
@@ -32,6 +32,8 @@ export interface BrowserState {
   activeTabId: string | null;
   visibleSessionId: string | null;
   visibleWindowCount: number;
+  tabLimit: number;
+  backgroundWindowCount: number;
   backgroundWindowVisible: boolean;
   tabs: BrowserTabState[];
   nativeViews: Array<{
@@ -75,10 +77,15 @@ function parseBrowserState(value: unknown): BrowserState {
   if (typeof value.visibleWindowCount !== "number" || typeof value.backgroundWindowVisible !== "boolean") {
     throw new Error("The desktop bridge did not report native window visibility.");
   }
+  if (typeof value.tabLimit !== "number" || typeof value.backgroundWindowCount !== "number") {
+    throw new Error("The desktop bridge did not report browser capacity and background host count.");
+  }
   return {
     activeTabId: typeof value.activeTabId === "string" ? value.activeTabId : null,
     visibleSessionId: typeof value.visibleSessionId === "string" ? value.visibleSessionId : null,
     visibleWindowCount: value.visibleWindowCount,
+    tabLimit: value.tabLimit,
+    backgroundWindowCount: value.backgroundWindowCount,
     backgroundWindowVisible: value.backgroundWindowVisible,
     nativeViews: value.nativeViews.map((view) => {
       if (!isRecord(view) || typeof view.attached !== "boolean" || typeof view.aboveApp !== "boolean"
@@ -173,6 +180,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     app,
     workspace,
     session,
+    sessionApiBase: `/workspace/${encodeURIComponent(workspace.workspaceId)}/${resolveEvalEngine() === "v2" ? "opencode2/api" : "opencode"}/session`,
 
     /** Persist a real transcript link and an attached file without invoking a model. */
     async seedTranscriptLink(sessionId: string) {
@@ -298,8 +306,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
      * reaches the UI command bus stamped with that conversation as its origin,
      * exactly as the OpenWork bridge stamps `openwork_execute` calls.
      */
-    async openTabAs(name: string, ownerSessionId: string): Promise<OpenedTab> {
-      const url = `${origin}/?viewport-probe=${encodeURIComponent(name)}`;
+    async openTabAs(name: string, ownerSessionId: string, url = `${origin}/?viewport-probe=${encodeURIComponent(name)}`): Promise<OpenedTab> {
       const result = await seed.evalIn(
         app,
         browserScript((value) => (window.__openworkControl.command(value)), [{
@@ -422,6 +429,14 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       ));
     },
 
+    /** Exclude the menu document, but include popups, hidden hosts, and all built-in pages. */
+    async pageTargets() {
+      return (await listTargets(app.handle.cdpUrl))
+        .filter(target => target.type === "page" && !/\/overlay\.html(?:[?#]|$)/.test(target.url))
+        .map(({ id, url }) => ({ id, url }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+    },
+
     /** Resolve a user-opened tab without opening or selecting another page. */
     async tabHandle(tab: BrowserTabState): Promise<BuiltinBrowserTab> {
       const targets = (await listTargets(app.handle.cdpUrl)).filter((target) => target.type === "page" && target.url === tab.url);
@@ -447,7 +462,10 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
         await navigate(client, INPUT_PROBE_PAGE);
         const deadline = Date.now() + 15_000;
         while (Date.now() < deadline) {
-          if ((await evaluate(client, () => (document.title))) === "input-probe") return;
+          if (await evaluate(client, () => (document.readyState === "complete"
+            && document.title === "input-probe"
+            && Boolean(document.getElementById("hit") && document.getElementById("field"))
+            && typeof window.__clicks === "number"))) return;
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
         throw new Error("The input probe page did not load in the built-in browser tab.");
@@ -566,14 +584,6 @@ export async function transcriptLinkWorld(seed: Seed, world: Awaited<ReturnType<
 
     async readClipboard() {
       return evaluate(app.client, () => (navigator.clipboard.readText()), { awaitPromise: true });
-    },
-
-    /** Exclude the menu document, but include popups and all built-in pages. */
-    async pageTargets() {
-      return (await listTargets(app.handle.cdpUrl))
-        .filter(target => target.type === "page" && !/\/overlay\.html(?:[?#]|$)/.test(target.url))
-        .map(({ id, url }) => ({ id, url }))
-        .sort((a, b) => a.id.localeCompare(b.id));
     },
 
     /** Attach to the real WebContentsView, never invoke its choice/close bridge. */


### PR DESCRIPTION
## Summary
Keep conversation-owned browser tabs without allowing native page allocations to grow without a bound.

- Limit the built-in browser to 12 tabs across conversations, checked synchronously before allocation. At capacity, show an actionable error; do not evict, navigate, or replace an existing document.
- Roll back pages allocated by unsuccessful browser-open requests, including CDP target-discovery and navigation failures.
- Close only the deleted conversation’s pages after confirmed deletion, through both direct deletion and session-event paths. Preserve shared tabs and other conversations.
- Release empty hidden browser hosts on close and foreground restoration, and clean up externally destroyed CDP targets.
- Extend the existing browser ownership journey; show tab-creation errors through the existing toast.

## Behavior and tradeoffs
Conversation ownership, shared login storage, live documents, CDP handles, and background browsing remain intact. Switching conversations, hiding the panel, or finishing a task does not discard a page. At 12 tabs, close an unused tab in any conversation before opening another.

This bounds retained page count, not Chromium helper count or bytes of memory. It does not claim a measured RAM reduction. Automatic idle-page discarding and macOS memory benchmarking are deferred: URL-only restoration would lose unsaved input and existing CDP handles.

## Verification — Incomplete
Current head: `adae1f9c99eac0a15d442e9ff7a0d3af61536e1f`.

Passed on this head:
- `node --test apps/desktop/electron/browser-panel.test.mjs` — exit 0; 19 passed, 0 failed, 0 skipped. Colocated unit checks, not journey proof.
- `pnpm evals:check-browser` — exit 0; 728 browser callbacks checked.
- `git diff --check` — exit 0.

Earlier exact-head journey attempt on `d4e9b98d8a4e2756dc6f615cf1a5802437cbb0ae`:
```sh
OPENWORK_EVAL_REF=d4e9b98d8a4e2756dc6f615cf1a5802437cbb0ae OPENWORK_EVAL_DAYTONA_REF=d4e9b98d8a4e2756dc6f615cf1a5802437cbb0ae pnpm evals:e2e browser-tabs-owned-by-thread
```
Placement: `daytona (daytona CLI authenticated)`.
- 3 completed tests passed: session-deletion isolation, failed-open rollback/recovery, and existing silent background browsing.
- 2 completed tests failed when the scripts clicked hover-only close buttons before revealing them. Added the missing hover interactions in the second commit; these corrections have not been re-proved.
- 2 tests did not complete before the execution wrapper terminated the command at 20 minutes. These are not skips, and there is no completed aggregate runner exit code.
- The initial unpinned attempt selected dev and timed out; it is not candidate proof. Retained sandboxes from interrupted attempts were deleted.

The earlier run is historical evidence only. A complete cold-boot, current-head journey run and its published evidence remain required before claiming Passed. No current-head runtime verdict or memory benchmark is claimed.

Reproduce on this head:
```sh
OPENWORK_EVAL_REF=adae1f9c99eac0a15d442e9ff7a0d3af61536e1f OPENWORK_EVAL_DAYTONA_REF=adae1f9c99eac0a15d442e9ff7a0d3af61536e1f pnpm evals:e2e browser-tabs-owned-by-thread
```
Allow more than 20 minutes for the seven isolated desktop journeys, then publish the head-matching test runs with `pnpm evals:e2e --publish --pr <number> --test-run <run>`.

No merge, release, or deployment is included.