### PR TITLE
feat(desktop): resume interrupted tasks gradually after restart

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1810,7 +1810,7 @@ export default {
   "settings.update_keep_working": "Keep working",
   "settings.update_restart_confirm_action": "Restart & update",
   "settings.update_restart_now_title": "Restart {appName}?",
-  "settings.update_restart_now_message": "{appName} will close and reopen with the latest version. Running tasks will be interrupted. You can keep working and the update will install when you quit.",
+  "settings.update_restart_now_message": "{appName} will close and reopen with the latest version. Eligible running tasks resume gradually after restart; tasks waiting for input or with an uncertain outcome stay paused. You can keep working and the update will install when you quit.",
   "settings.update_install_button": "Install & restart",
   "settings.update_install_failed": "Couldn't install the update",
   "settings.update_last_checked": "Last checked {time}",

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -76,7 +76,7 @@ function createWorkspaceSessionClient(local, workspaceId, fetchImpl) {
     // Automation run receipts own recovery; desktop restart must not independently
     // resume an occurrence that its scheduler may already have settled or retried.
     fetch: (input, init) => {
-      const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined))
+      const headers = new Headers(init?.headers)
       headers.set("x-openwork-task-recovery", "off")
       return fetchImpl(input, { ...init, headers })
     },

--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -73,7 +73,13 @@ function createWorkspaceSessionClient(local, workspaceId, fetchImpl) {
     baseUrl: local.baseUrl,
     workspaceId,
     token: local.token,
-    fetch: fetchImpl,
+    // Automation run receipts own recovery; desktop restart must not independently
+    // resume an occurrence that its scheduler may already have settled or retried.
+    fetch: (input, init) => {
+      const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined))
+      headers.set("x-openwork-task-recovery", "off")
+      return fetchImpl(input, { ...init, headers })
+    },
     requestTimeoutMs: 0,
   })
 }

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -1110,6 +1110,7 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
   assert.equal(result.resultSummary, "Desktop runner result")
   assert.deepEqual(result.usage, { inputTokens: 12, outputTokens: 7, costMicros: null })
   const localRequests = requests.filter((request) => request.path !== "/workspaces")
+  assert(localRequests.every((request) => new Headers(request.options.headers).get("x-openwork-task-recovery") === "off"))
   assert.deepEqual(localRequests.slice(0, 2).map(({ path, method, body }) => ({ path, method, body })), [
     {
       path: sessionPaths.create,

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1971,6 +1971,7 @@ export function createRuntimeManager({
       opencodeBaseUrl: options.opencodeBaseUrl ?? undefined,
       opencodeDirectory: activeWorkspace || undefined,
       manageOpencode: options.manageOpencode === true,
+      resumeInterruptedTasks: true,
       opencodeBin: managedOpencode?.path ?? undefined,
       opencodeCwd: managedOpencodeWorkdir(),
       localManagedMcpVaultKey,

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -23,6 +23,44 @@ The server logs the client token and host token on boot when they are auto-gener
 
 Add `--verbose` to print resolved config details on startup. Use `--version` to print the server version and exit.
 
+## Desktop task recovery
+
+The desktop enables `resumeInterruptedTasks` when embedding a server that owns
+its local engines. Standalone servers, attached engines, remote workspaces, and
+read-only servers do not opt in. Recovery works with both OpenCode v1 and v2 and
+does not depend on an open conversation tab.
+
+The `desktop_task_recovery` table in the existing runtime SQLite database stores
+up to 1,000 task identities, their workspace path, original engine, last observed
+user turn, and recovery phase. It stores no prompts, transcripts, or credentials.
+Only tasks admitted after this feature is enabled are tracked; old unfinished
+conversations are not swept or resumed retroactively.
+
+On quit or update, a final checkpoint runs before engine teardown with two task
+snapshots in flight and a 10-second budget. On restart, the coordinator checks two task
+snapshots every two seconds and admits at most one continuation every two seconds,
+with at most two recovered tasks active. Already-active native runs are observed,
+not re-prompted, and native active work also limits new recovery admissions.
+
+Completed, archived, manually stopped, approval/question-blocked, and active
+delegated work are excluded. New manual work invalidates the old recovery intent.
+Missing workspaces, changed directories, unavailable policy, and unverified
+snapshots never authorize a send. V1 requires the original user turn and model
+in its recent 100-message snapshot; v2 keeps the session's native model. A
+continuation asks to inspect completed effects first, not rerun the original prompt.
+
+A send is claimed durably before admission. Lost acknowledgements are never
+blindly retried, even after another restart. Crash recovery requires an observed
+running task and a still-unfinished matching turn; unexplained aborts stay stopped.
+Tasks whose admission or shutdown checkpoint cannot be confirmed remain manual.
+This prevents duplicate recovery admissions, not exactly-once execution of external
+tools; uncertain earlier effects must be inspected or clarified before continuing.
+
+Desktop Automation and remote-command requests opt out with
+`x-openwork-task-recovery: off`; their existing execution ownership is unchanged.
+Runtime journey verification for actual Electron restarts on both engines remains
+separate from the focused coordinator and mocked-proxy tests.
+
 ## Config file
 
 Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CONFIG` or `--config`).

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -6,6 +6,7 @@
  * of owning the process lifecycle.
  */
 import { randomUUID } from "node:crypto";
+import { stopTaskRecovery } from "./task-recovery.js";
 import { managedDesktopPolicy } from "./managed-desktop-policy.js";
 import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
@@ -49,6 +50,7 @@ export type EmbeddedServerOptions = CliArgs & {
   opencodeCwd?: string;
   /** Secure key custody for the local managed MCP credential vault. */
   localManagedMcpVaultKey?: LocalManagedMcpVaultKeyProvider;
+  resumeInterruptedTasks?: boolean;
 };
 
 export type EmbeddedServerHandle = {
@@ -71,6 +73,7 @@ export type EmbeddedServerHandle = {
 export async function startEmbeddedServer(options: EmbeddedServerOptions): Promise<EmbeddedServerHandle> {
   const config = await resolveServerConfig(options);
   config.localManagedMcpVaultKey = options.localManagedMcpVaultKey;
+  config.resumeInterruptedTasks = options.resumeInterruptedTasks === true && options.manageOpencode === true && !config.opencodeBaseUrl;
   const logger = createServerLogger(config);
 
   // Spawn managed OpenCode if requested and no explicit base URL was provided.
@@ -85,6 +88,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
 
   const releaseResources = async (): Promise<void> => {
     const errors: unknown[] = [];
+    try { await stopTaskRecovery(config); } catch (error) { errors.push(error); }
 
     const identity = managedOpencodeIdentity;
     managedOpencodeIdentity = null;

--- a/apps/server/src/opencode-proxy.e2e.test.ts
+++ b/apps/server/src/opencode-proxy.e2e.test.ts
@@ -35,7 +35,7 @@ function auth(token: string) {
   return { Authorization: `Bearer ${token}` };
 }
 
-function startMockOpencode(input?: { holdCommand?: Promise<void>; foreignSessionDirectory?: string }) {
+function startMockOpencode(input?: { holdCommand?: Promise<void>; foreignSessionDirectory?: string; recovery?: { active: boolean; turn: number } }) {
   const requests: Array<{ pathname: string; search: string; directory: string | null; method: string; body?: unknown }> = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -53,6 +53,21 @@ function startMockOpencode(input?: { holdCommand?: Promise<void>; foreignSession
         if (text) record.body = JSON.parse(text);
       }
       requests.push(record);
+
+      if (input?.recovery) {
+        if (url.pathname === "/session/ses_1/prompt_async") {
+          input.recovery.active = true;
+          input.recovery.turn++;
+          return new Response(null, { status: 204 });
+        }
+        if (url.pathname === "/session/status") return Response.json(input.recovery.active ? { ses_1: { type: "busy" } } : {});
+        if (["/permission", "/question"].includes(url.pathname)) return Response.json([]);
+        if (url.pathname === "/api/session/ses_1/permission") return Response.json({ data: [] });
+        if (url.pathname === "/session/ses_1/message") return Response.json([
+          { info: { id: `user-${input.recovery.turn}`, role: "user", sessionID: "ses_1", model: { providerID: "test", modelID: "test" } }, parts: [] },
+          { info: { id: `assistant-${input.recovery.turn}`, role: "assistant", sessionID: "ses_1", time: {} }, parts: [] },
+        ]);
+      }
 
       if (url.pathname === "/session") {
         if (request.method === "POST") {
@@ -163,6 +178,7 @@ async function startOpenworkServer(input: {
   secondWorkspaceRoot?: string;
   opencodeBaseUrl?: string;
   readOnly?: boolean;
+  resumeInterruptedTasks?: boolean;
 }) {
   const workspaces: WorkspaceInfo[] = [{
     id: "ws_1",
@@ -187,6 +203,8 @@ async function startOpenworkServer(input: {
     port: 0,
     token: "owt_test_token",
     hostToken: "owt_host_token",
+    configPath: join(input.workspaceRoot, "server.json"),
+    resumeInterruptedTasks: input.resumeInterruptedTasks,
     approval: { mode: "auto", timeoutMs: 1000 },
     corsOrigins: ["*"],
     workspaces,
@@ -200,7 +218,7 @@ async function startOpenworkServer(input: {
   };
   const server = await startServer(config) as Served;
   stops.push(() => server.stop(true));
-  return { server, token: config.token };
+  return { server, token: config.token, config };
 }
 
 function deferred() {
@@ -220,6 +238,29 @@ async function waitUntil(predicate: () => boolean) {
 }
 
 describe("workspace OpenCode proxy", () => {
+  test("desktop-owned recovery survives a server restart and admits one continuation through the authenticated proxy", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const recovery = { active: false, turn: 0 };
+    const mock = startMockOpencode({ recovery });
+    const openwork = await startOpenworkServer({ workspaceRoot, opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`, readOnly: false, resumeInterruptedTasks: true });
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/opencode/session/ses_1/prompt_async`, {
+      method: "POST", headers: { ...auth(openwork.token), "content-type": "application/json" }, body: JSON.stringify({ parts: [{ type: "text", text: "Finish the task" }] }),
+    });
+    expect(response.status).toBe(204);
+    await openwork.server.stop();
+    recovery.active = false;
+    const restarted = await startServer({ ...openwork.config, port: 0 });
+    stops.push(() => restarted.stop());
+    const resumed = () => mock.requests.filter((request) => request.method === "POST" && JSON.stringify(request.body).includes("Continue the interrupted task"));
+    const deadline = Date.now() + 5_000;
+    while (resumed().length === 0 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(resumed()).toHaveLength(1);
+    expect(resumed()[0].directory).toBe(workspaceRoot);
+    expect(resumed()[0].body).toMatchObject({ model: { providerID: "test", modelID: "test" } });
+    await new Promise((resolve) => setTimeout(resolve, 2_100));
+    expect(resumed()).toHaveLength(1);
+  });
+
   test("accepts empty engine request bodies and rejects malformed JSON before forwarding", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,4 +1,5 @@
 import { managedDesktopPolicy } from "./managed-desktop-policy.js";
+import { createTaskRecovery, setTaskRecovery } from "./task-recovery.js";
 import { managedPolicyActionSchema } from "./managed-policy-rules.js";
 import { readFile, realpath, writeFile, rm, stat } from "node:fs/promises";
 import { homedir, hostname } from "node:os";
@@ -713,6 +714,7 @@ function isPromptAsyncProxyRequest(method: string, proxyPath: string) {
 }
 
 export async function startServer(config: ServerConfig): Promise<ServeResult> {
+  let taskRecovery: Awaited<ReturnType<typeof createTaskRecovery>> | undefined;
   const approvals = new ApprovalService(config.approval);
   const uiControl = new UiControlMailbox();
   const reloadEvents = new ReloadEventStore();
@@ -843,7 +845,9 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           await assertWorkspaceOwnsProxiedSessionRead(config, workspace, request.method, mount.restPath);
           proxyService = "opencode";
           proxyBaseUrl = workspace.baseUrl?.trim() || undefined;
-          const response = await proxyOpencodeRequest({ config, request, url, workspace, proxyPath: mount.restPath });
+          const send = () => proxyOpencodeRequest({ config, request, url, workspace, proxyPath: mount.restPath,
+            recoverySignal: taskRecovery?.owns(request) ? request.signal : undefined });
+          const response = taskRecovery ? await taskRecovery.forward(workspace, "v1", mount.restPath, request, send) : await send();
           return finalize(response);
         } catch (error) {
           const requestCanceled = isExpectedRequestCancellation(error, request.signal);
@@ -877,14 +881,16 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           // Reconcile through v2's runtime MCP API before the next call. The
           // ordinary connection routes remain authoritative; v1 is untouched.
           await engineV2Preview.syncWorkspaceMcp(workspace.id, workspace.path);
-          const response = await proxyOpencodeV2Request({
+          const send = () => proxyOpencodeV2Request({
             config,
             request,
             url,
             workspace,
             proxyPath: mount.restPath,
             connection,
+            recoverySignal: taskRecovery?.owns(request) ? request.signal : undefined,
           });
+          const response = taskRecovery ? await taskRecovery.forward(workspace, "v2", mount.restPath, request, send) : await send();
           return finalize(response);
         } catch (error) {
           const requestCanceled = isExpectedRequestCancellation(error, request.signal);
@@ -949,7 +955,8 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           if (workspace) {
             await assertWorkspaceOwnsProxiedSessionRead(config, workspace, request.method, url.pathname);
           }
-          const response = await proxyOpencodeRequest({ config, request, url, workspace });
+          const send = () => proxyOpencodeRequest({ config, request, url, workspace });
+          const response = taskRecovery && workspace ? await taskRecovery.forward(workspace, "v1", url.pathname, request, send) : await send();
           return finalize(response);
         } catch (error) {
           const requestCanceled = isExpectedRequestCancellation(error, request.signal);
@@ -1032,11 +1039,17 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
 
   let server: ServeResult;
   try {
+    if (config.resumeInterruptedTasks && !config.readOnly) {
+      taskRecovery = await createTaskRecovery(config, async (request) => serverOptions.fetch(request),
+        () => managedDesktopPolicy(config).assert("sync"));
+      setTaskRecovery(config, taskRecovery);
+    }
     server = await serve({
       ...serverOptions,
       idleTimeout: 120,
     });
   } catch (error) {
+    await taskRecovery?.stop().catch(() => undefined);
     captureServerException(error, { method: "START", route: "startServer" });
     cloudProviderSync.stop();
     await engineV2Preview.stop().catch(() => undefined);
@@ -1082,6 +1095,8 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   return {
     ...server,
     stop: async () => {
+      let recoveryError: unknown;
+      try { await taskRecovery?.stop(); } catch (error) { recoveryError = error; }
       managedDesktopPolicy(config).onChange = undefined;
       cloudProviderSync.stop();
       await engineV2Preview.stop().catch(() => undefined);
@@ -1091,6 +1106,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
       watcherHandle.close();
       reloadBaselineRefreshers.delete(config);
       await server.stop();
+      if (recoveryError) throw recoveryError;
     },
   };
 }
@@ -1110,6 +1126,7 @@ async function proxyOpencodeV2Request(input: {
   workspace: WorkspaceInfo;
   proxyPath: string;
   connection: { url: string; username: string; password: string };
+  recoverySignal?: AbortSignal;
 }): Promise<Response> {
   const method = input.request.method.toUpperCase();
   if (method !== "GET" && method !== "HEAD") ensureWritable(input.config);
@@ -1224,7 +1241,7 @@ async function proxyOpencodeV2Request(input: {
     headers.delete("content-length");
     headers.set("content-type", "application/json");
   }
-  const response = await loopbackFetch(target.toString(), { method, headers, body });
+  const response = await loopbackFetch(target.toString(), { method, headers, body, signal: input.recoverySignal });
   if (method === "GET" && /^\/api\/provider(?:\/|$)/.test(decodeURIComponent(forwardedPath)) && response.ok) {
     // Provider.Info includes request settings/headers, which may contain the
     // mirrored server-owned key. Clients only need public catalog metadata.
@@ -1447,6 +1464,7 @@ export async function proxyOpencodeRequest(input: {
   url: URL;
   workspace?: WorkspaceInfo;
   proxyPath?: string;
+  recoverySignal?: AbortSignal;
 }) {
   const workspace = input.workspace;
   const proxyPath = input.proxyPath ?? input.url.pathname;
@@ -1572,7 +1590,7 @@ export async function proxyOpencodeRequest(input: {
   const forward = async () => {
     let response: Response;
     try {
-      response = await loopbackFetch(targetUrl, { method, headers, body });
+      response = await loopbackFetch(targetUrl, { method, headers, body, signal: input.recoverySignal });
       enginePoolForConfig(input.config)?.reportRequestSuccess(baseUrl);
     } catch (error) {
       if (workspace) enginePoolForConfig(input.config)?.reportRequestFailure(baseUrl, error, workspace);
@@ -1586,7 +1604,7 @@ export async function proxyOpencodeRequest(input: {
       try {
         fallbackResponse = await loopbackFetch(
           buildOpencodeProxyUrl(route.fallback.baseUrl, proxyPath, search),
-          { method, headers: fallbackHeaders, body },
+          { method, headers: fallbackHeaders, body, signal: input.recoverySignal },
         );
       } catch (error) {
         if (workspace) enginePoolForConfig(input.config)?.reportRequestFailure(route.fallback.baseUrl, error, workspace);

--- a/apps/server/src/task-recovery.test.ts
+++ b/apps/server/src/task-recovery.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, expect, setSystemTime, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createTaskRecovery, RECOVERY_INTERVAL_MS } from "./task-recovery.js";
+import type { ServerConfig } from "./types.js";
+import { createWorkspaceKvStore } from "./workspace-kv-store.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  setSystemTime();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function fixture(engine: "v1" | "v2") {
+  const root = await mkdtemp(join(tmpdir(), "task-recovery-"));
+  const previousDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  const workspace = { id: "ws", name: "Work", path: root, preset: "starter", workspaceType: "local" as const };
+  const config: ServerConfig = {
+    host: "127.0.0.1", port: 1234, token: "test-token", hostToken: "test-host", configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 1000 }, corsOrigins: [], workspaces: [workspace], authorizedRoots: [root],
+    readOnly: false, startedAt: Date.now(), tokenSource: "generated", hostTokenSource: "generated", logFormat: "json", logRequests: false,
+  };
+  type Task = { active: boolean; blocked: boolean; completed: boolean; aborted: boolean; user: number; delegated?: boolean };
+  const tasks = new Map<string, Task>();
+  const resumes: Array<{ id: string; time: number; body: Record<string, unknown> }> = [];
+  let loseAcknowledgement = false;
+  let beforeRead: (() => Promise<void>) | undefined;
+  let policyReady = true;
+  const beforeResume = async () => { if (!policyReady) throw new Error("Policy unavailable"); };
+  let recovery: Awaited<ReturnType<typeof createTaskRecovery>>;
+  const prefix = engine === "v2" ? "/opencode2/api" : "/opencode";
+  const respond = (data: unknown) => Response.json(engine === "v2" ? { data } : data);
+  const handle = async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const path = url.pathname.replace(`/workspace/ws${prefix}`, "");
+    const id = path.match(/(?:\/api)?\/session\/([^/]+)/)?.[1] ?? "";
+    if (req.method === "POST") {
+      if (path.endsWith("/abort") || path.endsWith("/interrupt")) {
+        const task = tasks.get(id);
+        if (task) { task.active = false; task.aborted = true; }
+        return respond(true);
+      }
+      const body = await req.json();
+      const recovering = JSON.stringify(body).includes("Continue the interrupted task");
+      const task = tasks.get(id) ?? { active: true, blocked: false, completed: false, aborted: false, user: 0 };
+      task.user++; task.active = true; task.completed = false; task.aborted = false;
+      tasks.set(id, task);
+      if (recovering) {
+        resumes.push({ id, time: Date.now(), body });
+        if (loseAcknowledgement) throw new Error("Acknowledgement lost");
+      }
+      return new Response(null, { status: 204 });
+    }
+    await beforeRead?.();
+    if (path === "/session/status" || path === "/session/active") return respond(Object.fromEntries(
+      [...tasks].filter(([, task]) => task.active).map(([id]) => [id, { type: engine === "v2" ? "running" : "busy" }]),
+    ));
+    if (path === "/permission" || path === "/question" || path === "/form/request") return respond(
+      path === "/permission" ? [...tasks].filter(([, task]) => task.blocked).map(([id]) => ({ id: `p-${id}`, sessionID: id })) : [],
+    );
+    const task = tasks.get(id);
+    if (!task) return new Response(null, { status: 404 });
+    if (path.endsWith("/permission")) {
+      const data = task.blocked ? [{ id: `p-${id}`, sessionID: id }] : [];
+      return engine === "v1" ? Response.json({ data }) : respond(data);
+    }
+    if (path.endsWith("/message") || path.endsWith("/context")) {
+      const messages = [
+        { id: `user-${task.user}`, role: "user", type: "user", model: { providerID: "test", modelID: "test" }, agent: "build", variant: "high" },
+        { id: `assistant-${task.user}`, role: "assistant", type: "assistant", time: task.completed || task.aborted ? { completed: 1 } : {},
+          ...(task.aborted ? { error: { name: "MessageAbortedError" } } : {}) },
+      ];
+      const parts = task.delegated ? [{ type: "tool", name: "subagent", tool: "task", state: { status: "running" } }] : [];
+      return respond(engine === "v2" ? messages.map((message) => ({ ...message, content: parts })) : messages.map((info) => ({ info, parts })));
+    }
+    return respond({ id, directory: root, location: { directory: root }, time: {},
+      ...(engine === "v2" ? { outcome: task.completed ? "succeeded" : task.aborted ? "interrupted" : null } : {}) });
+  };
+  const request = (req: Request): Promise<Response> => recovery.forward(workspace, engine,
+    new URL(req.url).pathname.replace("/workspace/ws", ""), req, () => handle(req));
+  recovery = await createTaskRecovery(config, request, beforeResume);
+  cleanups.push(async () => {
+    await recovery.stop();
+    if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    await rm(root, { recursive: true, force: true });
+  });
+  let now = Date.now();
+  const tick = async () => { now += RECOVERY_INTERVAL_MS; setSystemTime(now); await recovery.tick(); };
+  return {
+    tasks, resumes, tick, config,
+    readHook(hook?: () => Promise<void>) { beforeRead = hook; },
+    policy(ready: boolean) { policyReady = ready; },
+    loseAck() { loseAcknowledgement = true; },
+    async send(id: string, stop = false, optOut = false) {
+      return request(new Request(`http://localhost/workspace/ws${prefix}/session/${id}/${stop ? engine === "v2" ? "interrupt" : "abort" : engine === "v2" ? "prompt" : "prompt_async"}`, {
+        method: "POST", headers: { "content-type": "application/json", ...(optOut ? { "x-openwork-task-recovery": "off" } : {}) }, body: JSON.stringify({ text: "Do the task" }),
+      }));
+    },
+    async restart(aborted = false) {
+      await recovery.stop();
+      for (const task of tasks.values()) { task.active = false; if (aborted) task.aborted = true; }
+      recovery = await createTaskRecovery(config, request, beforeResume);
+    },
+    async crash(aborted = false) {
+      const journal = createWorkspaceKvStore<unknown[]>({ tableName: "desktop_task_recovery", valueColumn: "state_json", parse: JSON.parse, serialize: JSON.stringify });
+      const saved = await journal.getRow(config, "desktop");
+      await recovery.stop();
+      if (saved) await journal.setSerialized(config, "desktop", saved.valueJson, Date.now());
+      for (const task of tasks.values()) { task.active = false; task.aborted = aborted; }
+      recovery = await createTaskRecovery(config, request, beforeResume);
+    },
+  };
+}
+
+for (const engine of ["v1", "v2"] as const) {
+  test(`${engine}: a durable unfinished task resumes once on its original engine and survives a second restart`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.tick();
+    await f.restart(true); await f.tick();
+    expect(f.resumes).toHaveLength(1);
+    expect(f.resumes[0].id).toBe("ses_work");
+    if (engine === "v1") expect(f.resumes[0].body).toMatchObject({ model: { providerID: "test", modelID: "test" }, agent: "build", variant: "high" });
+    await f.tick();
+    expect(f.resumes).toHaveLength(1);
+    await f.restart(true); await f.tick();
+    expect(f.resumes).toHaveLength(2);
+  });
+
+  test(`${engine}: stopped, completed, blocked, unknown, automation, and newer turns are never replayed`, async () => {
+    const f = await fixture(engine);
+    for (const id of ["stopped", "completed", "blocked", "newer", "unknown"]) await f.send(id);
+    await f.send("automation", false, true);
+    for (let i = 0; i < 3; i++) await f.tick();
+    await f.send("stopped", true);
+    f.tasks.get("blocked")!.blocked = true;
+    f.tasks.get("completed")!.completed = true;
+    await f.restart();
+    f.tasks.get("newer")!.user++;
+    f.tasks.get("unknown")!.completed = true;
+    for (let i = 0; i < 5; i++) await f.tick();
+    expect(f.resumes.map((item) => item.id)).not.toContain("stopped");
+    expect(f.resumes.map((item) => item.id)).not.toContain("completed");
+    expect(f.resumes.map((item) => item.id)).not.toContain("blocked");
+    expect(f.resumes.map((item) => item.id)).not.toContain("newer");
+    expect(f.resumes.map((item) => item.id)).not.toContain("automation");
+    expect(f.resumes.map((item) => item.id)).not.toContain("unknown");
+  });
+
+  test(`${engine}: starts are spaced and at most two recovered tasks run at once`, async () => {
+    const f = await fixture(engine);
+    for (let i = 0; i < 6; i++) { await f.send(`ses_${i}`); await f.tick(); }
+    await f.restart();
+    for (let i = 0; i < 8; i++) await f.tick();
+    expect(f.resumes).toHaveLength(2);
+    expect(f.resumes[1].time - f.resumes[0].time).toBeGreaterThanOrEqual(RECOVERY_INTERVAL_MS);
+    const first = f.tasks.get(f.resumes[0].id)!;
+    first.active = false; first.completed = true;
+    for (let i = 0; i < 6; i++) await f.tick();
+    expect(f.resumes).toHaveLength(3);
+  });
+
+  test(`${engine}: manual Stop during reconciliation cancels the pending resume`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.tick(); await f.restart();
+    let release = () => {};
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    f.readHook(() => held);
+    const ticking = f.tick();
+    await f.send("ses_work", true);
+    release(); await ticking; f.readHook();
+    expect(f.resumes).toEqual([]);
+  });
+
+  test(`${engine}: a lost recovery acknowledgement is not resent on restart`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.tick(); await f.restart();
+    f.loseAck(); await f.tick();
+    expect(f.resumes).toHaveLength(1);
+    await f.restart(); await f.tick();
+    expect(f.resumes).toHaveLength(1);
+  });
+
+  test(`${engine}: a natively recovered active run is observed without a second prompt`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.tick(); await f.restart();
+    f.tasks.get("ses_work")!.active = true;
+    await f.tick();
+    expect(f.resumes).toEqual([]);
+  });
+
+  test(`${engine}: crash recovery requires a still-unfinished turn, not an unexplained abort`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.tick(); await f.crash(); await f.tick();
+    expect(f.resumes).toHaveLength(1);
+    await f.tick(); await f.crash(true); await f.tick();
+    expect(f.resumes).toHaveLength(1);
+  });
+
+  test(`${engine}: shutdown checkpoints a just-admitted task before the first poll`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.restart(true); await f.tick();
+    expect(f.resumes).toHaveLength(1);
+  });
+
+  test(`${engine}: startup waits for policy restoration before claiming a continuation`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.restart(); f.policy(false);
+    await f.tick(); await f.tick();
+    expect(f.resumes).toHaveLength(0);
+    f.policy(true); await f.tick();
+    expect(f.resumes).toHaveLength(1);
+  });
+
+  test(`${engine}: delegated work is excluded and native active work counts against the startup limit`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_child_owner"); f.tasks.get("ses_child_owner")!.delegated = true;
+    await f.send("ses_work"); await f.restart();
+    f.tasks.set("external-a", { active: true, blocked: false, completed: false, aborted: false, user: 1 });
+    f.tasks.set("external-b", { active: true, blocked: false, completed: false, aborted: false, user: 1 });
+    await f.tick();
+    expect(f.resumes).toEqual([]);
+    f.tasks.delete("external-b"); await f.tick();
+    expect(f.resumes.map((item) => item.id)).toEqual(["ses_work"]);
+  });
+
+  test(`${engine}: removed or retargeted workspaces never inherit a recovery request`, async () => {
+    const f = await fixture(engine);
+    await f.send("ses_work"); await f.restart();
+    f.config.workspaces[0].path += "-different";
+    await f.tick();
+    expect(f.resumes).toEqual([]);
+  });
+}

--- a/apps/server/src/task-recovery.ts
+++ b/apps/server/src/task-recovery.ts
@@ -1,0 +1,278 @@
+import { z } from "zod";
+import { createWorkspaceKvStore, isRecord } from "./workspace-kv-store.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+export const RECOVERY_INTERVAL_MS = 2_000;
+export const RECOVERY_CONCURRENCY = 2;
+const MAX_TASKS = 1_000;
+const recordSchema = z.object({
+  workspaceId: z.string(), directory: z.string(), sessionId: z.string(),
+  engine: z.enum(["v1", "v2"]),
+  phase: z.enum(["observing", "running", "blocked", "claimed"]),
+  userId: z.string().nullable(), shutdown: z.boolean(),
+});
+type RecoveryRecord = z.infer<typeof recordSchema>;
+type Engine = RecoveryRecord["engine"];
+const store = createWorkspaceKvStore<RecoveryRecord[]>({
+  tableName: "desktop_task_recovery", valueColumn: "state_json",
+  parse: (json) => z.array(recordSchema).max(MAX_TASKS).parse(JSON.parse(json)),
+  serialize: JSON.stringify,
+});
+const RECOVERY_PROMPT = "Continue the interrupted task from the current state. First inspect the conversation and workspace to verify which actions already completed. Preserve completed work, do not repeat side effects, and finish only what remains. Stop and ask if an earlier action's outcome cannot be verified.";
+
+/** One desktop server owns this journal; no transcript, prompt, or credentials are persisted. */
+export async function createTaskRecovery(
+  config: ServerConfig,
+  request: (request: Request) => Promise<Response>,
+  beforeResume: () => Promise<void> = async () => {},
+) {
+  const records = new Map<string, RecoveryRecord>();
+  const startup = new Set<string>();
+  const recovered = new Set<string>();
+  const ownedRequests = new WeakMap<Request, RecoveryRecord>();
+  const admissions = new Map<string, Promise<unknown>>();
+  const observingSince = new Map<string, number>();
+  const key = (record: Pick<RecoveryRecord, "workspaceId" | "engine" | "sessionId">) =>
+    JSON.stringify([record.workspaceId, record.engine, record.sessionId]);
+  for (const record of await store.get(config, "desktop") ?? []) {
+    if (record.phase !== "running") continue;
+    records.set(key(record), record);
+    startup.add(key(record));
+  }
+  let stopped = false;
+  let checkpointSignal: AbortSignal | undefined;
+  let ticking: Promise<void> | undefined;
+  let writes = Promise.resolve();
+  let nextLaunch = 0;
+  let cursor = 0;
+  const persist = () => {
+    const json = store.serialize([...records.values()]);
+    writes = writes.catch(() => {}).then(() => store.setSerialized(config, "desktop", json, Date.now()));
+    return writes;
+  };
+  const current = (record: RecoveryRecord) => !stopped && records.get(key(record)) === record;
+  const remove = (record: RecoveryRecord) => {
+    records.delete(key(record)); startup.delete(key(record)); recovered.delete(key(record));
+    observingSince.delete(key(record));
+  };
+  const call = async (record: RecoveryRecord, path: string, body?: unknown) => {
+    const mount = `/workspace/${encodeURIComponent(record.workspaceId)}/${record.engine === "v2" ? "opencode2/api" : "opencode"}`;
+    const req = new Request(`http://127.0.0.1:${config.port}${mount}${path}`, {
+      method: body === undefined ? "GET" : "POST",
+      headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: checkpointSignal
+        ? AbortSignal.any([checkpointSignal, AbortSignal.timeout(10_000)])
+        : AbortSignal.timeout(10_000),
+    });
+    if (req.signal.aborted) throw new Error("Recovery request cancelled");
+    ownedRequests.set(req, record);
+    return Promise.race([
+      request(req).then(async (response) => {
+        if (!response.ok) {
+          await response.body?.cancel();
+          throw new Error(`Recovery request unavailable (${response.status})`);
+        }
+        if (body !== undefined) { await response.body?.cancel(); return null; }
+        const payload: unknown = await response.json();
+        return record.engine === "v2" && isRecord(payload) ? payload.data : payload;
+      }),
+      new Promise<never>((_, reject) => req.signal.addEventListener("abort", () => reject(new Error("Recovery request timed out")), { once: true })),
+    ]);
+  };
+  const observe = async (record: RecoveryRecord) => {
+    const v2 = record.engine === "v2";
+    const sessionPath = `/session/${encodeURIComponent(record.sessionId)}`;
+    const [session, statuses, messages, permissions, questions, nativePermissions] = await Promise.all([
+      call(record, sessionPath), call(record, v2 ? "/session/active" : "/session/status"),
+      call(record, `${sessionPath}/${v2 ? "context" : "message?limit=100"}`),
+      call(record, v2 ? `${sessionPath}/permission` : "/permission"),
+      call(record, v2 ? "/form/request" : "/question"),
+      v2 ? [] : call(record, `/api${sessionPath}/permission`),
+    ]);
+    if (!isRecord(session) || !isRecord(statuses) || !Array.isArray(messages)
+      || !Array.isArray(permissions) || !Array.isArray(questions)) throw new Error("Invalid recovery snapshot");
+    const extraPermissions = isRecord(nativePermissions) ? nativePermissions.data : nativePermissions;
+    if (!Array.isArray(extraPermissions)) throw new Error("Invalid native permission snapshot");
+    const info = isRecord(session.info) ? session.info : session;
+    const history = messages.flatMap((message: unknown) => {
+      if (!isRecord(message)) return [];
+      const item = v2 ? message : message.info;
+      return isRecord(item) ? [item] : [];
+    });
+    const user = [...history].reverse().find((message) => message[v2 ? "type" : "role"] === "user");
+    const assistant = history.slice(user ? history.indexOf(user) + 1 : history.length)
+      .reverse().find((message) => message[v2 ? "type" : "role"] === "assistant");
+    const status = statuses[record.sessionId];
+    const active = isRecord(status) && ["busy", "retry", "running"].includes(String(status.type));
+    // A delegated task can be waiting on a child permission while the root
+    // remains busy. Do not resume its parent independently of that child.
+    const delegated = messages.some((message: unknown) => {
+      if (!isRecord(message)) return false;
+      const item = v2 ? message : message.info;
+      if (!user || !isRecord(item) || history.indexOf(item) <= history.indexOf(user)) return false;
+      const parts = v2 ? message.content : message.parts;
+      return Array.isArray(parts) && parts.some((part: unknown) => isRecord(part) && part.type === "tool"
+        && ["task", "subagent"].includes(String(v2 ? part.name : part.tool))
+        && isRecord(part.state) && ["pending", "running"].includes(String(part.state.status)));
+    });
+    const blocked = delegated || [...permissions, ...extraPermissions, ...questions].some((item: unknown) => isRecord(item) && item.sessionID === record.sessionId);
+    const archived = isRecord(info.time) && typeof info.time.archived === "number" && info.time.archived > 0;
+    const completed = assistant && isRecord(assistant.time) && typeof assistant.time.completed === "number";
+    const aborted = assistant && isRecord(assistant.error) && assistant.error.name === "MessageAbortedError";
+    // Idle alone is not proof of interruption. Require the same unfinished turn,
+    // or an abort produced after our own graceful-shutdown checkpoint.
+    const unfinished = assistant && (!assistant.error && (!completed || assistant.finish === "tool-calls")
+      || record.shutdown && aborted) || record.shutdown && info.outcome === "interrupted";
+    const terminal = archived || info.outcome === "succeeded" || info.outcome === "failed"
+      || Boolean(assistant?.error && !(record.shutdown && aborted));
+    const activeCount = Object.values(statuses).filter((status) => isRecord(status)
+      && ["busy", "retry", "running"].includes(String(status.type))).length;
+    return { active, activeCount, blocked, terminal, unfinished: Boolean(unfinished),
+      userId: typeof user?.id === "string" ? user.id : null, user };
+  };
+  const check = async (record: RecoveryRecord) => {
+    const workspace = config.workspaces.find((workspace) => workspace.id === record.workspaceId);
+    if (!workspace || workspace.workspaceType !== "local" || workspace.path !== record.directory || config.readOnly) {
+      if (current(record)) { remove(record); await persist(); }
+      return;
+    }
+    // Wait for restored sign-in/policy before claiming work. The actual send
+    // still traverses the authenticated policy-enforcing proxy.
+    if (startup.has(key(record))) await beforeResume();
+    const snapshot = await observe(record);
+    if (!current(record)) return;
+    const pending = startup.has(key(record));
+    if (record.phase === "claimed" && (snapshot.active || admissions.has(key(record)))) return;
+    if (snapshot.terminal || (record.userId !== null && snapshot.userId !== record.userId)
+      || (pending && snapshot.blocked)) {
+      remove(record); await persist(); return;
+    }
+    if (snapshot.active || snapshot.blocked) {
+      // An engine which recovered its own run is observed, never re-prompted.
+      startup.delete(key(record));
+      if (pending) recovered.add(key(record));
+      record.phase = snapshot.blocked ? "blocked" : "running";
+      record.userId = snapshot.userId;
+      record.shutdown = false;
+      await persist(); return;
+    }
+    if (!pending) {
+      if (record.phase !== "observing" || Date.now() - (observingSince.get(key(record)) ?? 0) > 30_000) { remove(record); await persist(); }
+      return;
+    }
+    if (!snapshot.unfinished || !record.userId) { remove(record); await persist(); return; }
+    if (recovered.size >= RECOVERY_CONCURRENCY || snapshot.activeCount >= RECOVERY_CONCURRENCY || Date.now() < nextLaunch) return;
+    // Claim durably before admission. A lost acknowledgement is never retried,
+    // including across another process restart.
+    record.phase = "claimed";
+    startup.delete(key(record));
+    recovered.add(key(record));
+    nextLaunch = Date.now() + RECOVERY_INTERVAL_MS;
+    await persist();
+    if (!current(record)) return;
+    const model = snapshot.user?.model;
+    if (record.engine === "v1" && (!isRecord(model) || typeof model.providerID !== "string" || typeof model.modelID !== "string")) {
+      remove(record); await persist(); return;
+    }
+    await call(record, `/session/${encodeURIComponent(record.sessionId)}/${record.engine === "v2" ? "prompt" : "prompt_async"}`,
+      record.engine === "v2" ? { text: RECOVERY_PROMPT } : {
+        parts: [{ type: "text", text: RECOVERY_PROMPT }], model,
+        ...(typeof snapshot.user?.agent === "string" ? { agent: snapshot.user.agent } : {}),
+        ...(typeof snapshot.user?.variant === "string" ? { variant: snapshot.user.variant } : {}),
+      });
+    if (!current(record)) return;
+    record.phase = "observing"; record.userId = null; record.shutdown = false;
+    observingSince.set(key(record), Date.now());
+    await persist();
+  };
+  const tick = () => {
+    if (stopped) return Promise.resolve();
+    if (ticking) return ticking;
+    const batch = [...records.values()];
+    // Bound background reads as well as starts; rotate so a large backlog is fair.
+    const selected = batch.length ? [batch[cursor % batch.length], batch[(cursor + 1) % batch.length]] : [];
+    cursor += RECOVERY_CONCURRENCY;
+    ticking = Promise.all([...new Set(selected)].map((record) => check(record).catch(() => {
+      // Unavailable or ambiguous state never grants permission to send. A claimed
+      // send retains its slot until a later observation establishes its outcome.
+    }))).then(() => {}).finally(() => { ticking = undefined; });
+    return ticking;
+  };
+  const timer = setInterval(() => void tick(), RECOVERY_INTERVAL_MS);
+  timer.unref();
+  return {
+    tick,
+    owns: (request: Request) => ownedRequests.has(request),
+    async forward(workspace: WorkspaceInfo, engine: Engine, path: string, req: Request, send: () => Promise<Response>) {
+      if (workspace.workspaceType !== "local" || !["POST", "PUT", "PATCH", "DELETE"].includes(req.method)) return send();
+      const match = path.replace(/^\/opencode2\/api|^\/opencode/, "").match(/^\/session\/([^/]+)(.*)$/);
+      if (!match) return send();
+      const sessionId = decodeURIComponent(match[1]);
+      const suffix = match[2];
+      const owned = ownedRequests.get(req);
+      const admissionKey = key({ workspaceId: workspace.id, engine, sessionId });
+      const serializedSend = async () => {
+        const previous = admissions.get(admissionKey);
+        const operation = (previous ?? Promise.resolve()).catch(() => {}).then(() => {
+          if (owned && (!current(owned) || req.signal.aborted)) throw new Error("Recovery admission cancelled");
+          return send();
+        });
+        admissions.set(admissionKey, operation);
+        try { return await operation; }
+        finally { if (admissions.get(admissionKey) === operation) admissions.delete(admissionKey); }
+      };
+      if (owned) return serializedSend();
+      // Permission replies may let a tracked blocked turn continue. All other
+      // manual mutations invalidate recovery before the engine sees them.
+      if (/^\/(permission|form)\//.test(suffix)) return serializedSend();
+      const record: RecoveryRecord = { workspaceId: workspace.id, directory: workspace.path, engine, sessionId,
+        phase: "observing", userId: null, shutdown: false };
+      const previous = records.get(key(record));
+      if (previous) remove(previous);
+      const admission = req.method === "POST" && ["/prompt_async", "/prompt", "/command"].includes(suffix)
+        && req.headers.get("x-openwork-task-recovery") !== "off";
+      if (!stopped && admission && records.size < MAX_TASKS) {
+        records.set(key(record), record);
+        observingSince.set(key(record), Date.now());
+      }
+      await persist();
+      const response = await serializedSend();
+      if (current(record) && !response.ok) { remove(record); await persist(); }
+      return response;
+    },
+    async stop() {
+      if (stopped) return writes;
+      clearInterval(timer);
+      // Freeze before engines are killed, so their shutdown idle/error cannot
+      // erase intent. In-flight observations are discarded by current().
+      stopped = true;
+      const candidates = [...records.values()].filter((record) => record.phase !== "claimed" && !startup.has(key(record)));
+      // An unprocessed or unavailable final snapshot is not eligible. Checkpoint
+      // at most two sessions at once, within one bounded shutdown window.
+      for (const record of candidates) { record.phase = "blocked"; record.shutdown = false; }
+      await persist();
+      const deadline = Date.now() + 10_000;
+      checkpointSignal = AbortSignal.timeout(10_000);
+      let index = 0;
+      await Promise.all(Array.from({ length: RECOVERY_CONCURRENCY }, async () => {
+        while (index < candidates.length && Date.now() < deadline) {
+          const record = candidates[index++];
+          try {
+            const snapshot = await observe(record);
+            if (records.get(key(record)) === record && snapshot.active && !snapshot.blocked && !snapshot.terminal
+              && snapshot.userId && (record.userId === null || snapshot.userId === record.userId)) {
+              record.phase = "running"; record.shutdown = true; record.userId = snapshot.userId;
+            }
+          } catch { /* Leave unverified work excluded. */ }
+        }
+      }));
+      await persist();
+    },
+  };
+}
+
+type TaskRecovery = Awaited<ReturnType<typeof createTaskRecovery>>;
+const coordinators = new WeakMap<ServerConfig, TaskRecovery>();
+export function setTaskRecovery(config: ServerConfig, recovery: TaskRecovery) { coordinators.set(config, recovery); }
+export async function stopTaskRecovery(config: ServerConfig) { await coordinators.get(config)?.stop(); }

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -105,6 +105,8 @@ export interface ServerConfig {
   logRequests: boolean;
   /** In-memory secure key custody supplied by an embedding host such as OpenWork Desktop. */
   localManagedMcpVaultKey?: LocalManagedMcpVaultKeyProvider;
+  /** Desktop-owned managed engines only; never enabled by remote clients. */
+  resumeInterruptedTasks?: boolean;
 }
 
 export interface Capabilities {

--- a/evals/packages/cdp/src/browser-globals.d.ts
+++ b/evals/packages/cdp/src/browser-globals.d.ts
@@ -14,6 +14,7 @@ declare global {
     };
     __reauthOriginalOpen?: typeof window.open;
     __OPENWORK_ELECTRON__: {
+      shell: { relaunch(): Promise<void> };
       browserLogins: {
         testWitnessUrl(): Promise<string>;
         writeTestStore(request: { path: string; cookies: unknown[] }): Promise<unknown>;

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { backgroundUpdateWorld } from "../worlds/first-run.ts";
+import { restartUpdateTaskWorld } from "../worlds/chat.ts";
 
 const test = spec.world(backgroundUpdateWorld);
 
@@ -57,5 +58,97 @@ test("updates download outside Settings and offer a persistent, optional restart
   await probe.eventually(world.snapshot, {
     within: 5_000, label: "restart only after confirmation",
     until: (value) => typeof value === "object" && value !== null && Reflect.get(value, "installs") === 1,
+  });
+});
+
+const recoveryTest = spec.world(restartUpdateTaskWorld, { timeout: 600_000 });
+
+recoveryTest("a confirmed update relaunch resumes only the unfinished task on its original engine", async ({ world, user, agent, probe, step }) => {
+  user = user.on(world.app);
+  agent = agent.on(world.app);
+  probe = probe.on(world.app);
+  const v2 = world.engine === "v2";
+  const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
+  const record = (value: unknown): Record<string, unknown> => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected an engine record");
+    return Object.fromEntries(Object.entries(value));
+  };
+  const read = async (path: string): Promise<unknown> => {
+    const response = await probe.desktopApi(`${mount}${path}`);
+    expect(response.status).toBe(200);
+    return v2 ? record(response.body).data : response.body;
+  };
+  const messages = async (sessionId: string) => {
+    const value = await read(`/session/${sessionId}/${v2 ? "context" : "message?limit=100"}`);
+    if (!Array.isArray(value)) throw new Error("Expected engine messages");
+    return value.map((entry: unknown) => {
+      const message = record(entry);
+      const info = v2 ? message : record(message.info);
+      const parts = v2 ? message.content : message.parts;
+      if (!Array.isArray(parts)) throw new Error("Expected message parts");
+      return { id: info.id, role: info[v2 ? "type" : "role"], parts: parts.map(record) };
+    });
+  };
+  const open = async (session: { sessionId: string; title: string }) => {
+    await user.click({ text: session.title });
+    await probe.eventually(() => probe.hash(), { within: 30_000, label: "the intended task is selected",
+      until: (hash) => hash.includes(`/session/${session.sessionId}`) });
+  };
+  const send = async (text: string) => { await user.type("composer", text, { verify: true }); await user.press("Enter"); };
+  const active = async (id: string) => {
+    const statuses = record(await read(v2 ? "/session/active" : "/session/status"));
+    const status = statuses[id];
+    return status !== undefined && ["running", "busy", "retry"].includes(String(record(status).type));
+  };
+
+  await step("one task completes and another is explicitly stopped", async () => {
+    await send(world.completed.prompt);
+    await user.see({ text: world.completed.reply }, { timeoutMs: 45_000 });
+    await open(world.stopped);
+    await send(world.stopped.prompt);
+    await probe.eventually(() => active(world.stopped.sessionId), { within: 30_000, label: "the task is running before Stop", until: Boolean });
+    await user.click({ role: "button", label: "Stop" });
+    await probe.eventually(() => active(world.stopped.sessionId), { within: 30_000, label: "Stop settles its original run", until: (value) => !value });
+  });
+  const completedBefore = await messages(world.completed.sessionId);
+  const stoppedBefore = await messages(world.stopped.sessionId);
+
+  await step("an eligible task is executing when update is confirmed", async () => {
+    await open(world.active);
+    await send(world.active.prompt);
+    await probe.eventually(async () => ({ active: await active(world.active.sessionId), messages: await messages(world.active.sessionId) }), {
+      within: 30_000, label: "the original engine is running the unfinished tool",
+      until: (state) => state.active && state.messages.some((message) => message.parts.some((part) => part.type === "tool" && record(part.state).status === "running")),
+    });
+    // Settings' existing Check for updates action consumes the arranged release
+    // feed. Do not manipulate recovery state or inject a continuation here.
+    await agent.run("settings.panel.open", { panel: "updates" });
+    await user.click({ role: "button", text: "Check now" });
+    await user.see({ text: "Restart to update" }, { timeoutMs: 30_000 });
+    await user.click({ text: "Restart to update" });
+    await user.see({ text: "Restart OpenWork?" });
+    await user.click("Restart & update");
+  });
+  await step("a new renderer continues once without touching stopped or completed work", async () => {
+    const restart = await world.reconnectAfterRestart();
+    expect(restart.timeOrigin).not.toBe(restart.originalTimeOrigin);
+    await probe.eventually(() => messages(world.active.sessionId), { within: 90_000, label: "startup produces the continuation reply on the original engine",
+      until: (items) => items.some((message) => message.role === "assistant" && message.parts.some((part) => part.type === "text" && part.text === world.recovery.reply)) });
+    const history = await messages(world.active.sessionId);
+    expect(history.filter((message) => message.role === "user" && message.parts.some((part) => typeof part.text === "string" && part.text.includes(world.recovery.marker)))).toHaveLength(1);
+    expect((await messages(world.stopped.sessionId)).map((message) => message.id)).toEqual(stoppedBefore.map((message) => message.id));
+    expect((await messages(world.completed.sessionId)).map((message) => message.id)).toEqual(completedBefore.map((message) => message.id));
+    expect((await world.mock.agentRequests({ promptMarker: world.active.prompt })).filter((call) => call.kind === "tool")).toHaveLength(1);
+    expect((await world.mock.agentRequests({ promptMarker: world.recovery.marker })).filter((call) => call.kind === "final")).toHaveLength(1);
+    const observeUntil = Date.now() + 6_000;
+    await probe.eventually(async () => {
+      expect((await messages(world.stopped.sessionId)).map((message) => message.id)).toEqual(stoppedBefore.map((message) => message.id));
+      expect((await messages(world.completed.sessionId)).map((message) => message.id)).toEqual(completedBefore.map((message) => message.id));
+      expect((await world.mock.agentRequests({ promptMarker: world.recovery.marker })).filter((call) => call.kind === "final")).toHaveLength(1);
+      return Date.now() >= observeUntil;
+    }, { within: 10_000, label: "later recovery ticks do not duplicate work or restart excluded tasks", until: Boolean });
+    await agent.run("session.open", { sessionId: world.active.sessionId });
+    await user.see({ text: world.recovery.reply });
+    await user.screenshot();
   });
 });

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -40,6 +40,7 @@ test("updates download outside Settings and offer a persistent, optional restart
   await user.click("Restart to update");
   await user.notSee({ text: "Ready when you are." });
   await user.see({ text: "Restart OpenWork?" });
+  await user.see({ text: /Eligible running tasks resume gradually after restart/ });
   await user.click("Keep working");
   await user.notSee({ text: "Restart OpenWork?" });
   expect(await world.snapshot()).toMatchObject({ installs: 0 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1,4 +1,4 @@
-import { browserScript } from "@openwork/cdp";
+import { browserScript, reattachSurface } from "@openwork/cdp";
 import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
@@ -328,6 +328,77 @@ export async function permissionStopRecovery(seed: Seed) {
   const stoppedSession = await seedSessionRetry(seed, base.app, { title: "Stop permission task" });
   const otherSession = await seedSessionRetry(seed, base.app, { title: "Keep permission task" });
   return { ...base, engine, retry, followup, stopped: { ...stopped, ...stoppedSession }, other: { ...other, ...otherSession } };
+}
+
+/** Synthetic release/model responses, but real Electron quit, engine teardown, and relaunch. */
+export async function restartUpdateTaskWorld(seed: Seed) {
+  const engine = resolveEvalEngine();
+  const active = { prompt: "Prepare the restart continuity report", title: "Continue after update" };
+  const stopped = { prompt: "Prepare the cancelled continuity report", title: "Keep stopped after update" };
+  const completed = { prompt: "Prepare the completed continuity report", title: "Keep completed after update", reply: "The completed report is ready." };
+  const recovery = { marker: "Continue the interrupted task", reply: "The interrupted report continued after restart." };
+  const base = await splitPaneQuestions(seed, "restart-update-task", [
+    ...[active, stopped].map((task): MockAgentWorkload => ({
+      promptMarker: task.prompt, latestUserTurn: true, finalReply: "The original turn finished without restarting.",
+      steps: [{ tool: engine === "v2" ? "shell" : "bash", arguments: {
+        command: "sleep 120", description: "Wait for the report input", timeout: 180_000,
+      } }],
+    })),
+    { promptMarker: completed.prompt, latestUserTurn: true, finalReply: completed.reply, steps: [] },
+    { promptMarker: recovery.marker, latestUserTurn: true, finalReply: recovery.reply, steps: [] },
+  ], { permission: { bash: "allow" } });
+  const activeSession = await seedSessionRetry(seed, base.app, { title: active.title });
+  const stoppedSession = await seedSessionRetry(seed, base.app, { title: stopped.title });
+  const completedSession = await seedSessionRetry(seed, base.app, { title: completed.title });
+  const originalTimeOrigin = await evalIn(base.app, () => performance.timeOrigin);
+  await seed.evalIn(base.app, () => {
+    const currentVersion = "0.18.0";
+    window.__openworkReadDesktopVersionMetadataEval = () => ({
+      minAppVersion: "0.1.0", latestAppVersion: "9.9.9", publishedDesktopVersions: ["9.9.9"],
+    });
+    window.__openworkUpdaterEvalBridge = {
+      getChannel: async () => ({ channel: "stable", currentVersion }),
+      setChannel: async (channel) => ({ channel, currentVersion }),
+      check: async () => ({ available: true, channel: "stable", currentVersion, latestVersion: "9.9.9" }),
+      download: async () => ({ ok: true }),
+      // Do not replace a binary in a journey. Unlike the download-only fixture,
+      // confirmation goes through real main-process app.relaunch()/app.quit().
+      installAndRestart: async () => {
+        await window.__OPENWORK_ELECTRON__.shell.relaunch();
+        return { ok: true };
+      },
+      onDownloadProgress: () => () => {},
+    };
+  });
+  return {
+    ...base, engine, recovery,
+    active: { ...active, ...activeSession }, stopped: { ...stopped, ...stoppedSession }, completed: { ...completed, ...completedSession },
+    async reconnectAfterRestart() {
+      const deadline = Date.now() + 90_000;
+      while (Date.now() < deadline) {
+        try {
+          await reattachSurface(base.app, { timeoutMs: 3_000 });
+          const origin = await evalIn(base.app, () => performance.timeOrigin, { timeoutMs: 3_000 });
+          if (origin !== originalTimeOrigin) return { originalTimeOrigin, timeOrigin: origin };
+        } catch { /* The old renderer and CDP socket disappear during quit. */ }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      throw new Error("Update confirmation did not relaunch the Electron renderer");
+    },
+    async [Symbol.asyncDispose]() {
+      // The original seed owns the profile and processes; close the relaunched
+      // browser before its normal fixture cleanup removes that profile.
+      await base.app.client.send("Browser.close").catch(() => undefined);
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        const alive = await fetch(`${base.app.handle.cdpUrl}/json/version`, { signal: AbortSignal.timeout(1_000) })
+          .then((response) => response.ok, () => false);
+        if (!alive) return;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      throw new Error("Relaunched Electron did not close before profile cleanup");
+    },
+  };
 }
 
 export async function newSplitPrimary(seed: Seed) {


### PR DESCRIPTION
## Summary
Automatically continue eligible local tasks after restarting OpenWork, including update restarts, without requiring their conversation tabs to be mounted.

Follow-up to merged #4590. This PR targets dev and contains only the recovery increment and its review fixes.

## Behavior
- A desktop-owned server coordinator records task identity, workspace path, original engine (v1 or v2), last observed user turn, and recovery phase in the existing runtime SQLite database. No prompts, transcripts, or credentials are added to the journal.
- Track admitted prompt/command work, not todo-list labels or a sweep of old conversations. Normal shutdown checkpoints before engine teardown; crash recovery requires an observed running task and a still-unfinished matching turn.
- Reconcile through the existing authenticated workspace proxy, preserving ownership and policy checks. Wait for policy restoration before claiming a continuation. Keep the original engine; v1 reads the original model/agent/variant from the user turn and v2 uses its native session model.
- Admit one recovery every 2 seconds, with at most 2 recovered tasks active. Native active work also limits admission. Check at most 2 task snapshots per cycle; cap the journal at 1,000 records. Shutdown checkpointing has a 10-second budget.
- Never re-prompt a run the native engine already recovered. Persist the claim before dispatch; a lost acknowledgement is not blindly retried on this or a later boot.
- Exclude completed, archived, explicitly stopped, approval/question-blocked, and active delegated work. Manual session mutations invalidate old recovery intent before forwarding. Changed/removed workspaces and unverified outcomes never authorize sends.
- Automation and remote-command execution opt out because their existing execution receipts own recovery. Standalone servers, attached engines, remote workspaces, and read-only servers are not enabled.

## Review Fixes
- Fix the failing Electron IPC-contract typecheck: HeadlessFetch passes a URL string, so build headers from its RequestInit instead of using an invalid instanceof Request branch. Recovery opt-out and authentication headers are preserved.
- Extend the existing background-desktop-update journey with real native work and a confirmed Electron relaunch. The release feed and model are synthetic; confirmation invokes the real main-process shell relaunch IPC rather than incrementing an install counter. No binary replacement is attempted.
- Assert a new renderer, exactly one continuation and model reply on the original engine, no repeated original tool call, and unchanged message identities for stopped/completed tasks across later recovery ticks. The scenario selects v1 or v2 through OPENWORK_EVAL_ENGINE.

## Verification: Incomplete
Current head: 1c48405d3b69ae9dc41e3ad6771ba9b7ea2baf60. Commit signature verified.

Passed for this update:
- `pnpm --filter @openwork/desktop typecheck:electron`: exit 0. This exact CI command previously reproduced TS2358 in automation-runner.mjs:79; the fix removes that failure.
- `node --test apps/desktop/electron/automation-runner.test.mjs`: exit 0; 45 passed, 0 failed, 0 skipped.
- `pnpm --dir apps/server exec bun --conditions=development test src/task-recovery.test.ts`: exit 0; 22 passed, 0 failed, 0 skipped; 51 assertions, with 11 cases per engine.
- `pnpm --dir evals exec tsc --noEmit --strict --skipLibCheck --module preserve --moduleResolution bundler --target es2023 --lib esnext,dom,dom.iterable --allowImportingTsExtensions --allowJs --jsx react-jsx packages/cdp/src/browser-globals.d.ts specs/background-desktop-update.e2e.test.ts`: exit 0. Typechecks the modified journey and its imported worlds without launching resources.
- `pnpm --dir evals check:browser -- worlds/chat.ts specs/background-desktop-update.e2e.test.ts`: exit 0; 739 browser callbacks checked.
- `git diff --check origin/dev...HEAD`: exit 0.

Deferred by execution scope:
- `OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e background-desktop-update`
- `OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e background-desktop-update`
- Exact-head runtime evidence publication, crash/load journey execution, and binary replacement verification.

The new restart scenario is authored and typechecked, not runtime-validated. The earlier copy-only assertion is not used as recovery proof. No Daytona resources or expensive eval commands were started. New-head CI is pending its own results; the old-head build failure is not described as a passing check.

## Limits
Only work admitted after this feature is present can be recovered; the first upgrade from an older version has no recovery journal to consume. V1 needs its original user turn/model within the recent 100-message snapshot. Failed or unconfirmed admissions/checkpoints remain manual. Active delegated work is conservatively excluded rather than independently restarting its parent.

The continuation instructs the task to inspect already-completed effects and ask when uncertain. At-most-once recovery admission is not an exactly-once guarantee for external tool side effects. Missing real-engine proof keeps the overall verdict Incomplete.

No merge, release, or deployment is part of this PR.