### PR TITLE
Make the managed model picker OpenWork-only with contextual upgrades

### DIFF
--- a/apps/app/src/app/lib/inference-access.ts
+++ b/apps/app/src/app/lib/inference-access.ts
@@ -1,12 +1,21 @@
-import { INFERENCE_ACCESS_REASONS, type InferenceAccess } from "@openwork/types/den/inference";
+import { INFERENCE_ACCESS_REASONS, type InferenceAccess, type ManagedModelRecommendation } from "@openwork/types/den/inference";
 import { z } from "zod";
-import type { ModelRef } from "../types";
+import type { ModelOption, ModelRef } from "../types";
 
 export const FREE_LUNA_MODEL: ModelRef = { providerID: "openwork", modelID: "openai/gpt-5.6-luna" };
 export const inferenceAccessRefreshEvent = "openwork.inference-access-refresh";
 export const explicitModelChoiceKey = "openwork.modelChoice.explicit";
 
 const usd = z.number().finite().nonnegative().nullable();
+const managedModelRecommendationSchema: z.ZodType<ManagedModelRecommendation> = z.object({
+  modelID: z.string().trim().min(1),
+  displayName: z.string().trim().min(1),
+  providerName: z.string().trim().min(1),
+  summary: z.string().trim(),
+  recommended: z.boolean(),
+  rank: z.number().finite(),
+  capabilities: z.array(z.string().trim().min(1)),
+});
 export const inferenceAccessSchema: z.ZodType<InferenceAccess & { canUpgrade: boolean }> = z.object({
   kind: z.enum(["paid", "free", "exhausted", "unavailable"]),
   modelID: z.string().nullable(),
@@ -17,14 +26,47 @@ export const inferenceAccessSchema: z.ZodType<InferenceAccess & { canUpgrade: bo
   resetsAt: z.iso.datetime().nullable(),
   reason: z.enum(INFERENCE_ACCESS_REASONS).nullable(),
   canUpgrade: z.boolean(),
+  // Optional presentation data must never discard a valid entitlement response.
+  catalog: z.array(managedModelRecommendationSchema).optional().catch(undefined),
+  plan: z.object({
+    name: z.string().trim().min(1),
+    priceLabel: z.string().trim().min(1).nullable(),
+    usageLabel: z.string().trim().min(1),
+  }).optional().catch(undefined),
 });
 
 export type InferenceUpgradeReason = "free_allowance_exhausted" | "managed_model_requires_upgrade";
 
+export function managedModelRecommendation(access: InferenceAccess | null, model: ModelRef) {
+  return model.providerID === FREE_LUNA_MODEL.providerID
+    ? access?.catalog?.find((item) => item.modelID === model.modelID)
+    : undefined;
+}
+
+export function managedModelAccessLabel(access: InferenceAccess | null, model: ModelRef) {
+  if (model.providerID !== FREE_LUNA_MODEL.providerID || !access) return null;
+  if (access.kind === "paid") return "Included";
+  if (access.kind !== "free" && access.kind !== "exhausted") return null;
+  return model.modelID === access.modelID ? "Free" : "Upgrade";
+}
+
+export function managedModelRecommendations(access: InferenceAccess | null, options: readonly ModelOption[]) {
+  const available = options.filter((option) => option.providerID === FREE_LUNA_MODEL.providerID && !option.disabled);
+  if (!access?.catalog?.length) return [];
+  const free = available.find((option) => option.modelID === (access.modelID ?? FREE_LUNA_MODEL.modelID));
+  const recommendations = [...access.catalog].sort((a, b) => a.rank - b.rank)
+    .filter((item) => item.recommended)
+    .flatMap((item) => {
+      const option = available.find((option) => option.modelID === item.modelID);
+      return option ? [option] : [];
+    });
+  return [...new Map([...(free ? [free] : []), ...recommendations].map((option) => [option.modelID, option])).values()].slice(0, 4);
+}
+
 export function modelSelectionUpgradeReason(access: InferenceAccess | null, model: ModelRef): InferenceUpgradeReason | null {
   // Organization BYOK uses lpr_* identities, even when its provider is managed.
   if (model.providerID !== FREE_LUNA_MODEL.providerID || !access || (access.kind !== "free" && access.kind !== "exhausted")) return null;
-  if (model.modelID !== FREE_LUNA_MODEL.modelID) return "managed_model_requires_upgrade";
+  if (model.modelID !== access.modelID) return "managed_model_requires_upgrade";
   return access.kind === "exhausted" ? "free_allowance_exhausted" : null;
 }
 

--- a/apps/app/src/app/lib/inference-access.ts
+++ b/apps/app/src/app/lib/inference-access.ts
@@ -37,6 +37,17 @@ export const inferenceAccessSchema: z.ZodType<InferenceAccess & { canUpgrade: bo
 
 export type InferenceUpgradeReason = "free_allowance_exhausted" | "managed_model_requires_upgrade";
 
+export function modelPickerView(options: readonly ModelOption[], input: {
+  access: InferenceAccess | null;
+  signedIn: boolean;
+  target: "session" | "default";
+}) {
+  const managedOnly = input.signedIn && input.target === "session"
+    && (input.access?.kind === "free" || input.access?.kind === "exhausted" || input.access?.kind === "paid");
+  // This is a view filter, not a provider restriction or a change to saved choices.
+  return { managedOnly, options: managedOnly ? options.filter((option) => option.providerID === "openwork") : options };
+}
+
 export function managedModelRecommendation(access: InferenceAccess | null, model: ModelRef) {
   return model.providerID === FREE_LUNA_MODEL.providerID
     ? access?.catalog?.find((item) => item.modelID === model.modelID)

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -19,8 +19,8 @@ import {
 import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
-import { InferenceAllowanceSummary, useInferenceAccess } from "@/react-app/domains/cloud/inference-access-provider";
-import { markExplicitModelChoice, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
+import { InferenceAllowanceSummary, OwnProviderAction, useInferenceAccess } from "@/react-app/domains/cloud/inference-access-provider";
+import { managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, markExplicitModelChoice, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
 import {
   OPENWORK_MODELS_PROVIDER_ID,
   OPENWORK_MODELS_PROVIDER_NAME,
@@ -44,7 +44,7 @@ import {
   CommandList,
   CommandPanel,
 } from "@/components/ui/command";
-import { openModelPickerEvent, openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
+import { openModelPickerEvent } from "@/react-app/shell/new-providers-listener";
 import { newProvidersEvent } from "@/app/lib/provider-events";
 import { usePlatform } from "@/react-app/kernel/platform";
 import {
@@ -241,10 +241,11 @@ export function ModelSelect({
   behaviorOptions = [],
   onBehaviorChange,
 }: ModelSelectProps) {
-  const [pane, setPane] = React.useState<"root" | "model" | "effort" | "favorites">("root");
+  const [pane, setPane] = React.useState<"model" | "effort">("model");
   const [search, setSearch] = React.useState("");
   const [thinkingFor, setThinkingFor] = React.useState<ModelOption | null>(null);
   const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const thinkingBackRef = React.useRef<HTMLButtonElement>(null);
   const platform = usePlatform();
   const denAuth = useDenAuth();
   const inference = useInferenceAccess();
@@ -259,8 +260,6 @@ export function ModelSelect({
     }),
     [behaviorLabel, behaviorOptions, behaviorValue, catalogOptions, value],
   );
-  const checkDesktopRestriction = useCheckDesktopRestriction();
-  const canAddProviders = !checkDesktopRestriction({ restriction: "allowCustomProviders" });
   const shortcutOs = resolveThinkingModeShortcutOs(
     platform.os,
     typeof navigator === "undefined" ? "" : navigator.platform,
@@ -288,6 +287,7 @@ export function ModelSelect({
     }
 
     if (pane !== "model") {
+      thinkingBackRef.current?.focus();
       return;
     }
 
@@ -319,32 +319,39 @@ export function ModelSelect({
       return option && !favoriteKeys.has(modelRefKey(model)) ? [option] : [];
     });
   }, [favoriteKeys, optionsByKey, recent]);
-  const groups = React.useMemo(() => {
-    const quickGroups: ModelSelectGroup[] = [];
-    if (favoriteOptions.length > 0) {
-      quickGroups.push({
-        value: "Favorites",
-        items: favoriteOptions.map((option) => ({ id: `favorite:${modelRefKey(option)}`, option })),
-      });
-    }
-    if (recentOptions.length > 0) {
-      quickGroups.push({
-        value: "Recent",
-        items: recentOptions.map((option) => ({ id: `recent:${modelRefKey(option)}`, option })),
-      });
-    }
-    return [...quickGroups, ...groupByProvider(modelOptions)];
-  }, [favoriteOptions, modelOptions, recentOptions]);
+  const recommendations = managedModelRecommendations(inference.access, modelOptions);
+  const groups: ModelSelectGroup[] = [];
+  const shown = new Set<string>();
+  const query = search.trim().toLowerCase();
+  const addGroup = (label: string, options: readonly ModelOption[]) => {
+    const items = options.filter((option) => {
+      const recommendation = managedModelRecommendation(inference.access, option);
+      return !option.disabled && !shown.has(modelRefKey(option)) && (!query || [
+        option.providerID, option.modelID, option.title, option.description,
+        recommendation?.displayName, recommendation?.providerName, recommendation?.summary, ...(recommendation?.capabilities ?? []),
+      ].some((text) => text?.toLowerCase().includes(query)));
+    }).map((option) => {
+      const id = modelRefKey(option);
+      shown.add(id);
+      return { id, option };
+    });
+    if (items.length) groups.push({ value: label, items });
+  };
+  addGroup("Recommended by OpenWork", recommendations);
+  addGroup("Current model", selectedOption ? [selectedOption] : []);
+  addGroup("Favorites", favoriteOptions);
+  addGroup("Recent", recentOptions.slice(0, 3));
+  const remaining = modelOptions.filter((option) => query || recommendations.length === 0 || option.providerID !== "openwork");
+  for (const group of groupByProvider(remaining)) addGroup(group.value, group.items.map((item) => item.option));
   const selectedThinkingOptions = selectedOption ? thinkingOptionsFor(selectedOption) : [];
   const effectiveBehaviorLabel = behaviorLabel ?? selectedOption?.behaviorLabel ?? "Default";
-  const currentFavorite = favoriteOptions.find((option) => isSameModel(value, option)) ?? favoriteOptions[0] ?? null;
-  const nextFavorite = nextFavoriteModel(favorites.filter((model) => !modelSelectionUpgradeReason(inference.access, model)), value);
+  const nextFavorite = nextFavoriteModel(favoriteOptions.filter((model) => !model.disabled && !modelSelectionUpgradeReason(inference.access, model)), value);
   const showBehavior = !hideValue
     && selectedThinkingOptions.length > 0
     && Boolean(effectiveBehaviorLabel);
 
   const applyModel = (option: ModelOption, behavior?: string | null) => {
-    if (!inference.checkSelection(option, sessionId)) { onOpenChange(false); return; }
+    if (!inference.checkSelection(option, sessionId, modelOptions, value)) { onOpenChange(false); return; }
     markExplicitModelChoice();
     useModelCollectionsStore.getState().recordRecent(option);
     onChange({ providerID: option.providerID, modelID: option.modelID }, behavior);
@@ -353,18 +360,11 @@ export function ModelSelect({
     }
     setSearch("");
     setThinkingFor(null);
-    setPane("root");
+    setPane("model");
     onOpenChange(false);
   };
 
   const handleSelect = (option: ModelOption) => {
-    if (!inference.checkSelection(option, sessionId)) { onOpenChange(false); return; }
-    const thinking = thinkingOptionsFor(option);
-    if (thinking.length > 0 && onBehaviorChange) {
-      setThinkingFor(option);
-      setPane("effort");
-      return;
-    }
     applyModel(option);
   };
 
@@ -379,7 +379,7 @@ export function ModelSelect({
     if (isSameModel(value, thinkingFor)) {
       onBehaviorChange?.(option.value);
       setThinkingFor(null);
-      setPane("root");
+      setPane("model");
       onOpenChange(false);
       return;
     }
@@ -397,13 +397,6 @@ export function ModelSelect({
     applyModel(option, compatibleBehavior);
   };
 
-  const handleConnectProvider = React.useCallback(() => {
-    onOpenChange(false);
-    setSearch("");
-    setPane("root");
-    window.dispatchEvent(new Event(openProviderAuthEvent));
-  }, [onOpenChange]);
-
   return (
     <Popover
       open={open}
@@ -411,12 +404,12 @@ export function ModelSelect({
         onOpenChange(nextOpen);
 
         if (nextOpen) {
-          setPane("root");
+          setPane("model");
           setThinkingFor(null);
         } else {
           setSearch("");
           setThinkingFor(null);
-          setPane("root");
+          setPane("model");
         }
       }}
     >
@@ -449,102 +442,22 @@ export function ModelSelect({
         </TooltipContent>
       </Tooltip>
       <PopoverContent
-        className="w-80 overflow-hidden rounded-2xl bg-popover p-0 shadow-xl ring-1 ring-foreground/5 dark:ring-foreground/10"
+        className="w-96 max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl bg-popover p-0 shadow-xl ring-1 ring-foreground/5 dark:ring-foreground/10"
         align="start"
         initialFocus={false}
+        data-testid="managed-model-picker"
+        aria-label="Choose a model"
       >
-        <InferenceAllowanceSummary className="px-3 pt-2" available={catalogOptions.some((option) => option.providerID === "openwork")} />
-        {pane === "root" ? (
-          <div data-slot="model-select-root" className="space-y-0.5 p-2">
-            <button
-              type="button"
-              disabled={!selectedOption || selectedThinkingOptions.length === 0 || !onBehaviorChange}
-              className="flex w-full cursor-pointer items-center gap-3 rounded-xl px-2.5 py-2 text-left text-sm transition-colors hover:bg-accent disabled:cursor-default disabled:opacity-50"
-              onClick={() => {
-                if (!selectedOption) return;
-                setThinkingFor(selectedOption);
-                setPane("effort");
-              }}
-            >
-              <span className="min-w-0 flex-1 font-medium text-foreground">Effort</span>
-              <span className="max-w-24 truncate text-muted-foreground">
-                {selectedThinkingOptions.length > 0 ? effectiveBehaviorLabel : "Unavailable"}
-              </span>
-              <kbd className="hidden shrink-0 rounded border border-border/70 bg-muted/40 px-1.5 py-0.5 font-sans text-[10px] leading-none text-muted-foreground sm:inline-flex">
-                {shortcutLabel}
-              </kbd>
-              <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-            </button>
-            <button
-              type="button"
-              disabled={favoriteOptions.length === 0}
-              className="flex w-full cursor-pointer items-center gap-3 rounded-xl px-2.5 py-2 text-left text-sm transition-colors hover:bg-accent disabled:cursor-default disabled:opacity-50"
-              onClick={() => setPane("favorites")}
-            >
-              <span className="min-w-0 flex-1 font-medium text-foreground">Favorites</span>
-              <span className="max-w-36 truncate text-muted-foreground">
-                {currentFavorite?.title ?? "None"}
-              </span>
-              <kbd className="hidden shrink-0 rounded border border-border/70 bg-muted/40 px-1.5 py-0.5 font-sans text-[10px] leading-none text-muted-foreground sm:inline-flex">
-                {favoriteShortcutLabel}
-              </kbd>
-              <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-            </button>
-            <button
-              type="button"
-              className="flex w-full cursor-pointer items-center gap-3 rounded-xl px-2.5 py-2 text-left text-sm transition-colors hover:bg-accent"
-              onClick={() => setPane("model")}
-            >
-              <span className="min-w-0 flex-1 font-medium text-foreground">Model</span>
-              <span className="max-w-36 truncate text-muted-foreground">
-                {selectedOption?.title ?? value.modelID ?? "Select model"}
-              </span>
-              <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-            </button>
-          </div>
-        ) : pane === "favorites" ? (
-          <div data-slot="model-favorites-submenu" className="flex max-h-(--available-height) flex-col">
-            <div className="flex items-center gap-2 border-b border-border px-2 py-1.5">
-              <button
-                type="button"
-                className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg px-1 py-1 text-left hover:bg-accent"
-                onClick={() => setPane("root")}
-              >
-                <ChevronLeft className="size-4 shrink-0 text-muted-foreground" />
-                <span className="text-sm font-medium">Favorites</span>
-              </button>
-              <button
-                type="button"
-                disabled={!nextFavorite}
-                className="cursor-pointer rounded-lg px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-50"
-                onClick={cycleFavorite}
-              >
-                Next · {favoriteModelShortcutLabel}
-              </button>
-            </div>
-            <div className="min-h-0 flex-1 overflow-y-auto p-1">
-              {favoriteOptions.map((option) => (
-                <button
-                  key={modelRefKey(option)}
-                  type="button"
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
-                  onClick={() => handleSelect(option)}
-                >
-                  <ProviderIcon providerId={option.providerID} providerName={option.description} className="size-3.5 opacity-70" size={14} />
-                  <span className="min-w-0 flex-1 truncate text-foreground">{option.title}</span>
-                  {isSameModel(value, option) ? <Check className="size-3.5 shrink-0 text-muted-foreground" /> : null}
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : pane === "effort" && thinkingFor ? (
+        {pane === "effort" && thinkingFor ? (
           <div data-slot="model-thinking-submenu" className="flex max-h-(--available-height) flex-col">
             <button
+              ref={thinkingBackRef}
               type="button"
+              aria-label="Back to models"
               className="flex cursor-pointer items-center gap-2 border-b border-border px-3 py-2 text-left hover:bg-accent"
               onClick={() => {
                 setThinkingFor(null);
-                setPane(isSameModel(value, thinkingFor) ? "root" : "model");
+                setPane("model");
               }}
             >
               <ChevronLeft className="size-4 shrink-0 text-muted-foreground" />
@@ -561,6 +474,7 @@ export function ModelSelect({
                   <button
                     key={option.value}
                     type="button"
+                    aria-pressed={selected}
                     className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
                     onClick={() => applyThinking(option)}
                   >
@@ -572,33 +486,23 @@ export function ModelSelect({
             </div>
           </div>
         ) : (
-          <div className="flex max-h-[min(var(--available-height),28rem)] flex-col">
-            <button
-              type="button"
-              className="flex cursor-pointer items-center gap-2 border-b border-border px-3 py-1.5 text-left hover:bg-accent"
-              onClick={() => {
-                setSearch("");
-                setPane("root");
-              }}
-            >
-              <ChevronLeft className="size-4 shrink-0 text-muted-foreground" />
-              <span className="text-sm font-medium">Model</span>
-            </button>
-            <Command items={groups} value={search} onValueChange={setSearch}>
+          <div className="flex max-h-[min(var(--available-height),36rem)] flex-col">
+            <Command items={groups} filter={null} value={search} onValueChange={setSearch}>
               <div className="flex min-h-0 flex-1 flex-col">
               <CommandHeader className="p-1.5 pb-1">
-                <CommandInput ref={searchInputRef} placeholder="Search models..." className="h-9 text-sm" />
+                <CommandInput ref={searchInputRef} placeholder="Search all models..." aria-label="Search all models" className="h-9 text-sm" />
               </CommandHeader>
+              <InferenceAllowanceSummary className="px-3 pb-2" available={catalogOptions.some((option) => option.providerID === "openwork")} />
               {openWorkModelsSyncing ? (
                 <div className="mx-1 mb-1 flex items-center gap-2 rounded-md border border-amber-6/60 bg-amber-2/40 px-2 py-1.5">
                   <ProviderIcon providerId={OPENWORK_MODELS_PROVIDER_ID} providerName={OPENWORK_MODELS_PROVIDER_NAME} className="size-3.5 shrink-0 text-amber-11" size={14} />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-xs font-medium text-foreground">{OPENWORK_MODELS_PROVIDER_NAME}</span>
-                    <span className="block truncate text-[11px] text-muted-foreground">Included — pending workspace reload…</span>
+                    <span className="block truncate text-[11px] text-muted-foreground">Pending workspace reload…</span>
                   </span>
                 </div>
               ) : null}
-              <CommandPanel className="h-0 min-h-0 flex-1 overflow-y-auto overscroll-y-contain">
+              <CommandPanel className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain">
                 <CommandEmpty>No models found.</CommandEmpty>
                 <CommandList className="not-empty:scroll-py-1 not-empty:p-1">
                   {(group: ModelSelectGroup) => (
@@ -607,25 +511,35 @@ export function ModelSelect({
                       <CommandCollection>
                         {(item: ModelSelectItem) => {
                           const option = item.option;
-                          const hasThinking = Boolean(onBehaviorChange) && thinkingOptionsFor(option).length > 0;
+                          const selected = isSameModel(value, option);
+                          const recommendation = managedModelRecommendation(inference.access, option);
+                          const name = recommendation?.displayName ?? option.title;
+                          const accessLabel = managedModelAccessLabel(inference.access, option);
                           const favorite = favoriteKeys.has(modelRefKey(option));
                           return (
                             <CommandItem
                               className="min-h-0 gap-2 rounded-lg px-2 py-1.5"
                               key={item.id}
-                              value={`${option.providerID}:${option.modelID} ${option.title} ${option.description ?? ""}`}
+                              value={`${option.providerID}:${option.modelID} ${name} ${option.title} ${option.description ?? ""} ${recommendation?.summary ?? ""} ${recommendation?.capabilities.join(" ") ?? ""}`}
                               onClick={() => handleSelect(option)}
-                              data-checked={isSameModel(value, option)}
+                              data-checked={selected}
+                              data-testid={`model-option-${option.providerID}-${option.modelID}`}
+                              aria-description={recommendation?.summary}
+                              aria-label={`${name}${accessLabel ? `, ${accessLabel}` : ""}${selected ? ", current model" : ""}${modelSelectionUpgradeReason(inference.access, option) === "free_allowance_exhausted" ? ", allowance used up" : ""}${modelSelectionUpgradeReason(inference.access, option) ? ", opens upgrade options without changing your model" : ""}`}
                             >
                               <ProviderIcon providerId={option.providerID} providerName={option.description} className="size-3.5 opacity-70" size={14} />
                               <span className="min-w-0 flex-1">
-                                <span className="block truncate text-foreground">{option.title}</span>
-                                <span className="block truncate text-xs text-muted-foreground">{option.description ?? getProviderDisplayName(option.providerID)}</span>
+                                <span className="block truncate text-foreground">{name}</span>
+                                <span className="block truncate text-xs text-muted-foreground">{recommendation?.summary || option.description || getProviderDisplayName(option.providerID)}</span>
+                                {recommendation?.capabilities.length ? <span className="block truncate text-[11px] text-muted-foreground">{recommendation.capabilities.join(" · ")}</span> : null}
                               </span>
+                              {accessLabel ? <span data-testid="model-access-label" className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">{accessLabel}</span> : null}
                               <button
                                 type="button"
                                 className="cursor-pointer rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                                aria-label={favorite ? `Remove ${option.title} from favorites` : `Add ${option.title} to favorites`}
+                                aria-label={favorite ? `Remove ${name} from favorites` : `Add ${name} to favorites`}
+                                aria-pressed={favorite}
+                                onKeyDown={(event) => event.stopPropagation()}
                                 onPointerDown={(event) => {
                                   event.preventDefault();
                                   event.stopPropagation();
@@ -638,7 +552,7 @@ export function ModelSelect({
                               >
                                 <Star className="size-3.5" fill={favorite ? "currentColor" : "none"} />
                               </button>
-                              {hasThinking ? <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" /> : null}
+                              {selected ? <Check className="size-3.5 shrink-0 text-muted-foreground" /> : null}
                             </CommandItem>
                           );
                         }}
@@ -647,13 +561,16 @@ export function ModelSelect({
                   )}
                 </CommandList>
               </CommandPanel>
-              {canAddProviders ? (
-                <div className="border-t border-border px-2 py-1">
-                  <button type="button" className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground" onClick={handleConnectProvider}>
-                    Connect more providers
-                  </button>
-                </div>
-              ) : null}
+              {!hideValue && selectedOption && selectedThinkingOptions.length > 0 && onBehaviorChange ? <div className="border-t border-border px-2 py-1" data-testid="selected-model-detail">
+                <button type="button" aria-label={`Thinking and effort for ${selectedOption.title}`} className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring" onClick={() => {
+                  setThinkingFor(selectedOption);
+                  setPane("effort");
+                }}>
+                  <span className="min-w-0 flex-1 truncate">{selectedOption.title} · {effectiveBehaviorLabel}</span>
+                  <kbd className="text-muted-foreground">{shortcutLabel}</kbd>
+                  <ChevronRight className="size-3.5" />
+                </button>
+              </div> : null}
               <div className="border-t border-border px-2 py-1">
                 <button
                   type="button"
@@ -661,13 +578,17 @@ export function ModelSelect({
                   onClick={() => {
                     onOpenChange(false);
                     setSearch("");
-                    setPane("root");
+                    setPane("model");
                     window.dispatchEvent(new CustomEvent(openModelPickerEvent, sessionId ? { detail: { sessionId } } : undefined));
                   }}
                 >
                   <Settings2 className="size-3.5" />
-                  All models
+                  See all models
                 </button>
+                {favoriteOptions.length > 0 ? <button type="button" disabled={!nextFavorite} className="flex w-full items-center justify-between rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-50" aria-label="Cycle favorite models" onClick={cycleFavorite}>
+                  <span>Next favorite</span><kbd>{favoriteShortcutLabel}</kbd>
+                </button> : null}
+                <OwnProviderAction onBeforeOpen={() => onOpenChange(false)} />
               </div>
               </div>
             </Command>

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -20,7 +20,7 @@ import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
 import { InferenceAllowanceSummary, OwnProviderAction, useInferenceAccess } from "@/react-app/domains/cloud/inference-access-provider";
-import { managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, markExplicitModelChoice, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
+import { managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, markExplicitModelChoice, modelPickerView, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
 import {
   OPENWORK_MODELS_PROVIDER_ID,
   OPENWORK_MODELS_PROVIDER_NAME,
@@ -56,7 +56,7 @@ import {
   nextFavoriteModel,
   useModelCollectionsStore,
 } from "@/react-app/domains/session/models/model-collections-store";
-import { favoriteModelShortcutLabel } from "@/react-app/shell/favorite-model-shortcut";
+import { favoriteModelShortcutLabel, isFavoriteModelShortcut } from "@/react-app/shell/favorite-model-shortcut";
 
 function getProviderDisplayName(providerId: string) {
   return providerId
@@ -252,14 +252,21 @@ export function ModelSelect({
   const favorites = useModelCollectionsStore((state) => state.favorites);
   const recent = useModelCollectionsStore((state) => state.recent);
   const catalogOptions = useModelOptions(open, fallbackOptions, denAuth.isSignedIn);
-  const modelOptions = React.useMemo(
-    () => overlaySelectedBehavior(catalogOptions, value, {
+  const { options: modelOptions, managedOnly } = React.useMemo(
+    () => modelPickerView(overlaySelectedBehavior(catalogOptions, value, {
       value: behaviorValue,
       label: behaviorLabel,
       options: behaviorOptions,
-    }),
-    [behaviorLabel, behaviorOptions, behaviorValue, catalogOptions, value],
+    }), { access: inference.access, signedIn: denAuth.isSignedIn, target: "session" }),
+    [behaviorLabel, behaviorOptions, behaviorValue, catalogOptions, value, inference.access, denAuth.isSignedIn],
   );
+  const selectedTitle = catalogOptions.find((option) => isSameModel(value, option))?.title ?? value.modelID;
+  React.useEffect(() => {
+    if (managedOnly && thinkingFor && thinkingFor.providerID !== "openwork") {
+      setThinkingFor(null);
+      setPane("model");
+    }
+  }, [managedOnly, thinkingFor]);
   const shortcutOs = resolveThinkingModeShortcutOs(
     platform.os,
     typeof navigator === "undefined" ? "" : navigator.platform,
@@ -351,6 +358,7 @@ export function ModelSelect({
     && Boolean(effectiveBehaviorLabel);
 
   const applyModel = (option: ModelOption, behavior?: string | null) => {
+    if (!modelOptions.some((available) => isSameModel(available, option) && !available.disabled)) return;
     if (!inference.checkSelection(option, sessionId, modelOptions, value)) { onOpenChange(false); return; }
     markExplicitModelChoice();
     useModelCollectionsStore.getState().recordRecent(option);
@@ -429,7 +437,7 @@ export function ModelSelect({
             <span className="truncate">
               {hideValue || (!denAuth.isSignedIn && isCloudManagedProviderKey(value.providerID))
                 ? "Select model"
-                : (selectedOption?.title ?? value.modelID ?? "Select model")}
+                : selectedTitle}
             </span>
             {showBehavior ? (
               <span className="shrink-0 text-gray-9">· {effectiveBehaviorLabel}</span>
@@ -446,9 +454,16 @@ export function ModelSelect({
         align="start"
         initialFocus={false}
         data-testid="managed-model-picker"
-        aria-label="Choose a model"
+        data-model-scope={managedOnly ? "openwork" : "all"}
+        aria-label={managedOnly ? "Choose an OpenWork model" : "Choose a model"}
+        onKeyDownCapture={(event) => {
+          if (!managedOnly || !isFavoriteModelShortcut(event)) return;
+          event.preventDefault();
+          event.stopPropagation();
+          if (!event.repeat) cycleFavorite();
+        }}
       >
-        {pane === "effort" && thinkingFor ? (
+        {pane === "effort" && thinkingFor && (!managedOnly || thinkingFor.providerID === "openwork") ? (
           <div data-slot="model-thinking-submenu" className="flex max-h-(--available-height) flex-col">
             <button
               ref={thinkingBackRef}
@@ -491,6 +506,7 @@ export function ModelSelect({
               <div className="flex min-h-0 flex-1 flex-col">
               <CommandHeader className="p-1.5 pb-1">
                 <CommandInput ref={searchInputRef} placeholder="Search all models..." aria-label="Search all models" className="h-9 text-sm" />
+                {managedOnly ? <p className="px-2 pb-1 text-xs font-medium text-muted-foreground">OpenWork models</p> : null}
               </CommandHeader>
               <InferenceAllowanceSummary className="px-3 pb-2" available={catalogOptions.some((option) => option.providerID === "openwork")} />
               {openWorkModelsSyncing ? (
@@ -503,7 +519,9 @@ export function ModelSelect({
                 </div>
               ) : null}
               <CommandPanel className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain">
-                <CommandEmpty>No models found.</CommandEmpty>
+                <CommandEmpty>{managedOnly
+                  ? query ? "No OpenWork models match your search." : "No OpenWork models are available. Open the full list to refresh."
+                  : "No models found."}</CommandEmpty>
                 <CommandList className="not-empty:scroll-py-1 not-empty:p-1">
                   {(group: ModelSelectGroup) => (
                     <CommandGroup key={group.value} items={group.items} className="[[role=group]+&]:mt-1">
@@ -583,7 +601,7 @@ export function ModelSelect({
                   }}
                 >
                   <Settings2 className="size-3.5" />
-                  See all models
+                  {managedOnly ? "See all OpenWork models" : "See all models"}
                 </button>
                 {favoriteOptions.length > 0 ? <button type="button" disabled={!nextFavorite} className="flex w-full items-center justify-between rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-50" aria-label="Cycle favorite models" onClick={cycleFavorite}>
                   <span>Next favorite</span><kbd>{favoriteShortcutLabel}</kbd>

--- a/apps/app/src/react-app/domains/cloud/inference-access-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/inference-access-provider.tsx
@@ -1,24 +1,35 @@
 import { createContext, use, useEffect, useRef, useState, type ReactNode } from "react";
 import type { InferenceAccess } from "@openwork/types/den/inference";
-import type { ModelRef } from "@/app/types";
+import type { ModelOption, ModelRef } from "@/app/types";
 import { createDenClient, readDenSettings } from "@/app/lib/den";
 import { denSessionUpdatedEvent, denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { newProvidersEvent } from "@/app/lib/provider-events";
-import { allowanceResetLabel, formatAllowanceUsd, inferenceAccessRefreshEvent, modelSelectionUpgradeReason, pendingInferenceUsageLabel, type InferenceUpgradeReason } from "@/app/lib/inference-access";
+import { allowanceResetLabel, formatAllowanceUsd, inferenceAccessRefreshEvent, managedModelRecommendation, modelSelectionUpgradeReason, pendingInferenceUsageLabel, type InferenceUpgradeReason } from "@/app/lib/inference-access";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { usePlatform } from "@/react-app/kernel/platform";
-import { openModelPickerEvent } from "@/react-app/shell/new-providers-listener";
+import { openModelPickerEvent, openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
 import { useDenAuth } from "./den-auth-provider";
+import { useCheckDesktopRestriction } from "./desktop-config-provider";
 import { getOpenWorkModelsActionUrl } from "./openwork-models-promo";
 
 type Access = InferenceAccess & { canUpgrade: boolean };
-type Upgrade = { reason: InferenceUpgradeReason; sessionId?: string };
+type RequestedModel = ModelRef & { title?: string };
+type PickerRequest = { model: RequestedModel; sessionId?: string; scope: string };
+type Upgrade = {
+  reason: InferenceUpgradeReason;
+  sessionId?: string;
+  model?: RequestedModel;
+  currentModel?: ModelRef;
+  freeModel?: ModelOption;
+  scope: string;
+};
 const InferenceAccessContext = createContext<{
   access: Access | null;
-  checkSelection: (model: ModelRef, sessionId?: string) => boolean;
-  showUpgrade: (reason: InferenceUpgradeReason, sessionId?: string) => void;
-}>({ access: null, checkSelection: () => true, showUpgrade: () => undefined });
+  pickerRequest: PickerRequest | null;
+  checkSelection: (model: RequestedModel, sessionId?: string, availableModels?: readonly ModelOption[], currentModel?: ModelRef) => boolean;
+  showUpgrade: (reason: InferenceUpgradeReason, sessionId?: string, model?: RequestedModel, availableModels?: readonly ModelOption[], currentModel?: ModelRef) => void;
+}>({ access: null, pickerRequest: null, checkSelection: () => true, showUpgrade: () => undefined });
 
 export function useInferenceAccess() { return use(InferenceAccessContext); }
 
@@ -28,6 +39,7 @@ export function InferenceAccessProvider({ children }: { children: ReactNode }) {
   const [revision, setRevision] = useState(0);
   const [result, setResult] = useState<{ scope: string; access: Access } | null>(null);
   const [upgrade, setUpgrade] = useState<Upgrade | null>(null);
+  const [pickerRequest, setPickerRequest] = useState<PickerRequest | null>(null);
   const epoch = useRef(0);
   const settings = readDenSettings();
   const identity = auth.verifiedIdentity;
@@ -40,13 +52,17 @@ export function InferenceAccessProvider({ children }: { children: ReactNode }) {
       epoch.current += 1;
       setResult(null);
       setUpgrade(null);
+      setPickerRequest(null);
       setRevision((value) => value + 1);
     };
     window.addEventListener(denSettingsChangedEvent, clear);
     window.addEventListener(denSessionUpdatedEvent, clear);
+    const clearRequest = () => { setUpgrade(null); setPickerRequest(null); };
+    window.addEventListener("hashchange", clearRequest);
     return () => {
       window.removeEventListener(denSettingsChangedEvent, clear);
       window.removeEventListener(denSessionUpdatedEvent, clear);
+      window.removeEventListener("hashchange", clearRequest);
     };
   }, []);
 
@@ -54,6 +70,7 @@ export function InferenceAccessProvider({ children }: { children: ReactNode }) {
     const generation = ++epoch.current;
     setResult(null);
     setUpgrade(null);
+    setPickerRequest(null);
     if (!scope) return;
     const captured = readDenSettings();
     const token = captured.authToken;
@@ -107,44 +124,91 @@ export function InferenceAccessProvider({ children }: { children: ReactNode }) {
     };
   }, [scope]);
 
-  const showUpgrade = (reason: InferenceUpgradeReason, sessionId?: string) => {
-    setUpgrade({ reason, sessionId });
+  const showUpgrade = (reason: InferenceUpgradeReason, sessionId?: string, model?: RequestedModel, availableModels?: readonly ModelOption[], currentModel?: ModelRef) => {
+    if (!scope) return;
+    const freeModel = availableModels?.find((option) => !option.disabled && option.providerID === "openwork" && option.modelID === access?.modelID);
+    setUpgrade({ reason, sessionId, model, currentModel, freeModel, scope });
+    setPickerRequest(null);
     window.dispatchEvent(new Event(inferenceAccessRefreshEvent));
   };
-  const checkSelection = (model: ModelRef, sessionId?: string) => {
+  const checkSelection = (model: RequestedModel, sessionId?: string, availableModels?: readonly ModelOption[], currentModel?: ModelRef) => {
     const reason = modelSelectionUpgradeReason(access, model);
-    if (!reason) return true;
-    showUpgrade(reason, sessionId);
+    if (!reason) {
+      if (pickerRequest) setPickerRequest(null);
+      return true;
+    }
+    showUpgrade(reason, sessionId, model, availableModels, currentModel);
     return false;
+  };
+  const activeUpgrade = upgrade?.scope === scope ? upgrade : null;
+  const recommendation = activeUpgrade?.model ? managedModelRecommendation(access, activeUpgrade.model) : undefined;
+  const modelName = recommendation?.displayName ?? activeUpgrade?.model?.title ?? activeUpgrade?.model?.modelID;
+  const eligible = Boolean(activeUpgrade?.model && access && (access.kind === "paid"
+    || (access.kind === "free" && activeUpgrade.model.modelID === access.modelID)));
+  const keepingLuna = access?.kind === "free" && activeUpgrade?.currentModel && activeUpgrade.freeModel
+    && activeUpgrade.currentModel.providerID === activeUpgrade.freeModel.providerID
+    && activeUpgrade.currentModel.modelID === activeUpgrade.freeModel.modelID;
+  const openRequestedPicker = (model: RequestedModel) => {
+    if (!scope || !activeUpgrade) return;
+    // Re-enter the real picker, not a captured callback whose session may have changed.
+    setPickerRequest({ model, sessionId: activeUpgrade.sessionId, scope });
+    setUpgrade(null);
+    window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { sessionId: activeUpgrade.sessionId } }));
   };
   const reset = allowanceResetLabel(access?.resetsAt);
   return (
-    <InferenceAccessContext value={{ access, checkSelection, showUpgrade }}>
+    <InferenceAccessContext value={{ access, pickerRequest: pickerRequest?.scope === scope ? pickerRequest : null, checkSelection, showUpgrade }}>
       {children}
-      <Dialog open={upgrade !== null} onOpenChange={(open) => { if (!open) setUpgrade(null); }}>
+      <Dialog open={activeUpgrade !== null} onOpenChange={(open) => { if (!open) setUpgrade(null); }}>
         <DialogContent className="sm:max-w-md" data-testid="inference-upgrade-dialog">
           <DialogHeader>
-            <DialogTitle>{upgrade?.reason === "free_allowance_exhausted" ? "Your free Luna allowance is used up" : "This model requires OpenWork Models"}</DialogTitle>
+            <DialogTitle>{eligible ? `${modelName} is ready to use` : activeUpgrade?.reason === "free_allowance_exhausted"
+              ? "Your free Luna allowance is used up" : modelName ? `Unlock ${modelName}` : "Upgrade your model access"}</DialogTitle>
             <DialogDescription>
-              {upgrade?.reason === "free_allowance_exhausted"
-                ? `You've used this week's free allowance.${reset ? ` Resets ${reset}.` : " Check your allowance again after the weekly reset."}`
-                : "Free access includes standard Luna. Upgrade to use the other managed OpenWork models."}
+              {eligible ? "Return to the model picker to confirm your selection. No task will run automatically."
+                : activeUpgrade?.reason === "free_allowance_exhausted"
+                 ? `You've used this week's free allowance.${reset ? ` Resets ${reset}.` : " Check your allowance again after the weekly reset."}`
+                 : recommendation?.summary || "This model is available with a paid OpenWork plan. Free access includes standard Luna."}
               {" Your selected model and draft have not changed."}
             </DialogDescription>
           </DialogHeader>
-          {access?.canUpgrade === false ? <p className="text-sm text-muted-foreground">Ask a workspace owner or admin to upgrade OpenWork Models. You can keep using your own providers.</p> : null}
+          {!eligible && activeUpgrade?.reason === "free_allowance_exhausted" ? <InferenceAllowanceSummary /> : null}
+          {!eligible && recommendation?.capabilities.length ? <p className="text-xs text-muted-foreground">{recommendation.capabilities.join(" · ")}</p> : null}
+          {!eligible && access?.plan ? <div className="rounded-lg border border-border p-3 text-sm" data-testid="inference-upgrade-plan">
+            <p className="font-medium">{access.plan.name}{access.plan.priceLabel ? ` · ${access.plan.priceLabel}` : ""}</p>
+            <p className="text-muted-foreground">{access.plan.usageLabel}</p>
+            {!access.plan.priceLabel ? <p className="text-xs text-muted-foreground">View plans for pricing.</p> : null}
+          </div> : !eligible ? <p className="text-sm text-muted-foreground">View plans for current pricing and usage limits.</p> : null}
+          {!eligible && access?.canUpgrade === false ? <p className="text-sm text-muted-foreground" data-testid="inference-ask-admin">Ask a workspace owner or admin to upgrade OpenWork Models. Only they can manage the plan.</p> : null}
           <DialogFooter className="flex-wrap">
-            <Button variant="outline" onClick={() => {
-              window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { sessionId: upgrade?.sessionId } }));
-              setUpgrade(null);
-            }}>Choose another provider</Button>
-            {access?.canUpgrade === true ? <Button onClick={() => platform.openLink(getOpenWorkModelsActionUrl(true))}>Upgrade</Button> : null}
             <Button variant="ghost" onClick={() => setUpgrade(null)}>Close</Button>
+            {!eligible && activeUpgrade?.currentModel ? <Button data-testid="inference-keep-current-model" variant="secondary" onClick={() => setUpgrade(null)}>
+              {keepingLuna ? "Keep using Luna" : "Keep current model"}
+            </Button> : null}
+            {eligible && activeUpgrade?.model ? <Button data-testid="inference-use-model" onClick={() => {
+              if (activeUpgrade.model) openRequestedPicker(activeUpgrade.model);
+            }}>Use {modelName}</Button> : !eligible && access?.canUpgrade === true ? <Button data-testid="inference-view-upgrade" onClick={() => platform.openLink(getOpenWorkModelsActionUrl(true))}>View upgrade</Button> : null}
           </DialogFooter>
+          <OwnProviderAction onBeforeOpen={() => setUpgrade(null)} />
         </DialogContent>
       </Dialog>
     </InferenceAccessContext>
   );
+}
+
+export function OwnProviderAction({ onBeforeOpen }: { onBeforeOpen?: () => void }) {
+  const checkRestriction = useCheckDesktopRestriction();
+  if (checkRestriction({ restriction: "allowCustomProviders" })) return null;
+  return <button type="button" data-testid="model-own-provider" className="rounded-md px-2 py-1 text-left text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" onClick={() => {
+    onBeforeOpen?.();
+    const path = window.location.hash.replace(/^#/, "");
+    if (path.includes("/settings/")) {
+      const workspace = path.match(/^\/workspace\/[^/]+/);
+      window.location.hash = `${workspace?.[0] ?? ""}/settings/ai`;
+    } else {
+      window.dispatchEvent(new Event(openProviderAuthEvent));
+    }
+  }}>Use my own provider…</button>;
 }
 
 export function InferenceAllowanceSummary({ available = true, className = "" }: { available?: boolean; className?: string }) {
@@ -159,21 +223,19 @@ export function InferenceAllowanceSummary({ available = true, className = "" }: 
   </p>;
 }
 
-export function InferenceErrorActions({ reason, resetsAt, sessionId, onOpenModelPicker }: {
-  reason: InferenceUpgradeReason; resetsAt?: string | null; sessionId?: string; onOpenModelPicker?: () => void;
+export function InferenceErrorActions({ reason, resetsAt, sessionId, onOpenModelPicker, requestedModel }: {
+  reason: InferenceUpgradeReason; resetsAt?: string | null; sessionId?: string; onOpenModelPicker?: () => void; requestedModel?: RequestedModel;
 }) {
   const { access, showUpgrade } = useInferenceAccess();
-  const platform = usePlatform();
   const reset = allowanceResetLabel(resetsAt);
   return <div className="flex flex-col gap-2" data-testid="inference-error-actions">
     {reset && reason === "free_allowance_exhausted" ? <p className="text-sm">Allowance resets {reset}.</p> : null}
     <div className="flex flex-wrap gap-2">
-      <Button size="sm" variant="outline" onClick={() => access?.canUpgrade === true
-        ? platform.openLink(getOpenWorkModelsActionUrl(true)) : showUpgrade(reason, sessionId)}>
-        {access?.canUpgrade === true ? "Upgrade" : access?.canUpgrade === false ? "Ask admin" : "View allowance"}
+      <Button size="sm" onClick={() => showUpgrade(reason, sessionId, requestedModel)}>
+        {access?.canUpgrade === true ? "View upgrade" : access?.canUpgrade === false ? "Ask admin" : "View allowance"}
       </Button>
       <Button size="sm" variant="ghost" onClick={() => onOpenModelPicker ? onOpenModelPicker()
-        : window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { sessionId } }))}>Choose another provider</Button>
+        : window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { sessionId } }))}>Change model</Button>
     </div>
   </div>;
 }

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
@@ -8,7 +8,7 @@ declare const expect: (value: unknown) => {
 
 import { DEFAULT_DEN_BASE_URL, HOSTED_DEFAULT_DEN_BASE_URL, setDenBootstrapConfig } from "../../../app/lib/den";
 import { INFERENCE_ACCESS_REASONS, type InferenceAccess } from "@openwork/types/den/inference";
-import { FREE_LUNA_MODEL, inferenceAccessSchema, managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, modelSelectionUpgradeReason, pendingInferenceUsageLabel, shouldSelectInitialLuna } from "../../../app/lib/inference-access";
+import { FREE_LUNA_MODEL, inferenceAccessSchema, managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, modelPickerView, modelSelectionUpgradeReason, pendingInferenceUsageLabel, shouldSelectInitialLuna } from "../../../app/lib/inference-access";
 import type { ModelOption } from "../../../app/types";
 import { nextFavoriteModel } from "../session/models/model-collections-store";
 import {
@@ -84,6 +84,31 @@ const freeAccess: InferenceAccess & { canUpgrade: boolean } = {
 };
 
 describe("member allowance model decisions", () => {
+  test("restricts only positively managed session catalogs, not settings or legacy provider selection", () => {
+    const options: ModelOption[] = ["opencode", "openwork", "lpr_own", "anthropic"].map((providerID) => ({
+      providerID, modelID: "fixture", title: "Fixture", behaviorTitle: "", behaviorLabel: "", behaviorDescription: "", behaviorValue: null, isFree: false,
+    }));
+    const kinds: InferenceAccess["kind"][] = ["free", "exhausted", "paid"];
+    for (const kind of kinds) {
+      const access = { ...freeAccess, kind };
+      const view = modelPickerView(options, { access, signedIn: true, target: "session" });
+      expect(view.managedOnly).toBe(true);
+      expect(view.options.map((model) => model.providerID).join(",")).toBe("openwork");
+      expect(modelPickerView(options, { access, signedIn: true, target: "default" }).options).toBe(options);
+      expect(modelPickerView(options, { access, signedIn: false, target: "session" }).options).toBe(options);
+      const waiting = modelPickerView(options.filter((model) => model.providerID !== "openwork"), { access, signedIn: true, target: "session" });
+      expect(waiting.managedOnly).toBe(true);
+      expect(waiting.options.length).toBe(0);
+    }
+    const legacyAccess: Array<InferenceAccess | null> = [null, { ...freeAccess, kind: "unavailable", reason: "free_disabled" }];
+    for (const access of legacyAccess) {
+      const view = modelPickerView(options, { access, signedIn: true, target: "session" });
+      expect(view.managedOnly).toBe(false);
+      expect(view.options).toBe(options);
+    }
+    expect(options.map((model) => model.providerID).join(",")).toBe("opencode,openwork,lpr_own,anthropic");
+  });
+
   test("gates only paid OpenWork selections, never Luna or organization BYOK", () => {
     expect(modelSelectionUpgradeReason(freeAccess, FREE_LUNA_MODEL)).toBe(null);
     expect(modelSelectionUpgradeReason(freeAccess, { providerID: "openwork", modelID: "openai/gpt-5.6-luna-fast" })).toBe("managed_model_requires_upgrade");

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
@@ -8,7 +8,8 @@ declare const expect: (value: unknown) => {
 
 import { DEFAULT_DEN_BASE_URL, HOSTED_DEFAULT_DEN_BASE_URL, setDenBootstrapConfig } from "../../../app/lib/den";
 import { INFERENCE_ACCESS_REASONS, type InferenceAccess } from "@openwork/types/den/inference";
-import { FREE_LUNA_MODEL, inferenceAccessSchema, modelSelectionUpgradeReason, pendingInferenceUsageLabel, shouldSelectInitialLuna } from "../../../app/lib/inference-access";
+import { FREE_LUNA_MODEL, inferenceAccessSchema, managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, modelSelectionUpgradeReason, pendingInferenceUsageLabel, shouldSelectInitialLuna } from "../../../app/lib/inference-access";
+import type { ModelOption } from "../../../app/types";
 import { nextFavoriteModel } from "../session/models/model-collections-store";
 import {
   hasOpenWorkModelsAvailable,
@@ -118,6 +119,46 @@ describe("member allowance model decisions", () => {
     expect(inferenceAccessSchema.safeParse({ ...freeAccess, canUpgrade: undefined }).success).toBe(false);
     expect(inferenceAccessSchema.safeParse({ ...freeAccess, remainingUsd: -1 }).success).toBe(false);
     expect(inferenceAccessSchema.safeParse({ ...freeAccess, resetsAt: "invalid" }).success).toBe(false);
+  });
+
+  test("validates optional catalog and plan data without losing authoritative access", () => {
+    const catalog = [{ modelID: "fixture-paid", displayName: "Fixture model", providerName: "Fixture provider", summary: "Server summary", recommended: true, rank: 1, capabilities: ["Reasoning"], token: "discard" }];
+    const plan = { name: "Fixture plan", priceLabel: null, usageLabel: "Server limits", checkoutSecret: "discard" };
+    const parsed = inferenceAccessSchema.parse({ ...freeAccess, catalog, plan });
+    expect(parsed.catalog?.[0]?.summary).toBe("Server summary");
+    expect(parsed.catalog?.[0] && "token" in parsed.catalog[0]).toBe(false);
+    expect(parsed.plan?.priceLabel).toBe(null);
+    expect(parsed.plan && "checkoutSecret" in parsed.plan).toBe(false);
+    for (const invalid of [null, "unexpected", [{ ...catalog[0], rank: "1" }], [{ ...catalog[0], capabilities: [12] }]]) {
+      const access = inferenceAccessSchema.parse({ ...freeAccess, catalog: invalid, plan: { priceLabel: 20 } });
+      expect(access.kind).toBe("free");
+      expect(access.canUpgrade).toBe(true);
+      expect(access.catalog).toBe(undefined);
+      expect(access.plan).toBe(undefined);
+      expect(modelSelectionUpgradeReason(access, { providerID: "openwork", modelID: "fixture-paid" })).toBe("managed_model_requires_upgrade");
+    }
+  });
+
+  test("intersects ranked recommendations with available managed models and caps the section at four", () => {
+    const option = (modelID: string, providerID = "openwork"): ModelOption => ({
+      providerID, modelID, title: modelID, behaviorTitle: "", behaviorLabel: "", behaviorDescription: "", behaviorValue: null, isFree: true,
+    });
+    const models = [FREE_LUNA_MODEL.modelID, "fixture-a", "fixture-b", "fixture-c", "fixture-d"];
+    const options = models.map((id) => option(id));
+    const access: InferenceAccess = { ...freeAccess, catalog: ["unavailable", ...models.slice(1).reverse(), models[1]].map((modelID, rank) => ({
+      modelID, displayName: modelID, providerName: "Fixture", summary: "", recommended: true, rank, capabilities: [],
+    })) };
+    expect(managedModelRecommendations(access, options).map((model) => model.modelID).join(",")).toBe([models[0], models[4], models[3], models[2]].join(","));
+    expect(managedModelRecommendations(access, [option("fixture-a", "lpr_own"), option("fixture-b", "opencode"), { ...option("fixture-c"), disabled: true }]).length).toBe(0);
+    expect(managedModelRecommendations(null, options).length).toBe(0);
+    expect(managedModelRecommendations(freeAccess, options).length).toBe(0);
+    expect(managedModelRecommendation(access, option("fixture-a", "lpr_own"))).toBe(undefined);
+    expect(managedModelAccessLabel(freeAccess, option("fixture-a"))).toBe("Upgrade");
+    expect(managedModelAccessLabel(freeAccess, option(FREE_LUNA_MODEL.modelID))).toBe("Free");
+    expect(managedModelAccessLabel({ ...freeAccess, kind: "paid" }, option("fixture-a"))).toBe("Included");
+    expect(managedModelAccessLabel(freeAccess, option("fixture-a", "lpr_own"))).toBe(null);
+    expect(managedModelAccessLabel(freeAccess, option("fixture-a", "opencode"))).toBe(null);
+    expect(managedModelAccessLabel(null, option("fixture-a"))).toBe(null);
   });
 
   test("accepts canonical busy access as free and labels pending cost as an estimate", () => {

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -22,11 +22,11 @@ import { t } from "@/i18n";
 import { readDenSettings } from "@/app/lib/den";
 import { modelEquals, resolveProviderDisplayName } from "../../../../app/utils";
 import type { ModelOption, ModelRef } from "../../../../app/types";
-import { isRecommendedModel } from "../../../../app/defaults";
 import { ProviderIcon } from "../../../design-system/provider-icon";
 import { useDenAuth } from "../../cloud/den-auth-provider";
-import { InferenceAllowanceSummary, useInferenceAccess } from "../../cloud/inference-access-provider";
-import { markExplicitModelChoice } from "@/app/lib/inference-access";
+import { InferenceAllowanceSummary, OwnProviderAction, useInferenceAccess } from "../../cloud/inference-access-provider";
+import { managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, markExplicitModelChoice, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
+import { modelRefKey, useModelCollectionsStore } from "../models/model-collections-store";
 import { usePlatform } from "../../../kernel/platform";
 import {
   OPENWORK_MODELS_PROVIDER_ID,
@@ -121,6 +121,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   const [refreshingOrganizationModels, setRefreshingOrganizationModels] = useState(false);
   const denAuth = useDenAuth();
   const inference = useInferenceAccess();
+  const requested = inference.pickerRequest?.sessionId === props.sessionId ? inference.pickerRequest?.model : undefined;
   const platform = usePlatform();
   const organizationModelsSettingsUrl = props.organizationModelsSettingsUrl;
   const organizationProviderLabel = useMemo(
@@ -136,9 +137,9 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   // Reset on open
   useEffect(() => {
     if (props.open) {
-      props.setQuery("");
+      props.setQuery(requested?.modelID ?? "");
     }
-  }, [props.open]);
+  }, [props.open, requested?.modelID]);
 
   // Focus search
   useEffect(() => {
@@ -151,17 +152,22 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   const filteredOptions = useMemo(() => {
     const q = props.query.trim().toLowerCase();
     if (!q) return props.options;
-    return props.options.filter(
-      (o) =>
+    return props.options.filter((o) => {
+      const recommendation = managedModelRecommendation(inference.access, o);
+      return (
         o.title.toLowerCase().includes(q) ||
         o.providerID.toLowerCase().includes(q) ||
         o.modelID.toLowerCase().includes(q) ||
-        (o.description ?? "").toLowerCase().includes(q),
-    );
-  }, [props.options, props.query]);
+        (o.description ?? "").toLowerCase().includes(q) ||
+        [recommendation?.displayName, recommendation?.providerName, recommendation?.summary, ...(recommendation?.capabilities ?? [])].some((text) => text?.toLowerCase().includes(q))
+      );
+    });
+  }, [props.options, props.query, inference.access]);
 
   // Group by provider
   const providerGroups = useMemo<ProviderGroup[]>(() => {
+    const recommendations = managedModelRecommendations(inference.access, props.options);
+    const ranks = new Map(recommendations.map((option, index) => [modelRefKey(option), index]));
     const map = new Map<string, ProviderGroup>();
     for (const opt of filteredOptions) {
       let group = map.get(opt.providerID);
@@ -178,7 +184,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         };
         map.set(opt.providerID, group);
       }
-      if (isRecommendedModel(opt.modelID)) {
+      if (ranks.has(modelRefKey(opt))) {
         group.recommended.push(opt);
       } else {
         group.other.push(opt);
@@ -189,16 +195,17 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     }
     const groups = [...map.values()];
     for (const group of groups) {
-      group.recommended.sort((a, b) => a.title.localeCompare(b.title));
+      group.recommended.sort((a, b) => (ranks.get(modelRefKey(a)) ?? 0) - (ranks.get(modelRefKey(b)) ?? 0));
       group.other.sort((a, b) => a.title.localeCompare(b.title));
     }
     return groups.sort((a, b) => {
       if (a.isDisabled !== b.isDisabled) return a.isDisabled ? 1 : -1;
+      if ((a.id === OPENWORK_MODELS_PROVIDER_ID) !== (b.id === OPENWORK_MODELS_PROVIDER_ID)) return a.id === OPENWORK_MODELS_PROVIDER_ID ? -1 : 1;
       if (a.isNew !== b.isNew) return a.isNew ? -1 : 1;
       if (a.hasCurrent !== b.hasCurrent) return a.hasCurrent ? -1 : 1;
       return a.name.localeCompare(b.name);
     });
-  }, [filteredOptions, props.current, disabledSet]);
+  }, [filteredOptions, props.current, props.options, disabledSet, inference.access]);
 
   // Auto-expand on search
   useEffect(() => {
@@ -244,11 +251,12 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   }, []);
 
   const handleSelect = (opt: ModelOption) => {
-    if (!inference.checkSelection(opt, props.sessionId)) {
+    if (!inference.checkSelection(opt, props.sessionId, props.options.filter((option) => !disabledSet.has(option.providerID)), props.current)) {
       props.onClose({ restorePromptFocus: false });
       return;
     }
     markExplicitModelChoice();
+    useModelCollectionsStore.getState().recordRecent(opt);
     props.onSelect({ providerID: opt.providerID, modelID: opt.modelID });
   };
 
@@ -287,13 +295,14 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         if (!open) props.onClose();
       }}
     >
-      <DialogContent className="flex max-h-[calc(100vh-2rem)] min-h-0 w-full max-w-lg flex-col overflow-hidden sm:max-w-lg">
+      <DialogContent data-testid="all-models-picker" className="flex max-h-[calc(100vh-2rem)] min-h-0 w-full max-w-lg flex-col overflow-hidden sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("models.title")}</DialogTitle>
           <DialogDescription>
             {resolveModelPickerSubtitle(props.subtitle)}
           </DialogDescription>
           <InferenceAllowanceSummary available={props.options.some((option) => option.providerID === "openwork")} />
+          {requested ? <p role="status" className="text-sm text-muted-foreground" data-testid="requested-model-ready">Select {managedModelRecommendation(inference.access, requested)?.displayName ?? requested.title ?? requested.modelID} to use it. Your model and draft are unchanged.</p> : null}
         </DialogHeader>
 
         <div className="flex min-h-0 flex-1 flex-col">
@@ -305,6 +314,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               type="text"
               className="h-10 w-full rounded-xl border border-dls-border bg-dls-surface pl-9 pr-3 text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)]"
               placeholder={t("models.search_placeholder")}
+              aria-label="Search all models"
               value={props.query}
               onChange={(e) => props.setQuery(e.target.value)}
             />
@@ -319,7 +329,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
                     <span>{OPENWORK_MODELS_PROVIDER_NAME}</span>
                   </div>
                   <div className="truncate text-[11px] text-dls-secondary">
-                    Included on your plan — pending workspace reload.
+                    Pending workspace reload.
                   </div>
                 </div>
               </div>
@@ -345,9 +355,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
                   </Button>
                 ) : null}
                 {emptyState.showConnectProvider ? (
-                  <Button variant="outline" onClick={props.onOpenSettings}>
-                    {t("models.connect_provider")}
-                  </Button>
+                  <OwnProviderAction onBeforeOpen={() => props.onClose({ restorePromptFocus: false })} />
                 ) : null}
               </div>
             ) : (
@@ -357,6 +365,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
                   group={group}
                   expanded={expandedProviders.has(group.id)}
                   current={props.current}
+                  requested={requested}
                   canToggleProvider={!!props.onToggleProvider}
                   onToggleExpand={() => toggleProvider(group.id)}
                   onToggleProvider={props.onToggleProvider}
@@ -370,6 +379,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
 
         {/* Footer */}
         <DialogFooter className="shrink-0">
+          {!props.restrictToCloud && !emptyState?.showConnectProvider ? <OwnProviderAction onBeforeOpen={() => props.onClose({ restorePromptFocus: false })} /> : null}
           <DialogClose render={<Button variant="outline" />}>
             {t("models.done")}
           </DialogClose>
@@ -387,6 +397,7 @@ function ProviderAccordion({
   group,
   expanded,
   current,
+  requested,
   canToggleProvider,
   onToggleExpand,
   onToggleProvider,
@@ -396,6 +407,7 @@ function ProviderAccordion({
   group: ProviderGroup;
   expanded: boolean;
   current: ModelRef;
+  requested?: ModelRef;
   canToggleProvider: boolean;
   onToggleExpand: () => void;
   onToggleProvider?: (providerId: string, enabled: boolean) => void;
@@ -413,6 +425,7 @@ function ProviderAccordion({
           type="button"
           className="flex min-w-0 flex-1 items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors hover:bg-dls-hover"
           onClick={onToggleExpand}
+          aria-expanded={expanded}
         >
           <Chevron size={14} className="shrink-0 text-dls-secondary" />
           <ProviderIcon providerId={group.id} size={18} className="shrink-0 text-dls-text" />
@@ -462,7 +475,7 @@ function ProviderAccordion({
                 Recommended
               </div>
               {group.recommended.map((opt) => (
-                <DefaultModelRow key={opt.modelID} opt={opt} current={current} onSelect={onSelect} recommended />
+                <DefaultModelRow key={opt.modelID} opt={opt} current={current} requested={requested} onSelect={onSelect} />
               ))}
             </>
           ) : null}
@@ -474,7 +487,7 @@ function ProviderAccordion({
                 </div>
               ) : null}
               {group.other.map((opt) => (
-                <DefaultModelRow key={opt.modelID} opt={opt} current={current} onSelect={onSelect} />
+                <DefaultModelRow key={opt.modelID} opt={opt} current={current} requested={requested} onSelect={onSelect} />
               ))}
             </>
           ) : null}
@@ -489,27 +502,37 @@ function ProviderAccordion({
 /* ------------------------------------------------------------------ */
 
 function DefaultModelRow({
-  opt, current, onSelect, recommended,
+  opt, current, requested, onSelect,
 }: {
-  opt: ModelOption; current: ModelRef; onSelect: (opt: ModelOption) => void; recommended?: boolean;
+  opt: ModelOption; current: ModelRef; requested?: ModelRef; onSelect: (opt: ModelOption) => void;
 }) {
   const active = modelEquals(current, { providerID: opt.providerID, modelID: opt.modelID });
+  const highlighted = requested ? modelEquals(requested, opt) : false;
+  const { access } = useInferenceAccess();
+  const favorites = useModelCollectionsStore((state) => state.favorites);
+  const favorite = favorites.some((model) => modelEquals(model, opt));
+  const recommendation = managedModelRecommendation(access, opt);
+  const name = recommendation?.displayName ?? opt.title;
+  const accessLabel = managedModelAccessLabel(access, opt);
 
   return (
-    <button
-      type="button"
-      className={[
-        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors",
-        active ? "bg-green-3/50" : "hover:bg-dls-hover",
-      ].join(" ")}
-      onClick={() => onSelect(opt)}
-    >
-      {recommended ? <Star size={12} className="shrink-0 text-amber-9" /> : <div className="w-3 shrink-0" />}
-      <div className="min-w-0 flex-1">
-        <span className={["text-[12px]", active ? "font-medium text-dls-text" : "text-dls-text"].join(" ")}>{opt.title}</span>
-        <span className="ml-2 font-mono text-[10px] text-dls-secondary/60">{opt.modelID}</span>
-      </div>
-      {active ? <Check size={14} className="shrink-0 text-green-11" /> : null}
-    </button>
+    <div className={`flex items-center gap-1 rounded-lg ${active ? "bg-green-3/50" : ""} ${highlighted ? "ring-2 ring-ring" : ""}`} data-requested={highlighted || undefined}>
+      <button type="button" disabled={opt.disabled} data-testid={`model-option-${opt.providerID}-${opt.modelID}`} data-checked={active}
+        aria-description={recommendation?.summary}
+        aria-label={`${name}${accessLabel ? `, ${accessLabel}` : ""}${active ? ", current model" : ""}${modelSelectionUpgradeReason(access, opt) === "free_allowance_exhausted" ? ", allowance used up" : ""}${modelSelectionUpgradeReason(access, opt) ? ", opens upgrade options without changing your model" : ""}`}
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 py-1.5 text-left hover:bg-dls-hover focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50" onClick={() => onSelect(opt)}>
+        <span className="min-w-0 flex-1">
+          <span className="block text-xs font-medium text-dls-text">{name}</span>
+          {recommendation?.summary ? <span className="block text-xs text-muted-foreground">{recommendation.summary}</span> : null}
+          {recommendation?.capabilities.length ? <span className="block text-[11px] text-muted-foreground">{recommendation.capabilities.join(" · ")}</span> : null}
+          <span className="block truncate font-mono text-[10px] text-dls-secondary/60">{opt.modelID}</span>
+        </span>
+        {accessLabel ? <span data-testid="model-access-label" className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">{accessLabel}</span> : null}
+        {active ? <Check size={14} className="shrink-0 text-green-11" /> : null}
+      </button>
+      <button type="button" className="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring" aria-label={favorite ? `Remove ${name} from favorites` : `Add ${name} to favorites`} onClick={() => useModelCollectionsStore.getState().toggleFavorite(opt)}>
+        <Star size={14} fill={favorite ? "currentColor" : "none"} />
+      </button>
+    </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -25,8 +25,9 @@ import type { ModelOption, ModelRef } from "../../../../app/types";
 import { ProviderIcon } from "../../../design-system/provider-icon";
 import { useDenAuth } from "../../cloud/den-auth-provider";
 import { InferenceAllowanceSummary, OwnProviderAction, useInferenceAccess } from "../../cloud/inference-access-provider";
-import { managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, markExplicitModelChoice, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
-import { modelRefKey, useModelCollectionsStore } from "../models/model-collections-store";
+import { managedModelAccessLabel, managedModelRecommendation, managedModelRecommendations, markExplicitModelChoice, modelPickerView, modelSelectionUpgradeReason } from "@/app/lib/inference-access";
+import { modelRefKey, nextFavoriteModel, useModelCollectionsStore } from "../models/model-collections-store";
+import { isFavoriteModelShortcut } from "@/react-app/shell/favorite-model-shortcut";
 import { usePlatform } from "../../../kernel/platform";
 import {
   OPENWORK_MODELS_PROVIDER_ID,
@@ -121,7 +122,12 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   const [refreshingOrganizationModels, setRefreshingOrganizationModels] = useState(false);
   const denAuth = useDenAuth();
   const inference = useInferenceAccess();
-  const requested = inference.pickerRequest?.sessionId === props.sessionId ? inference.pickerRequest?.model : undefined;
+  const favorites = useModelCollectionsStore((state) => state.favorites);
+  const { options, managedOnly } = useMemo(() => modelPickerView(props.options, {
+    access: inference.access, signedIn: denAuth.isSignedIn, target: props.target,
+  }), [props.options, inference.access, denAuth.isSignedIn, props.target]);
+  const requested = inference.pickerRequest?.sessionId === props.sessionId
+    && (!managedOnly || inference.pickerRequest?.model.providerID === "openwork") ? inference.pickerRequest?.model : undefined;
   const platform = usePlatform();
   const organizationModelsSettingsUrl = props.organizationModelsSettingsUrl;
   const organizationProviderLabel = useMemo(
@@ -151,8 +157,8 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   // Filter by search
   const filteredOptions = useMemo(() => {
     const q = props.query.trim().toLowerCase();
-    if (!q) return props.options;
-    return props.options.filter((o) => {
+    if (!q) return options;
+    return options.filter((o) => {
       const recommendation = managedModelRecommendation(inference.access, o);
       return (
         o.title.toLowerCase().includes(q) ||
@@ -162,11 +168,11 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         [recommendation?.displayName, recommendation?.providerName, recommendation?.summary, ...(recommendation?.capabilities ?? [])].some((text) => text?.toLowerCase().includes(q))
       );
     });
-  }, [props.options, props.query, inference.access]);
+  }, [options, props.query, inference.access]);
 
   // Group by provider
   const providerGroups = useMemo<ProviderGroup[]>(() => {
-    const recommendations = managedModelRecommendations(inference.access, props.options);
+    const recommendations = managedModelRecommendations(inference.access, options);
     const ranks = new Map(recommendations.map((option, index) => [modelRefKey(option), index]));
     const map = new Map<string, ProviderGroup>();
     for (const opt of filteredOptions) {
@@ -205,12 +211,12 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
       if (a.hasCurrent !== b.hasCurrent) return a.hasCurrent ? -1 : 1;
       return a.name.localeCompare(b.name);
     });
-  }, [filteredOptions, props.current, props.options, disabledSet, inference.access]);
+  }, [filteredOptions, props.current, options, disabledSet, inference.access]);
 
   // Auto-expand on search
   useEffect(() => {
     if (props.query.trim()) {
-      setExpandedProviders(new Set(providerGroups.map((g) => g.id)));
+      setExpandedProviders((previous) => new Set([...previous, ...providerGroups.map((g) => g.id)]));
     }
   }, [props.query, providerGroups]);
 
@@ -251,7 +257,8 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   }, []);
 
   const handleSelect = (opt: ModelOption) => {
-    if (!inference.checkSelection(opt, props.sessionId, props.options.filter((option) => !disabledSet.has(option.providerID)), props.current)) {
+    if (!options.some((option) => modelEquals(option, opt) && !option.disabled && !disabledSet.has(option.providerID))) return;
+    if (!inference.checkSelection(opt, props.sessionId, options.filter((option) => !disabledSet.has(option.providerID)), props.current)) {
       props.onClose({ restorePromptFocus: false });
       return;
     }
@@ -273,9 +280,9 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   const emptyState = resolveModelPickerEmptyState({
     providerGroupCount: providerGroups.length,
     query: props.query,
-    organizationModelsEmpty: Boolean(props.organizationModelsEmpty),
+    organizationModelsEmpty: Boolean(props.organizationModelsEmpty) || (managedOnly && options.length === 0),
     restrictToCloud: Boolean(props.restrictToCloud),
-    organizationModelsSettingsUrl,
+    organizationModelsSettingsUrl: managedOnly ? undefined : organizationModelsSettingsUrl,
   });
 
   // Escape
@@ -295,13 +302,23 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         if (!open) props.onClose();
       }}
     >
-      <DialogContent data-testid="all-models-picker" className="flex max-h-[calc(100vh-2rem)] min-h-0 w-full max-w-lg flex-col overflow-hidden sm:max-w-lg">
+      <DialogContent data-testid="all-models-picker" data-model-scope={managedOnly ? "openwork" : "all"} className="flex max-h-[calc(100vh-2rem)] min-h-0 w-full max-w-lg flex-col overflow-hidden sm:max-w-lg"
+        onKeyDownCapture={(event) => {
+          if (!managedOnly || !isFavoriteModelShortcut(event)) return;
+          event.preventDefault();
+          event.stopPropagation();
+          if (event.repeat) return;
+          const next = nextFavoriteModel(favorites.filter((model) => options.some((option) => modelEquals(option, model)
+            && !option.disabled && !disabledSet.has(option.providerID)) && !modelSelectionUpgradeReason(inference.access, model)), props.current);
+          const option = next ? options.find((option) => modelEquals(option, next)) : undefined;
+          if (option) handleSelect(option);
+        }}>
         <DialogHeader>
-          <DialogTitle>{t("models.title")}</DialogTitle>
+          <DialogTitle>{managedOnly ? "OpenWork models" : t("models.title")}</DialogTitle>
           <DialogDescription>
             {resolveModelPickerSubtitle(props.subtitle)}
           </DialogDescription>
-          <InferenceAllowanceSummary available={props.options.some((option) => option.providerID === "openwork")} />
+          <InferenceAllowanceSummary available={options.some((option) => option.providerID === "openwork")} />
           {requested ? <p role="status" className="text-sm text-muted-foreground" data-testid="requested-model-ready">Select {managedModelRecommendation(inference.access, requested)?.displayName ?? requested.title ?? requested.modelID} to use it. Your model and draft are unchanged.</p> : null}
         </DialogHeader>
 
@@ -341,10 +358,13 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             {emptyState ? (
               <div className="space-y-3 rounded-2xl border border-dls-border bg-dls-hover/30 px-4 py-6 text-center">
                 <div className="text-sm text-dls-secondary">
-                  {t(emptyState.messageKey)}
+                  {managedOnly ? props.query.trim()
+                    ? "No OpenWork models match your search."
+                    : "No OpenWork models are available. Refresh to try again."
+                    : t(emptyState.messageKey)}
                 </div>
-                {emptyState.showRefreshOrganizationModels ? (
-                  <Button variant="outline" onClick={() => void handleRefreshOrganizationModels()} disabled={refreshingOrganizationModels}>
+                {emptyState.showRefreshOrganizationModels && props.onRefreshOrganizationModels ? (
+                  <Button data-testid="model-catalog-refresh" variant="outline" onClick={() => void handleRefreshOrganizationModels()} disabled={refreshingOrganizationModels}>
                     <RefreshCw className={`mr-1 size-3 ${refreshingOrganizationModels ? "animate-spin" : ""}`} />
                     {refreshingOrganizationModels ? t("models.refreshing_organization_models") : t("models.refresh_organization_models")}
                   </Button>

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -112,7 +112,6 @@ export function useModelPicker(input: UseModelPickerInput) {
 
   const modelOptions = useMemo(() => {
     const data = providerListQuery.data;
-    if (!data?.all) return [];
 
     // Flag models from recently-added providers so they appear in the
     // "Recently added" section at the top of the picker.

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -65,10 +65,12 @@ function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
           <BrandThemeProvider>
             <RestrictionNoticeProvider>
               <LocalProvider>
-                <AutomationRunnerBridge />
-                <GlobalQueueDrainerBridge />
-                <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
-                <Toaster />
+                <InferenceAccessProvider>
+                  <AutomationRunnerBridge />
+                  <GlobalQueueDrainerBridge />
+                  <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
+                  <Toaster />
+                </InferenceAccessProvider>
               </LocalProvider>
             </RestrictionNoticeProvider>
           </BrandThemeProvider>
@@ -99,9 +101,7 @@ export function AppProviders({ children }: AppProvidersProps) {
       <ServerProvider defaultUrl={defaultUrl}>
         <ArchitectureMismatchGate>
           <DenAuthProvider>
-            <InferenceAccessProvider>
-              <EnterpriseAwareAppProviders>{children}</EnterpriseAwareAppProviders>
-            </InferenceAccessProvider>
+            <EnterpriseAwareAppProviders>{children}</EnterpriseAwareAppProviders>
           </DenAuthProvider>
         </ArchitectureMismatchGate>
       </ServerProvider>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -3734,7 +3734,7 @@ export function SessionRoute() {
           ? MODEL_PICKER_UNAVAILABLE_SUBTITLE
           : undefined
       }
-      target="default"
+      target="session"
       current={
         (modelPickerSessionId ? getSessionModelSelection(modelPickerSessionId)?.model : null)
           ?? local.prefs.defaultModel

--- a/apps/app/tests/composer-model-controls.test.ts
+++ b/apps/app/tests/composer-model-controls.test.ts
@@ -36,6 +36,9 @@ describe("composer model controls", () => {
     expect(modelSelectSource).not.toContain("setThinkingOpen(true)");
     expect(modelSelectSource).toContain('data-slot="model-thinking-submenu"');
     expect(modelSelectSource).not.toContain("onMouseEnter");
+    const sessionRouteSource = readFileSync(sessionRoutePath, "utf8");
+    const fullPicker = sessionRouteSource.slice(sessionRouteSource.indexOf("<ModelPickerModal"));
+    expect(fullPicker).toContain('target="session"');
   });
 
   test("tracks steering until the active run stops streaming", () => {

--- a/apps/app/tests/composer-model-controls.test.ts
+++ b/apps/app/tests/composer-model-controls.test.ts
@@ -32,7 +32,7 @@ describe("composer model controls", () => {
     expect(modelSelect).toContain("disabled={props.steering}");
     expect(modelSelect).not.toContain("disabled={props.busy}");
     expect(modelSelect).toContain("behaviorOptions={props.modelBehaviorOptions}");
-    expect(modelSelectSource).toContain("setThinkingFor(option)");
+    expect(modelSelectSource).toContain("setThinkingFor(selectedOption)");
     expect(modelSelectSource).not.toContain("setThinkingOpen(true)");
     expect(modelSelectSource).toContain('data-slot="model-thinking-submenu"');
     expect(modelSelectSource).not.toContain("onMouseEnter");

--- a/apps/app/tests/model-picker-modal.test.ts
+++ b/apps/app/tests/model-picker-modal.test.ts
@@ -1,12 +1,13 @@
 import { afterAll, describe, expect, spyOn, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act, createElement } from "react";
+import { act, createElement, useState } from "react";
 import type { InferenceAccess } from "@openwork/types/den/inference";
+import type { ModelOption, ModelRef } from "../src/app/types";
 import * as den from "../src/app/lib/den";
 import type { DenAuthStore } from "../src/react-app/domains/cloud/den-auth-provider";
 import { denSettingsChangedEvent } from "../src/app/lib/den-session-events";
 import { MODEL_PREF_KEY } from "../src/app/constants";
-import { explicitModelChoiceKey, FREE_LUNA_MODEL, markExplicitModelChoice, shouldSelectInitialLuna } from "../src/app/lib/inference-access";
+import { explicitModelChoiceKey, FREE_LUNA_MODEL, markExplicitModelChoice, modelSelectionUpgradeReason, shouldSelectInitialLuna } from "../src/app/lib/inference-access";
 import { LOCAL_PREFERENCES_KEY } from "../src/react-app/kernel/local-preferences-storage";
 import { readModelPreferenceBeforeRepair, readStoredDefaultModel, writeStoredDefaultModel } from "../src/react-app/kernel/model-config";
 import { resolveEntitledOrgDefaultModel } from "../src/react-app/domains/connections/provider-auth/provider-policy";
@@ -16,13 +17,22 @@ Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: tr
 afterAll(async () => { await GlobalRegistrator.unregister(); });
 const { createRoot } = await import("react-dom/client");
 const auth = await import("../src/react-app/domains/cloud/den-auth-provider");
+const desktopConfig = await import("../src/react-app/domains/cloud/desktop-config-provider");
 const { InferenceAccessProvider, InferenceAllowanceSummary, useInferenceAccess } = await import("../src/react-app/domains/cloud/inference-access-provider");
 const { createDefaultPlatform, PlatformProvider } = await import("../src/react-app/kernel/platform");
 const {
+  ModelPickerModal,
   MODEL_PICKER_DEFAULT_SUBTITLE,
   MODEL_PICKER_UNAVAILABLE_SUBTITLE,
   resolveModelPickerSubtitle,
 } = await import("../src/react-app/domains/session/modals/model-picker-modal");
+
+const modelOption = (modelID: string, providerID = "openwork", title = modelID): ModelOption => ({
+  providerID, modelID, title, description: providerID,
+  behaviorTitle: "Effort", behaviorLabel: "Default", behaviorDescription: "", behaviorValue: null,
+  behaviorOptions: [{ value: "low", label: "Low", description: "" }, { value: "high", label: "High", description: "" }],
+  isFree: false,
+});
 
 describe("model picker subtitle", () => {
   test("keeps the normal session subtitle by default", () => {
@@ -37,6 +47,7 @@ describe("model picker subtitle", () => {
 });
 
 test("member access ignores stale organization reads and opens upgrades only on a managed selection", async () => {
+  localStorage.removeItem(explicitModelChoiceKey);
   const settings = { ...den.readDenSettings(), baseUrl: "https://den.example.com", activeOrgId: "org-a", authToken: "fixture-a" };
   const authState: DenAuthStore = {
     status: "signed_in", user: null, verifiedIdentity: { principalId: "person-a", organizationId: "org-a" },
@@ -46,6 +57,8 @@ test("member access ignores stale organization reads and opens upgrades only on 
   const originalClient = den.createDenClient({ baseUrl: settings.baseUrl });
   const settingsSpy = spyOn(den, "readDenSettings").mockImplementation(() => settings);
   const authSpy = spyOn(auth, "useDenAuth").mockImplementation(() => authState);
+  let restrictProviders = false;
+  const restrictionSpy = spyOn(desktopConfig, "useCheckDesktopRestriction").mockImplementation(() => () => restrictProviders);
   const clientSpy = spyOn(den, "createDenClient").mockImplementation(() => ({
     ...originalClient,
     getInferenceAccess: (orgId) => new Promise((resolve) => { pending.push({ orgId, resolve }); }),
@@ -54,13 +67,30 @@ test("member access ignores stale organization reads and opens upgrades only on 
   let clock = now;
   const clockSpy = spyOn(Date, "now").mockImplementation(() => clock);
   const opened: string[] = [];
+  const pickerEvents: unknown[] = [];
+  const onPicker = (event: Event) => { if (event instanceof CustomEvent) pickerEvents.push(event.detail); };
+  window.addEventListener("openwork-open-model-picker", onPicker);
+  const selected: ModelRef[] = [];
+  const paidModel = modelOption("minimax/minimax-m3", "openwork", "Provider display name");
+  const freeModel = modelOption(FREE_LUNA_MODEL.modelID);
+  const ownModel = modelOption("fixture-own", "lpr_own");
+  const availableModels = [freeModel, paidModel, ownModel];
+  const { useModelCollectionsStore } = await import("../src/react-app/domains/session/models/model-collections-store");
+  const previousCollections = useModelCollectionsStore.getState();
+  useModelCollectionsStore.setState({ favorites: [ownModel, freeModel], recent: [ownModel] });
   const platform = { ...createDefaultPlatform(), openLink: (url: string) => { opened.push(url); } };
   let inference: ReturnType<typeof useInferenceAccess> | undefined;
   function Probe() {
     inference = useInferenceAccess();
+    const [query, setQuery] = useState("");
     return createElement("div", null,
       createElement("span", { "data-testid": "access" }, inference.access?.kind ?? "unknown"),
-      createElement(InferenceAllowanceSummary));
+      createElement(InferenceAllowanceSummary),
+      createElement(ModelPickerModal, {
+        open: Boolean(inference.pickerRequest), options: availableModels, current: ownModel,
+        query, setQuery, target: "session", sessionId: "session-b", onSelect: (model) => selected.push(model),
+        onBehaviorChange: () => undefined, onOpenSettings: () => undefined, onClose: () => undefined,
+      }));
   }
   const host = document.createElement("div");
   document.body.append(host);
@@ -70,6 +100,7 @@ test("member access ignores stale organization reads and opens upgrades only on 
   const free: InferenceAccess & { canUpgrade: boolean } = {
     kind: "free", modelID: "openai/gpt-5.6-luna", weeklyLimitUsd: 1, usedUsd: 0.2, reservedUsd: 0.1,
     remainingUsd: 0.8, resetsAt: "2026-09-14T00:00:00Z", reason: "free_request_in_progress", canUpgrade: false,
+    catalog: [{ modelID: paidModel.modelID, displayName: "Fixture Paid", providerName: "Fixture Provider", summary: "Server supplied benefit", recommended: true, rank: 1, capabilities: ["Reasoning"] }],
   };
   try {
     await act(async () => { render(); });
@@ -93,25 +124,90 @@ test("member access ignores stale organization reads and opens upgrades only on 
     expect(inference?.checkSelection({ providerID: "openwork", modelID: "openai/gpt-5.6-luna" })).toBe(true);
     expect(inference?.checkSelection({ providerID: "lpr_managed", modelID: "minimax/minimax-m3" })).toBe(true);
     await act(async () => {
-      expect(inference?.checkSelection({ providerID: "openwork", modelID: "minimax/minimax-m3" })).toBe(false);
+      expect(inference?.checkSelection(paidModel, "session-b", availableModels, ownModel)).toBe(false);
     });
     expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("Ask a workspace owner or admin");
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("Unlock Fixture Paid");
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("Server supplied benefit");
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("View plans for current pricing and usage limits");
+    expect(document.querySelector('[data-testid="inference-keep-current-model"]')?.textContent).toContain("Keep current model");
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).not.toContain("Keep using Luna");
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).not.toContain("$");
+    expect(document.querySelector('[data-testid="inference-view-upgrade"]')).toBeNull();
+    await act(async () => { restrictProviders = true; render(); });
+    expect(document.querySelector('[data-testid="model-own-provider"]')).toBeNull();
+    expect(selected).toEqual([]);
+    expect(localStorage.getItem(explicitModelChoiceKey)).toBeNull();
     expect(opened).toEqual([]);
+    for (const { currentModel, label } of [
+      { currentModel: ownModel, label: "Keep current model" },
+      { currentModel: freeModel, label: "Keep using Luna" },
+      { currentModel: { ...freeModel, providerID: "lpr_own" }, label: "Keep current model" },
+    ]) {
+      await act(async () => { inference?.checkSelection(paidModel, "session-b", availableModels, currentModel); });
+      const keep = document.querySelector<HTMLButtonElement>('[data-testid="inference-keep-current-model"]');
+      if (!keep) throw new Error("Expected a dismiss-only action for the current model");
+      expect(keep.textContent?.trim()).toBe(label);
+      await act(async () => keep.click());
+      expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')).toBeNull();
+      expect(document.querySelector('[data-testid="all-models-picker"]')).toBeNull();
+      expect(inference?.pickerRequest).toBeNull();
+      expect(pickerEvents).toEqual([]);
+      expect(selected).toEqual([]);
+      expect(useModelCollectionsStore.getState().favorites).toEqual([ownModel, freeModel]);
+      expect(useModelCollectionsStore.getState().recent).toEqual([ownModel]);
+      expect(localStorage.getItem(explicitModelChoiceKey)).toBeNull();
+    }
+    await act(async () => { inference?.showUpgrade("managed_model_requires_upgrade", "session-b", paidModel); });
+    expect(document.querySelector('[data-testid="inference-keep-current-model"]')).toBeNull();
     await act(async () => {
       clock += 60_000;
       window.dispatchEvent(new Event("openwork.inference-access-refresh"));
     });
     expect(pending[2]?.orgId).toBe("org-b");
-    await act(async () => { pending[2]?.resolve({ ...free, kind: "exhausted", usedUsd: 1, reservedUsd: 0, remainingUsd: 0, reason: "free_allowance_exhausted", canUpgrade: true }); });
+    await act(async () => { pending[2]?.resolve({ ...free, kind: "exhausted", usedUsd: 1, reservedUsd: 0, remainingUsd: 0, reason: "free_allowance_exhausted", canUpgrade: true,
+      plan: { name: "Fixture plan", priceLabel: "Server price", usageLabel: "Server usage limits" },
+    }); });
     await act(async () => {
       expect(inference?.checkSelection({ providerID: "openwork", modelID: "openai/gpt-5.6-luna" })).toBe(false);
     });
     expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("Your free Luna allowance is used up");
-    const upgrade = Array.from(document.querySelectorAll("button")).find((button) => button.textContent === "Upgrade");
+    expect(document.querySelector('[data-testid="inference-upgrade-plan"]')?.textContent).toContain("Fixture plan · Server price");
+    expect(document.querySelector('[data-testid="inference-upgrade-plan"]')?.textContent).toContain("Server usage limits");
+    const upgrade = Array.from(document.querySelectorAll("button")).find((button) => button.textContent === "View upgrade");
     if (!upgrade) throw new Error("Expected the explicit Upgrade action");
     await act(async () => upgrade.click());
     expect(opened).toEqual(["https://den.example.com/dashboard/inference"]);
     expect(document.body.textContent).not.toContain("fixture-b");
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).not.toContain("Keep using Luna");
+    await act(async () => { inference?.checkSelection(paidModel, "session-b", availableModels); });
+    await act(async () => {
+      clock += 60_000;
+      window.dispatchEvent(new Event("focus"));
+    });
+    await act(async () => { pending[3]?.resolve({ ...free, kind: "paid", canUpgrade: true }); });
+    expect(document.querySelector('[data-testid="inference-upgrade-dialog"]')?.textContent).toContain("Fixture Paid is ready to use");
+    expect(pickerEvents).toEqual([]);
+    expect(selected).toEqual([]);
+    const useModel = document.querySelector<HTMLButtonElement>('[data-testid="inference-use-model"]');
+    if (!useModel) throw new Error("Expected explicit continuation after the server grants paid access");
+    await act(async () => useModel.click());
+    expect(pickerEvents).toEqual([{ sessionId: "session-b" }]);
+    expect(inference?.pickerRequest?.model).toEqual(paidModel);
+    expect(document.querySelector('[data-testid="requested-model-ready"]')?.textContent).toContain("Select Fixture Paid");
+    expect(document.querySelector('[data-requested="true"]')?.textContent).toContain("Fixture Paid");
+    expect(document.querySelector('[data-requested="true"]')?.textContent).toContain("Included");
+    expect(selected).toEqual([]);
+    expect(localStorage.getItem(explicitModelChoiceKey)).toBeNull();
+    const choose = document.querySelector<HTMLButtonElement>('[data-requested="true"] button');
+    if (!choose) throw new Error("Expected the requested model highlighted in the real picker");
+    await act(async () => choose.click());
+    expect(selected).toEqual([{ providerID: paidModel.providerID, modelID: paidModel.modelID }]);
+    expect(localStorage.getItem(explicitModelChoiceKey)).toBe("1");
+    await act(async () => { inference?.showUpgrade("managed_model_requires_upgrade", "session-b", paidModel, availableModels); });
+    expect(document.querySelector('[data-testid="inference-use-model"]')).not.toBeNull();
+    await act(async () => { window.dispatchEvent(new Event("hashchange")); });
+    expect(document.querySelector('[data-testid="inference-use-model"]')).toBeNull();
     await act(async () => {
       authState.status = "signed_out";
       authState.verifiedIdentity = null;
@@ -120,6 +216,7 @@ test("member access ignores stale organization reads and opens upgrades only on 
       render();
     });
     expect(inference?.access).toBeNull();
+    expect(inference?.pickerRequest).toBeNull();
     expect(inference?.checkSelection({ providerID: "openwork", modelID: "minimax/minimax-m3" })).toBe(true);
   } finally {
     await act(async () => { root.unmount(); });
@@ -128,6 +225,136 @@ test("member access ignores stale organization reads and opens upgrades only on 
     settingsSpy.mockRestore();
     authSpy.mockRestore();
     clockSpy.mockRestore();
+    restrictionSpy.mockRestore();
+    useModelCollectionsStore.setState({ favorites: previousCollections.favorites, recent: previousCollections.recent });
+    window.removeEventListener("openwork-open-model-picker", onPicker);
+  }
+});
+
+test("compact picker opens model rows, dedupes recommendations and favorites, and selects before effort", async () => {
+  const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
+  const { WorkspaceProvider } = await import("../src/react-app/shell/workspace-provider");
+  const { ModelSelect } = await import("../src/components/model-select");
+  const inferenceModule = await import("../src/react-app/domains/cloud/inference-access-provider");
+  const { useModelCollectionsStore } = await import("../src/react-app/domains/session/models/model-collections-store");
+  const freeModel = modelOption(FREE_LUNA_MODEL.modelID, "openwork", "Fixture Free");
+  const paidModel = modelOption("fixture-paid", "openwork", "Fixture Paid");
+  const hiddenModel = modelOption("fixture-other", "openwork", "Other managed model");
+  const ownModel = modelOption("fixture-own", "lpr_own", "My own model");
+  const options = [freeModel, paidModel, hiddenModel, ownModel];
+  const access: InferenceAccess & { canUpgrade: boolean } = {
+    kind: "free", modelID: freeModel.modelID, weeklyLimitUsd: 1, usedUsd: 0, reservedUsd: 0,
+    remainingUsd: 1, resetsAt: null, reason: null, canUpgrade: true,
+    catalog: options.slice(0, 2).map((model, rank) => ({ modelID: model.modelID, displayName: model.title, providerName: "Fixture provider", summary: "Fixture summary", recommended: true, rank, capabilities: ["Thinking"] })),
+  };
+  const selected: ModelRef[] = [];
+  const behaviors: Array<string | null> = [];
+  const locked: ModelRef[] = [];
+  const lockedCurrentModels: Array<ModelRef | undefined> = [];
+  let providerSetup = 0;
+  const onProvider = () => { providerSetup++; };
+  window.addEventListener("openwork-open-provider-auth", onProvider);
+  const authSpy = spyOn(auth, "useDenAuth").mockReturnValue({ status: "signed_in", user: null, verifiedIdentity: { principalId: "fixture", organizationId: "fixture" }, isSignedIn: true, error: null, refresh: async () => undefined });
+  const restrictionSpy = spyOn(desktopConfig, "useCheckDesktopRestriction").mockImplementation(() => () => false);
+  const inferenceSpy = spyOn(inferenceModule, "useInferenceAccess").mockReturnValue({ access, pickerRequest: null, showUpgrade: () => undefined, checkSelection: (model, _sessionId, _availableModels, currentModel) => {
+    if (modelSelectionUpgradeReason(access, model)) { locked.push(model); lockedCurrentModels.push(currentModel); return false; }
+    return true;
+  } });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  localStorage.removeItem(explicitModelChoiceKey);
+  useModelCollectionsStore.setState({ favorites: [paidModel, ownModel], recent: [freeModel, ownModel] });
+  function Picker() {
+    const [open, setOpen] = useState(false);
+    const [value, setValue] = useState<ModelRef>(ownModel);
+    return createElement(ModelSelect, { open, onOpenChange: setOpen, value, fallbackOptions: options,
+      onChange: (model) => { selected.push(model); setValue(model); }, onBehaviorChange: (value) => behaviors.push(value),
+    });
+  }
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const click = async (selector: string) => {
+    const button = document.querySelector<HTMLElement>(selector);
+    if (!button) throw new Error(`Missing picker control: ${selector}`);
+    await act(async () => button.click());
+  };
+  const search = async (value: string) => {
+    const input = document.querySelector<HTMLInputElement>('[aria-label="Search all models"]');
+    if (!input) throw new Error("Missing model search");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  };
+  try {
+    await act(async () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children:
+      createElement(QueryClientProvider, { client: queryClient, children:
+        createElement(WorkspaceProvider, { client: null, selectedWorkspaceRoot: "", children: createElement(Picker) }) }) })));
+    await click('[aria-label="Change model"]');
+    expect(document.querySelector('[data-testid="managed-model-picker"]')).not.toBeNull();
+    expect(document.querySelector('[aria-label="Search all models"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="model-select-root"]')).toBeNull();
+    expect(document.querySelector('[data-slot="model-thinking-submenu"]')).toBeNull();
+    expect(document.querySelectorAll('[data-testid="model-option-openwork-fixture-paid"]').length).toBe(1);
+    expect(document.querySelector('[data-testid="model-option-openwork-fixture-paid"]')?.textContent).toContain("Upgrade");
+    expect(document.querySelector('[data-testid="model-option-openwork-fixture-paid"]')?.getAttribute("aria-label")).toContain("opens upgrade options without changing your model");
+    expect(document.querySelector(`[data-testid="model-option-openwork-${freeModel.modelID}"]`)?.textContent).toContain("Free");
+    expect(document.querySelector('[data-testid="model-option-lpr_own-fixture-own"]')?.textContent).not.toContain("Upgrade");
+    expect(document.querySelector('[data-testid="model-option-openwork-fixture-other"]')).toBeNull();
+    expect(selected).toEqual([]);
+    await search("Other managed model");
+    expect(document.querySelector('[data-testid="model-option-openwork-fixture-other"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="model-option-openwork-fixture-paid"]')).toBeNull();
+    await search("");
+    await click('[data-testid="model-option-openwork-fixture-paid"]');
+    expect(locked).toEqual([paidModel]);
+    expect(lockedCurrentModels).toEqual([ownModel]);
+    expect(selected).toEqual([]);
+    expect(behaviors).toEqual([]);
+    expect(localStorage.getItem(explicitModelChoiceKey)).toBeNull();
+    expect(useModelCollectionsStore.getState().favorites).toEqual([paidModel, ownModel]);
+    await click('[aria-label="Change model"]');
+    await search("Fixture Free");
+    await act(async () => {
+      document.querySelector('[aria-label="Search all models"]')?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    expect(selected).toEqual([{ providerID: freeModel.providerID, modelID: freeModel.modelID }]);
+    expect(behaviors).toEqual([]);
+    expect(localStorage.getItem(explicitModelChoiceKey)).toBe("1");
+    expect(document.querySelector('[data-slot="model-thinking-submenu"]')).toBeNull();
+    await click('[aria-label="Change model"]');
+    await click('[aria-label="Thinking and effort for Fixture Free"]');
+    expect(document.querySelector('[data-slot="model-thinking-submenu"]')).not.toBeNull();
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Back to models");
+    const effort = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-slot="model-thinking-submenu"] button')).find((button) => button.textContent === "High");
+    if (!effort) throw new Error("Missing selected model effort option");
+    await act(async () => effort.click());
+    expect(behaviors).toEqual(["high"]);
+    expect(selected.length).toBe(1);
+    await click('[aria-label="Change model"]');
+    await click('[aria-label="Cycle favorite models"]');
+    expect(selected[1]).toEqual({ providerID: ownModel.providerID, modelID: ownModel.modelID });
+    expect(locked.length).toBe(1);
+    await click('[aria-label="Change model"]');
+    await click('[data-testid="model-own-provider"]');
+    expect(providerSetup).toBe(1);
+    access.catalog = undefined;
+    await click('[aria-label="Change model"]');
+    expect(document.querySelector('[data-testid="model-option-openwork-fixture-other"]')).not.toBeNull();
+    await act(async () => { window.location.hash = "/workspace/fixture/settings/preferences"; });
+    await click('[data-testid="model-own-provider"]');
+    expect(window.location.hash).toBe("#/workspace/fixture/settings/ai");
+    expect(providerSetup).toBe(1);
+  } finally {
+    await act(async () => root.unmount());
+    host.remove();
+    queryClient.clear();
+    authSpy.mockRestore();
+    restrictionSpy.mockRestore();
+    inferenceSpy.mockRestore();
+    useModelCollectionsStore.setState({ favorites: [], recent: [] });
+    window.removeEventListener("openwork-open-provider-auth", onProvider);
+    window.location.hash = "";
   }
 });
 

--- a/apps/app/tests/model-picker-modal.test.ts
+++ b/apps/app/tests/model-picker-modal.test.ts
@@ -11,6 +11,7 @@ import { explicitModelChoiceKey, FREE_LUNA_MODEL, markExplicitModelChoice, model
 import { LOCAL_PREFERENCES_KEY } from "../src/react-app/kernel/local-preferences-storage";
 import { readModelPreferenceBeforeRepair, readStoredDefaultModel, writeStoredDefaultModel } from "../src/react-app/kernel/model-config";
 import { resolveEntitledOrgDefaultModel } from "../src/react-app/domains/connections/provider-auth/provider-policy";
+import { isFavoriteModelShortcut } from "../src/react-app/shell/favorite-model-shortcut";
 // Base UI detects DOM support when its module loads.
 GlobalRegistrator.register({ url: "http://localhost" });
 Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
@@ -231,7 +232,7 @@ test("member access ignores stale organization reads and opens upgrades only on 
   }
 });
 
-test("compact picker opens model rows, dedupes recommendations and favorites, and selects before effort", async () => {
+test("managed compact picker hides own models without changing stored choices and selects before effort", async () => {
   const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
   const { WorkspaceProvider } = await import("../src/react-app/shell/workspace-provider");
   const { ModelSelect } = await import("../src/components/model-select");
@@ -241,7 +242,9 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
   const paidModel = modelOption("fixture-paid", "openwork", "Fixture Paid");
   const hiddenModel = modelOption("fixture-other", "openwork", "Other managed model");
   const ownModel = modelOption("fixture-own", "lpr_own", "My own model");
-  const options = [freeModel, paidModel, hiddenModel, ownModel];
+  const starter = modelOption("big-pickle", "opencode", "Big Pickle");
+  const options = [freeModel, paidModel, hiddenModel, ownModel, starter];
+  let availableOptions = options;
   const access: InferenceAccess & { canUpgrade: boolean } = {
     kind: "free", modelID: freeModel.modelID, weeklyLimitUsd: 1, usedUsd: 0, reservedUsd: 0,
     remainingUsd: 1, resetsAt: null, reason: null, canUpgrade: true,
@@ -251,6 +254,9 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
   const behaviors: Array<string | null> = [];
   const locked: ModelRef[] = [];
   const lockedCurrentModels: Array<ModelRef | undefined> = [];
+  let escapedFavoriteShortcuts = 0;
+  const onGlobalShortcut = (event: KeyboardEvent) => { if (isFavoriteModelShortcut(event)) escapedFavoriteShortcuts++; };
+  window.addEventListener("keydown", onGlobalShortcut);
   let providerSetup = 0;
   const onProvider = () => { providerSetup++; };
   window.addEventListener("openwork-open-provider-auth", onProvider);
@@ -262,17 +268,24 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
   } });
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   localStorage.removeItem(explicitModelChoiceKey);
-  useModelCollectionsStore.setState({ favorites: [paidModel, ownModel], recent: [freeModel, ownModel] });
+  writeStoredDefaultModel(starter);
+  const storedPreference = localStorage.getItem(MODEL_PREF_KEY);
+  const favorites = [paidModel, ownModel, starter];
+  const recent = [freeModel, ownModel, starter];
+  useModelCollectionsStore.setState({ favorites, recent });
   function Picker() {
     const [open, setOpen] = useState(false);
-    const [value, setValue] = useState<ModelRef>(ownModel);
-    return createElement(ModelSelect, { open, onOpenChange: setOpen, value, fallbackOptions: options,
+    const [value, setValue] = useState<ModelRef>(starter);
+    return createElement(ModelSelect, { open, onOpenChange: setOpen, value, fallbackOptions: availableOptions,
       onChange: (model) => { selected.push(model); setValue(model); }, onBehaviorChange: (value) => behaviors.push(value),
     });
   }
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
+  const render = () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children:
+    createElement(QueryClientProvider, { client: queryClient, children:
+      createElement(WorkspaceProvider, { client: null, selectedWorkspaceRoot: "", children: createElement(Picker) }) }) }));
   const click = async (selector: string) => {
     const button = document.querySelector<HTMLElement>(selector);
     if (!button) throw new Error(`Missing picker control: ${selector}`);
@@ -287,11 +300,15 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
     });
   };
   try {
-    await act(async () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children:
-      createElement(QueryClientProvider, { client: queryClient, children:
-        createElement(WorkspaceProvider, { client: null, selectedWorkspaceRoot: "", children: createElement(Picker) }) }) })));
+    await act(async () => { render(); });
     await click('[aria-label="Change model"]');
     expect(document.querySelector('[data-testid="managed-model-picker"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="managed-model-picker"]')?.getAttribute("data-model-scope")).toBe("openwork");
+    expect(document.querySelector('[aria-label="Change model"]')?.textContent).toContain("Big Pickle");
+    expect(document.querySelector('[data-testid="managed-model-picker"]')?.textContent).not.toContain("Big Pickle");
+    expect(document.querySelector('[data-testid="managed-model-picker"]')?.textContent).not.toContain("My own model");
+    expect(document.querySelector('[data-testid="selected-model-detail"]')).toBeNull();
+    expect(document.querySelector('[data-testid="managed-model-picker"]')?.textContent).toContain("See all OpenWork models");
     expect(document.querySelector('[aria-label="Search all models"]')).not.toBeNull();
     expect(document.querySelector('[data-slot="model-select-root"]')).toBeNull();
     expect(document.querySelector('[data-slot="model-thinking-submenu"]')).toBeNull();
@@ -299,20 +316,34 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
     expect(document.querySelector('[data-testid="model-option-openwork-fixture-paid"]')?.textContent).toContain("Upgrade");
     expect(document.querySelector('[data-testid="model-option-openwork-fixture-paid"]')?.getAttribute("aria-label")).toContain("opens upgrade options without changing your model");
     expect(document.querySelector(`[data-testid="model-option-openwork-${freeModel.modelID}"]`)?.textContent).toContain("Free");
-    expect(document.querySelector('[data-testid="model-option-lpr_own-fixture-own"]')?.textContent).not.toContain("Upgrade");
+    expect(document.querySelector('[data-testid="model-option-lpr_own-fixture-own"]')).toBeNull();
+    expect(document.querySelector('[data-testid="model-option-opencode-big-pickle"]')).toBeNull();
     expect(document.querySelector('[data-testid="model-option-openwork-fixture-other"]')).toBeNull();
     expect(selected).toEqual([]);
+    expect(localStorage.getItem(MODEL_PREF_KEY)).toBe(storedPreference);
+    expect(useModelCollectionsStore.getState().favorites).toEqual(favorites);
+    expect(useModelCollectionsStore.getState().recent).toEqual(recent);
+    await act(async () => {
+      document.querySelector('[aria-label="Search all models"]')?.dispatchEvent(new KeyboardEvent("keydown", { key: "m", ctrlKey: true, shiftKey: true, bubbles: true }));
+    });
+    expect(escapedFavoriteShortcuts).toBe(0);
+    expect(selected).toEqual([]);
+    for (const query of ["opencode", "Big Pickle", "My own model", "lpr_own"]) {
+      await search(query);
+      expect(document.querySelector('[data-testid="managed-model-picker"]')?.textContent).toContain("No OpenWork models match your search.");
+      expect(document.querySelector('[data-testid^="model-option-"]')).toBeNull();
+    }
     await search("Other managed model");
     expect(document.querySelector('[data-testid="model-option-openwork-fixture-other"]')).not.toBeNull();
     expect(document.querySelector('[data-testid="model-option-openwork-fixture-paid"]')).toBeNull();
     await search("");
     await click('[data-testid="model-option-openwork-fixture-paid"]');
     expect(locked).toEqual([paidModel]);
-    expect(lockedCurrentModels).toEqual([ownModel]);
+    expect(lockedCurrentModels).toEqual([starter]);
     expect(selected).toEqual([]);
     expect(behaviors).toEqual([]);
     expect(localStorage.getItem(explicitModelChoiceKey)).toBeNull();
-    expect(useModelCollectionsStore.getState().favorites).toEqual([paidModel, ownModel]);
+    expect(useModelCollectionsStore.getState().favorites).toEqual(favorites);
     await click('[aria-label="Change model"]');
     await search("Fixture Free");
     await act(async () => {
@@ -332,10 +363,10 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
     expect(behaviors).toEqual(["high"]);
     expect(selected.length).toBe(1);
     await click('[aria-label="Change model"]');
+    expect(document.querySelector<HTMLButtonElement>('[aria-label="Cycle favorite models"]')?.disabled).toBe(true);
     await click('[aria-label="Cycle favorite models"]');
-    expect(selected[1]).toEqual({ providerID: ownModel.providerID, modelID: ownModel.modelID });
+    expect(selected.length).toBe(1);
     expect(locked.length).toBe(1);
-    await click('[aria-label="Change model"]');
     await click('[data-testid="model-own-provider"]');
     expect(providerSetup).toBe(1);
     access.catalog = undefined;
@@ -345,6 +376,23 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
     await click('[data-testid="model-own-provider"]');
     expect(window.location.hash).toBe("#/workspace/fixture/settings/ai");
     expect(providerSetup).toBe(1);
+    availableOptions = [ownModel, starter];
+    await act(async () => { render(); });
+    await click('[aria-label="Change model"]');
+    expect(document.querySelector('[data-testid="managed-model-picker"]')?.textContent).toContain("No OpenWork models are available.");
+    expect(document.querySelector('[data-testid^="model-option-"]')).toBeNull();
+    expect(document.querySelector('[aria-label="Cycle favorite models"]')).toBeNull();
+    expect(document.querySelector('[data-testid="model-access-label"]')).toBeNull();
+    expect(selected.length).toBe(1);
+    expect(useModelCollectionsStore.getState().favorites).toEqual(favorites);
+    authSpy.mockReturnValue({ status: "signed_out", user: null, verifiedIdentity: null, isSignedIn: false, error: null, refresh: async () => undefined });
+    await act(async () => { render(); });
+    expect(document.querySelector('[data-testid="managed-model-picker"]')?.getAttribute("data-model-scope")).toBe("all");
+    expect(document.querySelector('[data-testid="model-option-opencode-big-pickle"]')?.textContent).toContain("Big Pickle");
+    expect(document.querySelector('[data-testid="managed-model-picker"]')?.textContent).toContain("See all models");
+    expect(localStorage.getItem(MODEL_PREF_KEY)).toBe(storedPreference);
+    await click('[data-testid="model-option-opencode-big-pickle"]');
+    expect(selected[1]).toEqual({ providerID: starter.providerID, modelID: starter.modelID });
   } finally {
     await act(async () => root.unmount());
     host.remove();
@@ -354,7 +402,118 @@ test("compact picker opens model rows, dedupes recommendations and favorites, an
     inferenceSpy.mockRestore();
     useModelCollectionsStore.setState({ favorites: [], recent: [] });
     window.removeEventListener("openwork-open-provider-auth", onProvider);
+    window.removeEventListener("keydown", onGlobalShortcut);
     window.location.hash = "";
+  }
+});
+
+test("full session catalogs contain only hosted models while default/provider settings can still select BYOK", async () => {
+  const inferenceModule = await import("../src/react-app/domains/cloud/inference-access-provider");
+  const { useModelCollectionsStore } = await import("../src/react-app/domains/session/models/model-collections-store");
+  const ownModel = modelOption("fixture-own", "lpr_own", "My own model");
+  const starter = modelOption("big-pickle", "opencode", "Big Pickle");
+  const freeModel = modelOption(FREE_LUNA_MODEL.modelID, "openwork", "Fixture Free");
+  const options = [ownModel, starter, freeModel, modelOption("fixture-paid")];
+  let availableOptions = options;
+  const base: InferenceAccess & { canUpgrade: boolean } = {
+    kind: "free", modelID: freeModel.modelID, weeklyLimitUsd: 1, usedUsd: 0, reservedUsd: 0,
+    remainingUsd: 1, resetsAt: null, reason: null, canUpgrade: true,
+  };
+  let access: (InferenceAccess & { canUpgrade: boolean }) | null = base;
+  let target: "session" | "default" = "session";
+  const selected: ModelRef[] = [];
+  let refreshes = 0;
+  let escapedFavoriteShortcuts = 0;
+  const onGlobalShortcut = (event: KeyboardEvent) => { if (isFavoriteModelShortcut(event)) escapedFavoriteShortcuts++; };
+  window.addEventListener("keydown", onGlobalShortcut);
+  const previousCollections = useModelCollectionsStore.getState();
+  useModelCollectionsStore.setState({ favorites: [ownModel, starter], recent: [starter] });
+  const authSpy = spyOn(auth, "useDenAuth").mockReturnValue({ status: "signed_in", user: null, verifiedIdentity: { principalId: "fixture", organizationId: "fixture" }, isSignedIn: true, error: null, refresh: async () => undefined });
+  const restrictionSpy = spyOn(desktopConfig, "useCheckDesktopRestriction").mockImplementation(() => () => false);
+  const inferenceSpy = spyOn(inferenceModule, "useInferenceAccess").mockImplementation(() => ({
+    access, pickerRequest: null, showUpgrade: () => undefined,
+    checkSelection: (model) => !modelSelectionUpgradeReason(access, model),
+  }));
+  function Picker() {
+    const [query, setQuery] = useState("");
+    return createElement(ModelPickerModal, {
+      open: true, options: availableOptions, target, current: ownModel, query, setQuery,
+      onSelect: (model) => selected.push(model), onClose: () => undefined, onOpenSettings: () => undefined, onBehaviorChange: () => undefined,
+      onRefreshOrganizationModels: async () => { refreshes++; },
+    });
+  }
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const render = () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children: createElement(Picker) }));
+  const search = async (value: string) => {
+    const input = document.querySelector<HTMLInputElement>('[aria-label="Search all models"]');
+    if (!input) throw new Error("Missing full model search");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  };
+  try {
+    const kinds: InferenceAccess["kind"][] = ["free", "paid", "exhausted"];
+    for (const kind of kinds) {
+      access = { ...base, kind };
+      await act(async () => { render(); });
+      const picker = document.querySelector('[data-testid="all-models-picker"]');
+      expect(picker?.getAttribute("data-model-scope")).toBe("openwork");
+      expect(picker?.textContent).toContain("Fixture Free");
+      expect(picker?.textContent).not.toContain("Big Pickle");
+      expect(picker?.textContent).not.toContain("My own model");
+      for (const query of ["opencode", "Big Pickle", "lpr_own", "My own model"]) {
+        await search(query);
+        expect(document.querySelector('[data-testid^="model-option-"]')).toBeNull();
+        expect(picker?.textContent).toContain("No OpenWork models match your search.");
+      }
+      await search("");
+      await act(async () => {
+        document.querySelector('[aria-label="Search all models"]')?.dispatchEvent(new KeyboardEvent("keydown", { key: "m", ctrlKey: true, shiftKey: true, bubbles: true }));
+      });
+      expect(escapedFavoriteShortcuts).toBe(0);
+      expect(selected).toEqual([]);
+      expect(useModelCollectionsStore.getState().favorites).toEqual([ownModel, starter]);
+      expect(useModelCollectionsStore.getState().recent).toEqual([starter]);
+    }
+    availableOptions = [ownModel, starter];
+    await act(async () => { render(); });
+    expect(document.querySelector('[data-testid="all-models-picker"]')?.textContent).toContain("No OpenWork models are available. Refresh to try again.");
+    expect(document.querySelector('[data-testid^="model-option-"]')).toBeNull();
+    const refresh = document.querySelector<HTMLButtonElement>('[data-testid="model-catalog-refresh"]');
+    if (!refresh) throw new Error("Missing managed catalog recovery action");
+    await act(async () => refresh.click());
+    expect(refreshes).toBe(1);
+    expect(selected).toEqual([]);
+    availableOptions = options;
+    for (const legacyAccess of [null, { ...base, kind: "unavailable", reason: "free_disabled" } satisfies InferenceAccess]) {
+      access = legacyAccess;
+      await act(async () => { render(); });
+      expect(document.querySelector('[data-testid="all-models-picker"]')?.getAttribute("data-model-scope")).toBe("all");
+      await search("Big Pickle");
+      expect(document.querySelector('[data-testid="model-option-opencode-big-pickle"]')).not.toBeNull();
+      await search("");
+    }
+    target = "default";
+    access = { ...base, kind: "paid" };
+    await act(async () => { render(); });
+    expect(document.querySelector('[data-testid="all-models-picker"]')?.getAttribute("data-model-scope")).toBe("all");
+    await search("My own model");
+    const own = document.querySelector<HTMLButtonElement>('[data-testid="model-option-lpr_own-fixture-own"]');
+    if (!own) throw new Error("Provider settings must still allow selecting connected BYOK models");
+    await act(async () => own.click());
+    expect(selected).toEqual([{ providerID: ownModel.providerID, modelID: ownModel.modelID }]);
+    expect(useModelCollectionsStore.getState().favorites).toEqual([ownModel, starter]);
+  } finally {
+    await act(async () => root.unmount());
+    host.remove();
+    authSpy.mockRestore();
+    restrictionSpy.mockRestore();
+    inferenceSpy.mockRestore();
+    useModelCollectionsStore.setState({ favorites: previousCollections.favorites, recent: previousCollections.recent });
+    window.removeEventListener("keydown", onGlobalShortcut);
   }
 });
 

--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false } },
+  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false, "feature/managed-model-discovery": false } },
   "framework": "vite",
   "ignoreCommand": "turbo query affected --base=$VERCEL_GIT_PREVIOUS_SHA --packages @openwork/app --exit-code || exit 1",
   "buildCommand": "pnpm run build:web",

--- a/ee/apps/den-api/src/inference.ts
+++ b/ee/apps/den-api/src/inference.ts
@@ -27,6 +27,8 @@ import {
   freeInferenceAccess,
   freeInferenceWindow,
   inferenceAccessMode,
+  inferencePlanPresentation,
+  managedModelCatalog,
 } from "@openwork/types/den/inference"
 import type { InferenceAccess, InferenceOrganizationMetadata, InferenceTier, InferenceWindowType } from "@openwork/types/den/inference"
 import { db } from "./db.js"
@@ -238,16 +240,21 @@ export async function getMemberInferenceAccess(input: {
     .where(and(eq(MemberTable.id, input.memberId), eq(MemberTable.organizationId, input.organizationId),
       eq(MemberTable.userId, input.userId), isNull(MemberTable.removedAt), isNotNull(MemberTable.joinedAt))).limit(1)
   const mode = row ? inferenceAccessMode(row.metadata) : "not_eligible"
+  const metadata = row?.metadata?.inference
+  const presentation = {
+    catalog: managedModelCatalog(mode === "free" ? { freeModelID: env.inferenceFree.modelID } : {}),
+    plan: inferencePlanPresentation(mode === "paid" && isRecord(metadata) && metadata.tier === "tier2" ? "tier2" : "tier1"),
+  }
   const now = new Date()
-  if (mode !== "free" || !env.inferenceFree.enabled) return freeInferenceAccess({ config: env.inferenceFree, mode, now })
+  if (mode !== "free" || !env.inferenceFree.enabled) return { ...freeInferenceAccess({ config: env.inferenceFree, mode, now }), ...presentation }
   try {
     const [bucket] = await db.select().from(InferenceFreeUsageBucketTable).where(and(
       eq(InferenceFreeUsageBucketTable.user_id, input.userId),
       eq(InferenceFreeUsageBucketTable.window_start_at, freeInferenceWindow(now).start),
     )).limit(1)
-    return freeInferenceAccess({ config: env.inferenceFree, mode, bucket, now })
+    return { ...freeInferenceAccess({ config: env.inferenceFree, mode, bucket, now }), ...presentation }
   } catch {
-    return { ...freeInferenceAccess({ config: env.inferenceFree, mode, now }), kind: "unavailable", reason: "accounting_unavailable", usedUsd: null, reservedUsd: null, remainingUsd: null }
+    return { ...freeInferenceAccess({ config: env.inferenceFree, mode, now }), ...presentation, kind: "unavailable", reason: "accounting_unavailable", usedUsd: null, reservedUsd: null, remainingUsd: null }
   }
 }
 

--- a/ee/apps/den-api/src/routes/org/inference.ts
+++ b/ee/apps/den-api/src/routes/org/inference.ts
@@ -42,6 +42,16 @@ const inferenceProviderMissingSchema = z.object({
   message: z.string(),
 }).meta({ ref: "InferenceProviderMissingError" })
 
+const managedModelRecommendationSchema = z.object({
+  modelID: z.string(),
+  displayName: z.string(),
+  providerName: z.string(),
+  summary: z.string(),
+  recommended: z.boolean(),
+  rank: z.number(),
+  capabilities: z.array(z.string()),
+}).meta({ ref: "ManagedModelRecommendation" })
+
 const inferenceAccessResponseSchema = z.object({
   access: z.object({
     kind: z.enum(["paid", "free", "exhausted", "unavailable"]),
@@ -53,6 +63,12 @@ const inferenceAccessResponseSchema = z.object({
     resetsAt: z.string().nullable(),
     reason: z.enum(INFERENCE_ACCESS_REASONS).nullable(),
     canUpgrade: z.boolean(),
+    catalog: z.array(managedModelRecommendationSchema).optional(),
+    plan: z.object({
+      name: z.string(),
+      priceLabel: z.string().nullable(),
+      usageLabel: z.string(),
+    }).optional(),
   }),
   upgradePath: z.literal("/dashboard/billing").nullable(),
 }).meta({ ref: "InferenceAccessResponse" })
@@ -63,7 +79,7 @@ export function registerOrgInferenceRoutes<T extends { Variables: OrgRouteVariab
     describeRoute({
       tags: ["Inference"],
       summary: "Get my managed inference access",
-      description: "Returns the signed-in joined member's access and person-wide weekly free allowance, without credentials or administrative settings.",
+      description: "Returns the signed-in joined member's access and person-wide weekly free allowance, without credentials or administrative settings. The catalog describes registered, enabled managed aliases for discovery only; clients must intersect it with their available, policy-filtered provider models. Plan allowances describe the current paid tier or the entry paid tier offered on upgrade; a null price requires review on the billing page.",
       responses: {
         200: jsonResponse("Managed inference access returned successfully.", inferenceAccessResponseSchema),
         401: jsonResponse("Sign in to read inference access.", unauthorizedSchema),

--- a/ee/apps/den-api/test/llm-provider-access-parity.test.ts
+++ b/ee/apps/den-api/test/llm-provider-access-parity.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, beforeAll, expect, mock, spyOn, test } from "bun:test"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { serializeSignedCookie } from "better-call"
-import { freeInferenceWindow, INFERENCE_ACCESS_REASONS, INFERENCE_FREE_MODEL_ID } from "@openwork/types/den/inference"
+import { freeInferenceWindow, INFERENCE_ACCESS_REASONS, INFERENCE_FREE_MODEL_ID, INFERENCE_MODEL_ALIASES, INFERENCE_TIER_LIMITS, INFERENCE_USAGE_CONVERSION_FACTOR, inferencePlanPresentation, managedModelCatalog } from "@openwork/types/den/inference"
+import type { InferenceAccess } from "@openwork/types/den/inference"
 
 const API_ORIGIN = "http://127.0.0.1:8790"
 
@@ -300,10 +301,13 @@ test("joined members enroll once and read a person-wide allowance without paid p
   const access = await request(memberCookie, `${accessPath}?userId=${ownerUserId}`)
   expect(access.headers.get("cache-control")).toBe("no-store")
   const accessText = await access.text()
-  expect(JSON.parse(accessText)).toEqual({
-    access: { kind: "free", modelID: INFERENCE_FREE_MODEL_ID, weeklyLimitUsd: 1, usedUsd: 0, reservedUsd: 0, remainingUsd: 1, resetsAt: freeInferenceWindow().end.toISOString(), reason: null, canUpgrade: false },
+  const freePayload: { access: InferenceAccess } = JSON.parse(accessText)
+  expect(freePayload).toEqual({
+    access: { kind: "free", modelID: INFERENCE_FREE_MODEL_ID, weeklyLimitUsd: 1, usedUsd: 0, reservedUsd: 0, remainingUsd: 1, resetsAt: freeInferenceWindow().end.toISOString(), reason: null, canUpgrade: false, catalog: managedModelCatalog({ freeModelID: INFERENCE_FREE_MODEL_ID }), plan: inferencePlanPresentation("tier1") },
     upgradePath: null,
   })
+  expect(freePayload.access.catalog?.find((model) => model.modelID === INFERENCE_FREE_MODEL_ID)?.capabilities).toEqual(["reasoning", "tools"])
+  expect(freePayload.access.catalog?.filter((model) => model.modelID !== INFERENCE_FREE_MODEL_ID)).toEqual(managedModelCatalog().filter((model) => model.modelID !== INFERENCE_FREE_MODEL_ID))
   expect(accessText).not.toContain(provider.apiKey)
   expect(accessText).not.toContain("key_hash")
   expect(accessText).not.toContain("upstreamProviderConfigured")
@@ -339,7 +343,9 @@ test("joined members enroll once and read a person-wide allowance without paid p
   expect(workerReads).toEqual(["GET /opencode/config"])
   expect(await (await request(ownerCookie, accessPath)).json()).toMatchObject({ access: { usedUsd: 0, reservedUsd: 0, remainingUsd: 1 } })
   await db.update(schema.InferenceFreeUsageBucketTable).set({ used_amount: 101_000_000, reserved_amount: 0 }).where(eq(schema.InferenceFreeUsageBucketTable.user_id, memberUserId))
-  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "exhausted", reason: "free_allowance_exhausted", usedUsd: 1.01, reservedUsd: 0, remainingUsd: 0 } })
+  const exhaustedPayload: { access: InferenceAccess } = await (await request(memberCookie, accessPath)).json()
+  expect(exhaustedPayload).toMatchObject({ access: { kind: "exhausted", reason: "free_allowance_exhausted", usedUsd: 1.01, reservedUsd: 0, remainingUsd: 0 } })
+  expect(exhaustedPayload.access.catalog?.find((model) => model.modelID === INFERENCE_FREE_MODEL_ID)?.capabilities).toEqual(["reasoning", "tools"])
   await db.update(schema.InferenceFreeUsageBucketTable).set({ blocked: true }).where(eq(schema.InferenceFreeUsageBucketTable.user_id, memberUserId))
   expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "unavailable", reason: "accounting_unavailable" } })
   expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: null } })
@@ -374,11 +380,16 @@ test("rollout, paid precedence, billing fallback and explicit admin disable pres
   expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: null } })
   expect(providerIds(await (await request(memberCookie, "/v1/llm-providers")).json())).not.toContain(provider.id)
   await db.update(schema.OrganizationTable).set({ metadata: { inference: { enabled: true, tier: "tier2" }, inferenceFree: { offerAllowed: true } } }).where(eq(schema.OrganizationTable.id, organizationId))
-  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "paid", modelID: null, weeklyLimitUsd: null, remainingUsd: null } })
+  const paidPayload: { access: InferenceAccess } = await (await request(memberCookie, accessPath)).json()
+  expect(paidPayload).toMatchObject({ access: { kind: "paid", modelID: null, weeklyLimitUsd: null, remainingUsd: null } })
+  expect(paidPayload).toMatchObject({ access: {
+    catalog: managedModelCatalog(), plan: inferencePlanPresentation("tier2"), canUpgrade: false,
+  }, upgradePath: null })
+  expect(paidPayload.access.catalog?.find((model) => model.modelID === INFERENCE_FREE_MODEL_ID)?.capabilities).toEqual(["reasoning", "tools", "images", "documents"])
   expect(await (await request(memberCookie, connectPath)).json()).toMatchObject({ llmProvider: { apiKey: provider.apiKey } })
   env.inferenceFree.enabled = true
   await inference.setInferenceEnabled({ organizationId, enabled: false, source: "billing" })
-  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "free" } })
+  expect(await (await request(memberCookie, accessPath)).json()).toMatchObject({ access: { kind: "free", modelID: INFERENCE_FREE_MODEL_ID, plan: inferencePlanPresentation("tier1") } })
   const [downgraded] = await db.select().from(schema.LlmProviderTable).where(eq(schema.LlmProviderTable.id, provider.id))
   expect(downgraded?.providerConfig).toEqual(provider.providerConfig)
   expect(await db.select().from(schema.LlmProviderModelTable).where(eq(schema.LlmProviderModelTable.llmProviderId, provider.id))).toHaveLength(1)
@@ -446,7 +457,53 @@ test("model catalog retains paid entries for contextual upgrade discovery", asyn
   expect(fetchWitness).toHaveBeenCalledTimes(1)
 })
 
-test("member access OpenAPI exposes the shared metered reason contract", async () => {
+test("managed presentation lists only enabled aliases, preserves accounting, and has four task defaults", () => {
+  const aliasesBefore = structuredClone(INFERENCE_MODEL_ALIASES)
+  const catalog = managedModelCatalog()
+  const freeCatalog = managedModelCatalog({ freeModelID: INFERENCE_FREE_MODEL_ID })
+  expect(freeCatalog.find((model) => model.modelID === INFERENCE_FREE_MODEL_ID)?.capabilities).toEqual(["reasoning", "tools"])
+  expect(freeCatalog.filter((model) => model.modelID !== INFERENCE_FREE_MODEL_ID)).toEqual(catalog.filter((model) => model.modelID !== INFERENCE_FREE_MODEL_ID))
+  expect(managedModelCatalog().find((model) => model.modelID === INFERENCE_FREE_MODEL_ID)?.capabilities).toEqual(["reasoning", "tools", "images", "documents"])
+  expect(managedModelCatalog({ freeModelID: "not-registered" })).toEqual(catalog)
+  expect(catalog.filter((model) => model.recommended).map((model) => model.modelID)).toEqual([
+    INFERENCE_FREE_MODEL_ID, "openai/gpt-6-astra", "moonshotai/kimi-k2.7-code", "z-ai/glm-5.2",
+  ])
+  expect(catalog.map((model) => model.modelID).sort()).toEqual(Object.keys(INFERENCE_MODEL_ALIASES).sort())
+  expect(catalog.map((model) => model.rank)).toEqual([...catalog.map((model) => model.rank)].sort((left, right) => left - right))
+  expect(new Set(catalog.map((model) => model.rank)).size).toBe(catalog.length)
+  expect(catalog.find((model) => model.modelID === "openai/gpt-6-astra")).toMatchObject({
+    displayName: "GPT-6 Astra", providerName: "OpenAI", capabilities: ["reasoning", "tools", "images", "documents"],
+  })
+  expect(catalog.some((model) => model.modelID === "openai/gpt-6-astra-pro")).toBe(false)
+  for (const model of catalog) {
+    expect(model.summary.length).toBeGreaterThan(0)
+    expect(model.capabilities.length).toBeGreaterThan(0)
+  }
+  // A retired alias must disappear even if its presentation metadata remains.
+  const astra = INFERENCE_MODEL_ALIASES["openai/gpt-6-astra"]
+  try {
+    Reflect.set(INFERENCE_MODEL_ALIASES, "openai/gpt-6-astra", { ...astra, enabled: false })
+    expect(managedModelCatalog().some((model) => model.modelID === "openai/gpt-6-astra")).toBe(false)
+    expect(managedModelCatalog().filter((model) => model.recommended)).toHaveLength(3)
+    Reflect.deleteProperty(INFERENCE_MODEL_ALIASES, "openai/gpt-6-astra")
+    expect(managedModelCatalog().some((model) => model.modelID === "openai/gpt-6-astra")).toBe(false)
+  } finally {
+    Reflect.set(INFERENCE_MODEL_ALIASES, "openai/gpt-6-astra", astra)
+  }
+  catalog[0]?.capabilities.push("not-a-capability")
+  expect(managedModelCatalog()[0]?.capabilities).not.toContain("not-a-capability")
+  expect(INFERENCE_MODEL_ALIASES).toEqual(aliasesBefore)
+
+  for (const tier of ["tier1", "tier2"] as const) {
+    const plan = inferencePlanPresentation(tier)
+    expect(plan.name).toBe("OpenWork Models")
+    expect(plan.priceLabel).toBeNull()
+    expect(plan.usageLabel).toBe(`Shared workspace usage allowances: $${INFERENCE_TIER_LIMITS[tier].five_hour / INFERENCE_USAGE_CONVERSION_FACTOR} per member / 5 hours, $${INFERENCE_TIER_LIMITS[tier].weekly / INFERENCE_USAGE_CONVERSION_FACTOR} per member / week, and $${INFERENCE_TIER_LIMITS[tier].monthly / INFERENCE_USAGE_CONVERSION_FACTOR} per member / month.`)
+    expect(plan.usageLabel.toLowerCase()).not.toContain("unlimited")
+  }
+})
+
+test("member access OpenAPI exposes optional presentation and the shared metered reason contract", async () => {
   const response = await request("", "/openapi.json")
   expect(response.status).toBe(200)
   const document: unknown = await response.json()
@@ -454,4 +511,24 @@ test("member access OpenAPI exposes the shared metered reason contract", async (
   expect(document).toHaveProperty(["components", "schemas", "InferenceAccessResponse", "properties", "access", "properties", "reason"], {
     anyOf: [{ type: "string", enum: [...INFERENCE_ACCESS_REASONS] }, { type: "null" }],
   })
+  expect(document).toHaveProperty(["components", "schemas", "InferenceAccessResponse", "properties", "access", "properties", "catalog"], {
+    type: "array", items: { $ref: "#/components/schemas/ManagedModelRecommendation" },
+  })
+  expect(document).toHaveProperty(["components", "schemas", "ManagedModelRecommendation"], expect.objectContaining({
+    type: "object",
+    required: ["modelID", "displayName", "providerName", "summary", "recommended", "rank", "capabilities"],
+    properties: expect.objectContaining({
+      modelID: { type: "string" }, displayName: { type: "string" }, providerName: { type: "string" }, summary: { type: "string" },
+      recommended: { type: "boolean" }, rank: { type: "number" }, capabilities: { type: "array", items: { type: "string" } },
+    }),
+  }))
+  expect(document).toHaveProperty(["components", "schemas", "InferenceAccessResponse", "properties", "access", "properties", "plan"], expect.objectContaining({
+    type: "object", required: ["name", "priceLabel", "usageLabel"],
+    properties: {
+      name: { type: "string" }, priceLabel: { anyOf: [{ type: "string" }, { type: "null" }] }, usageLabel: { type: "string" },
+    },
+  }))
+  expect(document).toHaveProperty(["components", "schemas", "InferenceAccessResponse", "properties", "access", "required"], [
+    "kind", "modelID", "weeklyLimitUsd", "usedUsd", "reservedUsd", "remainingUsd", "resetsAt", "reason", "canUpgrade",
+  ])
 })

--- a/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
+import { managedModelCatalog } from "@openwork/types/den/inference";
 import { DenButton } from "../../_components/ui/button";
 import { DenPageHeader } from "../../_components/ui/page-header";
 import { DenCard } from "../../_components/ui/card";
@@ -18,24 +18,6 @@ import { getBillingRoute, getCustomLlmProvidersRoute, getOrgAccessFlags } from "
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
-/**
- * Editorial detail per model: what a knowledge worker should reach for it for,
- * and the vendor monogram shown in the lineup table. Keyed by model alias so
- * unmapped models still render with sane defaults.
- */
-const MODEL_DETAILS: Record<string, { bestFor: string; monogram: string } | undefined> = {
-  "openai/gpt-5.6-luna": { bestFor: "Everyday knowledge work", monogram: "OA" },
-  "moonshotai/kimi-k3": { bestFor: "Research & synthesis", monogram: "MS" },
-  "z-ai/glm-5.2": { bestFor: "Multi-step tasks", monogram: "ZA" },
-  "moonshotai/kimi-k2.7-code": { bestFor: "Spreadsheets & scripts", monogram: "MS" },
-  "tencent/hy3-preview": { bestFor: "Long documents", monogram: "TC" },
-  "moonshotai/kimi-k2.6": { bestFor: "Everyday drafting", monogram: "MS" },
-  "deepseek/deepseek-v4-flash": { bestFor: "Quick summaries", monogram: "DS" },
-  "minimax/minimax-m2.7": { bestFor: "Tools & integrations", monogram: "MM" },
-  "minimax/minimax-m3": { bestFor: "Images & screenshots", monogram: "MM" },
-  "z-ai/glm-5.1": { bestFor: "Balanced default", monogram: "ZA" },
-};
-
 type LineupModel = {
   id: string;
   name: string;
@@ -43,17 +25,13 @@ type LineupModel = {
   monogram: string;
 };
 
-const MODEL_LINEUP: LineupModel[] = Object.entries(INFERENCE_MODEL_ALIASES)
-  .filter(([, model]) => model.enabled)
-  .map(([id, model]) => {
-    const detail = MODEL_DETAILS[id];
-    return {
-      id,
-      name: model.displayName.replace(/^OpenWork:\s*/, ""),
-      bestFor: detail?.bestFor ?? "General knowledge work",
-      monogram: detail?.monogram ?? id.split("/")[0].slice(0, 2).toUpperCase(),
-    };
-  });
+// Keep the upgrade page's task guidance aligned with the managed picker catalog.
+const MODEL_LINEUP: LineupModel[] = managedModelCatalog().map((model) => ({
+  id: model.modelID,
+  name: model.displayName,
+  bestFor: model.summary,
+  monogram: model.providerName.slice(0, 2).toUpperCase(),
+}));
 
 const MODEL_COLUMNS: readonly DenTableColumn<LineupModel>[] = [
   {
@@ -73,7 +51,7 @@ const MODEL_COLUMNS: readonly DenTableColumn<LineupModel>[] = [
   },
   {
     key: "bestFor",
-    header: "Best for",
+    header: "Use for",
     width: "190px",
     render: (model) => <span className="text-[13px] text-gray-500">{model.bestFor}</span>,
   },

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { Check, KeyRound, ArrowUpRight, ArrowRight } from "lucide-react";
+import { Check, ArrowUpRight, ArrowRight } from "lucide-react";
 import { DenBadge } from "../../_components/ui/badge";
 import { DesktopHandoffAction } from "../../_components/auth-panel";
 import { SetupFrame } from "../../_components/setup-frame";
@@ -41,19 +41,19 @@ export function MarketplaceOnboardingScreen() {
   }
 
   return (
-    <SetupFrame step="ready" title="Choose what powers your work." description="Use OpenWork Models or bring your own provider. You can decide now or set this up later.">
+    <SetupFrame step="ready" title="You're ready to get to work." description="Explore models hosted by OpenWork, without managing API keys.">
       <div className="grid gap-6" data-testid="marketplace-onboarding">
         <section aria-labelledby="setup-models-heading" className="grid gap-4">
           <div>
-            <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-400">Optional · Models</p>
-            <h2 id="setup-models-heading" ref={modelsHeading} tabIndex={-1} className="mt-2 text-xl font-semibold tracking-[-0.03em]">Your choice of model.</h2>
+            <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-400">Hosted by OpenWork</p>
+            <h2 id="setup-models-heading" ref={modelsHeading} tabIndex={-1} className="mt-2 text-xl font-semibold tracking-[-0.03em]">{modelAccess?.kind === "free" ? "Start with Luna." : "OpenWork Models"}</h2>
             <p className="mt-2 text-sm leading-6 text-[var(--dls-text-secondary)]" role="status">
               {modelsLoading ? "Checking OpenWork Models..." : modelsError || !modelAccess ? "Model status is unavailable. You can still complete setup." : allowance ?? (modelsEnabled ? "OpenWork Models are on for this workspace." : "Keep your existing provider, or choose one when you are ready.")}
             </p>
             {modelsEnabled ? <DenBadge icon={Check}>Models on</DenBadge> : null}
             {modelAccess?.kind === "free" ? <DenBadge icon={Check}>Free Luna included</DenBadge> : null}
           </div>
-          <div className="divide-y divide-[var(--dls-border)] overflow-hidden rounded-2xl border border-[var(--dls-border)]">
+          <div className="overflow-hidden rounded-2xl border border-[var(--dls-border)]">
             <div className="flex items-start gap-3 p-4 sm:p-5" data-testid="onboarding-choice-openwork-models">
               <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-[var(--dls-hover)]">
                 <img src="/openwork-mark.svg" alt="" aria-hidden className="h-5 w-5" />
@@ -63,16 +63,6 @@ export function MarketplaceOnboardingScreen() {
                 <p className="mt-1 text-[13px] leading-5 text-[var(--dls-text-secondary)]">{allowance ? "Standard Luna with a free weekly allowance. Upgrade for other managed models." : "Managed models, billed per member. No API keys to look after."}</p>
                 <Link href={getInferenceRoute(orgSlug)} className="mt-3 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-neutral-950">
                   {modelsEnabled ? "Manage models" : "Explore models"}<ArrowUpRight className="size-3.5" aria-hidden />
-                </Link>
-              </div>
-            </div>
-            <div className="flex items-start gap-3 p-4 sm:p-5" data-testid="onboarding-choice-byok">
-              <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-[var(--dls-hover)]"><KeyRound className="size-[18px] text-[var(--dls-text-secondary)]" aria-hidden /></div>
-              <div className="min-w-0 flex-1">
-                <h3 className="text-sm font-semibold">Bring your Own Keys</h3>
-                <p className="mt-1 text-[13px] leading-5 text-[var(--dls-text-secondary)]">Connect your provider or gateway. Keep your own billing and model choices.</p>
-                <Link href={getCustomLlmProvidersRoute(orgSlug)} className="mt-3 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-neutral-950">
-                  Add a provider<ArrowUpRight className="size-3.5" aria-hidden />
                 </Link>
               </div>
             </div>
@@ -89,6 +79,9 @@ export function MarketplaceOnboardingScreen() {
               {completing ? "Completing..." : desktopAuthRequested ? "Complete and open the app" : "Complete setup"}<ArrowRight className="size-4" aria-hidden />
             </button>
           )}
+          <Link data-testid="onboarding-choice-byok" href={getCustomLlmProvidersRoute(orgSlug)} className="w-fit rounded-sm text-xs text-[var(--dls-text-secondary)] underline-offset-4 hover:text-[var(--dls-text-primary)] hover:underline focus-visible:ring-2 focus-visible:ring-neutral-950">
+            Use my own provider…
+          </Link>
         </section>
       </div>
     </SetupFrame>

--- a/ee/apps/den-web/tests/onboarding-page.test.ts
+++ b/ee/apps/den-web/tests/onboarding-page.test.ts
@@ -22,11 +22,15 @@ describe("Marketplace onboarding page", () => {
     expect(screen).toContain("completeSetup(orgId)");
   });
 
-  test("offers OpenWork Models and Bring your Own Keys as the model path", () => {
+  test("leads with managed models and keeps a quiet direct provider setup link", () => {
     expect(screen).toContain("onboarding-choice-openwork-models");
     expect(screen).toContain("onboarding-choice-byok");
     expect(screen).toContain("Explore models");
-    expect(screen).toContain("Bring your Own Keys");
+    expect(screen).toContain("Use my own provider…");
+    expect(screen).toContain("getCustomLlmProvidersRoute(orgSlug)");
+    expect(screen).not.toContain("Bring your Own Keys");
+    expect(screen).not.toContain("KeyRound");
+    expect(screen.indexOf('data-testid="onboarding-choice-byok"')).toBeGreaterThan(screen.indexOf("Complete and open the app"));
     expect(screen).toContain("/openwork-mark.svg");
   });
 

--- a/ee/apps/den-web/tests/openwork-models-page.test.ts
+++ b/ee/apps/den-web/tests/openwork-models-page.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { INFERENCE_ACCESS_REASONS, INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
+import { INFERENCE_ACCESS_REASONS, INFERENCE_MODEL_ALIASES, managedModelCatalog } from "@openwork/types/den/inference";
 import { freeAllowanceDescription, parseInferenceAccessPayload } from "../app/(den)/_lib/inference-status";
 
 const screen = readFileSync(
@@ -21,14 +21,17 @@ describe("OpenWork Models page", () => {
       expect(screen).toContain(primitive);
     }
     expect(screen).toContain('headerTone="plain"');
-    expect(screen).toContain("Best for");
+    expect(screen).toContain("Use for");
     expect(screen).toContain("Model ID");
   });
 
   test("describes every shipped model", () => {
+    expect(screen).toContain("managedModelCatalog().map");
+    expect(screen).not.toContain("MODEL_DETAILS");
+    const catalog = managedModelCatalog();
     for (const [id, model] of Object.entries(INFERENCE_MODEL_ALIASES)) {
       if (!model.enabled) continue;
-      expect(screen).toContain(`"${id}": { bestFor:`);
+      expect(catalog.find((entry) => entry.modelID === id)?.summary.length).toBeGreaterThan(0);
     }
   });
 

--- a/ee/apps/den-web/vercel.json
+++ b/ee/apps/den-web/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false } },
+  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false, "feature/managed-model-discovery": false } },
   "framework": "nextjs",
   "ignoreCommand": "turbo query affected --base=$VERCEL_GIT_PREVIOUS_SHA --packages @openwork-ee/den-web --exit-code || exit 1",
   "installCommand": "cd ../../.. && pnpm install --frozen-lockfile --filter @openwork-ee/den-web..."

--- a/ee/apps/diagnostics/vercel.json
+++ b/ee/apps/diagnostics/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false } },
+  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false, "feature/managed-model-discovery": false } },
   "framework": "nextjs",
   "ignoreCommand": "turbo query affected --base=$VERCEL_GIT_PREVIOUS_SHA --packages @openwork-ee/diagnostics --exit-code || exit 1",
   "fluid": true,

--- a/ee/apps/inference/src/models/openwork-models.json
+++ b/ee/apps/inference/src/models/openwork-models.json
@@ -364,5 +364,70 @@
         "cache_write": 0.5
       }
     }
+  },
+  "openai/gpt-6-astra": {
+    "id": "openai/gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "reasoning_options": [
+      {
+        "type": "effort",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    ],
+    "tool_call": true,
+    "structured_output": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 1050000,
+      "input": 922000,
+      "output": 128000
+    },
+    "cost": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1,
+      "cache_write": 12.5,
+      "tiers": [
+        {
+          "input": 20,
+          "output": 75,
+          "cache_read": 2,
+          "cache_write": 25,
+          "tier": {
+            "type": "context",
+            "size": 272000
+          }
+        }
+      ],
+      "context_over_200k": {
+        "input": 20,
+        "output": 75,
+        "cache_read": 2,
+        "cache_write": 25
+      }
+    }
   }
 }

--- a/ee/apps/landing/vercel.json
+++ b/ee/apps/landing/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false } },
+  "git": { "deploymentEnabled": { "feature/new-install-signin": false, "feature/luna-weekly-allowance": false, "feature/managed-model-discovery": false } },
   "framework": "nextjs",
   "ignoreCommand": "turbo query affected --base=$VERCEL_GIT_PREVIOUS_SHA --packages @openwork-ee/landing --exit-code || exit 1",
   "buildCommand": "pnpm --dir ../../../packages/email build && pnpm --dir ../../../packages/ui build && pnpm exec next build"

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -2,7 +2,7 @@ import { spec } from "@openwork/testkit";
 import { expect } from "vitest";
 import { modelPicker } from "../worlds/chat.ts";
 
-const test = spec.world(modelPicker, { scope: "file", timeout: 360_000 });
+const test = spec.world(modelPicker, { timeout: 360_000 });
 
 test("managed model discovery keeps the task unchanged until an explicit eligible selection", async ({ world, user, probe, step }) => {
   const draft = "Keep this model-picker draft. Do not send it.";

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -82,7 +82,7 @@ test("managed model discovery keeps the task unchanged until an explicit eligibl
     await user.see({ role: "button", label: "Back to models" });
     await user.see({ role: "button", label: "Low" });
     await user.click({ role: "button", label: "Low" });
-    await user.see({ role: "button", label: "Change model" }, { text: /Luna.*Low/ });
+    await user.see({ role: "button", label: "Change model" }, { text: /Luna[\s\S]*Low/ });
     await user.notSee({ testId: "inference-upgrade-dialog" });
   });
   const selectedLuna = (await probe.composer()).selectedModelLabel;

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -1,42 +1,190 @@
 import { spec } from "@openwork/testkit";
+import { expect } from "vitest";
 import { modelPicker } from "../worlds/chat.ts";
 
-const test = spec.world(modelPicker);
+const test = spec.world(modelPicker, { scope: "file", timeout: 360_000 });
 
-test("the composer model pickers keep their controls without the OpenWork Models subscribe promo", async ({ user, step }) => {
-  await user.type("composer", "Keep this model-picker draft.");
-  await user.click({ role: "button", label: "Change model" });
-  await user.click({ role: "button", label: /^Model\s+Big Pickle/ });
+test("managed model discovery keeps the task unchanged until an explicit eligible selection", async ({ world, user, probe, step }) => {
+  const draft = "Keep this model-picker draft. Do not send it.";
+  const contains = (text: string) => new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const row = (modelID: string, providerID = "openwork") => ({ testId: `model-option-${providerID}-${modelID}` });
+  const luna = row(world.luna.modelID);
+  const astra = row(world.astra.modelID);
+  const own = row("big-pickle", "opencode");
+  const search = { label: "Search all models" };
+  const messagesPath = `/workspace/${world.workspace.workspaceId}/opencode/session/${world.session.sessionId}/message`;
+  const browserBefore = await world.browserDestinations();
+  await user.type("composer", draft);
+  const initial = await probe.composer();
+  expect(initial.selectedModelLabel).toContain("Big Pickle");
+  expect(initial.userMessageCount).toBe(0);
+  expect(initial.assistantMessageCount).toBe(0);
+  const unchanged = async (selectedModelLabel: string) => {
+    expect(await probe.composer()).toMatchObject({
+      draftText: draft, route: initial.route, selectedModelLabel,
+      userMessageCount: 0, assistantMessageCount: 0, modelUnavailable: false,
+    });
+    const messages = await probe.desktopApi(messagesPath);
+    expect(messages.status).toBe(200);
+    expect(messages.body).toEqual([]);
+    const requests = await world.proxy.requestLog();
+    expect(requests.filter((request) => request.method === "POST"
+      && /checkout|billing|llm-providers|model-picker-fixture\/inference|chat\/completions|responses/.test(request.path))).toEqual([]);
+    expect(await world.browserDestinations()).toEqual(browserBefore);
+  };
 
-  await step("the compact picker keeps controls without subscribe promotion", async () => {
-    await user.see({ placeholder: "Search models..." });
-    await user.see({ role: "button", label: "All models" });
-    await user.see({ role: "button", label: "Connect more providers" });
+  await step("real Den enrollment supplies free access and recommendations without unsolicited promotion", async () => {
+    const access = await probe.api(world.member, world.accessPath);
+    expect(access.response.status).toBe(200);
+    expect(access.body).toEqual(world.freeResponse);
+    expect(world.configuredModels).toEqual(expect.arrayContaining(world.catalog.map((model) => model.modelID)));
+    const requests = await world.proxy.requestLog();
+    expect(requests.some((request) => request.path === "/api/den/v1/inference/access" && request.status === 200 && !request.faulted)).toBe(true);
+    expect(requests.some((request) => request.path === `/api/den/v1/llm-providers/${world.registeredProviderId}/connect` && request.status === 200 && !request.faulted)).toBe(true);
     await user.notSee({ testId: "inference-upgrade-dialog" });
-    await user.see("composer", { text: "Keep this model-picker draft." });
+    await user.click({ role: "button", label: "Change model" });
+    // Search and rows are the first surface, not a legacy Model submenu.
+    await user.see(search);
+    await user.see({ text: "Recommended by OpenWork" });
+    await user.see({ ...own, label: "Big Pickle, current model" });
+    for (const model of world.catalog.filter((model) => model.recommended)) {
+      await user.see(row(model.modelID), { text: contains(model.summary) });
+    }
+    await user.see({ ...luna, label: `${world.luna.displayName}, Free` });
+    await user.see({ ...astra, label: `${world.astra.displayName}, Upgrade, opens upgrade options without changing your model` });
+    await user.see({ testId: "inference-allowance" }, { text: /\$1\.00 of \$1\.00 left this week/ });
+    await user.see({ role: "button", label: "See all models" });
+    await user.see({ testId: "model-own-provider" });
     for (const removed of [
-      "Your API keys",
-      "Add your keys",
-      "hosted · no API keys",
-      "One subscription unlocks these in every workspace.",
-      "Enable →",
-      "Sign in →",
-      "Hide",
+      "Your API keys", "Add your keys", "hosted · no API keys",
+      "One subscription unlocks these in every workspace.", "Enable →", "Sign in →", "Hide",
     ]) await user.notSee({ text: removed });
+    await user.notSee({ role: "button", label: "Subscribe" });
+    await user.notSee({ testId: "inference-upgrade-dialog" });
+    await unchanged(initial.selectedModelLabel);
+    // Supplementary capture only; no vision key or vision verdict is required.
+    await user.screenshot();
   });
 
-  await user.click({ role: "button", label: "All models" });
-  await step("the full Models dialog keeps controls without subscribe promotion", async () => {
-    await user.see({ text: "Models" });
+  await step("a free selection preserves the draft, favorite, and accessible effort controls", async () => {
+    await user.click({ role: "button", label: "Add Big Pickle to favorites" });
+    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
+    await unchanged(initial.selectedModelLabel);
+    await user.click(luna);
+    await user.notSee({ testId: "managed-model-picker" });
+    await user.see({ role: "button", label: "Change model" }, { text: contains(world.luna.displayName) });
+    await user.see("composer", { text: draft });
+    await user.click({ role: "button", label: "Change model" });
+    await user.see({ text: "Favorites" });
+    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
+    await user.see({ ...luna, label: `${world.luna.displayName}, Free, current model` });
+    await user.click({ role: "button", label: /^Thinking and effort for .*Luna/ });
+    await user.see({ role: "button", label: "Back to models" });
+    await user.see({ role: "button", label: "Low" });
+    await user.click({ role: "button", label: "Low" });
+    await user.see({ role: "button", label: "Change model" }, { text: /Luna.*Low/ });
+    await user.notSee({ testId: "inference-upgrade-dialog" });
+  });
+  const selectedLuna = (await probe.composer()).selectedModelLabel;
+  await unchanged(selectedLuna);
+
+  await step("the full picker searches the real catalog and labels paid rows before clicking", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ role: "button", label: "See all models" });
+    await user.see({ testId: "all-models-picker" });
     await user.see({ text: "Select a model for this session." });
-    await user.see({ placeholder: "Search providers and models..." });
+    await user.see(search);
     await user.see({ role: "button", label: "Done" });
     await user.notSee({ role: "button", label: "Hide OpenWork Models" });
     await user.notSee({ text: "Subscribe to use hosted frontier models in this workspace." });
     await user.notSee({ text: "Sign in to unlock hosted frontier models for your team." });
     await user.notSee({ role: "button", label: "Subscribe" });
     await user.notSee({ testId: "inference-upgrade-dialog" });
+    await user.see({ ...luna, label: `${world.luna.displayName}, Free, current model` });
+    await user.type(search, world.astra.summary, { replace: true });
+    await user.see(astra, { text: contains(world.astra.summary) });
+    await user.see({ ...astra, label: `${world.astra.displayName}, Upgrade, opens upgrade options without changing your model` });
+    await user.notSee(luna);
+    await user.type(search, "Big Pickle", { replace: true });
+    await user.see({ ...own, label: "Big Pickle" });
+    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
+    await user.notSee({ testId: "model-access-label" });
+    await user.click({ role: "button", label: "Done" });
+    await unchanged(selectedLuna);
   });
-  await user.click({ role: "button", label: "Done" });
-  await user.see("composer", { text: "Keep this model-picker draft." });
+
+  await step("choosing paid Astra opens only its contextual offer; Close and Keep using Luna do not run a task", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.see({ ...astra, label: `${world.astra.displayName}, Upgrade, opens upgrade options without changing your model` });
+    await user.click(astra);
+    await user.see({ testId: "inference-upgrade-dialog" }, { text: contains(`Unlock ${world.astra.displayName}`) });
+    await user.see({ testId: "inference-upgrade-dialog" }, { text: contains(world.astra.summary) });
+    await user.see({ testId: "inference-upgrade-plan" }, { text: contains(world.plan.usageLabel) });
+    await user.see({ testId: "inference-upgrade-plan" }, { text: contains(world.plan.name) });
+    await user.see({ testId: "inference-view-upgrade" });
+    await unchanged(selectedLuna);
+    await user.click({ role: "button", label: /^Close$/ });
+    await user.notSee({ testId: "inference-upgrade-dialog" });
+    await unchanged(selectedLuna);
+    await user.click({ role: "button", label: "Change model" });
+    await user.click(astra);
+    await user.click({ role: "button", label: "Keep using Luna" });
+    await user.notSee({ testId: "inference-upgrade-dialog" });
+    await user.notSee({ testId: "all-models-picker" });
+    await user.notSee({ testId: "managed-model-picker" });
+    await unchanged(selectedLuna);
+  });
+
+  await step("Use my own provider opens Connect providers directly, without keys or documentation tabs", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ testId: "model-own-provider" });
+    await user.see({ text: "Connect providers" });
+    await user.see({ placeholder: "Filter providers by name or ID" });
+    await user.notSee({ testId: "inference-upgrade-dialog" });
+    await user.notSee({ role: "button", label: "Save key" });
+    await unchanged(selectedLuna);
+    await user.press("Escape");
+    await user.notSee({ placeholder: "Filter providers by name or ID" });
+  });
+
+  await step("a fixture non-admin access report shows Ask admin and no checkout action", async () => {
+    await world.seedFault("non-admin");
+    await user.click({ role: "button", label: "Change model" });
+    await user.click(astra);
+    await user.see({ testId: "inference-ask-admin" }, { timeoutMs: 70_000, text: /Ask a workspace owner or admin/ });
+    await user.notSee({ testId: "inference-view-upgrade" });
+    await user.notSee({ testId: "inference-use-model" });
+    await unchanged(selectedLuna);
+  });
+
+  await step("a fixture paid access report makes Astra ready but still requires explicit confirmation in the full picker", async () => {
+    // No billing mutation, checkout, purchase, or inference is performed here.
+    // The normal focus/interval refresh consumes the fixture-owned access response.
+    await world.seedFault("paid");
+    await user.see({ testId: "inference-upgrade-dialog" }, { timeoutMs: 70_000, text: contains(`${world.astra.displayName} is ready to use`) });
+    await user.notSee({ testId: "inference-view-upgrade" });
+    await user.notSee({ testId: "inference-ask-admin" });
+    await unchanged(selectedLuna);
+    await user.click({ testId: "inference-use-model" });
+    await user.see({ testId: "all-models-picker" });
+    await user.see({ testId: "requested-model-ready" }, { text: contains(`Select ${world.astra.displayName}`) });
+    await user.see(search, { value: world.astra.modelID });
+    await user.see({ ...astra, label: `${world.astra.displayName}, Included` });
+    expect((await probe.dom(`[data-requested="true"] [data-testid="${astra.testId}"]`)).elements).toHaveLength(1);
+    await unchanged(selectedLuna);
+    await user.click(astra);
+    await user.notSee({ testId: "all-models-picker" });
+    await user.see({ role: "button", label: "Change model" }, { text: contains(world.astra.displayName) });
+    const selectedAstra = (await probe.composer()).selectedModelLabel;
+    await unchanged(selectedAstra);
+    await user.click({ role: "button", label: "Change model" });
+    await user.see({ ...astra, label: `${world.astra.displayName}, Included, current model` });
+    await user.see({ ...luna, label: `${world.luna.displayName}, Included` });
+    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
+    await user.press("Escape");
+    await unchanged(selectedAstra);
+    // Bypass the fixture to verify that the actual account is still free.
+    const realAccess = await probe.api(world.den.admin, world.accessPath);
+    expect(realAccess.body).toEqual(world.freeResponse);
+  });
 });

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -14,6 +14,10 @@ test("managed model discovery keeps the task unchanged until an explicit eligibl
   const search = { label: "Search all models" };
   const messagesPath = `/workspace/${world.workspace.workspaceId}/opencode/session/${world.session.sessionId}/message`;
   const browserBefore = await world.browserDestinations();
+  const onlyManagedRows = async (picker: string) => {
+    expect((await probe.dom(`[data-testid="${picker}"] [data-testid^="model-option-"]:not([data-testid^="model-option-openwork-"])`)).elements).toHaveLength(0);
+    await user.notSee(own);
+  };
   await user.type("composer", draft);
   const initial = await probe.composer();
   expect(initial.selectedModelLabel).toContain("Big Pickle");
@@ -46,14 +50,15 @@ test("managed model discovery keeps the task unchanged until an explicit eligibl
     // Search and rows are the first surface, not a legacy Model submenu.
     await user.see(search);
     await user.see({ text: "Recommended by OpenWork" });
-    await user.see({ ...own, label: "Big Pickle, current model" });
+    await onlyManagedRows("managed-model-picker");
+    await user.notSee({ role: "button", label: /Thinking and effort for .*Big Pickle/ });
     for (const model of world.catalog.filter((model) => model.recommended)) {
       await user.see(row(model.modelID), { text: contains(model.summary) });
     }
     await user.see({ ...luna, label: `${world.luna.displayName}, Free` });
     await user.see({ ...astra, label: `${world.astra.displayName}, Upgrade, opens upgrade options without changing your model` });
     await user.see({ testId: "inference-allowance" }, { text: /\$1\.00 of \$1\.00 left this week/ });
-    await user.see({ role: "button", label: "See all models" });
+    await user.see({ role: "button", label: "See all OpenWork models" });
     await user.see({ testId: "model-own-provider" });
     for (const removed of [
       "Your API keys", "Add your keys", "hosted · no API keys",
@@ -62,21 +67,18 @@ test("managed model discovery keeps the task unchanged until an explicit eligibl
     await user.notSee({ role: "button", label: "Subscribe" });
     await user.notSee({ testId: "inference-upgrade-dialog" });
     await unchanged(initial.selectedModelLabel);
-    // Supplementary capture only; no vision key or vision verdict is required.
-    await user.screenshot();
   });
 
   await step("a free selection preserves the draft, favorite, and accessible effort controls", async () => {
-    await user.click({ role: "button", label: "Add Big Pickle to favorites" });
-    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
     await unchanged(initial.selectedModelLabel);
     await user.click(luna);
     await user.notSee({ testId: "managed-model-picker" });
     await user.see({ role: "button", label: "Change model" }, { text: contains(world.luna.displayName) });
     await user.see("composer", { text: draft });
     await user.click({ role: "button", label: "Change model" });
-    await user.see({ text: "Favorites" });
-    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
+    await onlyManagedRows("managed-model-picker");
+    await user.click({ role: "button", label: `Add ${world.luna.displayName} to favorites` });
+    await user.see({ role: "button", label: `Remove ${world.luna.displayName} from favorites` });
     await user.see({ ...luna, label: `${world.luna.displayName}, Free, current model` });
     await user.click({ role: "button", label: /^Thinking and effort for .*Luna/ });
     await user.see({ role: "button", label: "Back to models" });
@@ -84,14 +86,22 @@ test("managed model discovery keeps the task unchanged until an explicit eligibl
     await user.click({ role: "button", label: "Low" });
     await user.see({ role: "button", label: "Change model" }, { text: /Luna[\s\S]*Low/ });
     await user.notSee({ testId: "inference-upgrade-dialog" });
+    await user.click({ role: "button", label: "Change model" });
+    await onlyManagedRows("managed-model-picker");
+    // Show the managed scenario with Luna selected, not the fixture's retained
+    // legacy default. This capture is supplementary to the observable assertions.
+    await user.screenshot();
+    await user.press("Escape");
   });
   const selectedLuna = (await probe.composer()).selectedModelLabel;
   await unchanged(selectedLuna);
 
   await step("the full picker searches the real catalog and labels paid rows before clicking", async () => {
     await user.click({ role: "button", label: "Change model" });
-    await user.click({ role: "button", label: "See all models" });
+    await user.click({ role: "button", label: "See all OpenWork models" });
     await user.see({ testId: "all-models-picker" });
+    await user.see({ role: "heading", label: "OpenWork models" });
+    await onlyManagedRows("all-models-picker");
     await user.see({ text: "Select a model for this session." });
     await user.see(search);
     await user.see({ role: "button", label: "Done" });
@@ -106,9 +116,15 @@ test("managed model discovery keeps the task unchanged until an explicit eligibl
     await user.see({ ...astra, label: `${world.astra.displayName}, Upgrade, opens upgrade options without changing your model` });
     await user.notSee(luna);
     await user.type(search, "Big Pickle", { replace: true });
-    await user.see({ ...own, label: "Big Pickle" });
-    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
+    await user.notSee(own);
+    await user.see({ text: "No OpenWork models match your search." });
+    await user.type(search, "OpenCode", { replace: true });
+    await user.notSee(own);
+    await user.see({ text: "No OpenWork models match your search." });
     await user.notSee({ testId: "model-access-label" });
+    await user.type(search, world.luna.displayName, { replace: true });
+    await user.see(luna);
+    await user.see({ role: "button", label: `Remove ${world.luna.displayName} from favorites` });
     await user.click({ role: "button", label: "Done" });
     await unchanged(selectedLuna);
   });
@@ -180,7 +196,8 @@ test("managed model discovery keeps the task unchanged until an explicit eligibl
     await user.click({ role: "button", label: "Change model" });
     await user.see({ ...astra, label: `${world.astra.displayName}, Included, current model` });
     await user.see({ ...luna, label: `${world.luna.displayName}, Included` });
-    await user.see({ role: "button", label: "Remove Big Pickle from favorites" });
+    await user.see({ role: "button", label: `Remove ${world.luna.displayName} from favorites` });
+    await onlyManagedRows("managed-model-picker");
     await user.press("Escape");
     await unchanged(selectedAstra);
     // Bypass the fixture to verify that the actual account is still free.

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -529,7 +529,7 @@ desktopTest("desktop-origin signup completes the questions before issuing a fres
     noHandoff();
     await modelsOff();
     // Model/provider settings stay usable; returning to Ready does not complete setup.
-    await user.click({ role: "link", label: "Add a provider" });
+    await user.click({ role: "link", label: "Use my own provider…" });
     await user.see({ role: "link", label: "Back to setup" }, { timeoutMs: 90_000 });
     expect(await world.pathname()).toBe("/dashboard/custom-llm-providers");
     await user.reload();

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1,10 +1,11 @@
-import { browserScript } from "@openwork/cdp";
+import { browserScript, listTargets } from "@openwork/cdp";
 import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { join, resolve } from "node:path";
 import { evalIn, assertNoLiveSecret, liveOpenAiEnabled, liveOpenAiModel, liveProviderId, provisionLiveOpenAi } from "@openwork/behaviors";
 import { resolveEvalEngine, type Seed } from "@openwork/env";
+import { captureExternalBrowserUrls } from "@openwork/hosts";
 import type { MockAgentWorkload } from "@openwork/labs";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -377,10 +378,141 @@ export async function focusContinuity(seed: Seed) {
 }
 
 export async function modelPicker(seed: Seed) {
-  const den = await seed.den();
-  const app = await seed.desktop({ den, as: "admin" });
-  const session = await seedSessionRetry(seed, app);
-  return { app, den, session };
+  const den = await seed.den({ env: {
+    INFERENCE_FREE_ENABLED: "true",
+    INFERENCE_FREE_WEEKLY_BUDGET_USD: "1",
+    INFERENCE_FREE_MODEL_ID: "openai/gpt-5.6-luna",
+    // Enrollment is real; this world must never contact inference or Stripe.
+    INFERENCE_PROXY_BASE_URL: "http://127.0.0.1:9",
+    OPENROUTER_MANAGEMENT_API_KEY: "",
+    INFERENCE_FREE_UPSTREAM_API_KEY: "",
+    STRIPE_SECRET_KEY: "",
+  } });
+  const proxy = await seed.faultProxy(den);
+  const member = { ...den.admin, ...proxy.ref };
+  const response = await seed.api(member, "/v1/inference/access");
+  const body = response.body;
+  if (!response.response.ok || !isRecord(body) || !isRecord(body.access)) throw new Error("Real Den access read failed");
+  const access = body.access;
+  if (access.kind !== "free" || access.modelID !== "openai/gpt-5.6-luna" || access.weeklyLimitUsd !== 1
+    || access.remainingUsd !== 1 || access.canUpgrade !== true || !Array.isArray(access.catalog)
+    || !isRecord(access.plan) || typeof access.plan.name !== "string" || typeof access.plan.usageLabel !== "string") {
+    throw new Error("Fresh Den did not report free Luna access, catalog, and plan limits");
+  }
+  const catalog = access.catalog.map((model) => {
+    if (!isRecord(model) || typeof model.modelID !== "string" || typeof model.displayName !== "string"
+      || typeof model.summary !== "string" || !model.summary || typeof model.recommended !== "boolean") {
+      throw new Error("Den returned incomplete managed model discovery metadata");
+    }
+    return { modelID: model.modelID, displayName: model.displayName, summary: model.summary, recommended: model.recommended };
+  });
+  const luna = catalog.find((model) => model.modelID === access.modelID);
+  const astra = catalog.find((model) => model.modelID === "openai/gpt-6-astra");
+  if (!luna || !astra) throw new Error("Real Den catalog must include Luna and Astra");
+  const providers = await seed.api(member, "/v1/llm-providers");
+  const registered = isRecord(providers.body) && Array.isArray(providers.body.llmProviders)
+    ? providers.body.llmProviders.find((provider) => isRecord(provider) && provider.source === "openwork" && provider.providerId === "openwork") : null;
+  if (!providers.response.ok || !isRecord(registered) || typeof registered.id !== "string") {
+    throw new Error("Ordinary Den enrollment did not create the managed provider");
+  }
+
+  // Only the models.dev transport is isolated. Managed definitions come from the
+  // checked-in catalog; the provider/key is still imported through real Den.
+  const definitions: unknown = JSON.parse(await readFile(new URL("../../ee/apps/inference/src/models/openwork-models.json", import.meta.url), "utf8"));
+  if (!isRecord(definitions)) throw new Error("Managed model definitions are not an object");
+  const models = Object.fromEntries(catalog.map((model) => {
+    const definition = definitions[model.modelID];
+    if (!isRecord(definition) || definition.id !== model.modelID) throw new Error(`Missing managed definition: ${model.modelID}`);
+    return [model.modelID, { ...definition, name: `OpenWork: ${model.displayName}` }];
+  }));
+  const providerBase = `${proxy.ref.webUrl}/model-picker-fixture/inference`;
+  const fixtureCatalog = {
+    openwork: { id: "openwork", name: "OpenWork Models", env: ["OPENWORK_API_KEY"], doc: "https://example.test/models", npm: "@openrouter/ai-sdk-provider", api: providerBase, models },
+    opencode: { id: "opencode", name: "OpenCode", env: [], doc: "https://example.test/models", npm: "@ai-sdk/openai-compatible", api: providerBase, models: {
+      "big-pickle": { id: "big-pickle", name: "Big Pickle", attachment: false, reasoning: false, tool_call: true,
+        temperature: true, release_date: "2025-01-01", cost: { input: 0, output: 0 }, limit: { context: 128000, output: 4096 } },
+    } },
+  };
+  const installFaults = async () => {
+    await proxy.faults.clear();
+    await proxy.faults.status("/api/runtime-config", 200, { times: 1000, body: { denApiUrl: proxy.ref.apiUrl } });
+    await proxy.faults.status("/model-picker-fixture/catalog", 200, { times: 1000, body: fixtureCatalog });
+    await proxy.faults.status("/model-picker-fixture/inference", 409, { times: 1000, body: { error: "generation_forbidden_in_picker_journey" } });
+    await proxy.faults.status("/api/den/v1/billing", 409, { times: 1000, body: { error: "checkout_forbidden_in_picker_journey" } });
+  };
+  await installFaults();
+  const workspacePath = seed.tmpPath("managed-model-picker");
+  const app = await seed.desktop({ den: { ...den, ref: proxy.ref }, as: "admin", model: "opencode/big-pickle", workspacePath, env: {
+    DAYTONA_SECRETS_ENV: "/tmp/openwork-model-picker-no-secrets",
+    VITE_DISABLE_OPENWORK_MODELS: "0",
+    OPENCODE_MODELS_URL: `${proxy.ref.webUrl}/model-picker-fixture/catalog`,
+    OPENCODE_CONFIG: "",
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({
+      enabled_providers: ["opencode", "openwork"], small_model: "opencode/big-pickle",
+      provider: {
+        opencode: { npm: "@ai-sdk/openai-compatible", options: { baseURL: providerBase, apiKey: "sk-eval-picker-only" }, whitelist: ["big-pickle"] },
+      },
+    }),
+  } });
+  const workspace = await seed.workspace(app, workspacePath);
+  const configuredModels = await seed.evalIn(app, browserScript(async (workspaceId, expectedIds) => {
+    const record = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+    const deadline = Date.now() + 60000;
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port")
+          + "/workspace/" + workspaceId + "/opencode/provider", {
+          headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") }, signal: AbortSignal.timeout(5000),
+        });
+        const providers: unknown = response.ok ? await response.json() : null;
+        if (record(providers) && Array.isArray(providers.all) && Array.isArray(providers.connected)) {
+          const managed = providers.all.find((provider) => record(provider) && provider.id === "openwork");
+          if (providers.connected.includes("openwork") && record(managed) && record(managed.models)) {
+            const ids = Object.keys(managed.models);
+            if (expectedIds.every((id) => ids.includes(id))) return ids;
+          }
+        }
+      } catch { /* The engine can reload while the ordinary Den import settles. */ }
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    throw new Error("Real enrolled OpenWork provider did not materialize the isolated catalog in the engine");
+  }, [workspace.workspaceId, catalog.map((model) => model.modelID)]), { awaitPromise: true, timeoutMs: 70000 });
+  // Retain that real imported provider and key, but pin its engine model map and
+  // upstream to fixture data. No catalog mock can invent a managed enrollment.
+  await configureProvider(seed, app, workspace.workspaceId, "opencode", "big-pickle", {
+    provider: { openwork: { options: { baseURL: providerBase }, models: Object.fromEntries(catalog.map((model) => {
+      const definition = definitions[model.modelID];
+      if (!isRecord(definition)) throw new Error(`Missing managed definition: ${model.modelID}`);
+      const efforts = Array.isArray(definition.reasoning_options) ? definition.reasoning_options.flatMap((option) =>
+        isRecord(option) && option.type === "effort" && Array.isArray(option.values)
+          ? option.values.filter((value): value is string => typeof value === "string") : []) : [];
+      return [model.modelID, {
+        ...Object.fromEntries(["id", "family", "attachment", "reasoning", "tool_call", "temperature", "limit", "modalities"].map((key) => [key, definition[key]])),
+        name: `OpenWork: ${model.displayName}`,
+        variants: Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }])),
+      }];
+    })) } },
+  });
+  const session = await seedSessionRetry(seed, app, { title: "Managed model discovery" });
+  const external = app.handle.hostKind === "daytona" ? await captureExternalBrowserUrls(app.handle) : null;
+  return {
+    app, den, proxy, member, workspace, session, luna, astra, catalog, configuredModels,
+    accessPath: "/v1/inference/access", registeredProviderId: registered.id,
+    freeResponse: body, plan: { name: access.plan.name, usageLabel: access.plan.usageLabel },
+    async seedFault(kind: "paid" | "non-admin") {
+      // UI-only access-report transition, not a purchase or billing-state proof.
+      await installFaults();
+      await proxy.faults.status("/api/den/v1/inference/access", 200, { times: 1000, body: {
+        ...body, upgradePath: kind === "non-admin" ? null : body.upgradePath,
+        access: { ...access, kind: kind === "paid" ? "paid" : "free", canUpgrade: kind !== "non-admin" },
+      } });
+    },
+    async browserDestinations() {
+      return { pages: (await listTargets(app.handle.cdpUrl)).filter((target) => target.type === "page").map((target) => target.url).sort(),
+        external: external ? await external.opened() : null };
+    },
+    async [Symbol.asyncDispose]() { await external?.[Symbol.asyncDispose](); },
+  };
 }
 
 export async function connectionsMenu(seed: Seed) {

--- a/packages/sdk/src/gen/sdk.gen.ts
+++ b/packages/sdk/src/gen/sdk.gen.ts
@@ -3827,7 +3827,7 @@ export class DenClient extends HeyApiClient {
   /**
    * Get my managed inference access
    *
-   * Returns the signed-in joined member's access and person-wide weekly free allowance, without credentials or administrative settings.
+   * Returns the signed-in joined member's access and person-wide weekly free allowance, without credentials or administrative settings. The catalog describes registered, enabled managed aliases for discovery only; clients must intersect it with their available, policy-filtered provider models. Plan allowances describe the current paid tier or the entry paid tier offered on upgrade; a null price requires review on the billing page.
    */
   public getV1InferenceAccess<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
     return (options?.client ?? this.client).get<

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -897,6 +897,16 @@ export type DesktopPolicyListResponse = {
   }>;
 };
 
+export type ManagedModelRecommendation = {
+  modelID: string;
+  displayName: string;
+  providerName: string;
+  summary: string;
+  recommended: boolean;
+  rank: number;
+  capabilities: Array<string>;
+};
+
 export type InferenceAccessResponse = {
   access: {
     kind: "paid" | "free" | "exhausted" | "unavailable";
@@ -916,6 +926,12 @@ export type InferenceAccessResponse = {
       | "upstream_unavailable"
       | null;
     canUpgrade: boolean;
+    catalog?: Array<ManagedModelRecommendation>;
+    plan?: {
+      name: string;
+      priceLabel: string | null;
+      usageLabel: string;
+    };
   };
   upgradePath: "/dashboard/billing" | null;
 };

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -143,22 +143,22 @@ type ManagedModelMetadata = Omit<ManagedModelRecommendation, "modelID" | "displa
 const MANAGED_MODEL_METADATA = new Map<string, ManagedModelMetadata>([
   ["openai/gpt-5.6-luna", {
     providerName: "OpenAI",
-    summary: "Everyday questions, writing, and lightweight tasks",
+    summary: "Everyday writing and small tasks",
     recommended: true, rank: 1, capabilities: ["reasoning", "tools", "images", "documents"],
   }],
   ["openai/gpt-6-astra", {
     providerName: "OpenAI",
-    summary: "Complex analysis, software engineering, and deep research",
+    summary: "Analysis, coding, and research",
     recommended: true, rank: 2, capabilities: ["reasoning", "tools", "images", "documents"],
   }],
   ["moonshotai/kimi-k2.7-code", {
     providerName: "Moonshot AI",
-    summary: "Code changes and end-to-end programming tasks",
+    summary: "Code changes and programming",
     recommended: true, rank: 3, capabilities: ["reasoning", "tools", "images"],
   }],
   ["z-ai/glm-5.2", {
     providerName: "Z.ai",
-    summary: "Long-running tasks, reasoning, and project-level coding",
+    summary: "Reasoning and project-level coding",
     recommended: true, rank: 4, capabilities: ["reasoning", "tools"],
   }],
   ["moonshotai/kimi-k3", {

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -114,9 +114,107 @@ export const INFERENCE_MODEL_ALIASES = {
     enabled: true,
     usageFactor: 1,
   },
+  "openai/gpt-6-astra": {
+    upstreamModel: "openai/gpt-6-astra",
+    displayName: "OpenWork: GPT-6 Astra",
+    enabled: true,
+    usageFactor: 1,
+  },
 } as const;
 
 export type InferenceModelAlias = keyof typeof INFERENCE_MODEL_ALIASES;
+
+export type ManagedModelRecommendation = {
+  modelID: string;
+  displayName: string;
+  providerName: string;
+  summary: string;
+  recommended: boolean;
+  rank: number;
+  capabilities: string[];
+};
+
+type ManagedModelMetadata = Omit<ManagedModelRecommendation, "modelID" | "displayName">;
+
+// Task captions describe model capabilities, not benchmark rankings. Capabilities
+// follow the checked-in managed models; the four defaults were also checked
+// against public OpenRouter discovery on 2026-09-08. Keep this outside the
+// generated aliases so catalog refreshes preserve presentation choices.
+const MANAGED_MODEL_METADATA = new Map<string, ManagedModelMetadata>([
+  ["openai/gpt-5.6-luna", {
+    providerName: "OpenAI",
+    summary: "Everyday questions, writing, and lightweight tasks",
+    recommended: true, rank: 1, capabilities: ["reasoning", "tools", "images", "documents"],
+  }],
+  ["openai/gpt-6-astra", {
+    providerName: "OpenAI",
+    summary: "Complex analysis, software engineering, and deep research",
+    recommended: true, rank: 2, capabilities: ["reasoning", "tools", "images", "documents"],
+  }],
+  ["moonshotai/kimi-k2.7-code", {
+    providerName: "Moonshot AI",
+    summary: "Code changes and end-to-end programming tasks",
+    recommended: true, rank: 3, capabilities: ["reasoning", "tools", "images"],
+  }],
+  ["z-ai/glm-5.2", {
+    providerName: "Z.ai",
+    summary: "Long-running tasks, reasoning, and project-level coding",
+    recommended: true, rank: 4, capabilities: ["reasoning", "tools"],
+  }],
+  ["moonshotai/kimi-k3", {
+    providerName: "Moonshot AI",
+    summary: "Visual understanding, coding, and planning",
+    recommended: false, rank: 5, capabilities: ["reasoning", "tools", "images"],
+  }],
+  ["minimax/minimax-m3", {
+    providerName: "MiniMax",
+    summary: "Reasoning with text, images, and video",
+    recommended: false, rank: 6, capabilities: ["reasoning", "tools", "images", "video"],
+  }],
+  ["deepseek/deepseek-v4-flash", {
+    providerName: "DeepSeek",
+    summary: "Text reasoning and tool-assisted tasks",
+    recommended: false, rank: 7, capabilities: ["reasoning", "tools"],
+  }],
+  ["moonshotai/kimi-k2.6", {
+    providerName: "Moonshot AI",
+    summary: "Reasoning over text and images with tools",
+    recommended: false, rank: 8, capabilities: ["reasoning", "tools", "images"],
+  }],
+  ["z-ai/glm-5.1", {
+    providerName: "Z.ai",
+    summary: "Text reasoning and tool-assisted tasks",
+    recommended: false, rank: 9, capabilities: ["reasoning", "tools"],
+  }],
+  ["minimax/minimax-m2.7", {
+    providerName: "MiniMax",
+    summary: "Text reasoning and tool-assisted tasks",
+    recommended: false, rank: 10, capabilities: ["reasoning", "tools"],
+  }],
+  ["tencent/hy3-preview", {
+    providerName: "Tencent",
+    summary: "Preview model for text reasoning and tool use",
+    recommended: false, rank: 11, capabilities: ["reasoning", "tools"],
+  }],
+]);
+
+// Discovery metadata is not an entitlement or a provider configuration. Clients
+// must intersect this catalog with their currently available, policy-filtered models.
+export function managedModelCatalog(options: { freeModelID?: string } = {}): ManagedModelRecommendation[] {
+  return Object.entries(INFERENCE_MODEL_ALIASES).flatMap(([modelID, alias]) => {
+    const metadata = MANAGED_MODEL_METADATA.get(modelID);
+    if (!alias.enabled || !metadata) return [];
+    return [{
+      modelID,
+      displayName: alias.displayName.replace(/^OpenWork: /, ""),
+      ...metadata,
+      // Free admission accepts text and function tools, not multimodal inputs.
+      capabilities: modelID === options.freeModelID
+        ? metadata.capabilities.filter((capability) => capability === "reasoning" || capability === "tools")
+        : [...metadata.capabilities],
+    }];
+  }).sort((left, right) => left.rank - right.rank || left.modelID.localeCompare(right.modelID));
+}
 
 export type InferenceOrganizationMetadata = {
   enabled: true;
@@ -187,7 +285,21 @@ export type InferenceAccess = {
   resetsAt: string | null;
   reason: InferenceAccessReason | null;
   canUpgrade?: boolean;
+  catalog?: ManagedModelRecommendation[];
+  // Current paid tier, or the entry paid tier offered on upgrade. A null price
+  // means the configured billing SKU's price must be reviewed on the billing page.
+  plan?: { name: string; priceLabel: string | null; usageLabel: string };
 };
+
+export function inferencePlanPresentation(tier: InferenceTier = "tier1"): NonNullable<InferenceAccess["plan"]> {
+  const limits = INFERENCE_TIER_LIMITS[tier];
+  const usd = (amount: number) => `$${amount / INFERENCE_USAGE_CONVERSION_FACTOR}`;
+  return {
+    name: "OpenWork Models",
+    priceLabel: null,
+    usageLabel: `Shared workspace usage allowances: ${usd(limits.five_hour)} per member / 5 hours, ${usd(limits.weekly)} per member / week, and ${usd(limits.monthly)} per member / month.`,
+  };
+}
 
 // Den writes inferenceFree.offerAllowed explicitly, including false on admin
 // disable. Missing paid metadata alone never authorizes the free upstream key.


### PR DESCRIPTION
## Stack

Parent: #4620 (`feature/luna-weekly-allowance`). This is the picker/discovery follow-up; allowance accounting, subscriptions and installation policy are unchanged.

## Changes

- Open the composer picker directly to searchable models, with useful, catalog-owned recommendations for Luna, GPT-6 Astra, Kimi K2.7 Code and GLM-5.2.
- In the signed-in managed-model session flow, show **only OpenWork-hosted models**. OpenCode and other provider entries are excluded from current/favorite/recent rows, search and the full managed picker. Preserve stored provider configurations, selections and favorites; default/provider-settings and legacy flows remain available.
- Show **Free / Upgrade / Included** before selection. Keep effort controls accessible without making them a mandatory step in choosing a model.
- Paid selections open a model-specific offer with task guidance and plan allowance details. Unknown prices are not guessed. An access upgrade requires explicit model confirmation; it never submits the draft or runs a task.
- Keep “Use my own provider…” as a quiet, direct setup link, not a documentation-only detour. Onboarding keeps “Complete and open the app” primary and moves BYOK below it.
- Register the exact Astra alias confirmed by public OpenRouter model discovery. Discovery metadata is filtered against available models and is not execution authority. Free Luna captions reflect the free route's text/tool capabilities rather than advertising paid-only inputs.
- Regenerate the SDK for the optional catalog/plan fields.

## Verification — Incomplete

Current head: `bb42760deda01683f702d4340b5231eda7b36c02`.

**Passed focused checks:** 38 UI/model-picker tests and app typecheck. During implementation, Den Web checks (11), real-DB catalog/access checks (7), inference tests (94), catalog validation and SDK consistency/type checks also passed.

**Runtime history:** `OPENWORK_EVAL_REF=c582cf62e1407939f182ad07e9cdfe5cc4773cc1 pnpm evals:e2e composer-model-picker-no-subscribe-promo` passed one complete journey, zero failures/skips, `placement: daytona (daytona CLI authenticated)`. It covered real free enrollment/catalog, selection labels, contextual offers, preserved drafts/favorites/effort, direct provider setup and fixture-reported paid/non-admin transitions without checkout or generation.

The subsequent OpenWork-only filtering change is covered by focused tests and an updated journey, but its exact-head end-to-end run was **interrupted at the requester's direction**. No passing runtime verdict is claimed for the current head. Further lengthy validation is deferred.

Reproduction when requested: `OPENWORK_EVAL_REF=bb42760deda01683f702d4340b5231eda7b36c02 pnpm evals:e2e composer-model-picker-no-subscribe-promo`.

Paid/non-admin transitions in the UI journey are explicit response fixtures, not real purchases. Live Astra generation, checkout, rollout and the changed final-onboarding screen's full regression journey remain unverified.

## Boundaries

- Ready for review, not merged or released.
- No production flags, credentials, provider keys, billing or allowances changed.
- Native Git deployments for `feature/managed-model-discovery` are disabled in all four Vercel project configs; the branch has zero deployment records. No Vercel deploy command was run.
- Existing parent-stack work and the separate anonymous-Luna proposal are untouched. Reconcile and re-prove the stack after parent rebases before merge consideration.
