### PR TITLE
fix(app): toggle the selected Files panel from the rail

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1938,7 +1938,7 @@ export function SessionPage(props: SessionPageProps) {
                 "rounded-xl transition-colors hover:bg-muted hover:text-foreground",
                 panelRailActive && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
               )}
-              onClick={openArtifactRailPane}
+              onClick={panelRailActive ? closeRightPane : openArtifactRailPane}
               title={`Files (${artifactTargetCount})`}
               aria-label={`Files (${artifactTargetCount})`}
               aria-pressed={panelRailActive}

--- a/evals/specs/responsive-session-layout.e2e.test.ts
+++ b/evals/specs/responsive-session-layout.e2e.test.ts
@@ -130,6 +130,31 @@ test.skipIf(!runnable)(
     }
 
     await openSessionRoute(app, workspaceId, primary.sessionId);
+    await setViewport(app, { width: 1440, height: 844, deviceScaleFactor: 1 });
+    for (const open of [true, false, true, false]) {
+      const clicked = await evalIn(app, () => {
+        const button = document.querySelector<HTMLButtonElement>('aside button[aria-label^="Files ("]');
+        if (!button) return false;
+        button.click();
+        return true;
+      });
+      expect(clicked).toBe(true);
+      await waitFor(app, browserScript((open, sessionId) => {
+        const button = document.querySelector<HTMLButtonElement>('aside button[aria-label^="Files ("]');
+        const panel = document.querySelector<HTMLButtonElement>('button[aria-label="Close panel"]');
+        return button?.getAttribute("aria-pressed") === String(open)
+          && Boolean(panel && panel.getBoundingClientRect().width > 0) === open
+          && Boolean(document.querySelector(`[data-session-surface-id="${sessionId}"]`));
+      }, [open, primary.sessionId]), {
+        timeoutMs: 15_000,
+        label: `Files rail toggles panel ${open ? "open" : "closed"} without replacing the chat`,
+      });
+    }
+    evidence.recordAssertionEvidence(
+      "Files rail opens, hides, and reopens the empty panel without replacing the chat",
+      "Repeated rail clicks matched the pressed state and panel visibility; the primary chat remained mounted.",
+      true,
+    );
     await openSessionInSplit(app, workspaceId, secondary.sessionId);
     await waitFor(app, browserScript((sessionId) => (Boolean(document.querySelector<HTMLElement>(
       `[data-workbench-pane="secondary"] [data-session-surface-id="${sessionId}"]`


### PR DESCRIPTION
## Summary
- Close the right-side panel when its selected Files rail button is clicked, matching Browser; the next click reopens it.
- Preserve the Files menu action and existing artifact-opening behavior.
- Extend the responsive-session journey with repeated empty-panel open/close/reopen assertions, pressed-state and visibility checks, and preservation of the primary chat.

## Verification
**Verdict: Incomplete.** Published ready for review; runtime evidence is still missing.

Checked commit: `94f37abaf66cd52bf4ef6db1bbe2c5c0568b94cf`, rebased onto `fd2868d03eb5fefff4e1992c65ce8981f417992b`.

- Passed: `git diff origin/dev...HEAD --check` (exit 0).
- Passed: `bun test apps/app/tests/session-header-actions.test.ts` (exit 0; 1 passed, 0 failed). This existing header check does not prove the toggle.
- Passed: `bun build apps/app/src/react-app/domains/session/chat/session-page.tsx evals/specs/responsive-session-layout.e2e.test.ts --external "*" --outdir <temporary-output-directory>` (exit 0; both files). Syntax compilation only, not typechecking or runtime proof.
- Unrun/deferred: `pnpm evals:e2e responsive-session-layout`. Eval dependencies are absent. The read-only placement resolver selects Daytona because its CLI is authenticated; no reusable test resources are configured. Execution would provision a sandbox and was not run.
- Missing: a successful cold-boot journey run on this exact head and its published assertion evidence. No runtime pass is claimed.

## Manual Reproduction
1. Open a desktop conversation with no file artifacts.
2. Click the Files button on the right rail to open the panel.
3. Click the selected Files button again; the panel should hide and the button should no longer be pressed.
4. Click Files again; the panel should reopen while the conversation remains visible.