### PR TITLE
fix(app): show sent messages immediately across new chats

### DIFF
--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -123,6 +123,8 @@ export type SlashCommandOption = {
 };
 
 export type ComposerDraft = {
+  /** Client identity for reconciling the pending user turn with server events. */
+  messageId?: string;
   mode: PromptMode;
   parts: ComposerPart[];
   attachments: ComposerAttachment[];

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -63,7 +63,7 @@ export type NewTaskComposerProps = {
   draft: string;
   onDraftChange: (value: string) => void;
   /** Called with a non-empty draft and in-memory attachments; the caller creates the session (and workspace if needed). */
-  onRunTask: (resolvedDraft: string, attachments: ComposerAttachment[]) => void;
+  onRunTask: (resolvedDraft: string, attachments: ComposerAttachment[]) => void | Promise<void>;
   /** Disable submission while a default workspace is being prepared. */
   busy: boolean;
   context: NewTaskComposerContext | null;
@@ -91,6 +91,13 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const [mcpStatus, setMcpStatus] = useState<string | null>(null);
   const [importedPlugins, setImportedPlugins] = useState<CloudImportedPlugin[]>([]);
   const [pastedText, setPastedText] = useState<PastedTextChip[]>([]);
+  const submittingRef = useRef(false);
+  const draftRevisionRef = useRef(0);
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [failedSubmission, setFailedSubmission] = useState<{ text: string; attachments: ComposerAttachment[]; pastedText: PastedTextChip[] } | null>(null);
+  const draftRef = useRef(props.draft);
+  draftRef.current = props.draft;
   const skillsConnectPushRef = useRef(0);
   const mcpConnectPushRef = useRef(0);
   const pluginConnectPushRef = useRef(0);
@@ -202,6 +209,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   };
 
   const handleDraftChange = (value: string) => {
+    draftRevisionRef.current += 1;
     props.onDraftChange(value);
     const idsInDraft = new Set(
       [...value.matchAll(/\[attachment ([^\]]+)\]/g)].map((match) => match[1]).filter((id): id is string => Boolean(id)),
@@ -243,8 +251,33 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     props.onDraftChange(props.draft.replaceAll(`[attachment ${id}]`, ""));
   };
 
-  const handleRunTask = () => {
-    props.onRunTask(resolvePastedTextPlaceholders(props.draft, pastedText), attachments);
+  const handleRunTask = async () => {
+    if (submittingRef.current || props.busy || failedSubmission || (!props.draft.trim() && !attachments.length)) return;
+    submittingRef.current = true;
+    const originalDraft = props.draft;
+    const revision = draftRevisionRef.current;
+    const resolved = resolvePastedTextPlaceholders(originalDraft, pastedText);
+    const saved = { text: originalDraft, attachments, pastedText };
+    setPendingPrompt(resolved.replace(/\[attachment [^\]]+\]/g, ""));
+    setSubmissionError(null);
+    props.onDraftChange("");
+    draftRef.current = "";
+    setAttachments([]);
+    setPastedText([]);
+    try {
+      await props.onRunTask(resolved, attachments);
+    } catch (error) {
+      if (draftRevisionRef.current === revision && !draftRef.current) {
+        props.onDraftChange(originalDraft);
+        setAttachments(saved.attachments);
+        setPastedText(saved.pastedText);
+      } else {
+        setFailedSubmission(saved);
+      }
+      setSubmissionError(error instanceof Error ? error.message : "Could not create the conversation. Try again.");
+      setPendingPrompt(null);
+      submittingRef.current = false;
+    }
   };
 
   const handleUnsupportedFileLinks = (links: string[]) => {
@@ -253,6 +286,15 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   };
 
   return (
+    <>
+    {pendingPrompt !== null ? <div className="mb-4 whitespace-pre-wrap rounded-xl bg-muted px-4 py-3 text-sm" data-message-role="user">{pendingPrompt}</div> : null}
+    {submissionError ? <div role="alert" className="mb-2 text-sm text-red-11">{submissionError}</div> : null}
+    {failedSubmission ? <button type="button" disabled={Boolean(props.draft || attachments.length)} className="mb-2 text-sm disabled:opacity-50" onClick={() => {
+      props.onDraftChange(failedSubmission.text);
+      setAttachments(failedSubmission.attachments);
+      setPastedText(failedSubmission.pastedText);
+      setFailedSubmission(null);
+    }}>Clear the current draft to restore the unsent message</button> : null}
     <ReactSessionComposer
       runModeControl={<WorkspaceRunModeMenu client={workspaceClient} workspaceId={workspaceId} busy={props.busy} />}
       draft={props.draft}
@@ -264,7 +306,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onStop={noop}
       busy={false}
       steering={false}
-      submissionPreparing={props.busy}
+      submissionPreparing={props.busy || pendingPrompt !== null || failedSubmission !== null}
       queuedCount={0}
       disabled={Boolean(context?.modelUnavailable)}
       modelUnavailable={context?.modelUnavailable}
@@ -318,6 +360,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       flush
       draftScopeKey={`new-task:${workspaceId ?? "chat-first"}`}
     />
+    </>
   );
 }
 

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -51,7 +51,7 @@ export type SessionEmptyHeroProps = {
   /** Disable submission while a default workspace is being prepared. */
   busy?: boolean;
   /** Called with the task prompt and attachments; the caller creates the session (and workspace if needed). */
-  onRunTask: (prompt: string, attachments: ComposerAttachment[]) => void;
+  onRunTask: (prompt: string, attachments: ComposerAttachment[]) => void | Promise<void>;
   onOpenProviderAuth?: () => void;
   /** Workspace-scoped wiring for the full composer (skills, agents, models). */
   composer?: NewTaskComposerContext | null;
@@ -103,8 +103,8 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
 
   const submit = (resolvedPrompt: string, attachments: ComposerAttachment[]) => {
     const trimmedPrompt = resolvedPrompt.trim();
-    if (!trimmedPrompt || props.busy) return;
-    props.onRunTask(trimmedPrompt, attachments);
+    if ((!trimmedPrompt && !attachments.length) || props.busy) return;
+    return props.onRunTask(trimmedPrompt, attachments);
   };
 
   const fillPrompt = (value: string) => {

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -159,7 +159,7 @@ export type SessionPageSidebarProps = {
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
   onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
-  onCreateTaskWithPrompt?: (workspaceId: string, prompt: string, attachments?: ComposerAttachment[]) => void;
+  onCreateTaskWithPrompt?: (workspaceId: string, prompt: string, attachments?: ComposerAttachment[]) => Promise<void>;
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;
   onRevealWorkspace: (workspaceId: string) => void;
@@ -261,7 +261,7 @@ export type SessionPageProps = {
   extensionsActive?: boolean;
   onOpenProviderAuth?: () => void;
   /** Chat-first: create a default workspace and start a task from the empty-state composer. */
-  onChatFirstTask?: (prompt: string, attachments?: ComposerAttachment[]) => void;
+  onChatFirstTask?: (prompt: string, attachments?: ComposerAttachment[]) => Promise<void>;
   chatFirstBusy?: boolean;
   /** Workspace-scoped wiring for the empty-state hero's full composer. */
   newTaskComposer?: NewTaskComposerContext | null;

--- a/apps/app/src/react-app/domains/session/surface/composer-auto-send.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-auto-send.ts
@@ -15,3 +15,7 @@ export function markComposerAutoSend(sessionId: string) {
 export function consumeComposerAutoSend(sessionId: string): boolean {
   return pendingAutoSendSessionIds.delete(sessionId.trim());
 }
+
+export function hasComposerAutoSend(sessionId: string): boolean {
+  return pendingAutoSendSessionIds.has(sessionId.trim());
+}

--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -24,6 +24,8 @@ export type ComposerSessionState = {
 };
 
 export type ComposerStateStore = {
+  failedDrafts: Record<string, ComposerSessionState[]>;
+  pendingMessages: Record<string, { draft: ComposerDraft & { messageId: string }; previousMessageIds: string[] }[]>;
   pendingFocusSessionId: string | null;
   sessions: Record<string, ComposerSessionState>;
   queuedDrafts: Record<string, QueuedComposerItem[]>;
@@ -101,6 +103,8 @@ function createQueuedItem(draft: ComposerDraft, id?: string): QueuedComposerItem
 }
 
 export const useComposerStateStore = create<ComposerStateStore>((set) => ({
+  failedDrafts: {},
+  pendingMessages: {},
   pendingFocusSessionId: null,
   sessions: {},
   queuedDrafts: {},

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -144,7 +144,7 @@ import {
   readCloudInventoryScope,
 } from "@/react-app/domains/connections/cloud-inventory-cache";
 import { connectPluginsForComposer, EMPTY_CONNECT_CAPABILITY_INVENTORY } from "@/react-app/domains/session/surface/connect-capability-inventory";
-import { consumeComposerAutoSend } from "./composer-auto-send";
+import { consumeComposerAutoSend, hasComposerAutoSend } from "./composer-auto-send";
 import { useOrgMcpConnections } from "@/react-app/domains/connections/use-org-mcp-connections";
 import { buildConnectorToolIdentities } from "@/react-app/domains/connections/connector-tool-identity";
 
@@ -921,10 +921,6 @@ function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }
   URL.revokeObjectURL(attachment.previewUrl);
 }
 
-function sameAttachments(left: ComposerAttachment[], right: ComposerAttachment[]): boolean {
-  return left.length === right.length && left.every((attachment, index) => attachment.id === right[index]?.id);
-}
-
 function draftWithEditedText(draft: ComposerDraft, text: string): ComposerDraft {
   return {
     ...draft,
@@ -1094,7 +1090,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     : Boolean(props.modelUnavailable);
   // This surface is retained across navigation. Async completions must keep
   // their original owner, including when different servers reuse session IDs.
-  const sessionOwner = JSON.stringify([props.opencodeBaseUrl, props.workspaceId, props.sessionId]);
+  const sessionOwner = JSON.stringify([props.draftScope, props.opencodeBaseUrl, props.workspaceId, props.sessionId]);
   const activeSessionOwnerRef = useRef(sessionOwner);
   activeSessionOwnerRef.current = sessionOwner;
   const [ownedError, setOwnedError] = useState<{ owner: string; error: SessionError } | null>(null);
@@ -1335,11 +1331,46 @@ export function SessionSurface(props: SessionSurfaceProps) {
     () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
     [snapshot, transcriptState],
   );
+  const pendingMessages = useComposerStateStore((state) => state.pendingMessages[sessionOwner]);
+  const failedDraft = useComposerStateStore((state) => state.failedDrafts[sessionOwner]?.[0]);
+  const autoSending = hasComposerAutoSend(props.sessionId) && !sessionModelUnavailable;
+  const unmatchedPendingMessages = useMemo(() => {
+    const matchedIds = new Set<string>();
+    const remaining = (pendingMessages ?? []).filter(({ draft: pending, previousMessageIds }) => {
+      const match = baseRenderedMessages.find((message) => message.role === "user"
+        && !matchedIds.has(message.id)
+        && (message.id === pending.messageId || (!previousMessageIds.includes(message.id)
+          && message.parts.some((part) => part.type === "text" && part.text === (pending.resolvedText ?? pending.text)))));
+      if (!match) return true;
+      matchedIds.add(match.id);
+      return false;
+    });
+    // A server turn can acknowledge only one pending send, even when two
+    // consecutive prompts have identical text and v2 assigns its own IDs.
+    return matchedIds.size ? remaining.map((item) => ({
+      ...item,
+      previousMessageIds: [...item.previousMessageIds, ...matchedIds],
+    })) : remaining;
+  }, [baseRenderedMessages, pendingMessages]);
+  useEffect(() => {
+    if (!pendingMessages || pendingMessages.length === unmatchedPendingMessages.length) return;
+    useComposerStateStore.setState((state) => ({
+      pendingMessages: { ...state.pendingMessages, [sessionOwner]: unmatchedPendingMessages },
+    }));
+  }, [pendingMessages, sessionOwner, unmatchedPendingMessages]);
   const renderedMessages = useMemo(() => {
-    if (evalMarkdownMessages.length === 0) return baseRenderedMessages;
-
-    return [...baseRenderedMessages, ...evalMarkdownMessages];
-  }, [baseRenderedMessages, evalMarkdownMessages]);
+    const pending: UIMessage[] = unmatchedPendingMessages.map(({ draft: item }) => ({
+      id: item.messageId,
+      role: "user",
+      parts: [{ type: "text", text: item.resolvedText ?? item.text }],
+    }));
+    if (autoSending && draft.trim()) pending.push({
+      id: `${props.sessionId}:first-send`,
+      role: "user",
+      parts: [{ type: "text", text: resolvePastedTextPlaceholders(draft, pasteParts).replace(/\[attachment [^\]]+\]/g, "") }],
+    });
+    return [...baseRenderedMessages, ...pending, ...evalMarkdownMessages];
+  }, [autoSending, baseRenderedMessages, draft, evalMarkdownMessages, pasteParts, props.sessionId, unmatchedPendingMessages]);
   const renderedMessagesRef = useRef(renderedMessages);
   useEffect(() => {
     renderedMessagesRef.current = renderedMessages;
@@ -1851,29 +1882,59 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const originalDraft = draft;
     const text = originalDraft.trim();
     if (!text && attachments.length === 0) return;
-    const nextDraft = buildDraft(text, attachments);
+    const nextDraft = {
+      ...buildDraft(text, attachments),
+      messageId: `msg_${(Date.now() * 4096).toString(16)}${crypto.randomUUID().replaceAll("-", "").slice(0, 14)}`,
+    };
     const sentAttachments = attachments;
+    const savedComposer = useComposerStateStore.getState().sessions[props.sessionId];
+    clearComposer();
+    const clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
+    const removePending = () => useComposerStateStore.setState((state) => ({
+      pendingMessages: {
+        ...state.pendingMessages,
+        [sessionOwner]: (state.pendingMessages[sessionOwner] ?? []).filter((item) => item.draft !== nextDraft),
+      },
+    }));
+    const restore = () => {
+      removePending();
+      const state = useComposerStateStore.getState();
+      // Identity, not text equality: typing and then deleting is still a newer edit.
+      if (savedComposer && state.sessions[props.sessionId] === clearedComposer
+        && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
+        useComposerStateStore.setState({ sessions: { ...state.sessions, [props.sessionId]: savedComposer } });
+        props.onDraftChange(nextDraft);
+      } else if (savedComposer) {
+        useComposerStateStore.setState({ failedDrafts: {
+          ...state.failedDrafts,
+          [sessionOwner]: [...(state.failedDrafts[sessionOwner] ?? []), savedComposer],
+        } });
+      }
+    };
+    useComposerStateStore.setState((state) => ({
+      pendingMessages: {
+        ...state.pendingMessages,
+        [sessionOwner]: [...(state.pendingMessages[sessionOwner] ?? []), {
+          draft: nextDraft,
+          previousMessageIds: baseRenderedMessages.map((message) => message.id),
+        }],
+      },
+    }));
     if (sentAttachments.length) setAttachmentsUploading(true);
     try {
       const result = await sendDraft(nextDraft);
-      if (result.outcome === "blocked" || result.outcome === "cancelled") return;
-      const currentState = useComposerStateStore.getState();
-      const currentDraft = getComposerDraft(currentState, props.sessionId);
-      const currentAttachments = getComposerAttachments(currentState, props.sessionId);
-      if (currentDraft === originalDraft && sameAttachments(currentAttachments, sentAttachments)) {
-        clearComposer();
-        sentAttachments.forEach(revokeAttachmentPreview);
-      } else {
-        const retainedIds = new Set(currentAttachments.map((attachment) => attachment.id));
-        sentAttachments
-          .filter((attachment) => !retainedIds.has(attachment.id))
-          .forEach(revokeAttachmentPreview);
+      if (result.outcome === "blocked" || result.outcome === "cancelled") {
+        restore();
+        return;
       }
+      if (nextDraft.command || nextDraft.mode === "shell") removePending();
+      sentAttachments.forEach(revokeAttachmentPreview);
     } catch {
+      restore();
     } finally {
       setAttachmentsUploading(false);
     }
-  }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft, sessionOwner]);
+  }, [attachments, baseRenderedMessages, buildDraft, clearComposer, draft, persistedDraftKey, props.onDraftChange, props.sessionId, sendDraft, sessionOwner]);
 
   // One-step run from the empty-state hero: the route seeds this session's
   // draft and marks it for auto-send. Fire the same send path as the send
@@ -1884,10 +1945,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (model.transitionState !== "idle") return;
     if (chatStreaming) return;
     if (sessionModelUnavailable) return;
-    if (!draft.trim()) return;
+    if (!draft.trim() && !attachments.length) return;
     if (!consumeComposerAutoSend(props.sessionId)) return;
     void handleSend();
-  }, [chatStreaming, draft, handleSend, model.transitionState, sessionModelUnavailable, props.sessionId]);
+  }, [attachments.length, chatStreaming, draft, handleSend, model.transitionState, sessionModelUnavailable, props.sessionId]);
 
   const handleSteer = useCallback(async () => {
     setSteering(true);
@@ -2107,11 +2168,15 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     if (hydratedDraftScopeKey !== persistedDraftKey) return;
+    // Auto-send can clear the store in an earlier effect from this render.
+    // Never persist that render's stale draft back over the cleared composer.
+    const current = useComposerStateStore.getState();
+    if (getComposerDraft(current, props.sessionId) !== draft || getComposerAttachments(current, props.sessionId) !== attachments) return;
     const nextDraft = buildDraft(draft, attachments);
     const persistableText = persistableComposerDraftText(nextDraft.text);
     persistDraft({ text: persistableText, mode: nextDraft.mode });
     props.onDraftChange(nextDraft);
-  }, [attachments, buildDraft, draft, hydratedDraftScopeKey, persistDraft, persistedDraftKey, props.onDraftChange]);
+  }, [attachments, buildDraft, draft, hydratedDraftScopeKey, persistDraft, persistedDraftKey, props.onDraftChange, props.sessionId]);
 
   const handleAttachFiles = useCallback((files: File[]) => {
     if (!props.attachmentsEnabled) {
@@ -2908,9 +2973,29 @@ export function SessionSurface(props: SessionSurfaceProps) {
             </button>
           </div>
         ) : null}
+        {failedDraft ? (
+          <div className="mx-3 mb-2 flex items-center gap-3 text-xs text-red-11">
+            <span>Your unsent message is saved. Clear the current draft to restore it.</span>
+            <button type="button" disabled={Boolean(draft || attachments.length)} className="font-medium disabled:opacity-50" onClick={() => {
+              const state = useComposerStateStore.getState();
+              if (getComposerDraft(state, props.sessionId) || getComposerAttachments(state, props.sessionId).length) return;
+              const failedDrafts = { ...state.failedDrafts };
+              failedDrafts[sessionOwner] = (failedDrafts[sessionOwner] ?? []).slice(1);
+              useComposerStateStore.setState({
+                sessions: { ...state.sessions, [props.sessionId]: failedDraft },
+                failedDrafts,
+              });
+            }}>Restore unsent message</button>
+          </div>
+        ) : null}
+        {unmatchedPendingMessages.flatMap(({ draft: pending }) => pending.attachments.map((attachment) => (
+          <div key={attachment.id} className="mx-3 mb-2 text-xs text-muted-foreground" data-attachment-status={sending ? "uploading" : "ready"}>
+            {attachment.name}{sending ? " · Uploading…" : ""}
+          </div>
+        )))}
         <ReactSessionComposer
           runModeControl={<WorkspaceRunModeMenu client={props.client} workspaceId={props.workspaceId} busy={chatStreaming || preparingCloudTools || Boolean(props.activePermission || props.activeQuestion)} />}
-          draft={draft}
+          draft={autoSending ? "" : draft}
           mentions={mentions}
           onDraftChange={handleComposerDraftChange}
         onSend={handleSend}
@@ -2919,7 +3004,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onStop={handleAbort}
         busy={chatStreaming}
         steering={steering}
-        submissionPreparing={preparingCloudTools}
+        submissionPreparing={preparingCloudTools || sending}
         queuedCount={queuedItems.length}
         disabled={model.transitionState !== "idle" || sessionModelUnavailable}
         modelUnavailable={sessionModelUnavailable}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1393,6 +1393,7 @@ export function SessionRoute() {
                 });
                 const result = await opencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
+                  messageID: draft.messageId,
                   parts,
                   model: sendModel ?? undefined,
                   agent: selectedAgent ?? undefined,
@@ -1713,6 +1714,7 @@ export function SessionRoute() {
                 });
                 const result = await workspaceOpencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
+                  messageID: draft.messageId,
                   parts,
                   model: sendModel ?? undefined,
                   agent: selectedAgent ?? undefined,
@@ -3011,7 +3013,6 @@ export function SessionRoute() {
               { token: sessionToken, mode: "openwork" },
             ).session.create({ directory: workspacePath || undefined })
               .then((result) => unwrap(result))
-              .catch(() => null)
           : null;
         setLegacySelectedWorkspaceId(targetWorkspaceId);
         writeActiveWorkspaceId(targetWorkspaceId);
@@ -3023,7 +3024,7 @@ export function SessionRoute() {
         captureAnalyticsEvent("workspace_created", { workspace_type: "local" });
         if (session?.id) {
           captureAnalyticsEvent("task_created", { source: "workspace_created", workspace_type: "local" });
-          if (firstTaskPrompt) {
+          if (firstTaskPrompt || firstTaskAttachments.length) {
             // Attachment chips only survive in-memory (File objects), so the
             // persisted fallback draft drops their tokens.
             saveSessionDraft(sessionDraftScope, targetWorkspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
@@ -3056,6 +3057,7 @@ export function SessionRoute() {
       }
     } catch (error) {
       setCreateWorkspaceError(describeWorkspaceCreateError(error));
+      if (options?.firstTaskPrompt || options?.firstTaskAttachments?.length) throw error;
     } finally {
       setCreateWorkspaceBusy(false);
     }
@@ -3066,26 +3068,24 @@ export function SessionRoute() {
    * workspace under the user's home folder instead of asking where to put
    * it. Falls back to the create-workspace modal off desktop.
    */
-  const handleChatFirstTask = useCallback((prompt: string, attachments?: ComposerAttachment[]) => {
-    void (async () => {
-      if (!isDesktopRuntime()) {
-        // The cloud workspace is provisioned by Den; boot takeover covers the pre-attach state.
-        if (!canCreateWorkspaces()) return;
-        handleOpenCreateWorkspace();
-        return;
-      }
-      const home = await getDesktopHomeDir().catch(() => "");
-      if (!home) {
-        handleOpenCreateWorkspace();
-        return;
-      }
-      const folder = await joinDesktopPath(home, "OpenWork Chat").catch(() => "");
-      if (!folder) {
-        handleOpenCreateWorkspace();
-        return;
-      }
-      await handleCreateWorkspace("starter", folder, { firstTaskPrompt: prompt, firstTaskAttachments: attachments ?? [] });
-    })();
+  const handleChatFirstTask = useCallback(async (prompt: string, attachments?: ComposerAttachment[]) => {
+    if (!isDesktopRuntime()) {
+      // The cloud workspace is provisioned by Den; boot takeover covers the pre-attach state.
+      if (!canCreateWorkspaces()) throw new Error("Workspace creation is unavailable.");
+      handleOpenCreateWorkspace();
+      throw new Error("Choose a workspace before sending this message.");
+    }
+    const home = await getDesktopHomeDir().catch(() => "");
+    if (!home) {
+      handleOpenCreateWorkspace();
+      throw new Error("Choose a workspace before sending this message.");
+    }
+    const folder = await joinDesktopPath(home, "OpenWork Chat").catch(() => "");
+    if (!folder) {
+      handleOpenCreateWorkspace();
+      throw new Error("Choose a workspace before sending this message.");
+    }
+    await handleCreateWorkspace("starter", folder, { firstTaskPrompt: prompt, firstTaskAttachments: attachments ?? [] });
   }, [handleCreateWorkspace, handleOpenCreateWorkspace]);
 
   const createWorkspaceControlAction = useMemo<OpenworkControlAction>(() => ({
@@ -3396,51 +3396,44 @@ export function SessionRoute() {
         onCreateSplitTaskInWorkspace: (workspaceId) => {
           void handleCreateSplitTaskInWorkspace(workspaceId);
         },
-        onCreateTaskWithPrompt: (workspaceId, prompt, attachments) => {
-          void (async () => {
-            const workspace = workspaces.find((item) => item.id === workspaceId);
-            if (!workspace) return;
-            const endpoint = endpointForWorkspace(workspace);
-            if (!endpoint?.token) return;
-            try {
-              const session = await createRouteSession(endpoint, workspace.path?.trim() || undefined);
-              if (workspaceId === selectedWorkspaceId) {
-                void refreshCloudProviderSync("new_chat");
-              }
-              const firstTaskPrompt = prompt.trim();
-              if (firstTaskPrompt) {
-                const firstTaskAttachments = attachments ?? [];
-                // Attachment chips only survive in-memory (File objects), so the
-                // persisted fallback draft drops their tokens.
-                saveSessionDraft(sessionDraftScope, workspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
-                claimComposerSessionDraftScope(
-                  session.id,
-                  sessionDraftScopeKey(sessionDraftScope, workspaceId, session.id),
-                );
-                // The composer reads its draft from the composer state store,
-                // not the persisted draft store — seed both.
-                useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
-                if (firstTaskAttachments.length) {
-                  useComposerStateStore.getState().setAttachments(session.id, firstTaskAttachments);
-                }
-                // One-step run: the session surface sends the seeded draft itself.
-                markComposerAutoSend(session.id);
-              }
-              writeActiveWorkspaceId(workspaceId || null);
-              writeLastSessionFor(workspaceId, session.id);
-              rememberPendingCreatedSession(workspaceId, session.id);
-              applyLastUsedModelToSession(session.id);
-              setSessionsByWorkspaceId((current) => ({
-                ...current,
-                [workspaceId]: mergeWorkspaceRouteSession(current[workspaceId] ?? [], session),
-              }));
-              navigateToWorkspaceSession(workspaceId, session.id);
-              focusPromptSoon();
-            } catch {
-              // Fall back to normal task creation without prompt
-              void handleCreateTaskInWorkspace(workspaceId);
+        onCreateTaskWithPrompt: async (workspaceId, prompt, attachments) => {
+          const workspace = workspaces.find((item) => item.id === workspaceId);
+          if (!workspace) throw new Error("Workspace is unavailable. Try again.");
+          const endpoint = endpointForWorkspace(workspace);
+          if (!endpoint?.token) throw new Error("Workspace is disconnected. Reconnect and try again.");
+          const session = await createRouteSession(endpoint, workspace.path?.trim() || undefined);
+          if (workspaceId === selectedWorkspaceId) {
+            void refreshCloudProviderSync("new_chat");
+          }
+          const firstTaskPrompt = prompt.trim();
+          if (firstTaskPrompt || attachments?.length) {
+            const firstTaskAttachments = attachments ?? [];
+            // Attachment chips only survive in-memory (File objects), so the
+            // persisted fallback draft drops their tokens.
+            saveSessionDraft(sessionDraftScope, workspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
+            claimComposerSessionDraftScope(
+              session.id,
+              sessionDraftScopeKey(sessionDraftScope, workspaceId, session.id),
+            );
+            // The composer reads its draft from the composer state store,
+            // not the persisted draft store — seed both.
+            useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
+            if (firstTaskAttachments.length) {
+              useComposerStateStore.getState().setAttachments(session.id, firstTaskAttachments);
             }
-          })();
+            // One-step run: the session surface sends the seeded draft itself.
+            markComposerAutoSend(session.id);
+          }
+          writeActiveWorkspaceId(workspaceId || null);
+          writeLastSessionFor(workspaceId, session.id);
+          rememberPendingCreatedSession(workspaceId, session.id);
+          applyLastUsedModelToSession(session.id);
+          setSessionsByWorkspaceId((current) => ({
+            ...current,
+            [workspaceId]: mergeWorkspaceRouteSession(current[workspaceId] ?? [], session),
+          }));
+          navigateToWorkspaceSession(workspaceId, session.id);
+          focusPromptSoon();
         },
         onOpenRenameWorkspace: handleOpenRenameWorkspace,
         onShareWorkspace: handleShareWorkspace,

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -3,11 +3,13 @@ import { expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { createRequire } from "node:module";
-import { act } from "react";
+import { act, useState } from "react";
 import { createRoot } from "react-dom/client";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import type { ComposerDraft } from "../src/app/types";
+import type { CloudMcpSubmissionResult } from "../src/react-app/domains/connections/cloud-mcp-submit-readiness";
 
 const workspaceId = "workspace-focus-continuity";
 const sessionId = "session-focus-continuity";
@@ -23,7 +25,13 @@ function createSnapshot(status: SessionStatus, updated: number): OpenworkSession
       version: "1",
       time: { created: 1, updated },
     },
-    messages: [],
+    messages: [{
+      info: {
+        id: "existing-user-message", sessionID: sessionId, role: "user", time: { created: 1 },
+        agent: "build", model: { providerID: "test", modelID: "test-model" },
+      },
+      parts: [{ id: "existing-user-part", sessionID: sessionId, messageID: "existing-user-message", type: "text", text: "Keep this session mounted." }],
+    }],
     todos: [],
     status,
   };
@@ -40,7 +48,7 @@ async function waitFor(predicate: () => boolean, label: string) {
   throw new Error(`Timed out waiting for ${label}`);
 }
 
-test("a same-session snapshot swap preserves Lexical focus and draft text", async () => {
+test("composer focus and optimistic sends preserve drafts through snapshots and first-message handoff", async () => {
   const require = createRequire(import.meta.url);
   // Bun's isolated test loader cycles Lexical's ESM entries; use their real CJS entries before the app imports the editor.
   for (const moduleId of [
@@ -87,6 +95,7 @@ test("a same-session snapshot swap preserves Lexical focus and draft text", asyn
   window.localStorage.setItem("openwork.shell-config", JSON.stringify({ starterCards: false }));
   let fetchedSnapshot = createSnapshot({ type: "busy" }, 1);
   mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
+  mock.module("@/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
   mock.module("@/app/lib/opencode-session-native", () => ({
     composeNativeSessionSnapshot: async () => fetchedSnapshot,
   }));
@@ -105,6 +114,8 @@ test("a same-session snapshot swap preserves Lexical focus and draft text", asyn
   document.body.append(container);
   const root = createRoot(container);
   const draft = "Keep this draft while the task finishes";
+  let submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+  const sentDrafts: ComposerDraft[] = [];
 
   try {
     await act(async () => {
@@ -128,7 +139,10 @@ test("a same-session snapshot swap preserves Lexical focus and draft text", asyn
                 selectedModel={{ providerID: "test", modelID: "test-model" }}
                 onModelPickerOpenChange={() => {}}
                 onModelChange={() => {}}
-                onSendDraft={async () => ({ outcome: "accepted" })}
+                onSendDraft={(value) => {
+                  sentDrafts.push(value);
+                  return submission.promise;
+                }}
                 cloudMcpSubmissionState={IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE}
                 onOpenConnect={() => {}}
                 onDraftChange={() => {}}
@@ -178,9 +192,94 @@ test("a same-session snapshot swap preserves Lexical focus and draft text", asyn
     expect(container.querySelector('[data-lexical-editor="true"]')).toBe(editor);
     expect(document.activeElement).toBe(editor);
     expect(editor.textContent).toBe(draft);
+
+    const send = () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Run task"]');
+      if (!button || button.disabled) throw new Error(`Expected an enabled send button: ${container.textContent}`);
+      button.click();
+      button.click();
+    };
+    await act(async () => send());
+    expect(sentDrafts).toHaveLength(1);
+    expect(editor.textContent).toBe("");
+    expect(container.textContent).toContain(draft);
+    expect(useComposerStateStore.getState().sessions[sessionId]).toBeUndefined();
+
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "A newer draft"));
+    await act(async () => submission.reject(new Error("Submission unavailable")));
+    expect(editor.textContent).toBe("A newer draft");
+    expect(container.textContent).not.toContain(draft);
+    expect(Object.values(useComposerStateStore.getState().failedDrafts).flat().map((item) => item.draft)).toEqual([draft]);
+    expect(useComposerStateStore.getState().queuedDrafts[sessionId]).toBeUndefined();
+
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, ""));
+    await act(async () => {
+      const restore = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent === "Restore unsent message");
+      expect(restore?.disabled).toBe(false);
+      restore?.click();
+    });
+    expect(editor.textContent).toBe(draft);
+
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Dismiss error"]')?.click());
+    await act(async () => send());
+    await act(async () => submission.resolve({ outcome: "cancelled", reason: "context_changed" }));
+    expect(editor.textContent).toBe(draft);
+
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    const { markComposerAutoSend } = await import("../src/react-app/domains/session/surface/composer-auto-send");
+    await act(async () => {
+      markComposerAutoSend(sessionId);
+      useComposerStateStore.getState().setDraft(sessionId, "First message auto-send");
+    });
+    await waitFor(() => sentDrafts.length === 3, "first-message auto-send");
+    expect(editor.textContent).toBe("");
+    expect(container.textContent).toContain("First message auto-send");
+    const messageId = sentDrafts[2]?.messageId;
+    expect(messageId).toStartWith("msg_");
+    await act(async () => {
+      queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{
+        id: messageId,
+        role: "user",
+        parts: [{ type: "text", text: "First message auto-send" }],
+      }]);
+      submission.resolve({ outcome: "accepted" });
+    });
+    expect(editor.textContent).toBe("");
+    expect(container.textContent?.split("First message auto-send").length).toBe(2);
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
+
+    const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
+    const creation = Promise.withResolvers<void>();
+    let creations = 0;
+    let updateHeroDraft = (_text: string) => {};
+    function Hero() {
+      const [text, setText] = useState("First hero message");
+      updateHeroDraft = setText;
+      return <NewTaskComposer draft={text} onDraftChange={setText} busy={false} context={null} onRunTask={() => {
+        creations++;
+        return creation.promise;
+      }} />;
+    }
+    await act(async () => root.render(<LocalProvider><ShellConfigProvider><Hero /></ShellConfigProvider></LocalProvider>));
+    await act(async () => send());
+    expect(creations).toBe(1);
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("");
+    expect(container.querySelector('[data-message-role="user"]')?.textContent).toBe("First hero message");
+    await act(async () => updateHeroDraft("Newer hero draft"));
+    await act(async () => creation.reject(new Error("Session creation failed")));
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Newer hero draft");
+    expect(container.textContent).toContain("Session creation failed");
+    await act(async () => updateHeroDraft(""));
+    await act(async () => {
+      [...container.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent === "Clear the current draft to restore the unsent message")?.click();
+    });
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("First hero message");
+    expect(creations).toBe(1);
   } finally {
     await act(async () => root.unmount());
-    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });
+    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {}, pendingMessages: {}, failedDrafts: {} });
     queryClient.clear();
     container.remove();
     mock.restore();

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -27,6 +27,36 @@ function expectSettledDocument(visibleText: string) {
   for (const syntax of rawSyntax) expect(visibleText).not.toContain(syntax);
 }
 
+test("sending clears the composer and shows one pending turn in existing and new conversations", async ({ world, user, probe, step }) => {
+  for (const scenario of ["existing", "new"]) {
+    if (scenario === "new") await user.click({ role: "button", label: "New task" });
+    const text = `Keep this ${scenario} conversation message while submission is delayed.`;
+    await user.type("composer", text);
+    await world.holdNextSubmission();
+    await step(`${scenario}: Send clears the input before server acceptance`, async () => {
+      await user.click("Run task");
+      await user.see("composer", { text: "", timeoutMs: 500 });
+      await user.see({ text }, { timeoutMs: 500 });
+      expect(await probe.eventually(() => world.submissionAttempts(), {
+        within: 20_000, label: "held submission", until: (count) => count === 1,
+      })).toBe(1);
+      expect((await probe.composer()).draftText).toBe("");
+      expect(occurrences(await probe.text(), text)).toBe(1);
+    });
+    await step(`${scenario}: failure retains the message without replacing newer typing`, async () => {
+      await user.type("composer", "A newer draft");
+      await world.rejectSubmission();
+      await user.see({ text: /Your unsent message is saved/ });
+      expect((await probe.composer()).draftText).toBe("A newer draft");
+      expect(await world.submissionAttempts()).toBe(1);
+      await user.type("composer", "", { replace: true });
+      await user.click("Restore unsent message");
+      await user.see("composer", { text });
+      expect(await world.submissionAttempts()).toBe(1);
+    });
+  }
+});
+
 test("a streaming answer renders as markdown block by block and settles to the same document", async ({ world, user, probe, step }) => {
   const entries = [
     { role: "user", text: prompt } satisfies { role: "user"; text: string },

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -10,6 +10,12 @@ import { chatContinuity } from "./chat-continuity.ts";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 
+declare global {
+  interface Window {
+    __openworkSubmissionFault?: { attempts: number; release: () => void };
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -775,6 +781,35 @@ export async function streamedMarkdown(seed: Seed) {
   if (ready !== true) throw new Error(`Selected ${engine} engine was not ready for the streaming journey`);
   const session = await seedSessionRetry(seed, app);
   return { app, den, workspace, session,
+    async holdNextSubmission() {
+      await seed.evalIn(app, () => {
+        const originalFetch = window.fetch;
+        const fault = { attempts: 0, release: () => {} };
+        window.__openworkSubmissionFault = fault;
+        window.fetch = async (input, init) => {
+          const url = input instanceof Request ? input.url : String(input);
+          const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+          if (method === "POST" && /\/session\/[^/]+\/(prompt_async|prompt)(\?|$)/.test(url)) {
+            fault.attempts++;
+            await new Promise<void>((resolve) => {
+              const timer = setTimeout(resolve, 30_000);
+              fault.release = () => { clearTimeout(timer); resolve(); };
+            });
+            window.fetch = originalFetch;
+            return new Response(JSON.stringify({ name: "SubmissionUnavailable", message: "Submission unavailable" }), {
+              status: 503, headers: { "content-type": "application/json" },
+            });
+          }
+          return originalFetch(input, init);
+        };
+      });
+    },
+    async submissionAttempts() {
+      return seed.evalIn(app, () => window.__openworkSubmissionFault?.attempts ?? 0);
+    },
+    async rejectSubmission() {
+      await seed.evalIn(app, () => window.__openworkSubmissionFault?.release());
+    },
     async videoState(play = false) {
       return seed.evalIn(app, browserScript(async (play) => {
         const video = document.querySelector<HTMLVideoElement>('video[data-openwork-video-path="clip.mp4"]');


### PR DESCRIPTION
## Problem
Send left the submitted text in the composer until context preparation and prompt submission completed. The transcript waited for server events. A first message also traveled through the new conversation composer before auto-send, making the route transition look like an unsent draft.

## Changes
- Clear the composer at submission and render a session-scoped pending user turn immediately. Reconcile it with server messages without duplicate turns.
- Show the first message while conversation creation is pending, hide the seeded destination draft during auto-send, and prevent repeated submissions.
- Restore cancelled or failed submissions when the composer is untouched. Preserve newer typing and offer explicit recovery of the unsent draft without automatically retrying it.
- Prevent an earlier render from persisting an auto-sent draft back into the cleared composer.
- Extend the existing composer continuity check and streaming-answer journey rather than adding a new journey file.

## Verification
**Verdict: Incomplete.** Focused checks passed on `99d504e9f`; executable end-to-end evidence is still missing.

| Command | Result |
| --- | --- |
| `pnpm --filter @openwork/app exec bun test --isolate tests/composer-focus-continuity.test.tsx tests/composer-state-store.test.ts` | Exit 0; 7 passed, 0 failed, 0 skipped; 48 assertions |
| `pnpm --filter @openwork/app typecheck` | Exit 0 |
| `pnpm evals:check-browser` | Exit 0; 737 browser callbacks checked |
| `git diff --check origin/dev...HEAD` | Exit 0 |

Covering runtime command: `pnpm evals:e2e streamed-markdown-answer`. Not executed: the default placement preflight finds authenticated Daytona, and new sandbox provisioning is deferred. The journey CLI was not launched, so there is no printed placement line, runtime test count, or publishable evidence run. Unit and static checks are not a substitute for that proof.

The added journey holds prompt submission at the transport boundary, checks immediate empty input and one visible pending message in existing/new conversations, then checks failure recovery without replacing newer typing. The existing streaming assertions cover server-message continuity and deduplication.

## Reproduction
1. In an existing conversation, type a message and Send while prompt submission is delayed. The input should clear immediately and exactly one user turn should appear before server acceptance.
2. Open New task and repeat. The first message should be visible while the conversation is created and should not reappear as composer text during the transition.
3. Type a newer draft while submission is pending, then fail the submission. The newer draft must remain untouched; clear it and choose Restore unsent message to recover the original. With no intervening edit, the original draft should restore directly.

Ready for review with the explicit Incomplete verdict; no merge or deployment included.