### PR TITLE
perf(app): avoid redundant composer draft sync during streaming

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -16,7 +16,7 @@ import {
   type ComposerSettingsSection,
 } from "@/react-app/domains/settings/library";
 import { ModelSelect } from "@/components/model-select";
-import { LexicalPromptEditor, syncAttachmentChipStatus, type LexicalPromptEditorHandle } from "./editor";
+import { LexicalPromptEditor, syncAttachmentChipStatus, type ComposerAttachmentToken, type LexicalPromptEditorHandle } from "./editor";
 import { listRunningAppsForMention } from "./app-mentions";
 import { COMPUTER_MENTIONS } from "./computer-mentions";
 import type { ComposerMentionKind } from "./mention-encoding";
@@ -726,6 +726,16 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
     () => props.pastedText.map((item) => ({ label: item.label, lines: item.lines, text: item.text })),
     [props.pastedText],
   );
+  // Stable tokens keep streaming renders from re-running Lexical's draft sync.
+  const attachmentTokens = useMemo<ComposerAttachmentToken[]>(
+    () => props.attachments.map((attachment) => ({
+      id: attachment.id,
+      name: attachment.name,
+      kind: isImageAttachment(attachment) ? "image" : "file",
+      previewUrl: attachment.previewUrl,
+    })),
+    [props.attachments],
+  );
 
   const handleExpandPastedText = useCallback((label: string) => {
     const target = props.pastedText.find((item) => item.label === label);
@@ -1314,12 +1324,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
               value={props.draft}
               mentions={props.mentions}
               pastedText={pastedTextTokens}
-              attachments={props.attachments.map((attachment) => ({
-                id: attachment.id,
-                name: attachment.name,
-                kind: isImageAttachment(attachment) ? "image" : "file",
-                previewUrl: attachment.previewUrl,
-              }))}
+              attachments={attachmentTokens}
               submitDisabled={props.disabled}
               placeholder={t("composer.placeholder")}
               onChange={props.onDraftChange}


### PR DESCRIPTION
## Summary
- Memoize composer attachment tokens using the same pattern as pasted-text tokens.
- Previously, each composer render allocated a fresh attachment array, including when empty. That changed a Lexical SyncPlugin effect dependency and serialized the current draft before its unchanged-value bailout. Streaming parent renders could therefore repeatedly scan an untouched draft.
- Preserve normal updates when attachments change. No custom prop comparator, deferred draft state, streaming throttle, first-token delay, or send-path changes.

## Scope and dependencies
- Independent change against current dev; no unmerged dependencies.
- Existing streaming improvements #4104, #4130, #4422, and #4614 are merged, as is optimistic send #4631. This addresses the remaining composer token identity issue rather than duplicating those changes.
- Open #4585 changes streaming Markdown recovery and video attachments, but does not change this composer file. Attachment upload feedback, submission preparation, and Starting state are outside this change.

## Verification
**Incomplete**: tests, builds, installs, runtime profiling, and environment setup were skipped at requester direction. Ready for review as explicitly requested; no runtime performance result is claimed.

- Passed: `git diff --check` and `git diff --check origin/dev...HEAD` (exit 0).
- Signed commit verified with `git log --format="%H %G? %s" origin/dev..HEAD`: signature status `G`.

## Reviewer reproduction (not run)
1. Open a conversation and request a long streaming Markdown response.
2. While the response streams, type and edit a long multiline follow-up draft with no attachments. Confirm text and cursor remain intact, and queue or steer immediately after the last keystroke.
3. Repeat with an attachment and pasted-text chip. Add/remove an attachment and confirm chip content and submission remain current.
4. With React profiling enabled, inspect Lexical SyncPlugin while streaming without editing the draft: unchanged attachment tokens should no longer retrigger its draft-serialization effect. Confirm actual draft edits still synchronize and the first streamed token is not delayed.

Runtime assertions and a measured responsiveness comparison remain deferred.