### PR TITLE
fix(app): keep attachment feedback during new chat creation

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -94,6 +94,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const submittingRef = useRef(false);
   const draftRevisionRef = useRef(0);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const [pendingAttachmentNames, setPendingAttachmentNames] = useState<string[]>([]);
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [failedSubmission, setFailedSubmission] = useState<{ text: string; attachments: ComposerAttachment[]; pastedText: PastedTextChip[] } | null>(null);
   const draftRef = useRef(props.draft);
@@ -259,6 +260,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     const resolved = resolvePastedTextPlaceholders(originalDraft, pastedText);
     const saved = { text: originalDraft, attachments, pastedText };
     setPendingPrompt(resolved.replace(/\[attachment [^\]]+\]/g, ""));
+    setPendingAttachmentNames(attachments.map((attachment) => attachment.name));
     setSubmissionError(null);
     props.onDraftChange("");
     draftRef.current = "";
@@ -276,6 +278,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       }
       setSubmissionError(error instanceof Error ? error.message : "Could not create the conversation. Try again.");
       setPendingPrompt(null);
+      setPendingAttachmentNames([]);
       submittingRef.current = false;
     }
   };
@@ -287,7 +290,17 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
 
   return (
     <>
-    {pendingPrompt !== null ? <div className="mb-4 whitespace-pre-wrap rounded-xl bg-muted px-4 py-3 text-sm" data-message-role="user">{pendingPrompt}</div> : null}
+    {pendingPrompt !== null ? <div className="mb-4 whitespace-pre-wrap rounded-xl bg-muted px-4 py-3 text-sm" data-message-role="user">
+      {pendingPrompt}
+      {pendingAttachmentNames.length > 0 ? <div role="status" className="mt-2 flex flex-wrap gap-2">
+        {pendingAttachmentNames.map((name, index) => (
+          <span key={index} className="inline-flex max-w-full items-center gap-2 rounded-xl border border-border/70 px-2 py-1 text-xs text-muted-foreground" data-attachment-status="preparing">
+            <span className="truncate" title={name}>{name}</span>
+            <span className="shrink-0">Preparing attachment...</span>
+          </span>
+        ))}
+      </div> : null}
+    </div> : null}
     {submissionError ? <div role="alert" className="mb-2 text-sm text-red-11">{submissionError}</div> : null}
     {failedSubmission ? <button type="button" disabled={Boolean(props.draft || attachments.length)} className="mb-2 text-sm disabled:opacity-50" onClick={() => {
       props.onDraftChange(failedSubmission.text);


### PR DESCRIPTION
## Summary

- Keep filenames visible with an accessible Preparing attachment status while a new conversation is being created, including attachment-only submissions.
- Clear the pending attachment status on creation failure alongside the pending prompt; existing explicit errors and draft restoration remain unchanged.
- File selection, paste, and drop already create chips synchronously. Existing-session upload feedback and validated-upload-before-send guards already exist and are unchanged.

## Cause

The immediate-send path clears the new-chat composer before session creation finishes. Its pending bubble retained only text and stripped attachment tokens, so attached files disappeared during that handoff. Retain only the submitted filenames for this pending display; do not introduce another upload lifecycle.

## Dependencies and overlap

- Based on current dev at ca0a4bd6f93ed7e54f02a546959753197ed2b544, including merged #4631. No unmerged dependency.
- Targeted overlap review included #4585. This change touches only new-task-composer.tsx, which is not in that PR. Video transport, model validation, streaming, optional send preparation, and starting-state behavior remain untouched.

## Verification

**Verdict: Incomplete.** Ready for review at requester direction, not a runtime-verified completion claim.

- Passed: git diff --check and git diff origin/dev...HEAD --check, exit 0.
- Commit 4b61ef4ae37ea6e74788f2be1167ea83b1297c8a has verified signing status G.
- Skipped at requester direction: all runtime tests, manual reproduction, typechecks, builds, installs, environment setup, and runtime evidence. No test placement or pass counts exist because no tests ran.
- Deferred coverage: extend the existing attachment-upload-loading-state journey to observe the new-chat creation handoff and failure restoration, then run pnpm evals:e2e attachment-upload-loading-state on the exact head when authorized. No spec changes are included in this bounded patch.

## Reproduction to verify (not run)

1. Start a new chat and select, paste, or drop files; verify chips appear immediately.
2. Submit while conversation creation is delayed. Verify each submitted filename remains visible with Preparing attachment, including an attachment-only submission, and a second submission stays blocked.
3. Let creation finish; verify the session takes over and upload completion precedes provider submission.
4. Repeat with conversation creation failing. Verify the explicit error, removal of pending status, and restoration of the original draft and attachments without overwriting newer edits.
