### PR TITLE
fix(app): clarify run activity and protect follow-up admission

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -44,7 +44,36 @@ export type OpencodeAuth = {
 const DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS = 10_000;
 const OAUTH_OPENCODE_REQUEST_TIMEOUT_MS = 5 * 60_000;
 const MCP_AUTH_OPENCODE_REQUEST_TIMEOUT_MS = 90_000;
-const SESSION_LONG_RUNNING_URL_RE = /\/session\/[^/?#]+\/(?:command|prompt_async|summarize)(?:[?#]|$)/;
+// Bound the acceptance handshake, not the task. A timeout leaves admission
+// unknown, so the transport must never automatically resend the prompt.
+const PROMPT_ASYNC_REQUEST_TIMEOUT_MS = 30_000;
+const SESSION_LONG_RUNNING_URL_RE = /\/session\/[^/?#]+\/(?:command|summarize)(?:[?#]|$)/;
+const SESSION_PROMPT_ASYNC_URL_RE = /\/session\/[^/?#]+\/prompt_async(?:[?#]|$)/;
+
+export class PromptAdmissionUnknownError extends Error {
+  readonly admission = "unknown";
+
+  constructor(options?: { cause?: unknown; messageID?: string }) {
+    super("Message acceptance is unknown. It may already be running; do not resend it while checking the conversation.", { cause: options?.cause });
+    this.name = "PromptAdmissionUnknownError";
+    this.messageID = options?.messageID;
+  }
+
+  readonly messageID?: string;
+}
+
+export function isPromptAdmissionUnknown(error: unknown): error is PromptAdmissionUnknownError {
+  return error instanceof PromptAdmissionUnknownError;
+}
+
+let lastMessageStamp = 0;
+
+/** Native sortable msg_ format. This identifies a submission, NOT an idempotency key. */
+export function createPromptMessageID(): string {
+  lastMessageStamp = Math.max(Date.now() * 0x1000, lastMessageStamp + 1);
+  // Native stores the low six bytes of the timestamp/counter, then 14 random characters.
+  return `msg_${lastMessageStamp.toString(16).padStart(12, "0").slice(-12)}${crypto.randomUUID().replaceAll("-", "").slice(0, 14)}`;
+}
 
 function getRequestUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;
@@ -57,6 +86,9 @@ function resolveRequestTimeoutMs(input: RequestInfo | URL, fallbackMs: number): 
   const url = getRequestUrl(input);
   if (SESSION_LONG_RUNNING_URL_RE.test(url)) {
     return 0;
+  }
+  if (SESSION_PROMPT_ASYNC_URL_RE.test(url)) {
+    return Math.max(fallbackMs, PROMPT_ASYNC_REQUEST_TIMEOUT_MS);
   }
   if (/\/provider\/oauth\//.test(url) || /\/mcp\/auth\/callback\b/.test(url)) {
     return Math.max(fallbackMs, OAUTH_OPENCODE_REQUEST_TIMEOUT_MS);
@@ -79,7 +111,7 @@ async function postSessionRequest<T>(
   baseUrl: string,
   path: string,
   body: Record<string, unknown>,
-  options?: { headers?: Record<string, string>; directory?: string; throwOnError?: boolean },
+  options?: { headers?: Record<string, string>; directory?: string; throwOnError?: boolean; signal?: AbortSignal },
 ): Promise<FieldsResult<T>> {
   const headers = new Headers(options?.headers);
   headers.set("Content-Type", "application/json");
@@ -92,6 +124,7 @@ async function postSessionRequest<T>(
     method: "POST",
     headers,
     body: JSON.stringify(body),
+    signal: options?.signal,
   });
 
   const request = new Request(`${baseUrl}${path}`, {
@@ -101,7 +134,13 @@ async function postSessionRequest<T>(
   });
 
   if (response.ok) {
-    const data = response.status === 204 ? ({} as T) : ((await response.json()) as T);
+    let data: T;
+    try {
+      data = response.status === 204 ? ({} as T) : ((await response.json()) as T);
+    } catch (cause) {
+      if (SESSION_PROMPT_ASYNC_URL_RE.test(path)) throw new PromptAdmissionUnknownError({ cause });
+      throw cause;
+    }
     return { data, request, response };
   }
 
@@ -162,8 +201,17 @@ async function fetchWithTimeout(
   });
 
   try {
-    return await Promise.race([fetchImpl(input, initWithSignal), timeoutPromise]);
+    const response = await Promise.race([fetchImpl(input, initWithSignal), timeoutPromise]);
+    // A proxy/server failure can happen after native admission. Only an
+    // explicit client rejection establishes that the prompt was not accepted.
+    if (SESSION_PROMPT_ASYNC_URL_RE.test(getRequestUrl(input)) && (response.status >= 500 || response.status === 408)) {
+      throw new PromptAdmissionUnknownError();
+    }
+    return response;
   } catch (error) {
+    if (SESSION_PROMPT_ASYNC_URL_RE.test(getRequestUrl(input))) {
+      throw isPromptAdmissionUnknown(error) ? error : new PromptAdmissionUnknownError({ cause: error });
+    }
     const name = (error && typeof error === "object" && "name" in error ? (error as any).name : "") as string;
     if (name === "AbortError") {
       throw new Error("Request timed out.");
@@ -260,6 +308,7 @@ export function unwrap<T>(result: FieldsResult<T>): NonNullable<T> {
   if (result.data !== undefined) {
     return result.data as NonNullable<T>;
   }
+  if (isPromptAdmissionUnknown(result.error)) throw result.error;
   const message =
     result.error instanceof Error
       ? result.error.message
@@ -298,17 +347,23 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
     command: (parameters: CommandParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<{}>>;
   };
 
-  const promptAsyncOriginal = sessionOverrides.promptAsync.bind(session);
-  sessionOverrides.promptAsync = (parameters: PromptAsyncParameters, options?: { throwOnError?: boolean }) => {
-    if (!openworkMount && !("reasoning_effort" in parameters)) {
-      return promptAsyncOriginal(parameters, options);
-    }
+  sessionOverrides.promptAsync = async (parameters: PromptAsyncParameters, options?: { throwOnError?: boolean }) => {
     const { sessionID, directory: requestDirectory, ...body } = parameters;
-    return postSessionRequest(fetchImpl, baseUrl, `/session/${encodeURIComponent(sessionID)}/prompt_async`, body, {
-      headers: Object.keys(headers).length ? headers : undefined,
-      directory: requestDirectory ?? directory,
-      throwOnError: options?.throwOnError,
-    });
+    try {
+      // Keep the tagged transport failure intact instead of serializing it
+      // through the SDK's error result. Native still receives prompt_async.
+      return await withAdmissionDeadline(PROMPT_ASYNC_REQUEST_TIMEOUT_MS, (signal) => postSessionRequest(fetchImpl, baseUrl, `/session/${encodeURIComponent(sessionID)}/prompt_async`, body, {
+        headers: Object.keys(headers).length ? headers : undefined,
+        directory: requestDirectory ?? directory,
+        throwOnError: options?.throwOnError,
+        signal,
+      }), () => new PromptAdmissionUnknownError({ messageID: parameters.messageID }));
+    } catch (error) {
+      if (isPromptAdmissionUnknown(error)) {
+        throw new PromptAdmissionUnknownError({ cause: error, messageID: parameters.messageID });
+      }
+      throw error;
+    }
   };
 
   const commandOriginal = sessionOverrides.command.bind(session);
@@ -325,6 +380,32 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
   };
 
   return client;
+}
+
+/** Includes body consumption: receiving headers alone cannot release a send lock. */
+async function withAdmissionDeadline<T>(timeoutMs: number, operation: (signal: AbortSignal) => Promise<T>, timeoutError: () => Error): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(timeoutError());
+      controller.abort();
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation(controller.signal), deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function hasAcceptedPromptMessage(client: ReturnType<typeof createClient>, sessionID: string, messageID: string): Promise<boolean> {
+  const result = await withAdmissionDeadline(DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS,
+    (signal) => client.session.message({ sessionID, messageID }, { signal }),
+    () => new Error("Acceptance check timed out. The message is still held."));
+  const message = result.data?.info;
+  // Absence (including a transient 404) is not proof of rejection.
+  return message?.id === messageID && message.sessionID === sessionID && message.role === "user";
 }
 
 export async function waitForHealthy(

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -91,7 +91,7 @@ import { CodeModeTool } from "@/components/chat/code-mode-tool"
 import { codeModeToolCalls } from "@/lib/code-mode-tools"
 import { hasPreservedMcpAppResult, McpAppFrame } from "@/components/chat/mcp-app-frame"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
-import { SubagentRunLine } from "@/components/chat/subagent-run-line"
+import { ActiveSubagentTasksContext, SubagentRunLine } from "@/components/chat/subagent-run-line"
 import { ToolAggregateGroup } from "@/components/chat/tool-aggregate-group"
 import {
   CurrentToolLifecycleProvider,
@@ -109,13 +109,17 @@ import {
   isReadToolPart,
   isSkillToolPart,
   isTaskToolPart,
+  taskChildSessionId,
   isTodoWriteToolPart,
   isWebFetchToolPart,
   isWebSearchToolPart,
   isWriteToolPart,
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
-import type { SessionActivityStatus } from "@/react-app/domains/session/status/session-activity-store"
+import { useSessionActivityStore, type SessionActivityStatus } from "@/react-app/domains/session/status/session-activity-store"
+import { activeDelegatedTasks, delegatedActivityTitle, hasNoNewActivity, lastTaskProgressAt } from "@/react-app/domains/session/status/session-progress"
+import { revalidateWorkspaceSessionSync } from "@/react-app/domains/session/sync/session-sync"
+import { useWorkspaceMaybe } from "@/react-app/shell/workspace-provider"
 import { formatElapsedSeconds, formatToolCallDuration } from "@/lib/tool-call-duration"
 import { collectLatestAssistantToolParts } from "@/lib/latest-assistant-tool-parts"
 import { isToolPartInFlight } from "@/lib/tool-activity"
@@ -185,6 +189,9 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
   const { connectorIdentities, onMcpReconnect, onMcpReopenAuthorization, onMcpRetry } = useMessageList()
   const resolveLifecycle = useCurrentToolLifecycleResolver()
   const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
+
+  // Delegated work has its own lifecycle, even after a parent follow-up/error.
+  if (isTaskToolPart(part)) return <SubagentRunLine part={part} />
 
   if (part.type === "dynamic-tool") {
     const calls = codeModeToolCalls(part)
@@ -289,10 +296,6 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 
   if (part.type === "dynamic-tool" && isAutomationProposalToolPart(part)) {
     return <OpenWorkAutomationProposalTool part={part} />
-  }
-
-  if (isTaskToolPart(part)) {
-    return <SubagentRunLine part={part} />
   }
 
   // Failed calls use the same sentence line with the "failures are
@@ -832,6 +835,7 @@ const MessageComponent = React.memo(
         <ErrorMessage
           error={getMessagesText([message]) || "Session failed"}
           description={presentation?.description}
+          showDescriptionOnResume={presentation?.kind === "provider-incomplete"}
           resumePrompt={presentation?.recoveryPrompt}
           technicalDetails={presentation?.technicalDetails}
         />
@@ -925,7 +929,9 @@ ReconnectingMessage.displayName = "ReconnectingMessage"
 interface ErrorMessageProps {
   error: string | null
   description?: string | null
-  /** Set only for interrupted runs (aborted / provider timeout) that can resume. */
+  /** Keep safety guidance visible without expanding ordinary interruption rows. */
+  showDescriptionOnResume?: boolean
+  /** Set only for interrupted runs that can resume. */
   resumePrompt?: string | null
   /** Error type, status, provider, code, response body — for bug reports and support. */
   technicalDetails?: string | null
@@ -993,7 +999,7 @@ function SessionErrorTechnicalDetails({ details, tone }: { details: string; tone
   )
 }
 
-function ErrorMessage({ error, description, resumePrompt, technicalDetails }: ErrorMessageProps) {
+function ErrorMessage({ error, description, showDescriptionOnResume, resumePrompt, technicalDetails }: ErrorMessageProps) {
   const { onResumeInterrupted, developerMode } = useMessageList()
   // Status codes, provider names, and response bodies are for developers,
   // admins, and support — not the plain-language card end users see. They
@@ -1022,6 +1028,11 @@ function ErrorMessage({ error, description, resumePrompt, technicalDetails }: Er
             {t("session.resume_interrupted")}
           </button>
         </div>
+        {showDescriptionOnResume && description ? (
+          <p data-testid="session-error-interruption-warning" className="text-sm text-muted-foreground whitespace-pre-wrap">
+            {description}
+          </p>
+        ) : null}
         {details ? <SessionErrorTechnicalDetails details={details} tone="line" /> : null}
       </Message>
     )
@@ -1035,7 +1046,7 @@ function ErrorMessage({ error, description, resumePrompt, technicalDetails }: Er
             <AlertTriangle aria-hidden="true" size={16} className="mt-0.5 shrink-0 text-destructive" />
             <div className="flex flex-col gap-1">
               <p className="whitespace-pre-wrap text-destructive">{error}</p>
-              {description && !resumePrompt ? (
+              {description && (!resumePrompt || showDescriptionOnResume) ? (
                 <p className="text-sm text-destructive/80 whitespace-pre-wrap">{description}</p>
               ) : null}
             </div>
@@ -1465,9 +1476,27 @@ export function shouldShowRunReconnecting(status: ThreadStatus, syncDegraded: bo
 }
 
 export function MessageList({ messages, status, activityStatus, retryStatus, syncHealth }: MessageListProps) {
+  const { workspaceId, sessionId } = useMessageList()
+  const workspace = useWorkspaceMaybe()
+  const tasks = React.useMemo(() => activeDelegatedTasks(messages), [messages])
+  const carriedTaskIds = React.useMemo(() => new Set(tasks.map((part) => part.toolCallId)), [tasks])
+  const [observedAt] = React.useState(() => Date.now())
+  const lastProgressAt = useSessionActivityStore((state) => {
+    const records = state.recordsByWorkspaceId[workspaceId]
+    const own = records?.[sessionId]
+    return lastTaskProgressAt(Math.max(own?.runStartedAt || observedAt, own?.lastProgressAt ?? 0), tasks, records)
+  })
+  const childBlocked = useSessionActivityStore((state) => tasks.some((part) => {
+    const id = taskChildSessionId(part)
+    const child = id ? state.recordsByWorkspaceId[workspaceId]?.[id] : undefined
+    return (child?.waitingPermissionIds.length ?? 0) > 0 || (child?.waitingQuestionIds.length ?? 0) > 0
+      || child?.compacting || child?.retrying
+  }))
   const isStreaming = status === "streaming" || status === "retrying"
   const runActive = status === "submitted" || status === "streaming" || status === "retrying"
   const syncDegraded = syncHealth?.degraded === true
+  const activityActive = runActive || tasks.length > 0
+  const delegationTitle = useSessionActivityStore((state) => delegatedActivityTitle(tasks, state.recordsByWorkspaceId[workspaceId], syncDegraded, runActive))
   const runStartedAtRef = React.useRef<number | null>(null)
   const [runElapsedSeconds, setRunElapsedSeconds] = React.useState(0)
   // Anchor the counter to the user message that started the run (server
@@ -1483,7 +1512,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
     return null
   }, [messages, runActive])
   React.useEffect(() => {
-    if (!runActive) {
+    if (!activityActive) {
       runStartedAtRef.current = null
       setRunElapsedSeconds(0)
       return
@@ -1502,7 +1531,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
     updateElapsed()
     const interval = window.setInterval(updateElapsed, 1000)
     return () => window.clearInterval(interval)
-  }, [runActive, runStartedAt, syncDegraded])
+  }, [activityActive, runStartedAt, syncDegraded])
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
   const hasSessionErrorMessage = React.useMemo(() => messages.some(isSessionErrorMessage), [messages])
@@ -1511,14 +1540,27 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
     [messages],
   )
   const hasVisibleToolActivity = latestAssistantToolParts.some(isToolPartInFlight)
-  const showReconnecting = shouldShowRunReconnecting(status, syncDegraded)
-  const showLoading = !showReconnecting && shouldShowMessageListLoading(status, messages.length, hasVisibleToolActivity)
+  const waiting = activityStatus === "waiting" || activityStatus === "compacting" || childBlocked
+  const showReconnecting = !waiting && !retryStatus && shouldShowRunReconnecting(status, syncDegraded)
+  const noNewActivity = hasNoNewActivity({
+    active: activityActive && activityStatus !== "error", waiting, retrying: status === "retrying" || Boolean(retryStatus),
+    disconnected: syncDegraded, lastProgressAt, now: Date.now(),
+  })
+  const showLoading = !waiting && !noNewActivity && !showReconnecting && tasks.length === 0
+    && shouldShowMessageListLoading(status, messages.length, hasVisibleToolActivity)
+  const baseUrl = workspace?.opencodeBaseUrl
+  React.useEffect(() => {
+    if (!noNewActivity || !baseUrl) return
+    // Revalidate existing state only. Silence never aborts or resubmits work.
+    void revalidateWorkspaceSessionSync({ workspaceId, baseUrl })
+  }, [noNewActivity, workspaceId, sessionId, baseUrl])
   const currentToolCallIds = React.useMemo(
     () => new Set(latestAssistantToolParts.map((part) => part.toolCallId)),
     [latestAssistantToolParts],
   )
 
   return (
+    <ActiveSubagentTasksContext.Provider value={carriedTaskIds}>
     <CurrentToolLifecycleProvider
       activityStatus={activityStatus}
       currentToolCallIds={currentToolCallIds}
@@ -1553,11 +1595,25 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
         )
         })}
 
+        {tasks.length > 0 ? (
+          <Message data-testid="active-subagents" className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
+            <div className="text-sm font-medium">{delegationTitle}</div>
+            {tasks.map((part) => <SubagentRunLine key={part.toolCallId} part={part} liveSummary parentActive={runActive} />)}
+          </Message>
+        ) : null}
+        {noNewActivity ? (
+          <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-1 px-2 md:px-10">
+            <div data-loading-message="no-new-activity" role="status" className="text-sm text-amber-11">No new activity</div>
+            <p className="text-xs text-muted-foreground">No new progress has been received for over a minute. The task may still be running.</p>
+            {baseUrl ? <button type="button" className="text-xs underline underline-offset-2" onClick={() => void revalidateWorkspaceSessionSync({ workspaceId, baseUrl })}>Check activity</button> : null}
+          </Message>
+        ) : null}
         {showLoading && <LoadingMessage elapsedSeconds={runElapsedSeconds} />}
         {showReconnecting && <ReconnectingMessage lastConfirmedAt={syncHealth?.lastConfirmedAt ?? null} />}
         {retryStatus ? <RetryMessage status={retryStatus} /> : null}
         {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
       </div>
     </CurrentToolLifecycleProvider>
+    </ActiveSubagentTasksContext.Provider>
   )
 }

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { createContext, useContext, useEffect, useState } from "react"
 import { ArrowUpRight, ShieldAlert } from "lucide-react"
 
 import {
@@ -15,23 +15,41 @@ import { formatElapsedSeconds, getToolCallStartedAt, trackToolCallDuration } fro
 import { cn } from "@/lib/utils"
 import { t } from "@/i18n"
 import { useSessionActivityStore } from "@/react-app/domains/session/status/session-activity-store"
+import { hasNoNewActivity } from "@/react-app/domains/session/status/session-progress"
+import { statusKey } from "@/react-app/domains/session/sync/session-sync"
+import { useQueryCacheState } from "@/react-app/infra/query-cache-state"
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
+
+export const ActiveSubagentTasksContext = createContext<ReadonlySet<string>>(new Set())
 
 type SubagentRunLineProps = {
   part: TaskToolPart
   className?: string
+  liveSummary?: boolean
+  parentActive?: boolean
 }
 
 export function subagentRunActivity(input: {
   permissionPending: boolean
+  questionPending?: boolean
+  retrying?: boolean
+  resultPending?: boolean
+  childFailed?: boolean
+  noNewActivity?: boolean
   syncDegraded?: boolean
   inFlight: boolean
   failed: boolean
-}): "waiting-permission" | "reconnecting" | "shimmer" | "failed" | "completed" {
+}): "waiting-permission" | "waiting-question" | "waiting-result" | "retrying" | "no-new-activity" | "reconnecting" | "shimmer" | "failed" | "completed" {
   // A pending ask is the actionable state and does not depend on the stream
   // ticking; a lost connection only downgrades the live "Working" treatment.
   if (input.permissionPending) return "waiting-permission"
-  if (input.inFlight) return input.syncDegraded ? "reconnecting" : "shimmer"
-  if (input.failed) return "failed"
+  if (input.questionPending) return "waiting-question"
+  if (input.inFlight && input.retrying) return "retrying"
+  if (input.inFlight && input.syncDegraded) return "reconnecting"
+  if (input.failed || input.childFailed) return "failed"
+  if (input.inFlight && input.resultPending) return "waiting-result"
+  if (input.inFlight && input.noNewActivity) return "no-new-activity"
+  if (input.inFlight) return "shimmer"
   return "completed"
 }
 
@@ -48,48 +66,77 @@ function agentName(slug: string): string {
  * Line 1 = task title + agent name; line 2 = live status verb or
  * "Completed". The card is the doorway into the sub-agent's own session:
  * when the engine reports the child session id, clicking it opens that
- * session in the main chat surface. Otherwise the prompt and result live
- * under the collapsed panel.
+ * session in the main chat surface. Without that route, details stay limited
+ * to safe task/output labels, never raw prompts or payloads.
  */
-export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
+export function SubagentRunLine({ part, className, liveSummary = false, parentActive = true }: SubagentRunLineProps) {
   const [open, setOpen] = useState(false)
   const { onOpenSubagentSession, syncDegraded, workspaceId } = useMessageList()
   const childSessionId = taskChildSessionId(part)
-  const permissionPending = useSessionActivityStore((state) => (
+  const carriedTasks = useContext(ActiveSubagentTasksContext)
+  const history = !liveSummary && carriedTasks.has(part.toolCallId)
+  const child = useSessionActivityStore((state) => (
     childSessionId
-      ? (state.recordsByWorkspaceId[workspaceId]?.[childSessionId]?.waitingPermissionIds.length ?? 0) > 0
-      : false
+      ? state.recordsByWorkspaceId[workspaceId]?.[childSessionId]
+      : undefined
   ))
+  const childStatus = useQueryCacheState<SessionStatus | null>(
+    childSessionId ? statusKey(workspaceId, childSessionId) : null, null,
+  )
+  const permissionPending = (child?.waitingPermissionIds.length ?? 0) > 0
+  const questionPending = (child?.waitingQuestionIds.length ?? 0) > 0
   const inFlight = isToolPartInFlight(part)
   const isFailed = part.state === "output-error"
-  const activity = subagentRunActivity({ permissionPending, syncDegraded, inFlight, failed: isFailed })
   const duration = trackToolCallDuration(part)
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   // First-seen-in-flight time lives in a module map, so remounting (like
   // switching sessions and back) resumes the counter instead of restarting.
   const startedAt = getToolCallStartedAt(part)
+  const noNewActivity = hasNoNewActivity({
+    active: inFlight, lastProgressAt: Math.max(child?.runStartedAt || startedAt || 0, child?.lastProgressAt ?? 0), now: Date.now(),
+  })
+  const activity = subagentRunActivity({
+    permissionPending, questionPending, retrying: childStatus?.type === "retry" || child?.retrying, noNewActivity,
+    syncDegraded, inFlight, failed: isFailed,
+    childFailed: inFlight && child?.errorActive,
+    resultPending: Boolean(child && !child.runActive && child.runStatusAt > 0) || (!parentActive && !child?.runActive),
+  })
   useEffect(() => {
     // While run liveness is unconfirmed the counter must not tick; the
     // module-scoped anchor resumes the true elapsed time on recovery.
-    if (!inFlight || startedAt === null || syncDegraded) return
+    if (!inFlight || startedAt === null || syncDegraded || history) return
     const update = () => {
       setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)))
     }
     update()
     const interval = window.setInterval(update, 1000)
     return () => window.clearInterval(interval)
-  }, [inFlight, startedAt, part.toolCallId, syncDegraded])
-  const title = part.input?.description?.trim() || "Sub-agent task"
+  }, [inFlight, startedAt, part.toolCallId, syncDegraded, history])
+  const title = part.input?.description?.trim().slice(0, 160) || "Sub-agent task"
   const agent = agentName(part.input?.subagent_type ?? "")
   const status = permissionPending
     ? t("session.subagent_permission_needed")
+    : questionPending ? "Waiting for your answer"
+    : activity === "retrying" ? "Retrying"
+    : activity === "failed" ? "Task reported an error"
+    : activity === "waiting-result" ? "Waiting for task result"
+    : activity === "no-new-activity" ? "No new activity"
     : inFlight
     ? syncDegraded
       ? "Connection lost — reconnecting…"
       : `Working ${formatElapsedSeconds(elapsedSeconds)}`
     : isFailed
-      ? part.errorText?.split("\n")[0]?.trim() || "Failed"
+      ? "Task failed"
       : "Completed"
+
+  if (history) {
+    return (
+      <div data-subagent-history={part.toolCallId} className={cn("flex min-w-0 max-w-full flex-col gap-0.5 text-sm text-muted-foreground", className)}>
+        <span className="truncate">{title} · {agent} agent</span>
+        <span className="text-xs text-muted-foreground/70">Delegated task - activity below</span>
+      </div>
+    )
+  }
 
   const lines = (
     <>
@@ -113,9 +160,12 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
         ) : null}
       </span>
       <span className={cn("min-w-0 truncate text-xs", permissionPending ? "font-medium text-amber-11" : "text-muted-foreground/70")}>
-        {isFailed ? `Failed — ${status}` : status}
+        {status}
         {!inFlight && !isFailed && duration ? ` · ${duration}` : ""}
       </span>
+      {inFlight && child?.latestActivity ? (
+        <span className="text-xs text-muted-foreground/70">Last activity: {child.latestActivity}{child.lastProgressAt > 0 ? ` · ${formatElapsedSeconds(Math.max(0, Math.floor((Date.now() - child.lastProgressAt) / 1000)))} ago` : ""}</span>
+      ) : null}
     </>
   )
 
@@ -126,7 +176,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
         data-subagent-session-id={childSessionId}
         data-subagent-activity={activity}
         data-subagent-permission={permissionPending ? "pending" : undefined}
-        className={className}
+        className={cn("min-w-0 max-w-full", className)}
       >
         <button
           type="button"
@@ -147,7 +197,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
       data-subagent-permission={permissionPending ? "pending" : undefined}
       open={open}
       onOpenChange={setOpen}
-      className={className}
+      className={cn("min-w-0 max-w-full", className)}
     >
       <CollapsibleTrigger
         className="group flex min-w-0 max-w-full cursor-pointer flex-col gap-0.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
@@ -157,21 +207,8 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
       </CollapsibleTrigger>
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
         <div className="mt-2 flex flex-col gap-2 rounded-lg bg-muted p-2 text-xs">
-          {part.input?.prompt ? (
-            <pre className="max-h-40 overflow-auto whitespace-pre-wrap wrap-break-word">
-              {part.input.prompt}
-            </pre>
-          ) : null}
-          {part.state === "output-available" ? (
-            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
-              {part.output}
-            </pre>
-          ) : null}
-          {isFailed && part.errorText ? (
-            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
-              {part.errorText}
-            </pre>
-          ) : null}
+          <span>{childSessionId ? "Child chat navigation is unavailable." : "The child chat is not available yet."}</span>
+          <span>{part.state === "output-available" ? "Task output received" : isFailed ? "Task reported an error" : "Waiting for task output"}</span>
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -1,5 +1,7 @@
 /** @jsxImportSource react */
 import { create } from "zustand";
+import type { UIMessage } from "ai";
+import { transcriptProgress } from "./session-progress";
 
 import { t } from "../../../../i18n";
 
@@ -10,7 +12,13 @@ type SessionMessageRole = "assistant" | "system" | "user";
 type SessionActivityRecord = {
   status: SessionActivityStatus;
   runActive: boolean;
+  retrying: boolean;
   runStatusAt: number;
+  runStartedAt: number;
+  lastProgressAt: number;
+  progressRevision: string | null;
+  progressParts: Record<string, string>;
+  latestActivity: string | null;
   assistantOutput: boolean;
   errorActive: boolean;
   errorMessage: string | null;
@@ -42,6 +50,7 @@ type SessionActivityStore = {
     options?: { snapshotStartedAt?: number },
   ) => void;
   setRunStatus: (workspaceId: string, sessionId: string, status: unknown) => void;
+  observeTranscript: (workspaceId: string, sessionId: string, messages: UIMessage[], snapshot?: boolean) => void;
   markMessageRole: (workspaceId: string, sessionId: string, messageId: string, role: SessionMessageRole) => void;
   markAssistantOutput: (workspaceId: string, sessionId: string, messageId?: string, options?: { allowUnknownMessageRole?: boolean }) => void;
   setWaitingRequest: (workspaceId: string, sessionId: string, kind: "permission" | "question", requestId: string, waiting: boolean) => void;
@@ -55,7 +64,13 @@ type SessionActivityStore = {
 const createRecord = (): SessionActivityRecord => ({
   status: "idle",
   runActive: false,
+  retrying: false,
   runStatusAt: 0,
+  runStartedAt: 0,
+  lastProgressAt: 0,
+  progressRevision: null,
+  progressParts: {},
+  latestActivity: null,
   assistantOutput: false,
   errorActive: false,
   errorMessage: null,
@@ -129,7 +144,12 @@ function sameActivityRecord(
 ): boolean {
   return current.status === status
     && current.runActive === next.runActive
+    && current.retrying === next.retrying
     && current.runStatusAt === next.runStatusAt
+    && current.runStartedAt === next.runStartedAt
+    && current.lastProgressAt === next.lastProgressAt
+    && current.progressRevision === next.progressRevision
+    && current.latestActivity === next.latestActivity
     && current.assistantOutput === next.assistantOutput
     && current.errorActive === next.errorActive
     && current.errorMessage === next.errorMessage
@@ -232,6 +252,8 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
           return {
             ...record,
             runActive,
+            retrying: normalized === "retry",
+            runStartedAt: runActive && !record.runActive ? Date.now() : record.runStartedAt,
             assistantOutput: runActive && record.runActive ? record.assistantOutput : false,
             errorActive: runActive ? false : record.errorActive,
             errorMessage: runActive ? null : record.errorMessage,
@@ -261,6 +283,8 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
         ...record,
         runActive,
         runStatusAt: snapshotStartedAt ?? record.runStatusAt,
+        retrying: normalized === "retry",
+        runStartedAt: runActive && !record.runActive ? Date.now() : record.runStartedAt,
         assistantOutput: runActive && (assistantOutput ?? record.assistantOutput),
         errorActive: runActive ? false : record.errorActive,
         errorMessage: runActive ? null : record.errorMessage,
@@ -281,12 +305,29 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
         ...record,
         runActive,
         runStatusAt: Date.now(),
+        retrying: normalized === "retry",
+        runStartedAt: runActive && !record.runActive ? Date.now() : record.runStartedAt,
         assistantOutput: runActive && record.runActive ? record.assistantOutput : false,
         errorActive: runActive ? false : record.errorActive,
         errorMessage: runActive ? null : record.errorMessage,
         compacting: runActive ? record.compacting : false,
         waitingPermissionIds: runActive ? record.waitingPermissionIds : [],
         waitingQuestionIds: runActive ? record.waitingQuestionIds : [],
+      };
+    }));
+  },
+  observeTranscript: (workspaceId, sessionId, messages, snapshot = false) => {
+    set((state) => updateRecord(state, workspaceId, sessionId, (record) => {
+      const progress = transcriptProgress(messages, record.progressParts);
+      if (record.progressRevision === progress.revision) return record;
+      return {
+        ...record,
+        progressRevision: progress.revision,
+        progressParts: progress.parts,
+        latestActivity: progress.label ?? record.latestActivity,
+        lastProgressAt: progress.label
+          ? Math.max(record.lastProgressAt, snapshot && record.progressRevision === null ? progress.timestamp : Date.now())
+          : record.lastProgressAt,
       };
     }));
   },
@@ -344,6 +385,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       errorActive: true,
       errorMessage: message ? message : "Session failed",
       runActive: false,
+      retrying: false,
       runStatusAt: Date.now(),
       assistantOutput: false,
       compacting: false,

--- a/apps/app/src/react-app/domains/session/status/session-progress.ts
+++ b/apps/app/src/react-app/domains/session/status/session-progress.ts
@@ -1,0 +1,139 @@
+import { isToolUIPart, type UIMessage } from "ai";
+
+import { isTaskToolPart, taskChildSessionId, type TaskToolPart } from "../../../../lib/build-in-tools";
+import { isToolPartInFlight } from "../../../../lib/tool-activity";
+
+export const NO_NEW_ACTIVITY_AFTER_MS = 60_000;
+
+export function activeDelegatedTasks(messages: UIMessage[]): TaskToolPart[] {
+  const calls = new Map<string, TaskToolPart>();
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.parts) {
+      if (isToolUIPart(part) && isTaskToolPart(part)) calls.set(part.toolCallId, part);
+    }
+  }
+  // A child being idle is not evidence that the delegating tool completed.
+  return [...calls.values()].filter(isToolPartInFlight);
+}
+
+export function delegatedActivityTitle(tasks: TaskToolPart[], children: Record<string, {
+  runActive: boolean; runStatusAt: number; retrying: boolean; errorActive: boolean;
+  waitingPermissionIds: string[]; waitingQuestionIds: string[];
+}> | undefined, disconnected: boolean, parentActive = true): string {
+  const count = tasks.length;
+  const noun = count === 1 ? "subagent" : "subagents";
+  if (disconnected) return `Checking ${count} ${noun}`;
+  const running = tasks.filter((task) => {
+    const id = taskChildSessionId(task);
+    const child = id ? children?.[id] : undefined;
+    return (!child && parentActive) || (child && !child.errorActive && !child.retrying
+      && child.waitingPermissionIds.length === 0 && child.waitingQuestionIds.length === 0
+      && (child.runActive || (parentActive && child.runStatusAt === 0)));
+  }).length;
+  if (running === count) return `Running ${count} ${noun}`;
+  if (running > 0) return `Running ${running} ${running === 1 ? "subagent" : "subagents"} · ${count - running} waiting`;
+  return `Subagent activity · ${count} ${count === 1 ? "task" : "tasks"}`;
+}
+
+/** Fixed tool categories keep context useful without reflecting arguments or payloads. */
+function safeToolActivity(part: UIMessage["parts"][number]): string {
+  if (!isToolUIPart(part)) return "Tool activity received";
+  const name = part.type === "dynamic-tool" ? part.toolName : part.type.slice(5);
+  switch (name) {
+    case "bash": case "shell": return "Running a command";
+    case "read": return "Reading files";
+    case "write": case "edit": case "apply_patch": return "Updating files";
+    case "grep": case "glob": return "Searching files";
+    case "webfetch": case "websearch": return "Researching the web";
+    case "task": case "subagent": return "Running a delegated task";
+    case "todowrite": return "Updating the plan";
+    case "question": return "Asking for input";
+    default: return "Using a tool";
+  }
+}
+
+type Progress = { revision: string; parts: Record<string, string>; label: string | null; timestamp: number };
+
+function fingerprint(value: unknown): string {
+  let hash = 2166136261;
+  const text = JSON.stringify(value) ?? "";
+  for (let index = 0; index < text.length; index++) hash = Math.imul(hash ^ text.charCodeAt(index), 16777619);
+  return String(hash >>> 0);
+}
+
+// Settled parts retain identity during streaming. Do not rehash old text or
+// large tool results on every new token; the weak keys follow cache eviction.
+const partFingerprints = new WeakMap<UIMessage["parts"][number], string>();
+function partFingerprint(part: UIMessage["parts"][number], value: () => unknown): string {
+  const cached = partFingerprints.get(part);
+  if (cached !== undefined) return cached;
+  const next = fingerprint(value());
+  partFingerprints.set(part, next);
+  return next;
+}
+
+/** Only content and lifecycle changes count. Never hash polling/timing metadata. */
+export function transcriptProgress(messages: UIMessage[], previousParts: Record<string, string> = {}): Progress {
+  const parts: Record<string, string> = {};
+  let label: string | null = null;
+  let timestamp = 0;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    let meaningful = false;
+    for (const [index, part] of message.parts.entries()) {
+      const key = `${message.id}:${isToolUIPart(part) ? part.toolCallId : index}`;
+      let activity: string;
+      if ((part.type === "text" || part.type === "reasoning") && part.text.trim()) {
+        parts[key] = partFingerprint(part, () => [part.type, part.text, part.state]);
+        activity = part.type === "text" ? "Response updated" : "Reasoning activity received";
+      } else if (isToolUIPart(part)) {
+        parts[key] = partFingerprint(part, () => [part.state, part.input,
+          part.state === "output-available" ? part.output : null,
+          part.state === "output-error" ? part.errorText : null]);
+        // Fixed labels, not raw arguments, outputs, prompts, or tool payloads.
+        activity = part.state === "output-available" ? "Tool result received"
+          : part.state === "output-error" ? "Tool reported an error"
+          : safeToolActivity(part);
+      } else if (part.type === "file") {
+        parts[key] = partFingerprint(part, () => [part.type, part.url]);
+        activity = "File output received";
+      } else continue;
+      if (parts[key] !== previousParts[key]) label = activity;
+      meaningful = true;
+    }
+    if (!meaningful) continue;
+    const metadata = message.metadata;
+    if (!metadata || typeof metadata !== "object" || !("opencode" in metadata)) continue;
+    const time = metadata.opencode;
+    if (!time || typeof time !== "object") continue;
+    for (const key of ["created", "completed"]) {
+      const value = Reflect.get(time, key);
+      if (typeof value === "number" && Number.isFinite(value)) timestamp = Math.max(timestamp, value);
+    }
+  }
+  return { revision: fingerprint(parts), parts, label, timestamp };
+}
+
+export function lastTaskProgressAt(
+  own: number,
+  tasks: TaskToolPart[],
+  children: Record<string, { lastProgressAt: number }> | undefined,
+): number {
+  return tasks.reduce((latest, part) => {
+    const id = taskChildSessionId(part);
+    return Math.max(latest, id ? children?.[id]?.lastProgressAt ?? 0 : 0);
+  }, own);
+}
+
+export function hasNoNewActivity(input: {
+  active: boolean;
+  waiting?: boolean;
+  retrying?: boolean;
+  disconnected?: boolean;
+  lastProgressAt: number;
+  now: number;
+}): boolean {
+  return input.active && !input.waiting && !input.retrying && !input.disconnected
+    && input.now - input.lastProgressAt > NO_NEW_ACTIVITY_AFTER_MS;
+}

--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 
+import { createPromptMessageID } from "../../../../app/lib/opencode";
 import type { ComposerAttachment, ComposerDraft } from "../../../../app/types";
 import type { ComposerMentionKind } from "./composer/mention-encoding";
 
@@ -99,7 +100,7 @@ function getWritableSession(state: ComposerStateStore, sessionId: string): Compo
 }
 
 function createQueuedItem(draft: ComposerDraft, id?: string): QueuedComposerItem {
-  return { id: id ?? crypto.randomUUID(), draft };
+  return { id: id ?? crypto.randomUUID(), draft: { ...draft, messageId: draft.messageId ?? createPromptMessageID() } };
 }
 
 export const useComposerStateStore = create<ComposerStateStore>((set) => ({
@@ -199,7 +200,7 @@ export const useComposerStateStore = create<ComposerStateStore>((set) => ({
     const next = current.map((item) => {
       if (item.id !== id) return item;
       changed = true;
-      return { ...item, draft };
+      return { ...item, draft: { ...draft, messageId: item.draft.messageId } };
     });
     if (!changed) return state;
     return { queuedDrafts: { ...state.queuedDrafts, [sessionId]: next } };
@@ -226,7 +227,7 @@ export const useComposerStateStore = create<ComposerStateStore>((set) => ({
   prependQueuedDrafts: (sessionId, items) => set((state) => {
     if (items.length === 0) return state;
     const current = state.queuedDrafts[sessionId] ?? EMPTY_QUEUED_DRAFTS;
-    return { queuedDrafts: { ...state.queuedDrafts, [sessionId]: [...items, ...current] } };
+    return { queuedDrafts: { ...state.queuedDrafts, [sessionId]: [...items.map((item) => createQueuedItem(item.draft, item.id)), ...current] } };
   }),
   clearSession: (sessionId) => set((state) => {
     if (!state.sessions[sessionId]) return state;

--- a/apps/app/src/react-app/domains/session/surface/queued-drain-machine.ts
+++ b/apps/app/src/react-app/domains/session/surface/queued-drain-machine.ts
@@ -9,8 +9,8 @@
  * later queued item was wedged behind it.
  *
  * This machine replaces the edge-wait with explicit per-item admission state
- * keyed by the queued item id (which the drain also uses as the engine
- * message admission key). Every queued item resolves to exactly one of:
+ * keyed by the queued item id. A separate native messageID reconciles uncertain
+ * POSTs; neither ID grants permission to replay a request. Resolutions include:
  *
  * - `admitted_running`               — admission + a busy observation
  * - `admitted_awaiting_observation`  — admitted, run not yet observed
@@ -20,9 +20,9 @@
  *                                      must retry explicitly
  * - `rejected`                       — the send was cancelled (context
  *                                      changed / unmounted); item re-queued
- * - `retryable_unknown`              — the send threw; item re-queued
- * - `terminal_failure`               — the same item exhausted its send
- *                                      attempts; drain halts until user retry
+ * - `admission_unknown`              — POST may have been accepted; only exact
+ *                                      message observation releases the hold
+ * - `terminal_failure`               — definite failure; explicit retry required
  *
  * A missing busy event is never the only signal that allows progress: an
  * item stuck in `awaiting_observation` is released by a *level-reconciled*
@@ -42,13 +42,10 @@ export const QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS = 10_000;
  * (for example the status endpoint is briefly unreachable). */
 export const QUEUE_ADMISSION_PROBE_RETRY_MS = 5_000;
 
-/** Send attempts allowed per queued item before the drain halts as a
- * terminal failure and waits for an explicit user retry. */
-export const QUEUE_SEND_ATTEMPT_LIMIT = 3;
-
 export type QueuedDrainPhase =
   | { kind: "ready" }
   | { kind: "sending"; itemId: string; busySeen: boolean }
+  | { kind: "admission_unknown"; itemId: string; messageID: string; at: number }
   | { kind: "awaiting_observation"; itemId: string; admittedAt: number }
   | { kind: "running"; itemId: string }
   | { kind: "halted"; itemId: string; reason: "needs_input" | "terminal_failure" };
@@ -59,7 +56,7 @@ export type QueuedItemResolution =
   | "completed"
   | "needs_input"
   | "rejected"
-  | "retryable_unknown"
+  | "admission_unknown"
   | "terminal_failure";
 
 export type QueuedDrainState = {
@@ -69,9 +66,11 @@ export type QueuedDrainState = {
 };
 
 export type QueuedDrainEvent =
-  | { type: "send_started"; itemId: string }
+  | { type: "send_started"; itemId: string; steer?: boolean }
   | { type: "send_result"; itemId: string; outcome: "sent" | "accepted" | "blocked" | "cancelled"; at: number }
   | { type: "send_error"; itemId: string }
+  | { type: "send_unknown"; itemId: string; messageID: string; at: number }
+  | { type: "admission_observed"; itemId: string; messageID: string; at: number }
   | { type: "busy_observed" }
   /** An authoritative status level read (SSE-followed idle after a busy
    * observation, or an explicit snapshot/status probe). `observedAt` is when
@@ -105,10 +104,15 @@ export function reduceQueuedDrain(state: QueuedDrainState, event: QueuedDrainEve
   const { phase } = state;
   switch (event.type) {
     case "send_started": {
-      if (phase.kind !== "ready") return state;
+      if (phase.kind !== "ready") {
+        if (!event.steer) return state;
+        if (phase.kind === "running" || phase.kind === "awaiting_observation") {
+          if (phase.itemId === event.itemId) return state;
+        } else if (phase.kind !== "halted" || phase.itemId !== event.itemId) return state;
+      }
       const attempts = (state.attemptsByItemId[event.itemId] ?? 0) + 1;
       return {
-        phase: { kind: "sending", itemId: event.itemId, busySeen: false },
+        phase: { kind: "sending", itemId: event.itemId, busySeen: phase.kind === "running" },
         attemptsByItemId: { ...state.attemptsByItemId, [event.itemId]: attempts },
         lastResolution: state.lastResolution,
       };
@@ -143,16 +147,17 @@ export function reduceQueuedDrain(state: QueuedDrainState, event: QueuedDrainEve
     }
     case "send_error": {
       if (phase.kind !== "sending" || phase.itemId !== event.itemId) return state;
-      const attempts = state.attemptsByItemId[event.itemId] ?? 1;
-      if (attempts >= QUEUE_SEND_ATTEMPT_LIMIT) {
-        return resolved(
-          state,
-          { kind: "halted", itemId: event.itemId, reason: "terminal_failure" },
-          event.itemId,
-          "terminal_failure",
-        );
-      }
-      return resolved(state, { kind: "ready" }, event.itemId, "retryable_unknown");
+      return resolved(state, { kind: "halted", itemId: event.itemId, reason: "terminal_failure" }, event.itemId, "terminal_failure");
+    }
+    case "send_unknown": {
+      if (phase.kind !== "sending" || phase.itemId !== event.itemId) return state;
+      return resolved(state, { kind: "admission_unknown", itemId: event.itemId, messageID: event.messageID, at: event.at }, event.itemId, "admission_unknown");
+    }
+    case "admission_observed": {
+      if (phase.kind !== "admission_unknown" || phase.itemId !== event.itemId || phase.messageID !== event.messageID) return state;
+      // This proves admission, not completion. Require a subsequent run/status
+      // observation; a busy/idle from the previously running parent is not proof.
+      return resolved(state, { kind: "awaiting_observation", itemId: event.itemId, admittedAt: event.at }, event.itemId, "admitted_awaiting_observation");
     }
     case "busy_observed": {
       if (phase.kind === "sending") {
@@ -190,10 +195,9 @@ export function reduceQueuedDrain(state: QueuedDrainState, event: QueuedDrainEve
       };
     }
     case "queue_cleared": {
-      // Stop means stop: an aborted queue must not leave a halted or
-      // awaiting admission behind to wedge the next queueing round. A
-      // running admission resolves through the normal idle level.
-      if (phase.kind === "running" || phase.kind === "sending") return state;
+      // Stop invalidates preflight work, but cannot prove whether an in-flight
+      // POST was accepted. Keep its slot until that send settles or is observed.
+      if (phase.kind === "running" || phase.kind === "sending" || phase.kind === "admission_unknown") return state;
       return { ...INITIAL_QUEUED_DRAIN_STATE, lastResolution: state.lastResolution };
     }
   }
@@ -214,8 +218,8 @@ export function canAdmitNextQueuedItem(state: QueuedDrainState): boolean {
 /** When (epoch ms) the awaiting admission should be probed against an
  * authoritative status level; null when no probe is due. */
 export function nextObservationProbeAt(state: QueuedDrainState, lastProbeAt: number | null): number | null {
-  if (state.phase.kind !== "awaiting_observation") return null;
-  const due = state.phase.admittedAt + QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS;
+  if (state.phase.kind !== "awaiting_observation" && state.phase.kind !== "admission_unknown") return null;
+  const due = (state.phase.kind === "admission_unknown" ? state.phase.at : state.phase.admittedAt) + QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS;
   if (lastProbeAt === null) return due;
   return Math.max(due, lastProbeAt + QUEUE_ADMISSION_PROBE_RETRY_MS);
 }
@@ -230,12 +234,24 @@ export function nextObservationProbeAt(state: QueuedDrainState, lastProbeAt: num
 
 const drainStateBySession = new Map<string, QueuedDrainState>();
 const drainListenersBySession = new Map<string, Set<() => void>>();
+const sendGenerationBySession = new Map<string, number>();
+
+export function getQueuedSendGeneration(sessionId: string): number {
+  return sendGenerationBySession.get(sessionId) ?? 0;
+}
+
+export function assertQueuedSendCurrent(sessionId: string, generation: number): void {
+  if (getQueuedSendGeneration(sessionId) !== generation) throw new Error("Send cancelled by Stop.");
+}
 
 export function getQueuedDrainState(sessionId: string): QueuedDrainState {
   return drainStateBySession.get(sessionId) ?? INITIAL_QUEUED_DRAIN_STATE;
 }
 
 export function dispatchQueuedDrain(sessionId: string, event: QueuedDrainEvent): QueuedDrainState {
+  if (event.type === "queue_cleared") {
+    sendGenerationBySession.set(sessionId, getQueuedSendGeneration(sessionId) + 1);
+  }
   const current = getQueuedDrainState(sessionId);
   const next = reduceQueuedDrain(current, event);
   if (next === current) return current;
@@ -252,10 +268,10 @@ export function dispatchQueuedDrain(sessionId: string, event: QueuedDrainEvent):
 /** Atomically claim the send slot for one queued item. Returns false when
  * another surface (for example a split view of the same session) already
  * holds a non-ready phase, so a queued item can never be sent twice. */
-export function claimQueuedSend(sessionId: string, itemId: string): boolean {
-  if (!canAdmitNextQueuedItem(getQueuedDrainState(sessionId))) return false;
-  const next = dispatchQueuedDrain(sessionId, { type: "send_started", itemId });
-  return next.phase.kind === "sending" && next.phase.itemId === itemId;
+export function claimQueuedSend(sessionId: string, itemId: string, steer = false): boolean {
+  const current = getQueuedDrainState(sessionId);
+  const next = dispatchQueuedDrain(sessionId, { type: "send_started", itemId, steer });
+  return next !== current && next.phase.kind === "sending" && next.phase.itemId === itemId;
 }
 
 export function subscribeQueuedDrain(sessionId: string, listener: () => void): () => void {
@@ -272,4 +288,5 @@ export function subscribeQueuedDrain(sessionId: string, listener: () => void): (
 export function resetQueuedDrainForTests() {
   drainStateBySession.clear();
   drainListenersBySession.clear();
+  sendGenerationBySession.clear();
 }

--- a/apps/app/src/react-app/domains/session/surface/safe-edit-resend.ts
+++ b/apps/app/src/react-app/domains/session/surface/safe-edit-resend.ts
@@ -1,3 +1,5 @@
+import { isPromptAdmissionUnknown } from "../../../../app/lib/opencode";
+
 export type SafeEditResendInput = {
   revertMessageId?: string | undefined;
   abort: () => Promise<unknown>;
@@ -5,6 +7,7 @@ export type SafeEditResendInput = {
   prompt: () => Promise<void>;
   unrevert: () => Promise<unknown>;
   onUnrevertError?: (error: unknown) => void;
+  assertCurrent?: () => void;
 };
 
 /**
@@ -12,6 +15,7 @@ export type SafeEditResendInput = {
  * revert is rolled back when the replacement prompt cannot be dispatched.
  */
 export async function sendWithRevertRollback(input: SafeEditResendInput): Promise<void> {
+  input.assertCurrent?.();
   const revertMessageId = input.revertMessageId?.trim();
   if (!revertMessageId) {
     await input.prompt();
@@ -19,10 +23,14 @@ export async function sendWithRevertRollback(input: SafeEditResendInput): Promis
   }
 
   await input.abort();
+  input.assertCurrent?.();
   await input.revert(revertMessageId);
   try {
+    input.assertCurrent?.();
     await input.prompt();
   } catch (error) {
+    // The replacement may already exist. Unrevert would mutate its history.
+    if (isPromptAdmissionUnknown(error)) throw error;
     try {
       await input.unrevert();
     } catch (unrevertError) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -7,7 +7,7 @@ import { Check, CirclePause, Minimize2 } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
 
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
-import { createClient, unwrap } from "@/app/lib/opencode";
+import { createClient, createPromptMessageID, hasAcceptedPromptMessage, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
@@ -61,6 +61,7 @@ import {
   claimQueuedSend,
   dispatchQueuedDrain,
   getQueuedDrainState,
+  getQueuedSendGeneration,
   nextObservationProbeAt,
   subscribeQueuedDrain,
 } from "./queued-drain-machine";
@@ -1151,7 +1152,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const opencodeClient = useMemo(
     () => isOpencodeV2BaseUrl(props.opencodeBaseUrl)
       ? createClientV2(props.opencodeBaseUrl, props.workspaceRoot || undefined, { token: props.openworkToken })
-      : createClient(props.opencodeBaseUrl, undefined, { token: props.openworkToken, mode: "openwork" }),
+      : createClient(props.opencodeBaseUrl, props.workspaceRoot.trim() || undefined, { token: props.openworkToken, mode: "openwork" }),
     [props.opencodeBaseUrl, props.openworkToken, props.workspaceRoot],
   );
 
@@ -1342,7 +1343,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const remaining = (pendingMessages ?? []).filter(({ draft: pending, previousMessageIds }) => {
       const match = baseRenderedMessages.find((message) => message.role === "user"
         && !matchedIds.has(message.id)
-        && (message.id === pending.messageId || (!previousMessageIds.includes(message.id)
+        && (message.id === pending.messageId || (isOpencodeV2BaseUrl(props.opencodeBaseUrl) && !previousMessageIds.includes(message.id)
           && message.parts.some((part) => part.type === "text" && part.text === (pending.resolvedText ?? pending.text)))));
       if (!match) return true;
       matchedIds.add(match.id);
@@ -1354,7 +1355,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       ...item,
       previousMessageIds: [...item.previousMessageIds, ...matchedIds],
     })) : remaining;
-  }, [baseRenderedMessages, pendingMessages]);
+  }, [baseRenderedMessages, pendingMessages, props.opencodeBaseUrl]);
   useEffect(() => {
     if (!pendingMessages || pendingMessages.length === unmatchedPendingMessages.length) return;
     useComposerStateStore.setState((state) => ({
@@ -1842,13 +1843,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Core sender shared by initial send and steered follow-ups. OpenCode
   // accepts follow-up user turns mid-run (steering) — the running loop picks
   // up the new message — so this is safe to call while the agent is busy.
-  const sendDraft = useCallback(async (nextDraft: ComposerDraft) => {
+  const sendDraft = useCallback(async (nextDraft: ComposerDraft, itemId: string): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
+    const messageId = nextDraft.messageId ?? createPromptMessageID();
+    const generation = getQueuedSendGeneration(props.sessionId);
     const submissionId = Symbol();
     pendingSendsRef.current.set(submissionId, sessionOwner);
     setPendingSendSessions([...pendingSendsRef.current.values()]);
     setError(null);
     try {
-      const result = await props.onSendDraft(nextDraft, props.sessionId);
+      const result = await props.onSendDraft({ ...nextDraft, messageId }, props.sessionId);
+      dispatchQueuedDrain(props.sessionId, { type: "send_result", itemId, outcome: result.outcome, at: Date.now() });
+      if (getQueuedSendGeneration(props.sessionId) !== generation) return result;
       if (result.outcome === "blocked" || result.outcome === "cancelled") return result;
       // Only report a run after the pre-send gate released the exact queued
       // submission and the route accepted or sent it.
@@ -1859,6 +1864,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
       }
       return result;
     } catch (nextError) {
+      if (isPromptAdmissionUnknown(nextError)) {
+        dispatchQueuedDrain(props.sessionId, { type: "send_unknown", itemId, messageID: messageId, at: Date.now() });
+        if (activeSessionOwnerRef.current === sessionOwner) setAwaitingAssistantBaseline(null);
+        return { outcome: "unknown" };
+      }
+      if (getQueuedSendGeneration(props.sessionId) !== generation) {
+        dispatchQueuedDrain(props.sessionId, { type: "send_result", itemId, outcome: "cancelled", at: Date.now() });
+        return { outcome: "cancelled", reason: "context_changed" };
+      }
+      dispatchQueuedDrain(props.sessionId, { type: "send_error", itemId });
       const parsed = parseSessionError(nextError);
       captureAnalyticsEvent("task_send_failed", {});
       setError(parsed);
@@ -1885,10 +1900,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const originalDraft = draft;
     const text = originalDraft.trim();
     if (!text && attachments.length === 0) return;
-    const nextDraft = {
-      ...buildDraft(text, attachments),
-      messageId: `msg_${(Date.now() * 4096).toString(16)}${crypto.randomUUID().replaceAll("-", "").slice(0, 14)}`,
-    };
+    const nextDraft = { ...buildDraft(text, attachments), messageId: createPromptMessageID() };
+    // Immediate sends and queued sends share the same slot across all panes.
+    dispatchQueuedDrain(props.sessionId, { type: "user_retry" });
+    if (!claimQueuedSend(props.sessionId, nextDraft.messageId, true)) return;
     const sentAttachments = attachments;
     const savedComposer = useComposerStateStore.getState().sessions[props.sessionId];
     clearComposer();
@@ -1925,12 +1940,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }));
     if (sentAttachments.length) setAttachmentsUploading(true);
     try {
-      const result = await sendDraft(nextDraft);
+      const result = await sendDraft(nextDraft, nextDraft.messageId);
       if (result.outcome === "blocked" || result.outcome === "cancelled") {
         restore();
         return;
       }
-      if (nextDraft.command || nextDraft.mode === "shell") removePending();
+      if (result.outcome !== "unknown" && (nextDraft.command || nextDraft.mode === "shell")) removePending();
       sentAttachments.forEach(revokeAttachmentPreview);
     } catch {
       restore();
@@ -1997,39 +2012,48 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [sendingQueued, setSendingQueued] = useState(false);
   const sendQueuedDraftNow = useCallback(async (id: string) => {
     if (drainingQueueRef.current || sendingQueued) return;
-    const item = queuedItems.find((queued) => queued.id === id);
+    const item = getComposerQueuedDrafts(useComposerStateStore.getState(), props.sessionId).find((queued) => queued.id === id);
     const target = withoutRevertTarget(item?.draft ?? null);
     if (!item || !target) return;
+    if (!claimQueuedSend(props.sessionId, item.id, true)) return;
+    const generation = getQueuedSendGeneration(props.sessionId);
     setSendingQueued(true);
     removeQueuedDraftFromStore(props.sessionId, id);
     try {
-      const result = await sendDraft(target);
+      const result = await sendDraft(target, item.id);
       if (result.outcome === "blocked" || result.outcome === "cancelled") {
-        prependQueuedDrafts(props.sessionId, [{ id: item.id, draft: target }]);
+        if (getQueuedSendGeneration(props.sessionId) === generation) {
+          prependQueuedDrafts(props.sessionId, [{ id: item.id, draft: target }]);
+        } else {
+          target.attachments.forEach(revokeAttachmentPreview);
+        }
         return;
       }
       target.attachments.forEach(revokeAttachmentPreview);
     } catch {
-      prependQueuedDrafts(props.sessionId, [{ id: item.id, draft: target }]);
+      if (getQueuedSendGeneration(props.sessionId) === generation) {
+        prependQueuedDrafts(props.sessionId, [{ id: item.id, draft: target }]);
+      }
     } finally {
       setSendingQueued(false);
     }
   }, [
     prependQueuedDrafts,
     props.sessionId,
-    queuedItems,
     removeQueuedDraftFromStore,
     sendDraft,
     sendingQueued,
   ]);
 
   const handleAbort = useCallback(async () => {
-    if (!chatStreaming) return;
+    const phase = getQueuedDrainState(props.sessionId).phase;
+    if (!chatStreaming && phase.kind !== "sending" && phase.kind !== "admission_unknown") return;
     setError(null);
     // Stop means stop: drop queued follow-ups before aborting, otherwise the
     // queue-drain effect below re-prompts the agent the moment the abort
     // lands and the session reports idle (#2014).
-    queuedItems.forEach((item) => item.draft.attachments.forEach(revokeAttachmentPreview));
+    getComposerQueuedDrafts(useComposerStateStore.getState(), props.sessionId)
+      .forEach((item) => item.draft.attachments.forEach(revokeAttachmentPreview));
     clearQueuedDrafts(props.sessionId);
     dispatchQueuedDrain(props.sessionId, { type: "queue_cleared" });
     // The prompt was sent through a directory-scoped client (session-route
@@ -2052,7 +2076,24 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
     captureAnalyticsEvent("task_run_stopped", {});
     await snapshotQuery.refetch();
-  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, queuedItems, snapshotQuery.refetch, setError]);
+  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, snapshotQuery.refetch, setError]);
+
+  const checkUnknownAdmission = useCallback(async (notify = false) => {
+    const phase = getQueuedDrainState(props.sessionId).phase;
+    if (phase.kind !== "admission_unknown") return;
+    try {
+      if (await hasAcceptedPromptMessage(opencodeClient, props.sessionId, phase.messageID)) {
+        dispatchQueuedDrain(props.sessionId, {
+          type: "admission_observed", itemId: phase.itemId, messageID: phase.messageID, at: Date.now(),
+        });
+        if (notify) toast.success("Message acceptance confirmed. Nothing was resent.");
+      } else if (notify) {
+        toast.info("Acceptance is still unknown. The message has not been resent; check again later.");
+      }
+    } catch {
+      if (notify) toast.error("Could not check acceptance. The message has not been resent; check again when connected.");
+    }
+  }, [opencodeClient, props.sessionId]);
 
   const handleDismissError = useCallback(() => {
     setError(null);
@@ -2094,6 +2135,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
       lastObservationProbeAtRef.current = startedAt;
       void (async () => {
         try {
+          const phase = getQueuedDrainState(props.sessionId).phase;
+          if (phase.kind === "admission_unknown") {
+            await checkUnknownAdmission();
+            return;
+          }
           const result = await snapshotQuery.refetch();
           const probed = result.data?.session.id === props.sessionId ? result.data.status : null;
           if (!probed) return;
@@ -2111,7 +2157,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       })();
     }, Math.max(0, probeAt - Date.now()));
     return () => window.clearTimeout(timer);
-  }, [observationProbeVersion, props.sessionId, queuedDrainState, snapshotQuery.refetch]);
+  }, [checkUnknownAdmission, observationProbeVersion, props.sessionId, queuedDrainState, snapshotQuery.refetch]);
 
   useEffect(() => {
     if (drainingQueueRef.current || sendingQueued) return;
@@ -2119,7 +2165,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (queuedItems.length === 0) return;
     if (chatStreaming || liveStatus.type !== "idle") return;
     if (!canAdmitNextQueuedItem(queuedDrainState)) return;
-    const nextItem = queuedItems[0];
+    const nextItem = getComposerQueuedDrafts(useComposerStateStore.getState(), props.sessionId)[0];
     if (!nextItem) return;
     const nextDraft = withoutRevertTarget(nextItem.draft);
     if (!nextDraft) return;
@@ -2129,17 +2175,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
     // per-session (not per-surface), so a split view of this session cannot
     // deliver the same queued item twice.
     if (!claimQueuedSend(props.sessionId, nextItem.id)) return;
+    const generation = getQueuedSendGeneration(props.sessionId);
     drainingQueueRef.current = true;
     removeQueuedDraftFromStore(props.sessionId, nextItem.id);
     void (async () => {
       try {
-        const result = await sendDraft(nextDraft);
-        dispatchQueuedDrain(props.sessionId, {
-          type: "send_result",
-          itemId: nextItem.id,
-          outcome: result.outcome,
-          at: Date.now(),
-        });
+        const result = await sendDraft(nextDraft, nextItem.id);
+        if (getQueuedSendGeneration(props.sessionId) !== generation) {
+          nextDraft.attachments.forEach(revokeAttachmentPreview);
+          return;
+        }
         if (result.outcome === "blocked") {
           cloudQueueBlockedRef.current = true;
           prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
@@ -2149,8 +2194,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
           nextDraft.attachments.forEach(revokeAttachmentPreview);
         }
       } catch {
-        dispatchQueuedDrain(props.sessionId, { type: "send_error", itemId: nextItem.id });
-        prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
+        if (getQueuedSendGeneration(props.sessionId) === generation) {
+          prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
+        }
       } finally {
         drainingQueueRef.current = false;
       }
@@ -2321,13 +2367,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     label: "Send the composer prompt",
     description: "Send the currently visible composer draft to the active session.",
     sideEffect: "mutation",
-    disabled: sessionModelUnavailable || (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle",
+    disabled: sessionModelUnavailable || (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle" || queuedDrainState.phase.kind === "admission_unknown",
     targetRef: composerShellRef,
     execute: async () => {
       await handleSend();
       return true;
     },
-  }), [attachments.length, draft, handleSend, model.transitionState, sessionModelUnavailable]);
+  }), [attachments.length, draft, handleSend, model.transitionState, queuedDrainState.phase.kind, sessionModelUnavailable]);
   useControlAction(props.isControlTarget ? composerSendControlAction : null);
 
   const composerStopControlAction = useMemo<OpenworkControlAction>(() => ({
@@ -2335,13 +2381,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     label: "Stop the current run",
     description: "Stop the current streaming session run.",
     sideEffect: "mutation",
-    disabled: !chatStreaming,
+    disabled: !chatStreaming && queuedDrainState.phase.kind !== "sending" && queuedDrainState.phase.kind !== "admission_unknown",
     targetRef: composerShellRef,
     execute: async () => {
       await handleAbort();
       return true;
     },
-  }), [chatStreaming, handleAbort]);
+  }), [chatStreaming, handleAbort, queuedDrainState.phase.kind]);
   useControlAction(props.isControlTarget ? composerStopControlAction : null);
 
   const listSkills = useCallback(async (): Promise<SkillCard[]> => {
@@ -2536,21 +2582,25 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [resuming, setResuming] = useState(false);
   const handleResumeInterrupted = useCallback(async (recoveryPrompt: string) => {
     await resumeGuardRef.current.run(async () => {
+      const messageID = createPromptMessageID();
+      dispatchQueuedDrain(props.sessionId, { type: "user_retry" });
+      if (!claimQueuedSend(props.sessionId, messageID, true)) return;
       setResuming(true);
       try {
         await sendDraft({
+          messageId: messageID,
           mode: "prompt",
           parts: [{ type: "text", text: recoveryPrompt }],
           attachments: [],
           text: recoveryPrompt,
-        });
+        }, messageID);
       } catch {
         // sendDraft already surfaced the failure on the session error state.
       } finally {
         setResuming(false);
       }
     });
-  }, [sendDraft]);
+  }, [props.sessionId, sendDraft]);
   const handleResumeUnknownOutcome = useCallback(() => {
     void handleResumeInterrupted(interruptedTaskRecoveryPrompt);
   }, [handleResumeInterrupted]);
@@ -2822,6 +2872,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
           {/* Chat column: tighter than the composer (800px) so messages
                keep a comfortable reading width and don't feel "too big". */}
           <div ref={contentRef} className="mx-auto w-full max-w-[720px]">
+            {queuedDrainState.phase.kind === "admission_unknown" ? (
+              <div role="alert" className="mb-4 rounded-xl border border-dls-border bg-dls-hover/60 px-4 py-3 text-sm">
+                <p className="font-medium">Message acceptance is unknown</p>
+                <p className="mt-1 text-dls-secondary">It may already be running. Sending is paused to avoid duplicates. Check acceptance or stop the run; Stop does not resend the message.</p>
+                <div className="mt-3 flex gap-3">
+                  <button type="button" className="underline" onClick={() => void checkUnknownAdmission(true)}>Check acceptance</button>
+                  <button type="button" className="underline" onClick={() => void handleAbort()}>Stop</button>
+                </div>
+              </div>
+            ) : null}
             {revertMessageId ? (
               <RevertedMessagesBanner
                 hiddenCount={revertedMessageCount}
@@ -2923,7 +2983,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                 </OpenTargetProvider>
               </DevProfiler>
             )}
-            {admissionOutcomeUnresolved && renderedMessages.length > 0 ? (
+            {admissionOutcomeUnresolved && queuedDrainState.phase.kind !== "admission_unknown" && renderedMessages.length > 0 ? (
               <AdmissionOutcomeUnknownCard
                 resuming={resuming}
                 onResume={handleResumeUnknownOutcome}
@@ -3009,7 +3069,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         steering={steering}
         submissionPreparing={preparingCloudTools || sending}
         queuedCount={queuedItems.length}
-        disabled={model.transitionState !== "idle" || sessionModelUnavailable}
+        disabled={model.transitionState !== "idle" || sessionModelUnavailable || queuedDrainState.phase.kind === "admission_unknown"}
         modelUnavailable={sessionModelUnavailable}
         modelUnavailableMessage={sessionModelUnavailable ? props.modelUnavailableMessage : null}
         organizationModelsEmpty={props.organizationModelsEmpty}

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
@@ -1,7 +1,7 @@
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import { markTaskRunStart } from "@/app/lib/analytics";
-import { createClient } from "@/app/lib/opencode";
+import { createClient, createPromptMessageID, hasAcceptedPromptMessage, isPromptAdmissionUnknown } from "@/app/lib/opencode";
 import { shellInSession } from "@/app/lib/opencode-session";
 import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
 import type { ComposerDraft, ModelRef } from "@/app/types";
@@ -13,9 +13,11 @@ import {
 } from "../surface/composer-state-store";
 import {
   canAdmitNextQueuedItem,
+  assertQueuedSendCurrent,
   claimQueuedSend,
   dispatchQueuedDrain,
   getQueuedDrainState,
+  getQueuedSendGeneration,
   nextObservationProbeAt,
   subscribeQueuedDrain,
 } from "../surface/queued-drain-machine";
@@ -90,7 +92,9 @@ async function performQueuedDraftSend(
   context: QueuedSendContext,
   sessionId: string,
   draft: ComposerDraft,
+  generation: number,
 ) {
+  assertQueuedSendCurrent(sessionId, generation);
   const text = draft.text.trim();
   if (!text && draft.attachments.length === 0 && !draft.command) return;
 
@@ -122,20 +126,26 @@ async function performQueuedDraftSend(
     client: context.client,
     workspaceId: context.workspaceId,
   });
+  assertQueuedSendCurrent(sessionId, generation);
   const system = await buildOpenworkSessionSystemContext(context.client, {
     workspaceId: context.workspaceId,
     cacheKey: sessionId,
     runtimeKey: context.environmentRuntimeKey,
   });
+  assertQueuedSendCurrent(sessionId, generation);
   const result = await opencodeClient.session.promptAsync({
     sessionID: sessionId,
+    messageID: draft.messageId,
     parts,
     model: sendModel ?? undefined,
     agent: context.agent ?? undefined,
     ...(sendVariant ? { variant: sendVariant } : {}),
     system,
   });
-  if (result.error) throw new Error(serializeSDKError(result.error));
+  if (result.error) {
+    if (isPromptAdmissionUnknown(result.error)) throw result.error;
+    throw new Error(serializeSDKError(result.error));
+  }
   if (sendModel) {
     useSessionModelStore.getState().setModel(sessionId, sendModel, sendVariant ?? null);
   }
@@ -176,14 +186,28 @@ function armObservationProbe(watched: WatchedSession) {
     watched.probeInFlight = true;
     const controller = new AbortController();
     watched.probeController = controller;
-    void composeNativeSessionSnapshot(
-      {
-        opencodeBaseUrl: watched.context.opencodeBaseUrl,
-        token: watched.context.openworkToken,
-      },
-      watched.sessionId,
-      { limit: 140, signal: controller.signal },
-    ).then((snapshot) => {
+    void (async () => {
+      const phase = getQueuedDrainState(watched.sessionId).phase;
+      if (phase.kind === "admission_unknown") {
+        const client = createClient(watched.context.opencodeBaseUrl, watched.context.workspaceRoot || undefined, {
+          token: watched.context.openworkToken, mode: "openwork",
+        });
+        if (await hasAcceptedPromptMessage(client, watched.sessionId, phase.messageID)) {
+          if (watchedSessions.get(watched.sessionId) !== watched) return;
+          dispatchQueuedDrain(watched.sessionId, {
+            type: "admission_observed", itemId: phase.itemId, messageID: phase.messageID, at: Date.now(),
+          });
+        }
+        return;
+      }
+      const snapshot = await composeNativeSessionSnapshot(
+        {
+          opencodeBaseUrl: watched.context.opencodeBaseUrl,
+          token: watched.context.openworkToken,
+        },
+        watched.sessionId,
+        { limit: 140, signal: controller.signal },
+      );
       if (watchedSessions.get(watched.sessionId) !== watched) return;
       watched.lastObservedStatus = snapshot.status;
       if (snapshot.status.type === "idle") {
@@ -194,7 +218,7 @@ function armObservationProbe(watched: WatchedSession) {
       } else {
         dispatchQueuedDrain(watched.sessionId, { type: "busy_observed" });
       }
-    }).catch(() => {
+    })().catch(() => {
       // A spaced retry is armed below from the machine's timing helper.
     }).finally(() => {
       if (watchedSessions.get(watched.sessionId) !== watched) return;
@@ -286,7 +310,8 @@ function reconcileWatchedSessions() {
     const queuedItems = queuedDrafts[sessionId] ?? [];
     const context = getQueuedSendContext(sessionId);
     if (watched.sendInFlight) continue;
-    if (queuedItems.length === 0 || !context) {
+    const unknown = getQueuedDrainState(sessionId).phase.kind === "admission_unknown";
+    if ((queuedItems.length === 0 && !unknown) || !context) {
       releaseWatchedSession(watched, queuedItems.length === 0);
       continue;
     }
@@ -313,15 +338,16 @@ async function attemptDrain(sessionId: string) {
   if (!context || !nextItem || watched.lastObservedStatus?.type !== "idle") return;
   if (!canAdmitNextQueuedItem(getQueuedDrainState(sessionId))) return;
 
-  const draft = withoutRevertTarget(nextItem.draft);
+  const draft = { ...withoutRevertTarget(nextItem.draft), messageId: nextItem.draft.messageId ?? createPromptMessageID() };
   // Claim synchronously before any await so a mounted surface cannot win the
   // same item after this drainer observes it.
   if (!claimQueuedSend(sessionId, nextItem.id)) return;
+  const generation = getQueuedSendGeneration(sessionId);
   watched.sendInFlight = true;
   useComposerStateStore.getState().removeQueuedDraft(sessionId, nextItem.id);
 
   try {
-    await performQueuedDraftSend(context, sessionId, draft);
+    await performQueuedDraftSend(context, sessionId, draft, generation);
     dispatchQueuedDrain(sessionId, {
       type: "send_result",
       itemId: nextItem.id,
@@ -329,6 +355,7 @@ async function attemptDrain(sessionId: string) {
       at: Date.now(),
     });
     draft.attachments.forEach(revokeAttachmentPreview);
+    if (getQueuedSendGeneration(sessionId) !== generation) return;
     useComposerStateStore.getState().appendHistory(sessionId, draft.text);
     useSessionActivityStore.getState().setRunStatus(
       context.workspaceId,
@@ -336,15 +363,26 @@ async function attemptDrain(sessionId: string) {
       { type: "busy" },
     );
     markTaskRunStart(sessionId);
-  } catch {
-    dispatchQueuedDrain(sessionId, { type: "send_error", itemId: nextItem.id });
-    useComposerStateStore.getState().prependQueuedDrafts(sessionId, [{ id: nextItem.id, draft }]);
+  } catch (error) {
+    if (isPromptAdmissionUnknown(error)) {
+      dispatchQueuedDrain(sessionId, {
+        type: "send_unknown", itemId: nextItem.id, messageID: draft.messageId, at: Date.now(),
+      });
+      draft.attachments.forEach(revokeAttachmentPreview);
+    } else if (getQueuedSendGeneration(sessionId) !== generation) {
+      dispatchQueuedDrain(sessionId, { type: "send_result", itemId: nextItem.id, outcome: "cancelled", at: Date.now() });
+      draft.attachments.forEach(revokeAttachmentPreview);
+    } else {
+      dispatchQueuedDrain(sessionId, { type: "send_error", itemId: nextItem.id });
+      useComposerStateStore.getState().prependQueuedDrafts(sessionId, [{ id: nextItem.id, draft }]);
+    }
   } finally {
     watched.sendInFlight = false;
     if (startRefs > 0) {
       reconcileWatchedSessions();
     }
-    if (getComposerQueuedDrafts(useComposerStateStore.getState(), sessionId).length === 0) {
+    if (getComposerQueuedDrafts(useComposerStateStore.getState(), sessionId).length === 0
+      && getQueuedDrainState(sessionId).phase.kind !== "admission_unknown") {
       clearQueuedSendContext(sessionId);
     }
   }

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -3,7 +3,7 @@ import type { UIMessage } from "ai";
 import { safeStringify } from "../../../../app/utils";
 import { normalizeErrorText } from "../../../../lib/error-text";
 
-export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "free-model-limit" | "disk-full" | "database-error" | "generic";
+export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "provider-incomplete" | "free-model-limit" | "disk-full" | "database-error" | "generic";
 
 export type OpencodeSessionErrorPresentation = {
   kind: OpencodeSessionErrorKind;
@@ -80,6 +80,7 @@ function sessionErrorKind(
   ) {
     return "provider-timeout";
   }
+  if (/upstream_(?:incomplete|interrupted|malformed_stream|malformed_response|timeout)/.test(searchable)) return "provider-incomplete";
   if (responseBody?.includes("FreeUsageLimitError") || message?.includes("FreeUsageLimitError")) {
     return "free-model-limit";
   }
@@ -91,6 +92,7 @@ function errorTitle(kind: OpencodeSessionErrorKind, fallback: string) {
   if (kind === "database-error") return "OpenWork couldn’t access its saved data";
   if (kind === "aborted") return "Task interrupted";
   if (kind === "provider-timeout") return "Provider did not respond in time";
+  if (kind === "provider-incomplete") return "The model response was interrupted";
   if (kind === "free-model-limit") return "The free starter model is busy right now";
   return fallback;
 }
@@ -108,6 +110,7 @@ function errorDescription(kind: OpencodeSessionErrorKind) {
   if (kind === "provider-timeout") {
     return "The provider connection timed out before a response began. Output and files already produced are kept.";
   }
+  if (kind === "provider-incomplete") return "The response may contain partial text or incomplete tool calls. Review them before continuing.";
   if (kind === "free-model-limit") {
     return "Too many people are using the free model at once. Wait a few minutes and try again, or connect your own model provider in Settings → AI Providers to keep working.";
   }
@@ -115,7 +118,7 @@ function errorDescription(kind: OpencodeSessionErrorKind) {
 }
 
 function errorRecoveryPrompt(kind: OpencodeSessionErrorKind) {
-  return kind === "aborted" || kind === "provider-timeout"
+  return kind === "aborted" || kind === "provider-timeout" || kind === "provider-incomplete"
     ? interruptedTaskRecoveryPrompt
     : null;
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -126,7 +126,7 @@ const backgroundDeltaFlushMs = 100;
 // timeout: elapsed time never marks a task done.
 const activeSessionStatusReconcileIntervalMs = 250;
 
-type SessionStatusSource = "stream" | "connect-reconcile" | "active-reconcile";
+type SessionStatusSource = "stream" | "connect-reconcile" | "active-reconcile" | "snapshot";
 
 function developerDiagnosticsEnabled() {
   if (typeof window === "undefined") return false;
@@ -251,7 +251,7 @@ export const permissionKey = (workspaceId: string, sessionId: string) =>
 export const questionKey = (workspaceId: string, sessionId: string) =>
   ["react-session-questions", workspaceId, sessionId] as const;
 
-function syncKey(input: SyncOptions) {
+function syncKey(input: Pick<SyncOptions, "workspaceId" | "baseUrl">) {
   return `${input.workspaceId}:${input.baseUrl}`;
 }
 
@@ -1131,6 +1131,8 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, info.sessionID), (current = []) =>
       upsertMessage(current, next),
     );
+    useSessionActivityStore.getState().observeTranscript(workspaceId, info.sessionID,
+      queryClient.getQueryData<UIMessage[]>(transcriptKey(workspaceId, info.sessionID)) ?? []);
     return;
   }
 
@@ -1212,6 +1214,8 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       return next;
     });
     if (pending) entry.pendingDeltas.delete(part.id);
+    useSessionActivityStore.getState().observeTranscript(workspaceId, part.sessionID,
+      queryClient.getQueryData<UIMessage[]>(transcriptKey(workspaceId, part.sessionID)) ?? []);
     return;
   }
 
@@ -1329,6 +1333,8 @@ function commitDeltas(entry: SyncEntry, workspaceId: string, items: PendingDelta
         return result.messages;
       },
     );
+    useSessionActivityStore.getState().observeTranscript(workspaceId, sessionId,
+      queryClient.getQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId)) ?? []);
   }
 }
 
@@ -1412,16 +1418,7 @@ function applySessionRunStatus(
   }
   const observedAt = perfNow();
   if (live) {
-    entry.liveSessionIds.add(sessionId);
-    if (!wasTrackedLive) {
-      entry.runActiveObservedAt.set(sessionId, observedAt);
-      recordSessionCompletionMark("run-active", {
-        sessionID: sessionId,
-        source: options.source ?? "stream",
-        status: status.type,
-      });
-    }
-    scheduleActiveSessionStatusReconciliation(entry);
+    trackLiveSession(entry, sessionId, status, options.source ?? "stream");
   } else {
     entry.liveSessionIds.delete(sessionId);
     clearActiveSessionStatusReconcileTimer(entry);
@@ -1500,13 +1497,24 @@ async function reconcileSessionPermissions(entry: SyncEntry, sessionId: string) 
   }
 }
 
+// Snapshot-only busy observations need the same validation as stream edges.
+function trackLiveSession(entry: SyncEntry, sessionId: string, status: SessionStatus, source: SessionStatusSource) {
+  if (!entry.liveSessionIds.has(sessionId)) {
+    entry.liveSessionIds.add(sessionId);
+    entry.runActiveObservedAt.set(sessionId, perfNow());
+    recordSessionCompletionMark("run-active", { sessionID: sessionId, source, status: status.type });
+  }
+  scheduleActiveSessionStatusReconciliation(entry);
+}
+
 async function reconcileSessionRunStatuses(
   entry: SyncEntry,
   input: SyncOptions,
   signal: AbortSignal,
-  source: Exclude<SessionStatusSource, "stream">,
+  source: Exclude<SessionStatusSource, "stream" | "snapshot">,
 ) {
   const startedAt = Date.now();
+  const key = syncKey(input);
   const sequences = new Map(entry.nativeSequenceBySession);
   if (source === "connect-reconcile") {
     const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId] ?? {};
@@ -1524,12 +1532,17 @@ async function reconcileSessionRunStatuses(
     // presenting a confident ticking "Working" row. Aborted fetches are
     // lifecycle noise (dispose, generation rotation), not failures.
     if (!signal.aborted) {
-      useWorkspaceSyncStreamStore.getState().publishReconcileFailure(syncKey(input));
+      useWorkspaceSyncStreamStore.getState().publishReconcileFailure(key);
     }
     return;
   }
   if (signal.aborted) return;
-  useWorkspaceSyncStreamStore.getState().publishReconcileSuccess(syncKey(input), startedAt);
+  const streamStore = useWorkspaceSyncStreamStore.getState();
+  const recovered = (streamStore.reconcileHealthByKey[key]?.consecutiveFailures ?? 0) > 0;
+  streamStore.publishReconcileSuccess(key, startedAt);
+  // Reachability recovered with this credential: wake a parked stream rather
+  // than waiting out the outage's backoff. Healthy streams ignore the nudge.
+  if (recovered) entry.notifyStreamGenerationChanged?.();
 
   // Level-triggered convergence on every SSE (re)connect: sessions the fetch
   // reports live are seeded busy (heals a subscriber that missed the busy
@@ -1594,12 +1607,30 @@ function scheduleActiveSessionStatusReconciliation(entry: SyncEntry) {
  * retry backoff or the next watchdog tick: reconnect any parked stream with
  * fresh backoff and revalidate run statuses immediately, so a run that ended
  * or kept working while the machine was offline settles within one fetch.
+ * Resolving means the probe settled; reconcileHealthByKey carries failures.
  */
+export async function revalidateWorkspaceSessionSync(input: Pick<SyncOptions, "workspaceId" | "baseUrl">) {
+  const entry = syncs.get(syncKey(input));
+  if (!entry) return;
+  entry.notifyStreamGenerationChanged?.();
+  // Own the immediate probe so disposal cancels it and an older active poll
+  // cannot overwrite its result. This only reads status; it never resends.
+  entry.statusReconcileAbort?.abort();
+  if (entry.statusReconcileTimer) clearTimeout(entry.statusReconcileTimer);
+  entry.statusReconcileTimer = null;
+  const controller = new AbortController();
+  entry.statusReconcileAbort = controller;
+  try {
+    await reconcileSessionRunStatuses(entry, entry.input, controller.signal, "connect-reconcile");
+  } finally {
+    if (entry.statusReconcileAbort === controller) entry.statusReconcileAbort = null;
+    scheduleActiveSessionStatusReconciliation(entry);
+  }
+}
+
 function revalidateWorkspaceSyncs() {
   for (const entry of syncs.values()) {
-    entry.notifyStreamGenerationChanged?.();
-    const controller = new AbortController();
-    void reconcileSessionRunStatuses(entry, entry.input, controller.signal, "connect-reconcile");
+    void revalidateWorkspaceSessionSync(entry.input);
   }
 }
 
@@ -1753,6 +1784,13 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
     );
     if (snapshotStartedAt >= (record?.runStatusAt ?? 0)) {
       queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), status);
+      if (isLiveStatus(status)) {
+        for (const entry of syncs.values()) {
+          if (entry.input.workspaceId === workspaceId) {
+            trackLiveSession(entry, snapshot.session.id, status, "snapshot");
+          }
+        }
+      }
     }
   }
 
@@ -1769,6 +1807,8 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   ));
 
   queryClient.setQueryData(todoKey(workspaceId, snapshot.session.id), snapshot.todos);
+  useSessionActivityStore.getState().observeTranscript(workspaceId, snapshot.session.id,
+    queryClient.getQueryData<UIMessage[]>(key) ?? [], true);
 }
 
 /**

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -17,7 +17,7 @@ import { trackSessionActive, trackTaskStarted } from "@/app/lib/den-telemetry";
 import { buildDiagnosticsBundleJson } from "@/app/lib/diagnostics-bundle";
 import { downloadTextAsFile } from "@/app/lib/download";
 import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
-import { createClient, unwrap } from "@/app/lib/opencode";
+import { createClient, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
 import { isOpencodeV2BaseUrl, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession, unrevertSession } from "@/app/lib/opencode-session";
 import { getNativeSessionMessages } from "@/app/lib/opencode-session-native";
@@ -138,6 +138,7 @@ import {
 import { openModelPickerEvent, openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
 import { markComposerAutoSend } from "@/react-app/domains/session/surface/composer-auto-send";
 import { sendWithRevertRollback } from "@/react-app/domains/session/surface/safe-edit-resend";
+import { assertQueuedSendCurrent, getQueuedSendGeneration } from "@/react-app/domains/session/surface/queued-drain-machine";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import type { CreateWorkspaceOptions } from "@/react-app/domains/workspace/types";
@@ -1302,6 +1303,8 @@ export function SessionRoute() {
       onSendDraft: async (draft: ComposerDraft, sessionId: string): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || selectedSessionId;
         if (!targetSessionId) return { outcome: "cancelled", reason: "context_changed" };
+        const generation = getQueuedSendGeneration(targetSessionId);
+        const assertCurrent = () => assertQueuedSendCurrent(targetSessionId, generation);
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!text && draft.attachments.length === 0) {
           return { outcome: "cancelled", reason: "context_changed" };
@@ -1323,6 +1326,7 @@ export function SessionRoute() {
           skipGate: true,
           send: async () => {
             await sendWithRevertRollback({
+              assertCurrent,
               revertMessageId: draft.revertMessageId,
               abort: () => abortSessionSafe(opencodeClient, targetSessionId, selectedWorkspaceRoot || undefined, {
                 source: "session.edit_resend.before_revert",
@@ -1386,11 +1390,13 @@ export function SessionRoute() {
                 }
 
                 const parts = await draftToParts(draft, selectedWorkspaceRoot, targetSessionId, selectedWorkspaceEndpoint);
+                assertCurrent();
                 const system = await buildOpenworkSessionSystemContext(client, {
                   workspaceId: selectedWorkspaceId,
                   cacheKey: targetSessionId,
                   runtimeKey: environmentRuntimeKey,
                 });
+                assertCurrent();
                 const result = await opencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
                   messageID: draft.messageId,
@@ -1401,6 +1407,7 @@ export function SessionRoute() {
                   system,
                 });
                 if (result.error) {
+                  if (isPromptAdmissionUnknown(result.error)) throw result.error;
                   throw new Error(serializeSDKError(result.error));
                 }
                 // Remember what this conversation used last so returning to it
@@ -1648,6 +1655,8 @@ export function SessionRoute() {
       onApplyEnvironmentChanges: undefined,
       onSendDraft: async (draft: ComposerDraft, sessionId: string): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || session.sessionId;
+        const generation = getQueuedSendGeneration(targetSessionId);
+        const assertCurrent = () => assertQueuedSendCurrent(targetSessionId, generation);
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!targetSessionId || (!text && draft.attachments.length === 0)) {
           return { outcome: "cancelled", reason: "context_changed" };
@@ -1659,6 +1668,7 @@ export function SessionRoute() {
           skipGate: true,
           send: async () => {
             await sendWithRevertRollback({
+              assertCurrent,
               revertMessageId: draft.revertMessageId,
               abort: () => abortSessionSafe(workspaceOpencodeClient, targetSessionId, workspaceRoot || undefined, {
                 source: "session.edit_resend.before_revert",
@@ -1707,11 +1717,13 @@ export function SessionRoute() {
                   return;
                 }
                 const parts = await draftToParts(draft, workspaceRoot, targetSessionId, endpoint);
+                assertCurrent();
                 const system = await buildOpenworkSessionSystemContext(endpoint.client, {
                   workspaceId: workspace.id,
                   cacheKey: targetSessionId,
                   runtimeKey: workspace.workspaceType === "remote" ? null : environmentRuntimeKey,
                 });
+                assertCurrent();
                 const result = await workspaceOpencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
                   messageID: draft.messageId,
@@ -1721,7 +1733,10 @@ export function SessionRoute() {
                   ...(sendVariant ? { variant: sendVariant } : {}),
                   system,
                 });
-                if (result.error) throw new Error(serializeSDKError(result.error));
+                if (result.error) {
+                  if (isPromptAdmissionUnknown(result.error)) throw result.error;
+                  throw new Error(serializeSDKError(result.error));
+                }
                 if (sendModel) {
                   useSessionModelStore.getState().setModel(targetSessionId, sendModel, sendVariant ?? null);
                 }

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -89,7 +89,18 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
   document.write("<!doctype html><html><body></body></html>");
   document.close();
   Object.defineProperty(document, "compatMode", { configurable: true, value: "CSS1Compat" });
-  const fetchStub = async () => new Response("{}", { headers: { "content-type": "application/json" } });
+  let acceptedMessageId: string | null = null;
+  const acceptanceRequests: Request[] = [];
+  const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    if (new URL(request.url).pathname.includes(`/session/${sessionId}/message/`)) {
+      acceptanceRequests.push(request);
+      return acceptedMessageId
+        ? Response.json({ info: { id: acceptedMessageId, sessionID: sessionId, role: "user" }, parts: [] })
+        : new Response(null, { status: 404 });
+    }
+    return Response.json({});
+  };
   Object.defineProperty(globalThis, "fetch", { configurable: true, value: fetchStub });
   Object.defineProperty(window, "fetch", { configurable: true, value: fetchStub });
   window.localStorage.setItem("openwork.shell-config", JSON.stringify({ starterCards: false }));
@@ -101,6 +112,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
   }));
   const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
   const { snapshotKey, transcriptKey } = await import("../src/react-app/domains/session/sync/session-sync");
+  const { getQueuedDrainState, resetQueuedDrainForTests } = await import("../src/react-app/domains/session/surface/queued-drain-machine");
   const queryClient = getReactQueryClient();
   queryClient.clear();
   queryClient.setQueryData(snapshotKey(workspaceId, sessionId), createSnapshot({ type: "busy" }, 1));
@@ -249,6 +261,50 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(container.textContent?.split("First message auto-send").length).toBe(2);
     expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
 
+    const { PromptAdmissionUnknownError } = await import("../src/app/lib/opencode");
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Uncertain send"));
+    await act(async () => send());
+    const uncertainId = sentDrafts[3]?.messageId;
+    if (!uncertainId) throw new Error("Expected the canonical draft identity");
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()[0]?.draft.messageId).toBe(uncertainId);
+    expect(sentDrafts[3]).not.toHaveProperty("messageID");
+    expect(editor.textContent).toBe("");
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Newer uncertain draft"));
+    await act(async () => submission.reject(new PromptAdmissionUnknownError({ messageID: uncertainId })));
+    expect(editor.textContent).toBe("Newer uncertain draft");
+    expect(getQueuedDrainState(sessionId).phase).toMatchObject({ kind: "admission_unknown", messageID: uncertainId });
+    expect(Object.values(useComposerStateStore.getState().failedDrafts).flat()).toHaveLength(0);
+    expect(useComposerStateStore.getState().queuedDrafts[sessionId]).toBeUndefined();
+    await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{
+      id: "other-identical-prompt", role: "user", parts: [{ type: "text", text: "Uncertain send" }],
+    }]));
+    await waitFor(() => container.textContent?.split("Uncertain send").length === 3, "the unrelated same-text turn beside the pending bubble");
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
+    const checkAcceptance = () => {
+      const button = [...container.querySelectorAll<HTMLButtonElement>("button")].find((item) => item.textContent === "Check acceptance");
+      if (!button) throw new Error("Expected the read-only acceptance check");
+      button.click();
+    };
+    await act(async () => checkAcceptance());
+    expect(getQueuedDrainState(sessionId).phase.kind).toBe("admission_unknown");
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
+    acceptedMessageId = uncertainId;
+    await act(async () => checkAcceptance());
+    expect(getQueuedDrainState(sessionId).phase.kind).toBe("awaiting_observation");
+    for (const request of acceptanceRequests) {
+      expect(request.method).toBe("GET");
+      expect(new URL(request.url).pathname).toBe(`/opencode/session/${sessionId}/message/${uncertainId}`);
+      expect(new URL(request.url).searchParams.get("directory")).toBe("/tmp/project-focus-continuity");
+    }
+    expect(acceptanceRequests).toHaveLength(2);
+    await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{
+      id: uncertainId, role: "user", parts: [{ type: "text", text: "Uncertain send" }],
+    }]));
+    await waitFor(() => Object.values(useComposerStateStore.getState().pendingMessages).flat().length === 0, "the exact observed turn to replace the pending bubble");
+    expect(editor.textContent).toBe("Newer uncertain draft");
+    expect(sentDrafts).toHaveLength(4);
+
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
     const creation = Promise.withResolvers<void>();
     let creations = 0;
@@ -279,6 +335,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(creations).toBe(1);
   } finally {
     await act(async () => root.unmount());
+    resetQueuedDrainForTests();
     useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {}, pendingMessages: {}, failedDrafts: {} });
     queryClient.clear();
     container.remove();

--- a/apps/app/tests/composer-state-store.test.ts
+++ b/apps/app/tests/composer-state-store.test.ts
@@ -74,6 +74,9 @@ describe("composer state store", () => {
 
     const items = getComposerQueuedDrafts(useComposerStateStore.getState(), "session-a");
     const ids = items.map((item) => item.id);
+    const messageIDs = items.map((item) => item.draft.messageId);
+    expect(new Set(messageIDs).size).toBe(3);
+    for (const messageID of messageIDs) expect(messageID).toMatch(/^msg_[0-9a-f]{26}$/);
     reorderQueuedDrafts("session-a", [ids[2] ?? "", ids[0] ?? "", ids[1] ?? ""]);
     expect(queuedTexts("session-a")).toEqual(["third", "first", "second"]);
 
@@ -81,6 +84,12 @@ describe("composer state store", () => {
     expect(secondId).toBeTruthy();
     updateQueuedDraft("session-a", secondId ?? "", draft("first edited"));
     expect(queuedTexts("session-a")).toEqual(["third", "first edited", "second"]);
+    const reordered = getComposerQueuedDrafts(useComposerStateStore.getState(), "session-a");
+    expect(reordered.map((item) => item.draft.messageId)).toEqual([messageIDs[2], messageIDs[0], messageIDs[1]]);
+    const first = reordered[0]!;
+    useComposerStateStore.getState().removeQueuedDraft("session-a", first.id);
+    useComposerStateStore.getState().prependQueuedDrafts("session-a", [first]);
+    expect(getComposerQueuedDrafts(useComposerStateStore.getState(), "session-a")[0]?.draft.messageId).toBe(first.draft.messageId);
   });
 
   test("carries an edit boundary until clear, replacement, or session switch", () => {

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -1,6 +1,9 @@
 /** @jsxImportSource react */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { UIMessage } from "ai";
 
 import {
@@ -12,6 +15,18 @@ import {
 } from "../src/components/chat/message-list";
 import { MessageListProvider } from "../src/components/chat/message-list-provider";
 import type { ThreadStatus } from "../src/lib/messages";
+import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import { activeDelegatedTasks, hasNoNewActivity, lastTaskProgressAt, transcriptProgress } from "../src/react-app/domains/session/status/session-progress";
+import type { TaskToolPart } from "../src/lib/build-in-tools";
+import { WorkspaceProvider } from "../src/react-app/shell/workspace-provider";
+import * as sessionSync from "../src/react-app/domains/session/sync/session-sync";
+
+const inspectChild = mock((_sessionId: string) => {});
+
+afterEach(() => {
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+  inspectChild.mockClear();
+});
 
 const userMessage: UIMessage = {
   id: "user-1",
@@ -19,8 +34,8 @@ const userMessage: UIMessage = {
   parts: [{ type: "text", text: "Send this", state: "done" }],
 };
 
-function renderList(messages: UIMessage[], status: ThreadStatus, syncHealth?: RunSyncHealth) {
-  return renderToStaticMarkup(
+function list(messages: UIMessage[], status: ThreadStatus, syncHealth?: RunSyncHealth) {
+  return (
     <MessageListProvider
       workspaceId="ws"
       sessionId="session"
@@ -34,13 +49,18 @@ function renderList(messages: UIMessage[], status: ThreadStatus, syncHealth?: Ru
       onRevertToUserMessage={() => {}}
       onForkAtMessage={() => {}}
       onEditUserMessage={() => {}}
+      onOpenSubagentSession={inspectChild}
       onMcpReconnect={() => Promise.reject(new Error("unused"))}
       onMcpReopenAuthorization={() => Promise.resolve()}
       onMcpRetry={() => {}}
     >
-      <MessageList messages={messages} status={status} syncHealth={syncHealth} />
+      <MessageList messages={messages} status={status} activityStatus="thinking" syncHealth={syncHealth} />
     </MessageListProvider>,
   );
+}
+
+function renderList(messages: UIMessage[], status: ThreadStatus, syncHealth?: RunSyncHealth) {
+  return renderToStaticMarkup(list(messages, status, syncHealth));
 }
 
 describe("message-list loading feedback", () => {
@@ -68,6 +88,153 @@ describe("message-list loading feedback", () => {
 
   test("does not duplicate working feedback when a tool row is visible", () => {
     expect(shouldShowMessageListLoading("streaming", 2, true)).toBe(false);
+  });
+});
+
+const task: TaskToolPart = {
+  type: "dynamic-tool", toolName: "task", toolCallId: "delegation", state: "input-available",
+  input: { description: "Review project notes", prompt: "PRIVATE TASK PROMPT", subagent_type: "general" },
+  callProviderMetadata: { openwork: { childSessionId: "child" } },
+};
+const delegated: UIMessage = { id: "assistant", role: "assistant", parts: [task] };
+const followup: UIMessage = { id: "followup", role: "user", parts: [{ type: "text", text: "What is the update?" }] };
+
+describe("task-linked meaningful progress", () => {
+  test("carries old active tasks below the latest user follow-up without a second live card", () => {
+    const messages = [userMessage, delegated, followup];
+    expect(activeDelegatedTasks(messages)).toEqual([task]);
+    const html = renderList(messages, "streaming");
+    expect(html).toContain("Running 1 subagent");
+    expect(html.indexOf('data-testid="active-subagents"')).toBeGreaterThan(html.indexOf("What is the update?"));
+    expect(html.match(/data-subagent-run="delegation"/g)).toHaveLength(1);
+    expect(html).toContain('data-subagent-history="delegation"');
+    expect(html).not.toContain('data-loading-message="working"');
+    expect(html).not.toContain("PRIVATE TASK PROMPT");
+  });
+
+  test("deduplicates repeated call versions and removes only explicitly settled delegations", () => {
+    expect(activeDelegatedTasks([delegated, delegated, followup])).toEqual([task]);
+    const completed: UIMessage = { ...delegated, parts: [{ ...task, state: "output-available", output: "PRIVATE RESULT" }] };
+    expect(activeDelegatedTasks([delegated, followup, completed])).toEqual([]);
+    const html = renderList([userMessage, completed], "ready");
+    expect(html).not.toContain('data-testid="active-subagents"');
+    expect(html).toContain("Completed");
+    expect(html).not.toContain("PRIVATE RESULT");
+  });
+
+  test("does not claim an unobserved child is running after its parent stops", () => {
+    const html = renderList([userMessage, delegated, followup], "ready");
+    expect(html).toContain("Subagent activity · 1 task");
+    expect(html).toContain("Waiting for task result");
+    expect(html).not.toContain("Running 1 subagent");
+    expect(html).not.toContain("Completed");
+  });
+
+  test("busy polls, identical snapshots, user follow-ups and unrelated sessions do not reset silence", async () => {
+    const ownedDom = typeof window === "undefined";
+    if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+    const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const revalidate = spyOn(sessionSync, "revalidateWorkspaceSessionSync").mockResolvedValue(undefined);
+    const view = () => <WorkspaceProvider client={null} workspaceId="ws" opencodeBaseUrl="http://localhost/test-engine" selectedWorkspaceRoot="/tmp/test">
+      {list([userMessage, delegated, followup], "streaming")}
+    </WorkspaceProvider>;
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const store = useSessionActivityStore.getState();
+      store.setRunStatus("ws", "session", { type: "busy" });
+      store.observeTranscript("ws", "session", [userMessage, delegated]);
+      clock.mockReturnValue(62_000);
+      store.setRunStatus("ws", "session", { type: "busy" });
+      store.seedSessionRun("ws", "session", { type: "busy" }, true, { snapshotStartedAt: 62_000 });
+      store.observeTranscript("ws", "session", structuredClone([userMessage, delegated, followup]), true);
+      const output: UIMessage = { id: "child-output", role: "assistant", parts: [{ type: "text", text: "PRIVATE OUTPUT" }] };
+      store.observeTranscript("other-workspace", "child", [output]);
+      store.observeTranscript("ws", "unrelated-child", [output]);
+      let records = useSessionActivityStore.getState().recordsByWorkspaceId.ws;
+      expect(records.session.runStartedAt).toBe(1_000);
+      expect(records.session.lastProgressAt).toBe(1_000);
+      expect(lastTaskProgressAt(1_000, [task], records)).toBe(1_000);
+      await act(async () => { root.render(view()); });
+      let html = container.innerHTML;
+      expect(html).toContain('data-loading-message="no-new-activity"');
+      expect(html).not.toContain('data-loading-message="working"');
+      expect(html).not.toContain('data-testid="session-error-resume"');
+      expect(revalidate).toHaveBeenCalledTimes(1);
+      expect(revalidate).toHaveBeenCalledWith({ workspaceId: "ws", baseUrl: "http://localhost/test-engine" });
+      const inspect = container.querySelector<HTMLButtonElement>('[data-testid="active-subagents"] button');
+      if (!inspect) throw new Error("Missing child inspection button");
+      await act(async () => { inspect.click(); });
+      expect(inspectChild).toHaveBeenCalledTimes(1);
+      expect(inspectChild).toHaveBeenCalledWith("child");
+      expect(container.querySelectorAll('[data-subagent-history] button')).toHaveLength(0);
+      await act(async () => { root.render(view()); });
+      expect(revalidate).toHaveBeenCalledTimes(1);
+      await act(async () => { store.observeTranscript("ws", "child", [output]); });
+      records = useSessionActivityStore.getState().recordsByWorkspaceId.ws;
+      expect(lastTaskProgressAt(1_000, [task], records)).toBe(62_000);
+      html = container.innerHTML;
+      expect(html).not.toContain('data-loading-message="no-new-activity"');
+      expect(html).toContain("Running 1 subagent");
+      expect(html).not.toContain("PRIVATE OUTPUT");
+      expect(html).toContain("Last activity: Response updated");
+      clock.mockReturnValue(123_000);
+      await act(async () => {
+        store.observeTranscript("ws", "child", structuredClone([output]), true);
+        // Identical snapshots do not rerender: the ordinary UI tick must warn.
+        await new Promise((resolve) => window.setTimeout(resolve, 1_100));
+      });
+      expect(container.innerHTML).toContain('data-loading-message="no-new-activity"');
+      await act(async () => { store.setWaitingRequest("ws", "child", "question", "question-1", true); });
+      expect(container.innerHTML).not.toContain('data-loading-message="no-new-activity"');
+      expect(container.innerHTML).toContain("Waiting for your answer");
+      await act(async () => {
+        store.setWaitingRequest("ws", "child", "question", "question-1", false);
+        store.setRunStatus("ws", "child", { type: "retry" });
+      });
+      expect(container.innerHTML).not.toContain('data-loading-message="no-new-activity"');
+      expect(container.innerHTML).toContain("Retrying");
+      await act(async () => { store.setRunStatus("ws", "child", { type: "idle" }); });
+      expect(container.innerHTML).toContain("Subagent activity · 1 task");
+      expect(container.innerHTML).not.toContain("Completed");
+      expect(container.innerHTML).toContain("Waiting for task result");
+    } finally {
+      await act(async () => { root.unmount(); });
+      container.remove();
+      clock.mockRestore();
+      revalidate.mockRestore();
+      Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+      if (ownedDom) await GlobalRegistrator.unregister();
+    }
+  });
+
+  test("only content and tool lifecycle changes count, not changing provider metadata", () => {
+    const original = transcriptProgress([delegated]);
+    expect(transcriptProgress([{ ...delegated, metadata: { opencode: { updated: 999 } } }]).revision).toBe(original.revision);
+    expect(transcriptProgress([delegated, followup]).revision).toBe(original.revision);
+    const result: UIMessage = { ...delegated, parts: [{ ...task, state: "output-available", output: "PRIVATE RESULT" }] };
+    expect(transcriptProgress([result]).revision).not.toBe(original.revision);
+    expect(transcriptProgress([result]).label).toBe("Tool result received");
+    const reasoning: UIMessage = { id: "reason", role: "assistant", parts: [{ type: "reasoning", text: "PRIVATE REASONING" }] };
+    const next = transcriptProgress([delegated, reasoning]);
+    expect(next.revision).not.toBe(original.revision);
+    expect(JSON.stringify(next)).not.toContain("PRIVATE");
+    const response: UIMessage = { id: "response", role: "assistant", parts: [{ type: "text", text: "Already sent" }] };
+    const before = transcriptProgress([delegated, response]);
+    expect(transcriptProgress([result, response], before.parts).label).toBe("Tool result received");
+  });
+
+  test("warns strictly after a minute, preserving authoritative waiting, retry and disconnection", () => {
+    const input = { active: true, lastProgressAt: 1_000, now: 61_000 };
+    expect(hasNoNewActivity(input)).toBe(false);
+    expect(hasNoNewActivity({ ...input, now: 61_001 })).toBe(true);
+    expect(hasNoNewActivity({ ...input, now: 120_000, active: false })).toBe(false);
+    for (const override of [{ waiting: true }, { retrying: true }, { disconnected: true }]) {
+      expect(hasNoNewActivity({ ...input, now: 120_000, ...override })).toBe(false);
+    }
   });
 });
 

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
-import type { FieldsResult } from "../src/app/lib/opencode";
+import { createClient, createPromptMessageID, hasAcceptedPromptMessage, type FieldsResult } from "../src/app/lib/opencode";
 import {
   composeNativeSessionSnapshot,
   deleteNativeSession,
@@ -57,6 +57,42 @@ function operations(overrides: Partial<NativeSessionOperations> = {}): NativeSes
 }
 
 describe("native OpenCode session operations", () => {
+  test("acceptance requires an exact native user-message GET, never absence or another message", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Request[] = [];
+    let response = new Response(null, { status: 404 });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push(new Request(input, init));
+        return response;
+      },
+    });
+    try {
+      const client = createClient(endpoint.opencodeBaseUrl, session.directory, { token: endpoint.token, mode: "openwork" });
+      const messageID = createPromptMessageID();
+      expect(await hasAcceptedPromptMessage(client, session.id, messageID)).toBe(false);
+      for (const info of [
+        { id: "msg_other", sessionID: session.id, role: "user" },
+        { id: messageID, sessionID: "ses_other", role: "user" },
+        { id: messageID, sessionID: session.id, role: "assistant" },
+      ]) {
+        response = Response.json({ info, parts: [] });
+        expect(await hasAcceptedPromptMessage(client, session.id, messageID)).toBe(false);
+      }
+      response = Response.json({ info: { id: messageID, sessionID: session.id, role: "user" }, parts: [] });
+      expect(await hasAcceptedPromptMessage(client, session.id, messageID)).toBe(true);
+      expect(requests).toHaveLength(5);
+      for (const request of requests) {
+        expect(request.method).toBe("GET");
+        const url = new URL(request.url);
+        expect(`${url.origin}${url.pathname}`).toBe(`${endpoint.opencodeBaseUrl}/session/${session.id}/message/${messageID}`);
+        expect(url.searchParams.get("directory")).toBe(session.directory);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
   test("uses the resolved mounted endpoint and its workspace token", async () => {
     let receivedEndpoint: typeof endpoint | null = null;
     await getNativeSession(endpoint, session.id, undefined, {

--- a/apps/app/tests/opencode-stream-timeout.test.ts
+++ b/apps/app/tests/opencode-stream-timeout.test.ts
@@ -1,28 +1,17 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 let capturedFetch: typeof globalThis.fetch | null = null;
 
-async function unusedSessionMethod() {
-  throw new Error("SDK mock method should not be called");
-}
+const { createOpencodeClient: createSDKClient } = await import("@opencode-ai/sdk/v2/client");
 
 mock.module("@opencode-ai/sdk/v2/client", () => ({
-  createOpencodeClient: (options: { fetch?: typeof globalThis.fetch }) => {
-    capturedFetch = options.fetch ?? null;
-    return {
-      session: {
-        list: unusedSessionMethod,
-        get: unusedSessionMethod,
-        messages: unusedSessionMethod,
-        todo: unusedSessionMethod,
-        promptAsync: unusedSessionMethod,
-        command: unusedSessionMethod,
-      },
-    };
+  createOpencodeClient: (options: Parameters<typeof createSDKClient>[0]) => {
+    capturedFetch = options?.fetch ?? null;
+    return createSDKClient(options);
   },
 }));
 
-const { createClient } = await import("../src/app/lib/opencode");
+const { createClient, createPromptMessageID, PromptAdmissionUnknownError, hasAcceptedPromptMessage } = await import("../src/app/lib/opencode");
 
 const originalWindow = globalThis.window;
 const originalFetch = globalThis.fetch;
@@ -49,9 +38,11 @@ function restoreGlobals() {
 }
 
 function installControllableFetch() {
+  let attempts = 0;
   let observedSignal: AbortSignal | null = null;
   let rejectResponse: ((reason: unknown) => void) | null = null;
   const fetchImpl: typeof globalThis.fetch = (input, init) => {
+    attempts += 1;
     observedSignal = init?.signal ?? (input instanceof Request ? input.signal : null);
     return new Promise<Response>((_resolve, reject) => {
       rejectResponse = reject;
@@ -69,6 +60,7 @@ function installControllableFetch() {
     value: fetchImpl,
   });
   return {
+    attempts: () => attempts,
     observedSignal: () => observedSignal,
     cancel: () => rejectResponse?.(new Error("test cleanup")),
   };
@@ -104,6 +96,7 @@ function trackPromise<T>(promise: Promise<T>) {
 
 describe("OpenCode transport timeouts", () => {
   afterEach(() => {
+    jest.useRealTimers();
     restoreGlobals();
   });
 
@@ -143,6 +136,136 @@ describe("OpenCode transport timeouts", () => {
       cancel();
     }
   }, 15_000);
+
+  test.each(["web URL", "web Request", "desktop Request"])("bounds prompt_async acceptance at 30 seconds without resending (%s)", async (transport) => {
+    jest.useFakeTimers();
+    installWindow(transport === "desktop Request" ? { __OPENWORK_ELECTRON__: {} } : undefined);
+    const { cancel, observedSignal, attempts } = installControllableFetch();
+    const fetchImpl = createCapturedFetch();
+
+    const url = "http://127.0.0.1:8788/workspace/ws_test/opencode/session/ses_send/prompt_async";
+    const init = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    };
+    const response = transport === "web URL" ? fetchImpl(url, init) : fetchImpl(new Request(url, init));
+    const state = trackPromise(response);
+    const errorPromise = response.catch((error: unknown) => error);
+
+    try {
+      expect(observedSignal()).not.toBeNull();
+      jest.advanceTimersByTime(29_999);
+      await Promise.resolve();
+      expect(observedSignal()?.aborted).toBe(false);
+      expect(state()).toBe("pending");
+
+      jest.advanceTimersByTime(1);
+      expect(await errorPromise).toBeInstanceOf(PromptAdmissionUnknownError);
+      expect(observedSignal()?.aborted).toBe(true);
+      jest.advanceTimersByTime(60_000);
+      expect(attempts()).toBe(1);
+    } finally {
+      cancel();
+    }
+  });
+
+  test("keeps synchronous command and summarize requests untimed", async () => {
+    jest.useFakeTimers();
+    installWindow(undefined);
+    const { cancel, observedSignal } = installControllableFetch();
+    const fetchImpl = createCapturedFetch();
+
+    for (const path of ["command", "summarize"]) {
+      const response = fetchImpl(`https://web.example/workspace/ws_test/opencode/session/ses_send/${path}`, {
+        method: "POST",
+      });
+      const state = trackPromise(response);
+      const settled = response.catch(() => undefined);
+      jest.advanceTimersByTime(5 * 60_000);
+      await Promise.resolve();
+      expect(observedSignal()).toBeNull();
+      expect(state()).toBe("pending");
+      cancel();
+      await settled;
+    }
+  });
+
+  test.each([408, 500, 502, 503, 504, "network", "malformed"])("preserves uncertain prompt admission without replay (%s)", async (failure) => {
+    installWindow(undefined);
+    const requests: Request[] = [];
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push(new Request(input, init));
+        if (failure === "network") throw new TypeError("connection lost");
+        return new Response("not json", { status: failure === "malformed" ? 200 : failure });
+      },
+    });
+    const client = createClient("https://web.example/workspace/ws_test/opencode", "/workspace/test");
+    const messageID = createPromptMessageID();
+    await expect(client.session.promptAsync({
+      sessionID: "ses_parent", messageID, parts: [{ type: "text", text: "follow up" }],
+    })).rejects.toMatchObject({ name: "PromptAdmissionUnknownError", admission: "unknown", messageID });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+    expect(requests[0]?.url).toBe("https://web.example/workspace/ws_test/opencode/session/ses_parent/prompt_async");
+    expect(requests[0]?.headers.get("x-opencode-directory")).toBe("/workspace/test");
+    expect(await requests[0]?.json()).toMatchObject({ messageID });
+  });
+
+  test("keeps explicit client rejection distinct from unknown admission", async () => {
+    installWindow(undefined);
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async () => Response.json({ message: "invalid prompt" }, { status: 400 }),
+    });
+    const client = createClient("https://web.example");
+    const result = await client.session.promptAsync({ sessionID: "ses_parent", parts: [] });
+    expect(result.error).toEqual({ message: "invalid prompt" });
+  });
+
+  test.each(["prompt", "acceptance check"])("bounds a stalled response body without repeating the %s", async (operation) => {
+    jest.useFakeTimers();
+    installWindow(undefined);
+    let attempts = 0;
+    let body: ReadableStreamDefaultController<Uint8Array> | undefined;
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async () => {
+        attempts += 1;
+        return new Response(new ReadableStream<Uint8Array>({ start(controller) { body = controller; } }), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+    const client = createClient("https://web.example");
+    const messageID = createPromptMessageID();
+    const result = (operation === "prompt"
+      ? client.session.promptAsync({ sessionID: "ses_parent", messageID, parts: [] })
+      : hasAcceptedPromptMessage(client, "ses_parent", messageID)).catch((error: unknown) => error);
+    for (let index = 0; index < 20; index += 1) await Promise.resolve();
+    jest.advanceTimersByTime(operation === "prompt" ? 30_000 : 10_000);
+    const error = await result;
+    if (operation === "prompt") expect(error).toMatchObject({ admission: "unknown", messageID });
+    else expect(error).toMatchObject({ message: "Acceptance check timed out. The message is still held." });
+    jest.advanceTimersByTime(60_000);
+    expect(attempts).toBe(1);
+    body?.close();
+  });
+
+  test("the bounded native POST preserves the same message ID on its unknown error", async () => {
+    jest.useFakeTimers();
+    installWindow(undefined);
+    const { attempts } = installControllableFetch();
+    const client = createClient("https://web.example");
+    const messageID = createPromptMessageID();
+    const error = client.session.promptAsync({ sessionID: "ses_parent", messageID, parts: [] }).catch((error: unknown) => error);
+    jest.advanceTimersByTime(30_000);
+    expect(await error).toMatchObject({ admission: "unknown", messageID });
+    jest.advanceTimersByTime(60_000);
+    expect(attempts()).toBe(1);
+  });
 
   test("lets caller AbortSignal cancel web streams", async () => {
     installWindow(undefined);

--- a/apps/app/tests/queued-drain-admission-wedge.test.ts
+++ b/apps/app/tests/queued-drain-admission-wedge.test.ts
@@ -2,14 +2,15 @@ import { expect, test } from "bun:test";
 
 import {
   canAdmitNextQueuedItem,
+  assertQueuedSendCurrent,
   claimQueuedSend,
   dispatchQueuedDrain,
   getQueuedDrainState,
+  getQueuedSendGeneration,
   INITIAL_QUEUED_DRAIN_STATE,
   nextObservationProbeAt,
   QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS,
   QUEUE_ADMISSION_PROBE_RETRY_MS,
-  QUEUE_SEND_ATTEMPT_LIMIT,
   reduceQueuedDrain,
   resetQueuedDrainForTests,
   subscribeQueuedDrain,
@@ -77,18 +78,10 @@ test("a message accepted by admission whose upstream dispatch fails still releas
   expect(state.lastResolution).toEqual({ itemId: "item-1", resolution: "completed" });
   expect(canAdmitNextQueuedItem(state)).toBe(true);
 
-  // Contrast: a send whose transport THREW was never admitted — it stays
-  // retryable and halts as a terminal failure once attempts are exhausted,
-  // instead of retrying forever or silently dropping the item.
-  let failing = INITIAL_QUEUED_DRAIN_STATE;
-  for (let attempt = 1; attempt <= QUEUE_SEND_ATTEMPT_LIMIT; attempt += 1) {
-    failing = reduceQueuedDrain(failing, { type: "send_started", itemId: "item-2" });
-    failing = reduceQueuedDrain(failing, { type: "send_error", itemId: "item-2" });
-    if (attempt < QUEUE_SEND_ATTEMPT_LIMIT) {
-      expect(failing.lastResolution).toEqual({ itemId: "item-2", resolution: "retryable_unknown" });
-      expect(canAdmitNextQueuedItem(failing)).toBe(true);
-    }
-  }
+  // Only a definite rejection/preflight failure is retryable, and even that
+  // requires explicit user action. An uncertain POST uses send_unknown.
+  let failing = reduceQueuedDrain(INITIAL_QUEUED_DRAIN_STATE, { type: "send_started", itemId: "item-2" });
+  failing = reduceQueuedDrain(failing, { type: "send_error", itemId: "item-2" });
   expect(failing.phase).toEqual({ kind: "halted", itemId: "item-2", reason: "terminal_failure" });
   expect(failing.lastResolution).toEqual({ itemId: "item-2", resolution: "terminal_failure" });
   // Negative half: a terminal failure never self-heals into a send.
@@ -96,6 +89,72 @@ test("a message accepted by admission whose upstream dispatch fails still releas
   // An explicit user retry — and only that — releases it.
   failing = reduceQueuedDrain(failing, { type: "user_retry" });
   expect(canAdmitNextQueuedItem(failing)).toBe(true);
+});
+
+test("unknown admission survives idle, busy, retry, Stop, and remount until the exact message is observed", () => {
+  resetQueuedDrainForTests();
+  const sessionId = "ses_unknown";
+  expect(claimQueuedSend(sessionId, "item-1")).toBe(true);
+  dispatchQueuedDrain(sessionId, { type: "send_unknown", itemId: "item-1", messageID: "msg_exact", at: t0 });
+  const held = getQueuedDrainState(sessionId);
+  const unsubscribe = subscribeQueuedDrain(sessionId, () => {});
+  unsubscribe();
+  for (const event of [
+    { type: "idle_reconciled", observedAt: t0 + 60_000 },
+    { type: "busy_observed" },
+    { type: "user_retry" },
+    { type: "queue_cleared" },
+    { type: "admission_observed", itemId: "item-1", messageID: "msg_other", at: t0 + 1 },
+    { type: "admission_observed", itemId: "item-other", messageID: "msg_exact", at: t0 + 1 },
+  ] satisfies Parameters<typeof dispatchQueuedDrain>[1][]) {
+    dispatchQueuedDrain(sessionId, event);
+    expect(getQueuedDrainState(sessionId)).toBe(held);
+    expect(claimQueuedSend(sessionId, "item-1", true)).toBe(false);
+    expect(claimQueuedSend(sessionId, "item-2", true)).toBe(false);
+  }
+  expect(nextObservationProbeAt(held, null)).toBe(t0 + QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS);
+  dispatchQueuedDrain(sessionId, { type: "admission_observed", itemId: "item-1", messageID: "msg_exact", at: t0 + 100_000 });
+  expect(canAdmitNextQueuedItem(getQueuedDrainState(sessionId))).toBe(false);
+  dispatchQueuedDrain(sessionId, { type: "idle_reconciled", observedAt: t0 + 60_000 });
+  expect(canAdmitNextQueuedItem(getQueuedDrainState(sessionId))).toBe(false);
+  dispatchQueuedDrain(sessionId, { type: "idle_reconciled", observedAt: t0 + 110_000 });
+  expect(claimQueuedSend(sessionId, "item-2")).toBe(true);
+  resetQueuedDrainForTests();
+});
+
+test("send now shares the current claim with the idle drain and every split pane", () => {
+  resetQueuedDrainForTests();
+  const sessionId = "ses_steer";
+  expect(claimQueuedSend(sessionId, "item-1")).toBe(true);
+  expect(claimQueuedSend(sessionId, "item-1", true)).toBe(false);
+  expect(claimQueuedSend(sessionId, "item-2", true)).toBe(false);
+  dispatchQueuedDrain(sessionId, { type: "send_result", itemId: "item-1", outcome: "sent", at: t0 });
+  expect(claimQueuedSend(sessionId, "item-1", true)).toBe(false);
+  dispatchQueuedDrain(sessionId, { type: "busy_observed" });
+  expect(claimQueuedSend(sessionId, "item-2", true)).toBe(true);
+  expect(claimQueuedSend(sessionId, "item-2")).toBe(false);
+  expect(claimQueuedSend(sessionId, "item-3", true)).toBe(false);
+  dispatchQueuedDrain(sessionId, { type: "send_error", itemId: "item-2" });
+  expect(claimQueuedSend(sessionId, "item-2")).toBe(false);
+  expect(claimQueuedSend(sessionId, "item-3", true)).toBe(false);
+  // Explicit Send now can retry a definite rejection, never an unknown POST.
+  expect(claimQueuedSend(sessionId, "item-2", true)).toBe(true);
+  resetQueuedDrainForTests();
+});
+
+test("Stop invalidates preflight and late requeue without erasing a possibly admitted POST", () => {
+  resetQueuedDrainForTests();
+  const sessionId = "ses_stop";
+  expect(claimQueuedSend(sessionId, "item-1")).toBe(true);
+  const generation = getQueuedSendGeneration(sessionId);
+  assertQueuedSendCurrent(sessionId, generation);
+  dispatchQueuedDrain(sessionId, { type: "queue_cleared" });
+  expect(() => assertQueuedSendCurrent(sessionId, generation)).toThrow("Send cancelled by Stop.");
+  expect(getQueuedSendGeneration(sessionId)).not.toBe(generation);
+  expect(claimQueuedSend(sessionId, "item-2", true)).toBe(false);
+  dispatchQueuedDrain(sessionId, { type: "send_unknown", itemId: "item-1", messageID: "msg_exact", at: t0 });
+  expect(getQueuedDrainState(sessionId).phase.kind).toBe("admission_unknown");
+  resetQueuedDrainForTests();
 });
 
 test("an event-stream disconnect and reconnect during admission is healed by level reconciliation", () => {

--- a/apps/app/tests/safe-edit-resend.test.ts
+++ b/apps/app/tests/safe-edit-resend.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { sendWithRevertRollback } from "../src/react-app/domains/session/surface/safe-edit-resend";
+import { PromptAdmissionUnknownError } from "../src/app/lib/opencode";
+import { assertQueuedSendCurrent, dispatchQueuedDrain, getQueuedSendGeneration, resetQueuedDrainForTests } from "../src/react-app/domains/session/surface/queued-drain-machine";
 
 describe("safe edit resend", () => {
   test("sends a normal draft without history mutation", async () => {
@@ -37,5 +39,41 @@ describe("safe edit resend", () => {
 
     expect(calls).toEqual(["abort", "revert:message-a", "prompt", "unrevert"]);
     expect(thrown).toBe(promptError);
+  });
+
+  test("never unreverts or resubmits a replacement whose admission is unknown", async () => {
+    const calls: string[] = [];
+    const error = new PromptAdmissionUnknownError({ messageID: "msg_replacement" });
+    await expect(sendWithRevertRollback({
+      revertMessageId: "msg_original",
+      abort: async () => calls.push("abort"),
+      revert: async () => calls.push("revert"),
+      prompt: async () => { calls.push("prompt"); throw error; },
+      unrevert: async () => calls.push("unrevert"),
+    })).rejects.toBe(error);
+    expect(calls).toEqual(["abort", "revert", "prompt"]);
+  });
+
+  test.each(["abort", "revert"])("Stop during %s prevents the late replacement POST", async (stopAt) => {
+    resetQueuedDrainForTests();
+    const sessionId = "ses_edit_stop";
+    const generation = getQueuedSendGeneration(sessionId);
+    const calls: string[] = [];
+    await expect(sendWithRevertRollback({
+      assertCurrent: () => assertQueuedSendCurrent(sessionId, generation),
+      revertMessageId: "msg_original",
+      abort: async () => {
+        calls.push("abort");
+        if (stopAt === "abort") dispatchQueuedDrain(sessionId, { type: "queue_cleared" });
+      },
+      revert: async () => {
+        calls.push("revert");
+        if (stopAt === "revert") dispatchQueuedDrain(sessionId, { type: "queue_cleared" });
+      },
+      prompt: async () => { calls.push("prompt"); },
+      unrevert: async () => calls.push("unrevert"),
+    })).rejects.toThrow("Send cancelled by Stop.");
+    expect(calls).toEqual(stopAt === "abort" ? ["abort"] : ["abort", "revert", "unrevert"]);
+    resetQueuedDrainForTests();
   });
 });

--- a/apps/app/tests/session-error-resilience.test.tsx
+++ b/apps/app/tests/session-error-resilience.test.tsx
@@ -244,6 +244,29 @@ describe("session error resilience", () => {
     )
   }
 
+  test.each(["upstream_incomplete", "upstream_interrupted", "upstream_malformed_stream", "upstream_malformed_response", "upstream_timeout"])("renders the %s safety warning with Resume without exposing diagnostics", (code) => {
+    const error = {
+      name: "APIError",
+      data: {
+        message: `${code}: Connection closed before completion`,
+        statusCode: 200,
+        isRetryable: false,
+        responseBody: '{"request_id":"managed-interruption-diagnostic"}',
+      },
+    }
+    const presentation = presentOpencodeSessionError(error)
+    expect(presentation).toMatchObject({ kind: "provider-incomplete", title: "The model response was interrupted" })
+    expect(presentation.recoveryPrompt).toContain("do not repeat side effects")
+    const html = renderErrorTranscriptWithResume(error)
+    expect(html).toContain('data-testid="session-error-interruption-warning"')
+    expect(html).toContain("The response may contain partial text or incomplete tool calls. Review them before continuing.")
+    expect(html).toContain('data-testid="session-error-resume"')
+    expect(html).not.toContain('data-testid="session-error-details-toggle"')
+    expect(html).not.toContain(code)
+    expect(html).not.toContain("Status: 200")
+    expect(html).not.toContain("managed-interruption-diagnostic")
+  })
+
   test("offers Resume on the error card for an engine abort", () => {
     const html = renderErrorTranscriptWithResume({
       name: "MessageAbortedError",
@@ -262,6 +285,8 @@ describe("session error resilience", () => {
 
     expect(html).toContain("Task interrupted")
     expect(html).toContain('data-testid="session-error-interrupted"')
+    expect(html).not.toContain('data-testid="session-error-interruption-warning"')
+    expect(html).not.toContain("Output and files already produced are kept")
     expect(html).not.toContain("border-destructive/30")
     expect(html).not.toContain("bg-destructive/5")
   })
@@ -460,6 +485,17 @@ describe("session error technical details", () => {
     // Collapsed by default: the payload is not in the DOM until opened.
     expect(html).not.toContain('data-testid="session-error-details"')
     expect(html).not.toContain("Status: 429")
+  })
+
+  test("keeps managed interruption guidance visible when Resume is unavailable", () => {
+    const html = renderErrorTranscript({
+      name: "APIError",
+      data: { message: "upstream_incomplete: Connection closed before completion" },
+    }, false)
+    expect(html).toContain("The response may contain partial text or incomplete tool calls. Review them before continuing.")
+    expect(html).not.toContain('data-testid="session-error-resume"')
+    expect(html).not.toContain('data-testid="session-error-details-toggle"')
+    expect(html).not.toContain("upstream_incomplete")
   })
 
   test("storage errors show guidance without technical codes outside developer mode", () => {

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -15,8 +15,10 @@ import {
   __setWorkspaceSessionSyncStatusFetcherForTest,
   __setWorkspaceSessionSyncSubscriptionFactoryForTest,
   ensureWorkspaceSessionSync,
+  getWorkspaceSessionSyncStreamPhase,
   markSessionSnapshotFetchStart,
   reconcileFailureDegradedThreshold,
+  revalidateWorkspaceSessionSync,
   seedSessionState,
   snapshotKey,
   statusKey,
@@ -387,7 +389,13 @@ describe("session run status ordering", () => {
     cleanup();
   });
 
-  test("does not resurrect a finished run from a stale busy snapshot", () => {
+  test("does not resurrect a finished run from a stale busy snapshot", async () => {
+    jest.useFakeTimers();
+    let statusFetches = 0;
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      statusFetches += 1;
+      return {};
+    });
     const { input, cleanup, releaseSession } = createTestSync();
     const snapshot = createSnapshot({ type: "busy" });
     markSessionSnapshotFetchStart(snapshot, 100);
@@ -403,6 +411,10 @@ describe("session run status ordering", () => {
 
     expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.status).toBe("idle");
     expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+
+    jest.advanceTimersByTime(1_000);
+    await flushMicrotasks();
+    expect(statusFetches).toBe(0);
 
     releaseSession();
     cleanup();
@@ -633,6 +645,65 @@ describe("active session status reconciliation", () => {
     cleanup();
   });
 
+  test("validates a busy status seeded only from the durable snapshot", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    let statusFetches = 0;
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      statusFetches += 1;
+      return {};
+    });
+    const { cleanup, releaseSession } = createTestSync();
+    const queryClient = getReactQueryClient();
+
+    // Neither a busy nor a terminal stream edge arrives for this snapshot.
+    const snapshot = createSnapshot({ type: "busy" });
+    markSessionSnapshotFetchStart(snapshot, 100);
+    seedSessionState(workspaceId, snapshot);
+    seedSessionState(workspaceId, snapshot);
+
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("thinking");
+    expect(queryClient.getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+
+    setSystemTime(350);
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    expect(statusFetches).toBe(1);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
+    expect(queryClient.getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+
+    jest.advanceTimersByTime(1_000);
+    await flushMicrotasks();
+    expect(statusFetches).toBe(1);
+
+    releaseSession();
+    cleanup();
+  });
+
+  test("does not start validation for an idle snapshot", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    let statusFetches = 0;
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      statusFetches += 1;
+      return {};
+    });
+    const { cleanup, releaseSession } = createTestSync();
+
+    const snapshot = createSnapshot({ type: "idle" });
+    markSessionSnapshotFetchStart(snapshot, 100);
+    seedSessionState(workspaceId, snapshot);
+    jest.advanceTimersByTime(1_000);
+    await flushMicrotasks();
+
+    expect(statusFetches).toBe(0);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
+
+    releaseSession();
+    cleanup();
+  });
+
   test("keeps genuine tool, retry, waiting, and compaction work active until status is authoritatively idle", async () => {
     jest.useFakeTimers();
     setSystemTime(100);
@@ -845,6 +916,103 @@ describe("run status reconcile liveness health", () => {
     expect(useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)]).toBeUndefined();
   });
 
+  test("reconnects a parked stream as soon as validation recovers", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    let subscribeBlocked = false;
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(async (baseUrl, token, signal) => {
+      if (subscribeBlocked) throw Object.assign(new Error("workspace not registered yet"), { status: 404 });
+      return createSubscription(baseUrl, token, signal);
+    });
+    let statusUnreachable = false;
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      if (statusUnreachable) throw new Error("status unreachable");
+      return { [sessionId]: { type: "busy" } };
+    });
+    const input = {
+      workspaceId,
+      baseUrl: "https://run-status-health-parked.example/opencode",
+      openworkToken: "token",
+    };
+    syncInputs.push(input);
+    ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await flushMicrotasks();
+
+    expect(subscriptions).toHaveLength(1);
+    expect(getWorkspaceSessionSyncStreamPhase(input)).toBe("live");
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+
+    // A transient 404 parks the disconnected stream in slow auth backoff.
+    statusUnreachable = true;
+    subscribeBlocked = true;
+    subscriptions[0]?.end();
+    await flushMicrotasks();
+    for (let tick = 0; tick < 4; tick += 1) {
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+    }
+
+    expect(subscriptions).toHaveLength(1);
+    expect(getWorkspaceSessionSyncStreamPhase(input)).toBe("auth-blocked");
+    const degraded = useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)];
+    expect(degraded?.consecutiveFailures).toBeGreaterThanOrEqual(reconcileFailureDegradedThreshold);
+
+    statusUnreachable = false;
+    subscribeBlocked = false;
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    expect(subscriptions).toHaveLength(2);
+    expect(getWorkspaceSessionSyncStreamPhase(input)).toBe("live");
+    const recovered = useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)];
+    expect(recovered?.consecutiveFailures).toBe(0);
+
+    releaseSession();
+  });
+
+  test("explicit revalidation reads only the requested workspace and leaves a healthy stream connected", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    const fetchedUrls: string[] = [];
+    __setWorkspaceSessionSyncStatusFetcherForTest(async (baseUrl) => {
+      fetchedUrls.push(baseUrl);
+      return {};
+    });
+    const input = createSyncInput();
+    const other = { ...input, workspaceId: "other-workspace", baseUrl: "https://other.example/opencode" };
+    syncInputs.push(other);
+    ensureWorkspaceSessionSync(input);
+    ensureWorkspaceSessionSync(other);
+    await flushMicrotasks();
+    fetchedUrls.length = 0;
+
+    await revalidateWorkspaceSessionSync({ workspaceId: input.workspaceId, baseUrl: input.baseUrl });
+
+    expect(fetchedUrls).toEqual([input.baseUrl]);
+    expect(subscriptions).toHaveLength(2);
+    expect(subscriptions.every((subscription) => !subscription.signal.aborted)).toBe(true);
+    await revalidateWorkspaceSessionSync({ workspaceId: "missing", baseUrl: input.baseUrl });
+    expect(fetchedUrls).toEqual([input.baseUrl]);
+  });
+
+  test("disposal cancels explicit revalidation without resurrecting run state", async () => {
+    const { input } = createTestSync();
+    let observedSignal: AbortSignal | undefined;
+    let resolveStatuses: (statuses: Record<string, SessionStatus>) => void = () => {};
+    __setWorkspaceSessionSyncStatusFetcherForTest((_baseUrl, _token, signal) => {
+      observedSignal = signal;
+      return new Promise((resolve) => { resolveStatuses = resolve; });
+    });
+    const pending = revalidateWorkspaceSessionSync(input);
+    __disposeWorkspaceSessionSyncForTest(input);
+    expect(observedSignal?.aborted).toBe(true);
+    resolveStatuses({ [sessionId]: { type: "busy" } });
+    await pending;
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]).toBeUndefined();
+    expect(useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)]).toBeUndefined();
+  });
+
   test("revalidates parked run state immediately when the network returns", async () => {
     __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     let failing = true;
@@ -883,6 +1051,8 @@ describe("run status reconcile liveness health", () => {
     expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
     const health = useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)];
     expect(health?.consecutiveFailures ?? 0).toBe(0);
+    expect(subscriptions).toHaveLength(1);
+    expect(subscriptions[0]?.signal.aborted).toBe(false);
 
     releaseSession();
   });

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import type { Part, Session } from "@opencode-ai/sdk/v2/client";
 import type { UIMessage } from "ai";
 
@@ -17,6 +17,7 @@ import {
 } from "../src/react-app/domains/session/sync/parse-tool-parts";
 import { parseOpenWorkSessionCreateResult } from "../src/components/tools/openwork-session-create";
 import { codeModeToolCalls } from "../src/lib/code-mode-tools";
+import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
 
 afterEach(() => {
   getReactQueryClient().clear();
@@ -330,6 +331,8 @@ describe("tool part mapper", () => {
     const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
     const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
     const release = trackWorkspaceSessionSync(syncInput, "session-a");
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    useSessionActivityStore.getState().removeSession("workspace-a", "session-a");
 
     try {
       __applySessionSyncEventForTest(syncInput, {
@@ -358,7 +361,24 @@ describe("tool part mapper", () => {
         state: "input-streaming",
         input: { content: "hello", filePath: "src/main.ts" },
       });
+      const activity = () => useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"];
+      expect(activity()?.lastProgressAt).toBe(1_000);
+      clock.mockReturnValue(2_000);
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.part.updated",
+        properties: { part: writeToolPart("running", { content: "hello", filePath: "src/main.ts" }) },
+      });
+      expect(activity()?.lastProgressAt).toBe(1_000);
+      clock.mockReturnValue(3_000);
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.part.updated",
+        properties: { part: writeToolPart("completed", { content: "hello", filePath: "src/main.ts" }) },
+      });
+      expect(activity()?.lastProgressAt).toBe(3_000);
+      expect(activity()?.latestActivity).toBe("Tool result received");
+      expect(activity()?.progressParts).not.toHaveProperty("hello");
     } finally {
+      clock.mockRestore();
       release();
       cleanup();
     }

--- a/apps/app/tests/subagent-run-line.test.tsx
+++ b/apps/app/tests/subagent-run-line.test.tsx
@@ -102,4 +102,13 @@ describe("SubagentRunLine", () => {
       failed: false,
     })).toBe("reconnecting");
   });
+
+  test("silence is not completion and cannot replace waiting, retrying, or disconnected status", () => {
+    const input = { permissionPending: false, inFlight: true, failed: false, noNewActivity: true };
+    expect(subagentRunActivity(input)).toBe("no-new-activity");
+    expect(subagentRunActivity({ ...input, questionPending: true })).toBe("waiting-question");
+    expect(subagentRunActivity({ ...input, retrying: true })).toBe("retrying");
+    expect(subagentRunActivity({ ...input, syncDegraded: true })).toBe("reconnecting");
+    expect(subagentRunActivity({ ...input, inFlight: false })).toBe("completed");
+  });
 });

--- a/evals/specs/task-activity-shimmer.e2e.test.ts
+++ b/evals/specs/task-activity-shimmer.e2e.test.ts
@@ -5,7 +5,7 @@ import { taskActivity } from "../worlds/chat.ts";
 const test = spec.world(taskActivity);
 
 test("running delegated-task activity uses a quiet shimmer without a spinner", async ({ user, probe }) => {
-  await user.see({ role: "button", label: /Build isolated Azure repro/ });
+  await user.see({ testId: "active-subagents" }, { text: /Running 1 subagent/ });
   // TODO(primitive): inspect the visual treatment classes on a delegated-task status row.
   const rendered = await probe.eval(() => {
     const row = document.querySelector<HTMLElement>('[data-subagent-activity="shimmer"]');
@@ -13,11 +13,17 @@ test("running delegated-task activity uses a quiet shimmer without a spinner", a
       text: row instanceof HTMLElement ? row.innerText.replace(/\s+/g, " ").trim() : "",
       hasSpinner: Boolean(row?.querySelector<HTMLElement>(".animate-spin")),
       hasShimmer: Boolean(row?.querySelector<HTMLElement>(".ow-text-shimmer")),
+      liveCards: document.querySelectorAll('[data-subagent-run="eval-subagent-activity"]').length,
+      historyEntries: document.querySelectorAll('[data-subagent-history="eval-subagent-activity"]').length,
+      rawPromptVisible: document.body.innerText.includes("Reproduce the Azure failure in isolation."),
     };
   });
   expect(rendered).toMatchObject({
     text: expect.stringMatching(/Build isolated Azure repro.*Working/),
     hasSpinner: false,
     hasShimmer: true,
+    liveCards: 1,
+    historyEntries: 1,
+    rawPromptVisible: false,
   });
 });


### PR DESCRIPTION
## Summary

Long-running conversations can remain on an unexplained “Working” label even when no meaningful progress arrives. A later follow-up can also leave delegated work above the new message, obscuring what is still active.

- After 60 seconds without meaningful progress, show **No new activity** and revalidate the existing run. Heartbeats, repeated busy status, identical snapshots, and unrelated sessions do not reset the clock. Silence never marks work completed or automatically resends it.
- Keep active delegated tasks beneath the latest follow-up, with task descriptions, safe activity categories, elapsed/last-activity times, and child-chat navigation. Retain a static historical receipt rather than duplicate live cards. Distinguish running, waiting, retrying, errors, and unconfirmed child results.
- Bound native prompt admission to 30 seconds, including response-body reads. Hold uncertain sends behind **Check acceptance / Stop** and reconcile their exact native message ID instead of blindly replaying them.
- Share send ownership across direct sends, queue promotion, and background draining. Preserve immediate optimistic user messages from #4631, protect newer composer edits, invalidate late preflight/requeue callbacks after Stop, and avoid unreverting an uncertain replacement.
- Enroll snapshot-only busy sessions in status reconciliation, recover parked streams after connectivity returns, and present interrupted provider responses with recovery context.

Normal long tools and native same-parent follow-ups remain supported. No provider gateway, model-routing, or runtime retry policy changes are included. A follow-up does not silently replace an already-running child's original instructions.

## Verification — Incomplete

Rebased onto `ca0a4bd6f93ed7e54f02a546959753197ed2b544`, preserving the current v2 lifecycle and immediate-message changes. Focused checks passed on the resulting source tree:

From `apps/app`:

```sh
pnpm exec bun test --isolate tests/composer-focus-continuity.test.tsx
# 1 passed

pnpm exec bun test --isolate tests/composer-state-store.test.ts tests/queued-drain-admission-wedge.test.ts tests/safe-edit-resend.test.ts tests/opencode-stream-timeout.test.ts tests/opencode-session-native.test.ts tests/opencode-v2-adapter.test.ts
# 113 passed

pnpm exec bun test --isolate tests/session-sync-run-status.test.ts tests/session-sync-tool-parts.test.ts tests/session-sync-permissions.test.ts tests/session-sync-lifecycle.test.ts tests/session-sync-stream-generation-restart.test.ts tests/session-sync-token-rotation.test.ts tests/session-admission-terminal-invariant.test.ts tests/message-list-loading.test.tsx tests/subagent-run-line.test.tsx tests/session-error-resilience.test.tsx
# 144 passed

pnpm typecheck
# passed
```

**258 focused tests passed; no skips in those passing runs.** These are regression checks, not runtime journey proof.

### Missing / unsuccessful checks

- A pre-rebase `pnpm evals:e2e task-activity-shimmer` attempt selected `placement: daytona (daytona CLI authenticated)` but stopped during import with missing `@openwork/paths`; no test or sandbox launched. The dependency link was repaired. Runtime rerun is deferred to PR verification, not claimed passed.
- The extended `task-activity-shimmer` journey covers rendered status, one live task card, retained history, and prompt privacy. Actual native child progress, follow-up delivery, cancellation ownership, and heartbeat-only silence still require exact-head runtime evidence; the synthetic display fixture alone does not prove that lifecycle.
- An additional standalone `composer-editable-on-snapshot-error.test.tsx` check fails because its fixture lacks `DesktopConfigProvider`. A combined mock-heavy run also encountered a missing `getNativeSession` mock export; the native suite passes separately. Neither failure is classified as pre-existing without a clean control.
- An earlier browser-code check reported fixture/type diagnostics, starting with missing `DesktopShotSurface.workspaceId`; this is not runtime evidence and is not claimed resolved.

Please retain **Incomplete** until the required PR checks and runtime assertions finish. No merge or release is included.
