### PR TITLE
fix(app): keep sidebar expansion stationary

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -161,6 +161,52 @@ import { SessionTitle } from "./session-title";
 const OUTCOME_DOT_UNREAD = "#2FBE54";
 const OUTCOME_DOT_NEEDS_ACTION = "#E8933A";
 
+const SidebarReorderContext = React.createContext<{
+  isReordering: boolean;
+  setIsReordering: (value: boolean) => void;
+} | null>(null);
+
+function SidebarReorderScope({ children }: { children: React.ReactNode }) {
+  const [isReordering, setIsReordering] = React.useState(false);
+
+  return (
+    <SidebarReorderContext.Provider value={{ isReordering, setIsReordering }}>
+      <LazyMotion features={domMax}>{children}</LazyMotion>
+    </SidebarReorderContext.Provider>
+  );
+}
+
+function SidebarReorderItem(props: React.ComponentProps<typeof Reorder.Item>) {
+  const reorder = React.useContext(SidebarReorderContext);
+  const ownsGesture = React.useRef(false);
+  if (!reorder) throw new Error("SidebarReorderItem requires SidebarReorderScope");
+
+  // Removing a row mid-drag must not leave expansion animations enabled.
+  React.useEffect(() => () => {
+    if (ownsGesture.current) reorder.setIsReordering(false);
+  }, [reorder.setIsReordering]);
+
+  return (
+    <Reorder.Item
+      {...props}
+      layout="position"
+      dragElastic={0}
+      // Reorder's drag prop bypasses layoutDependency. Keep measuring every
+      // update, but only animate layout shifts during an actual reorder gesture.
+      transition={reorder.isReordering ? undefined : { layout: { duration: 0 } }}
+      onDragStart={() => {
+        ownsGesture.current = true;
+        reorder.setIsReordering(true);
+      }}
+      onDragEnd={() => {
+        ownsGesture.current = false;
+        reorder.setIsReordering(false);
+      }}
+      transformTemplate={(_latest, generated) => generated.replace(/ ?scale[XY]?\([^)]*\)/g, "")}
+    />
+  );
+}
+
 interface SessionStatusIndicatorProps {
   status?: string;
   isActiveWork: boolean;
@@ -1178,13 +1224,13 @@ export function AppSidebar(props: AppSidebarProps) {
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarHeader>
-        <LazyMotion features={domMax}>
+        <SidebarReorderScope>
           <m.div
             layoutScroll
             data-slot="sidebar-content"
             data-sidebar="content"
             data-session-number-modifier-held={props.sessionNumberShortcuts.modifierHeld ? "true" : undefined}
-            className="no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-x-hidden overflow-y-auto [--radius:var(--radius-md)] group-data-[collapsible=icon]:overflow-hidden"
+            className="no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-x-hidden overflow-y-auto [overflow-anchor:none] [--radius:var(--radius-md)] group-data-[collapsible=icon]:overflow-hidden"
           >
             {pinnedSessions.length > 0 ? (
               <GlobalPinnedSessions entries={pinnedSessions} />
@@ -1226,7 +1272,7 @@ export function AppSidebar(props: AppSidebarProps) {
               <GlobalArchivedSessions entries={archivedSessions} />
             ) : null}
           </m.div>
-        </LazyMotion>
+        </SidebarReorderScope>
 
         <SidebarFooter className="border-t border-sidebar-border/60 p-1.5 pe-0">
           <AccountStatusMenu {...props.status} onOpenAccountSettings={props.onOpenAccountSettings} />
@@ -1377,20 +1423,13 @@ function WorkspaceReorderItem({
   const dragControls = useDragControls();
 
   return (
-    <Reorder.Item
+    <SidebarReorderItem
       as="div"
       value={group.workspace.id}
       id={group.workspace.id}
       data-sidebar-workspace-id={group.workspace.id}
-      layout="position"
-      dragElastic={0}
       dragListener={false}
       dragControls={dragControls}
-      transformTemplate={(_latest, generated) =>
-        // Keep Motion's translate-based reorder movement, but drop projection scale
-        // so expanded workspace contents don't stretch during collapse/expand.
-        generated.replace(/ ?scale[XY]?\([^)]*\)/g, "")
-      }
       className="relative"
     >
       <WorkspaceSidebarGroup
@@ -1400,7 +1439,7 @@ function WorkspaceReorderItem({
         showMoreSessions={showMoreSessions}
         onWorkspaceTitlePointerDown={(event) => dragControls.start(event)}
       />
-    </Reorder.Item>
+    </SidebarReorderItem>
   );
 }
 
@@ -2112,15 +2151,12 @@ function SessionGroupSection({ group, rows, expanded, workspaceId, store, render
   const remaining = Math.max(0, rows.length - previewCount);
 
   return (
-    <Reorder.Item
+    <SidebarReorderItem
       as="div"
       value={group.id}
       id={group.id}
-      layout="position"
-      dragElastic={0}
       dragListener={false}
       dragControls={dragControls}
-      transformTemplate={(_latest, generated) => generated.replace(/ ?scale[XY]?\([^)]*\)/g, "")}
     >
       <GroupDropZone groupId={group.id} workspaceId={workspaceId}>
         <Collapsible
@@ -2161,7 +2197,7 @@ function SessionGroupSection({ group, rows, expanded, workspaceId, store, render
           </CollapsibleContent>
         </Collapsible>
       </GroupDropZone>
-    </Reorder.Item>
+    </SidebarReorderItem>
   );
 }
 
@@ -2340,15 +2376,12 @@ function SessionMenuItem({
   if (!draggable) return item;
 
   return (
-    <Reorder.Item
+    <SidebarReorderItem
       as="div"
       value={session.id}
       id={session.id}
-      layout="position"
-      dragElastic={0}
-      transformTemplate={(_latest, generated) => generated.replace(/ ?scale[XY]?\([^)]*\)/g, "")}
     >
       {item}
-    </Reorder.Item>
+    </SidebarReorderItem>
   );
 }

--- a/evals/packages/behaviors/src/index.ts
+++ b/evals/packages/behaviors/src/index.ts
@@ -16,3 +16,4 @@ export * from "./live-openai.ts";
 
 export { observeText, textProgressFailures } from "./text-observation.ts";
 export * from "./typing.ts";
+export { observeSidebarExpansion, readSidebarOverflow } from "./sidebar-observation.ts";

--- a/evals/packages/behaviors/src/sidebar-observation.ts
+++ b/evals/packages/behaviors/src/sidebar-observation.ts
@@ -1,0 +1,136 @@
+import { callFunctionOnSurface, type Surface } from "@openwork/cdp";
+
+/** Overflow, action-lane, and rail geometry without changing scroll position or focus. */
+export function readSidebarOverflow(surface: Surface, title = "") {
+  return callFunctionOnSurface(surface, title => {
+    const list = document.querySelector<HTMLElement>('[data-sidebar="content"]');
+    const rail = document.querySelector<HTMLElement>('[data-sidebar="rail"]')?.getBoundingClientRect();
+    const text = [...document.querySelectorAll<HTMLElement>("[data-session-title-text]")]
+      .find(node => node.textContent?.trim() === title);
+    const viewport = text?.parentElement;
+    return {
+      list: list ? { clientWidth: list.clientWidth, scrollLeft: list.scrollLeft, scrollWidth: list.scrollWidth } : null,
+      rail: rail ? { x: rail.left + rail.width / 2, y: rail.top + rail.height / 2 } : null,
+      title: text && viewport ? { clientWidth: viewport.clientWidth, scrollWidth: text.scrollWidth,
+        hiddenEdges: viewport.dataset.sessionTitleHiddenEdges ?? "", maskImage: getComputedStyle(viewport).maskImage } : null,
+      rows: [...document.querySelectorAll<HTMLElement>("[data-sidebar-session-id]")].map(row => {
+        const title = row.querySelector<HTMLElement>("[data-session-title-slot]");
+        const actions = row.querySelector<HTMLElement>("[data-session-hover-actions]");
+        if (!title || !actions) return null;
+        return { title: title.textContent?.trim() ?? "", titleRight: title.getBoundingClientRect().right,
+          actionsLeft: actions.getBoundingClientRect().left, actionsOpacity: getComputedStyle(actions).opacity };
+      }),
+    };
+  }, [title]);
+}
+
+interface SidebarGeometry {
+  at: number;
+  scrollTop: number;
+  viewport: { top: number; bottom: number };
+  hash: string;
+  selected: string[];
+  management: string | null;
+  rows: { id: string; top: number; bottom: number; x: number; y: number; projectionY: number }[];
+}
+
+interface ExpansionFrames {
+  before: SidebarGeometry;
+  triggerTop: number;
+  label: string;
+  frames: SidebarGeometry[];
+  complete: boolean;
+}
+
+declare global {
+  interface Window {
+    [key: `sidebar-observation-${string}`]: {
+      snapshot(): SidebarGeometry;
+      expansion: ExpansionFrames | null;
+      clicks: number;
+      stop(): void;
+    } | undefined;
+  }
+}
+
+/** Install during arrangement: capture before a trusted expansion click, not after its animation. */
+export async function observeSidebarExpansion(surface: Surface) {
+  const key: `sidebar-observation-${string}` = `sidebar-observation-${crypto.randomUUID()}`;
+  await callFunctionOnSurface(surface, (key: `sidebar-observation-${string}`) => {
+    const snapshot = (): SidebarGeometry => {
+      const content = document.querySelector<HTMLElement>('[data-sidebar="content"]');
+      if (!content) throw new Error("Sidebar scroller is unavailable");
+      const viewport = content.getBoundingClientRect();
+      const rows = [...content.querySelectorAll<HTMLElement>(
+        '[data-sidebar-session-id], [data-sidebar-workspace-title], [data-session-group], [role="button"][aria-expanded]',
+      )].filter(row => row.getClientRects().length && getComputedStyle(row).visibility !== "hidden")
+        .map(row => {
+          const box = row.getBoundingClientRect();
+          const workspace = row.closest<HTMLElement>('[data-sidebar-workspace-id]')?.dataset.sidebarWorkspaceId;
+          const id = row.dataset.sidebarSessionId ? `session:${row.dataset.sidebarSessionId}`
+            : row.hasAttribute("data-sidebar-workspace-title") ? `workspace:${workspace}`
+              : `group:${row.dataset.sessionGroup ?? "ungrouped"}`;
+          let projectionY = 0;
+          for (let ancestor: HTMLElement | null = row; ancestor && ancestor !== content; ancestor = ancestor.parentElement) {
+            const transform = getComputedStyle(ancestor).transform;
+            if (transform !== "none") projectionY += new DOMMatrixReadOnly(transform).m42;
+          }
+          // Group dragging starts on its title span, not its collapse icon or menu.
+          const handle = row.hasAttribute("data-session-group") ? row.querySelector("span.cursor-grab") : row;
+          const handleBox = (handle ?? row).getBoundingClientRect();
+          return { id, top: box.top, bottom: box.bottom, x: handleBox.left + handleBox.width / 2,
+            y: handleBox.top + handleBox.height / 2, projectionY };
+        });
+      return {
+        at: performance.now(), scrollTop: content.scrollTop,
+        viewport: { top: viewport.top, bottom: viewport.bottom }, rows,
+        hash: location.hash,
+        selected: [...document.querySelectorAll<HTMLElement>('[data-session-tab-active="true"]')]
+          .map(row => row.dataset.sessionTabId ?? ""),
+        management: localStorage.getItem("openwork.react.sessionManagement"),
+      };
+    };
+    let frame = 0;
+    let timer: ReturnType<typeof setTimeout>;
+    const observer: NonNullable<Window[typeof key]> = {
+      snapshot, expansion: null, clicks: 0,
+      stop() { cancelAnimationFrame(frame); clearTimeout(timer); document.removeEventListener("click", onClick, true); },
+    };
+    const onClick = (event: MouseEvent) => {
+      if (!event.isTrusted || !(event.target instanceof Element)) return;
+      const trigger = event.target.closest<HTMLElement>('[data-sidebar="menu-sub-button"]');
+      const label = trigger?.textContent?.trim() ?? "";
+      if (!trigger?.closest('[data-sidebar="content"]') || !/^Show \d+ more$/.test(label)) return;
+      cancelAnimationFrame(frame);
+      clearTimeout(timer);
+      const expansion: ExpansionFrames = { before: snapshot(), triggerTop: trigger.getBoundingClientRect().top,
+        label, frames: [], complete: false };
+      observer.expansion = expansion;
+      observer.clicks++;
+      const sample = () => {
+        expansion.frames.push(snapshot());
+        if (performance.now() - expansion.before.at >= 1_500) expansion.complete = true;
+        else if (expansion.frames.length < 240) frame = requestAnimationFrame(sample);
+      };
+      frame = requestAnimationFrame(sample);
+      // A suspended renderer or missing frames must fail rather than silently pass.
+      timer = setTimeout(() => cancelAnimationFrame(frame), 5_000);
+    };
+    document.addEventListener("click", onClick, true);
+    window[key] = observer;
+  }, [key]);
+  return {
+    read() {
+      return callFunctionOnSurface(surface, (key: `sidebar-observation-${string}`) => {
+        const observer = window[key];
+        if (!observer) throw new Error("Sidebar frame observation was lost");
+        return { current: observer.snapshot(), expansion: observer.expansion, clicks: observer.clicks };
+      }, [key]);
+    },
+    async [Symbol.asyncDispose]() {
+      await callFunctionOnSurface(surface, (key: `sidebar-observation-${string}`) => {
+        window[key]?.stop(); delete window[key];
+      }, [key]);
+    },
+  };
+}

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -18,3 +18,4 @@ export * from "./spec/index.ts";
 export * from "./state.ts";
 
 export { observeTranscript, readTranscriptMessages } from "./transcript-observer.ts";
+export { readSidebarOverflow } from "@openwork/behaviors";

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -1,9 +1,23 @@
 import { browserScript } from "@openwork/testkit";
-import { expect } from "vitest";
-import { spec, type Probe } from "@openwork/testkit";
-import { sidebarOverflow } from "../worlds/session-shell.ts";
+import { beforeEach, describe, expect } from "vitest";
+import { spec, readSidebarOverflow, type Surface } from "@openwork/testkit";
+import { sidebarExpansion, sidebarOverflow } from "../worlds/session-shell.ts";
 
-const test = spec.world(sidebarOverflow);
+type SidebarMode = "overflow" | "workspace" | "group" | "ungrouped";
+
+// Shared with the legacy rail gesture below: real, paced pointer input, never DOM events.
+async function dragPointer(app: Surface, from: { x: number; y: number }, to: { x: number; y: number }) {
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", ...from, button: "left", buttons: 1, clickCount: 1 });
+  try {
+    for (let index = 1; index <= 20; index++) {
+      await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: from.x + (to.x - from.x) * index / 20,
+        y: from.y + (to.y - from.y) * index / 20, button: "left", buttons: 1 });
+      await new Promise(resolve => setTimeout(resolve, 20));
+    }
+  } finally {
+    await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", ...to, button: "left", buttons: 0, clickCount: 1 });
+  }
+}
 
 interface TitleState {
   clientWidth: number;
@@ -29,19 +43,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-async function rowStates(probe: Probe): Promise<RowState[]> {
-  // TODO(primitive): probe.geometry should read the boxes of a row's title and actions.
-  const value = await probe.eval(() => ((() => [...document.querySelectorAll<HTMLElement>("[data-sidebar-session-id]")].map((row) => {
-    const title = row.querySelector<HTMLElement>("[data-session-title-slot]");
-    const actions = row.querySelector<HTMLElement>("[data-session-hover-actions]");
-    if (!(title instanceof HTMLElement) || !(actions instanceof HTMLElement)) return null;
-    return {
-      title: (title.textContent ?? "").trim(),
-      titleRight: title.getBoundingClientRect().right,
-      actionsLeft: actions.getBoundingClientRect().left,
-      actionsOpacity: getComputedStyle(actions).opacity,
-    };
-  }))()));
+async function rowStates(app: Surface): Promise<RowState[]> {
+  const value = (await readSidebarOverflow(app)).rows;
   if (!Array.isArray(value)) throw new Error(`Unexpected sidebar rows: ${JSON.stringify(value)}`);
   return value.map((row) => {
     if (!isRecord(row)
@@ -53,13 +56,8 @@ async function rowStates(probe: Probe): Promise<RowState[]> {
   });
 }
 
-async function listState(probe: Probe): Promise<ListState> {
-  // TODO(primitive): probe.geometry should read the scroll extents of a visible target.
-  const value = await probe.eval(() => {
-    const list = document.querySelector<HTMLElement>('[data-sidebar="content"]');
-    if (!(list instanceof HTMLElement)) return null;
-    return { clientWidth: list.clientWidth, scrollLeft: list.scrollLeft, scrollWidth: list.scrollWidth };
-  });
+async function listState(app: Surface): Promise<ListState> {
+  const value = (await readSidebarOverflow(app)).list;
   if (!isRecord(value)
     || typeof value.clientWidth !== "number"
     || typeof value.scrollLeft !== "number"
@@ -68,26 +66,14 @@ async function listState(probe: Probe): Promise<ListState> {
 }
 
 /** Nothing in the sidebar list is hidden sideways, so there is nothing to scroll to. */
-async function expectListFits(probe: Probe): Promise<void> {
-  const list = await listState(probe);
+async function expectListFits(app: Surface): Promise<void> {
+  const list = await listState(app);
   expect(list.scrollWidth).toBeLessThanOrEqual(list.clientWidth);
   expect(list.scrollLeft).toBe(0);
 }
 
-async function titleState(probe: Probe, title: string): Promise<TitleState> {
-  // TODO(primitive): probe.computedStyle should read overflow geometry and computed masks for a visible target.
-  const value = await probe.eval(browserScript((title) => {
-    const text = [...document.querySelectorAll<HTMLElement>("[data-session-title-text]")]
-      .find((node) => (node.textContent ?? "").trim() === title);
-    if (!(text instanceof HTMLElement) || !(text.parentElement instanceof HTMLElement)) return null;
-    const viewport = text.parentElement;
-    return {
-      clientWidth: viewport.clientWidth,
-      hiddenEdges: viewport.dataset.sessionTitleHiddenEdges ?? "",
-      maskImage: getComputedStyle(viewport).maskImage,
-      scrollWidth: text.scrollWidth,
-    };
-  }, [title]));
+async function titleState(app: Surface, title: string): Promise<TitleState> {
+  const value = (await readSidebarOverflow(app, title)).title;
   if (!isRecord(value)
     || typeof value.clientWidth !== "number"
     || typeof value.hiddenEdges !== "string"
@@ -101,9 +87,21 @@ async function titleState(probe: Probe, title: string): Promise<TitleState> {
   };
 }
 
+describe.sequential("sidebar expansion and title continuity", () => {
+let selectedMode: SidebarMode = "overflow";
+// Register one fixture: repeated extensions accumulate worlds in Vitest 3.
+const test = spec.world(async seed => {
+  const mode = selectedMode;
+  if (mode === "overflow") return { mode, ...await sidebarOverflow(seed) };
+  return { mode, ...await sidebarExpansion(seed, mode) };
+});
+
+describe("title overflow", () => {
+beforeEach(() => { selectedMode = "overflow"; });
 test("the sidebar title fade follows only the edges with hidden text", async ({ world, user, seed, probe, step }) => {
+  if (world.mode !== "overflow") throw new Error("Unexpected sidebar fixture");
   const workspaceName = world.workspacePath.split("/").at(-1) ?? world.workspacePath;
-  const resting = await probe.eventually(() => titleState(probe, world.longTitle), {
+  const resting = await probe.eventually(() => titleState(world.app, world.longTitle), {
     within: 60_000,
     label: "overflowing sidebar title",
     until: (state) => state.scrollWidth > state.clientWidth && state.hiddenEdges === "end",
@@ -164,18 +162,18 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
   });
 
   await step("the list fits the sidebar and does not scroll sideways", async () => {
-    await expectListFits(probe);
+    await expectListFits(world.app);
   });
 
   await step("a fitting workspace row stays fully visible on hover", async () => {
-    const fitting = await probe.eventually(() => titleState(probe, workspaceName), {
+    const fitting = await probe.eventually(() => titleState(world.app, workspaceName), {
       within: 30_000,
       label: "fitting workspace title",
       until: (state) => state.scrollWidth <= state.clientWidth && state.hiddenEdges === "none",
     });
     expect(fitting.maskImage).toBe("none");
     await user.hover({ text: workspaceName });
-    const hovered = await probe.eventually(() => titleState(probe, workspaceName), {
+    const hovered = await probe.eventually(() => titleState(world.app, workspaceName), {
       within: 10_000,
       label: "fitting workspace title after hover",
       until: (state) => state.hiddenEdges === "none",
@@ -186,13 +184,13 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
 
   await step("hover reveals the clipped ending without fading it", async () => {
     await user.hover({ text: world.longTitle });
-    const moving = await probe.eventually(() => titleState(probe, world.longTitle), {
+    const moving = await probe.eventually(() => titleState(world.app, world.longTitle), {
       within: 10_000,
       label: "title moves between clipped edges",
       until: (state) => state.hiddenEdges === "both",
     });
     expect(moving.maskImage).not.toBe("none");
-    const revealed = await probe.eventually(() => titleState(probe, world.longTitle), {
+    const revealed = await probe.eventually(() => titleState(world.app, world.longTitle), {
       within: 30_000,
       label: "title reveal reaches its final characters",
       until: (state) => state.hiddenEdges === "start",
@@ -203,39 +201,31 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
 
   await step("widening the sidebar removes the fade", async () => {
     // TODO(primitive): user.drag should resize a visible rail using trusted pointer input.
-    // TODO(primitive): probe.geometry should resolve the center of a visible target.
-    const point = await probe.eval(() => {
-      const rail = document.querySelector<HTMLElement>('[data-sidebar="rail"]');
-      if (!(rail instanceof HTMLElement)) return null;
-      const rect = rail.getBoundingClientRect();
-      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
-    });
+    const point = (await readSidebarOverflow(world.app)).rail;
     if (!isRecord(point) || typeof point.x !== "number" || typeof point.y !== "number") throw new Error("Sidebar rail was not measurable.");
-    await world.app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
-    await world.app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x + 340, y: point.y, button: "left" });
-    await world.app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x + 340, y: point.y, button: "left", clickCount: 1 });
-    const fitting = await probe.eventually(() => titleState(probe, world.longTitle), {
+    await dragPointer(world.app, { x: point.x, y: point.y }, { x: point.x + 340, y: point.y });
+    const fitting = await probe.eventually(() => titleState(world.app, world.longTitle), {
       within: 15_000,
       label: "expanded sidebar exposes full title",
       until: (state) => state.hiddenEdges === "none",
     });
     expect(fitting.clientWidth).toBeGreaterThanOrEqual(fitting.scrollWidth);
     expect(fitting.maskImage).toBe("none");
-    const workspaceAfterResize = await titleState(probe, workspaceName);
+    const workspaceAfterResize = await titleState(world.app, workspaceName);
     expect(workspaceAfterResize.hiddenEdges).toBe("none");
     expect(workspaceAfterResize.maskImage).toBe("none");
     await user.screenshot();
   });
 
   await step("the widened list still fits and does not scroll sideways", async () => {
-    await expectListFits(probe);
+    await expectListFits(world.app);
   });
 
   await step("below the hover breakpoint, titles stop before the always-visible row actions", async () => {
     // TODO(primitive): user.resizeViewport should narrow a desktop surface below the hover breakpoint.
     await world.app.client.send("Emulation.setDeviceMetricsOverride", { width: 900, height: 800, deviceScaleFactor: 1, mobile: false });
     await user.press("Meta+b");
-    const rows = await probe.eventually(() => rowStates(probe), {
+    const rows = await probe.eventually(() => rowStates(world.app), {
       within: 15_000,
       label: "session rows with visible actions",
       until: (rows) => rows.length > 0 && rows.every((row) => row.actionsOpacity === "1"),
@@ -243,4 +233,137 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
     for (const row of rows) expect(row.titleRight, row.title).toBeLessThanOrEqual(row.actionsLeft);
     await user.screenshot();
   });
+});
+
+});
+
+const expansionModes: ("workspace" | "group" | "ungrouped")[] = ["workspace", "group", "ungrouped"];
+for (const mode of expansionModes) {
+  describe(mode, () => {
+  beforeEach(() => { selectedMode = mode; });
+  test(`${mode} Show more keeps old rows anchored through every frame and still permits reordering`, async ({ world, user, probe, step }) => {
+    if (world.mode === "overflow") throw new Error("Unexpected sidebar fixture");
+    const first = world.sessions[0];
+    if (!first) throw new Error("Missing expansion anchor session");
+    await user.click({ role: "button", label: first.title });
+    const initial = await probe.eventually(() => world.observation.read(), {
+      within: 30_000, label: "expansion anchor selected",
+      until: value => value.current.selected.length === 1 && value.current.selected[0] === first.sessionId,
+    });
+    const expectedIds = [...world.sessions, ...(mode === "workspace" ? [world.neighbor] : [])].map(session => `session:${session.sessionId}`);
+    const listRows = (rows: typeof initial.current.rows) => rows.filter(row => expectedIds.includes(row.id));
+    expect(listRows(initial.current.rows).map(row => row.id)).toEqual(expectedIds.slice(0, 6));
+    let scrolledExpansions = 0;
+
+    for (const [index, count] of [12, 18, expectedIds.length].entries()) {
+      await step(`${mode} expansion ${index + 1} reveals ${count} rows without a scroll jump, floating rows, navigation, or reorder`, async () => {
+        const label = `Show ${Math.min(6, expectedIds.length - (6 + index * 6))} more`;
+        await user.click({ text: label });
+        const observed = await probe.eventually(() => world.observation.read(), {
+          within: 10_000, label: "complete expansion frame window",
+          until: value => value.clicks === index + 1 && value.expansion?.complete === true,
+        });
+        const capture = observed.expansion;
+        if (!capture) throw new Error("Trusted expansion click was not captured");
+        expect(capture.label).toBe(label);
+        expect(capture.before.selected).toEqual(initial.current.selected);
+        expect(capture.before.hash).toBe(initial.current.hash);
+        expect(listRows(capture.before.rows).map(row => row.id)).toEqual(expectedIds.slice(0, 6 + index * 6));
+        if (capture.before.scrollTop > 0) scrolledExpansions++;
+        const anchors = capture.before.rows.filter(row => row.top >= capture.before.viewport.top
+          && row.bottom <= Math.min(capture.before.viewport.bottom, capture.triggerTop));
+        expect(anchors.length, "visible old rows above the expansion control").toBeGreaterThan(0);
+        expect(capture.frames.length).toBeGreaterThanOrEqual(20);
+        expect(capture.frames[0]!.at - capture.before.at, "first expansion frame captured promptly").toBeLessThan(100);
+        let previousAt = capture.before.at;
+        let revealed = false;
+        for (const frame of capture.frames) {
+          expect(frame.at - previousAt, "no unobserved animation-sized frame gap").toBeLessThan(150);
+          previousAt = frame.at;
+          expect(frame.hash).toBe(capture.before.hash);
+          expect(frame.selected).toEqual(capture.before.selected);
+          expect(frame.management, "expanding must not mutate ordering, groups, or pins").toBe(capture.before.management);
+          expect(Math.abs(frame.scrollTop - capture.before.scrollTop), "sidebar scroll position").toBeLessThanOrEqual(1);
+          for (const anchor of anchors) {
+            const row = frame.rows.find(row => row.id === anchor.id);
+            expect(row, `old row ${anchor.id} remains rendered`).toBeDefined();
+            expect(Math.abs(row!.top - anchor.top), `old row ${anchor.id} remains stationary`).toBeLessThanOrEqual(1);
+          }
+          const visible = frame.rows.filter(row => row.bottom > frame.viewport.top && row.top < frame.viewport.bottom);
+          for (const [rowIndex, row] of visible.entries()) {
+            expect(Math.abs(row.projectionY), `${row.id} must not float during expansion`).toBeLessThanOrEqual(1);
+            const next = visible[rowIndex + 1];
+            if (next) expect(row.bottom, `${row.id} must not overlap ${next.id}`).toBeLessThanOrEqual(next.top + 1);
+          }
+          const ids = listRows(frame.rows).map(row => row.id);
+          if (ids.length === count) revealed = true;
+          expect(ids).toEqual(expectedIds.slice(0, revealed ? count : 6 + index * 6));
+        }
+        expect(revealed, "new batch appears within the observed frames").toBe(true);
+        expect(listRows(observed.current.rows).map(row => row.id)).toEqual(expectedIds.slice(0, count));
+      });
+    }
+    expect(scrolledExpansions, "exercise expansion in an already-scrolled sidebar").toBeGreaterThan(0);
+    await user.notSee({ text: /^Show \d+ more$/ }, { timeoutMs: 500 });
+
+    await step("drag still reorders after expansion without selecting another conversation", async () => {
+      const last = world.sessions.at(-1)!;
+      const preceding = world.sessions.at(-2)!;
+      let sourceId = `session:${last.sessionId}`;
+      let targetId = `session:${preceding.sessionId}`;
+      if (mode === "group") {
+        await user.click({ text: "Expansion group" });
+        await user.click({ text: "Neighbor group" });
+        await user.hover({ text: "Neighbor group" });
+        sourceId = "group:grp_neighbor";
+        targetId = "group:grp_expansion";
+      } else {
+        await user.hover({ role: "button", label: last.title });
+      }
+      const before = await probe.eventually(() => world.observation.read(), {
+        within: 10_000, label: "reorder targets visible and settled",
+        until: value => (mode !== "group" || value.current.rows.every(row => !row.id.startsWith("session:")))
+          && [sourceId, targetId].every(id => value.current.rows.some(row => row.id === id
+            && row.top >= value.current.viewport.top && row.bottom <= value.current.viewport.bottom && Math.abs(row.projectionY) < 1)),
+      });
+      const from = before.current.rows.find(row => row.id === sourceId)!;
+      const to = before.current.rows.find(row => row.id === targetId)!;
+      await dragPointer(world.app, from, { x: from.x, y: to.y - 4 });
+      const reordered = await probe.eventually(() => world.observation.read(), {
+        within: 10_000, label: "trusted drag changes row order and settles",
+        until: value => {
+          const ids = value.current.rows.map(row => row.id);
+          return ids.indexOf(sourceId) < ids.indexOf(targetId)
+            && value.current.rows.every(row => Math.abs(row.projectionY) < 1);
+        },
+      });
+      const idsBefore = before.current.rows.map(row => row.id);
+      const expected = [...idsBefore];
+      expected.splice(expected.indexOf(sourceId), 1);
+      expected.splice(expected.indexOf(targetId), 0, sourceId);
+      expect(reordered.current.rows.map(row => row.id)).toEqual(expected);
+      expect(reordered.current.hash).toBe(initial.current.hash);
+      if (mode === "group") {
+        // Collapsed panels unmount their session rows; restore the selection witness.
+        await user.click({ text: "Expansion group" });
+        await probe.eventually(() => world.observation.read(), {
+          within: 10_000, label: "selected conversation remains selected after group reorder",
+          until: value => value.current.selected.includes(first.sessionId),
+        });
+      }
+      expect((await world.observation.read()).current.selected).toEqual(initial.current.selected);
+      const management = await probe.storage("openwork.react.sessionManagement");
+      if (mode === "group") expect(management).toMatchObject({ state: { groupsByWorkspace: {
+        [world.workspace.workspaceId]: { groups: [{ id: "grp_neighbor" }, { id: "grp_expansion" }] },
+      } } });
+      else {
+        const sessionOrder = [...world.sessions.map(session => session.sessionId), world.neighbor.sessionId];
+        sessionOrder.splice(sessionOrder.indexOf(last.sessionId), 1);
+        sessionOrder.splice(sessionOrder.indexOf(preceding.sessionId), 0, last.sessionId);
+        expect(management).toMatchObject({ state: { orderByWorkspace: { [world.workspace.workspaceId]: sessionOrder } } });
+      }
+    });
+  });
+  });
+}
 });

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1,7 +1,7 @@
 import { browserScript } from "@openwork/cdp";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { mkdir, rm } from "node:fs/promises";
-import { engineSessionProbe, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
+import { engineSessionProbe, observeSidebarExpansion, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
 import { resolveEvalEngine } from "@openwork/env";
 import type { Seed } from "@openwork/env";
 import { daytonaSandbox, desktop as launchDesktop } from "@openwork/hosts";
@@ -197,6 +197,43 @@ export async function sidebarOverflow(seed: Seed) {
   const workspace = await seed.workspace(app, workspacePath);
   const sessions = await seed.sessions(app, [longTitle]);
   return { app, workspace, workspacePath, sessions, longTitle };
+}
+
+export async function sidebarExpansion(seed: Seed, mode: "workspace" | "group" | "ungrouped") {
+  const app = await seed.desktop({ name: `sidebar-${mode}-expansion` });
+  await app.client.send("Emulation.setDeviceMetricsOverride", { width: 1280, height: 600, deviceScaleFactor: 1, mobile: false });
+  const workspace = await seed.workspace(app, seed.tmpPath(`sidebar-${mode}`));
+  const sessions = await seed.sessions(app, Array.from({ length: 20 }, (_, index) => `Expansion task ${String(index + 1).padStart(2, "0")}`));
+  const [neighbor] = await seed.sessions(app, ["Neighbor task"]);
+  if (!neighbor) throw new Error("Sidebar expansion neighbor was not created");
+  const groups = mode === "workspace" ? [] : [
+    ...(mode === "group" ? [{ id: "grp_expansion", label: "Expansion group" }] : []),
+    { id: "grp_neighbor", label: "Neighbor group" },
+  ];
+  const assignments = mode === "workspace" ? {} : Object.fromEntries([
+    ...sessions.flatMap(session => mode === "group" ? [[session.sessionId, "grp_expansion"]] : []),
+    [neighbor.sessionId, "grp_neighbor"],
+  ]);
+  // Persist real group state and manual order before reload; no component/store imports.
+  await seed.evalIn(app, browserScript(async (workspaceId, groups, assignments, ids) => {
+    const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
+    if (!info?.baseUrl) throw new Error("Sidebar seed needs the local server");
+    const response = await fetch(`${info.baseUrl.replace(/\/+$/, "")}/workspace/${encodeURIComponent(workspaceId)}/session-groups`, {
+      method: "PUT", headers: { Authorization: `Bearer ${info.ownerToken ?? info.clientToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ state: { groups, assignments } }), signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) throw new Error(`Sidebar group seed failed: ${response.status}`);
+    localStorage.setItem("openwork.react.sessionManagement", JSON.stringify({ state: {
+      pinnedIds: [], unreadIds: [], orderByWorkspace: { [workspaceId]: ids },
+      groupsByWorkspace: { [workspaceId]: { groups, assignments, collapsedGroupIds: [] } },
+    }, version: 0 }));
+  }, [workspace.workspaceId, groups, assignments, [...sessions.map(session => session.sessionId), neighbor.sessionId]]));
+  await app.client.send("Page.reload");
+  await waitFor(app, () => Boolean(document.querySelector('[data-sidebar-session-id]')) && Boolean(window.__openworkControl), {
+    timeoutMs: 60_000, label: "sidebar expansion fixture reloaded",
+  });
+  const observation = await observeSidebarExpansion(app);
+  return { app, workspace, sessions, neighbor, observation, [Symbol.asyncDispose]: () => observation[Symbol.asyncDispose]() };
 }
 
 export async function sidebarWorkspaceTitles(seed: Seed) {


### PR DESCRIPTION
## Summary

Keep the left sidebar stationary when revealing more conversations, without removing animated title reveal or drag-and-drop ordering.

- Disable native scroll anchoring only in the sidebar's scrolling list.
- Keep Motion's position measurement and drag behavior, but animate positional layout changes only during an active reorder gesture. Idle expansion no longer slides existing rows, groups, or workspaces from their previous positions.
- Preserve the inline title marquee, hover actions, keyboard-focus reveal, and reduced-motion behavior unchanged.
- Extend the existing sidebar journey with repeated and final-batch expansion across ordinary, grouped, and ungrouped lists, frame-level position/overlap assertions, unchanged selection/order, and post-expansion reordering.

## Scope and tradeoffs

The product change is confined to `app-sidebar.tsx`. Idle insertions, collapse, and programmatic reordering now settle immediately; drag reordering retains its motion. Native anchoring is disabled throughout the sidebar, so background insertions should also be checked before merging. There are no scroll-reset timers, forced remounts, data-fetch changes, or new dependencies.

## Verification — Failed

This PR was merged while its app journey was still running. The completed result does **not** establish that sidebar expansion is fixed in every path.

- Passed: app TypeScript check; 14 focused sidebar/title tests, 0 failures; browser callback checker; diff whitespace check.
- Exact-head command: `OPENWORK_EVAL_REF=3516c4aac81a9fb356637ae2f6df4357280b5f7b pnpm evals:e2e sidebar-title-overflow-fade`.
- Placement: `daytona (daytona CLI authenticated)`. Desktop checkout confirmed the same SHA.
- Exit 1: **1 passed, 3 failed, 0 skipped**; approximately 12 minutes.
- Passed: existing title hover/fade, sidebar width and action-lane journey.
- Failed: workspace expansion's absolute-transform assertion reported 4px. That assertion conflates a static transform with movement; a geometry-based correction is retained locally, not part of the merged PR.
- Failed: grouped expansion reported a session/group overlap (`548 > 415`). Root cause remains unresolved.
- Failed: ungrouped expansion timed out locating the final `Show 2 more` control. Root cause remains unresolved.
- Deferred: corrected exact-head rerun and remaining drag/workspace/background-insertion coverage. Do not treat the unit or title-journey pass as expansion proof.

The interrupted earlier diagnostic run is not evidence for this PR. The final run's owned sandboxes were deleted by teardown.

## Manual acceptance

1. In a long sidebar, scroll to Show more and reveal successive batches, including the last partial batch. The visible old rows and scroll position must not jump or float.
2. Repeat in named groups and ungrouped sections; selection and ordering must not change from expansion.
3. Hover an overflowing title and focus it with the keyboard; the existing reveal should still work.
4. Drag sessions and groups after expansion; ordering should remain functional. Check workspace dragging and background session arrivals as additional regression coverage.
