### PR TITLE
fix(den): share dashboard apps without repeat sign-in

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2547,9 +2547,9 @@ export async function listMeLibraryConnectionItems(input: {
   })
 }
 
-export async function createResourceAccessGrant(input: { context: PluginArchActorContext; value: AccessGrantWrite } & ResourceTarget) {
+export async function createResourceAccessGrant(input: { context: PluginArchActorContext; requireFreshSession?: boolean; value: AccessGrantWrite } & ResourceTarget) {
   await ensureResourceInOrganization(input.context, input)
-  await requirePluginArchResourceRole({ context: input.context, resourceId: input.resourceId, resourceKind: input.resourceKind, role: "manager" })
+  await requirePluginArchResourceRole({ context: input.context, requireFreshSession: input.requireFreshSession, resourceId: input.resourceId, resourceKind: input.resourceKind, role: "manager" })
   if (input.value.orgWide === true && !isPluginArchOrgAdmin(input.context)) {
     throw new PluginArchAuthorizationError(403, "forbidden", "Only organization owners and admins can grant org-wide access.")
   }

--- a/ee/apps/den-api/src/saved-apps.ts
+++ b/ee/apps/den-api/src/saved-apps.ts
@@ -23,7 +23,9 @@ export async function shareSavedApp(context: PluginArchActorContext, appId: stri
   const resource: { context: PluginArchActorContext; resourceId: DenTypeId<"configObject">; resourceKind: "config_object" } = {
     context, resourceId: normalizeDenTypeId("configObject", view.configObjectId), resourceKind: "config_object",
   }
-  await requirePluginArchResourceRole({ ...resource, role: "manager" })
+  // Sharing a saved app with a teammate uses the existing signed-in session.
+  // Keep manager authorization without the step-up required by general access management.
+  await requirePluginArchResourceRole({ ...resource, requireFreshSession: false, role: "manager" })
   const organizationId = context.organizationContext.organization.id
   const [member] = await db.select({ id: MemberTable.id }).from(MemberTable)
     .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
@@ -33,7 +35,7 @@ export async function shareSavedApp(context: PluginArchActorContext, appId: stri
   const grants = await listResourceAccess(resource)
   // Repeated shares must not downgrade an existing editor or manager grant.
   if (!grants.items.some((grant) => grant.orgMembershipId === member.id && !grant.removedAt)) {
-    await createResourceAccessGrant({ ...resource, value: { orgMembershipId: member.id, orgWide: false, role: "viewer" } })
+    await createResourceAccessGrant({ ...resource, requireFreshSession: false, value: { orgMembershipId: member.id, orgWide: false, role: "viewer" } })
   }
   const id = normalizeDenTypeId("artifactView", view.id)
   await db.insert(DashboardAppTable).values({ organization_id: organizationId, member_id: member.id, artifact_view_id: id })

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 import { saveWorkflow, runWorkflow } from "@openwork/behaviors";
 import { spec } from "@openwork/testkit";
-import { creationPrompt, creationReply, field, record, savedAppCreation } from "../worlds/saved-apps.ts";
+import { creationPrompt, creationReply, field, record, savedAppCreation, savedAppSharing } from "../worlds/saved-apps.ts";
 
 const test = spec.world(savedAppCreation, { timeout: 900_000 });
 
@@ -196,6 +196,7 @@ test("create, preview, save and reopen an app without changing already-open resu
 
   // Keep an exact preview mounted while another client changes the saved app.
   await world.open(`/dashboard${originalPath}`);
+  await user.see({ text: "Saved app" }, { timeoutMs: 30_000 });
   await probe.eventually(() => world.previewText(), { within: 30_000, label: "original preview mounted", until: (text) => text.includes("Weekly overview") && text.includes("Launch briefing") });
   await world.showDetails();
   const mountedText = await world.previewText();
@@ -295,6 +296,59 @@ test("create, preview, save and reopen an app without changing already-open resu
   });
   evidence.recordAssertionEvidence("Members can delete their own apps but cannot delete another member's private app", "The member created and retired their own saved app, removing its placement and workflow selection while preserving historical results; deleting the admin's app was rejected and that app stayed saved.", true);
 
+  const beforeDelete = await readWorkflow();
+  const beforeDeleteSnapshots = (await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body;
+  await step("an admin cancels deletion in the app and confirms it on the dashboard", async () => {
+    await world.open(dashboardAppPath);
+    await user.click("App options for Team briefing");
+    await user.click("Delete Team briefing");
+    await user.see({ text: "Delete “Team briefing”?" });
+    await user.see({ text: "This removes the saved app from everyone’s dashboards and the app list. Its workflow and past results stay available." });
+    await user.screenshot();
+    await user.click("Cancel");
+    expect((await readApp()).onDashboard).toBe(true);
+    await world.open("/dashboard");
+    await user.click("App options for Team briefing");
+    await user.click("Delete Team briefing");
+    await user.click("Delete app");
+    await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });
+    await user.reload();
+    await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });
+    expect(record((await probe.api(world.den.admin, "/v1/apps")).body).items).toEqual([]);
+    expect((await readApp(originalPath))).toMatchObject({ onDashboard: false, view: { status: "retired", activeRevisionId: null }, payload: { data: { topic: "Launch briefing" } } });
+    expect((await readWorkflow()).currentVersion).toEqual(beforeDelete.currentVersion);
+    expect((await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body).toEqual(beforeDeleteSnapshots);
+    expect((await probe.api(world.den.admin, `/v1/dashboards/${world.dashboardId}`)).body).toEqual(companyBefore);
+    const readd = await seed.api(world.den.admin, `/v1/apps/${appId}/dashboard`, { method: "POST", body: JSON.stringify({ added: true }) });
+    expect(readd.response.status).toBe(404);
+    await user.screenshot();
+  });
+  evidence.recordAssertionEvidence("Admins can delete their own apps from the dashboard after a clear confirmation", "Delete is available in the open app and dashboard. Cancel preserves it; confirming removes it across reloads while retaining the workflow, historical results, and unrelated company dashboard.", true);
+
+  await step("Dashboard Add opens a creation conversation", async () => {
+    await world.open("/dashboard");
+    await user.click({ role: "button", label: "Add" });
+    await user.see("Choose an existing app");
+    await user.screenshot();
+    await user.click("Create with OpenWork");
+    await probe.eventually(() => probe.composer(), { within: 30_000, label: "app creation prompt", until: (composer) => JSON.stringify(composer).includes("Create a reusable app for my dashboard that") });
+    await user.screenshot();
+  });
+});
+
+spec.world(savedAppSharing, { timeout: 900_000 })("share dashboard apps with an aged authenticated desktop session", async ({ world, user, probe, seed, step, evidence }) => {
+  const { appId } = world;
+  const colleague = world.den.members.colleague;
+  if (!colleague) throw new Error("The second identity was not provisioned.");
+  const companyBefore = (await probe.api(world.den.admin, `/v1/dashboards/${world.dashboardId}`)).body;
+  const readApp = async () => {
+    const response = await probe.api(world.den.admin, `/v1/apps/${appId}`);
+    expect(response.response.status, response.text).toBe(200);
+    return record(response.body);
+  };
+  await world.open("/dashboard");
+  await user.see({ role: "button", label: "Share" });
+
   // Use a separate workflow so sharing the selected app cannot grant indirect access to this one.
   const privateInput = { topic: "Private planning" };
   const privateCode = 'return { topic: input.topic };';
@@ -334,17 +388,37 @@ test("create, preview, save and reopen an app without changing already-open resu
   expect(unpinCompanion.response.status, unpinCompanion.text).toBe(200);
   expect((await probe.api(colleague, `/v1/apps/${companionAppId}`)).response.status).toBe(403);
 
-  await step("share dashboard apps with a teammate", async () => {
+  await step("share dashboard apps with a teammate without a second login", async () => {
     await world.open("/dashboard");
+    await user.reload();
+    await user.see("Open Private planning");
+    const signedIn = await world.desktopIdentity();
+    expect(signedIn).toMatchObject({ email: world.den.admin.email, usesAdminToken: true });
+    await world.ageSession(signedIn.sessionId);
+    const aged = await world.desktopIdentity();
+    expect(aged).toMatchObject({ sessionId: signedIn.sessionId, userId: signedIn.userId, email: signedIn.email, usesAdminToken: true });
+    expect(Date.now() - Date.parse(aged.createdAt)).toBeGreaterThanOrEqual(19 * 60_000);
+    expect(Date.parse(aged.expiresAt)).toBeGreaterThan(Date.now());
+    const expectOrdinaryGrantReauth = async () => {
+      const denied = await seed.api(world.den.admin, `/v1/config-objects/${privateWorkflowId}/access`, {
+        method: "POST", body: JSON.stringify({ orgWide: true, role: "viewer" }),
+      });
+      expect(denied.response.status, denied.text).toBe(403);
+      expect(denied.body).toMatchObject({ error: "reauth", reason: "fresh_auth_required" });
+      expect((await probe.api(colleague, `/v1/workflows/${privateWorkflowId}`)).response.status).toBe(403);
+    };
+    await expectOrdinaryGrantReauth();
     await user.click({ role: "button", label: "Share" });
     await user.see({ text: "Share your dashboard" });
     await user.click("Cancel");
+    await user.notSee({ text: "Share your dashboard" });
     expect((await probe.api(colleague, `/v1/apps/${appId}`)).response.status).toBe(403);
     const deniedShare = await seed.api(colleague, `/v1/apps/${appId}/share`, {
       method: "POST", body: JSON.stringify({ email: world.den.admin.email }),
     });
     expect(deniedShare.response.status).toBe(403);
     await user.click({ role: "button", label: "Share" });
+    await user.see({ text: "Share your dashboard" });
     await user.click({ role: "checkbox", label: "Private planning" });
     await user.screenshot();
     await user.type({ label: "Teammate’s email" }, "unknown@openwork.test");
@@ -354,14 +428,16 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.type({ label: "Teammate’s email" }, colleague.email, { replace: true });
     await user.click("Share apps");
     await user.see({ text: `Shared 1 app with ${colleague.email}. They’ll appear when your teammate opens or reloads their dashboard.` }, { timeoutMs: 30_000 });
+    expect(await world.desktopIdentity()).toEqual(aged);
+    await expectOrdinaryGrantReauth();
     const sharedApp = await probe.api(colleague, `/v1/apps/${appId}`);
     expect(sharedApp.response.status, sharedApp.text).toBe(200);
-    expect(sharedApp.body).toMatchObject({ onDashboard: true, canManage: false, view: { id: appId }, payload: { data: { topic: "Next week’s briefing" } } });
+    expect(sharedApp.body).toMatchObject({ onDashboard: true, canManage: false, view: { id: appId }, payload: { data: { topic: "Launch briefing" } } });
     const sharedWorkflow = await probe.api(colleague, `/v1/workflows/${world.configObjectId}`);
     expect(sharedWorkflow.response.status, sharedWorkflow.text).toBe(200);
     const companion = await probe.api(colleague, `/v1/apps/${companionAppId}`);
     expect(companion.response.status, companion.text).toBe(200);
-    expect(companion.body).toMatchObject({ onDashboard: false, canManage: false, view: { id: companionAppId }, payload: { data: { topic: "Next week’s briefing" } } });
+    expect(companion.body).toMatchObject({ onDashboard: false, canManage: false, view: { id: companionAppId }, payload: { data: { topic: "Launch briefing" } } });
     const repeat = await seed.api(world.den.admin, `/v1/apps/${appId}/share`, {
       method: "POST", body: JSON.stringify({ email: colleague.email }),
     });
@@ -383,6 +459,7 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.screenshot();
     await user.click("Done");
   });
+  evidence.recordAssertionEvidence("An authenticated desktop can share dashboard apps without a second login after its session becomes stale", "The desktop's actual bearer session still authenticated as the same admin after its creation time was aged by 20 minutes. Ordinary access grants returned fresh_auth_required before and after sharing without exposing the private workflow. Dashboard Share succeeded through the UI with the same session ID and aged creation time, without a login or session refresh.", true);
   evidence.recordAssertionEvidence("Dashboard Share grants a teammate view access and adds the selected app to their dashboard", "Cancel and an unknown email left the app private. Sharing made one saved app visible on the recipient dashboard without manager access; repeat sharing did not duplicate it, the unchecked app and its separate workflow remained private, viewers could not reshare, and company dashboards stayed unchanged.", true);
   evidence.recordAssertionEvidence("Sharing includes the workflow, saved results, and sibling apps without adding every sibling to the dashboard", "The recipient could read the workflow and the latest saved result in both the selected app and its previously inaccessible companion. Both appeared in the accessible app list, but only the selected app was on their dashboard; the separate private workflow stayed inaccessible.", true);
 
@@ -390,43 +467,4 @@ test("create, preview, save and reopen an app without changing already-open resu
   expect(cleanupCompanion.response.status, cleanupCompanion.text).toBe(200);
   const cleanupPrivate = await seed.api(world.den.admin, `/v1/artifact-views/${privateAppId}/retire`, { method: "POST" });
   expect(cleanupPrivate.response.status, cleanupPrivate.text).toBe(200);
-
-  const beforeDelete = await readWorkflow();
-  const beforeDeleteSnapshots = (await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body;
-  await step("an admin cancels deletion in the app and confirms it on the dashboard", async () => {
-    await world.open(dashboardAppPath);
-    await user.click("App options for Team briefing");
-    await user.click("Delete Team briefing");
-    await user.see({ text: "Delete “Team briefing”?" });
-    await user.see({ text: "This removes the saved app from everyone’s dashboards and the app list. Its workflow and past results stay available." });
-    await user.screenshot();
-    await user.click("Cancel");
-    expect((await readApp()).onDashboard).toBe(true);
-    await world.open("/dashboard");
-    await user.click("App options for Team briefing");
-    await user.click("Delete Team briefing");
-    await user.click("Delete app");
-    await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });
-    await user.reload();
-    await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });
-    expect(record((await probe.api(world.den.admin, "/v1/apps")).body).items).toEqual([]);
-    expect((await readApp(originalPath))).toMatchObject({ onDashboard: false, view: { status: "retired", activeRevisionId: null }, payload: { data: { topic: "Launch briefing" } } });
-    expect((await readWorkflow()).currentVersion).toEqual(beforeDelete.currentVersion);
-    expect((await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body).toEqual(beforeDeleteSnapshots);
-    expect((await probe.api(world.den.admin, `/v1/dashboards/${world.dashboardId}`)).body).toEqual(companyBefore);
-    const readd = await seed.api(world.den.admin, `/v1/apps/${appId}/dashboard`, { method: "POST", body: JSON.stringify({ added: true }) });
-    expect(readd.response.status).toBe(404);
-    await user.screenshot();
-  });
-  evidence.recordAssertionEvidence("Admins can delete their own apps from the dashboard after a clear confirmation", "Delete is available in the open app and dashboard. Cancel preserves it; confirming removes it across reloads while retaining the workflow, historical results, and unrelated company dashboard.", true);
-
-  await step("Dashboard Add opens a creation conversation", async () => {
-    await world.open("/dashboard");
-    await user.click({ role: "button", label: "Add" });
-    await user.see("Choose an existing app");
-    await user.screenshot();
-    await user.click("Create with OpenWork");
-    await probe.eventually(() => probe.composer(), { within: 30_000, label: "app creation prompt", until: (composer) => JSON.stringify(composer).includes("Create a reusable app for my dashboard that") });
-    await user.screenshot();
-  });
 });

--- a/evals/worlds/saved-apps.ts
+++ b/evals/worlds/saved-apps.ts
@@ -1,7 +1,8 @@
 import { browserScript } from "@openwork/cdp";
-import type { Seed } from "@openwork/env";
-import { go, runWorkflow, saveWorkflow } from "@openwork/behaviors";
+import { queryDenDatabase, type Seed } from "@openwork/env";
+import { denFetch, go, runWorkflow, saveWorkflow } from "@openwork/behaviors";
 import { connect, debuggerUrlFor, evaluate, listTargets } from "@openwork/cdp";
+import { defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
 import { configureProvider } from "./chat.ts";
 
 export const creationPrompt = "Create a reusable app for my dashboard that shows a weekly briefing using my existing Weekly briefing workflow.";
@@ -23,12 +24,20 @@ export function field(value: unknown, key: string): string {
 
 export async function savedAppCreation(seed: Seed) {
   const den = await seed.den({
-    env: { DEN_GENERATED_ARTIFACT_VIEWS_ENABLED: "true", DEN_DASHBOARDS_ENABLED: "true" },
+    env: {
+      DEN_GENERATED_ARTIFACT_VIEWS_ENABLED: "true", DEN_DASHBOARDS_ENABLED: "true",
+      // Whitespace bypasses the dev script's empty-value Redis default, then
+      // normalizes to unconfigured. SQL session aging must not hit a warm cache.
+      DATABASE_REDIS_URL: " ",
+    },
     org: { name: `Saved Apps ${Date.now()}`, members: { colleague: { name: "Colleague" } } },
     mocks: {
       tracker: seed.mock({ allowUnauthenticatedMcp: true, appToolName: "search_issues_using_jql" }),
     },
   });
+  if (!den.placement || (den.placement.kind === "local" && !den.database)) {
+    throw new Error("Session aging requires a disposable Den with its own database, not an attached server.");
+  }
   const connection = await seed.orgConnection(den.admin, {
     name: "Issue tracker", url: den.mocks.tracker.mcpUrl,
     authType: "none", credentialMode: "shared", access: { orgWide: true },
@@ -135,6 +144,31 @@ export async function savedAppCreation(seed: Seed) {
   };
   return {
     app, den, proxy, resetProxy, workspace, configObjectId, dashboardId, rpc, run,
+    async desktopIdentity() {
+      const token = await evaluate(app.client, () => localStorage.getItem("openwork.den.authToken"));
+      if (typeof token !== "string" || !token) throw new Error("The desktop has no authenticated Den session.");
+      const response = await denFetch(den.ref, "/v1/me", { headers: { authorization: `Bearer ${token}` } });
+      if (response.response.status !== 200) throw new Error(`Desktop identity request failed (${response.response.status}).`);
+      const body = record(response.body);
+      return {
+        sessionId: field(body.session, "id"), createdAt: field(body.session, "createdAt"),
+        expiresAt: field(body.session, "expiresAt"), userId: field(body.user, "id"),
+        email: field(body.user, "email"), usesAdminToken: token === den.admin.token,
+      };
+    },
+    async ageSession(sessionId: string) {
+      const id = `0x${Buffer.from(sessionId).toString("hex")}`;
+      const statement = `UPDATE session SET created_at=DATE_SUB(NOW(3), INTERVAL 20 MINUTE) WHERE CAST(id AS BINARY)=${id};`;
+      if (den.placement?.kind === "daytona") {
+        await execInSandbox(defaultDaytonaExec, den.placement.sandboxId,
+          `echo ${Buffer.from(statement).toString("base64")} | base64 -d | mysql -h127.0.0.1 -uroot -ppassword -N openwork_den`,
+          { timeoutMs: 30_000, context: "Saved-app desktop session aging" });
+      } else if (den.database) {
+        await queryDenDatabase(den.database.url, statement);
+      } else {
+        throw new Error("Session aging requires the disposable Den database.");
+      }
+    },
     open: (path: string) => go(app, path),
     previewText: async () => String(await inPreview("read")),
     showDetails: () => inPreview("details"),
@@ -148,4 +182,20 @@ export async function savedAppCreation(seed: Seed) {
       return field(next.revisions[0], "id");
     },
   };
+}
+
+export async function savedAppSharing(seed: Seed) {
+  const world = await savedAppCreation(seed);
+  const built = await world.rpc("save_artifact_view", {
+    configObjectId: world.configObjectId, title: "Team briefing",
+    reactSource: 'export default function Briefing({data}) { return <p>{data.topic}</p> }',
+  });
+  const view = record(record(built.structuredContent).view);
+  const appId = field(view, "id");
+  if (!Array.isArray(view.revisions) || !view.revisions[0]) throw new Error("Sharing app has no revision.");
+  const saved = await seed.api(world.den.admin, `/v1/apps/${appId}/save`, {
+    method: "POST", body: JSON.stringify({ revisionId: field(view.revisions[0], "id"), title: "Team briefing", useInWorkflow: true, expectedActiveRevisionId: null }),
+  });
+  if (saved.response.status !== 200) throw new Error(`Sharing app setup failed: ${saved.text}`);
+  return { ...world, appId };
 }


### PR DESCRIPTION
## Summary

An already signed-in desktop user should not need to sign in again to share a saved dashboard app with a teammate.

- Skip privileged-session freshness only for the saved-app sharing operation, including its viewer-grant creation.
- Preserve authentication, manager authorization, same-organization recipient checks, and stronger existing access grants. General access-management mutations still require a fresh privileged session.
- Exercise sharing independently in the existing saved-app journey with a real desktop session aged 20 minutes. Keep the preview-continuity assertion and wait for the destination header before capturing its mounted state.

The exception is scoped to the sharing operation, not a client header, so authenticated web callers use the same behavior. This does not enable anonymous sharing or remove sign-in requirements for private apps.

## Verification — Failed

Head: `1861db68b4fb9ac9619f076658755b5072ed9dd0`

`pnpm evals:e2e saved-app-creation --local`

Placement: `local (--local)`; exit 1; **1 passed, 1 failed, 0 skipped**.

- **Passed:** aged-session desktop sharing through the UI without another login or a refreshed session. Ordinary access grants still return `fresh_auth_required` before and after sharing; viewers cannot reshare, unchecked private content stays private, and recipient placement/access boundaries remain intact.
- **Failed:** the creation/preview journey timed out waiting for the preview's Save button after creation. It failed before reaching the sharing behavior. Its cause has not been established against a clean-base control; this PR does not claim the broader journey is green.
- **Passed:** `git diff --check`.
- **Deferred:** cloud-placement verification and the unresolved creation-preview failure. The local sharing result is not a replacement verdict for the earlier incomplete cloud attempt.

No merge or deployment is included.
