### PR TITLE
fix(app): show Starting feedback immediately after Send

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -865,10 +865,10 @@ const MessageComponent = React.memo(
 
 MessageComponent.displayName = "MessageComponent"
 
-const LoadingMessage = React.memo(({ elapsedSeconds }: { elapsedSeconds: number }) => (
+const LoadingMessage = React.memo(({ elapsedSeconds, starting }: { elapsedSeconds: number; starting: boolean }) => (
     <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
-      <div data-loading-message="working" className="py-1 text-sm text-muted-foreground">
-        <span className="ow-text-shimmer tabular-nums">Working {formatElapsedSeconds(elapsedSeconds)}</span>
+      <div role={starting ? "status" : undefined} data-loading-message={starting ? "starting" : "working"} className="py-1 text-sm text-muted-foreground">
+        <span className="ow-text-shimmer tabular-nums">{starting ? "Starting…" : `Working ${formatElapsedSeconds(elapsedSeconds)}`}</span>
       </div>
     </Message>
 ))
@@ -1493,7 +1493,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
       || child?.compacting || child?.retrying
   }))
   const isStreaming = status === "streaming" || status === "retrying"
-  const runActive = status === "submitted" || status === "streaming" || status === "retrying"
+  const runActive = status === "streaming" || status === "retrying"
   const syncDegraded = syncHealth?.degraded === true
   const activityActive = runActive || tasks.length > 0
   const runStartedAtRef = React.useRef<number | null>(null)
@@ -1598,7 +1598,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
         )
         }}
       >
-        {showLoading && <LoadingMessage elapsedSeconds={runElapsedSeconds} />}
+        {showLoading && <LoadingMessage elapsedSeconds={runElapsedSeconds} starting={status === "submitted"} />}
         {showReconnecting && <ReconnectingMessage lastConfirmedAt={syncHealth?.lastConfirmedAt ?? null} />}
         {retryStatus ? <RetryMessage status={retryStatus} /> : null}
         {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -417,7 +417,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
           : attachment.name}
       </span>)}
     </div> : null}
-    {pendingSubmission ? <div role="status" className="mb-2 text-xs text-muted-foreground">Creating conversation...</div> : null}
+    {pendingSubmission ? <div role="status" data-loading-message="starting" className="mb-2 text-sm text-muted-foreground">Starting…</div> : null}
     {submissionError ? <div role="alert" className="mb-2 text-sm text-red-11">{submissionError}</div> : null}
     {failedSubmission ? <button type="button" disabled={Boolean(props.draft || attachments.length)} className="mb-2 text-sm disabled:opacity-50" onClick={() => {
       restoreComposer(failedSubmission);

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1437,12 +1437,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!chatStreaming) setSteering(false);
   }, [chatStreaming]);
   const [evalThreadStatus, setEvalThreadStatus] = useState<ThreadStatus | null>(null);
+  const autoSendPayload = getComposerAutoSendPayload(props.sessionId, sessionOwner);
+  const autoSending = (Boolean(autoSendPayload)
+    || hasComposerAutoSend(props.sessionId))
+    && !sessionModelUnavailable;
   const status = useMemo((): ThreadStatus => {
     if (evalThreadStatus) return evalThreadStatus;
-    if (sending) {
-      return "submitted";
-    }
-
     if (liveStatus.type === "busy") {
       return "streaming";
     }
@@ -1451,8 +1451,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return "retrying";
     }
 
+    if (sending || autoSending) {
+      return "submitted";
+    }
+
     return "ready";
-  }, [evalThreadStatus, liveStatus, sending]);
+  }, [autoSending, evalThreadStatus, liveStatus, sending]);
   const [evalMarkdownMessages, setEvalMarkdownMessages] = useState<UIMessage[]>(EMPTY_TRANSCRIPT);
   useEffect(() => {
     setEvalMarkdownMessages(EMPTY_TRANSCRIPT);
@@ -1466,10 +1470,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const pendingMessages = useComposerStateStore((state) => state.pendingMessages[sessionOwner]);
   const [submittedMessage, setSubmittedMessage] = useState<{ owner: string; id: string } | null>(null);
   const failedDraft = useComposerStateStore((state) => state.failedDrafts[sessionOwner]?.[0]);
-  const autoSendPayload = getComposerAutoSendPayload(props.sessionId, sessionOwner);
-  const autoSending = (Boolean(autoSendPayload)
-    || hasComposerAutoSend(props.sessionId))
-    && !sessionModelUnavailable;
   const pendingReconciliation = useMemo(() => {
     const matchedIds = new Set<string>();
     const messages = [...baseRenderedMessages];

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -172,7 +172,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     composeNativeSessionSnapshot: async (_target: unknown, id: string) => id === otherSessionId ? otherSnapshot : snapshotRead ?? fetchedSnapshot,
   }));
   const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
-  const { snapshotKey, transcriptKey } = await import("../src/react-app/domains/session/sync/session-sync");
+  const { snapshotKey, statusKey, transcriptKey } = await import("../src/react-app/domains/session/sync/session-sync");
   const { useSessionArchive } = await import("../src/react-app/domains/session/sidebar/use-session-archive");
   const { claimQueuedSend, dispatchQueuedDrain, getQueuedDrainState, resetQueuedDrainForTests, subscribeQueuedDrain } = await import("../src/react-app/domains/session/surface/queued-drain-machine");
   const queryClient = getReactQueryClient();
@@ -186,6 +186,17 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   const client = createOpenworkServerClient({ baseUrl: "http://127.0.0.1:1", token: "test-token" });
   const container = document.createElement("div");
   document.body.append(container);
+  const expectStarting = () => {
+    const indicators = container.querySelectorAll('[data-loading-message="starting"]');
+    expect(indicators).toHaveLength(1);
+    expect(indicators[0]?.getAttribute("role")).toBe("status");
+    expect(indicators[0]?.textContent).toBe("Starting…");
+    expect(container.querySelector('[data-loading-message="working"]')).toBeNull();
+  };
+  const expectSettled = () => {
+    expect(container.querySelector('[data-loading-message="starting"]')).toBeNull();
+    expect(container.querySelector('[data-loading-message="working"]')).toBeNull();
+  };
   const root = createRoot(container);
   const draft = "Keep this draft while the task finishes";
   let submission = Promise.withResolvers<CloudMcpSubmissionResult>();
@@ -762,9 +773,23 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(editor.textContent).toBe("");
     expect(container.textContent).toContain(draft);
     expect(useComposerStateStore.getState().sessions[sessionId]).toBeUndefined();
+    expectStarting();
+
+    // Native activity must win even when the submission promise is still pending.
+    await act(async () => queryClient.setQueryData(statusKey(workspaceId, sessionId), { type: "busy" }));
+    await waitFor(() => container.querySelector('[data-loading-message="working"]') !== null, "confirmed activity during pending submission");
+    expect(container.querySelector('[data-loading-message="starting"]')).toBeNull();
+    await act(async () => queryClient.setQueryData(statusKey(workspaceId, sessionId), {
+      type: "retry", attempt: 1, message: "Retrying test request", next: Date.now() + 10_000,
+    }));
+    await waitFor(() => container.textContent?.includes("Retrying test request") === true, "retry feedback during pending submission");
+    expectSettled();
+    await act(async () => queryClient.setQueryData(statusKey(workspaceId, sessionId), { type: "idle" }));
+    await waitFor(() => container.querySelector('[data-loading-message="starting"]') !== null, "pending feedback after observed idle");
 
     await act(async () => useComposerStateStore.getState().setDraft(sessionId, "A newer draft"));
     await act(async () => submission.reject(new Error("Submission unavailable")));
+    expectSettled();
     expect(editor.textContent).toBe("A newer draft");
     expect(container.textContent).not.toContain(draft);
     expect(Object.values(useComposerStateStore.getState().failedDrafts).flat().map((item) => item.draft)).toEqual([draft]);
@@ -786,8 +811,10 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
     await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Dismiss error"]')?.click());
     await act(async () => send());
+    expectStarting();
     await act(async () => submission.resolve({ outcome: "cancelled", reason: "context_changed" }));
     expect(editor.textContent).toBe(draft);
+    expectSettled();
 
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
     const { composerAutoSendScopeKey, markComposerAutoSend } = await import("../src/react-app/domains/session/surface/composer-auto-send");
@@ -798,6 +825,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     await waitFor(() => sentDrafts.length === 3, "first-message auto-send");
     expect(editor.textContent).toBe("");
     expect(container.textContent).toContain("First message auto-send");
+    expectStarting();
     const messageId = sentDrafts[2]?.messageId;
     expect(messageId).toStartWith("msg_");
     await act(async () => {
@@ -813,6 +841,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
 
     const { PromptAdmissionUnknownError } = await import("../src/app/lib/opencode");
+    expectSettled();
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
     await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Uncertain send"));
     await act(async () => send());
@@ -906,6 +935,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
       .filter((row) => row.textContent?.includes("First submitted body"));
     expect(scopedPendingRows()).toHaveLength(1);
     expect(scopedPendingRows()[0]?.querySelector('img[alt="scoped.png"]')?.getAttribute("src")).toBe(scopedAttachment.previewUrl);
+    expectStarting();
     expect(editor.querySelector('[data-attachment-status="uploading"]')).toBeNull();
     expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
     await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Continuation B before preparation[attachment continuation-image]"));
@@ -920,6 +950,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(editor.textContent).toContain("Continuation B after preparation");
     const continuationAfterPreparation = useComposerStateStore.getState().sessions[sessionId];
     await act(async () => submission.reject(new Error("Scoped submission unavailable")));
+    expectSettled();
     expect(editor.textContent).toContain("Continuation B after preparation");
     expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationAfterPreparation);
     expect(continuationAfterPreparation?.attachments).toEqual([continuationAttachment]);
@@ -1222,12 +1253,13 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(creations).toBe(1);
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("");
     expect(container.querySelector('[data-message-role="user"]')?.textContent).toBe("First hero message");
-    expect(container.querySelector('[role="status"]')?.textContent).toBe("Creating conversation...");
+    expectStarting();
     expect(container.querySelector('button[aria-label="Creating conversation..."]')?.getAttribute("aria-busy")).toBe("true");
     expect(container.querySelector('button[aria-label="Preparing connected service tools…"]')).toBeNull();
     await act(async () => updateHeroDraft("Newer hero draft"));
     expect(capturedHandoff?.getContinuation().draft).toBe("Newer hero draft");
     await act(async () => creation.reject(new Error("Session creation failed")));
+    expectSettled();
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Newer hero draft");
     expect(container.textContent).toContain("Session creation failed");
     await act(async () => updateHeroDraft(""));
@@ -1246,12 +1278,13 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     });
     await act(async () => send());
     expect(creations).toBe(2);
-    expect(container.querySelector('[role="status"]')?.textContent).toBe("Creating conversation...");
+    expect(container.querySelector('[role="status"]')?.textContent).toBe("Starting…");
     expect(container.querySelector('button[aria-label="Creating conversation..."]')?.getAttribute("aria-busy")).toBe("true");
     expect(container.querySelector('button[aria-label="Preparing connected service tools…"]')).toBeNull();
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("");
     expect(container.querySelector('[data-message-role="user"]')?.textContent).toContain("First hero message");
     expect(container.querySelector('[data-message-role="user"] img[alt="photo.png"]')).not.toBeNull();
+    expectStarting();
     expect(container.querySelector("[data-attachment-id]")).toBeNull();
     expect(capturedHandoff?.getContinuation()).toEqual({ draft: "", attachments: [], mentions: {}, pasteParts: [], revertMessageId: null });
     expect(capturedHandoff?.submitted.attachments[0]?.file).toBe(attachment.file);

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -1101,6 +1101,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     await act(async () => {
       fetchedSnapshot = createSnapshot({ type: "busy" }, 30);
       queryClient.setQueryData(snapshotKey(workspaceId, sessionId), fetchedSnapshot);
+      queryClient.setQueryData(statusKey(workspaceId, sessionId), fetchedSnapshot.status);
       renderSession();
     });
     await waitFor(() => container.querySelector('button[aria-label="Stop"]') !== null, "busy session for queue promotion");
@@ -1226,6 +1227,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
       useComposerStateStore.getState().appendQueuedDraft(sessionId, queueDraft("Do not retry uncertain admission"));
       fetchedSnapshot = createSnapshot({ type: "idle" }, 31);
       queryClient.setQueryData(snapshotKey(workspaceId, sessionId), fetchedSnapshot);
+      queryClient.setQueryData(statusKey(workspaceId, sessionId), fetchedSnapshot.status);
     });
     await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Send now"]')?.click());
     expect(sentDrafts).toHaveLength(sendsBeforeQueue + 5);

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -15,7 +15,7 @@ import {
 } from "../src/components/chat/message-list";
 import { MessageListProvider } from "../src/components/chat/message-list-provider";
 import type { ThreadStatus } from "../src/lib/messages";
-import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import { useSessionActivityStore, type SessionActivityStatus } from "../src/react-app/domains/session/status/session-activity-store";
 import { activeDelegatedTasks, hasNoNewActivity, lastTaskProgressAt, transcriptProgress } from "../src/react-app/domains/session/status/session-progress";
 import type { TaskToolPart } from "../src/lib/build-in-tools";
 import { WorkspaceProvider } from "../src/react-app/shell/workspace-provider";
@@ -35,7 +35,7 @@ const userMessage: UIMessage = {
   parts: [{ type: "text", text: "Send this", state: "done" }],
 };
 
-function list(messages: UIMessage[], status: ThreadStatus, syncHealth?: RunSyncHealth) {
+function list(messages: UIMessage[], status: ThreadStatus, syncHealth?: RunSyncHealth, activityStatus: SessionActivityStatus = "thinking") {
   return (
     <PlatformProvider value={createDefaultPlatform()}>
     <MessageListProvider
@@ -56,7 +56,7 @@ function list(messages: UIMessage[], status: ThreadStatus, syncHealth?: RunSyncH
       onMcpReopenAuthorization={() => Promise.resolve()}
       onMcpRetry={() => {}}
     >
-      <MessageList messages={messages} status={status} activityStatus="thinking" syncHealth={syncHealth} />
+      <MessageList messages={messages} status={status} activityStatus={activityStatus} syncHealth={syncHealth} />
     </MessageListProvider>
     </PlatformProvider>
   );
@@ -114,7 +114,9 @@ describe("message-list loading feedback", () => {
   test("acknowledges a submitted message before streaming starts", () => {
     const markup = renderList([userMessage], "submitted");
 
-    expect(markup).toContain("Working 0s");
+    expect(markup).toContain('role="status" data-loading-message="starting"');
+    expect(markup).toContain("Starting…");
+    expect(markup).not.toContain("Working");
     expect(markup).toContain("ow-text-shimmer");
     expect(markup).not.toContain("animate-spin");
     expect(markup).not.toContain("PaperGrainGradient");
@@ -124,10 +126,11 @@ describe("message-list loading feedback", () => {
     expect(shouldShowMessageListLoading("submitted", 0)).toBe(false);
   });
 
-  test("keeps the same loading treatment when streaming begins", () => {
+  test("shows active work only when streaming begins", () => {
     const markup = renderList([userMessage], "streaming");
 
     expect(markup).toContain("Working 0s");
+    expect(markup).not.toContain("Starting");
     expect(markup).toContain("ow-text-shimmer");
     expect(markup).not.toContain("animate-spin");
     expect(markup).not.toContain("PaperGrainGradient");
@@ -135,6 +138,51 @@ describe("message-list loading feedback", () => {
 
   test("does not duplicate working feedback when a tool row is visible", () => {
     expect(shouldShowMessageListLoading("streaming", 2, true)).toBe(false);
+    expect(shouldShowMessageListLoading("submitted", 2, true)).toBe(false);
+  });
+
+  test.each<SessionActivityStatus>(["waiting", "compacting"])("does not mask %s with pending feedback", (activityStatus) => {
+    const markup = renderToStaticMarkup(list([userMessage], "submitted", undefined, activityStatus));
+    expect(markup).not.toContain('data-loading-message="starting"');
+    expect(markup).not.toContain('data-loading-message="working"');
+  });
+
+  test("does not start a work timer or age out pending feedback before confirmed activity", async () => {
+    const ownedDom = typeof window === "undefined";
+    if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+    const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    const interval = spyOn(window, "setInterval");
+    try {
+      await act(async () => { root.render(list([userMessage], "submitted")); });
+      expect(container.textContent).toContain("Starting…");
+      expect(interval).not.toHaveBeenCalled();
+      clock.mockReturnValue(62_000);
+      await act(async () => { root.render(list([userMessage], "submitted")); });
+      expect(container.textContent).toContain("Starting…");
+      expect(container.querySelector('[data-loading-message="working"]')).toBeNull();
+      expect(interval).not.toHaveBeenCalled();
+      await act(async () => {
+        useSessionActivityStore.getState().setRunStatus("ws", "session", { type: "busy" });
+        root.render(list([userMessage], "streaming"));
+      });
+      expect(container.textContent).toContain("Working 0s");
+      expect(container.querySelector('[data-loading-message="starting"]')).toBeNull();
+      expect(interval).toHaveBeenCalledTimes(1);
+      await act(async () => { root.render(list([userMessage], "ready")); });
+      expect(container.querySelector("[data-loading-message]")).toBeNull();
+    } finally {
+      await act(async () => { root.unmount(); });
+      container.remove();
+      interval.mockRestore();
+      clock.mockRestore();
+      Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+      if (ownedDom) await GlobalRegistrator.unregister();
+    }
   });
 });
 
@@ -150,7 +198,7 @@ const delegated: UIMessage = { id: "assistant", role: "assistant", parts: [task]
 const followup: UIMessage = { id: "followup", role: "user", parts: [{ type: "text", text: "What is the update?" }] };
 
 describe("task-linked meaningful progress", () => {
-  test.each<ThreadStatus>(["streaming", "ready"])("keeps delegated tasks before the follow-up while the parent is %s", (status) => {
+  test.each<ThreadStatus>(["submitted", "streaming", "ready"])("keeps delegated tasks before the follow-up while the parent is %s", (status) => {
     const messages = [userMessage, delegated, followup];
     expect(activeDelegatedTasks(messages)).toEqual([task]);
     const html = renderList(messages, status);
@@ -159,6 +207,7 @@ describe("task-linked meaningful progress", () => {
     expect(html).not.toContain('data-testid="active-subagents"');
     expect(html).not.toContain("data-subagent-history");
     expect(html).not.toContain('data-loading-message="working"');
+    expect(html).not.toContain('data-loading-message="starting"');
     expect(html).not.toContain("PRIVATE TASK PROMPT");
   });
 
@@ -396,6 +445,13 @@ describe("task-linked meaningful progress", () => {
 });
 
 describe("message-list reconnecting feedback", () => {
+  test("does not mask a degraded connection with Starting", () => {
+    const markup = renderList([userMessage], "submitted", { degraded: true, lastConfirmedAt: null });
+    expect(markup).toContain('data-loading-message="reconnecting"');
+    expect(markup).not.toContain('data-loading-message="starting"');
+    expect(markup).not.toContain('data-loading-message="working"');
+  });
+
   test("replaces the ticking working row when run liveness cannot be validated", () => {
     const markup = renderList([userMessage], "streaming", {
       degraded: true,

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -163,6 +163,9 @@ test("workspace New task is instantly typable and every v1 send paints before en
     return {
       rowCount: rows.length,
       markerOccurrences: marker ? rows.reduce((total, row) => total + row.innerText.split(marker).length - 1, 0) : 0,
+      starting: [...(root?.querySelectorAll<HTMLElement>('[data-loading-message="starting"]') ?? [])]
+        .filter(visible).map((node) => ({ role: node.getAttribute("role"), text: node.innerText.trim() })),
+      workingCount: [...(root?.querySelectorAll<HTMLElement>('[data-loading-message="working"]') ?? [])].filter(visible).length,
       composerText: /^\s*$/.test(rawComposerText) ? "" : rawComposerText,
       composerEditable: Boolean(editor?.isContentEditable),
       focusedEditor: Boolean(editor && (document.activeElement === editor || editor.contains(document.activeElement))),
@@ -208,10 +211,13 @@ test("workspace New task is instantly typable and every v1 send paints before en
     label,
     until: (state) => state.ready,
   });
-  const waitReply = (reply: string) => probe.eventually(() => surfaceContains(reply), {
+  const waitReply = (reply: string) => probe.eventually(async () => ({
+    visible: await surfaceContains(reply),
+    starting: (await visibleFacts(reply)).starting,
+  }), {
     within: 60_000,
-    label: `the deterministic v1 reply ${reply.slice(0, 32)} is visible`,
-    until: (visible) => visible,
+    label: `the deterministic v1 reply ${reply.slice(0, 32)} is visible without Starting`,
+    until: (facts) => facts.visible && facts.starting.length === 0,
   });
   const waitBackendMarker = (sessionId: string, marker: string) => probe.eventually(() => world.messageFacts(sessionId, marker), {
     within: 30_000,
@@ -344,7 +350,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         const requestBeforeSend = readFaults();
         const createGate = faults.holdNext("creation", "request");
         const promptGate = faults.holdNext("prompt", "request");
-        const rowObserver = await world.observeRenderer("user-row", scenario.marker);
+        const rowObserver = await world.observeRenderer("user-row", scenario.marker, true);
         await user.press("Enter");
         if (index === 0) await user.press("Enter");
         const lazySample = sample(index + 1, await rowObserver.read(), {
@@ -355,6 +361,9 @@ test("workspace New task is instantly typable and every v1 send paints before en
         lazySendSamples.push(lazySample);
         pendingMeasurement.current = { observer: rowObserver, sample: lazySample };
         const creationHeld = await waitHeld(createGate);
+        expect(await visibleFacts(scenario.marker)).toMatchObject({
+          starting: [{ role: "status", text: "Starting…" }], workingCount: 0,
+        });
         const beforeEngineState = await rowObserver.read();
         updateRendererSample(lazySample, beforeEngineState);
         lazySample.beforeEngine = beforeEngineState.elapsedMs !== null && beforeEngineState.elapsedMs < sendLimitMs;
@@ -377,6 +386,9 @@ test("workspace New task is instantly typable and every v1 send paints before en
         if (!createdSessionId) throw new Error(`Lazy sample ${index + 1} did not expose its created session id.`);
         expectedSessionId = createdSessionId;
         const promptHeld = await waitHeld(promptGate);
+        expect(await visibleFacts(scenario.marker)).toMatchObject({
+          starting: [{ role: "status", text: "Starting…" }], workingCount: 0,
+        });
         lazySample.secondHoldMs = promptHeld.elapsedMs;
         lazySample.secondHeldCount = promptHeld.held;
         const backendBeforePromptRelease = await Promise.all(createdIds.map((sessionId) => world.messageFacts(sessionId, scenario.marker)));
@@ -582,8 +594,8 @@ test("workspace New task is instantly typable and every v1 send paints before en
       || entry.firstHeldCount !== 1 || entry.secondHeldCount !== 1 || !entry.exact || !entry.typedWithoutClick)
       .map((entry) => entry.index);
     evidence.recordAssertionEvidence(
-      "Twelve lazy first sends paint before engine work within 100 ms",
-      JSON.stringify({ metric: "trusted Enter to second consecutive visible-row frame before held engine requests", limitMs: sendLimitMs, count: lazyTiming.count, expectedCount: sampleCount, p50Ms: lazyTiming.p50Ms, p95Ms: lazyTiming.p95Ms, maxMs: lazyTiming.maxMs, failureIndices: lazyFailureIndices }),
+      "Twelve lazy first sends paint their user row and Starting before engine work within 100 ms",
+      JSON.stringify({ metric: "trusted Enter to second consecutive user-row and Starting frame before held engine requests", limitMs: sendLimitMs, count: lazyTiming.count, expectedCount: sampleCount, p50Ms: lazyTiming.p50Ms, p95Ms: lazyTiming.p95Ms, maxMs: lazyTiming.maxMs, failureIndices: lazyFailureIndices }),
       lazyTiming.count === sampleCount && lazyFailureIndices.length === 0,
     );
 
@@ -597,12 +609,15 @@ test("workspace New task is instantly typable and every v1 send paints before en
         const requestBefore = readFaults();
         const inventoryBefore = await world.sessionIds();
         const promptGate = faults.holdNext("prompt", "request");
-        const rowObserver = await world.observeRenderer("user-row", scenario.marker);
+        const rowObserver = await world.observeRenderer("user-row", scenario.marker, true);
         await user.press("Enter");
         const existingSample = sample(index + 1, await rowObserver.read(), { beforeEngine: false, exact: false });
         existingSendSamples.push(existingSample);
         pendingMeasurement.current = { observer: rowObserver, sample: existingSample };
         const held = await waitHeld(promptGate);
+        expect(await visibleFacts(scenario.marker)).toMatchObject({
+          starting: [{ role: "status", text: "Starting…" }], workingCount: 0,
+        });
         const beforeEngineState = await rowObserver.read();
         updateRendererSample(existingSample, beforeEngineState);
         existingSample.beforeEngine = beforeEngineState.elapsedMs !== null && beforeEngineState.elapsedMs < sendLimitMs;
@@ -634,8 +649,8 @@ test("workspace New task is instantly typable and every v1 send paints before en
       || entry.firstHoldMs < boundaryHoldMs || entry.firstHeldCount !== 1 || !entry.exact)
       .map((entry) => entry.index);
     evidence.recordAssertionEvidence(
-      "Twelve existing-session sends paint before engine work within 100 ms",
-      JSON.stringify({ metric: "trusted Enter to second consecutive visible-row frame before held engine request", limitMs: sendLimitMs, count: existingTiming.count, expectedCount: sampleCount, p50Ms: existingTiming.p50Ms, p95Ms: existingTiming.p95Ms, maxMs: existingTiming.maxMs, failureIndices: existingFailureIndices }),
+      "Twelve existing-session sends paint their user row and Starting before engine work within 100 ms",
+      JSON.stringify({ metric: "trusted Enter to second consecutive user-row and Starting frame before held engine request", limitMs: sendLimitMs, count: existingTiming.count, expectedCount: sampleCount, p50Ms: existingTiming.p50Ms, p95Ms: existingTiming.p95Ms, maxMs: existingTiming.maxMs, failureIndices: existingFailureIndices }),
       existingTiming.count === sampleCount && existingFailureIndices.length === 0,
     );
 
@@ -709,6 +724,9 @@ test("workspace New task is instantly typable and every v1 send paints before en
       const creationRow = await world.observeRenderer("user-row", world.failure.creationA);
       await user.press("Enter");
       await waitHeld(creationGate);
+      expect(await visibleFacts(world.failure.creationA)).toMatchObject({
+        starting: [{ role: "status", text: "Starting…" }], workingCount: 0,
+      });
       await world.insertFocusedText(world.failure.creationB);
       await creationGate.fail();
       await user.see({ text: originalFailureMessage }, { timeoutMs: 15_000 });
@@ -720,6 +738,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         label: "creation failure preserves editable draft B, the original failure, and a guarded restore action",
         until: (state) => state.composer.composerEditable
           && state.composer.composerText === world.failure.creationB
+          && state.composer.starting.length === 0 && state.composer.workingCount === 0
           && state.recovery.failureMessage.includes(originalFailureMessage)
           && state.recovery.restoreVisible && state.recovery.restoreDisabled === true,
       });
@@ -745,6 +764,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         label: "the real new-task restore action restores exactly failed payload A",
         until: (state) => state.composer.composerEditable
           && state.composer.composerText === world.failure.creationA
+          && state.composer.starting.length === 0 && state.composer.workingCount === 0
           && state.composer.rowCount === 0 && state.composer.markerOccurrences === 0
           && !state.recovery.restoreVisible,
       });
@@ -780,6 +800,9 @@ test("workspace New task is instantly typable and every v1 send paints before en
       const promptRow = await world.observeRenderer("user-row", world.failure.promptA);
       await user.press("Enter");
       await waitHeld(promptGate);
+      expect(await visibleFacts(world.failure.promptA)).toMatchObject({
+        starting: [{ role: "status", text: "Starting…" }], workingCount: 0,
+      });
       await world.insertFocusedText(world.failure.promptB);
       await promptGate.fail();
       await user.see({ text: originalFailureMessage }, { timeoutMs: 15_000 });
@@ -791,6 +814,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         label: "prompt failure preserves editable draft B, the original failure, and a guarded restore action",
         until: (state) => state.composer.composerEditable
           && state.composer.composerText === world.failure.promptB
+          && state.composer.starting.length === 0 && state.composer.workingCount === 0
           && state.recovery.failureMessage.includes(originalFailureMessage)
           && state.recovery.restoreVisible && state.recovery.restoreDisabled === true,
       });
@@ -816,6 +840,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         label: "the real existing-session restore action restores exactly failed payload A",
         until: (state) => state.composer.composerEditable
           && state.composer.composerText === world.failure.promptA
+          && state.composer.starting.length === 0 && state.composer.workingCount === 0
           && state.composer.rowCount === 0 && state.composer.markerOccurrences === 0
           && !state.recovery.restoreVisible,
       });

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -68,8 +68,9 @@ async function observeInstantRenderer(
   workspaceId: string,
   kind: InstantMetricKind,
   marker = "",
+  requireStarting = false,
 ) {
-  await seed.evalIn(app, browserScript((workspaceId, kind, marker) => {
+  await seed.evalIn(app, browserScript((workspaceId, kind, marker, requireStarting) => {
     if (window.__instantSendMetric) throw new Error("An instant-send renderer observer is already active");
     const state: InstantRendererState = {
       kind, started: false, trusted: false, elapsedMs: null, frames: 0,
@@ -127,6 +128,11 @@ async function observeInstantRenderer(
         const hit = document.elementFromPoint(x, y);
         return hit instanceof Node && node.contains(hit);
       }
+      if (requireStarting) {
+        const starting = [...surface.root.querySelectorAll<HTMLElement>('[data-loading-message="starting"]')].filter(visibleInViewport);
+        if (starting.length !== 1 || starting[0]?.getAttribute("role") !== "status" || starting[0]?.innerText.trim() !== "Starting…"
+          || [...surface.root.querySelectorAll<HTMLElement>('[data-loading-message="working"]')].some(visibleInViewport)) return false;
+      }
       const composer = editor();
       return [...surface.root.querySelectorAll<HTMLElement>('[data-message-role="user"]')]
         .some((row) => visibleInViewport(row) && row.innerText.includes(marker)
@@ -167,7 +173,7 @@ async function observeInstantRenderer(
       window.removeEventListener(eventName, capture, true);
     }
     window.__instantSendMetric = { state, stop };
-  }, [workspaceId, kind, marker]));
+  }, [workspaceId, kind, marker, requireStarting]));
   let disposed = false;
   return {
     async read(): Promise<InstantRendererState> {
@@ -1340,7 +1346,7 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
     prepareWorkspaceNewTask,
     clickWorkspaceNewTask,
     accessibleRunTaskReady,
-    observeRenderer: (kind: InstantMetricKind, marker = "") => observeInstantRenderer(seed, app, workspace.workspaceId, kind, marker),
+    observeRenderer: (kind: InstantMetricKind, marker = "", requireStarting = false) => observeInstantRenderer(seed, app, workspace.workspaceId, kind, marker, requireStarting),
     [Symbol.asyncDispose]: () => resources.disposeAsync(),
   };
 }

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1188,6 +1188,15 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
   }, [workspace.workspaceId, point.x, point.y]));
   const prepareWorkspaceNewTask = async (): Promise<Point> => {
     const deadline = Date.now() + 5_000;
+    // A reload can leave the pointer over the replacement header. Leave it
+    // before entering again so the real hover transition is rearmed.
+    await hoverAt(app, { x: 0, y: 0 });
+    let outside = await newTaskGeometry({ x: 0, y: 0 });
+    while (outside.headerHover && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      outside = await newTaskGeometry({ x: 0, y: 0 });
+    }
+    if (outside.headerHover) throw new Error("New task header did not release hover before re-entry");
     const reset = await seed.evalIn(app, browserScript((workspaceId) => {
       const workspace = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"]`);
       const plus = workspace?.querySelector<HTMLElement>("[data-workspace-new-task]") ?? null;


### PR DESCRIPTION
## Summary

Distinguish a pending send from confirmed work without undoing immediate-message rendering, attachment preparation, draft continuity, interruption or admission protections.

- Show **Starting...** for text and attachment submissions while creating a conversation, through the immutable auto-send handoff, and while an idle-session submission is pending.
- Give observed busy/retry status precedence over a pending submission promise. Do not start a Working timer merely because a send is pending.
- Preserve waiting, compaction, delegated-task, visible-tool and reconnecting treatments rather than overlaying Starting.
- Reuse rejection/cancellation cleanup and draft recovery. No transport, queue, attachment-preparation or persistent-state changes.

## Current-dev review

Reviewed existing signed head `640bdf096512501ed7e18c7f51941c1b8ba934b3` against freshly fetched `dev@858414c41c63a22eecfe331d17f3f5dd348dfc6f`. Rebase reports up to date; merge base equals that exact dev SHA. All three branch commits verify with `G` and Jalil's author identity. No new commit or force push was necessary.

Current dev still starts the Working lifecycle for submitted state and prioritizes pending send over observed engine activity. This remains a useful, small increment. The branch preserves dev's progressive message footer, creation busy-button, connected-service preparation, immutable handoff and admission protections. Its fixture aligns live-status and snapshot seeds; no production assertion is weakened. No review threads were present at review time.

The native-session fixture exports and prior scan-limit adjustment are already in dev and are excluded. This PR does not change review policy configuration. The journey's hover re-arming repair remains useful.

## Verification: Incomplete

Passed again in a fresh isolated checkout of the current head, with frozen offline app dependencies (all commands exit 0):

```sh
corepack pnpm --filter @openwork/app exec bun test --isolate ./tests/message-list-loading.test.tsx -t 'message-list loading feedback|message-list reconnecting feedback|keeps delegated tasks'
# 17 passed, 0 failed, 7 filtered out; 76 assertions
corepack pnpm --filter @openwork/app exec bun test --isolate ./tests/composer-focus-continuity.test.tsx
# 1 passed, 0 failed; 476 assertions
git diff --check origin/dev...HEAD
```

These are supporting component checks, not real-engine runtime evidence. React duplicate-key warnings were emitted by the composer fixture; they did not fail its assertions and remain unresolved by this PR.

- Failed: no selected check failed in this review.
- Skipped/not run: the seven unrelated filtered component cases and broad suites.
- Deferred: exact-head cold-boot runtime proof, cross-engine/provider/platform validation, and manual model-backed review. No paid resources or local E2E were run.

The existing covering journey is `pnpm evals:e2e workspace-new-task-hit-target`. It holds creation and prompt requests, observes Starting without Working, and checks exact-once sends, continuation preservation, recovery, navigation isolation and SSE-before-HTTP reconciliation.

All previously published runtime evidence is historical, including `52bf1e019b49b60807a1ec22d9930fb8ec6905e7` and `f981e6cdc3ff0a9363ef0f7715badd52aa52efd1`; it is not proof for `640bdf096512501ed7e18c7f51941c1b8ba934b3`. No merge, deployment, review request or branch deletion is included.
