### PR TITLE
feat(den): disable managed Models for DPA organizations

### DIFF
--- a/docs/features/managed-models-dpa.md
+++ b/docs/features/managed-models-dpa.md
@@ -1,0 +1,172 @@
+# DPA organizations and company-provided Models
+
+## Policy and storage
+
+The existing `organization.metadata` JSON column holds the decision. No migration,
+new column, or new table is required. The canonical top-level key is a boolean:
+
+```json
+{
+  "dpaSigned": true,
+  "inference": { "enabled": true, "tier": "tier1" },
+  "unrelatedSetting": { "retained": true }
+}
+```
+
+The shared contract is `@openwork/types/den/managed-models-policy`.
+
+- `dpaSigned: true`: company-provided OpenWork Models are forbidden.
+- Missing `dpaSigned` or explicit `false`: existing eligibility is unchanged.
+- Any present non-boolean value, malformed metadata, an array/scalar document,
+  a missing organization, or a failed policy lookup: do not authorize Models.
+- A known organization's SQL-null metadata is an empty metadata document.
+- The reader also supports legacy serialized JSON objects written through
+  Better Auth. Writers persist an object in the JSON column, not serialized JSON.
+
+This is organization-scoped. The inference key's authenticated organization is
+authoritative; request bodies, organization headers, another membership, provider
+names, and model aliases cannot select a different policy scope.
+
+## Trusted administration
+
+Use the existing Den authenticated platform-admin API:
+
+```http
+PATCH /v1/admin/organizations/{organizationId}/dpa
+Content-Type: application/json
+Authorization: Bearer <authorized internal credential>
+
+{"dpaSigned":true,"reason":"Internal approval reference"}
+```
+
+The caller must be an authenticated user on the platform-admin allowlist. Being
+an organization owner or administrator is insufficient. The body is strict:
+`dpaSigned` is a required boolean; `reason` is trimmed, 3–500 characters; additional
+fields are rejected. Use `false` through this same operation to unset.
+
+Successful response:
+
+```json
+{"ok":true,"organization":{"id":"<organizationId>","dpaSigned":true}}
+```
+
+The operation locks and rereads the current organization row, preserves all other
+metadata, and atomically inserts `organization.dpa_signed.updated` into the
+existing audit table. Audit payload: `previousDpaSigned` (boolean, or null when
+absent/non-boolean), `dpaSigned`, and `reason`; actor comes from authentication.
+An audit insert failure rolls the metadata change back. Do not put confidential
+legal correspondence in the reason or organization metadata.
+
+Ordinary organization create/profile APIs accept named fields and reject injected
+metadata/DPA fields. Raw Better Auth creation rejects the reserved key (including
+false); metadata replacement through Better Auth is rejected, including an empty
+object that would erase the decision. Existing general metadata writers reread
+under row locks, so a stale settings/plan/billing snapshot cannot erase the flag.
+Corrupt top-level metadata is not normalized into an authorizing empty object.
+Repair a corrupt document through a separately reviewed internal maintenance
+change; this endpoint does not guess how to recover unrelated data. A readable
+object with an invalid flag can be repaired explicitly through this audited API.
+
+No production SQL workaround or automatic production rollout is provided.
+
+## Enforcement and errors
+
+The inference service performs an **uncached database policy check** after key
+authentication (before catalog/body processing), and another immediately before
+its sole upstream fetch, after quota, upstream-key, and analytics awaits.
+
+| Condition | Status | Code |
+| --- | --- | --- |
+| DPA signed | 403 | `managed_models_disabled_for_dpa` |
+| Policy cannot be verified | 503 | `managed_models_policy_unavailable` |
+
+The inference API uses its existing OpenAI-style envelope:
+
+```json
+{
+  "error": {
+    "type": "invalid_request_error",
+    "code": "managed_models_disabled_for_dpa",
+    "message": "Company-provided OpenWork Models are unavailable for this organization because a DPA is signed. Permitted customer-key providers and AI Gateway may still be used."
+  }
+}
+```
+
+Den enable/checkout APIs use their existing `{ "error": "<code>", "message":
+"<explanation>" }` convention with the same 403/503 status. Unauthenticated or
+invalid-key requests retain their existing authentication errors.
+
+Managed member-key/provider provisioning is serialized with metadata marking by
+locking the organization row and checking current policy in the same transaction
+as the key, provider, and grant writes. Read/repair/member-join paths skip denied
+managed provisioning. Enablement rereads policy in its metadata transaction.
+Inference purchases check before Stripe work and immediately before checkout
+dispatch. Late successful checkouts/webhooks still record subscription history,
+but DPA denial does not activate Models or cause endless policy-denial retries.
+An unavailable policy remains a retryable failure.
+
+Usable provider lists, resource snapshots, and Web materialization exclude
+company-managed (`source: openwork`) configurations when policy denies them.
+Automation model authority rejects the OpenWork Models branch. In a list/connect
+race, direct managed connect deliberately stays HTTP 200 with null credentials,
+empty models, `memberCredential.state: blocked`, and `managedModelsPolicy` denial,
+so older desktops do not abort unrelated BYOK synchronization.
+
+These inventory checks are not the security boundary: even an old, renamed,
+manually copied, or locally cached managed key still reaches the policy-enforcing
+inference proxy. A customer-owned `custom`/`models_dev` provider using OpenRouter,
+OpenAI, or overlapping branding remains permitted. No hostname blacklist is used.
+
+## Caches and in-flight work
+
+- There is no managed-policy decision cache to invalidate. Both inference reads
+  use the database, not cached entitlements, sessions, catalogs, or provider data.
+- The marker does not revoke keys, force sign-out, rotate BYOK credentials, cancel
+  subscriptions, issue refunds, or delete providers/history. Unsetting restores
+  policy eligibility; all other existing access and entitlement checks still apply.
+- Desktop/Web inventories may remain visually stale until normal reconciliation.
+  Such stale entries cannot bypass the proxy. No UI redesign or silent fallback
+  to a different provider is introduced.
+- A request paused in preparation is checked again before dispatch. Client retries
+  are new requests and repeat policy checks. The proxy has no internal model retry
+  or fallback; redirects are rejected rather than following an unchecked dispatch.
+- Requests already transmitted upstream cannot be recalled and may finish,
+  including streaming responses. This is not a distributed cancellation/drain
+  protocol: the final policy read is the admission point. A change racing after
+  that read cannot retract an already-admitted fetch or bytes queued by the HTTP
+  transport. Do not claim the setter's return is a cross-replica egress barrier.
+- An upstream management-key create already transmitted before marking can finish
+  afterward; attachment to the organization is denied on the locked recheck. This
+  can leave an unattached upstream key requiring authorized internal reconciliation.
+  It is not automatically revoked. Similarly, a Stripe customer/session already
+  created or dispatched is not automatically canceled; later activation is blocked.
+
+Continuing charges, subscription cancellation, refunds, and stricter draining of
+already-admitted work require separate business/engineering decisions.
+
+## Safe staging rollout/check procedure (not executed)
+
+1. Deploy the shared package and enforcement to **all staging inference replicas**,
+   then staging Den's guarded writers/admin/provisioning routes. Do not rely on
+   marking while any old inference binary is still serving. No schema migration.
+2. Use synthetic staging organizations and deterministic local upstream witnesses;
+   never real customer prompts or paid inference. Keep one unmarked control org and
+   the same synthetic user in both organizations. Issue a managed key before marking.
+3. Run `pnpm evals:pr specs/managed-models-dpa.test.ts` on the exact candidate tree.
+   Inspect every assertion and confirm zero external HTTP attempts.
+4. Through the allowlisted staging admin API above, set true with an internal
+   reference. Verify the audit row, preservation of unrelated metadata, and 403
+   plus zero witness dispatch for the old key on every serving replica. Verify
+   ordinary owners cannot clear the marker and checkout/repair cannot restore use.
+5. Verify customer-key Gateway routing, including an OpenRouter-branded provider,
+   remains usable; verify control-org managed access remains usable. Exercise a
+   running staging desktop/Web session and automation before and after marking to
+   observe inventory reconciliation as well as the authoritative inference denial.
+6. Unset only with approved staging authority, verify a second audit transition and
+   original-key access if otherwise entitled, then restore the intended test state.
+7. Before any separately authorized production rollout, review billing treatment,
+   monitor 403/503 rates, and obtain explicit organization-specific authorization.
+   Rollback must retain enforcement on every serving inference replica for marked
+   organizations; rolling back to an unaware binary would reopen their access.
+
+See `docs/pr-proof/dpa-opt-out.md` for the local verification record and its limits.

--- a/docs/pr-proof/dpa-opt-out.md
+++ b/docs/pr-proof/dpa-opt-out.md
@@ -1,0 +1,173 @@
+<!-- test-evidence -->
+# DPA managed Models: local implementation and verification
+
+Date: 2026-09-08. Branch: `dpa-opt-out`. Starting HEAD:
+`5f8a802cacc36003aca7d9a2a0283048bb3c1b78`.
+This records the initial **pre-commit verification**; these receipts identify the
+starting SHA and were run against the modified working tree. PR-head verification
+is rerun after committing and published in the PR's test-evidence comments. No
+deployment, live organization mutation, or live key revocation was performed.
+
+## Boundary verdict: Passed
+
+```text
+pnpm evals:pr specs/managed-models-dpa.test.ts
+placement: local (testkit resolvePlace; isolated app-less Den and inference)
+exit 0; 1 passed; 0 failed; 0 skipped; 17 assertion groups passed
+```
+
+Final cold run: 29.64 seconds total, 29.00 seconds test time. Runner-selected
+placement, no forced local flag or reused Den.
+
+Receipt (worktree-relative):
+`evals/results/test-runs/2026-09-08T18-12-14-560Z-dpa-policy-blocks-warm-managed-keys-without-revoking-customer-owned-models-or-an/test-run.json`
+
+The receipt records each assertion's result and explanation. This new spec is a
+genuinely new legal-policy access lifecycle journey, not another analytics or
+team-role journey. It reuses the existing Models world and upstream witness;
+the spec calls real HTTP boundaries rather than importing product source.
+
+### Observed assertions
+
+1. Absent flag permits a real DB-backed managed key and one authenticated upstream
+   completion.
+2. Only allowlisted platform admins can set/unset; owner/member/foreign/anonymous
+   attempts and invalid bodies do not change metadata or audits.
+3. The same warm key/session is denied after marking. Spoofed organization inputs,
+   retries, and fallback payloads produce zero upstream dispatches. The same user's
+   distinct key in a second organization remains usable.
+4. A datastore-arranged managed-provider rename does not turn it into BYOK.
+5. Provider inventory/resource discovery hide managed entries; direct connect is
+   compatible and redacted. Enable/default/explicit inference checkout deny without
+   new keys or external HTTP attempts.
+6. GET repair cannot recreate arranged missing managed access.
+7. Actual invitation acceptance under DPA creates no managed key/provider.
+8. Owner/member/newcomer receive usable customer-key provider configurations despite
+   OpenRouter/OpenWork branding; their delivered endpoint/model/key reach the BYOK
+   HTTP witness successfully, while managed use stays forbidden.
+9. Ordinary and raw Better Auth metadata writes cannot set/erase the decision.
+10. Approved explicit-false unset restores the original key and records the actor,
+    previous state, new state, and reason.
+11. A real audit-storage failure rolls back the DPA update.
+12. Concurrent branding, capability, and DPA updates preserve the marker and nested
+    unrelated metadata.
+13. Legacy serialized true denies; malformed documents, all tested non-boolean
+    flags, and a real policy-storage read failure return 503 with zero dispatch.
+14. A SQL witness proves a request passed initial admission but waits on limits;
+    marking before release causes pre-dispatch 403 with zero upstream calls.
+15. An already-started checkout sync held across marking records purchase history
+    without restoring Models.
+16. Signed late/duplicate checkout-completion webhooks retain history without
+    activation; an invalid signature fails before SDK reads/history changes.
+17. Synthetic-only credentials, guarded subprocess egress, zero external HTTP
+    attempts, and expected authentication on every observed upstream call.
+
+Stripe's SDK HTTP transport is redirected only in the eval subprocess to a local
+witness; actual billing handlers and signature verification remain unchanged.
+The test's destructive storage-fault arrangements apply only to its disposable
+testkit database, never an existing service or organization.
+
+## Additional verification
+
+| Command | Result |
+| --- | --- |
+| `pnpm evals:pr specs/team-organization-admin.test.ts` | Exit 0; 1 passed, 0 failed, 0 skipped; 26.21s. This runner emitted no placement line. |
+| `NODE_OPTIONS=--conditions=development pnpm --dir ee/apps/inference exec tsx --test test/proxy.test.ts` | Exit 0; 58 passed, 0 failed, 0 skipped. Supplementary unit checks, not boundary proof. |
+| `pnpm --filter @openwork/types build` | Exit 0; JS and declaration build passed. |
+| `pnpm --dir ee/apps/inference exec tsc -p tsconfig.json --noEmit` | Exit 0. |
+| `pnpm --dir ee/apps/den-api exec tsc --noEmit --pretty false` | Exit 0. |
+| `git diff --check` | Exit 0. |
+
+Organization-admin regression receipt:
+`evals/results/test-runs/2026-09-08T18-13-53-588Z-team-admin-grants-are-live-scoped-protected-and-cleared-across-scim-lifecycles/test-run.json`
+
+Additional executor-run supplementary suites: Stripe 38 passed; automation model
+authority 6 passed; materialization 28 passed. No runtime acceptance claims rest
+solely on these tests or temporary diagnostic harnesses.
+
+### Broader checks: failed, reproduced on clean control
+
+Same Node 24.18.0, pnpm 11.4.0, TypeScript 5.9.3 and inherited environment; clean
+detached worktree at the starting HEAD above, offline frozen installs. The control
+was removed cleanly afterward. No unrelated fixes were made.
+
+| Exact command | Working tree / clean control | Identical diagnosis |
+| --- | --- | --- |
+| `pnpm --dir evals exec tsc -p tsconfig.primitives.json --noEmit` | Exit 2 / 2 | Six TS2550 errors: `Promise.withResolvers` absent from ES2023 library; `worlds/first-run.ts` lines 168/169/176 and `worlds/session-shell.ts` lines 504/508/517. |
+| `pnpm exec node evals/scripts/spec-boundary-ratchet.mjs` | Exit 1 / 1 | Fourteen violations in five other specs; no violation for the new DPA spec. |
+
+Ratchet files: `bench-opencode-engines.test.ts`,
+`bench-openwork-app-v1.e2e.test.ts`, `engine-v2-preview-flag.e2e.test.ts`,
+`opencode-v2-chat-routing.e2e.test.ts`, `opencode-v2-provider-hot-inject.test.ts`.
+First identical failure: `bench-opencode-engines.test.ts: imports product source`.
+
+Earlier local DPA runs exposed fixture arrangement/expectation errors. Subsequent
+review exposed a non-boolean flag authorization gap and an incorrect permissive
+test expectation; both were corrected. Only the final receipt above supports
+this boundary verdict.
+The introduced `erasableSyntaxOnly` parameter-property error was also fixed.
+
+## Remaining validation and operational limits
+
+- This is **server-boundary proof**, not a full desktop/Web/automation UI-runtime
+  certification. BYOK proof uses an HTTP client with Den-delivered configuration,
+  not a real Gateway/OpenCode runtime. Web materialization and automation guards
+  have supplementary checks but no new live-runtime journey in this change.
+- The existing analytics UI journey was preserved but not rerun. No claim about
+  immediate picker cleanup, runtime credential erasure, or cancellation is made.
+- Missing-organization handling is fail-closed in code; the boundary exercises an
+  actual metadata read failure rather than manufacturing a foreign-key-invalid
+  dangling key row.
+- Policy has no cache. The final fresh read is dispatch admission, not an atomic
+  distributed egress/drain barrier; already-admitted/transmitted requests are not
+  canceled. See the runbook for exact race and upstream-provisioning limits.
+- Broad eval typecheck/ratchet are not green. Although their failures are verified
+  pre-existing, repository-wide validation is not a Passed claim.
+- Billing cancellation/refunds and upstream orphan-key reconciliation require
+  separate approval. No feature is claimed active for any live organization.
+
+## Changed files
+
+Shared contract:
+- `packages/types/src/den/managed-models-policy.ts`
+- `packages/types/package.json`
+- `packages/types/tsup.config.ts`
+
+Inference boundary and supplementary tests:
+- `ee/apps/inference/src/keys.ts`
+- `ee/apps/inference/src/proxy.ts`
+- `ee/apps/inference/test/proxy.test.ts`
+
+Den policy, trusted administration, and protected metadata writers:
+- `ee/apps/den-api/src/organization-metadata.ts`
+- `ee/apps/den-api/src/organization-limits.ts`
+- `ee/apps/den-api/src/orgs.ts`
+- `ee/apps/den-api/src/auth.ts`
+- `ee/apps/den-api/src/audit-events.ts`
+- `ee/apps/den-api/src/openwork-web-access.ts`
+- `ee/apps/den-api/src/routes/admin/index.ts`
+- `ee/apps/den-api/src/routes/bootstrap/index.ts`
+- `ee/apps/den-api/src/routes/org/core.ts`
+- `ee/apps/den-api/src/mcp/admin-tools.ts`
+- `ee/apps/den-api/scripts/seed-demo-org.ts`
+
+Den provisioning, purchase, and provider delivery:
+- `ee/apps/den-api/src/inference.ts`
+- `ee/apps/den-api/src/stripe-billing.ts`
+- `ee/apps/den-api/src/routes/org/inference.ts`
+- `ee/apps/den-api/src/routes/org/billing.ts`
+- `ee/apps/den-api/src/routes/org/llm-providers.ts`
+- `ee/apps/den-api/src/routes/org/resources.ts`
+- `ee/apps/den-api/src/routes/webhooks/stripe.ts`
+- `ee/apps/den-api/src/llm/cloud-provider-materialization.ts`
+- `ee/apps/den-api/src/automations/authority.ts`
+
+Boundary journey and deterministic witnesses:
+- `evals/specs/managed-models-dpa.test.ts`
+- `evals/worlds/models-analytics.ts`
+- `evals/packages/labs/src/models-analytics-fixture.mjs`
+- `evals/packages/labs/src/models-egress-guard.mjs`
+
+Documentation:
+- `docs/features/managed-models-dpa.md`
+- `docs/pr-proof/dpa-opt-out.md`

--- a/ee/apps/den-api/scripts/seed-demo-org.ts
+++ b/ee/apps/den-api/scripts/seed-demo-org.ts
@@ -23,6 +23,8 @@ import { db } from "../src/db.js"
 import { ensureDefaultDesktopPolicyForOrganization } from "../src/desktop-policies.js"
 import { env } from "../src/env.js"
 import { seedDefaultOrganizationRoles } from "../src/orgs.js"
+import { updateOrganizationMetadata } from "../src/organization-metadata.js"
+import { readOrganizationMetadata } from "@openwork/types/den/managed-models-policy"
 import { calculateOrganizationSeatBillingCounts } from "../src/stripe-billing.js"
 
 const RESET_MODE = process.argv.includes("--reset")
@@ -334,11 +336,15 @@ async function ensureOrganization(ownerUserId: UserId): Promise<OrganizationId> 
   }
 
   if (existing[0]) {
+    await updateOrganizationMetadata(existing[0].id, (current) => ({
+      ...current,
+      demoSeed: { ...readOrganizationMetadata(current.demoSeed), ...metadata.demoSeed },
+      limits: { ...readOrganizationMetadata(current.limits), ...metadata.limits },
+    }))
     await db
       .update(OrganizationTable)
       .set({
         allowedEmailDomains: [DEMO_EMAIL_DOMAIN],
-        metadata,
         name: DEMO_ORG_NAME,
         updatedAt: new Date(),
       })

--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -26,6 +26,7 @@ export const ORGANIZATION_AUDIT_ACTIONS = {
   ssoConnectionDeleted: "organization.sso.connection_deleted",
   openWorkWebComplimentaryAccessGranted: "organization.openwork_web.complimentary_access_granted",
   openWorkWebComplimentaryAccessRevoked: "organization.openwork_web.complimentary_access_revoked",
+  dpaSignedUpdated: "organization.dpa_signed.updated",
 }
 
 type OrganizationAuditAction = typeof ORGANIZATION_AUDIT_ACTIONS[keyof typeof ORGANIZATION_AUDIT_ACTIONS]
@@ -71,6 +72,7 @@ export function isOrganizationAuditAlertAction(action: OrganizationAuditAction) 
     case ORGANIZATION_AUDIT_ACTIONS.ssoConnectionDeleted:
     case ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessGranted:
     case ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessRevoked:
+    case ORGANIZATION_AUDIT_ACTIONS.dpaSignedUpdated:
       return true
     case ORGANIZATION_AUDIT_ACTIONS.scimReconciliationRun:
       return false

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -1,4 +1,5 @@
 import * as crypto from "node:crypto";
+import { readOrganizationMetadata } from "@openwork/types/den/managed-models-policy";
 import { getInitialActiveOrganizationIdForUser } from "./active-organization.js";
 import { db } from "./db.js";
 import { resolveOrganizationMemberAuthority } from "./organization-team-roles.js";
@@ -1119,6 +1120,23 @@ export const auth = betterAuth({
         });
       },
       organizationHooks: {
+        beforeCreateOrganization: async ({ organization }) => {
+          let metadata: Record<string, unknown>;
+          try {
+            metadata = readOrganizationMetadata(organization.metadata);
+          } catch {
+            throw new APIError("BAD_REQUEST", { message: "Organization metadata must be a JSON object." });
+          }
+          if ("dpaSigned" in metadata) {
+            throw new APIError("FORBIDDEN", { message: "dpaSigned is reserved for internal platform administration." });
+          }
+        },
+        beforeUpdateOrganization: async ({ organization }) => {
+          // A replacement without dpaSigned can erase it just as easily as an explicit false.
+          if ("metadata" in organization) {
+            throw new APIError("FORBIDDEN", { message: "Use the Den organization settings API to update workspace configuration." });
+          }
+        },
         beforeCreateTeam: denyBetterAuthTeamMutation,
         beforeUpdateTeam: denyBetterAuthTeamMutation,
         beforeDeleteTeam: denyBetterAuthTeamMutation,

--- a/ee/apps/den-api/src/automations/authority.ts
+++ b/ee/apps/den-api/src/automations/authority.ts
@@ -10,6 +10,7 @@ import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { AUTOMATION_FREE_MODEL } from "@openwork/types/automations"
 import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference"
 import { db } from "../db.js"
+import { organizationAllowsManagedModels } from "../inference.js"
 import { calculateDesktopPolicyForOrgMember } from "../desktop-policies.js"
 
 type ProviderId = typeof LlmProviderTable.$inferSelect.id
@@ -72,6 +73,7 @@ const databaseAuthorityStore: AutomationModelAuthorityStore = {
   },
 
   async findOpenWorkProvider(input) {
+    if (!await organizationAllowsManagedModels(normalizeDenTypeId("organization", input.organizationId))) return null
     const providers = await db.select().from(LlmProviderTable).where(and(
       eq(LlmProviderTable.organizationId, normalizeDenTypeId("organization", input.organizationId)),
       eq(LlmProviderTable.createdByOrgMembershipId, normalizeDenTypeId("member", input.ownerMemberId)),

--- a/ee/apps/den-api/src/inference.ts
+++ b/ee/apps/den-api/src/inference.ts
@@ -10,12 +10,11 @@ import {
   MemberTable,
   OrganizationTable,
 } from "@openwork-ee/den-db/schema"
-import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import {
   createInferenceBearerKey,
   inferenceBearerKeyPrefix,
   inferenceBearerKeyStorageDigest,
-  type InferenceBearerKey,
 } from "@openwork-ee/utils/inference-bearer-key"
 import {
   INFERENCE_RESET_STRATEGY_BY_WINDOW_TYPE,
@@ -23,8 +22,10 @@ import {
   INFERENCE_WINDOW_DURATIONS_MS,
 } from "@openwork/types/den/inference"
 import type { InferenceOrganizationMetadata, InferenceTier, InferenceWindowType } from "@openwork/types/den/inference"
+import { assertManagedModelsAllowed, ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import { db } from "./db.js"
 import { env } from "./env.js"
+import { assertOrganizationManagedModelsAllowed, updateOrganizationMetadata } from "./organization-metadata.js"
 
 type OrgId = typeof OrganizationTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
@@ -32,6 +33,36 @@ type MemberId = typeof MemberTable.$inferSelect.id
 const OPENWORK_PROVIDER_ID = "openwork"
 const OPENROUTER_PROVIDER = "openrouter"
 const OPENROUTER_KEYS_URL = "https://openrouter.ai/api/v1/keys"
+
+// Read/repair surfaces omit only managed Models when policy cannot allow them.
+export async function organizationAllowsManagedModels(organizationId: OrgId): Promise<boolean> {
+  try {
+    await assertOrganizationManagedModelsAllowed(organizationId)
+    return true
+  } catch (error) {
+    if (error instanceof ManagedModelsPolicyError) return false
+    throw error
+  }
+}
+
+async function withManagedModelsAdmission(
+  organizationId: OrgId,
+  provision: (tx: Parameters<Parameters<typeof db.transaction>[0]>[0]) => Promise<void>,
+) {
+  await db.transaction(async (tx) => {
+    // Serialize admission with metadata marking; never do external I/O in this lock.
+    const [organization] = await tx
+      .select({ metadata: OrganizationTable.metadata })
+      .from(OrganizationTable)
+      .where(eq(OrganizationTable.id, organizationId))
+      .limit(1)
+      .for("update")
+      .catch(() => { throw new ManagedModelsPolicyError("managed_models_policy_unavailable") })
+    if (!organization) throw new ManagedModelsPolicyError("managed_models_policy_unavailable")
+    assertManagedModelsAllowed(organization.metadata)
+    await provision(tx)
+  })
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -57,9 +88,16 @@ export function readInferenceMetadata(metadata: Record<string, unknown> | null):
 function setInferenceMetadata(metadata: Record<string, unknown> | null, inference: InferenceOrganizationMetadata | null) {
   const next = { ...(metadata ?? {}) }
   if (inference) {
-    next.inference = inference
-  } else {
-    delete next.inference
+    next.inference = { ...(isRecord(next.inference) ? next.inference : {}), ...inference }
+  } else if (isRecord(next.inference)) {
+    const remaining = { ...next.inference }
+    delete remaining.enabled
+    delete remaining.tier
+    if (Object.keys(remaining).length > 0) {
+      next.inference = remaining
+    } else {
+      delete next.inference
+    }
   }
   return next
 }
@@ -138,41 +176,43 @@ async function deleteOpenWorkProviders(where: { organizationId: OrgId; memberId?
   })
 }
 
-async function createMemberInferenceKey(input: { organizationId: OrgId; memberId: MemberId }) {
+async function ensureMemberInferenceAccess(input: { organizationId: OrgId; memberId: MemberId }) {
+  await assertOrganizationManagedModelsAllowed(input.organizationId)
   const key = createInferenceBearerKey()
-  await db.insert(InferenceKeyTable).values({
-    id: createDenTypeId("inferenceKey"),
-    organization_id: input.organizationId,
-    org_membership_id: input.memberId,
-    name: "OpenWork Models",
-    key_hash: await inferenceBearerKeyStorageDigest(key),
-    key_prefix: inferenceBearerKeyPrefix(key),
-    status: "active",
-  })
-  return key
-}
-
-async function ensureOpenWorkLlmProviderForMember(input: { organizationId: OrgId; memberId: MemberId; inferenceKey: InferenceBearerKey }) {
+  const keyHash = await inferenceBearerKeyStorageDigest(key)
   const now = new Date()
-  const providerRows = await db
-    .select({ id: LlmProviderTable.id })
-    .from(LlmProviderTable)
-    .where(and(
-      eq(LlmProviderTable.organizationId, input.organizationId),
-      eq(LlmProviderTable.createdByOrgMembershipId, input.memberId),
-      eq(LlmProviderTable.source, "openwork"),
-      eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
-    ))
-    .limit(1)
-
   const providerConfig = buildOpenWorkProviderConfig()
-  const providerId = providerRows[0]?.id ?? createDenTypeId("llmProvider")
 
-  await db.transaction(async (tx) => {
+  await withManagedModelsAdmission(input.organizationId, async (tx) => {
+    await tx
+      .update(InferenceKeyTable)
+      .set({ status: "revoked", revoked_at: now })
+      .where(and(eq(InferenceKeyTable.org_membership_id, input.memberId), eq(InferenceKeyTable.status, "active")))
+    await tx.insert(InferenceKeyTable).values({
+      id: createDenTypeId("inferenceKey"),
+      organization_id: input.organizationId,
+      org_membership_id: input.memberId,
+      name: "OpenWork Models",
+      key_hash: keyHash,
+      key_prefix: inferenceBearerKeyPrefix(key),
+      status: "active",
+    })
+    const providerRows = await tx
+      .select({ id: LlmProviderTable.id })
+      .from(LlmProviderTable)
+      .where(and(
+        eq(LlmProviderTable.organizationId, input.organizationId),
+        eq(LlmProviderTable.createdByOrgMembershipId, input.memberId),
+        eq(LlmProviderTable.source, "openwork"),
+        eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
+      ))
+      .limit(1)
+    const providerId = providerRows[0]?.id ?? createDenTypeId("llmProvider")
+
     if (providerRows[0]) {
       await tx
         .update(LlmProviderTable)
-        .set({ name: "OpenWork Models", providerConfig, apiKey: input.inferenceKey.value, updatedAt: now })
+        .set({ name: "OpenWork Models", providerConfig, apiKey: key.value, updatedAt: now })
         .where(eq(LlmProviderTable.id, providerId))
       await tx.delete(LlmProviderModelTable).where(eq(LlmProviderModelTable.llmProviderId, providerId))
       await tx.delete(LlmProviderAccessTable).where(eq(LlmProviderAccessTable.llmProviderId, providerId))
@@ -185,7 +225,7 @@ async function ensureOpenWorkLlmProviderForMember(input: { organizationId: OrgId
         providerId: OPENWORK_PROVIDER_ID,
         name: "OpenWork Models",
         providerConfig,
-        apiKey: input.inferenceKey.value,
+        apiKey: key.value,
         createdAt: now,
         updatedAt: now,
       })
@@ -199,11 +239,6 @@ async function ensureOpenWorkLlmProviderForMember(input: { organizationId: OrgId
       createdAt: now,
     })
   })
-}
-
-async function ensureMemberInferenceAccess(input: { organizationId: OrgId; memberId: MemberId }) {
-  const key = await createMemberInferenceKey(input)
-  await ensureOpenWorkLlmProviderForMember({ ...input, inferenceKey: key })
 }
 
 async function memberHasOpenWorkInferenceAccess(input: { organizationId: OrgId; memberId: MemberId }) {
@@ -239,6 +274,7 @@ export async function repairMemberInferenceAccessIfNeeded(input: {
   organizationId: OrgId
   memberId: MemberId
 }): Promise<boolean> {
+  if (!await organizationAllowsManagedModels(input.organizationId)) return false
   const [organization] = await db
     .select({ metadata: OrganizationTable.metadata })
     .from(OrganizationTable)
@@ -254,12 +290,17 @@ export async function repairMemberInferenceAccessIfNeeded(input: {
     return false
   }
 
-  await revokeMemberInferenceKeys(input.memberId)
-  await ensureMemberInferenceAccess(input)
-  return true
+  try {
+    await ensureMemberInferenceAccess(input)
+    return true
+  } catch (error) {
+    if (error instanceof ManagedModelsPolicyError) return false
+    throw error
+  }
 }
 
 export async function syncInferenceForOrganizationMembers(input: { organizationId: OrgId }) {
+  if (!await organizationAllowsManagedModels(input.organizationId)) return
   const [organization] = await db
     .select({ metadata: OrganizationTable.metadata })
     .from(OrganizationTable)
@@ -293,6 +334,8 @@ export async function syncInferenceAfterMemberChange(input: {
     await deleteOpenWorkProviders({ organizationId: input.organizationId, memberId: input.memberId })
   }
 
+  if (!await organizationAllowsManagedModels(input.organizationId)) return
+
   const [organization] = await db
     .select({ metadata: OrganizationTable.metadata })
     .from(OrganizationTable)
@@ -306,7 +349,7 @@ export async function syncInferenceAfterMemberChange(input: {
   await syncInferenceLimitPolicies({ organizationId: input.organizationId, tier: inference.tier, memberCount: input.memberCount })
 
   if (input.change === "added") {
-    await ensureMemberInferenceAccess({ organizationId: input.organizationId, memberId: input.memberId })
+    await repairMemberInferenceAccessIfNeeded({ organizationId: input.organizationId, memberId: input.memberId })
   }
 }
 
@@ -395,6 +438,7 @@ function isOpenRouterKeyCreateResponse(value: unknown): value is OpenRouterKeyCr
 }
 
 async function createOpenRouterOrgApiKey(input: { organizationId: OrgId }) {
+  await assertOrganizationManagedModelsAllowed(input.organizationId)
   if (!env.openRouterManagementApiKey) {
     throw new Error("openrouter_management_api_key_missing")
   }
@@ -486,6 +530,7 @@ async function revokeOrgUpstreamProviderKeys(organizationId: OrgId) {
 }
 
 async function ensureOrgUpstreamProviderKey(organizationId: OrgId) {
+  await assertOrganizationManagedModelsAllowed(organizationId)
   const [existing] = await db
     .select({ id: InferenceOrgUpstreamProviderKeyTable.id })
     .from(InferenceOrgUpstreamProviderKeyTable)
@@ -502,29 +547,33 @@ async function ensureOrgUpstreamProviderKey(organizationId: OrgId) {
 
   const openRouterKey = await createOpenRouterOrgApiKey({ organizationId })
 
-  await db
-    .insert(InferenceOrgUpstreamProviderKeyTable)
-    .values({
-      id: createDenTypeId("inferenceOrgProviderKey"),
-      organization_id: organizationId,
-      provider: OPENROUTER_PROVIDER,
-      external_key_hash: openRouterKey.externalKeyHash,
-      external_workspace_id: openRouterKey.externalWorkspaceId,
-      encrypted_api_key: openRouterKey.key,
-      key_prefix: upstreamKeyPrefix(openRouterKey.key),
-      status: "active",
-      revoked_at: null,
-    })
-    .onDuplicateKeyUpdate({
-      set: {
+  // An already-transmitted external create cannot be rolled back atomically.
+  // If marking wins this lock, leave its unattached external key alone.
+  await withManagedModelsAdmission(organizationId, async (tx) => {
+    await tx
+      .insert(InferenceOrgUpstreamProviderKeyTable)
+      .values({
+        id: createDenTypeId("inferenceOrgProviderKey"),
+        organization_id: organizationId,
+        provider: OPENROUTER_PROVIDER,
         external_key_hash: openRouterKey.externalKeyHash,
         external_workspace_id: openRouterKey.externalWorkspaceId,
         encrypted_api_key: openRouterKey.key,
         key_prefix: upstreamKeyPrefix(openRouterKey.key),
         status: "active",
         revoked_at: null,
-      },
-    })
+      })
+      .onDuplicateKeyUpdate({
+        set: {
+          external_key_hash: openRouterKey.externalKeyHash,
+          external_workspace_id: openRouterKey.externalWorkspaceId,
+          encrypted_api_key: openRouterKey.key,
+          key_prefix: upstreamKeyPrefix(openRouterKey.key),
+          status: "active",
+          revoked_at: null,
+        },
+      })
+  })
 }
 
 async function getActiveUsageBuckets(organizationId: OrgId) {
@@ -553,13 +602,14 @@ async function getActiveUsageBuckets(organizationId: OrgId) {
 }
 
 export async function getInferenceStatus(organizationId: OrgId) {
+  const managedModelsAllowed = await organizationAllowsManagedModels(organizationId)
   const [organization] = await db
     .select({ metadata: OrganizationTable.metadata })
     .from(OrganizationTable)
     .where(eq(OrganizationTable.id, organizationId))
     .limit(1)
   const memberCount = await activeMemberCount(organizationId)
-  const inference = readInferenceMetadata(organization?.metadata ?? null)
+  const inference = managedModelsAllowed ? readInferenceMetadata(organization?.metadata ?? null) : null
   // Admin status reads are a natural repair point: org can show ENABLED in Den
   // while individual members are missing keys/providers after manual deletes.
   if (inference?.enabled === true) {
@@ -587,22 +637,10 @@ export async function getInferenceStatus(organizationId: OrgId) {
 }
 
 export async function setInferenceEnabled(input: { organizationId: OrgId; enabled: boolean; tier?: InferenceTier }) {
-  const [organization] = await db
-    .select({ metadata: OrganizationTable.metadata })
-    .from(OrganizationTable)
-    .where(eq(OrganizationTable.id, input.organizationId))
-    .limit(1)
-  if (!organization) {
-    return null
-  }
-
   if (!input.enabled) {
+    await updateOrganizationMetadata(input.organizationId, (metadata) => setInferenceMetadata(metadata, null))
     const members = await listOrgMembers(input.organizationId)
     await revokeOrgUpstreamProviderKeys(input.organizationId)
-    await db
-      .update(OrganizationTable)
-      .set({ metadata: setInferenceMetadata(organization.metadata, null) })
-      .where(eq(OrganizationTable.id, input.organizationId))
     if (members.length > 0) {
       await db
         .update(InferenceKeyTable)
@@ -613,12 +651,13 @@ export async function setInferenceEnabled(input: { organizationId: OrgId; enable
     return getInferenceStatus(input.organizationId)
   }
 
-  const tier = input.tier ?? readInferenceMetadata(organization.metadata)?.tier ?? "tier1"
+  await assertOrganizationManagedModelsAllowed(input.organizationId)
   await ensureOrgUpstreamProviderKey(input.organizationId)
-  await db
-    .update(OrganizationTable)
-    .set({ metadata: setInferenceMetadata(organization.metadata, { enabled: true, tier }) })
-    .where(eq(OrganizationTable.id, input.organizationId))
+  await updateOrganizationMetadata(input.organizationId, (metadata) => {
+    assertManagedModelsAllowed(metadata)
+    const tier = input.tier ?? readInferenceMetadata(metadata)?.tier ?? "tier1"
+    return setInferenceMetadata(metadata, { enabled: true, tier })
+  })
   await syncInferenceForOrganizationMembers({ organizationId: input.organizationId })
   return getInferenceStatus(input.organizationId)
 }

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { and, asc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, asc, eq, inArray, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   LlmProviderModelTable,
   LlmProviderTable,
@@ -8,6 +8,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { db } from "../db.js"
 import { env } from "../env.js"
+import { organizationAllowsManagedModels } from "../inference.js"
 import { appLogger } from "../observability/logger.js"
 import { fetchPreviewNoRedirect, fetchWithConnectRetry, previewFetch } from "../workers/preview-fetch.js"
 import {
@@ -155,10 +156,14 @@ const modelConfigPassthroughKeys = [
 
 const databaseMaterializationStore: CloudProviderMaterializationStore = {
   async listProviders(organizationId) {
+    const managedModelsAllowed = await organizationAllowsManagedModels(organizationId)
     const providers = await db
       .select()
       .from(LlmProviderTable)
-      .where(eq(LlmProviderTable.organizationId, organizationId))
+      .where(and(
+        eq(LlmProviderTable.organizationId, organizationId),
+        managedModelsAllowed ? undefined : sql`${LlmProviderTable.source} <> 'openwork'`,
+      ))
       .orderBy(asc(LlmProviderTable.id))
 
     if (providers.length === 0) {

--- a/ee/apps/den-api/src/mcp/admin-tools.ts
+++ b/ee/apps/den-api/src/mcp/admin-tools.ts
@@ -1,11 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { eq, or, sql, type SQL } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable } from "@openwork-ee/den-db/schema"
+import { readOrganizationMetadata } from "@openwork/types/den/managed-models-policy"
 import { z } from "zod"
 import { db } from "../db.js"
 import { getDesktopReleaseMetadata } from "../desktop-releases.js"
 import { parseOrganizationPlan, type PlanTier } from "../entitlements.js"
 import { normalizeOrganizationMetadata } from "../organization-limits.js"
+import { updateOrganizationMetadata } from "../organization-metadata.js"
 
 /**
  * den-admin MCP toolset: read-only Den analytics for allowlisted platform
@@ -454,20 +456,19 @@ export function registerAdminMcpTools(server: McpServer) {
           throw new Error(`No organization found for ${organizationId}`)
         }
 
-        const normalized = normalizeOrganizationMetadata(organization.metadata).metadata
-        const metadata = {
-          ...normalized,
-          plan: manualPlan(tier),
-          limits: {
-            ...normalized.limits,
-            members: seatLimit,
-          },
-        }
-
-        await db
-          .update(OrganizationTable)
-          .set({ metadata })
-          .where(eq(OrganizationTable.id, organizationId))
+        const metadata = await updateOrganizationMetadata(organizationId, (current) => {
+          const normalized = normalizeOrganizationMetadata(current).metadata
+          const plan = { ...readOrganizationMetadata(current.plan), ...manualPlan(tier) }
+          if (tier !== "enterprise") delete plan.grantedAt
+          return {
+            ...normalized,
+            plan,
+            limits: {
+              ...normalized.limits,
+              members: seatLimit,
+            },
+          }
+        })
 
         return {
           ok: true,

--- a/ee/apps/den-api/src/openwork-web-access.ts
+++ b/ee/apps/den-api/src/openwork-web-access.ts
@@ -1,3 +1,5 @@
+import { readOrganizationMetadata } from "@openwork/types/den/managed-models-policy"
+
 export type OpenWorkWebAccessSource = "subscription" | "complimentary" | null
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -24,9 +26,9 @@ export function hasOpenWorkWebComplimentaryAccess(metadata: Record<string, unkno
   return isRecord(complimentaryAccess) && complimentaryAccess.openworkWeb === true
 }
 
-export function setOpenWorkWebComplimentaryAccess(metadata: Record<string, unknown>, enabled: boolean) {
-  const nextMetadata = { ...metadata }
-  const current = isRecord(metadata.complimentaryAccess) ? metadata.complimentaryAccess : {}
+export function setOpenWorkWebComplimentaryAccess(metadata: unknown, enabled: boolean) {
+  const nextMetadata = { ...readOrganizationMetadata(metadata) }
+  const current = isRecord(nextMetadata.complimentaryAccess) ? nextMetadata.complimentaryAccess : {}
   const complimentaryAccess = { ...current }
 
   if (enabled) {

--- a/ee/apps/den-api/src/organization-limits.ts
+++ b/ee/apps/den-api/src/organization-limits.ts
@@ -1,6 +1,8 @@
 import { and, eq, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import { MemberTable, OrganizationTable, WorkerTable } from "@openwork-ee/den-db/schema"
+import { ManagedModelsPolicyError, readOrganizationMetadata } from "@openwork/types/den/managed-models-policy"
 import { db } from "./db.js"
+import { updateOrganizationMetadata } from "./organization-metadata.js"
 
 export const DEFAULT_ORGANIZATION_LIMITS = {
   members: 5,
@@ -45,7 +47,7 @@ export type OrganizationMetadata = {
 type OrganizationMetadataInput = Record<string, unknown> | string | null | undefined
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function normalizePositiveInteger(value: unknown, fallback: number) {
@@ -95,28 +97,11 @@ function sameStringArray(left: string[] | null, right: string[] | null) {
   return left.every((entry, index) => right[index] === entry)
 }
 
-function parseMetadata(input: OrganizationMetadataInput): Record<string, unknown> {
-  if (!input) {
-    return {}
-  }
-
-  if (typeof input === "string") {
-    try {
-      const parsed = JSON.parse(input) as unknown
-      return isRecord(parsed) ? parsed : {}
-    } catch {
-      return {}
-    }
-  }
-
-  return isRecord(input) ? input : {}
-}
-
 export function normalizeOrganizationMetadata(input: OrganizationMetadataInput): {
   metadata: OrganizationMetadata
   changed: boolean
 } {
-  const parsed = parseMetadata(input)
+  const parsed = readOrganizationMetadata(input)
   const rawLimits = isRecord(parsed.limits) ? parsed.limits : null
   const allowedDesktopVersions = normalizeAllowedDesktopVersions(parsed.allowedDesktopVersions)
   const members = normalizePositiveInteger(rawLimits?.members, DEFAULT_ORGANIZATION_LIMITS.members)
@@ -125,11 +110,12 @@ export function normalizeOrganizationMetadata(input: OrganizationMetadataInput):
   const metadata: OrganizationMetadata = {
     ...parsed,
     limits: {
+      ...rawLimits,
       members,
       workers,
     },
     ...(allowedDesktopVersions !== null ? { allowedDesktopVersions } : {}),
-  } as OrganizationMetadata
+  }
 
   if (allowedDesktopVersions === null) {
     delete metadata.allowedDesktopVersions
@@ -150,7 +136,7 @@ export function normalizeOrganizationMetadata(input: OrganizationMetadataInput):
 }
 
 export function serializeOrganizationMetadata(metadata: OrganizationMetadataInput) {
-  const parsed = parseMetadata(metadata)
+  const parsed = readOrganizationMetadata(metadata)
   return Object.keys(parsed).length > 0 ? JSON.stringify(parsed) : null
 }
 
@@ -161,12 +147,11 @@ export async function getOrInitializeOrganizationMetadata(organizationId: Organi
     .where(eq(OrganizationTable.id, organizationId))
     .limit(1)
 
-  const { metadata, changed } = normalizeOrganizationMetadata(rows[0]?.metadata)
+  if (!rows[0]) throw new ManagedModelsPolicyError("managed_models_policy_unavailable")
+  const { metadata, changed } = normalizeOrganizationMetadata(rows[0].metadata)
   if (changed) {
-    await db
-      .update(OrganizationTable)
-      .set({ metadata })
-      .where(eq(OrganizationTable.id, organizationId))
+    const updated = await updateOrganizationMetadata(organizationId, (current) => normalizeOrganizationMetadata(current).metadata)
+    return normalizeOrganizationMetadata(updated).metadata
   }
 
   return metadata

--- a/ee/apps/den-api/src/organization-metadata.ts
+++ b/ee/apps/den-api/src/organization-metadata.ts
@@ -1,0 +1,42 @@
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { OrganizationTable } from "@openwork-ee/den-db/schema"
+import { assertManagedModelsAllowed, ManagedModelsPolicyError, readOrganizationMetadata } from "@openwork/types/den/managed-models-policy"
+import { db } from "./db.js"
+
+type OrganizationId = typeof OrganizationTable.$inferSelect.id
+
+export async function updateOrganizationMetadata(
+  organizationId: OrganizationId,
+  transform: (metadata: Record<string, unknown>) => Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return db.transaction(async (tx) => {
+    const [organization] = await tx
+      .select({ metadata: OrganizationTable.metadata })
+      .from(OrganizationTable)
+      .where(eq(OrganizationTable.id, organizationId))
+      .limit(1)
+      .for("update")
+    if (!organization) throw new ManagedModelsPolicyError("managed_models_policy_unavailable")
+
+    const metadata = readOrganizationMetadata(transform(readOrganizationMetadata(organization.metadata)))
+    await tx.update(OrganizationTable).set({ metadata }).where(eq(OrganizationTable.id, organizationId))
+    return metadata
+  })
+}
+
+export async function assertOrganizationManagedModelsAllowed(organizationId: OrganizationId): Promise<void> {
+  let metadata: unknown
+  try {
+    // Deliberately bypass caches so an admin change applies to the next request.
+    const [organization] = await db
+      .select({ metadata: OrganizationTable.metadata })
+      .from(OrganizationTable)
+      .where(eq(OrganizationTable.id, organizationId))
+      .limit(1)
+    if (!organization) throw new ManagedModelsPolicyError("managed_models_policy_unavailable")
+    metadata = organization.metadata
+  } catch {
+    throw new ManagedModelsPolicyError("managed_models_policy_unavailable")
+  }
+  assertManagedModelsAllowed(metadata)
+}

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -1309,114 +1309,117 @@ export async function updateOrganizationSettings(input: {
     return null
   }
 
-  const updates: Partial<typeof OrganizationTable.$inferInsert> = {}
-  if (nextName) {
-    updates.name = nextName
-  }
-  if (input.allowedEmailDomains !== undefined) {
-    updates.allowedEmailDomains = normalizeAllowedEmailDomains(input.allowedEmailDomains).domains
-  }
-  if (input.allowedDesktopVersions !== undefined || input.requireSso !== undefined || input.brandAppName !== undefined || input.brandLogoUrl !== undefined || input.brandIconUrl !== undefined || input.brandLogoAsset !== undefined || input.brandIconAsset !== undefined || input.brandAccentColor !== undefined) {
-    const rows = await db
-      .select({ metadata: OrganizationTable.metadata })
+  return db.transaction(async (tx) => {
+    const updates: Partial<typeof OrganizationTable.$inferInsert> = {}
+    if (nextName) {
+      updates.name = nextName
+    }
+    if (input.allowedEmailDomains !== undefined) {
+      updates.allowedEmailDomains = normalizeAllowedEmailDomains(input.allowedEmailDomains).domains
+    }
+    if (input.allowedDesktopVersions !== undefined || input.requireSso !== undefined || input.brandAppName !== undefined || input.brandLogoUrl !== undefined || input.brandIconUrl !== undefined || input.brandLogoAsset !== undefined || input.brandIconAsset !== undefined || input.brandAccentColor !== undefined) {
+      const rows = await tx
+        .select({ metadata: OrganizationTable.metadata })
+        .from(OrganizationTable)
+        .where(eq(OrganizationTable.id, input.organizationId))
+        .limit(1)
+        .for("update")
+
+      const existingOrganization = rows[0]
+      if (!existingOrganization) {
+        return null
+      }
+
+      const nextMetadata: Record<string, unknown> = {
+        ...normalizeOrganizationMetadata(existingOrganization.metadata).metadata,
+      }
+
+      if (input.allowedDesktopVersions !== undefined) {
+        if (input.allowedDesktopVersions === null) {
+          delete nextMetadata.allowedDesktopVersions
+        } else {
+          nextMetadata.allowedDesktopVersions = input.allowedDesktopVersions
+        }
+      }
+
+      if (input.requireSso !== undefined) {
+        nextMetadata.requireSso = input.requireSso
+      }
+
+      if (input.brandAppName !== undefined) {
+        if (input.brandAppName === null) {
+          delete nextMetadata.brandAppName
+        } else {
+          nextMetadata.brandAppName = input.brandAppName
+        }
+      }
+
+      if (input.brandLogoUrl !== undefined) {
+        if (input.brandLogoUrl === null) {
+          delete nextMetadata.brandLogoUrl
+        } else {
+          nextMetadata.brandLogoUrl = input.brandLogoUrl
+        }
+        if (input.brandLogoAsset === undefined) {
+          delete nextMetadata.brandLogoAsset
+        }
+      }
+
+      if (input.brandIconUrl !== undefined) {
+        if (input.brandIconUrl === null) {
+          delete nextMetadata.brandIconUrl
+        } else {
+          nextMetadata.brandIconUrl = input.brandIconUrl
+        }
+        if (input.brandIconAsset === undefined) {
+          delete nextMetadata.brandIconAsset
+        }
+      }
+
+      if (input.brandLogoAsset !== undefined) {
+        if (input.brandLogoAsset === null) {
+          delete nextMetadata.brandLogoAsset
+        } else {
+          nextMetadata.brandLogoAsset = input.brandLogoAsset
+        }
+      }
+
+      if (input.brandIconAsset !== undefined) {
+        if (input.brandIconAsset === null) {
+          delete nextMetadata.brandIconAsset
+        } else {
+          nextMetadata.brandIconAsset = input.brandIconAsset
+        }
+      }
+
+      if (input.brandAccentColor !== undefined) {
+        if (input.brandAccentColor === null) {
+          delete nextMetadata.brandAccentColor
+        } else {
+          nextMetadata.brandAccentColor = input.brandAccentColor
+        }
+      }
+
+      updates.metadata = normalizeOrganizationMetadata(nextMetadata).metadata
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return null
+    }
+
+    await tx
+      .update(OrganizationTable)
+      .set(updates)
+      .where(eq(OrganizationTable.id, input.organizationId))
+
+    const rows = await tx
+      .select()
       .from(OrganizationTable)
       .where(eq(OrganizationTable.id, input.organizationId))
       .limit(1)
 
-    const existingOrganization = rows[0]
-    if (!existingOrganization) {
-      return null
-    }
-
-    const nextMetadata = {
-      ...normalizeOrganizationMetadata(existingOrganization.metadata).metadata,
-    } as Record<string, unknown>
-
-    if (input.allowedDesktopVersions !== undefined) {
-      if (input.allowedDesktopVersions === null) {
-        delete nextMetadata.allowedDesktopVersions
-      } else {
-        nextMetadata.allowedDesktopVersions = input.allowedDesktopVersions
-      }
-    }
-
-    if (input.requireSso !== undefined) {
-      nextMetadata.requireSso = input.requireSso
-    }
-
-    if (input.brandAppName !== undefined) {
-      if (input.brandAppName === null) {
-        delete nextMetadata.brandAppName
-      } else {
-        nextMetadata.brandAppName = input.brandAppName
-      }
-    }
-
-    if (input.brandLogoUrl !== undefined) {
-      if (input.brandLogoUrl === null) {
-        delete nextMetadata.brandLogoUrl
-      } else {
-        nextMetadata.brandLogoUrl = input.brandLogoUrl
-      }
-      if (input.brandLogoAsset === undefined) {
-        delete nextMetadata.brandLogoAsset
-      }
-    }
-
-    if (input.brandIconUrl !== undefined) {
-      if (input.brandIconUrl === null) {
-        delete nextMetadata.brandIconUrl
-      } else {
-        nextMetadata.brandIconUrl = input.brandIconUrl
-      }
-      if (input.brandIconAsset === undefined) {
-        delete nextMetadata.brandIconAsset
-      }
-    }
-
-    if (input.brandLogoAsset !== undefined) {
-      if (input.brandLogoAsset === null) {
-        delete nextMetadata.brandLogoAsset
-      } else {
-        nextMetadata.brandLogoAsset = input.brandLogoAsset
-      }
-    }
-
-    if (input.brandIconAsset !== undefined) {
-      if (input.brandIconAsset === null) {
-        delete nextMetadata.brandIconAsset
-      } else {
-        nextMetadata.brandIconAsset = input.brandIconAsset
-      }
-    }
-
-    if (input.brandAccentColor !== undefined) {
-      if (input.brandAccentColor === null) {
-        delete nextMetadata.brandAccentColor
-      } else {
-        nextMetadata.brandAccentColor = input.brandAccentColor
-      }
-    }
-
-    updates.metadata = normalizeOrganizationMetadata(nextMetadata).metadata
-  }
-
-  if (Object.keys(updates).length === 0) {
-    return null
-  }
-
-  await db
-    .update(OrganizationTable)
-    .set(updates)
-    .where(eq(OrganizationTable.id, input.organizationId))
-
-  const rows = await db
-    .select()
-    .from(OrganizationTable)
-    .where(eq(OrganizationTable.id, input.organizationId))
-    .limit(1)
-
-  return rows[0] ?? null
+    return rows[0] ?? null
+  })
 }
 
 export async function seedDefaultOrganizationRoles(orgId: OrgId) {

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -28,6 +28,7 @@ import {
   AuditEventTable,
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, isDenTypeId } from "@openwork-ee/utils/typeid"
+import { ManagedModelsPolicyError, readOrganizationMetadata } from "@openwork/types/den/managed-models-policy"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
@@ -41,6 +42,7 @@ import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/exte
 import { organizationInstallLinksEnabled } from "../../capability-sources/install-links-rollout.js"
 import { normalizeOrganizationCapabilities, readOrganizationCapabilityOverrides } from "../../organization-capabilities.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata } from "../../organization-limits.js"
+import { updateOrganizationMetadata } from "../../organization-metadata.js"
 import { env } from "../../env.js"
 import type { AuthContextVariables } from "../../session.js"
 import { buildOrganizationAuditEvent, logOrganizationAuditEvent, ORGANIZATION_AUDIT_ACTIONS } from "../../audit-events.js"
@@ -92,6 +94,11 @@ const updateOrganizationOpenWorkWebAccessSchema = z.object({
   enabled: z.boolean(),
   reason: z.string().trim().min(3).max(500),
 })
+
+const updateOrganizationDpaSchema = z.object({
+  dpaSigned: z.boolean(),
+  reason: z.string().trim().min(3).max(500),
+}).strict()
 
 const updateOrganizationCapabilitiesSchema = z.object({
   capabilities: z.object({
@@ -263,23 +270,6 @@ function parseBooleanQuery(value: string | undefined): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
-}
-
-function normalizeMetadata(input: Record<string, unknown> | string | null | undefined): Record<string, unknown> {
-  if (!input) {
-    return {}
-  }
-
-  if (typeof input === "string") {
-    try {
-      const parsed: unknown = JSON.parse(input)
-      return isRecord(parsed) ? parsed : {}
-    } catch {
-      return {}
-    }
-  }
-
-  return isRecord(input) ? input : {}
 }
 
 function readAdminVisibleOrganizationCapabilities(metadata: Record<string, unknown> | string | null | undefined): ReturnType<typeof normalizeOrganizationCapabilities> {
@@ -1598,20 +1588,19 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         return c.json({ error: "not_found", message: "Organization not found." }, 404)
       }
 
-      const normalized = normalizeOrganizationMetadata(organization.metadata).metadata
-      const metadata = {
-        ...normalizeMetadata(normalized),
-        plan: getManualPlanMetadata(body.data.tier),
-        limits: {
-          ...normalized.limits,
-          members: body.data.seatLimit,
-        },
-      }
-
-      await db
-        .update(OrganizationTable)
-        .set({ metadata })
-        .where(eq(OrganizationTable.id, organizationId))
+      const metadata = await updateOrganizationMetadata(organizationId, (current) => {
+        const normalized = normalizeOrganizationMetadata(current).metadata
+        const plan = { ...readOrganizationMetadata(current.plan), ...getManualPlanMetadata(body.data.tier) }
+        if (body.data.tier !== "enterprise") delete plan.grantedAt
+        return {
+          ...normalized,
+          plan,
+          limits: {
+            ...normalized.limits,
+            members: body.data.seatLimit,
+          },
+        }
+      })
 
       return c.json({ ok: true, organization: { id: organizationId, plan: parseOrganizationPlan(metadata), seatLimit: body.data.seatLimit } })
     },
@@ -1643,15 +1632,10 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
       }
 
       const seatsFreeAdditional = body.data.totalFreeSeats - DEFAULT_ORGANIZATION_FREE_SEAT_COUNT
-      const metadata = {
-        ...normalizeOrganizationMetadata(organization.metadata).metadata,
+      await updateOrganizationMetadata(organizationId, (current) => ({
+        ...current,
         seatsFreeAdditional,
-      }
-
-      await db
-        .update(OrganizationTable)
-        .set({ metadata })
-        .where(eq(OrganizationTable.id, organizationId))
+      }))
 
       const seatCounts = await getOrganizationSeatBillingCounts({ organizationId })
       await syncSeatSubscriptionQuantityAfterMemberChange({ organizationId, memberCount: seatCounts.total })
@@ -1666,6 +1650,64 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           billableSeatCount: seatCounts.chargeable,
         },
       })
+    },
+  )
+
+  app.patch(
+    "/v1/admin/organizations/:organizationId/dpa",
+    adminRoute(),
+    async (c) => {
+      const body = updateOrganizationDpaSchema.safeParse(await c.req.json().catch(() => null))
+      if (!body.success) {
+        return c.json({ error: "invalid_request", message: body.error.issues[0]?.message ?? "Invalid organization DPA request." }, 400)
+      }
+      const organizationId = c.req.param("organizationId")
+      if (!isOrganizationId(organizationId)) {
+        return c.json({ error: "invalid_request", message: "Invalid organization id." }, 400)
+      }
+      const actorUserId = c.get("user")?.id
+      if (!actorUserId) return c.json({ error: "unauthorized" }, 401)
+
+      const result = await db.transaction(async (tx) => {
+        const [organization] = await tx
+          .select({ metadata: OrganizationTable.metadata })
+          .from(OrganizationTable)
+          .where(eq(OrganizationTable.id, organizationId))
+          .limit(1)
+          .for("update")
+        if (!organization) return "not_found"
+
+        let metadata: Record<string, unknown>
+        try {
+          metadata = readOrganizationMetadata(organization.metadata)
+        } catch {
+          return "policy_unavailable"
+        }
+        const auditEvent = buildOrganizationAuditEvent({
+          organizationId,
+          actorUserId,
+          action: ORGANIZATION_AUDIT_ACTIONS.dpaSignedUpdated,
+          payload: {
+            previousDpaSigned: typeof metadata.dpaSigned === "boolean" ? metadata.dpaSigned : null,
+            dpaSigned: body.data.dpaSigned,
+            reason: body.data.reason,
+          },
+        })
+        await tx.update(OrganizationTable)
+          .set({ metadata: { ...metadata, dpaSigned: body.data.dpaSigned } })
+          .where(eq(OrganizationTable.id, organizationId))
+        await tx.insert(AuditEventTable).values(auditEvent)
+        return { auditEvent }
+      })
+      if (result === "not_found") {
+        return c.json({ error: "not_found", message: "Organization not found." }, 404)
+      }
+      if (result === "policy_unavailable") {
+        const error = new ManagedModelsPolicyError("managed_models_policy_unavailable")
+        return c.json({ error: error.code, message: error.message }, error.status)
+      }
+      logOrganizationAuditEvent(result.auditEvent)
+      return c.json({ ok: true, organization: { id: organizationId, dpaSigned: body.data.dpaSigned } })
     },
   )
 
@@ -1721,8 +1763,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           return "subscription_exists"
         }
 
-        const normalizedMetadata = normalizeOrganizationMetadata(organization.metadata).metadata
-        const metadata = setOpenWorkWebComplimentaryAccess(normalizedMetadata, body.data.enabled)
+        const metadata = setOpenWorkWebComplimentaryAccess(organization.metadata, body.data.enabled)
         const auditEvent = buildOrganizationAuditEvent({
           organizationId,
           actorUserId,
@@ -1814,41 +1855,37 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         return c.json({ error: "not_found", message: "Organization not found." }, 404)
       }
 
-      const capabilities = readOrganizationCapabilityOverrides(organization.metadata)
-      const installLinks = body.data.capabilities.installLinks
-      if (installLinks !== undefined) {
-        if (installLinks === null) {
-          delete capabilities.installLinks
-        } else {
-          capabilities.installLinks = installLinks
+      const metadata = await updateOrganizationMetadata(organizationId, (current) => {
+        const capabilities = readOrganizationCapabilityOverrides(current)
+        const installLinks = body.data.capabilities.installLinks
+        if (installLinks !== undefined) {
+          if (installLinks === null) {
+            delete capabilities.installLinks
+          } else {
+            capabilities.installLinks = installLinks
+          }
         }
-      }
-      const mcpConnections = body.data.capabilities.mcpConnections
-      if (mcpConnections !== undefined) {
-        if (mcpConnections === null) {
-          delete capabilities.mcpConnections
-        } else {
-          capabilities.mcpConnections = mcpConnections
+        const mcpConnections = body.data.capabilities.mcpConnections
+        if (mcpConnections !== undefined) {
+          if (mcpConnections === null) {
+            delete capabilities.mcpConnections
+          } else {
+            capabilities.mcpConnections = mcpConnections
+          }
         }
-      }
 
-      const modelsAnalytics = body.data.capabilities.modelsAnalytics
-      if (modelsAnalytics === null) delete capabilities.modelsAnalytics
-      else if (modelsAnalytics !== undefined) capabilities.modelsAnalytics = modelsAnalytics
+        const modelsAnalytics = body.data.capabilities.modelsAnalytics
+        if (modelsAnalytics === null) delete capabilities.modelsAnalytics
+        else if (modelsAnalytics !== undefined) capabilities.modelsAnalytics = modelsAnalytics
 
-      const normalizedMetadata = normalizeOrganizationMetadata(organization.metadata).metadata
-      const metadata = {
-        ...normalizedMetadata,
-        capabilities: {
-          ...readUnmanagedCapabilityMetadata(normalizedMetadata),
-          ...capabilities,
-        },
-      }
-
-      await db
-        .update(OrganizationTable)
-        .set({ metadata })
-        .where(eq(OrganizationTable.id, organizationId))
+        return {
+          ...current,
+          capabilities: {
+            ...readUnmanagedCapabilityMetadata(current),
+            ...capabilities,
+          },
+        }
+      })
 
       return c.json({ ok: true, organization: { id: organizationId }, capabilities: readAdminVisibleOrganizationCapabilities(metadata) })
     },

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -35,7 +35,7 @@ import { z } from "zod"
 import { cache } from "../../cache.js"
 import { db } from "../../db.js"
 import { parseOrganizationPlan, type PlanTier } from "../../entitlements.js"
-import { adminRoute, queryValidator } from "../../middleware/index.js"
+import { adminRoute, jsonValidator, queryValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { appLogger } from "../../observability/logger.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
@@ -1655,12 +1655,30 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
 
   app.patch(
     "/v1/admin/organizations/:organizationId/dpa",
+    describeRoute({
+      tags: ["Admin"],
+      summary: "Record an organization DPA decision",
+      description: "Allowlisted platform administrators only. Atomically updates the reserved metadata flag and records the authenticated actor and reason in the audit trail.",
+      responses: {
+        200: jsonResponse("DPA decision recorded.", z.object({
+          ok: z.literal(true),
+          organization: z.object({ id: denTypeIdSchema("organization"), dpaSigned: z.boolean() }),
+        })),
+        400: jsonResponse("Invalid DPA decision or organization identifier.", z.union([
+          invalidRequestSchema, z.object({ error: z.literal("invalid_request"), message: z.string() }),
+        ])),
+        401: jsonResponse("Authentication is required.", unauthorizedSchema),
+        403: jsonResponse("Platform administrator access is required.", forbiddenSchema),
+        404: jsonResponse("Organization not found.", z.object({ error: z.literal("not_found"), message: z.string() })),
+        503: jsonResponse("Organization metadata could not be read.", z.object({
+          error: z.literal("managed_models_policy_unavailable"), message: z.string(),
+        })),
+      },
+    }),
     adminRoute(),
+    jsonValidator(updateOrganizationDpaSchema),
     async (c) => {
-      const body = updateOrganizationDpaSchema.safeParse(await c.req.json().catch(() => null))
-      if (!body.success) {
-        return c.json({ error: "invalid_request", message: body.error.issues[0]?.message ?? "Invalid organization DPA request." }, 400)
-      }
+      const body = c.req.valid("json")
       const organizationId = c.req.param("organizationId")
       if (!isOrganizationId(organizationId)) {
         return c.json({ error: "invalid_request", message: "Invalid organization id." }, 400)
@@ -1689,12 +1707,12 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           action: ORGANIZATION_AUDIT_ACTIONS.dpaSignedUpdated,
           payload: {
             previousDpaSigned: typeof metadata.dpaSigned === "boolean" ? metadata.dpaSigned : null,
-            dpaSigned: body.data.dpaSigned,
-            reason: body.data.reason,
+            dpaSigned: body.dpaSigned,
+            reason: body.reason,
           },
         })
         await tx.update(OrganizationTable)
-          .set({ metadata: { ...metadata, dpaSigned: body.data.dpaSigned } })
+          .set({ metadata: { ...metadata, dpaSigned: body.dpaSigned } })
           .where(eq(OrganizationTable.id, organizationId))
         await tx.insert(AuditEventTable).values(auditEvent)
         return { auditEvent }
@@ -1707,7 +1725,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         return c.json({ error: error.code, message: error.message }, error.status)
       }
       logOrganizationAuditEvent(result.auditEvent)
-      return c.json({ ok: true, organization: { id: organizationId, dpaSigned: body.data.dpaSigned } })
+      return c.json({ ok: true, organization: { id: organizationId, dpaSigned: body.dpaSigned } })
     },
   )
 

--- a/ee/apps/den-api/src/routes/bootstrap/index.ts
+++ b/ee/apps/den-api/src/routes/bootstrap/index.ts
@@ -1,4 +1,5 @@
 import { and, eq, gt, isNotNull, isNull } from "@openwork-ee/den-db/drizzle"
+import { readOrganizationMetadata } from "@openwork/types/den/managed-models-policy"
 import {
   ConfigObjectAccessGrantTable,
   ConfigObjectTable,
@@ -489,10 +490,16 @@ export function registerBootstrapRoutes<T extends { Variables: AuthContextVariab
         await tx.update(MemberTable).set({ removedAt: now }).where(eq(MemberTable.id, claim.setupMemberId))
         await tx.update(WorkspaceClaimTable).set({ status: "claimed", claimedByUserId: normalizedUserId, claimedAt: now }).where(eq(WorkspaceClaimTable.id, claim.id))
         await tx.update(WorkspaceBootstrapTable).set({ status: "claimed", claimedAt: now }).where(eq(WorkspaceBootstrapTable.id, claim.bootstrapId))
+        const metadata = readOrganizationMetadata(claim.organization.metadata)
         await tx.update(OrganizationTable).set({
           metadata: {
-            ...(claim.organization.metadata ?? {}),
-            bootstrap: { provisional: false, claimedAt: now.toISOString(), claimedByUserId: normalizedUserId },
+            ...metadata,
+            bootstrap: {
+              ...readOrganizationMetadata(metadata.bootstrap),
+              provisional: false,
+              claimedAt: now.toISOString(),
+              claimedByUserId: normalizedUserId,
+            },
           },
         }).where(eq(OrganizationTable.id, claim.organizationId))
 

--- a/ee/apps/den-api/src/routes/bootstrap/index.ts
+++ b/ee/apps/den-api/src/routes/bootstrap/index.ts
@@ -498,6 +498,9 @@ export function registerBootstrapRoutes<T extends { Variables: AuthContextVariab
               ...readOrganizationMetadata(metadata.bootstrap),
               provisional: false,
               claimedAt: now.toISOString(),
+              // Preserve existing claim attribution: this is the authenticated
+              // account's internal ID stored at runtime, not a customer identity
+              // embedded in public source or fixtures.
               claimedByUserId: normalizedUserId,
             },
           },

--- a/ee/apps/den-api/src/routes/org/billing.ts
+++ b/ee/apps/den-api/src/routes/org/billing.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import { getCloudWorkerBillingStatus } from "../../billing/polar.js"
 import { createInferenceCheckoutSession, createInferencePortalSession, createOpenWorkWebCheckout, createSeatCheckoutSession, getOpenWorkWebBillingSummary, getOrgBillingSummary, syncStripeCheckoutSession } from "../../stripe-billing.js"
 import { orgRoleRoute } from "../../middleware/index.js"
@@ -18,6 +19,10 @@ const stripeCheckoutResponseSchema = z.object({ url: z.string() }).meta({ ref: "
 const stripeCheckoutSyncRequestSchema = z.object({ sessionId: z.string().trim().min(1) })
 const stripeCheckoutSyncResponseSchema = z.object({ synced: z.boolean() }).meta({ ref: "OrgStripeCheckoutSyncResponse" })
 const stripePortalResponseSchema = z.object({ url: z.string() }).meta({ ref: "OrgStripePortalResponse" })
+const managedModelsPolicyErrorSchema = z.object({
+  error: z.enum(["managed_models_disabled_for_dpa", "managed_models_policy_unavailable"]),
+  message: z.string(),
+})
 const openWorkWebUnavailableSchema = z.object({
   error: z.literal("openwork_web_not_available"),
   message: z.string(),
@@ -192,7 +197,8 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
       responses: {
         200: jsonResponse("Stripe Checkout session created successfully.", stripeCheckoutResponseSchema),
         401: jsonResponse("The caller must be signed in to start billing.", unauthorizedSchema),
-        403: jsonResponse("Only workspace owners and admins can start billing.", forbiddenSchema),
+        403: jsonResponse("Billing access is denied.", z.union([forbiddenSchema, managedModelsPolicyErrorSchema])),
+        503: jsonResponse("Managed Models policy is unavailable.", managedModelsPolicyErrorSchema),
         404: jsonResponse("OpenWork Web is not available for this organization.", openWorkWebUnavailableSchema),
       },
     }),
@@ -243,11 +249,15 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
             : checkoutSuccessUrl(c),
         cancelUrl: subscriptionType === "web" ? openWorkWebCheckoutCancelUrl(c) : checkoutCancelUrl(c),
       }).catch((error) => {
+        if (error instanceof ManagedModelsPolicyError) return error
         if (error instanceof Error && error.message === "stripe_openwork_web_subscription_exists") {
           return "subscription_exists" as const
         }
         throw error
       })
+      if (session instanceof ManagedModelsPolicyError) {
+        return c.json({ error: session.code, message: session.message }, session.status)
+      }
       if (session === "subscription_exists") {
         return c.json({
           error: "stripe_subscription_exists",
@@ -295,6 +305,7 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
         200: jsonResponse("Stripe Checkout session synced successfully.", stripeCheckoutSyncResponseSchema),
         401: jsonResponse("The caller must be signed in to sync billing.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can sync billing.", forbiddenSchema),
+        503: jsonResponse("Managed Models policy is unavailable.", managedModelsPolicyErrorSchema),
       },
     }),
     orgRoleRoute(["admin"]),
@@ -313,11 +324,15 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
         organizationId: payload.organization.id,
         sessionId: parsed.data.sessionId,
       }).catch((error) => {
+        if (error instanceof ManagedModelsPolicyError) return error
         if (error instanceof Error && (error.message === "stripe_checkout_session_org_mismatch" || error.message.includes("No such checkout.session"))) {
           return "org_mismatch"
         }
         throw error
       })
+      if (row instanceof ManagedModelsPolicyError) {
+        return c.json({ error: row.code, message: row.message }, row.status)
+      }
       if (row === "org_mismatch") {
         return c.json({ error: "stripe_checkout_session_not_found" }, 404)
       }

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -42,7 +42,7 @@ import { ensureOrganizationAdminRole, ensureOrganizationSuperAdmin, orgAccessFai
 
 const createOrganizationSchema = z.object({
   name: z.string().trim().min(2).max(120),
-})
+}).strict()
 
 const updateOrganizationSchema = z.object({
   name: z.string().trim().min(2).max(120).optional(),
@@ -53,7 +53,7 @@ const updateOrganizationSchema = z.object({
   brandLogoUrl: z.string().url().max(2048).nullable().optional(),
   brandIconUrl: z.string().url().max(2048).nullable().optional(),
   brandAccentColor: z.string().trim().min(1).max(32).nullable().optional(),
-}).refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined || value.allowedDesktopVersions !== undefined || value.requireSso !== undefined || value.brandAppName !== undefined || value.brandLogoUrl !== undefined || value.brandIconUrl !== undefined || value.brandAccentColor !== undefined, {
+}).strict().refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined || value.allowedDesktopVersions !== undefined || value.requireSso !== undefined || value.brandAppName !== undefined || value.brandLogoUrl !== undefined || value.brandIconUrl !== undefined || value.brandAccentColor !== undefined, {
   message: "Provide at least one organization field to update.",
 })
 

--- a/ee/apps/den-api/src/routes/org/inference.ts
+++ b/ee/apps/den-api/src/routes/org/inference.ts
@@ -1,6 +1,8 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
+import { assertOrganizationManagedModelsAllowed } from "../../organization-metadata.js"
 import { getInferenceStatus, setInferenceEnabled } from "../../inference.js"
 import { organizationHasActiveInferenceSubscription } from "../../stripe-billing.js"
 import { jsonValidator, orgRoleRoute } from "../../middleware/index.js"
@@ -40,6 +42,11 @@ const inferenceProviderMissingSchema = z.object({
   message: z.string(),
 }).meta({ ref: "InferenceProviderMissingError" })
 
+const managedModelsPolicyErrorSchema = z.object({
+  error: z.enum(["managed_models_disabled_for_dpa", "managed_models_policy_unavailable"]),
+  message: z.string(),
+})
+
 export function registerOrgInferenceRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
   app.get(
     "/v1/inference",
@@ -75,7 +82,8 @@ export function registerOrgInferenceRoutes<T extends { Variables: OrgRouteVariab
         200: jsonResponse("Inference settings updated successfully.", inferenceStatusResponseSchema),
         400: jsonResponse("The inference settings request was invalid.", z.union([invalidRequestSchema, inferenceProviderMissingSchema])),
         401: jsonResponse("The caller must be signed in to update inference settings.", unauthorizedSchema),
-        403: jsonResponse("Only workspace owners and admins can update inference settings.", forbiddenSchema),
+        403: jsonResponse("Inference settings access is denied.", z.union([forbiddenSchema, managedModelsPolicyErrorSchema])),
+        503: jsonResponse("Managed Models policy is unavailable.", managedModelsPolicyErrorSchema),
       },
     }),
     orgRoleRoute(["admin"]),
@@ -89,19 +97,20 @@ export function registerOrgInferenceRoutes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const input = c.req.valid("json")
 
-      if (input.enabled) {
-        const subscribed = await organizationHasActiveInferenceSubscription(payload.organization.id)
-        if (!subscribed) {
-          return c.json({
-            inference: {
-              ...await getInferenceStatus(payload.organization.id),
-              subscribed: false,
-            },
-          })
-        }
-      }
-
       try {
+        if (input.enabled) {
+          await assertOrganizationManagedModelsAllowed(payload.organization.id)
+          const subscribed = await organizationHasActiveInferenceSubscription(payload.organization.id)
+          if (!subscribed) {
+            return c.json({
+              inference: {
+                ...await getInferenceStatus(payload.organization.id),
+                subscribed: false,
+              },
+            })
+          }
+        }
+
         const inference = await setInferenceEnabled({
           organizationId: payload.organization.id,
           enabled: input.enabled,
@@ -109,6 +118,9 @@ export function registerOrgInferenceRoutes<T extends { Variables: OrgRouteVariab
         })
         return c.json({ inference: { ...inference, subscribed: await organizationHasActiveInferenceSubscription(payload.organization.id) } })
       } catch (error) {
+        if (error instanceof ManagedModelsPolicyError) {
+          return c.json({ error: error.code, message: error.message }, error.status)
+        }
         if (error instanceof Error && error.message === "openrouter_management_api_key_missing") {
           return c.json({
             error: "openrouter_management_api_key_missing",

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -1,5 +1,6 @@
 import { declarativeDeleteSchema, declarativeResponses, externalKeyParamsSchema, isDuplicateEntry, type ResourceActionContext, type ResourceOrganizationContext } from "./declarative.js"
-import { and, desc, eq, inArray, isNotNull, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, desc, eq, inArray, isNotNull, isNull, sql } from "@openwork-ee/den-db/drizzle"
+import { ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import {
   AuthUserTable,
   InvitationTable,
@@ -37,7 +38,8 @@ import {
 import { getModelsDevProvider, listModelsDevProviders } from "../../llm/models-dev.js"
 import type { MemberTeamsContext } from "../../middleware/member-teams.js"
 import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
-import { repairMemberInferenceAccessIfNeeded } from "../../inference.js"
+import { organizationAllowsManagedModels, repairMemberInferenceAccessIfNeeded } from "../../inference.js"
+import { assertOrganizationManagedModelsAllowed } from "../../organization-metadata.js"
 import { listAccessibleLlmProviderAccess, listGrantedLlmProviderMemberIds } from "./llm-provider-access.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationAdmin, ensureOrganizationAdminRole, idParamSchema, memberHasRole, orgAccessFailureStatus } from "./shared.js"
@@ -606,10 +608,11 @@ async function loadLlmProviders(input: {
         inArray(LlmProviderTable.id, accessibleProviderIds),
       )
 
+  const managedModelsAllowed = await organizationAllowsManagedModels(input.organizationId)
   const providers = await db
     .select()
     .from(LlmProviderTable)
-    .where(providerWhere)
+    .where(and(providerWhere, managedModelsAllowed ? undefined : sql`${LlmProviderTable.source} <> 'openwork'`))
     .orderBy(desc(LlmProviderTable.updatedAt))
 
   if (providers.length === 0) {
@@ -1394,6 +1397,25 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
           error: "forbidden",
           message: "You do not have access to this provider.",
         }, 403)
+      }
+
+      if (provider.source === "openwork") {
+        try {
+          await assertOrganizationManagedModelsAllowed(payload.organization.id)
+        } catch (error) {
+          if (!(error instanceof ManagedModelsPolicyError)) throw error
+          // A list/connect race must not abort older desktops' entire BYOK sync.
+          return c.json({
+            llmProvider: {
+              ...provider,
+              apiKey: null,
+              apiKeys: null,
+              models: [],
+              memberCredential: { state: "blocked" },
+              managedModelsPolicy: { allowed: false, code: error.code, message: error.message },
+            },
+          })
+        }
       }
 
       const models = await db

--- a/ee/apps/den-api/src/routes/org/resources.ts
+++ b/ee/apps/den-api/src/routes/org/resources.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, desc, eq, inArray, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   ConfigObjectTable,
   LlmProviderAccessTable,
@@ -14,6 +14,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
 import { env } from "../../env.js"
+import { organizationAllowsManagedModels } from "../../inference.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
 import { listAccessibleMarketplaceCapabilityReferences } from "../../mcp/marketplace-capabilities.js"
 import {
@@ -109,6 +110,7 @@ async function listAccessibleLlmProviders(input: {
     return {}
   }
 
+  const managedModelsAllowed = await organizationAllowsManagedModels(input.organizationId)
   const rows = await db
     .select({
       id: LlmProviderTable.id,
@@ -118,6 +120,7 @@ async function listAccessibleLlmProviders(input: {
     .where(and(
       eq(LlmProviderTable.organizationId, input.organizationId),
       inArray(LlmProviderTable.id, providerIds),
+      managedModelsAllowed ? undefined : sql`${LlmProviderTable.source} <> 'openwork'`,
     ))
     .orderBy(desc(LlmProviderTable.updatedAt), desc(LlmProviderTable.id))
 

--- a/ee/apps/den-api/src/routes/webhooks/stripe.ts
+++ b/ee/apps/den-api/src/routes/webhooks/stripe.ts
@@ -1,6 +1,7 @@
 import type { Env, Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import { signedWebhookRoute } from "../../middleware/index.js"
 import { captureException } from "../../observability/runtime.js"
 import { handleStripeWebhook } from "../../stripe-billing.js"
@@ -20,6 +21,7 @@ export function registerStripeWebhookRoutes<T extends Env>(app: Hono<T>) {
       summary: "Stripe webhook ingress",
       responses: {
         200: jsonResponse("Stripe webhook processed successfully.", stripeWebhookResponseSchema),
+        503: jsonResponse("Managed Models policy is unavailable.", z.object({ error: z.string(), message: z.string() })),
       },
     }),
     signedWebhookRoute,
@@ -29,6 +31,9 @@ export function registerStripeWebhookRoutes<T extends Env>(app: Hono<T>) {
       try {
         return c.json(await handleStripeWebhook({ payload, signature }))
       } catch (error) {
+        if (error instanceof ManagedModelsPolicyError) {
+          return c.json({ error: error.code, message: error.message }, error.status)
+        }
         const message = error instanceof Error ? error.message : "stripe_webhook_failed"
         const status = message.includes("missing") || message.includes("signature") ? 400 : 500
         if (status === 500) {

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -8,10 +8,12 @@ import {
   OrganizationTable,
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import { db } from "./db.js"
 import { env } from "./env.js"
 import type { DenOrgMode } from "./env.js"
 import { setInferenceEnabled } from "./inference.js"
+import { assertOrganizationManagedModelsAllowed } from "./organization-metadata.js"
 import { appLogger } from "./observability/logger.js"
 import { isOpenWorkWebAvailable } from "./openwork-web-availability.js"
 import { hasOpenWorkWebComplimentaryAccess, resolveOpenWorkWebAccess } from "./openwork-web-access.js"
@@ -799,6 +801,9 @@ export async function createOrgSubscriptionCheckoutSession(input: {
   successUrl: string
   cancelUrl: string
 }) {
+  if (input.subscriptionType === INFERENCE_SUBSCRIPTION_TYPE) {
+    await assertOrganizationManagedModelsAllowed(input.organizationId)
+  }
   const priceId = requirePriceIdForSubscriptionType(input.subscriptionType)
   const openworkProduct = input.subscriptionType === SEAT_SUBSCRIPTION_TYPE
     ? "openwork_seats"
@@ -849,6 +854,7 @@ export async function createOrgSubscriptionCheckoutSession(input: {
   }
 
   const quantity = Math.max(1, await activeMemberCount(input.organizationId))
+  await assertOrganizationManagedModelsAllowed(input.organizationId)
   return stripe().checkout.sessions.create({
     mode: "subscription",
     customer,
@@ -1172,9 +1178,20 @@ export async function syncStripeCheckoutSession(input: { organizationId: OrgId; 
     })
   }
   if (row?.type === INFERENCE_SUBSCRIPTION_TYPE && ACTIVE_STATUSES.has(subscriptionStatus(subscription.status))) {
-    await setInferenceEnabled({ organizationId: row.organization_id, enabled: true })
+    await activatePurchasedInference(row.organization_id)
   }
   return row
+}
+
+async function activatePurchasedInference(organizationId: OrgId) {
+  try {
+    await setInferenceEnabled({ organizationId, enabled: true })
+  } catch (error) {
+    // Keep the purchase history, but acknowledge a deliberate policy denial.
+    // Unavailable policy must still fail safely so a later delivery can retry.
+    if (error instanceof ManagedModelsPolicyError && error.code === "managed_models_disabled_for_dpa") return
+    throw error
+  }
 }
 
 async function syncCurrentStripeSubscription(stripeSubscriptionId: string, eventId: string) {
@@ -1352,7 +1369,7 @@ export async function handleStripeWebhook(input: { payload: string; signature: s
           })
         }
         if (row?.type === INFERENCE_SUBSCRIPTION_TYPE && ACTIVE_STATUSES.has(subscriptionStatus(subscription.status))) {
-          await setInferenceEnabled({ organizationId: row.organization_id, enabled: true })
+          await activatePurchasedInference(row.organization_id)
         }
         if (row?.type === WEB_SUBSCRIPTION_TYPE && isEligibleOpenWorkWebSubscriptionStatus(subscription.status)) {
           await syncWebSubscriptionQuantityAfterMemberChange({

--- a/ee/apps/inference/src/keys.ts
+++ b/ee/apps/inference/src/keys.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto"
 import { and, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
-import { InferenceKeyTable, InferenceOrgUpstreamProviderKeyTable, MemberTable } from "@openwork-ee/den-db"
+import { InferenceKeyTable, InferenceOrgUpstreamProviderKeyTable, MemberTable, OrganizationTable } from "@openwork-ee/den-db"
+import { assertManagedModelsAllowed, ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import {
   inferenceBearerKeyLookupDigests,
   type InferenceBearerKey,
@@ -31,6 +32,20 @@ export async function findActiveInferenceKey(key: InferenceBearerKey) {
     return null
   }
   return row.inferenceKey
+}
+
+export async function assertOrganizationManagedModelsAllowed(organizationId: string): Promise<void> {
+  try {
+    const [organization] = await db.select({ metadata: OrganizationTable.metadata })
+      .from(OrganizationTable)
+      .where(eq(OrganizationTable.id, normalizeDenTypeId("organization", organizationId)))
+      .limit(1)
+    if (!organization) throw new ManagedModelsPolicyError("managed_models_policy_unavailable")
+    assertManagedModelsAllowed(organization.metadata)
+  } catch (error) {
+    if (error instanceof ManagedModelsPolicyError) throw error
+    throw new ManagedModelsPolicyError("managed_models_policy_unavailable")
+  }
 }
 
 export async function getOpenRouterProviderKey(organizationId: string) {

--- a/ee/apps/inference/src/proxy.ts
+++ b/ee/apps/inference/src/proxy.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto"
 import { inferenceBearerKey } from "@openwork-ee/utils/inference-bearer-key"
+import { ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import type { Context, Hono } from "hono"
 import { env } from "./env.js"
-import type { findActiveInferenceKey as findActiveInferenceKeyFn, getOpenRouterProviderKey as getOpenRouterProviderKeyFn } from "./keys.js"
+import type { assertOrganizationManagedModelsAllowed as assertOrganizationManagedModelsAllowedFn, findActiveInferenceKey as findActiveInferenceKeyFn, getOpenRouterProviderKey as getOpenRouterProviderKeyFn } from "./keys.js"
 import type { ensureUsableBuckets as ensureUsableBucketsFn } from "./limits.js"
 import {
   buildInferencePayloadLog,
@@ -44,6 +45,10 @@ const defaultProxyDependencies: ProxyDependencies = {
     const keys = await import("./keys.js")
     return keys.findActiveInferenceKey(key)
   },
+  async assertOrganizationManagedModelsAllowed(organizationId) {
+    const keys = await import("./keys.js")
+    return keys.assertOrganizationManagedModelsAllowed(organizationId)
+  },
   async getOpenRouterProviderKey(organizationId) {
     const keys = await import("./keys.js")
     return keys.getOpenRouterProviderKey(organizationId)
@@ -61,6 +66,7 @@ const defaultProxyDependencies: ProxyDependencies = {
 
 type ProxyDependencies = {
   findActiveInferenceKey: typeof findActiveInferenceKeyFn
+  assertOrganizationManagedModelsAllowed: typeof assertOrganizationManagedModelsAllowedFn
   getOpenRouterProviderKey: typeof getOpenRouterProviderKeyFn
   ensureUsableBuckets: typeof ensureUsableBucketsFn
   fetch: typeof fetch
@@ -511,6 +517,18 @@ function localRouteRejection(path: string, method: string) {
 export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies = defaultProxyDependencies) {
   const reporter = dependencies.reporter ?? sentryInferenceReporter
 
+  async function managedModelsRejection(organizationId: string) {
+    try {
+      await dependencies.assertOrganizationManagedModelsAllowed(organizationId)
+      return null
+    } catch (error) {
+      const policyError = error instanceof ManagedModelsPolicyError
+        ? error
+        : new ManagedModelsPolicyError("managed_models_policy_unavailable")
+      return openAiError(policyError.status, policyError.code, policyError.message)
+    }
+  }
+
   async function handleApiRequest(c: Context) {
     const bearerKey = readInferenceBearerKey(c.req.raw)
     if (!bearerKey) {
@@ -523,6 +541,9 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
       logProxyError("Invalid inference API key", { path: c.req.path, method: c.req.method })
       return c.json({ error: { message: "Invalid OpenWork inference API key.", type: "authentication_error", code: "invalid_api_key" } }, 401)
     }
+
+    const policyRejection = await managedModelsRejection(inferenceKey.organization_id)
+    if (policyRejection) return policyRejection
 
     if (c.req.path === modelsPath && c.req.method === "GET") {
       return c.json(listOpenAiModels())
@@ -650,7 +671,11 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
         headers: sanitizeHeaders(c.req.raw, providerKey.encrypted_api_key, openworkRequestId),
         body: prepared.body,
         duplex: "half",
+        redirect: "error",
       }
+      // Re-read after every preparation await, immediately before the only dispatch.
+      const dispatchRejection = await managedModelsRejection(inferenceKey.organization_id)
+      if (dispatchRejection) return dispatchRejection
       upstream = await dependencies.fetch(upstreamUrl, upstreamInit)
     } catch (error) {
       analytics?.(false).finish("failed")

--- a/ee/apps/inference/test/proxy.test.ts
+++ b/ee/apps/inference/test/proxy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 import { Hono } from "hono"
+import { assertManagedModelsAllowed, ManagedModelsPolicyError } from "@openwork/types/den/managed-models-policy"
 import type { InferenceHandledErrorReport, InferenceReporter, InferenceRequestReport } from "../src/inference-reporting.js"
 
 process.env.OPENWORK_DEV_MODE = "1"
@@ -15,10 +16,12 @@ type UpstreamRequest = {
   method: string | undefined
   body: string | null
   headers: Headers
+  redirect: RequestRedirect | undefined
 }
 
 type DependencyCalls = {
   findActiveInferenceKey: number
+  policyOrganizationIds: string[]
   getOpenRouterProviderKey: number
   ensureUsableBuckets: number
 }
@@ -29,6 +32,9 @@ type CapturedReports = {
 }
 
 type TestServerOptions = {
+  assertOrganizationManagedModelsAllowed?: (organizationId: string) => Promise<void>
+  organizationMetadata?: unknown
+  invalidKey?: boolean
   analytics?: typeof import("../src/task-analytics.js").beginModelAnalytics
   organizationId?: string
   providerKey?: { encrypted_api_key: string } | null
@@ -115,6 +121,7 @@ function createTestServer(options: TestServerOptions = {}) {
   const reports: CapturedReports = { requests: [], handledErrors: [] }
   const calls: DependencyCalls = {
     findActiveInferenceKey: 0,
+    policyOrganizationIds: [],
     getOpenRouterProviderKey: 0,
     ensureUsableBuckets: 0,
   }
@@ -124,6 +131,7 @@ function createTestServer(options: TestServerOptions = {}) {
       method: init?.method,
       body: readInitBody(init?.body),
       headers: new Headers(init?.headers),
+      redirect: init?.redirect,
     })
     return Response.json({ ok: true })
   })
@@ -139,10 +147,19 @@ function createTestServer(options: TestServerOptions = {}) {
   registerProxyRoutes(app, {
     async findActiveInferenceKey(_key) {
       calls.findActiveInferenceKey += 1
+      if (options.invalidKey) return null
       return {
         id: "inference_key_123",
         organization_id: options.organizationId ?? "organization_123",
         org_membership_id: "member_123",
+      }
+    },
+    async assertOrganizationManagedModelsAllowed(organizationId) {
+      calls.policyOrganizationIds.push(organizationId)
+      if (options.assertOrganizationManagedModelsAllowed) {
+        await options.assertOrganizationManagedModelsAllowed(organizationId)
+      } else {
+        assertManagedModelsAllowed(options.organizationMetadata)
       }
     },
     async getOpenRouterProviderKey(_organizationId: string) {
@@ -181,6 +198,168 @@ function createTestServer(options: TestServerOptions = {}) {
 
   return { app, upstreamRequests, calls, reports }
 }
+
+for (const organizationMetadata of [undefined, null, {}, { dpaSigned: false }, '{"dpaSigned":false}', { nested: { dpaSigned: true } }]) {
+  test(`allows managed models for metadata ${JSON.stringify(organizationMetadata)}`, async () => {
+    const { app, upstreamRequests, calls } = createTestServer({ organizationMetadata })
+    const response = await app.fetch(inferenceRequest({
+      method: "POST", headers: authHeaders("application/json"),
+      body: JSON.stringify({ model: "z-ai/glm-5.2", messages: [], metadata: { dpaSigned: true } }),
+    }))
+    assert.equal(response.status, 200)
+    assert.deepEqual(calls.policyOrganizationIds, ["organization_123", "organization_123"])
+    assert.equal(upstreamRequests.length, 1)
+    assert.equal(upstreamRequests[0].redirect, "error")
+  })
+}
+
+for (const policy of [
+  { metadata: { dpaSigned: true }, code: "managed_models_disabled_for_dpa", status: 403 },
+  { metadata: '{"dpaSigned":true}', code: "managed_models_disabled_for_dpa", status: 403 },
+  { metadata: "{broken", code: "managed_models_policy_unavailable", status: 503 },
+  { metadata: [], code: "managed_models_policy_unavailable", status: 503 },
+]) {
+  test(`blocks catalog and chat before body reporting for ${JSON.stringify(policy.metadata)}`, async () => {
+    let analyticsCalls = 0
+    const { app, upstreamRequests, calls, reports } = createTestServer({
+      organizationMetadata: policy.metadata,
+      analytics: async () => { analyticsCalls += 1; return null },
+    })
+    for (const input of [
+      { method: "GET", path: "/api/v1/models" },
+      { method: "POST", path: "/api/v1/chat/completions", body: "{invalid body" },
+      { method: "POST", path: "/api/v1/chat/completions?model=ignored", body: "{}" },
+    ]) {
+      const request = inferenceRequest({ ...input, headers: authHeaders("application/json") })
+      const response = await app.fetch(request)
+      assert.equal(response.status, policy.status)
+      assert.equal(await readErrorCode(response), policy.code)
+      assert.equal(request.bodyUsed, false)
+    }
+    assert.deepEqual(calls.policyOrganizationIds, ["organization_123", "organization_123", "organization_123"])
+    assert.equal(calls.ensureUsableBuckets, 0)
+    assert.equal(calls.getOpenRouterProviderKey, 0)
+    assert.equal(analyticsCalls, 0)
+    assert.equal(upstreamRequests.length, 0)
+    assert.deepEqual(reports, { requests: [], handledErrors: [] })
+  })
+}
+
+test("policy lookup failures fail closed without leaking the underlying error", async () => {
+  for (const error of [new ManagedModelsPolicyError("managed_models_policy_unavailable"), new Error("private database failure")]) {
+    const { app, calls, reports, upstreamRequests } = createTestServer({
+      assertOrganizationManagedModelsAllowed: async () => { throw error },
+    })
+    const response = await app.fetch(inferenceRequest({ method: "GET", path: "/api/v1/models", headers: authHeaders() }))
+    assert.equal(response.status, 503)
+    assert.deepEqual(await response.json(), { error: {
+      message: new ManagedModelsPolicyError("managed_models_policy_unavailable").message,
+      type: "invalid_request_error",
+      code: "managed_models_policy_unavailable",
+    } })
+    assert.equal(calls.ensureUsableBuckets, 0)
+    assert.equal(calls.getOpenRouterProviderKey, 0)
+    assert.equal(upstreamRequests.length, 0)
+    assert.deepEqual(reports, { requests: [], handledErrors: [] })
+  }
+})
+
+test("policy uses only the authenticated key organization, not caller organization hints", async () => {
+  const { app, calls } = createTestServer({ organizationId: "organization_key_owner" })
+  const headers = authHeaders("application/json")
+  headers.set("x-organization-id", "organization_caller")
+  const response = await app.fetch(inferenceRequest({ method: "POST", headers,
+    body: JSON.stringify({ model: "z-ai/glm-5.2", messages: [], organizationId: "organization_caller", dpaSigned: false }),
+  }))
+  assert.equal(response.status, 200)
+  assert.deepEqual(calls.policyOrganizationIds, ["organization_key_owner", "organization_key_owner"])
+})
+
+for (const unavailable of [false, true]) {
+  test(`rechecks fresh policy after quota, key and analytics awaits (${unavailable ? "unavailable" : "disabled"})`, async () => {
+    let metadata: unknown = { dpaSigned: false }
+    let analyticsCalls = 0
+    const { app, calls, upstreamRequests } = createTestServer({
+      assertOrganizationManagedModelsAllowed: async () => { assertManagedModelsAllowed(metadata) },
+      analytics: async () => {
+        assert.equal(calls.ensureUsableBuckets, 1)
+        assert.equal(calls.getOpenRouterProviderKey, 1)
+        assert.equal(calls.policyOrganizationIds.length, 1)
+        await Promise.resolve()
+        analyticsCalls += 1
+        metadata = unavailable ? "{corrupt" : { dpaSigned: true }
+        return null
+      },
+    })
+    const request = () => inferenceRequest({ method: "POST", headers: authHeaders("application/json"),
+      body: JSON.stringify({ model: "z-ai/glm-5.2", messages: [] }),
+    })
+    const response = await app.fetch(request())
+    assert.equal(response.status, unavailable ? 503 : 403)
+    assert.equal(await readErrorCode(response), unavailable ? "managed_models_policy_unavailable" : "managed_models_disabled_for_dpa")
+    assert.deepEqual(calls.policyOrganizationIds, ["organization_123", "organization_123"])
+    assert.equal(upstreamRequests.length, 0)
+    const retry = await app.fetch(request())
+    assert.equal(retry.status, unavailable ? 503 : 403)
+    assert.equal(calls.policyOrganizationIds.length, 3)
+    assert.equal(calls.ensureUsableBuckets, 1)
+    assert.equal(calls.getOpenRouterProviderKey, 1)
+    assert.equal(analyticsCalls, 1)
+    assert.equal(upstreamRequests.length, 0)
+  })
+}
+
+test("new requests observe both enabling and disabling policy without a cached decision", async () => {
+  let metadata = { dpaSigned: false }
+  const { app, calls, upstreamRequests } = createTestServer({
+    assertOrganizationManagedModelsAllowed: async () => { assertManagedModelsAllowed(metadata) },
+  })
+  for (const dpaSigned of [false, true, false]) {
+    metadata = { dpaSigned }
+    const response = await app.fetch(inferenceRequest({ method: "POST", headers: authHeaders("application/json"),
+      body: JSON.stringify({ model: "z-ai/glm-5.2", messages: [] }),
+    }))
+    assert.equal(response.status, dpaSigned ? 403 : 200)
+  }
+  assert.equal(calls.policyOrganizationIds.length, 5)
+  assert.equal(upstreamRequests.length, 2)
+})
+
+test("redirect rejection is not retried and a client retry rechecks policy", async () => {
+  let fetchCalls = 0
+  let metadata = { dpaSigned: false }
+  const { app, calls } = createTestServer({
+    assertOrganizationManagedModelsAllowed: async () => { assertManagedModelsAllowed(metadata) },
+    fetch: async (_input, init) => {
+      fetchCalls += 1
+      assert.equal(init?.redirect, "error")
+      metadata = { dpaSigned: true }
+      throw new TypeError("redirect encountered")
+    },
+  })
+  const request = () => inferenceRequest({ method: "POST", headers: authHeaders("application/json"),
+    body: JSON.stringify({ model: "z-ai/glm-5.2", messages: [] }),
+  })
+  const response = await app.fetch(request())
+  assert.equal(response.status, 502)
+  assert.equal(await readErrorCode(response), "upstream_unreachable")
+  assert.equal(fetchCalls, 1)
+  const retry = await app.fetch(request())
+  assert.equal(retry.status, 403)
+  assert.equal(await readErrorCode(retry), "managed_models_disabled_for_dpa")
+  assert.equal(fetchCalls, 1)
+  assert.equal(calls.policyOrganizationIds.length, 3)
+})
+
+test("invalid authentication never reads organization policy", async () => {
+  const { app, calls, upstreamRequests, reports } = createTestServer({ invalidKey: true })
+  const response = await app.fetch(inferenceRequest({ method: "GET", path: "/api/v1/models", headers: authHeaders() }))
+  assert.equal(response.status, 401)
+  assert.equal(await readErrorCode(response), "invalid_api_key")
+  assert.deepEqual(calls.policyOrganizationIds, [])
+  assert.equal(upstreamRequests.length, 0)
+  assert.deepEqual(reports, { requests: [], handledErrors: [] })
+})
 
 test("analytics storage failures preserve exact streamed bytes and upstream status", async () => {
   const { observeModelResponse } = await import("../src/task-analytics.js")
@@ -742,6 +921,7 @@ test("requires authentication before returning the local model catalog", async (
   assert.equal(response.status, 401)
   assert.equal(await readErrorCode(response), "missing_api_key")
   assert.equal(calls.findActiveInferenceKey, 0)
+  assert.deepEqual(calls.policyOrganizationIds, [])
   assert.equal(calls.ensureUsableBuckets, 0)
   assert.equal(calls.getOpenRouterProviderKey, 0)
   assert.equal(upstreamRequests.length, 0)

--- a/evals/packages/labs/src/models-analytics-fixture.mjs
+++ b/evals/packages/labs/src/models-analytics-fixture.mjs
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import { createHash, randomUUID } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 const fixtureUpstreamKey = "models-analytics-fixture-upstream";
 export function modelsFixtureKey(memberId) { return `ow_inf_models-analytics-fixture-${memberId}`; }
 async function arrange(command, orgId, inferenceUrl) {
@@ -68,6 +69,62 @@ async function serveWitness() {
     const exports = [];
     let holdExport = false;
     let releaseExport = null;
+    const stripeRequests = [];
+    let holdStripe = false;
+    let releaseStripe = null;
+    let dpa = null;
+    if (process.env.MODELS_DPA_FIXTURE === "1") {
+        const url = new URL(process.env.DATABASE_URL);
+        if (url.hostname !== "127.0.0.1" || !/^\/(openwork_eval_|openwork_den$)/.test(url.pathname)) throw new Error("DPA witness requires an isolated testkit database");
+        const { createConnection } = createRequire(new URL("../../env/package.json", import.meta.url))("mysql2/promise");
+        const connection = await createConnection(process.env.DATABASE_URL);
+        const lock = await createConnection(process.env.DATABASE_URL);
+        const orgId = process.env.MODELS_DPA_ORG_ID;
+        const [rows] = await connection.execute("SELECT metadata FROM organization WHERE id = ?", [orgId]);
+        const metadata = typeof rows[0].metadata === "string" ? JSON.parse(rows[0].metadata) : rows[0].metadata;
+        const baseline = { ...metadata, plan: { tier: "enterprise", source: "manual" }, fixtureNested: { keep: { value: "unchanged" } } };
+        await connection.execute("UPDATE organization SET metadata = ? WHERE id = ?", [JSON.stringify(baseline), orgId]);
+        dpa = async (action, input) => {
+            if (action === "metadata") {
+                const value = input.mode === "restore" ? baseline : input.mode === "string-true" ? JSON.stringify({ ...baseline, dpaSigned: true }) : input.mode === "nonboolean" ? { ...baseline, dpaSigned: "true" } : input.value;
+                await connection.execute("UPDATE organization SET metadata = ? WHERE id = ?", [JSON.stringify(value), orgId]);
+            } else if (action === "hold") {
+                await lock.query("LOCK TABLES inference_org_limit_policies WRITE");
+            } else if (action === "release") {
+                await lock.query("UNLOCK TABLES");
+            } else if (action === "read-failure") {
+                await connection.query("ALTER TABLE organization RENAME COLUMN metadata TO fixture_metadata_unavailable");
+            } else if (action === "read-restore") {
+                await connection.query("ALTER TABLE organization RENAME COLUMN fixture_metadata_unavailable TO metadata");
+            } else if (action === "audit-failure") {
+                await connection.query("ALTER TABLE audit_event RENAME COLUMN payload TO fixture_payload_unavailable");
+            } else if (action === "audit-restore") {
+                await connection.query("ALTER TABLE audit_event RENAME COLUMN fixture_payload_unavailable TO payload");
+            } else if (action === "rename-managed") {
+                await connection.execute("UPDATE llm_provider SET name = 'Customer-looking renamed provider' WHERE organization_id = ? AND source = 'openwork'", [orgId]);
+            } else if (action === "stripe-hold") {
+                holdStripe = true;
+            } else if (action === "stripe-release") {
+                holdStripe = false;
+                releaseStripe?.();
+                releaseStripe = null;
+            } else if (action === "remove-member-access") {
+                // Arrange missing access for the non-admin member, never for the warm test key.
+                await connection.execute("UPDATE inference_keys SET status = 'revoked' WHERE organization_id = ? AND org_membership_id = ?", [orgId, input.memberId]);
+                await connection.execute("DELETE FROM llm_provider WHERE organization_id = ? AND created_by_org_membership_id = ? AND source = 'openwork'", [orgId, input.memberId]);
+            } else if (action !== "state") throw new Error("Unknown DPA witness action");
+            if (action !== "state") return { ok: true };
+            const [organizations] = await connection.execute("SELECT metadata FROM organization WHERE id = ?", [orgId]);
+            const stored = typeof organizations[0].metadata === "string" ? JSON.parse(organizations[0].metadata) : organizations[0].metadata;
+            const [audits] = await connection.execute("SELECT id, actor_user_id AS actorUserId, action, payload FROM audit_event WHERE org_id = ? AND action = 'organization.dpa_signed.updated' ORDER BY created_at, id", [orgId]);
+            const [keys] = await connection.execute("SELECT org_membership_id AS memberId, status FROM inference_keys WHERE organization_id = ? ORDER BY id", [orgId]);
+            const [providers] = await connection.execute("SELECT id, created_by_org_membership_id AS memberId, source, name FROM llm_provider WHERE organization_id = ? ORDER BY id", [orgId]);
+            const [subscriptions] = await connection.execute("SELECT type, status, quantity, last_event_id AS lastEventId FROM org_subscriptions WHERE organization_id = ? ORDER BY id", [orgId]);
+            const [pending] = await connection.query("SELECT COUNT(*) AS count FROM information_schema.processlist WHERE ID <> CONNECTION_ID() AND INFO LIKE 'select%inference_org_limit_policies%' AND STATE LIKE '%lock%'");
+            const egress = await readFile(process.env.MODELS_EGRESS_FILE, "utf8").catch((error) => { if (error.code === "ENOENT") return ""; throw error; });
+            return { metadata: stored, audits: audits.map((row) => ({ ...row, payload: typeof row.payload === "string" ? JSON.parse(row.payload) : row.payload })), keys, providers, subscriptions, stripeRequests, stripeInFlight: releaseStripe !== null, waitingForLimits: Number(pending[0].count) > 0, egress: egress.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line)) };
+        };
+    }
     const upstream = createServer(async (req, res) => {
         if (req.url === "/fixture/requests") {
             res.setHeader("content-type", "application/json");
@@ -83,6 +140,40 @@ async function serveWitness() {
                 res.writeHead(413).end();
                 return;
             }
+        }
+        if (dpa && req.url?.startsWith("/fixture/dpa/")) {
+            try {
+                res.setHeader("content-type", "application/json");
+                res.end(JSON.stringify(await dpa(req.url.slice("/fixture/dpa/".length), text ? JSON.parse(text) : {})));
+            } catch (error) {
+                res.writeHead(500).end(JSON.stringify({ error: String(error.message) }));
+            }
+            return;
+        }
+        if (dpa && req.url?.startsWith("/stripe/")) {
+            const authenticated = req.headers.authorization === "Bearer sk_test_models_dpa_fixture_not_real";
+            const path = new URL(req.url, "http://fixture.test").pathname.slice("/stripe".length);
+            stripeRequests.push({ method: req.method, path, authenticated });
+            res.setHeader("content-type", "application/json");
+            if (!authenticated) { res.writeHead(401).end("{}"); return; }
+            const orgId = process.env.MODELS_DPA_ORG_ID;
+            const metadata = { org_id: orgId, subscription_type: "inference" };
+            const subscription = {
+                id: `sub_fixture_${orgId}`, object: "subscription", customer: `cus_fixture_${orgId}`, status: "active", metadata,
+                items: { object: "list", data: [{ id: "si_fixture_dpa", quantity: 7, price: { id: "price_fixture_dpa" } }] },
+                cancel_at_period_end: false, current_period_start: 1788825600, current_period_end: 1791417600,
+            };
+            if (req.method === "GET" && path === "/v1/checkout/sessions/cs_fixture_dpa") {
+                if (holdStripe) await new Promise((resolve) => { releaseStripe = resolve; });
+                res.end(JSON.stringify({ id: "cs_fixture_dpa", object: "checkout.session", status: "complete", mode: "subscription", payment_status: "paid", subscription: subscription.id, metadata }));
+            } else if (req.method === "GET" && path === `/v1/subscriptions/${subscription.id}`) {
+                res.end(JSON.stringify(subscription));
+            } else if (req.method === "DELETE" && path === `/v1/subscriptions/${subscription.id}`) {
+                res.end(JSON.stringify({ ...subscription, status: "canceled" }));
+            } else {
+                res.writeHead(400).end(JSON.stringify({ error: { message: "Unexpected fixture Stripe operation", type: "invalid_request_error" } }));
+            }
+            return;
         }
         if (req.url === "/api/public/otel/v1/traces") {
             if (req.headers.authorization !== `Basic ${Buffer.from("fixture-public:fixture-secret").toString("base64")}`) {
@@ -102,7 +193,10 @@ async function serveWitness() {
         const prompt = JSON.stringify(latest?.content ?? "");
         const error = prompt.includes("fixture:error");
         const missing = prompt.includes("fixture:missing-usage");
-        calls.push({ model: String(payload.model), authenticated: req.headers.authorization === `Bearer ${fixtureUpstreamKey}`, kind: error ? "error" : missing ? "incomplete" : "success" });
+        const byok = req.url === "/byok/chat/completions";
+        const authenticated = req.headers.authorization === `Bearer ${byok ? "fixture-customer-owned-key" : fixtureUpstreamKey}`;
+        calls.push({ model: String(payload.model), authenticated, ...(dpa ? { route: byok ? "byok" : "managed" } : {}), kind: error ? "error" : missing ? "incomplete" : "success" });
+        if (dpa && !authenticated) { res.writeHead(401).end("{}"); return; }
         if (error) {
             res.writeHead(503, { "content-type": "application/json" });
             res.end(JSON.stringify({ error: { message: "Fixture upstream unavailable" } }));

--- a/evals/packages/labs/src/models-egress-guard.mjs
+++ b/evals/packages/labs/src/models-egress-guard.mjs
@@ -1,0 +1,47 @@
+/** Loaded only by the isolated DPA world, before application instrumentation. */
+import http from "node:http";
+import https from "node:https";
+import { appendFileSync } from "node:fs";
+import { createRequire, syncBuiltinESMExports } from "node:module";
+import { fileURLToPath } from "node:url";
+
+function check(input) {
+  const hostname = input instanceof URL ? input.hostname : input.hostname ?? input.host ?? "localhost";
+  if (["localhost", "127.0.0.1", "::1", "[::1]"].includes(hostname)) return;
+  // Never retain a URL, body, header or credential in assertion evidence.
+  appendFileSync(process.env.MODELS_EGRESS_FILE, `${JSON.stringify({ hostname })}\n`);
+  throw new Error("DPA fixture refused non-loopback HTTP egress");
+}
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (input, init) => {
+  check(new URL(typeof input === "string" || input instanceof URL ? input : input.url));
+  return originalFetch(input, { ...init, redirect: "error" });
+};
+for (const transport of [http, https]) {
+  for (const method of ["request", "get"]) {
+    const original = transport[method];
+    transport[method] = function (input, ...args) {
+      check(typeof input === "string" ? new URL(input) : input);
+      return original.call(this, input, ...args);
+    };
+  }
+}
+syncBuiltinESMExports();
+
+if (process.env.MODELS_STRIPE_PORT) {
+  // Redirect the SDK transport, not any Den billing function. Every response
+  // still crosses HTTP and is produced by the independent provider witness.
+  const sdk = new URL("../../../../ee/apps/den-api/node_modules/stripe/", import.meta.url);
+  const esm = await import(new URL("esm/net/NodeHttpClient.js", sdk));
+  const cjs = createRequire(import.meta.url)(fileURLToPath(new URL("cjs/net/NodeHttpClient.js", sdk)));
+  for (const { NodeHttpClient } of [esm, cjs]) {
+    const makeRequest = NodeHttpClient.prototype.makeRequest;
+    NodeHttpClient.prototype.makeRequest = function (host, port, path, method, headers, body, protocol, timeout) {
+      const authorization = Object.entries(headers).find(([key]) => key.toLowerCase() === "authorization")?.[1];
+      if (host !== "api.stripe.com" || authorization !== "Bearer sk_test_models_dpa_fixture_not_real") {
+        throw new Error("DPA Stripe transport requires the synthetic credential and expected SDK host");
+      }
+      return makeRequest.call(this, "127.0.0.1", Number(process.env.MODELS_STRIPE_PORT), `/stripe${path}`, method, headers, body, "http", Math.min(timeout, 5_000));
+    };
+  }
+}

--- a/evals/specs/managed-models-dpa.test.ts
+++ b/evals/specs/managed-models-dpa.test.ts
@@ -1,0 +1,378 @@
+import { expect } from "vitest";
+import { createHmac } from "node:crypto";
+import { spec } from "@openwork/testkit";
+import { denFetch } from "@openwork/behaviors";
+import { modelsInferenceWorld } from "../worlds/models-analytics.ts";
+
+const test = spec.world(modelsInferenceWorld, { timeout: 900_000, needs: {} });
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected an API object");
+  return Object.fromEntries(Object.entries(value));
+}
+function list(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) throw new Error("Expected an API array");
+  return value.map(record);
+}
+function text(value: unknown): string {
+  if (typeof value !== "string" || !value) throw new Error("Expected a nonempty string");
+  return value;
+}
+
+test("DPA policy blocks warm managed keys without revoking customer-owned models or another organization", async ({ world, evidence, probe }) => {
+  const admin = world.den.admin;
+  const teammate = world.den.members.teammate;
+  if (!teammate) throw new Error("Missing non-platform-admin member");
+  const api = (path: string, method = "GET", body?: unknown, session = admin, orgId = world.orgId) => denFetch(session, path, {
+    method, headers: { authorization: `Bearer ${session.token}`, "x-openwork-org-id": orgId },
+    body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(30_000),
+  });
+  const fixture = async (action = "state", body?: unknown) => {
+    const response = await fetch(`${world.witnessUrl}/fixture/dpa/${action}`, {
+      method: "POST", body: JSON.stringify(body ?? {}), signal: AbortSignal.timeout(15_000),
+    });
+    expect(response.status, `fixture ${action}`).toBe(200);
+    return record(await response.json());
+  };
+  const calls = async () => {
+    const response = await fetch(`${world.witnessUrl}/fixture/requests`, { signal: AbortSignal.timeout(10_000) });
+    expect(response.status).toBe(200);
+    return list(record(await response.json()).calls);
+  };
+  const complete = async (key = world.fixtureKey(world.memberId), extra: Record<string, unknown> = {}, headers: Record<string, string> = {}) => {
+    const response = await fetch(`${world.inferenceUrl}/api/v1/chat/completions`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: `Bearer ${key}`, "x-openwork-session-id": "warm-dpa-session", ...headers },
+      body: JSON.stringify({ model: "z-ai/glm-5.2", messages: [{ role: "user", content: "Synthetic boundary request" }], stream: false, ...extra }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    return { status: response.status, body: record(await response.json()) };
+  };
+  const adminPath = `/v1/admin/organizations/${world.orgId}/dpa`;
+  const setDpa = async (dpaSigned: boolean, reason: string) => {
+    const response = await api(adminPath, "PATCH", { dpaSigned, reason });
+    expect(response.response.status, response.text).toBe(200);
+  };
+  const blocked = async (extra: Record<string, unknown> = {}, headers: Record<string, string> = {}, status = 403) => {
+    const before = await calls();
+    const response = await complete(undefined, extra, headers);
+    expect(response.status).toBe(status);
+    expect(record(response.body.error).code).toBe(status === 403 ? "managed_models_disabled_for_dpa" : "managed_models_policy_unavailable");
+    expect(await calls()).toEqual(before);
+  };
+  const context = record((await api("/v1/org")).body);
+  const actorUserId = text(record(context.currentMember).userId);
+  const teammateId = text(record(record((await api("/v1/org", "GET", undefined, teammate)).body).currentMember).id);
+  const initialProviders = list(record((await api("/v1/llm-providers")).body).llmProviders);
+  const managed = initialProviders.find((provider) => provider.source === "openwork");
+  if (!managed) throw new Error("Missing provisioned managed provider");
+  const managedId = text(managed.id);
+  expect((await complete()).status).toBe(200);
+  expect(await calls()).toEqual([expect.objectContaining({ route: "managed", authenticated: true })]);
+  expect(list((await fixture()).audits)).toEqual([]);
+  evidence.recordAssertionEvidence("Absent DPA flag permits real managed inference", "A pre-issued DB-backed key returned HTTP 200 and the independent upstream saw exactly one authenticated managed request.", true);
+
+  // Keep the same user's bearer, but issue a different organization-bound key.
+  const created = await api("/v1/org", "POST", { name: "Unrestricted Control" });
+  expect(created.response.status, created.text).toBe(201);
+  const otherOrgId = text(record(record(created.body).organization).id);
+  await world.arrange("subscription", otherOrgId);
+  expect((await api("/v1/inference", "PATCH", { enabled: true }, admin, otherOrgId)).response.status).toBe(200);
+  await world.arrange("configure", otherOrgId);
+  const otherContext = record((await api("/v1/org", "GET", undefined, admin, otherOrgId)).body);
+  expect(record(otherContext.currentMember).userId).toBe(actorUserId);
+  const otherKey = world.fixtureKey(text(record(otherContext.currentMember).id));
+  const foreign = await world.anotherOrganization();
+
+  // A normal workspace administrator is deliberately not a platform administrator.
+  expect((await api(`/v1/members/${teammateId}/role`, "POST", { role: "admin" })).response.status).toBe(200);
+  for (const session of [teammate, foreign.admin]) {
+    const denied = await api(adminPath, "PATCH", { dpaSigned: true, reason: "unauthorized test" }, session);
+    expect(denied.response.status).toBe(403);
+  }
+  const unauth = await fetch(`${world.den.ref.apiUrl}${adminPath}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ dpaSigned: true, reason: "unauthenticated test" }), signal: AbortSignal.timeout(10_000) });
+  expect(unauth.status).toBe(401);
+  for (const body of [{ dpaSigned: "true", reason: "invalid boolean" }, { dpaSigned: true, reason: "x" }, { dpaSigned: true, reason: "unexpected field", extra: true }]) {
+    expect((await api(adminPath, "PATCH", body)).response.status).toBe(400);
+  }
+  expect(list((await fixture()).audits)).toEqual([]);
+  expect(record((await fixture()).metadata).dpaSigned).toBeUndefined();
+  evidence.recordAssertionEvidence("Only allowlisted platform administrators may record DPA decisions", "Workspace admin and foreign admin received 403, anonymous caller 401, invalid payloads 400; independent storage still had no flag or audit events.", true);
+
+  await setDpa(true, "boundary approved set");
+  const marked = await fixture();
+  expect(record(marked.metadata).dpaSigned).toBe(true);
+  expect(list(marked.audits)).toEqual([expect.objectContaining({ actorUserId, action: "organization.dpa_signed.updated", payload: { previousDpaSigned: null, dpaSigned: true, reason: "boundary approved set" } })]);
+  expect((await api(adminPath, "PATCH", { dpaSigned: false, reason: "unauthorized clear" }, teammate)).response.status).toBe(403);
+  expect((await fixture()).audits).toEqual(marked.audits);
+  expect(record((await fixture()).metadata).dpaSigned).toBe(true);
+  await blocked();
+  const models = await fetch(`${world.inferenceUrl}/api/v1/models`, { headers: { authorization: `Bearer ${world.fixtureKey(world.memberId)}` }, signal: AbortSignal.timeout(10_000) });
+  expect(models.status).toBe(403);
+  for (const extra of [
+    { organizationId: otherOrgId, orgId: otherOrgId, dpaSigned: false },
+    { models: ["z-ai/glm-5.2", "minimax/minimax-m3"], route: "fallback" },
+    { provider: { allow_fallbacks: true }, model: "openrouter/auto" },
+  ]) await blocked(extra, { "x-openwork-org-id": otherOrgId, "x-organization-id": otherOrgId, "x-openwork-member-id": text(record(otherContext.currentMember).id) });
+  await blocked();
+  const beforeOther = (await calls()).length;
+  expect((await complete(otherKey)).status).toBe(200);
+  expect((await calls()).length).toBe(beforeOther + 1);
+  const foreignList = await api("/v1/llm-providers", "GET", undefined, foreign.admin);
+  expect(foreignList.response.status).toBe(404);
+  expect(record(foreignList.body).error).toBe("organization_not_found");
+  evidence.recordAssertionEvidence("Warm-key denial is organization-bound and cannot be spoofed or retried around", "Same process, key, bearer and session: completion and models are 403, body/header scope spoofing, fallback payloads and retries add zero upstream calls. Same user in a second organization still completes with its own key; foreign membership does not confer access.", true);
+
+  // There is no name-only managed-provider PATCH: the public write schema
+  // requires a customer provider source. Arrange only the display name instead.
+  expect((await api(`/v1/llm-providers/${managedId}`, "PATCH", { name: "Customer-looking renamed provider" })).response.status).toBe(400);
+  await fixture("rename-managed");
+  const renamed = list((await fixture()).providers).find((provider) => provider.id === managedId);
+  expect(renamed).toMatchObject({ source: "openwork", name: "Customer-looking renamed provider" });
+
+  for (const session of [admin, teammate]) {
+    for (const scope of ["usable", "manageable"]) {
+      const providers = await api(`/v1/llm-providers?scope=${scope}`, "GET", undefined, session);
+      expect(providers.response.status).toBe(200);
+      expect(list(record(providers.body).llmProviders).some((provider) => provider.source === "openwork")).toBe(false);
+    }
+  }
+  const connect = await api(`/v1/llm-providers/${managedId}/connect`);
+  expect(connect.response.status).toBe(200);
+  expect(record(connect.body).llmProvider).toMatchObject({ apiKey: null, apiKeys: null, models: [], memberCredential: { state: "blocked" }, managedModelsPolicy: { allowed: false, code: "managed_models_disabled_for_dpa" } });
+  expect(connect.text).not.toContain(world.fixtureKey(world.memberId));
+  expect(record(record(connect.body).llmProvider).name).toBe("Customer-looking renamed provider");
+  await blocked();
+  evidence.recordAssertionEvidence("Managed denial follows source, not display name", "Name-only public PATCH is rejected with 400. A datastore-arranged rename preserves source=openwork; lists still hide it, direct connect stays redacted, and the warm inference key returns 403 with no upstream call. This does not claim public rename support.", true);
+  const resources = await api("/v1/resources");
+  expect(resources.response.status).toBe(200);
+  expect(record(record(record(resources.body).resources).llmProviders)[managedId]).toBeUndefined();
+  const beforePurchase = await fixture();
+  for (const { path, method, body } of [
+    { path: "/v1/inference", method: "PATCH", body: { enabled: true } },
+    { path: "/v1/billing/stripe/checkout", method: "POST", body: {} },
+    { path: "/v1/billing/stripe/checkout", method: "POST", body: { type: "inference" } },
+  ]) {
+    const denied = await api(path, method, body);
+    expect(denied.response.status, denied.text).toBe(403);
+    expect(record(denied.body).error).toBe("managed_models_disabled_for_dpa");
+  }
+  expect((await fixture()).egress).toEqual(beforePurchase.egress);
+  expect((await fixture()).stripeRequests).toEqual(beforePurchase.stripeRequests);
+  expect((await fixture()).keys).toEqual(beforePurchase.keys);
+  evidence.recordAssertionEvidence("Managed inventory and purchase admission are disabled without breaking connect sync", "Usable/manageable lists and resource snapshot hide managed providers. Direct connect stays 200 with null credentials and no models. Enable and both checkout forms return policy 403 without new keys or external HTTP attempts.", true);
+
+  await fixture("remove-member-access", { memberId: teammateId });
+  const missing = await fixture();
+  expect(list(missing.providers).some((provider) => provider.memberId === teammateId && provider.source === "openwork")).toBe(false);
+  for (const session of [admin, teammate]) {
+    expect((await api("/v1/inference", "GET", undefined, session)).response.status).toBe(200);
+    expect((await api("/v1/llm-providers", "GET", undefined, session)).response.status).toBe(200);
+  }
+  expect((await fixture()).keys).toEqual(missing.keys);
+  expect((await fixture()).providers).toEqual(missing.providers);
+  await blocked();
+  evidence.recordAssertionEvidence("GET repair cannot restore missing managed member access", "After arranging a missing member provider and revoked member key, both members' inference/list GETs returned 200 without changing stored keys/providers; the owner's pre-issued key remains 403.", true);
+
+  const invitation = await api("/v1/invitations", "POST", { email: foreign.admin.email, role: "member" });
+  expect(invitation.response.status, invitation.text).toBe(201);
+  const accepted = await api("/v1/orgs/invitations/accept", "POST", { id: text(record(invitation.body).inviteToken) }, foreign.admin);
+  expect(accepted.response.status, accepted.text).toBe(200);
+  const newcomerContext = await api("/v1/org", "GET", undefined, foreign.admin);
+  expect(newcomerContext.response.status).toBe(200);
+  const newcomerId = text(record(record(newcomerContext.body).currentMember).id);
+  const newcomerProviders = await api("/v1/llm-providers", "GET", undefined, foreign.admin);
+  expect(newcomerProviders.response.status).toBe(200);
+  expect(list(record(newcomerProviders.body).llmProviders)).toEqual([]);
+  const joined = await fixture();
+  expect(list(joined.keys).some((key) => key.memberId === newcomerId)).toBe(false);
+  expect(list(joined.providers).some((provider) => provider.memberId === newcomerId)).toBe(false);
+  evidence.recordAssertionEvidence("New member acceptance does not provision managed access under DPA", "An existing foreign account accepted a real invitation as an ordinary member; its scoped list is empty and independent storage contains no managed key or provider for that new membership.", true);
+
+  const byok = await api("/v1/llm-providers", "POST", {
+    name: "OpenWork OpenRouter Customer", source: "custom", apiKey: "fixture-customer-owned-key", allMembers: true,
+    customConfig: { id: "openrouter", name: "OpenWork Customer Models", npm: "@ai-sdk/openai-compatible", env: ["CUSTOMER_MODEL_KEY"], api: `${world.witnessUrl}/byok`, models: [{ id: "z-ai/glm-5.2", name: "Customer GLM" }] },
+  });
+  expect(byok.response.status, byok.text).toBe(201);
+  const byokId = text(record(record(byok.body).llmProvider).id);
+  for (const session of [admin, teammate, foreign.admin]) {
+    const inventory = await api("/v1/llm-providers", "GET", undefined, session);
+    expect(list(record(inventory.body).llmProviders).map((provider) => provider.id)).toContain(byokId);
+    expect(inventory.text).not.toContain("fixture-customer-owned-key");
+    const delivered = await api(`/v1/llm-providers/${byokId}/connect`, "GET", undefined, session);
+    expect(delivered.response.status).toBe(200);
+    const provider = record(record(delivered.body).llmProvider);
+    expect(provider.source).toBe("custom");
+    const baseUrl = text(record(provider.providerConfig).api);
+    expect(baseUrl).toBe(`${world.witnessUrl}/byok`);
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST", headers: { authorization: `Bearer ${text(provider.apiKey)}`, "content-type": "application/json" },
+      body: JSON.stringify({ model: text(list(provider.models)[0].id), messages: [{ role: "user", content: "Customer route" }] }), signal: AbortSignal.timeout(10_000),
+    });
+    expect(response.status).toBe(200);
+    expect(record(await response.json()).choices).toBeDefined();
+  }
+  expect((await calls()).filter((call) => call.route === "byok")).toEqual([
+    expect.objectContaining({ authenticated: true, model: "z-ai/glm-5.2" }), expect.objectContaining({ authenticated: true, model: "z-ai/glm-5.2" }), expect.objectContaining({ authenticated: true, model: "z-ai/glm-5.2" }),
+  ]);
+  await blocked();
+  evidence.recordAssertionEvidence("Customer-owned providers survive branding overlap and route with delivered credentials", "Owner and member list/connect the custom OpenRouter/OpenWork-branded provider, then use its delivered endpoint, model and credential for real HTTP completions witnessed as authenticated BYOK. Managed key stays blocked. This is a delivered-config client, not an OpenCode runtime claim.", true);
+
+  for (const metadata of [{ dpaSigned: true }, { dpaSigned: false }, {}, JSON.stringify({ dpaSigned: false })]) {
+    expect((await api("/v1/org", "PATCH", { metadata })).response.status).toBe(400);
+  }
+  expect((await api("/v1/org", "PATCH", { dpaSigned: false, name: "Protected" })).response.status).toBe(400);
+  const signedIn = await denFetch(admin, "/api/auth/sign-in/email", { method: "POST", body: JSON.stringify({ email: admin.email, password: admin.password }) });
+  const cookie = signedIn.response.headers.get("set-cookie")?.split(";")[0];
+  if (!cookie) throw new Error("Missing BetterAuth cookie");
+  for (const metadata of [{ dpaSigned: false }, {}, JSON.stringify({ dpaSigned: true })]) {
+    const denied = await denFetch(admin, "/api/auth/organization/update", { method: "POST", headers: { cookie }, body: JSON.stringify({ organizationId: world.orgId, data: { metadata } }) });
+    expect(denied.response.status, denied.text).toBe(403);
+  }
+  const rawCreate = await denFetch(admin, "/api/auth/organization/create", { method: "POST", headers: { cookie }, body: JSON.stringify({ name: "Raw DPA", slug: `raw-${world.orgId}`, metadata: { dpaSigned: true } }) });
+  expect(rawCreate.response.status, rawCreate.text).toBe(403);
+  expect(record((await fixture()).metadata).dpaSigned).toBe(true);
+  expect(list((await fixture()).audits)).toHaveLength(1);
+  await blocked();
+  evidence.recordAssertionEvidence("Ordinary and raw BetterAuth metadata writes cannot set or erase the flag", "Strict Den writes rejected extra metadata/flag with 400; raw BetterAuth replacement and creation attempts returned 403. Flag remains true with exactly one approved audit event.", true);
+
+  await setDpa(false, "boundary approved unset");
+  const unset = await fixture();
+  expect(record(unset.metadata).dpaSigned).toBe(false);
+  expect(list(unset.audits)).toHaveLength(2);
+  expect(list(unset.audits)[1]).toMatchObject({ actorUserId, payload: { previousDpaSigned: true, dpaSigned: false, reason: "boundary approved unset" } });
+  expect((await complete()).status).toBe(200);
+  evidence.recordAssertionEvidence("Approved unset restores the original key and records the transition", "The warm key returned 200 with explicit false; datastore audit identifies the approving actor, previous true, new false and reason.", true);
+
+  await fixture("audit-failure");
+  try {
+    expect((await api(adminPath, "PATCH", { dpaSigned: true, reason: "must roll back" })).response.status).toBe(500);
+  } finally { await fixture("audit-restore"); }
+  expect(record((await fixture()).metadata).dpaSigned).toBe(false);
+  expect(list((await fixture()).audits)).toHaveLength(2);
+  expect((await complete()).status).toBe(200);
+  evidence.recordAssertionEvidence("Audit insertion and DPA mutation are atomic", "A real audit column outage caused admin PATCH 500; after storage recovery no event was added and the flag stayed false with the original key usable.", true);
+
+  const priorAuditCount = list((await fixture()).audits).length;
+  for (let index = 0; index < 3; index++) {
+    const outcomes = await Promise.all([
+      api("/v1/org", "PATCH", { brandAppName: `Boundary ${index}` }),
+      api(adminPath, "PATCH", { dpaSigned: true, reason: `concurrent set ${index}` }),
+      api(`/v1/admin/organizations/${world.orgId}/capabilities`, "PUT", { capabilities: { modelsAnalytics: false } }),
+    ]);
+    expect(outcomes.map((outcome) => outcome.response.status)).toEqual([200, 200, 200]);
+    const metadata = record((await fixture()).metadata);
+    expect(metadata).toMatchObject({ dpaSigned: true, brandAppName: `Boundary ${index}`, fixtureNested: { keep: { value: "unchanged" } }, capabilities: { modelsAnalytics: false } });
+    await blocked();
+  }
+  expect(list((await fixture()).audits)).toHaveLength(priorAuditCount + 3);
+  evidence.recordAssertionEvidence("Concurrent ordinary/admin metadata changes preserve DPA and unrelated nested data", "Three concurrent rounds of branding, capability and DPA updates all returned 200, preserved nested fixture metadata and all requested changes, added one audit each, and kept inference blocked.", true);
+
+  for (const input of [
+    { mode: "string-true" },
+    { value: "{malformed" },
+    { value: [] },
+    { value: 42 },
+  ]) {
+    await fixture("metadata", input);
+    await blocked({}, {}, "mode" in input ? 403 : 503);
+  }
+  await fixture("metadata", { mode: "restore" });
+  await fixture("read-failure");
+  try { await blocked({}, {}, 503); } finally { await fixture("read-restore"); }
+  await fixture("metadata", { mode: "nonboolean" });
+  await blocked({}, {}, 503);
+  for (const dpaSigned of [null, 0, 1, "false", {}, []]) {
+    await fixture("metadata", { value: { dpaSigned } });
+    // The datastore witness confirms falsy and structured values were not
+    // defaulted away by fixture arrangement before exercising the real policy.
+    expect(record((await fixture()).metadata).dpaSigned).toEqual(dpaSigned);
+    await blocked({}, {}, 503);
+  }
+  await fixture("metadata", { mode: "restore" });
+  expect(record((await fixture()).metadata).dpaSigned).toBeUndefined();
+  expect((await complete()).status).toBe(200);
+  evidence.recordAssertionEvidence("Policy parsing and unavailable storage fail closed", "Serialized object true returns 403; malformed JSON, array, scalar, non-boolean flags and real missing metadata column return 503 with zero upstream calls. Restoring absent flag permits the original key.", true);
+
+  // A real SQL table lock pauses a dependency after the initial policy read.
+  await fixture("hold");
+  const beforeRace = await calls();
+  const inFlight = complete();
+  try {
+    await probe.eventually(async () => (await fixture()).waitingForLimits, { within: 10_000, label: "inference admitted and blocked on limits SQL", until: (waiting) => waiting === true });
+    await setDpa(true, "changed during admission");
+  } finally { await fixture("release"); }
+  const raced = await inFlight;
+  expect(raced.status).toBe(403);
+  expect(record(raced.body.error).code).toBe("managed_models_disabled_for_dpa");
+  expect(await calls()).toEqual(beforeRace);
+  await setDpa(false, "race recovery");
+  expect((await complete()).status).toBe(200);
+  evidence.recordAssertionEvidence("Policy is re-read immediately before dispatch", "Independent SQL processlist proved a request had passed initial admission and was blocked on limits. An approved policy change committed before releasing that lock. Same in-flight request returned 403 with zero upstream calls; unset restored 200.", true);
+
+  // A checkout completed earlier can reach Den after managed access is disabled.
+  // Hold the real Stripe SDK's HTTP response across the approved policy change.
+  const disabled = await api("/v1/inference", "PATCH", { enabled: false });
+  expect(disabled.response.status, disabled.text).toBe(200);
+  expect(record(record(disabled.body).inference).enabled).toBe(false);
+  const beforeDelayed = await fixture();
+  expect(list(beforeDelayed.keys).every((key) => key.status === "revoked")).toBe(true);
+  expect(list(beforeDelayed.providers).some((provider) => provider.source === "openwork")).toBe(false);
+  const beforeDelayedCalls = await calls();
+  await fixture("stripe-hold");
+  const delayedSync = api("/v1/billing/stripe/checkout/sync", "POST", { sessionId: "cs_fixture_dpa" });
+  try {
+    await probe.eventually(async () => (await fixture()).stripeInFlight, { within: 10_000, label: "real Stripe checkout retrieval held", until: (waiting) => waiting === true });
+    await setDpa(true, "DPA signed before delayed checkout returns");
+  } finally { await fixture("stripe-release"); }
+  const synced = await delayedSync;
+  expect(synced.response.status, synced.text).toBe(200);
+  expect(synced.body).toMatchObject({ synced: true });
+  const afterDelayed = await fixture();
+  expect(afterDelayed.subscriptions).toEqual([{ type: "inference", status: "active", quantity: 7, lastEventId: "checkout-session-sync:cs_fixture_dpa" }]);
+  expect(afterDelayed.keys).toEqual(beforeDelayed.keys);
+  expect(afterDelayed.providers).toEqual(beforeDelayed.providers);
+  expect(record(afterDelayed.metadata)).toMatchObject({ dpaSigned: true });
+  expect(record(afterDelayed.metadata).inference).toEqual(record(beforeDelayed.metadata).inference);
+  expect(list(afterDelayed.stripeRequests).slice(list(beforeDelayed.stripeRequests).length)).toEqual([
+    { method: "GET", path: "/v1/checkout/sessions/cs_fixture_dpa", authenticated: true },
+    { method: "GET", path: `/v1/subscriptions/sub_fixture_${world.orgId}`, authenticated: true },
+    { method: "GET", path: `/v1/subscriptions/sub_fixture_${world.orgId}`, authenticated: true },
+  ]);
+  expect(await calls()).toEqual(beforeDelayedCalls);
+  evidence.recordAssertionEvidence("Delayed checkout sync records purchase history without reactivation", "A real SDK checkout retrieval was held over the approved DPA transition. Release returned sync 200 and persisted active purchase quantity 7 plus checkout event ID. Revoked keys, absent managed providers and disabled inference metadata stayed unchanged; zero inference calls.", true);
+
+  const webhook = async (type: string, validSignature: boolean) => {
+    const payload = JSON.stringify({ id: `evt_fixture_${type.replaceAll(".", "_")}`, object: "event", type, data: { object: { id: "cs_fixture_dpa", object: "checkout.session", mode: "subscription", status: "complete", payment_status: "paid", subscription: `sub_fixture_${world.orgId}`, metadata: { org_id: world.orgId, subscription_type: "inference" } } } });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = createHmac("sha256", validSignature ? "whsec_models_dpa_fixture_not_real" : "wrong_fixture_secret").update(`${timestamp}.${payload}`).digest("hex");
+    return fetch(`${world.den.ref.apiUrl}/v1/webhooks/stripe`, { method: "POST", headers: { "content-type": "application/json", "stripe-signature": `t=${timestamp},v1=${signature}` }, body: payload, signal: AbortSignal.timeout(15_000) });
+  };
+  expect((await webhook("checkout.session.completed", false)).status).toBe(400);
+  expect((await fixture()).subscriptions).toEqual(afterDelayed.subscriptions);
+  expect((await fixture()).stripeRequests).toEqual(afterDelayed.stripeRequests);
+  for (const type of ["checkout.session.completed", "checkout.session.async_payment_succeeded"]) {
+    const beforeEvent = await fixture();
+    for (let delivery = 0; delivery < 2; delivery++) {
+      const response = await webhook(type, true);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ received: true, type });
+      const afterEvent = await fixture();
+      expect(afterEvent.subscriptions).toEqual([{ type: "inference", status: "active", quantity: 7, lastEventId: `evt_fixture_${type.replaceAll(".", "_")}` }]);
+      expect(afterEvent.keys).toEqual(beforeDelayed.keys);
+      expect(afterEvent.providers).toEqual(beforeDelayed.providers);
+      expect(record(afterEvent.metadata).dpaSigned).toBe(true);
+      expect(record(afterEvent.metadata).inference).toEqual(record(beforeDelayed.metadata).inference);
+      expect(await calls()).toEqual(beforeDelayedCalls);
+    }
+    expect(list((await fixture()).stripeRequests).length).toBe(list(beforeEvent.stripeRequests).length + 4);
+  }
+  const afterWebhooks = await api("/v1/inference");
+  expect(afterWebhooks.response.status).toBe(200);
+  expect(record(record(afterWebhooks.body).inference).enabled).toBe(false);
+  expect(list(record((await api("/v1/llm-providers")).body).llmProviders).some((provider) => provider.source === "openwork")).toBe(false);
+  evidence.recordAssertionEvidence("Signed delayed Stripe webhooks retain history without managed reactivation", "Invalid HMAC was rejected with 400 before any SDK read or history change. Real signature verification accepted completed and async-payment-success events, including repeated deliveries, with event IDs persisted. Keys/providers and disabled inference remained unchanged; no inference upstream calls.", true);
+  const final = await fixture();
+  expect(final.egress).toEqual([]);
+  expect(list(final.stripeRequests).every((request) => request.authenticated === true && request.method === "GET")).toBe(true);
+  expect((await calls()).every((call) => call.authenticated === true)).toBe(true);
+  evidence.recordAssertionEvidence("Synthetic providers only", "Den/inference child environments blank real provider, Stripe and telemetry credentials. Stripe uses only a fixture key and loopback SDK transport. Preload refuses non-loopback HTTP; zero external attempts were recorded and every provider request carried the expected synthetic credential.", true);
+});

--- a/evals/specs/managed-models-dpa.test.ts
+++ b/evals/specs/managed-models-dpa.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "vitest";
+import { createDenClient } from "@openwork/sdk";
 import { createHmac } from "node:crypto";
 import { spec } from "@openwork/testkit";
 import { denFetch } from "@openwork/behaviors";
@@ -47,9 +48,13 @@ test("DPA policy blocks warm managed keys without revoking customer-owned models
     return { status: response.status, body: record(await response.json()) };
   };
   const adminPath = `/v1/admin/organizations/${world.orgId}/dpa`;
+  const sdk = createDenClient({ baseUrl: world.den.ref.apiUrl, token: admin.token, orgId: world.orgId });
   const setDpa = async (dpaSigned: boolean, reason: string) => {
-    const response = await api(adminPath, "PATCH", { dpaSigned, reason });
-    expect(response.response.status, response.text).toBe(200);
+    const response = await sdk.patchV1AdminOrganizationsByOrganizationIdDpa(
+      { organizationId: world.orgId, dpaSigned, reason }, { signal: AbortSignal.timeout(30_000) },
+    );
+    expect(response.response.status, JSON.stringify(response.error)).toBe(200);
+    expect(response.data).toEqual({ ok: true, organization: { id: world.orgId, dpaSigned } });
   };
   const blocked = async (extra: Record<string, unknown> = {}, headers: Record<string, string> = {}, status = 403) => {
     const before = await calls();
@@ -241,6 +246,16 @@ test("DPA policy blocks warm managed keys without revoking customer-owned models
   expect(list(unset.audits)[1]).toMatchObject({ actorUserId, payload: { previousDpaSigned: true, dpaSigned: false, reason: "boundary approved unset" } });
   expect((await complete()).status).toBe(200);
   evidence.recordAssertionEvidence("Approved unset restores the original key and records the transition", "The warm key returned 200 with explicit false; datastore audit identifies the approving actor, previous true, new false and reason.", true);
+  const memberSdk = createDenClient({ baseUrl: world.den.ref.apiUrl, token: teammate.token, orgId: world.orgId });
+  const forbiddenSdk = await memberSdk.patchV1AdminOrganizationsByOrganizationIdDpa(
+    { organizationId: world.orgId, dpaSigned: true, reason: "SDK unauthorized mutation" },
+    { signal: AbortSignal.timeout(30_000) },
+  );
+  expect(forbiddenSdk.response.status).toBe(403);
+  expect(forbiddenSdk.data).toBeUndefined();
+  expect(record((await fixture()).metadata).dpaSigned).toBe(false);
+  expect((await fixture()).audits).toEqual(unset.audits);
+  evidence.recordAssertionEvidence("Generated SDK carries the DPA body and preserves admin authorization", "Generated typed set/unset calls send the flag and reason and return the declared success body, verified against persisted metadata and audit transitions. A workspace admin using the same generated method receives 403 with no mutation or new audit.", true);
 
   await fixture("audit-failure");
   try {

--- a/evals/worlds/models-analytics.ts
+++ b/evals/worlds/models-analytics.ts
@@ -20,16 +20,31 @@ function object(value: unknown): Record<string, unknown> {
   return Object.fromEntries(Object.entries(value));
 }
 
-export async function modelsAnalyticsWorld(seed: Seed) {
-  const den = await seed.den({ web: true, org: { name: "Models Analytics Upgrade", admin: { name: "Models Admin" }, members: { teammate: { name: "Models Member" } } },
-    env: { ...fixtureSecrets, DEN_ORG_MODE: "multi_org", OPENROUTER_MANAGEMENT_API_KEY: "fixture-management-unused", DEN_PLAN_GATING_ENABLED: "true" },
+async function createModelsWorld(seed: Seed, analyticsUpgrade: boolean) {
+  if (!analyticsUpgrade && process.env.OPENWORK_EVAL_DEN_API_URL) throw new Error("DPA proof requires a fresh isolated Den, not a reused service");
+  const egressFile = seed.tmpPath("models-egress") + ".jsonl";
+  const dpaWitnessPort = analyticsUpgrade ? null : await allocateFreePort();
+  const guard = "evals/packages/labs/src/models-egress-guard.mjs";
+  const preload = `import { existsSync } from 'node:fs'; await import(existsSync('/workspace/${guard}') ? 'file:///workspace/${guard}' : ${JSON.stringify(new URL(guard, `file://${root}`).href)});`;
+  const isolatedEnv = analyticsUpgrade ? {} : {
+    ...Object.fromEntries(Object.keys(process.env).filter((key) => /OPENAI|ANTHROPIC|OPENROUTER|STRIPE|SENTRY|LANGFUSE|POSTHOG|POLAR|RESEND|REDIS/.test(key)).map((key) => [key, ""])),
+    OPENAI_API_KEY: "", OPENAI_REALTIME_API_KEY: "", STRIPE_API_KEY: "",
+    STRIPE_SECRET_KEY: "sk_test_models_dpa_fixture_not_real", STRIPE_WEBHOOK_SECRET: "whsec_models_dpa_fixture_not_real",
+    MODELS_STRIPE_PORT: String(dpaWitnessPort),
+    SENTRY_DSN: "", NEXT_PUBLIC_SENTRY_DSN: "", DATABASE_REDIS_URL: "", RESEND_API_KEY: "",
+    MODELS_DPA_FIXTURE: "1", MODELS_EGRESS_FILE: egressFile,
+    NODE_OPTIONS: `--import=data:text/javascript,${encodeURIComponent(preload)}`,
+  };
+  const den = await seed.den({ web: analyticsUpgrade, org: { name: analyticsUpgrade ? "Models Analytics Upgrade" : "Models DPA Boundary", admin: { name: "Models Admin" }, members: { teammate: { name: "Models Member" } } },
+    env: { ...isolatedEnv, ...fixtureSecrets, DEN_ORG_MODE: "multi_org", OPENROUTER_MANAGEMENT_API_KEY: "fixture-management-unused", DEN_PLAN_GATING_ENABLED: "true" },
   });
+  if (!analyticsUpgrade) console.error(`placement: ${den.placement?.kind} (testkit resolvePlace; isolated app-less Den and inference)`);
   const context = object((await seed.api(den.admin, "/v1/org")).body);
   const orgId = String(object(context.organization).id);
   const memberId = String(object(context.currentMember).id);
   const remote = den.placement?.kind === "daytona" ? den.placement.sandboxId : null;
   const inferencePort = remote ? 8791 : await allocateFreePort();
-  const witnessPort = remote ? 8792 : await allocateFreePort();
+  const witnessPort = dpaWitnessPort ?? (remote ? 8792 : await allocateFreePort());
   const host = remote ? createDaytonaHost({ sandboxId: remote, repoRoot: root, log: () => {} }) : null;
   const inferenceUrl = host ? await host.previewUrl(inferencePort) : `http://127.0.0.1:${inferencePort}`;
   const witnessUrl = host ? await host.previewUrl(witnessPort) : `http://127.0.0.1:${witnessPort}`;
@@ -37,8 +52,9 @@ export async function modelsAnalyticsWorld(seed: Seed) {
   if (!databaseUrl) throw new Error("The upgrade world requires its own isolated Den database");
   const env = {
     OPENWORK_DEV_MODE: "1", DATABASE_URL: databaseUrl, DB_MODE: "mysql",
-    ...fixtureSecrets, SENTRY_DSN: "", NEXT_PUBLIC_SENTRY_DSN: "",
+    ...isolatedEnv, ...fixtureSecrets, SENTRY_DSN: "", NEXT_PUBLIC_SENTRY_DSN: "",
     PORT: String(inferencePort), MODELS_WITNESS_PORT: String(witnessPort),
+    MODELS_DPA_ORG_ID: orgId,
     OPENROUTER_UPSTREAM_URL: `http://127.0.0.1:${witnessPort}`,
   };
   async function remoteExec(script: string, context: string) {
@@ -63,7 +79,7 @@ export async function modelsAnalyticsWorld(seed: Seed) {
   const enabled = await seed.api(den.admin, "/v1/inference", { method: "PATCH", body: JSON.stringify({ enabled: true, tier: "tier1" }) });
   if (!enabled.response.ok) throw new Error(`Existing Models subscriber setup failed: HTTP ${enabled.response.status}`);
   await arrange("configure");
-  await arrange("before-migration");
+  if (analyticsUpgrade) await arrange("before-migration");
   let child: ReturnType<typeof spawn> | null = null;
   if (remote) {
     const config = Buffer.from(JSON.stringify(env)).toString("base64");
@@ -77,9 +93,10 @@ export async function modelsAnalyticsWorld(seed: Seed) {
     await new Promise((resolve) => setTimeout(resolve, 1_000));
   }
   if (!healthy) throw new Error("Models inference did not start");
-  const web = await seed.web({ den, signedInAs: den.admin, startPath: "/dashboard/inference", headless: true, viewport: { width: 1440, height: 1100 } });
   return {
-    den, web, orgId, memberId, witnessUrl, inferenceUrl,
+    den, orgId, memberId, witnessUrl, inferenceUrl,
+    arrange,
+    fixtureKey: modelsFixtureKey,
     async upgradeAnalytics() { await arrange("migrate"); },
     async analyticsStoreUnavailable(unavailable: boolean) { await arrange(unavailable ? "pause-analytics" : "resume-analytics"); },
     async anotherOrganization() { return provisionOrg(den.ref, {}); },
@@ -143,6 +160,20 @@ export async function modelsAnalyticsWorld(seed: Seed) {
       });
       return { status: response.status, body: await response.text() };
     },
-    async [Symbol.asyncDispose]() { child?.kill("SIGTERM"); },
+    async [Symbol.asyncDispose]() {
+      // Den's disposal can cancel fixture subscriptions through the SDK.
+      try { if (!analyticsUpgrade) await den[Symbol.asyncDispose](); }
+      finally { child?.kill("SIGTERM"); }
+    },
   };
+}
+
+export async function modelsAnalyticsWorld(seed: Seed) {
+  const world = await createModelsWorld(seed, true);
+  const web = await seed.web({ den: world.den, signedInAs: world.den.admin, startPath: "/dashboard/inference", headless: true, viewport: { width: 1440, height: 1100 } });
+  return { ...world, web };
+}
+
+export async function modelsInferenceWorld(seed: Seed) {
+  return createModelsWorld(seed, false);
 }

--- a/packages/sdk/src/gen/sdk.gen.ts
+++ b/packages/sdk/src/gen/sdk.gen.ts
@@ -374,6 +374,8 @@ import type {
   MintAutomationRunnerTokenResponses,
   PatchApiAuthScimV2GroupsByGroupIdResponses,
   PatchApiAuthScimV2UsersByUserIdResponses,
+  PatchV1AdminOrganizationsByOrganizationIdDpaErrors,
+  PatchV1AdminOrganizationsByOrganizationIdDpaResponses,
   PatchV1AdminOrganizationsByOrganizationIdFreeSeatsResponses,
   PatchV1AdminOrganizationsByOrganizationIdPlanResponses,
   PatchV1CapabilitiesGoogleWorkspaceCalendarEventByEventIdErrors,
@@ -854,6 +856,47 @@ export class DenClient extends HeyApiClient {
       url: "/v1/admin/organizations/{organizationId}/free-seats",
       ...options,
       ...params,
+    });
+  }
+
+  /**
+   * Record an organization DPA decision
+   *
+   * Allowlisted platform administrators only. Atomically updates the reserved metadata flag and records the authenticated actor and reason in the audit trail.
+   */
+  public patchV1AdminOrganizationsByOrganizationIdDpa<ThrowOnError extends boolean = false>(
+    parameters: {
+      organizationId: string;
+      dpaSigned?: boolean;
+      reason?: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "organizationId" },
+            { in: "body", key: "dpaSigned" },
+            { in: "body", key: "reason" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).patch<
+      PatchV1AdminOrganizationsByOrganizationIdDpaResponses,
+      PatchV1AdminOrganizationsByOrganizationIdDpaErrors,
+      ThrowOnError
+    >({
+      url: "/v1/admin/organizations/{organizationId}/dpa",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     });
   }
 
@@ -10133,6 +10176,7 @@ export class DenClient extends HeyApiClient {
       externalKey: string;
       name?: string;
       memberIds?: Array<string>;
+      grantsOrganizationAdmin?: boolean;
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -10144,6 +10188,7 @@ export class DenClient extends HeyApiClient {
             { in: "path", key: "externalKey" },
             { in: "body", key: "name" },
             { in: "body", key: "memberIds" },
+            { in: "body", key: "grantsOrganizationAdmin" },
           ],
         },
       ],
@@ -10214,6 +10259,7 @@ export class DenClient extends HeyApiClient {
       teamId: string;
       name?: string;
       memberIds?: Array<string>;
+      grantsOrganizationAdmin?: boolean;
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -10225,6 +10271,7 @@ export class DenClient extends HeyApiClient {
             { in: "path", key: "teamId" },
             { in: "body", key: "name" },
             { in: "body", key: "memberIds" },
+            { in: "body", key: "grantsOrganizationAdmin" },
           ],
         },
       ],
@@ -10254,6 +10301,7 @@ export class DenClient extends HeyApiClient {
     parameters?: {
       name?: string;
       memberIds?: Array<string>;
+      grantsOrganizationAdmin?: boolean;
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -10264,6 +10312,7 @@ export class DenClient extends HeyApiClient {
           args: [
             { in: "body", key: "name" },
             { in: "body", key: "memberIds" },
+            { in: "body", key: "grantsOrganizationAdmin" },
           ],
         },
       ],

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -18,6 +18,26 @@ export type DenApiReadinessResponse = {
   };
 };
 
+export type InvalidRequestError = {
+  error: "invalid_request";
+  details: Array<{
+    message: string;
+    path?: Array<string | number>;
+    [key: string]: unknown | string | Array<string | number> | undefined;
+  }>;
+  capability?: string;
+};
+
+export type UnauthorizedError = {
+  error: "unauthorized";
+};
+
+export type ForbiddenError = {
+  error: "forbidden" | "reauth";
+  reason?: string;
+  message?: string;
+};
+
 export type AdminPageInfo = {
   total: number;
   limit: number;
@@ -40,26 +60,6 @@ export type AdminUsersPageResponse = {
     billingUnavailableUsers: number | null;
   };
   generatedAt: string;
-};
-
-export type InvalidRequestError = {
-  error: "invalid_request";
-  details: Array<{
-    message: string;
-    path?: Array<string | number>;
-    [key: string]: unknown | string | Array<string | number> | undefined;
-  }>;
-  capability?: string;
-};
-
-export type UnauthorizedError = {
-  error: "unauthorized";
-};
-
-export type ForbiddenError = {
-  error: "forbidden" | "reauth";
-  reason?: string;
-  message?: string;
 };
 
 export type AdminOrganizationsPageResponse = {
@@ -3779,6 +3779,7 @@ export type TeamResponse = {
     updatedAt: string;
     memberIds: Array<string>;
     managedByScim: boolean;
+    grantsOrganizationAdmin: boolean;
   };
 };
 
@@ -4222,6 +4223,74 @@ export type PatchV1AdminOrganizationsByOrganizationIdFreeSeatsResponses = {
    */
   200: unknown;
 };
+
+export type PatchV1AdminOrganizationsByOrganizationIdDpaData = {
+  body: {
+    dpaSigned: boolean;
+    reason: string;
+  };
+  path: {
+    organizationId: string;
+  };
+  query?: never;
+  url: "/v1/admin/organizations/{organizationId}/dpa";
+};
+
+export type PatchV1AdminOrganizationsByOrganizationIdDpaErrors = {
+  /**
+   * Invalid DPA decision or organization identifier.
+   */
+  400:
+    | InvalidRequestError
+    | {
+        error: "invalid_request";
+        message: string;
+      };
+  /**
+   * Authentication is required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Platform administrator access is required.
+   */
+  403: ForbiddenError;
+  /**
+   * Organization not found.
+   */
+  404: {
+    error: "not_found";
+    message: string;
+  };
+  /**
+   * Organization metadata could not be read.
+   */
+  503: {
+    error: "managed_models_policy_unavailable";
+    message: string;
+  };
+};
+
+export type PatchV1AdminOrganizationsByOrganizationIdDpaError =
+  PatchV1AdminOrganizationsByOrganizationIdDpaErrors[keyof PatchV1AdminOrganizationsByOrganizationIdDpaErrors];
+
+export type PatchV1AdminOrganizationsByOrganizationIdDpaResponses = {
+  /**
+   * DPA decision recorded.
+   */
+  200: {
+    ok: true;
+    organization: {
+      /**
+       * Den TypeID with 'org_' prefix and a 26-character base32 suffix.
+       */
+      id: string;
+      dpaSigned: boolean;
+    };
+  };
+};
+
+export type PatchV1AdminOrganizationsByOrganizationIdDpaResponse =
+  PatchV1AdminOrganizationsByOrganizationIdDpaResponses[keyof PatchV1AdminOrganizationsByOrganizationIdDpaResponses];
 
 export type PutV1AdminOrganizationsByOrganizationIdOpenworkWebAccessData = {
   body?: never;
@@ -10454,9 +10523,21 @@ export type PatchV1InferenceErrors = {
    */
   401: UnauthorizedError;
   /**
-   * Only workspace owners and admins can update inference settings.
+   * Inference settings access is denied.
    */
-  403: ForbiddenError;
+  403:
+    | ForbiddenError
+    | {
+        error: "managed_models_disabled_for_dpa" | "managed_models_policy_unavailable";
+        message: string;
+      };
+  /**
+   * Managed Models policy is unavailable.
+   */
+  503: {
+    error: "managed_models_disabled_for_dpa" | "managed_models_policy_unavailable";
+    message: string;
+  };
 };
 
 export type PatchV1InferenceError = PatchV1InferenceErrors[keyof PatchV1InferenceErrors];
@@ -19206,6 +19287,7 @@ export type PutV1TeamsByKeyByExternalKeyData = {
   body: {
     name: string;
     memberIds?: Array<string>;
+    grantsOrganizationAdmin?: boolean;
   };
   path: {
     externalKey: string;
@@ -19333,6 +19415,7 @@ export type PatchV1TeamsByTeamIdData = {
   body: {
     name?: string;
     memberIds?: Array<string>;
+    grantsOrganizationAdmin?: boolean;
   };
   path: {
     /**
@@ -19378,6 +19461,7 @@ export type PostV1TeamsData = {
   body: {
     name: string;
     memberIds?: Array<string>;
+    grantsOrganizationAdmin?: boolean;
   };
   path?: never;
   query?: never;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -74,6 +74,11 @@
       "development": "./src/den/egress-diagnostics.ts",
       "default": "./src/den/egress-diagnostics.ts"
     },
+    "./den/managed-models-policy": {
+      "types": "./src/den/managed-models-policy.ts",
+      "development": "./src/den/managed-models-policy.ts",
+      "default": "./src/den/managed-models-policy.ts"
+    },
     "./den/inference": {
       "types": "./src/den/inference.ts",
       "development": "./src/den/inference.ts",

--- a/packages/types/src/den/managed-models-policy.ts
+++ b/packages/types/src/den/managed-models-policy.ts
@@ -1,0 +1,53 @@
+export type ManagedModelsDenialCode =
+  | "managed_models_disabled_for_dpa"
+  | "managed_models_policy_unavailable"
+
+export type ManagedModelsPolicy =
+  | { allowed: true }
+  | { allowed: false; code: ManagedModelsDenialCode; message: string }
+
+export class ManagedModelsPolicyError extends Error {
+  readonly code: ManagedModelsDenialCode
+  readonly status: 403 | 503
+
+  constructor(code: ManagedModelsDenialCode) {
+    super(code === "managed_models_disabled_for_dpa"
+      ? "Company-provided OpenWork Models are unavailable for this organization because a DPA is signed. Permitted customer-key providers and AI Gateway may still be used."
+      : "Company-provided OpenWork Models policy could not be verified. Please try again later.")
+    this.name = "ManagedModelsPolicyError"
+    this.code = code
+    this.status = code === "managed_models_disabled_for_dpa" ? 403 : 503
+  }
+}
+
+export function readOrganizationMetadata(input: unknown): Record<string, unknown> {
+  if (input === null || input === undefined) return {}
+  const value: unknown = typeof input === "string" ? JSON.parse(input) : input
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Organization metadata must be a JSON object.")
+  }
+  return Object.fromEntries(Object.entries(value))
+}
+
+export function evaluateManagedModelsPolicy(metadata: unknown): ManagedModelsPolicy {
+  let parsed: Record<string, unknown>
+  try {
+    parsed = readOrganizationMetadata(metadata)
+    if ("dpaSigned" in parsed && typeof parsed.dpaSigned !== "boolean") {
+      throw new Error("dpaSigned must be a boolean when present.")
+    }
+  } catch {
+    const error = new ManagedModelsPolicyError("managed_models_policy_unavailable")
+    return { allowed: false, code: error.code, message: error.message }
+  }
+  if (parsed.dpaSigned === true) {
+    const error = new ManagedModelsPolicyError("managed_models_disabled_for_dpa")
+    return { allowed: false, code: error.code, message: error.message }
+  }
+  return { allowed: true }
+}
+
+export function assertManagedModelsAllowed(metadata: unknown): void {
+  const policy = evaluateManagedModelsPolicy(metadata)
+  if (!policy.allowed) throw new ManagedModelsPolicyError(policy.code)
+}

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     "den/connect-diagnostics": "src/den/connect-diagnostics.ts",
     "den/egress-diagnostics": "src/den/egress-diagnostics.ts",
     "den/inference": "src/den/inference.ts",
+    "den/managed-models-policy": "src/den/managed-models-policy.ts",
     "den/mcp-connection-action": "src/den/mcp-connection-action.ts",
     "den/microsoft-365": "src/den/microsoft-365.ts",
   },


### PR DESCRIPTION
## Summary
- Store a strict boolean `dpaSigned` in existing organization metadata, with an audited allowlisted-platform-admin set/unset operation and reserved-key protection.
- Fail closed at managed inference admission and immediately before upstream dispatch; guard provisioning, repair, checkout, late billing activation, and managed provider delivery without blocking customer-owned Gateway credentials.
- Preserve unrelated metadata under concurrent writes and retain subscriptions, transaction history, and existing keys.

## Verification
Passed on PR head `d85ed4b4f` after rebasing onto current dev:
- `pnpm evals:pr specs/managed-models-dpa.test.ts`: 1 passed, 0 failed/skipped; 17 observable assertion groups. Placement: local (testkit resolvePlace; isolated app-less Den and inference). Independent upstream witness proves denied requests dispatch nothing; synthetic-only transport records zero external HTTP attempts.
- `pnpm evals:pr specs/team-organization-admin.test.ts`: 1 passed, 0 failed/skipped.
- Den and inference TypeScript checks passed.

Per-test testkit evidence is published in the PR comments. See `docs/pr-proof/dpa-opt-out.md` for the initial verification record and clean-control diagnosis of existing broader eval typecheck/ratchet failures.

## Scope and operational limits
- No schema migration, production organization mutation, live-key revocation, cancellation, refund, or deployment performed.
- The final uncached policy read is dispatch admission, not a distributed cancellation/drain barrier; already-admitted or transmitted requests are not canceled.
- BYOK boundary proof uses Den-delivered configuration with an HTTP client, not a full Gateway/OpenCode runtime. Desktop/Web/automation runtime reconciliation is not fully certified here.
- Safe staged rollout and rollback precautions: `docs/features/managed-models-dpa.md`.