### PR TITLE
feat(review): make PR evidence readable without adding a release gate

### DIFF
--- a/.github/workflows/evidence-review.yml
+++ b/.github/workflows/evidence-review.yml
@@ -1,0 +1,95 @@
+name: Evidence review
+
+# Publication runs after existing checks, on its own workflow. Never require
+# this check in branch protection: storage and presentation do not gate shipping.
+on:
+  pull_request:
+    paths:
+      - apps/review/**
+      - packages/review/**
+      - evals/packages/test-artifacts/**
+      - evals/bin/evals.mjs
+      - evals/docs-shots/run.ts
+      - evals/specs/evidence-review.test.ts
+      - evals/worlds/evidence-review.ts
+      - .github/workflows/evidence-review.yml
+  workflow_run:
+    workflows: [Build and core checks, Product journeys]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+concurrency:
+  group: evidence-review-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-app:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - uses: pnpm/action-setup@v4
+      - name: Install review and testkit dependencies
+        run: |
+          pnpm --filter @openwork/review-app... --filter @openwork/world... --filter @openwork/types... install --frozen-lockfile --ignore-scripts
+          pnpm --dir evals install --frozen-lockfile --ignore-scripts
+      - name: Build and verify the review app
+        env:
+          OPENWORK_EVAL_REVIEW: "1"
+        run: |
+          pnpm --filter @openwork/review-app build
+          node --test evals/packages/test-artifacts/test/*.test.ts evals/bin/evals.test.mjs
+          pnpm evals:pr specs/evidence-review.test.ts
+      - name: Save review journey evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: review-app-evidence
+          path: evals/results/test-runs/
+          retention-days: 7
+  publish:
+    if: >-
+      vars.OPENWORK_REVIEW_URL != '' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.pull_requests[0].number != null &&
+      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      # Only trusted default-branch code runs with the publishing credentials.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - uses: pnpm/action-setup@v4
+      - name: Install publisher dependencies
+        run: |
+          pnpm --filter @openwork/review... install --frozen-lockfile --ignore-scripts
+          pnpm --dir evals --filter @openwork/test-artifacts install --frozen-lockfile --ignore-scripts
+      - name: Read completed evidence and publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.OPENWORK_REVIEW_BLOB_TOKEN }}
+          OPENWORK_REVIEW_URL: ${{ vars.OPENWORK_REVIEW_URL }}
+          REVIEW_RUN_ID: ${{ github.event.workflow_run.id }}
+          REVIEW_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REVIEW_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+        run: node evals/scripts/publish-review.mjs

--- a/.github/workflows/evidence-review.yml
+++ b/.github/workflows/evidence-review.yml
@@ -8,6 +8,7 @@ on:
       - apps/review/**
       - packages/review/**
       - evals/packages/test-artifacts/**
+      - evals/packages/test-evidence/src/vitest.ts
       - evals/bin/evals.mjs
       - evals/docs-shots/run.ts
       - evals/specs/evidence-review.test.ts

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ opencode.jsonc
 transcript-analysis
 # Eval runner output
 evals/results/
+# DocShot review receipts are capture evidence, tied to the source commit.
+*.png.review.json
 .playwright-mcp/
 .vscode/
 

--- a/.opencode/skills/publish-evidence/SKILL.md
+++ b/.opencode/skills/publish-evidence/SKILL.md
@@ -21,8 +21,10 @@ never reruns a test.
 
 - Show the test name and verdict, each claim's assertion evidence, the relevant
   test artifacts, the source test run, and the reproduction command.
-- Require one sticky-comment section per claimed test. If a claim has no visible
-  test-evidence section, report the PR `Incomplete`.
+- Publish one compact sticky comment linking to a report with a section for every
+  claimed test. The report must show assertion evidence and original records.
+  When the review app is not configured, keep those sections in the comment.
+  If a claim has no inspectable evidence, report the PR `Incomplete`.
 - Write the `<!-- test-evidence -->` marker. The publisher recognizes old sticky
   markers only to update comments created before the migration.
 
@@ -30,22 +32,37 @@ never reruns a test.
 
 Run checks on the final PR head after any rebase or cherry-pick. Test runs are
 bound to a commit SHA, so history rewrites require rerunning and republishing.
-After a multi-test run, publish each test run whose `gitSha` matches the PR head:
+After a multi-test run, publish the complete selection together:
 
 ```bash
-pnpm evals:e2e --publish --pr <n> --test-run <dir|name>
+pnpm evals:e2e --publish --pr <n> --all
+# Or select runs explicitly; repeat --test-run for each claimed run.
+pnpm evals:e2e --publish --pr <n> --test-run <dir|name> --test-run <dir|name>
 ```
 
-`evals:e2e --publish` judges pending visual validations in the selected test
-run, then publishes it. It publishes existing `@openwork/testkit` evidence, not legacy
-flows, and never reruns tests.
+`--all` selects stored runs matching the current PR head. Include a DocShot
+receipt with `--docshot <image.png.review.json>`. It must match that commit too.
+Names and captions provide the default report; `--title` and repeatable `--gap`
+are optional context. No separate report-writing step is required.
 
-- Omitting `--test-run` selects the most recent test run; pass it explicitly
-  when several runs exist so each test's evidence is published deliberately.
-- Publishing replaces the sticky comment with the selected test run. Confirm the
-  final comment shows the test and verdict you intend reviewers to see.
-- Exit codes: `0` published, `1` failed claims published (or publish failed),
-  `2` pending claims still need judging (set a vision key and rerun).
+Publication reads recorded evidence. It never runs tests, captures images, or
+judges pending visual claims. If visual judging is needed, use the existing
+`pnpm --dir evals evidence:judge -- --test-run <dir|name>` command explicitly.
+Pending judgments remain visible and make the evidence `Incomplete`.
+
+Set `OPENWORK_REVIEW_URL` and `BLOB_READ_WRITE_TOKEN` to publish to the private
+review app. Setup is documented in `apps/review/README.md`. Upload errors must
+be reported as publication failures, independently of the test verdict; report
+publication is not a required CI check or a release dependency.
+
+- Omitting `--test-run` selects the most recent run. Prefer explicit selection
+  or `--all` when making claims about several tests.
+- Publication updates the compact comment with the complete selected report.
+  Confirm its commit and included tests. Reference images make no pass/fail claim.
+- A successful publisher exit means published, not tests passed. Derive the PR
+  verdict from recorded results and gaps. Failed and incomplete reports are
+  useful evidence and can be published.
+- Single-run legacy publication remains available without the review app.
 
 ## Stacked PRs
 

--- a/apps/review/.env.example
+++ b/apps/review/.env.example
@@ -1,5 +1,4 @@
-# Review server: shared HTTP Basic password; username is "review".
-OPENWORK_REVIEW_PASSWORD=
+# Access: enable Vercel Authentication for Preview in the project settings.
 # Private Vercel Blob store token, used by both the app and publisher.
 BLOB_READ_WRITE_TOKEN=
 # Publisher: the deployed review app's origin.

--- a/apps/review/.env.example
+++ b/apps/review/.env.example
@@ -1,0 +1,8 @@
+# Review server: shared HTTP Basic password; username is "review".
+OPENWORK_REVIEW_PASSWORD=
+# Private Vercel Blob store token, used by both the app and publisher.
+BLOB_READ_WRITE_TOKEN=
+# Publisher: the deployed review app's origin.
+OPENWORK_REVIEW_URL=
+# Optional local artifact directory, shared by the local app and publisher.
+OPENWORK_REVIEW_LOCAL_DIR=

--- a/apps/review/.gitignore
+++ b/apps/review/.gitignore
@@ -1,0 +1,1 @@
+*.tsbuildinfo

--- a/apps/review/README.md
+++ b/apps/review/README.md
@@ -15,25 +15,38 @@ OPENWORK_EVAL_REVIEW=1 pnpm evals:pr specs/evidence-review.test.ts
 ```
 
 The journey boots the production app with isolated local storage and checks
-composed reports, failed and incomplete evidence, private images, and source
-records through HTTP. Its inputs are explicitly synthetic fixtures; they do
-not claim to have tested the example behaviors shown in the report.
+composed reports, failed and incomplete evidence, images, source records, and
+rejection of production deployments through HTTP. Its inputs are explicitly
+synthetic fixtures; they do not claim to have tested the example behaviors shown
+in the report.
 
 For development, create a directory and set `OPENWORK_REVIEW_LOCAL_DIR` to its
 absolute path in both the app and publisher environments. Run
 `pnpm --filter @openwork/review-app dev` (port 3011). `uploadReview()` also accepts
 local storage through this environment variable, using the same manifest-last
-write behavior. Production always requires `OPENWORK_REVIEW_PASSWORD`; HTTP
-Basic username is `review`. Keep local development bound to loopback.
+write behavior. Local development has no login; keep it bound to loopback.
 
 ## Deploy once to Vercel
 
 Create a project with root directory `apps/review`, enable source files outside
 that directory, and connect a **private** Vercel Blob store. Configure
-`BLOB_READ_WRITE_TOKEN` and `OPENWORK_REVIEW_PASSWORD` for the app. Deployment
-Protection may additionally restrict access to team members. Pages, original
-JSON, and images all share the app's access boundary; Blob URLs are never sent
-to the browser. Unconfigured production instances return 503.
+`BLOB_READ_WRITE_TOKEN` for the Preview environment. Enable **Vercel Authentication**
+under Deployment Protection with **Standard Protection** (or All Deployments).
+Deploy with `vercel deploy --target preview` and use that protected preview URL
+for `OPENWORK_REVIEW_URL`.
+
+Teammates open the PR's report link using their existing Vercel account with
+access to this project. There is no app password. Vercel authenticates requests
+before they reach pages, original JSON, or images; private Blob URLs are never
+sent to the browser. Keep Deployment Protection enabled and the review domain
+out of protection exceptions. Vercel deployments outside Preview return 503,
+because Standard Protection does not protect production domains.
+
+The local journey verifies app behavior after Vercel authentication. Verify
+the hosted boundary with an anonymous request to the preview: report, JSON,
+and image routes must return Vercel's authentication response. An authenticated
+request (or `vercel curl` for verification) must reach the app with no Basic
+authorization header. See [Vercel Authentication](https://vercel.com/docs/deployment-protection/methods-to-protect-deployments/vercel-authentication).
 
 The app only rebuilds when it or its dependencies change. Report publication
 uploads data to the existing app; it never creates a deployment.

--- a/apps/review/README.md
+++ b/apps/review/README.md
@@ -1,0 +1,83 @@
+# OpenWork Review
+
+An immutable, private review page composed from existing test records and
+DocShot receipts. Publication reads completed files; it never runs tests,
+captures screenshots, or calls a model. Reference images have no implied test
+result. Pending judgments and coverage gaps remain visible.
+
+## Develop and verify
+
+```sh
+pnpm --filter @openwork/review-app... install --frozen-lockfile
+pnpm --dir evals install --frozen-lockfile --ignore-scripts
+pnpm --filter @openwork/review-app build
+OPENWORK_EVAL_REVIEW=1 pnpm evals:pr specs/evidence-review.test.ts
+```
+
+The journey boots the production app with isolated local storage and checks
+composed reports, failed and incomplete evidence, private images, and source
+records through HTTP. Its inputs are explicitly synthetic fixtures; they do
+not claim to have tested the example behaviors shown in the report.
+
+For development, create a directory and set `OPENWORK_REVIEW_LOCAL_DIR` to its
+absolute path in both the app and publisher environments. Run
+`pnpm --filter @openwork/review-app dev` (port 3011). `uploadReview()` also accepts
+local storage through this environment variable, using the same manifest-last
+write behavior. Production always requires `OPENWORK_REVIEW_PASSWORD`; HTTP
+Basic username is `review`. Keep local development bound to loopback.
+
+## Deploy once to Vercel
+
+Create a project with root directory `apps/review`, enable source files outside
+that directory, and connect a **private** Vercel Blob store. Configure
+`BLOB_READ_WRITE_TOKEN` and `OPENWORK_REVIEW_PASSWORD` for the app. Deployment
+Protection may additionally restrict access to team members. Pages, original
+JSON, and images all share the app's access boundary; Blob URLs are never sent
+to the browser. Unconfigured production instances return 503.
+
+The app only rebuilds when it or its dependencies change. Report publication
+uploads data to the existing app; it never creates a deployment.
+
+Set `OPENWORK_REVIEW_URL` and `BLOB_READ_WRITE_TOKEN` in the publishing
+environment. The existing command publishes a compact link when configured:
+
+```sh
+pnpm evals:e2e --publish --pr 123 --test-run <run-directory>
+pnpm evals:e2e --publish --pr 123 --all --docshot <image.png.review.json>
+```
+
+Repeat `--test-run` to choose several runs deliberately, or `--all` to choose
+all stored runs matching the current PR head. Every selected source, including
+DocShot, must carry the same commit. Optional `--title` and repeatable `--gap`
+provide context. Test and image captions supply the default structure. Each
+publish replaces the compact comment with the complete selection, preserving
+the comment's identity. Include all claimed runs in that selection.
+
+`--dry-run` validates and renders the summary without uploads or GitHub calls
+(except resolving the PR head if `--all --pr` is used). Legacy single-run
+publication remains available when the review app is not configured.
+Visual judging is explicit: `pnpm --dir evals evidence:judge -- --test-run <run>`.
+
+For automatic publication, configure repository variable `OPENWORK_REVIEW_URL`
+and secret `OPENWORK_REVIEW_BLOB_TOKEN`. The separate **Evidence review** workflow
+consumes existing uploaded artifacts after checks finish. It runs trusted
+default-branch code, ignores stale runs, and only publishes when GitHub supplies
+an associated PR and matching source commit. It never runs downloaded code.
+An existing review of that commit takes precedence, preserving the author's
+selected evidence. Explicit publication can update that selection.
+**Do not require Evidence review in branch protection.** Failures remain visible
+in its optional workflow; existing test checks retain their verdicts.
+
+## Contract
+
+`packages/review/src/schema.ts` is the runtime schema and TypeScript source of
+truth. Sections refer to evidence by stable IDs, allowing the same evidence to
+appear in several sections. Images are deduplicated by content within a report.
+Original records retain diagnostics; the page loads them only when opened.
+Each upload has a new immutable ID. The manifest is written only after all
+assets succeed, and the publisher rechecks the PR head before updating GitHub.
+
+Status describes selected evidence: a failed assertion or visual judgment is
+Failed; skipped/unknown tests, missing assertion evidence, pending judgments,
+and declared gaps are Incomplete. An image-only document is Reference. Human
+approval and discussion stay in GitHub.

--- a/apps/review/app/layout.tsx
+++ b/apps/review/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import "./style.css";
+
+export const metadata = {
+  title: "OpenWork Review",
+  robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="masthead">
+          <a href="/">
+            openwork<span>/ review</span>
+          </a>
+          <span>Evidence, in context.</span>
+        </header>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/review/app/page.tsx
+++ b/apps/review/app/page.tsx
@@ -1,0 +1,16 @@
+export default function Home() {
+  return (
+    <main className="home">
+      <p className="eyebrow">OpenWork Review</p>
+      <h1>
+        A clearer view
+        <br />
+        of what changed.
+      </h1>
+      <p>
+        Open the report linked from your pull request to explore verified
+        behavior, screenshots, and coverage gaps.
+      </p>
+    </main>
+  );
+}

--- a/apps/review/app/r/[id]/assets/[name]/route.ts
+++ b/apps/review/app/r/[id]/assets/[name]/route.ts
@@ -1,0 +1,22 @@
+import { readReview, readReviewAsset } from "@openwork/review/storage";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; name: string }> },
+) {
+  const { id, name } = await params;
+  const report = await readReview(id);
+  if (!report) return new Response("Report not found", { status: 404 });
+  const allowed =
+    name === "report.json" ||
+    report.sources.some((source) => source.asset === name) ||
+    report.evidence.some(
+      (item) => item.kind === "image" && item.asset === name,
+    );
+  if (!allowed) return new Response("Evidence not found", { status: 404 });
+  const response = await readReviewAsset(id, name);
+  if (!response) return new Response("Evidence not found", { status: 404 });
+  response.headers.set("cache-control", "private, no-store");
+  response.headers.set("x-content-type-options", "nosniff");
+  return response;
+}

--- a/apps/review/app/r/[id]/page.tsx
+++ b/apps/review/app/r/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from "next/navigation";
+import { readReview } from "@openwork/review/storage";
+import { Report } from "../../../components/report";
+
+export const dynamic = "force-dynamic";
+
+export default async function ReviewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const report = await readReview(id);
+  if (!report) notFound();
+  return <Report id={id} report={report} />;
+}

--- a/apps/review/app/style.css
+++ b/apps/review/app/style.css
@@ -1,0 +1,403 @@
+:root {
+  color-scheme: light;
+  --ink: #20241f;
+  --muted: #72776d;
+  --line: #e1e4dc;
+  --paper: #fafbf7;
+  --green: #32724d;
+  --red: #a13c35;
+  --amber: #946621;
+}
+* {
+  box-sizing: border-box;
+}
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 28px;
+}
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font:
+    15px/1.6 -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+a:focus-visible,
+summary:focus-visible {
+  outline: 3px solid #70a27d;
+  outline-offset: 5px;
+}
+a:hover {
+  text-decoration: underline;
+}
+.masthead {
+  height: 78px;
+  margin: 0 auto;
+  max-width: 1440px;
+  padding: 0 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--line);
+}
+.masthead > a {
+  font-size: 21px;
+  font-weight: 650;
+  letter-spacing: -0.7px;
+}
+.masthead > a span {
+  color: var(--muted);
+  font-weight: 400;
+  margin-left: 12px;
+}
+.masthead > span {
+  font-size: 13px;
+  color: var(--muted);
+}
+.report {
+  max-width: 1328px;
+  margin: auto;
+  padding: 0 40px;
+}
+.intro {
+  padding: 64px 0 46px;
+  max-width: 1000px;
+}
+.eyebrow {
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 12px;
+}
+.eyebrow span {
+  font-family: monospace;
+  font-weight: 400;
+  letter-spacing: 0.2px;
+}
+h1 {
+  font-size: clamp(34px, 4vw, 54px);
+  line-height: 1.14;
+  letter-spacing: -1.8px;
+  font-weight: 500;
+  max-width: 1000px;
+  margin: 0 0 26px;
+  overflow-wrap: anywhere;
+}
+.summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  font-size: 13px;
+}
+.badge {
+  border: 1px solid currentColor;
+  padding: 4px 12px;
+  border-radius: 5px;
+  font-weight: 600;
+}
+.badge.passed {
+  color: var(--green);
+  background: #edf5ed;
+}
+.badge.failed {
+  color: var(--red);
+  background: #fff0ec;
+}
+.badge.incomplete {
+  color: var(--amber);
+  background: #fff8e9;
+}
+.scope {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 20px 0 0;
+}
+.scope time {
+  display: inline-block;
+  margin-left: 12px;
+}
+.gaps {
+  border-left: 3px solid #c59d5a;
+  margin-top: 26px;
+  background: #f6f0e3;
+  padding: 14px 20px;
+  font-size: 13px;
+}
+.gaps ul {
+  margin: 5px 0 0;
+  padding-left: 18px;
+}
+.report-body {
+  display: grid;
+  grid-template-columns: 232px minmax(0, 1fr);
+  gap: 52px;
+  border-top: 1px solid var(--line);
+  padding-top: 40px;
+}
+.contents {
+  position: sticky;
+  top: 30px;
+  align-self: start;
+}
+.contents > a {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  line-height: 1.55;
+  padding: 11px 0;
+  color: #53594f;
+}
+.contents > a span {
+  font-family: monospace;
+  font-size: 11px;
+  color: #969b91;
+  flex-shrink: 0;
+}
+.contents > a.download {
+  margin-top: 25px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+}
+.section {
+  padding-bottom: 44px;
+  margin-bottom: 40px;
+  border-bottom: 1px solid var(--line);
+}
+.section-heading {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 25px;
+}
+.section-heading .eyebrow {
+  font-size: 10px;
+  margin-bottom: 5px;
+}
+.section-heading > div {
+  flex: 1;
+  min-width: 0;
+}
+.number {
+  font: 12px monospace;
+  color: var(--muted);
+  padding-top: 3px;
+}
+.section-heading h2 {
+  font-size: 25px;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: -0.5px;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.result {
+  font-size: 11px;
+  text-transform: capitalize;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.result.passed {
+  color: var(--green);
+}
+.result.failed {
+  color: var(--red);
+}
+.result.incomplete,
+.result.pending,
+.result.skipped,
+.result.unknown {
+  color: var(--amber);
+}
+.section-heading > .result {
+  margin-top: 25px;
+}
+details {
+  font-size: 13px;
+}
+summary {
+  cursor: pointer;
+  color: #52594d;
+  padding: 13px 0;
+}
+summary span {
+  float: right;
+  color: var(--muted);
+  font-size: 11px;
+}
+.checks {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 26px;
+}
+.assertions {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+}
+.assertions li {
+  display: flex;
+  gap: 12px;
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+  align-items: baseline;
+}
+.assertions li > div {
+  flex: 1;
+  min-width: 0;
+}
+.assertions strong {
+  font-size: 13px;
+  font-weight: 500;
+}
+.assertions p {
+  margin: 5px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--muted);
+}
+.dot.passed {
+  background: var(--green);
+}
+.dot.failed {
+  background: var(--red);
+}
+.dot.pending {
+  background: var(--amber);
+}
+figure {
+  margin: 0 0 32px;
+}
+.image-link {
+  display: block;
+  padding: 18px;
+  background: #eceee7;
+  border: 1px solid #dfe3d8;
+  border-radius: 8px;
+}
+.image-link img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 3px;
+  box-shadow: 0 3px 15px #26302215;
+}
+figcaption {
+  padding: 15px 1px 0;
+  font-size: 13px;
+}
+figcaption strong {
+  font-weight: 550;
+}
+figcaption p {
+  color: var(--muted);
+  font-size: 12px;
+  margin: 4px 0 0;
+}
+.visual {
+  margin-top: 8px;
+}
+.visual summary {
+  font-size: 11px;
+  color: var(--muted);
+}
+.provenance {
+  font-size: 12px;
+  color: var(--muted);
+}
+.provenance summary {
+  font-size: 12px;
+}
+.provenance code {
+  overflow-wrap: anywhere;
+}
+.provenance a {
+  text-decoration: underline;
+}
+.empty {
+  font-size: 13px;
+  color: var(--amber);
+}
+footer {
+  padding: 0 0 40px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.home {
+  max-width: 760px;
+  padding: 100px 40px;
+  margin: auto;
+}
+.home > p:last-child {
+  color: var(--muted);
+  max-width: 520px;
+  font-size: 17px;
+}
+@media (max-width: 800px) {
+  .masthead {
+    padding: 0 24px;
+    height: 66px;
+  }
+  .masthead > span {
+    display: none;
+  }
+  .report {
+    padding: 0 24px;
+  }
+  .intro {
+    padding: 38px 0 30px;
+  }
+  .report-body {
+    display: block;
+    padding-top: 28px;
+  }
+  .contents {
+    position: static;
+    display: none;
+  }
+  .section-heading h2 {
+    font-size: 22px;
+  }
+  .scope time {
+    display: block;
+    margin: 6px 0 0;
+  }
+  .image-link {
+    padding: 8px;
+  }
+  .section-heading {
+    gap: 10px;
+  }
+  .summary {
+    gap: 10px 16px;
+  }
+  summary span {
+    display: none;
+  }
+  .home {
+    padding: 70px 24px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/apps/review/components/report.tsx
+++ b/apps/review/components/report.tsx
@@ -1,0 +1,213 @@
+import { summarizeReview } from "@openwork/review";
+import type { ReviewEvidence, ReviewReport } from "@openwork/review";
+
+function Judgments({ items }: { items: ReviewEvidence["judgments"] }) {
+  return (
+    <ul className="assertions">
+      {items.map((item, index) => (
+        <li key={index}>
+          <span className={`dot ${item.state}`} aria-label={item.state} />
+          <div>
+            <strong>{item.expectation}</strong>
+            <p>{item.reasoning}</p>
+          </div>
+          <span className={`result ${item.state}`}>{item.state}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function Report({ report, id }: { report: ReviewReport; id: string }) {
+  const summary = summarizeReview(report);
+  const assetUrl = (name: string) => `/r/${id}/assets/${name}`;
+  const evidenceById = new Map(report.evidence.map((item) => [item.id, item]));
+  return (
+    <main className="report">
+      <div className="intro">
+        <p className="eyebrow">
+          Change verification <span> / {report.gitSha.slice(0, 7)}</span>
+        </p>
+        <h1>{report.title}</h1>
+        <div className="summary">
+          <span className={`badge ${summary.verdict.toLowerCase()}`}>
+            {summary.verdict}
+          </span>
+          {summary.tests > 0 && (
+            <span>
+              {summary.passedTests} of {summary.tests} tests passed
+            </span>
+          )}
+          {summary.assertions > 0 && (
+            <span>
+              {summary.passedAssertions} of {summary.assertions} assertions
+              passed
+            </span>
+          )}
+          <span>{summary.images} images</span>
+        </div>
+        <p className="scope">
+          Results cover the selected evidence below.{" "}
+          <time dateTime={report.createdAt}>
+            {new Date(report.createdAt).toLocaleString("en-US", {
+              dateStyle: "medium",
+              timeStyle: "short",
+              timeZone: "UTC",
+            })}{" "}
+            UTC
+          </time>
+        </p>
+        {(report.gaps.length > 0 || summary.pendingVisual > 0) && (
+          <aside className="gaps">
+            <strong>Still to verify</strong>
+            <ul>
+              {report.gaps.map((gap, index) => (
+                <li key={index}>{gap}</li>
+              ))}
+              {summary.pendingVisual > 0 && (
+                <li>{summary.pendingVisual} visual judgment(s) pending.</li>
+              )}
+            </ul>
+          </aside>
+        )}
+      </div>
+      <div className="report-body">
+        <nav className="contents" aria-label="Report sections">
+          <p className="eyebrow">In this review</p>
+          {report.sections.map((section, index) => (
+            <a key={section.id} href={`#${section.id}`}>
+              <span>{String(index + 1).padStart(2, "0")}</span>
+              {section.title}
+            </a>
+          ))}
+          <a className="download" href={assetUrl("report.json")}>
+            Download report ↗
+          </a>
+        </nav>
+        <div className="sections">
+          {report.sections.map((section, index) => {
+            const source = report.sources.find(
+              (item) => item.id === section.sourceId,
+            );
+            if (!source) return null;
+            const items = section.evidenceIds.flatMap((key) => {
+              const item = evidenceById.get(key);
+              return item ? [item] : [];
+            });
+            const assertions = items
+              .filter((item) => item.kind === "assertion")
+              .flatMap((item) => item.judgments);
+            const verdict = summarizeReview({
+              sources: [source],
+              evidence: items,
+              gaps: [],
+            }).verdict;
+            return (
+              <section className="section" id={section.id} key={section.id}>
+                <div className="section-heading">
+                  <span className="number">
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <div>
+                    <p className="eyebrow">
+                      {source.kind === "docshot"
+                        ? "Documentation reference"
+                        : "Test run"}
+                    </p>
+                    <h2>{section.title}</h2>
+                  </div>
+                  <span className={`result ${verdict.toLowerCase()}`}>
+                    {verdict}
+                  </span>
+                </div>
+                {source.kind === "test-run" && source.outcome !== "passed" && (
+                  <p className="empty">
+                    Execution {source.outcome}
+                    {source.failure ? `: ${source.failure}` : ""}
+                  </p>
+                )}
+                {assertions.length > 0 && (
+                  <details
+                    className="checks"
+                    open={assertions.some((item) => item.state !== "passed")}
+                  >
+                    <summary>
+                      {assertions.length} recorded assertion
+                      {assertions.length === 1 ? "" : "s"}
+                      <span>Inspect results</span>
+                    </summary>
+                    <Judgments items={assertions} />
+                  </details>
+                )}
+                {source.kind === "test-run" && assertions.length === 0 && (
+                  <p className="empty">
+                    No assertion evidence was recorded for this run.
+                  </p>
+                )}
+                {items
+                  .filter((item) => item.kind === "image")
+                  .map((item) => (
+                    <figure key={item.id}>
+                      <a
+                        className="image-link"
+                        href={assetUrl(item.asset)}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <img
+                          src={assetUrl(item.asset)}
+                          alt={item.caption}
+                          loading="lazy"
+                        />
+                      </a>
+                      <figcaption>
+                        <strong>{item.caption}</strong>
+                        {item.description && <p>{item.description}</p>}
+                      </figcaption>
+                      {item.judgments.length > 0 && (
+                        <details
+                          className="visual"
+                          open={item.judgments.some(
+                            (judgment) => judgment.state !== "passed",
+                          )}
+                        >
+                          <summary>
+                            Visual checks ·{" "}
+                            {
+                              item.judgments.filter(
+                                (judgment) => judgment.state === "passed",
+                              ).length
+                            }
+                            /{item.judgments.length} passed
+                          </summary>
+                          <Judgments items={item.judgments} />
+                        </details>
+                      )}
+                    </figure>
+                  ))}
+                <details className="provenance">
+                  <summary>Source and diagnostics</summary>
+                  <p>
+                    Commit <code>{source.gitSha}</code>
+                  </p>
+                  <p>Captured {source.createdAt}</p>
+                  <a href={assetUrl(source.asset)}>
+                    Open original{" "}
+                    {source.kind === "test-run"
+                      ? "test record, steps, and trace"
+                      : "DocShot receipt"}{" "}
+                    ↗
+                  </a>
+                </details>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+      <footer>
+        Recorded evidence · Human discussion and approval remain on the pull
+        request.
+      </footer>
+    </main>
+  );
+}

--- a/apps/review/next-env.d.ts
+++ b/apps/review/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/review/next.config.ts
+++ b/apps/review/next.config.ts
@@ -1,0 +1,8 @@
+import { resolve } from "node:path";
+import type { NextConfig } from "next";
+
+const config: NextConfig = {
+  outputFileTracingRoot: resolve(import.meta.dirname, "../.."),
+  transpilePackages: ["@openwork/review"],
+};
+export default config;

--- a/apps/review/package.json
+++ b/apps/review/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@openwork/review-app",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "next dev --hostname 127.0.0.1 --port ${REVIEW_PORT:-3011}",
+    "build": "next build",
+    "start": "next start --hostname 127.0.0.1 --port ${REVIEW_PORT:-3011}",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openwork/review": "workspace:*",
+    "next": "16.2.11",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/review/proxy.ts
+++ b/apps/review/proxy.ts
@@ -1,4 +1,4 @@
-import { createHash, timingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
@@ -11,13 +11,11 @@ export function proxy(request: NextRequest) {
       status: 503,
     });
   if (password) {
-    const expected = `Basic ${Buffer.from(`review:${password}`).toString("base64")}`;
-    const hash = (value: string) => createHash("sha256").update(value).digest();
+    const expected = Buffer.from(`Basic ${Buffer.from(`review:${password}`).toString("base64")}`);
+    const supplied = Buffer.from(request.headers.get("authorization") ?? "");
     if (
-      !timingSafeEqual(
-        hash(request.headers.get("authorization") ?? ""),
-        hash(expected),
-      )
+      supplied.length !== expected.length ||
+      !timingSafeEqual(supplied, expected)
     ) {
       return new NextResponse("Sign in to review this evidence.", {
         status: 401,

--- a/apps/review/proxy.ts
+++ b/apps/review/proxy.ts
@@ -1,0 +1,39 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// One access boundary covers pages, original records, and every image.
+// Vercel Deployment Protection can additionally restrict access to team members.
+export function proxy(request: NextRequest) {
+  const password = process.env.OPENWORK_REVIEW_PASSWORD;
+  if (!password && process.env.NODE_ENV === "production")
+    return new NextResponse("Review access is not configured.", {
+      status: 503,
+    });
+  if (password) {
+    const expected = `Basic ${Buffer.from(`review:${password}`).toString("base64")}`;
+    const hash = (value: string) => createHash("sha256").update(value).digest();
+    if (
+      !timingSafeEqual(
+        hash(request.headers.get("authorization") ?? ""),
+        hash(expected),
+      )
+    ) {
+      return new NextResponse("Sign in to review this evidence.", {
+        status: 401,
+        headers: {
+          "www-authenticate": 'Basic realm="OpenWork Review", charset="UTF-8"',
+          "cache-control": "private, no-store",
+        },
+      });
+    }
+  }
+  const response = NextResponse.next();
+  response.headers.set("cache-control", "private, no-store");
+  response.headers.set("x-robots-tag", "noindex, nofollow, noarchive");
+  response.headers.set("referrer-policy", "same-origin");
+  response.headers.set("x-content-type-options", "nosniff");
+  return response;
+}
+
+export const config = { matcher: ["/:path*"] };

--- a/apps/review/proxy.ts
+++ b/apps/review/proxy.ts
@@ -1,31 +1,13 @@
-import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
 
-// One access boundary covers pages, original records, and every image.
-// Vercel Deployment Protection can additionally restrict access to team members.
-export function proxy(request: NextRequest) {
-  const password = process.env.OPENWORK_REVIEW_PASSWORD;
-  if (!password && process.env.NODE_ENV === "production")
-    return new NextResponse("Review access is not configured.", {
+// Vercel Authentication protects the entire preview, including JSON and images.
+// Standard Protection leaves production domains public, so do not serve there.
+export function proxy() {
+  if (process.env.VERCEL && process.env.VERCEL_ENV !== "preview")
+    return new NextResponse("Open this app through its protected Vercel preview.", {
       status: 503,
+      headers: { "cache-control": "private, no-store" },
     });
-  if (password) {
-    const expected = Buffer.from(`Basic ${Buffer.from(`review:${password}`).toString("base64")}`);
-    const supplied = Buffer.from(request.headers.get("authorization") ?? "");
-    if (
-      supplied.length !== expected.length ||
-      !timingSafeEqual(supplied, expected)
-    ) {
-      return new NextResponse("Sign in to review this evidence.", {
-        status: 401,
-        headers: {
-          "www-authenticate": 'Basic realm="OpenWork Review", charset="UTF-8"',
-          "cache-control": "private, no-store",
-        },
-      });
-    }
-  }
   const response = NextResponse.next();
   response.headers.set("cache-control", "private, no-store");
   response.headers.set("x-robots-tag", "noindex, nofollow, noarchive");

--- a/apps/review/tsconfig.json
+++ b/apps/review/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "allowJs": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/review/vercel.json
+++ b/apps/review/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "ignoreCommand": "turbo query affected --base=$VERCEL_GIT_PREVIOUS_SHA --packages @openwork/review-app --exit-code || exit 1",
+  "fluid": true
+}

--- a/evals/bin/evals.mjs
+++ b/evals/bin/evals.mjs
@@ -19,10 +19,15 @@ Run E2E tests:
 
 Without a placement flag, Daytona is used when the daytona CLI is authenticated, otherwise local.
 
-Judge then publish evidence:
-  --publish         Enter judge-then-publish mode
+Publish recorded evidence (no test reruns or model calls):
+  --publish         Publish completed evidence
   --pr <n>          Publish to pull request n
   --test-run <value> Select a test run path, directory ID, name, or latest (default: latest)
+  --all             Combine all runs matching the current PR head
+  --docshot <path>  Include a DocShot .review.json receipt (repeatable)
+  --title <text>    Report title (defaults to Change verification)
+  --gap <text>      Declare a coverage gap (repeatable)
+  --review-url <url> Override OPENWORK_REVIEW_URL
   --dry-run         Render publication output without posting
   --force           Forward force to the publisher
 
@@ -40,9 +45,9 @@ Run exit codes:
   2  A named test skipped and its result is incomplete
 
 Publish exit codes:
-  0  Judge and publisher succeeded
-  1  Failed claims were published, or publishing failed
-  2  Pending claims require judging before publication
+  0  Publisher succeeded
+  1  Publication failed
+  Visual judgments retain their recorded passed, failed, or pending state.
 `;
 
 export function consentVarsFromSource(text) {
@@ -88,10 +93,16 @@ export function parseArgs(args) {
     else if (arg === "--publish") options.publish = true;
     else if (arg === "--dry-run") options.dryRun = true;
     else if (arg === "--force") options.force = true;
+    else if (arg === "--all") (options.reviewArgs ??= []).push(arg);
+    else if (["--docshot", "--title", "--gap", "--review-url"].includes(arg)) {
+      (options.reviewArgs ??= []).push(arg, valueAfter(args, index, arg));
+      index += 1;
+    }
     else if (arg === "--den" || arg === "--pr" || arg === "--test-run") {
       const value = valueAfter(args, index, arg);
       if (arg === "--den") options.den = value;
       else if (arg === "--pr") options.pr = value;
+      else if (options.testRun !== undefined) (options.reviewArgs ??= []).push("--test-run", value);
       else options.testRun = value;
       index += 1;
     } else if (arg.startsWith("-")) {
@@ -128,6 +139,7 @@ export function parseArgs(args) {
     if (options.testRun !== undefined) publishFlags.push("--test-run");
     if (options.dryRun) publishFlags.push("--dry-run");
     if (options.force) publishFlags.push("--force");
+    if (options.reviewArgs) publishFlags.push("review options");
     if (publishFlags.length > 0) {
       throw new Error(`${publishFlags.join(", ")} require --publish.`);
     }
@@ -287,32 +299,19 @@ function childStatus(result) {
 }
 
 function publish(options) {
-  const testRun = options.testRun ?? "latest";
-  const judge = spawnSync(process.execPath, [
-    join(evalsDir, "packages/test-evidence/bin/test-evidence-judge.mjs"),
-    "--test-run",
-    testRun,
-  ], { cwd: repoRoot, env: process.env, stdio: "inherit" });
-  const judgeStatus = childStatus(judge);
-
-  if (judgeStatus === 2 && !options.dryRun) {
-    process.stderr.write("Pending claims need OPENAI_API_KEY or ANTHROPIC_API_KEY for judging; rerun after providing one, or use --dry-run.\n");
-    return 2;
-  }
-  if (![0, 1, 2].includes(judgeStatus)) return judgeStatus;
-
   const publishArgs = [join(evalsDir, "packages/test-artifacts/bin/publish-pr.mjs")];
   if (options.pr) publishArgs.push("--pr", options.pr);
   if (options.testRun) publishArgs.push("--test-run", options.testRun);
   if (options.dryRun) publishArgs.push("--dry-run");
   if (options.force) publishArgs.push("--force");
+  if (options.reviewArgs) publishArgs.push(...options.reviewArgs);
   const published = spawnSync(process.execPath, publishArgs, {
     cwd: repoRoot,
     env: process.env,
     stdio: "inherit",
   });
   const publishStatus = childStatus(published);
-  return judgeStatus === 1 && publishStatus === 0 ? 1 : publishStatus;
+  return publishStatus;
 }
 
 function run(options) {

--- a/evals/docs-shots/run.ts
+++ b/evals/docs-shots/run.ts
@@ -12,7 +12,9 @@
  * Redis on 127.0.0.1:6379 (pnpm dev:den:mysql).
  */
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { basename, dirname, resolve } from "node:path";
+import { docShotReceiptSchema } from "@openwork/review";
 import { emulateFocus, freezeMotion, paintBackdrop, setViewport } from "@openwork/cdp";
 import { Ctx } from "./ctx.ts";
 import { captureUntil } from "./loop.ts";
@@ -45,6 +47,9 @@ if (unknown.length > 0) {
   process.exit(1);
 }
 const selected = requested.length > 0 ? shots.filter((shot) => requested.includes(shot.id)) : shots;
+const git = spawnSync("git", ["rev-parse", "HEAD"], { cwd: REPO_ROOT, encoding: "utf8" });
+if (git.status !== 0) throw new Error("DocShot requires a source commit.");
+const gitSha = git.stdout.trim();
 
 const ctx = new Ctx();
 const failures: string[] = [];
@@ -67,6 +72,10 @@ try {
       const outPath = resolve(REPO_ROOT, shot.out);
       await mkdir(dirname(outPath), { recursive: true });
       await writeFile(outPath, png);
+      await writeFile(`${outPath}.review.json`, JSON.stringify(docShotReceiptSchema.parse({
+        schemaVersion: 1, kind: "docshot", name: shot.id, gitSha,
+        createdAt: new Date().toISOString(), fileName: basename(outPath),
+      }), null, 2));
       console.log(`[docs-shots] wrote ${shot.out} (${png.byteLength} bytes)`);
     } catch (error) {
       failures.push(shot.id);

--- a/evals/package.json
+++ b/evals/package.json
@@ -33,7 +33,8 @@
     "@openwork/test-evidence": "workspace:*",
     "@openwork/testkit": "workspace:*",
     "@openwork/types": "link:../packages/types",
-    "@openwork/world": "link:../packages/world"
+    "@openwork/world": "link:../packages/world",
+    "@openwork/review": "link:../packages/review"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",

--- a/evals/packages/test-artifacts/bin/publish-pr.mjs
+++ b/evals/packages/test-artifacts/bin/publish-pr.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { publishReviewPr } from "../src/publish-pr.ts";
 import { formatTestRunAge, publishPr, readTestRunDirectory, scanTestRuns } from "../src/index.ts";
 
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
@@ -10,6 +11,12 @@ const resultsDir = join(repoRoot, "evals", "results");
 const args = process.argv.slice(2);
 let pr;
 let testRunArg;
+const testRunArgs = [];
+const docShots = [];
+const gaps = [];
+let title;
+let all = false;
+let reviewUrl = process.env.OPENWORK_REVIEW_URL;
 let dryRun = false;
 let force = false;
 let shouldOpen = false;
@@ -17,6 +24,7 @@ let shouldOpen = false;
 for (let index = 0; index < args.length; index += 1) {
   const arg = args[index];
   if (arg === "--") continue;
+  if (arg === "--all") { all = true; continue; }
   if (arg === "--dry-run") {
     dryRun = true;
     continue;
@@ -29,11 +37,15 @@ for (let index = 0; index < args.length; index += 1) {
     shouldOpen = true;
     continue;
   }
-  if (arg === "--pr" || arg === "--test-run") {
+  if (["--pr", "--test-run", "--docshot", "--title", "--gap", "--review-url"].includes(arg)) {
     const value = args[index + 1];
     if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value.`);
     if (arg === "--pr") pr = value;
-    else testRunArg = value;
+    else if (arg === "--test-run") { testRunArg = value; testRunArgs.push(value); }
+    else if (arg === "--docshot") docShots.push(resolve(value));
+    else if (arg === "--gap") gaps.push(value);
+    else if (arg === "--title") title = value;
+    else reviewUrl = value;
     index += 1;
     continue;
   }
@@ -43,6 +55,28 @@ for (let index = 0; index < args.length; index += 1) {
 if (!dryRun && !shouldOpen && !pr) throw new Error("--pr <n> is required unless --dry-run or --open is set.");
 if (shouldOpen && (pr || dryRun || force)) throw new Error("--open cannot be combined with --pr, --dry-run, or --force.");
 const entries = (await scanTestRuns(resultsDir)).filter((entry) => entry.kind === "test-run");
+if (!shouldOpen && (all || testRunArgs.length > 1 || docShots.length > 0 || reviewUrl || title || gaps.length > 0)) {
+  if (force || shouldOpen) throw new Error("Composed reviews cannot use --force or --open.");
+  let selected = testRunArgs;
+  if (all) {
+    const head = pr ? spawnSync("gh", ["pr", "view", pr, "--json", "headRefOid", "--jq", ".headRefOid"], { encoding: "utf8" })
+      : spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
+    if (head.status !== 0) throw new Error("Cannot resolve the source commit.");
+    selected = entries.filter((entry) => entry.testRun.gitSha === head.stdout.trim()).map((entry) => entry.directoryPath);
+  }
+  const testRunDirs = [];
+  for (const value of selected) {
+    const candidate = resolve(value);
+    const stored = await readTestRunDirectory(candidate);
+    const entry = stored ? { directoryPath: candidate } : value === "latest" ? entries[0] : entries.find((entry) => entry.directoryName === value || entry.name === value);
+    if (!entry) throw new Error(`No test run found for ${value}`);
+    testRunDirs.push(entry.directoryPath);
+  }
+  if (testRunDirs.length === 0 && docShots.length === 0 && !all && entries[0]) testRunDirs.push(entries[0].directoryPath);
+  const result = await publishReviewPr({ pr, testRunDirs, docShots, title, gaps, reviewUrl, dryRun });
+  if (!dryRun) process.stdout.write(`${result.updated ? "Updated" : "Posted"} review: ${result.urls.report}\n`);
+  process.exit(0);
+}
 let testRunDir;
 let selectedTestRun;
 if (testRunArg && testRunArg !== "latest") {

--- a/evals/packages/test-artifacts/package.json
+++ b/evals/packages/test-artifacts/package.json
@@ -8,6 +8,10 @@
       "types": "./src/index.ts",
       "development": "./src/index.ts",
       "default": "./src/index.ts"
-    }
+    },
+    "./review": "./src/review.ts"
+  },
+  "dependencies": {
+    "@openwork/review": "link:../../../packages/review"
   }
 }

--- a/evals/packages/test-artifacts/src/publish-pr.ts
+++ b/evals/packages/test-artifacts/src/publish-pr.ts
@@ -3,6 +3,7 @@ import { lstat, realpath } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { renderPrMarkdown } from "./render.ts";
 import { readTestRunDirectory } from "./scan.ts";
+import type { uploadReview } from "@openwork/review/storage";
 
 const MARKER = "<!-- test-evidence -->";
 const LEGACY_MARKERS = ["<!-- photo-roll -->", "<!-- fraimz -->"];
@@ -23,6 +24,7 @@ export type CommandRunner = (command: string, args: string[], opts?: CommandOpti
 export interface PublishDependencies {
   exec?: CommandRunner;
   stdout?: (markdown: string) => void;
+  upload?: typeof uploadReview;
 }
 
 export interface PublishPrOptions {
@@ -173,6 +175,9 @@ export async function publishPr(
   options: PublishPrOptions,
   dependencies: PublishDependencies = {},
 ): Promise<PublishPrResult> {
+  if (process.env.OPENWORK_REVIEW_URL && !options.force) {
+    return publishReviewPr({ ...options, testRunDirs: [options.testRunDir] }, dependencies);
+  }
   const stored = await readTestRunDirectory(options.testRunDir);
   if (!stored) throw new Error(`No valid test-run.json or legacy result found in ${options.testRunDir}`);
   const { format, testRun } = stored;
@@ -222,4 +227,98 @@ export async function publishPr(
   });
   const updated = postStickyComment(String(options.pr), markdown, postedAttachments, exec);
   return { markdown, posted: true, updated, urls };
+}
+
+export async function publishReviewPr(
+  options: {
+    pr?: string | number;
+    testRunDirs: string[];
+    docShots?: string[];
+    title?: string;
+    gaps?: string[];
+    reviewUrl?: string;
+    dryRun?: boolean;
+    preserveCurrentReport?: boolean;
+  },
+  dependencies: PublishDependencies = {},
+): Promise<PublishPrResult> {
+  // Testkit imports this package too. Load the report stack only when publishing.
+  const { assembleReview, renderReviewComment } = await import("./review.ts");
+  const { report, assets } = await assembleReview(options);
+  if (options.dryRun) {
+    const markdown = renderReviewComment(report);
+    (dependencies.stdout ?? ((body) => process.stdout.write(`${body}\n`)))(
+      markdown,
+    );
+    return { markdown, posted: false, updated: false, urls: {} };
+  }
+  if (options.pr === undefined)
+    throw new Error("Publishing requires --pr <n>.");
+  const pr = String(options.pr);
+  const exec = dependencies.exec ?? commandRunner;
+  const base = options.reviewUrl ?? process.env.OPENWORK_REVIEW_URL;
+  if (!base) throw new Error("Set OPENWORK_REVIEW_URL to the review app URL.");
+  const url = new URL(base);
+  if (
+    url.username ||
+    url.password ||
+    (url.protocol !== "https:" &&
+      !(
+        url.protocol === "http:" &&
+        ["localhost", "127.0.0.1"].includes(url.hostname)
+      ))
+  )
+    throw new Error("Review URL must use HTTPS (or local HTTP).");
+  const requireCurrentHead = () => {
+    if (resolvePrHeadSha(pr, exec).toLowerCase() !== report.gitSha)
+      throw new Error(
+        "Refusing stale evidence: every selected source must match the current PR head.",
+      );
+  };
+  requireCurrentHead();
+  if (options.preserveCurrentReport) {
+    const current = exec("gh", ["pr", "view", pr, "--json", "comments"]);
+    requireSuccess(current, "Reading current evidence");
+    const payload: unknown = JSON.parse(current.stdout);
+    if (isRecord(payload) && Array.isArray(payload.comments)) {
+      const existing = payload.comments.find((comment) => isRecord(comment)
+        && typeof comment.body === "string" && comment.body.includes(MARKER)
+        && comment.body.includes(`Commit \`${report.gitSha}\``) && comment.body.includes("[Open review report]("));
+      if (isRecord(existing) && typeof existing.body === "string") {
+        return { markdown: existing.body, posted: false, updated: false, urls: {} };
+      }
+    }
+  }
+  const upload = dependencies.upload ?? (await import("@openwork/review/storage")).uploadReview;
+  const id = await upload(report, assets);
+  const reportUrl = new URL(`/r/${id}`, url).href;
+  // A push while media was uploading must not replace current evidence with an older report.
+  requireCurrentHead();
+  const markdown = renderReviewComment(report, reportUrl);
+  const viewed = exec("gh", ["pr", "view", pr, "--json", "comments"]);
+  requireSuccess(viewed, "Reading PR comments");
+  const commentId = stickyCommentId(viewed.stdout);
+  const posted = commentId
+    ? exec(
+        "gh",
+        [
+          "api",
+          "--method",
+          "PATCH",
+          `repos/{owner}/{repo}/issues/comments/${commentId}`,
+          "--input",
+          "-",
+        ],
+        { input: JSON.stringify({ body: markdown }) },
+      )
+    : exec("gh", ["pr", "comment", pr, "--body-file", "-"], {
+        input: markdown,
+      });
+  requireSuccess(posted, "Publishing review link");
+  return {
+    markdown,
+    posted: true,
+    updated: commentId !== null,
+    urls: { report: reportUrl },
+  };
 }

--- a/evals/packages/test-artifacts/src/review.ts
+++ b/evals/packages/test-artifacts/src/review.ts
@@ -1,0 +1,179 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import {
+  docShotReceiptSchema,
+  reviewSchema,
+  summarizeReview,
+} from "@openwork/review";
+import type { ReviewReport } from "@openwork/review";
+import type { ReviewAsset } from "@openwork/review/storage";
+import { readTestRunDirectory } from "./scan.ts";
+
+const digest = (value: string) =>
+  createHash("sha256").update(value).digest("hex").slice(0, 20);
+
+async function regularFile(path: string): Promise<Buffer> {
+  const info = await lstat(path);
+  if (!info.isFile() || info.size > 25 * 1024 * 1024)
+    throw new Error(`Invalid or oversized evidence file: ${basename(path)}`);
+  return readFile(path);
+}
+
+export async function assembleReview(options: {
+  testRunDirs: string[];
+  docShots?: string[];
+  title?: string;
+  gaps?: string[];
+}): Promise<{ report: ReviewReport; assets: ReviewAsset[] }> {
+  const sources: ReviewReport["sources"] = [];
+  const sections: ReviewReport["sections"] = [];
+  const evidence: ReviewReport["evidence"] = [];
+  const assets = new Map<string, ReviewAsset>();
+  async function image(path: string) {
+    const body = await regularFile(path);
+    if (
+      !body
+        .subarray(0, 8)
+        .equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+    )
+      throw new Error(`Invalid PNG: ${basename(path)}`);
+    const name = `${createHash("sha256").update(body).digest("hex")}.png`;
+    assets.set(name, { name, body });
+    return name;
+  }
+  for (const directory of [...new Set(options.testRunDirs)]) {
+    const stored = await readTestRunDirectory(directory);
+    if (!stored?.testRun.gitSha)
+      throw new Error(`No committed test evidence in ${directory}`);
+    const run = stored.testRun;
+    const sourceId = `run-${digest(`${run.gitSha}:${run.name}:${run.createdAt}`)}`;
+    if (sources.some((source) => source.id === sourceId)) continue;
+    const sourceAsset = `${sourceId}.json`;
+    assets.set(sourceAsset, {
+      name: sourceAsset,
+      body: await regularFile(
+        join(
+          directory,
+          stored.format === "current" ? "test-run.json" : "roll.json",
+        ),
+      ),
+    });
+    sources.push({
+      id: sourceId,
+      kind: "test-run",
+      name: run.name,
+      gitSha: stored.testRun.gitSha.toLowerCase(),
+      createdAt: run.createdAt,
+      asset: sourceAsset,
+      outcome: run.outcome,
+      ...(run.failure === undefined ? {} : { failure: run.failure }),
+    });
+    const evidenceIds: string[] = [];
+    for (const [index, artifact] of run.artifacts.entries()) {
+      const id = `${sourceId}-${index}`;
+      const judgments =
+        artifact.judgments.length > 0
+          ? artifact.judgments
+          : artifact.results.map(
+              (result) =>
+                ({
+                  expectation: result.expectation,
+                  state: result.passed ? "passed" : "failed",
+                  reasoning: result.evidence,
+                }) satisfies ReviewReport["evidence"][number]["judgments"][number],
+            );
+      if (artifact.fileName) {
+        if (
+          basename(artifact.fileName) !== artifact.fileName ||
+          !artifact.fileName.endsWith(".png")
+        )
+          throw new Error("Invalid screenshot path.");
+        evidence.push({
+          id,
+          sourceId,
+          kind: "image",
+          caption: artifact.caption,
+          description: artifact.description,
+          judgments,
+          asset: await image(join(directory, artifact.fileName)),
+        });
+      } else {
+        if (judgments.length === 0) continue;
+        evidence.push({
+          id,
+          sourceId,
+          kind: "assertion",
+          caption: artifact.caption,
+          judgments,
+        });
+      }
+      evidenceIds.push(id);
+    }
+    sections.push({ id: sourceId, sourceId, title: run.name, evidenceIds });
+  }
+  for (const path of options.docShots ?? []) {
+    const body = await regularFile(path);
+    const shot = docShotReceiptSchema.parse(JSON.parse(body.toString("utf8")));
+    const sourceId = `shot-${digest(`${shot.gitSha}:${shot.name}:${shot.createdAt}`)}`;
+    if (sources.some((source) => source.id === sourceId)) continue;
+    const sourceAsset = `${sourceId}.json`;
+    assets.set(sourceAsset, { name: sourceAsset, body });
+    sources.push({
+      id: sourceId,
+      kind: "docshot",
+      name: shot.name,
+      gitSha: shot.gitSha,
+      createdAt: shot.createdAt,
+      asset: sourceAsset,
+    });
+    const id = `${sourceId}-image`;
+    evidence.push({
+      id,
+      sourceId,
+      kind: "image",
+      caption: shot.name,
+      description: "Documentation reference",
+      judgments: [],
+      asset: await image(join(dirname(path), shot.fileName)),
+    });
+    sections.push({
+      id: sourceId,
+      sourceId,
+      title: shot.name,
+      evidenceIds: [id],
+    });
+  }
+  const first = sources[0];
+  if (!first) throw new Error("Select at least one test run or DocShot.");
+  const report = reviewSchema.parse({
+    schemaVersion: 1,
+    title: options.title ?? "Change verification",
+    gitSha: first.gitSha,
+    createdAt: new Date().toISOString(),
+    gaps: options.gaps ?? [],
+    sources,
+    sections,
+    evidence,
+  });
+  return { report, assets: [...assets.values()] };
+}
+
+export function renderReviewComment(
+  report: ReviewReport,
+  url?: string,
+): string {
+  const summary = summarizeReview(report);
+  const lines = [
+    "<!-- test-evidence -->",
+    `**${summary.verdict}** · ${summary.passedTests}/${summary.tests} tests · ${summary.passedAssertions}/${summary.assertions} assertions · ${summary.images} images`,
+    "",
+    `Commit \`${report.gitSha}\` · selected evidence`,
+  ];
+  if (url) lines.push("", `[Open review report](${url})`);
+  if (report.gaps.length > 0)
+    lines.push("", `Coverage gaps: ${report.gaps.join("; ")}`);
+  if (summary.pendingVisual > 0)
+    lines.push("", `${summary.pendingVisual} visual judgment(s) pending.`);
+  return lines.join("\n");
+}

--- a/evals/packages/test-artifacts/src/scan.ts
+++ b/evals/packages/test-artifacts/src/scan.ts
@@ -69,7 +69,7 @@ function timestampFromName(name: string): string | null {
 async function readStoredTestRun(path: string, format: StoredTestRunFormat): Promise<TestRunRecord | null> {
   try {
     const info = await lstat(path);
-    if (!info.isFile()) return null;
+    if (!info.isFile() || info.size > 25 * 1024 * 1024) return null;
     const raw = await readFile(path, "utf8");
     const value: unknown = JSON.parse(raw);
     return format === "current" ? parseTestRunJson(value) : parseLegacyTestRunJson(value);

--- a/evals/packages/test-artifacts/test/publish-pr.test.ts
+++ b/evals/packages/test-artifacts/test/publish-pr.test.ts
@@ -3,7 +3,11 @@ import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promis
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { publishPr } from "../src/publish-pr.ts";
+import { publishPr, publishReviewPr } from "../src/publish-pr.ts";
+import { assembleReview } from "../src/review.ts";
+import { reviewSchema, summarizeReview } from "@openwork/review";
+import { uploadReview } from "@openwork/review/storage";
+import { readFile, readdir } from "node:fs/promises";
 import type { CommandRunner } from "../src/publish-pr.ts";
 import type { TestRunRecord } from "../src/schema.ts";
 
@@ -174,5 +178,206 @@ test("publishPr posts a notice without attachments when gh lacks --attach", asyn
     assert.doesNotMatch(posted?.input ?? "", /!\[Published validation\]/);
   } finally {
     await rm(testRunDir, { recursive: true, force: true });
+  }
+});
+
+async function reviewFixture(root: string, name: string) {
+  const directory = join(root, name);
+  await mkdir(directory);
+  const run = testRunRecord(directory);
+  run.name = name;
+  const screenshot = run.artifacts[0];
+  if (!screenshot) throw new Error("Missing test image.");
+  run.artifacts.push({
+    ...screenshot,
+    fileName: "",
+    caption: "Recorded assertion",
+  });
+  await writeFile(join(directory, "test-run.json"), JSON.stringify(run));
+  await writeFile(
+    join(directory, screenshot.fileName),
+    Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jr1sAAAAASUVORK5CYII=",
+      "base64",
+    ),
+  );
+  return directory;
+}
+
+test("review composition preserves sources, deduplicates images, and validates evidence references", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-review-compose-"));
+  try {
+    const first = await reviewFixture(root, "First behavior");
+    const second = await reviewFixture(root, "Second behavior");
+    const shot = join(first, "shot.review.json");
+    await writeFile(
+      shot,
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: "docshot",
+        name: "Documentation reference",
+        gitSha: TEST_RUN_SHA,
+        createdAt: "2026-07-02T10:00:00.000Z",
+        fileName: "01-published.png",
+      }),
+    );
+    const { report, assets } = await assembleReview({
+      testRunDirs: [first, second, first],
+      docShots: [shot],
+    });
+    assert.equal(report.sources.length, 3);
+    assert.equal(report.sections.length, 3);
+    assert.equal(
+      assets.filter((asset) => asset.name.endsWith(".png")).length,
+      1,
+    );
+    assert.equal(summarizeReview(report).verdict, "Passed");
+    const document = await assembleReview({
+      testRunDirs: [],
+      docShots: [shot],
+    });
+    assert.equal(summarizeReview(document.report).verdict, "Reference");
+    const incomplete = structuredClone(report);
+    incomplete.gaps.push("Not exercised");
+    assert.equal(summarizeReview(incomplete).verdict, "Incomplete");
+    assert.equal(
+      reviewSchema.safeParse({
+        ...report,
+        sections: [{ ...report.sections[0], evidenceIds: ["missing"] }],
+      }).success,
+      false,
+    );
+    assert.equal(
+      reviewSchema.safeParse({ ...report, schemaVersion: 2 }).success,
+      false,
+    );
+    await writeFile(
+      shot,
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: "docshot",
+        name: "Old reference",
+        gitSha: "2".repeat(40),
+        createdAt: "2026-07-02T10:00:00.000Z",
+        fileName: "01-published.png",
+      }),
+    );
+    await assert.rejects(
+      assembleReview({ testRunDirs: [first], docShots: [shot] }),
+      /match the report commit/,
+    );
+    const storage = join(root, "storage");
+    await mkdir(storage);
+    const id = await uploadReview(report, assets, { localDir: storage });
+    assert.deepEqual(
+      JSON.parse(await readFile(join(storage, id, "report.json"), "utf8")),
+      report,
+    );
+    assert.equal((await readdir(join(storage, id))).length, assets.length + 1);
+    await assert.rejects(
+      uploadReview(report, [], { localDir: storage }),
+      /referenced review asset is missing/,
+    );
+    const secondId = await uploadReview(report, assets, { localDir: storage });
+    assert.notEqual(id, secondId);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("review publication validates before uploading and preserves the comment when upload or head checks fail", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-review-publish-"));
+  try {
+    const directory = await reviewFixture(root, "Publication");
+    const options = {
+      pr: 17,
+      testRunDirs: [directory],
+      reviewUrl: "https://review.example.test",
+    };
+    const calls: RecordedCommand[] = [];
+    let uploads = 0;
+    const upload = async () => {
+      uploads++;
+      return "a".repeat(32);
+    };
+    const exec = recordingExec(calls, [
+      { databaseId: 77, body: "<!-- test-evidence --> previous" },
+    ]);
+    const dryRun = await publishReviewPr(
+      { ...options, dryRun: true },
+      { exec, upload, stdout: () => {} },
+    );
+    assert.equal(dryRun.posted, false);
+    assert.equal(calls.length, 0);
+    assert.equal(uploads, 0);
+    const result = await publishReviewPr(options, { exec, upload });
+    assert.equal(result.updated, true);
+    assert.equal(uploads, 1);
+    assert.match(result.markdown, /Open review report/);
+    assert.ok(result.markdown.length < 500);
+    assert.equal(
+      calls.some(
+        (call) =>
+          call.args.includes("DELETE") || call.args.includes("--attach"),
+      ),
+      false,
+    );
+    assert.ok(calls.some((call) => call.args.includes("PATCH")));
+    calls.length = 0;
+    const priorUploads = uploads;
+    const preserved = await publishReviewPr({ ...options, preserveCurrentReport: true }, {
+      exec: recordingExec(calls, [{ databaseId: 77, body: result.markdown }]), upload,
+    });
+    assert.equal(preserved.posted, false);
+    assert.equal(uploads, priorUploads);
+    assert.equal(calls.some((call) => call.args.includes("PATCH")), false);
+    calls.length = 0;
+    await assert.rejects(
+      publishReviewPr(options, {
+        exec,
+        upload: async () => {
+          throw new Error("Storage unavailable");
+        },
+      }),
+      /Storage unavailable/,
+    );
+    assert.equal(
+      calls.some(
+        (call) => call.args.includes("PATCH") || call.args.includes("comment"),
+      ),
+      false,
+    );
+    calls.length = 0;
+    let headReads = 0;
+    const changedHead: CommandRunner = (command, args, opts) => {
+      if (args.includes("headRefOid") && ++headReads > 1)
+        return {
+          status: 0,
+          stdout: JSON.stringify({ headRefOid: "2".repeat(40) }),
+          stderr: "",
+        };
+      return exec(command, args, opts);
+    };
+    await assert.rejects(
+      publishReviewPr(options, { exec: changedHead, upload }),
+      /Refusing stale evidence/,
+    );
+    assert.equal(
+      calls.some(
+        (call) => call.args.includes("PATCH") || call.args.includes("comment"),
+      ),
+      false,
+    );
+    const run = testRunRecord(directory);
+    run.gitSha = "2".repeat(40);
+    await writeFile(join(directory, "test-run.json"), JSON.stringify(run));
+    const before = uploads;
+    await assert.rejects(
+      publishReviewPr(options, { exec, upload }),
+      /Refusing stale evidence/,
+    );
+    assert.equal(uploads, before);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });

--- a/evals/packages/test-evidence/src/vitest.ts
+++ b/evals/packages/test-evidence/src/vitest.ts
@@ -4,13 +4,9 @@ import { createTestEvidence } from "./test-evidence.ts";
 import type { TestEvidenceRecorder } from "./test-evidence.ts";
 import type { VisualEvidenceResult } from "./validate.ts";
 
-function slug(value: string): string {
-  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 80) || "test";
-}
-
 export const test = base.extend<{ evidence: TestEvidenceRecorder }>({
   evidence: [async ({ task }, use) => {
-    const testEvidence = createTestEvidence({ name: slug(task.name) });
+    const testEvidence = createTestEvidence({ name: task.name });
     const leaveTestEvidence = enterTestEvidence(testEvidence);
     try {
       await use(testEvidence);

--- a/evals/pnpm-lock.yaml
+++ b/evals/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@openwork/matchers':
         specifier: workspace:*
         version: link:packages/matchers
+      '@openwork/review':
+        specifier: link:../packages/review
+        version: link:../packages/review
       '@openwork/sdk':
         specifier: link:../packages/sdk
         version: link:../packages/sdk
@@ -155,7 +158,11 @@ importers:
 
   packages/matchers: {}
 
-  packages/test-artifacts: {}
+  packages/test-artifacts:
+    dependencies:
+      '@openwork/review':
+        specifier: link:../../../packages/review
+        version: link:../../../packages/review
 
   packages/test-evidence:
     dependencies:

--- a/evals/scripts/publish-review.mjs
+++ b/evals/scripts/publish-review.mjs
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { publishReviewPr } from "../packages/test-artifacts/src/publish-pr.ts";
+import { readTestRunDirectory } from "../packages/test-artifacts/src/scan.ts";
+
+const { REVIEW_PR: pr, REVIEW_SHA: sha, REVIEW_RUN_ID: runId } = process.env;
+if (
+  !pr ||
+  !/^\d+$/.test(pr) ||
+  !runId ||
+  !/^\d+$/.test(runId) ||
+  !sha ||
+  !/^[a-f0-9]{40}$/.test(sha)
+)
+  throw new Error("Missing CI report identity.");
+const current = spawnSync(
+  "gh",
+  ["pr", "view", pr, "--json", "headRefOid", "--jq", ".headRefOid"],
+  { encoding: "utf8", timeout: 30_000 },
+);
+if (current.status !== 0) throw new Error("Cannot resolve PR head.");
+if (current.stdout.trim() !== sha) {
+  console.log(
+    "Source run is no longer current; existing evidence is unchanged.",
+  );
+} else {
+  const directory = await mkdtemp(join(tmpdir(), "openwork-review-"));
+  try {
+    const download = spawnSync(
+      "gh",
+      ["run", "download", runId, "--dir", directory],
+      { stdio: "inherit", timeout: 90_000 },
+    );
+    if (download.status !== 0)
+      throw new Error("Unable to download completed evidence.");
+    const testRunDirs = [];
+    async function visit(path, depth = 0) {
+      if (depth > 12)
+        throw new Error("Evidence directory nesting exceeds the limit.");
+      const entries = await readdir(path, { withFileTypes: true });
+      if (
+        entries.some(
+          (entry) => entry.isFile() && entry.name === "test-run.json",
+        )
+      ) {
+        const stored = await readTestRunDirectory(path);
+        if (!stored) throw new Error("Malformed recorded evidence.");
+        if (stored.testRun.gitSha === sha) testRunDirs.push(path);
+      }
+      for (const entry of entries)
+        if (entry.isDirectory()) await visit(join(path, entry.name), depth + 1);
+    }
+    await visit(directory);
+    if (testRunDirs.length === 0) {
+      console.log(
+        "No test records for this PR head were uploaded by the source workflow.",
+      );
+    } else {
+      const result = await publishReviewPr({ pr, testRunDirs, preserveCurrentReport: true });
+      console.log(result.posted ? result.urls.report : "A review already covers this commit; preserving the author's selection.");
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}

--- a/evals/specs/evidence-review.test.ts
+++ b/evals/specs/evidence-review.test.ts
@@ -10,13 +10,14 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
   console.log(
     "placement: local (isolated production review app; no external services)",
   );
-  const get = (path: string, authenticated = true) =>
+  const get = (path: string) =>
     fetch(`${world.baseUrl}${path}`, {
-      headers: authenticated ? world.headers : {},
       signal: AbortSignal.timeout(10_000),
     });
   const page = await get(`/r/${world.passed}`);
   expect(page.status).toBe(200);
+  expect(page.headers.get("www-authenticate")).toBeNull();
+  expect(page.headers.get("cache-control")).toContain("private");
   const html = await page.text();
   expect(html).toContain("Sharing a skill, from link to access");
   expect(html).toContain("A shared skill can be opened");
@@ -44,28 +45,13 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
   expect((await media.arrayBuffer()).byteLength).toBeGreaterThan(1000);
   const original = await get(`/r/${world.passed}/assets/${source.asset}`);
   expect(await original.text()).toContain("internal diagnostics fixture");
-  expect((await get(`/r/${world.passed}`, false)).status).toBe(401);
-  for (const authorization of [
-    "Basic invalid",
-    `${world.headers.authorization.slice(0, -1)}!`,
-  ]) {
-    const unauthorized = await fetch(`${world.baseUrl}/r/${world.passed}`, {
-      headers: { authorization },
-      signal: AbortSignal.timeout(10_000),
-    });
-    expect(unauthorized.status).toBe(401);
-  }
-  expect((await get(mediaPath, false)).status).toBe(401);
-  expect(
-    (await get(`/r/${world.passed}/assets/${source.asset}`, false)).status,
-  ).toBe(401);
   expect(
     (await get(`/r/${world.passed}/assets/not-referenced.json`)).status,
   ).toBe(404);
   expect((await get(`/r/${"0".repeat(32)}`)).status).toBe(404);
   evidence.recordAssertionEvidence(
-    "The same access boundary protects pages, images, and source records",
-    "Authenticated requests return the image and original diagnostics. Anonymous requests return 401 for all three, as do incorrect credentials of equal or different length; missing reports and unreferenced assets return 404.",
+    "Preview pages, images, and source records need no second login",
+    "Requests reaching the preview app return the page, image, and original diagnostics without Basic authentication. Responses are private; missing reports and unreferenced assets return 404. Hosted Vercel authentication is verified separately.",
     true,
   );
 
@@ -88,6 +74,25 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
   evidence.recordAssertionEvidence(
     "Incomplete, failed, and reference evidence cannot become a passing report",
     "A skipped run, declared gap, and pending visual check render Incomplete; a failed assertion overrides passed execution; a DocShot-only report renders Reference.",
+    true,
+  );
+
+  await using production = await reviewWorld("production");
+  for (const path of [
+    "/",
+    `/r/${production.passed}`,
+    `/r/${production.passed}/assets/report.json`,
+    `/r/${production.passed}/assets/${image.asset}`,
+  ]) {
+    const response = await fetch(`${production.baseUrl}${path}`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toContain("private");
+  }
+  evidence.recordAssertionEvidence(
+    "Production deployments cannot serve review evidence",
+    "The home page, report, JSON, and image routes all return 503 when the app runs in Vercel's production environment, where Standard Protection can leave production domains public.",
     true,
   );
 });

--- a/evals/specs/evidence-review.test.ts
+++ b/evals/specs/evidence-review.test.ts
@@ -45,6 +45,16 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
   const original = await get(`/r/${world.passed}/assets/${source.asset}`);
   expect(await original.text()).toContain("internal diagnostics fixture");
   expect((await get(`/r/${world.passed}`, false)).status).toBe(401);
+  for (const authorization of [
+    "Basic invalid",
+    `${world.headers.authorization.slice(0, -1)}!`,
+  ]) {
+    const unauthorized = await fetch(`${world.baseUrl}/r/${world.passed}`, {
+      headers: { authorization },
+      signal: AbortSignal.timeout(10_000),
+    });
+    expect(unauthorized.status).toBe(401);
+  }
   expect((await get(mediaPath, false)).status).toBe(401);
   expect(
     (await get(`/r/${world.passed}/assets/${source.asset}`, false)).status,
@@ -55,7 +65,7 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
   expect((await get(`/r/${"0".repeat(32)}`)).status).toBe(404);
   evidence.recordAssertionEvidence(
     "The same access boundary protects pages, images, and source records",
-    "Authenticated requests return the image and original diagnostics. Anonymous requests return 401 for all three; missing reports and unreferenced assets return 404.",
+    "Authenticated requests return the image and original diagnostics. Anonymous requests return 401 for all three, as do incorrect credentials of equal or different length; missing reports and unreferenced assets return 404.",
     true,
   );
 

--- a/evals/specs/evidence-review.test.ts
+++ b/evals/specs/evidence-review.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "vitest";
+import { needs, test } from "@openwork/testkit";
+import { reviewWorld } from "../worlds/evidence-review.ts";
+
+test("A reviewer can inspect two runs and a DocShot with honest results and private evidence", async ({
+  evidence,
+}) => {
+  needs({ optIn: ["OPENWORK_EVAL_REVIEW"] });
+  await using world = await reviewWorld();
+  console.log(
+    "placement: local (isolated production review app; no external services)",
+  );
+  const get = (path: string, authenticated = true) =>
+    fetch(`${world.baseUrl}${path}`, {
+      headers: authenticated ? world.headers : {},
+      signal: AbortSignal.timeout(10_000),
+    });
+  const page = await get(`/r/${world.passed}`);
+  expect(page.status).toBe(200);
+  const html = await page.text();
+  expect(html).toContain("Sharing a skill, from link to access");
+  expect(html).toContain("A shared skill can be opened");
+  expect(html).toContain("The owner can revoke a link");
+  expect(html).toContain("Documentation reference");
+  expect(html).toContain("badge passed");
+  expect(html).not.toContain("UNVALIDATED");
+  expect(html).not.toContain("internal diagnostics fixture");
+  expect(html).toContain("<details");
+  evidence.recordAssertionEvidence(
+    "Multiple runs and DocShot compose into one readable review",
+    "The production page contains both run sections and the documentation reference; it shows Passed, hides raw diagnostics, and gives reference images no unvalidated label.",
+    true,
+  );
+
+  const source = world.report.sources[0];
+  const image = world.report.evidence.find((item) => item.kind === "image");
+  if (!source || image?.kind !== "image")
+    throw new Error("Missing expected review evidence.");
+  const mediaPath = `/r/${world.passed}/assets/${image.asset}`;
+  const media = await get(mediaPath);
+  expect(media.status).toBe(200);
+  expect(media.headers.get("content-type")).toBe("image/png");
+  expect(media.headers.get("cache-control")).toContain("private");
+  expect((await media.arrayBuffer()).byteLength).toBeGreaterThan(1000);
+  const original = await get(`/r/${world.passed}/assets/${source.asset}`);
+  expect(await original.text()).toContain("internal diagnostics fixture");
+  expect((await get(`/r/${world.passed}`, false)).status).toBe(401);
+  expect((await get(mediaPath, false)).status).toBe(401);
+  expect(
+    (await get(`/r/${world.passed}/assets/${source.asset}`, false)).status,
+  ).toBe(401);
+  expect(
+    (await get(`/r/${world.passed}/assets/not-referenced.json`)).status,
+  ).toBe(404);
+  expect((await get(`/r/${"0".repeat(32)}`)).status).toBe(404);
+  evidence.recordAssertionEvidence(
+    "The same access boundary protects pages, images, and source records",
+    "Authenticated requests return the image and original diagnostics. Anonymous requests return 401 for all three; missing reports and unreferenced assets return 404.",
+    true,
+  );
+
+  const incomplete = await (await get(`/r/${world.incomplete}`)).text();
+  expect(incomplete).toContain("badge incomplete");
+  expect(incomplete).toContain(
+    "Desktop restart remains outside this selected evidence.",
+  );
+  expect(incomplete).toContain("visual judgment(s) pending");
+  expect(incomplete).toContain("Execution ");
+  expect(incomplete).toContain("skipped");
+  expect(incomplete).not.toContain("badge passed");
+  const failed = await (await get(`/r/${world.failed}`)).text();
+  expect(failed).toContain("badge failed");
+  expect(failed).toContain("result failed");
+  expect(failed).not.toContain("badge passed");
+  const reference = await (await get(`/r/${world.reference}`)).text();
+  expect(reference).toContain("badge reference");
+  expect(reference).not.toContain("badge passed");
+  evidence.recordAssertionEvidence(
+    "Incomplete, failed, and reference evidence cannot become a passing report",
+    "A skipped run, declared gap, and pending visual check render Incomplete; a failed assertion overrides passed execution; a DocShot-only report renders Reference.",
+    true,
+  );
+});

--- a/evals/worlds/evidence-review.ts
+++ b/evals/worlds/evidence-review.ts
@@ -1,0 +1,255 @@
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { assembleReview } from "@openwork/test-artifacts/review";
+import { uploadReview } from "@openwork/review/storage";
+import type { TestRunRecord } from "@openwork/test-artifacts";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+
+/** Synthetic report inputs exercise the real publisher and production HTTP app. */
+export async function reviewWorld() {
+  const directory = await mkdtemp(join(tmpdir(), "openwork-review-world-"));
+  const storage = join(directory, "reports");
+  await mkdir(storage);
+  const git = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  if (git.status !== 0)
+    throw new Error("Cannot resolve the review fixture commit.");
+  const gitSha = git.stdout.trim();
+  const png = await readFile(
+    join(root, "packages/docs/images/sharing-create-link-dialog.png"),
+  );
+  const createdAt = new Date().toISOString();
+  const records: TestRunRecord[] = [
+    "A shared skill can be opened",
+    "The owner can revoke a link",
+  ].map((name, index) => ({
+    name,
+    dir: `fixture-${index}`,
+    gitSha,
+    engine: "v1",
+    createdAt,
+    closedAt: createdAt,
+    outcome: "passed",
+    summary: {
+      ok: true,
+      totalArtifacts: 2,
+      passedArtifacts: 1,
+      failedArtifacts: 0,
+      unvalidatedArtifacts: 1,
+      pendingArtifacts: 0,
+      passedExpectations: 1,
+      failedExpectations: 0,
+      pendingJudgments: 0,
+    },
+    steps: [{ seq: 1, name, depth: 0, ok: true }],
+    trace: [
+      {
+        seq: 1,
+        at: createdAt,
+        stage: "body",
+        channel: "probe",
+        verb: "inspect",
+        detail: "internal diagnostics fixture",
+        ok: true,
+      },
+    ],
+    artifacts: [
+      {
+        caption: name,
+        fileName: "",
+        hash: "",
+        route: "",
+        at: createdAt,
+        model: "",
+        description: "",
+        ok: true,
+        results: [
+          {
+            expectation: name,
+            passed: true,
+            evidence: "Synthetic assertion used to verify report rendering.",
+          },
+        ],
+        judgments: [
+          {
+            expectation: name,
+            state: "passed",
+            reasoning: "Synthetic assertion used to verify report rendering.",
+          },
+        ],
+      },
+      ...(index === 0
+        ? [
+            {
+              caption: "Share link dialog · fixture",
+              fileName: "dialog.png",
+              hash: "",
+              route: "",
+              at: createdAt,
+              model: "",
+              description:
+                "Existing documentation image, reused as a report fixture.",
+              ok: null,
+              results: [],
+              judgments: [],
+            },
+          ]
+        : []),
+    ],
+  }));
+  const runDirs: string[] = [];
+  for (const [index, record] of records.entries()) {
+    const path = join(directory, `run-${index}`);
+    await mkdir(path);
+    await writeFile(join(path, "test-run.json"), JSON.stringify(record));
+    await writeFile(join(path, "dialog.png"), png);
+    runDirs.push(path);
+  }
+  const receipt = join(directory, "dialog.png.review.json");
+  await writeFile(join(directory, "dialog.png"), png);
+  await writeFile(
+    receipt,
+    JSON.stringify({
+      schemaVersion: 1,
+      kind: "docshot",
+      name: "Documentation reference · fixture",
+      fileName: "dialog.png",
+      gitSha,
+      createdAt,
+    }),
+  );
+  const bundle = await assembleReview({
+    testRunDirs: runDirs,
+    docShots: [receipt],
+    title: "Sharing a skill, from link to access",
+  });
+  const passed = await uploadReview(bundle.report, bundle.assets, {
+    localDir: storage,
+  });
+  const incompleteReport = structuredClone(bundle.report);
+  incompleteReport.gaps.push(
+    "Desktop restart remains outside this selected evidence.",
+  );
+  const skipped = incompleteReport.sources.find(
+    (source) => source.kind === "test-run",
+  );
+  if (skipped?.kind === "test-run") skipped.outcome = "skipped";
+  const pending = incompleteReport.evidence.find(
+    (item) => item.kind === "image",
+  );
+  pending?.judgments.push({
+    expectation: "Dialog is readable",
+    state: "pending",
+    reasoning: "Visual judging was deferred.",
+  });
+  const incomplete = await uploadReview(incompleteReport, bundle.assets, {
+    localDir: storage,
+  });
+  const failedReport = structuredClone(bundle.report);
+  const assertion = failedReport.evidence.find(
+    (item) => item.kind === "assertion",
+  );
+  if (!assertion?.judgments[0]) throw new Error("Missing fixture assertion.");
+  assertion.judgments[0].state = "failed";
+  const failed = await uploadReview(failedReport, bundle.assets, {
+    localDir: storage,
+  });
+  const referenceBundle = await assembleReview({
+    testRunDirs: [],
+    docShots: [receipt],
+  });
+  const reference = await uploadReview(
+    referenceBundle.report,
+    referenceBundle.assets,
+    { localDir: storage },
+  );
+  const port = await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string")
+        return reject(new Error("Missing review port."));
+      server.close(() => resolve(address.port));
+    });
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const password = "isolated-review-fixture";
+  const child = spawn(
+    process.execPath,
+    [
+      join(root, "apps/review/node_modules/next/dist/bin/next"),
+      "start",
+      "--hostname",
+      "127.0.0.1",
+      "--port",
+      String(port),
+    ],
+    {
+      cwd: join(root, "apps/review"),
+      env: {
+        ...process.env,
+        OPENWORK_REVIEW_LOCAL_DIR: storage,
+        OPENWORK_REVIEW_PASSWORD: password,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let logs = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    logs = (logs + chunk.toString()).slice(-8000);
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    logs = (logs + chunk.toString()).slice(-8000);
+  });
+  async function dispose() {
+    if (child.exitCode === null && child.signalCode === null) {
+      const exited = new Promise<void>((resolve) =>
+        child.once("exit", () => resolve()),
+      );
+      child.kill("SIGTERM");
+      const kill = setTimeout(() => child.kill("SIGKILL"), 5000);
+      await exited;
+      clearTimeout(kill);
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+  try {
+    const deadline = Date.now() + 30_000;
+    while (true) {
+      const response = await fetch(baseUrl, {
+        signal: AbortSignal.timeout(1000),
+      }).catch(() => null);
+      if (response?.status === 401) break;
+      if (Date.now() > deadline || child.exitCode !== null)
+        throw new Error(
+          `Review app did not start. Run its build first.\n${logs}`,
+        );
+      await delay(100);
+    }
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+  return {
+    baseUrl,
+    headers: {
+      authorization: `Basic ${Buffer.from(`review:${password}`).toString("base64")}`,
+    },
+    passed,
+    incomplete,
+    failed,
+    reference,
+    report: bundle.report,
+    directory,
+    [Symbol.asyncDispose]: dispose,
+  };
+}

--- a/evals/worlds/evidence-review.ts
+++ b/evals/worlds/evidence-review.ts
@@ -12,7 +12,9 @@ import type { TestRunRecord } from "@openwork/test-artifacts";
 const root = fileURLToPath(new URL("../../", import.meta.url));
 
 /** Synthetic report inputs exercise the real publisher and production HTTP app. */
-export async function reviewWorld() {
+export async function reviewWorld(
+  environment: "preview" | "production" = "preview",
+) {
   const directory = await mkdtemp(join(tmpdir(), "openwork-review-world-"));
   const storage = join(directory, "reports");
   await mkdir(storage);
@@ -182,7 +184,6 @@ export async function reviewWorld() {
     });
   });
   const baseUrl = `http://127.0.0.1:${port}`;
-  const password = "isolated-review-fixture";
   const child = spawn(
     process.execPath,
     [
@@ -198,7 +199,8 @@ export async function reviewWorld() {
       env: {
         ...process.env,
         OPENWORK_REVIEW_LOCAL_DIR: storage,
-        OPENWORK_REVIEW_PASSWORD: password,
+        VERCEL: "1",
+        VERCEL_ENV: environment,
       },
       stdio: ["ignore", "pipe", "pipe"],
     },
@@ -228,7 +230,7 @@ export async function reviewWorld() {
       const response = await fetch(baseUrl, {
         signal: AbortSignal.timeout(1000),
       }).catch(() => null);
-      if (response?.status === 401) break;
+      if (response?.status === (environment === "preview" ? 200 : 503)) break;
       if (Date.now() > deadline || child.exitCode !== null)
         throw new Error(
           `Review app did not start. Run its build first.\n${logs}`,
@@ -241,9 +243,6 @@ export async function reviewWorld() {
   }
   return {
     baseUrl,
-    headers: {
-      authorization: `Basic ${Buffer.from(`review:${password}`).toString("base64")}`,
-    },
     passed,
     incomplete,
     failed,

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openwork/review",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/schema.ts",
+    "./storage": "./src/storage.ts"
+  },
+  "dependencies": {
+    "@vercel/blob": "^2.3.0",
+    "zod": "4.3.6"
+  }
+}

--- a/packages/review/src/schema.ts
+++ b/packages/review/src/schema.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+
+export const reportIdSchema = z.string().regex(/^[a-f0-9]{32}$/);
+export const assetNameSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*\.(png|json)$/);
+const id = z.string().regex(/^[a-zA-Z0-9_-]+$/);
+const sha = z.string().regex(/^[a-f0-9]{40}$/);
+const judgment = z.object({
+  expectation: z.string(),
+  state: z.enum(["passed", "failed", "pending"]),
+  reasoning: z.string(),
+});
+const source = z.object({
+  id,
+  name: z.string(),
+  gitSha: sha,
+  createdAt: z.iso.datetime(),
+  asset: assetNameSchema,
+});
+const evidence = z.object({ id, sourceId: id, caption: z.string() });
+
+export const reviewSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    title: z.string().min(1),
+    gitSha: sha,
+    createdAt: z.iso.datetime(),
+    gaps: z.array(z.string()),
+    sources: z
+      .array(
+        z.discriminatedUnion("kind", [
+          source.extend({
+            kind: z.literal("test-run"),
+            outcome: z.enum(["passed", "failed", "skipped", "unknown"]),
+            failure: z.string().optional(),
+          }),
+          source.extend({ kind: z.literal("docshot") }),
+        ]),
+      )
+      .min(1),
+    sections: z
+      .array(
+        z.object({
+          id,
+          title: z.string(),
+          sourceId: id,
+          evidenceIds: z.array(id),
+        }),
+      )
+      .min(1),
+    evidence: z.array(
+      z.discriminatedUnion("kind", [
+        evidence.extend({
+          kind: z.literal("assertion"),
+          judgments: z.array(judgment).min(1),
+        }),
+        evidence.extend({
+          kind: z.literal("image"),
+          asset: assetNameSchema,
+          description: z.string(),
+          judgments: z.array(judgment),
+        }),
+      ]),
+    ),
+  })
+  .superRefine((report, ctx) => {
+    const fail = (message: string) => ctx.addIssue({ code: "custom", message });
+    for (const entries of [report.sources, report.sections, report.evidence]) {
+      if (new Set(entries.map((entry) => entry.id)).size !== entries.length)
+        fail("IDs must be unique within each collection.");
+    }
+    const sources = new Set(report.sources.map((entry) => entry.id));
+    const evidenceIds = new Set(report.evidence.map((entry) => entry.id));
+    if (report.sources.some((entry) => entry.gitSha !== report.gitSha))
+      fail("Every source must match the report commit.");
+    for (const entry of [...report.sections, ...report.evidence]) {
+      if (!sources.has(entry.sourceId))
+        fail(`Unknown source: ${entry.sourceId}`);
+    }
+    for (const section of report.sections) {
+      if (section.evidenceIds.some((entry) => !evidenceIds.has(entry)))
+        fail(`Unknown evidence in ${section.id}`);
+    }
+  });
+
+export type ReviewReport = z.infer<typeof reviewSchema>;
+export type ReviewEvidence = ReviewReport["evidence"][number];
+
+export const docShotReceiptSchema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("docshot"),
+  name: z.string(),
+  gitSha: sha,
+  createdAt: z.iso.datetime(),
+  fileName: assetNameSchema,
+});
+
+/** No stored summary flags: all renderers use the same recorded facts. */
+export function summarizeReview(
+  report: Pick<ReviewReport, "sources" | "evidence" | "gaps">,
+) {
+  const tests = report.sources.filter((entry) => entry.kind === "test-run");
+  const assertions = report.evidence
+    .filter((entry) => entry.kind === "assertion")
+    .flatMap((entry) => entry.judgments);
+  const visual = report.evidence
+    .filter((entry) => entry.kind === "image")
+    .flatMap((entry) => entry.judgments);
+  const judgments = [...assertions, ...visual];
+  const failed =
+    tests.some((entry) => entry.outcome === "failed") ||
+    judgments.some((entry) => entry.state === "failed");
+  const incomplete =
+    tests.some((entry) => entry.outcome !== "passed") ||
+    report.gaps.length > 0 ||
+    judgments.some((entry) => entry.state === "pending") ||
+    tests.some(
+      (entry) =>
+        !report.evidence.some(
+          (item) => item.sourceId === entry.id && item.kind === "assertion",
+        ),
+    );
+  const verdict = failed
+    ? "Failed"
+    : incomplete
+      ? "Incomplete"
+      : tests.length === 0
+        ? "Reference"
+        : "Passed";
+  return {
+    verdict,
+    tests: tests.length,
+    passedTests: tests.filter((entry) => entry.outcome === "passed").length,
+    assertions: assertions.length,
+    passedAssertions: assertions.filter((entry) => entry.state === "passed")
+      .length,
+    images: report.evidence.filter((entry) => entry.kind === "image").length,
+    pendingVisual: visual.filter((entry) => entry.state === "pending").length,
+  };
+}

--- a/packages/review/src/storage.ts
+++ b/packages/review/src/storage.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { get, put } from "@vercel/blob";
+import { assetNameSchema, reportIdSchema, reviewSchema } from "./schema.ts";
+import type { ReviewReport } from "./schema.ts";
+
+export interface ReviewAsset {
+  name: string;
+  body: Uint8Array;
+}
+
+export async function uploadReview(
+  report: ReviewReport,
+  assets: ReviewAsset[],
+  options: { localDir?: string } = {},
+): Promise<string> {
+  reviewSchema.parse(report);
+  const names = new Set(
+    assets.map((asset) => assetNameSchema.parse(asset.name)),
+  );
+  if (names.size !== assets.length || names.has("report.json"))
+    throw new Error("Duplicate or reserved review asset name.");
+  const referenced = [
+    ...report.sources,
+    ...report.evidence.filter((item) => item.kind === "image"),
+  ];
+  if (referenced.some((item) => !names.has(item.asset)))
+    throw new Error("A referenced review asset is missing.");
+  const id = randomUUID().replaceAll("-", "");
+  const localDir = options.localDir ?? process.env.OPENWORK_REVIEW_LOCAL_DIR;
+  const signal = AbortSignal.timeout(60_000);
+  if (localDir) await mkdir(join(localDir, id), { recursive: false });
+  async function write(name: string, body: Uint8Array | string) {
+    if (localDir) {
+      await writeFile(join(localDir, id, name), body, { flag: "wx" });
+    } else {
+      await put(
+        `reviews/${id}/${name}`,
+        typeof body === "string" ? body : Buffer.from(body),
+        {
+          access: "private",
+          addRandomSuffix: false,
+          allowOverwrite: false,
+          contentType: name.endsWith(".png") ? "image/png" : "application/json",
+          abortSignal: signal,
+        },
+      );
+    }
+  }
+  // Bound concurrency and commit the manifest last. A failed upload never gets a report URL.
+  for (let index = 0; index < assets.length; index += 4) {
+    await Promise.all(
+      assets
+        .slice(index, index + 4)
+        .map((asset) => write(asset.name, asset.body)),
+    );
+  }
+  await write("report.json", JSON.stringify(report));
+  return id;
+}
+
+export async function readReviewAsset(
+  id: string,
+  name: string,
+): Promise<Response | null> {
+  if (
+    !reportIdSchema.safeParse(id).success ||
+    !assetNameSchema.safeParse(name).success
+  )
+    return null;
+  const localDir = process.env.OPENWORK_REVIEW_LOCAL_DIR;
+  const contentType = name.endsWith(".png") ? "image/png" : "application/json";
+  if (localDir) {
+    try {
+      return new Response(await readFile(join(localDir, id, name)), {
+        headers: { "content-type": contentType },
+      });
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT")
+        return null;
+      throw error;
+    }
+  }
+  const result = await get(`reviews/${id}/${name}`, {
+    access: "private",
+    abortSignal: AbortSignal.timeout(15_000),
+  });
+  if (result?.statusCode !== 200) return null;
+  return new Response(result.stream, {
+    headers: { "content-type": contentType },
+  });
+}
+
+export async function readReview(id: string): Promise<ReviewReport | null> {
+  const response = await readReviewAsset(id, "report.json");
+  if (!response) return null;
+  return reviewSchema.parse(await response.json());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,34 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
 
+  apps/review:
+    dependencies:
+      '@openwork/review':
+        specifier: workspace:*
+        version: link:../../packages/review
+      next:
+        specifier: 16.2.11
+        version: 16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.8
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.8(react@19.2.8)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/server:
     dependencies:
       '@modelcontextprotocol/client':
@@ -1418,6 +1446,15 @@ importers:
       '@types/react':
         specifier: ^19.1.13
         version: 19.2.14
+
+  packages/review:
+    dependencies:
+      '@vercel/blob':
+        specifier: ^2.3.0
+        version: 2.8.0
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
 
   packages/sdk:
     devDependencies:
@@ -5094,8 +5131,23 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/blob@2.8.0':
+    resolution: {integrity: sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/cli-config@0.2.4':
+    resolution: {integrity: sha512-kZ5SojbrV06GHoU6QIWGwDXLov+s9rWZ7QqdqKfJfBGCNUieGfgaCjeeenNy8Y+QC0bwC0dZ2B4l5Hvdmrgpdw==}
+
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==}
+    engines: {node: '>= 18'}
+
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.8.5':
+    resolution: {integrity: sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==}
     engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@5.2.0':
@@ -5304,6 +5356,9 @@ packages:
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -6965,6 +7020,10 @@ packages:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -7097,6 +7156,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
@@ -7954,6 +8016,10 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
@@ -8470,6 +8536,10 @@ packages:
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
   rettime@0.11.11:
@@ -9371,6 +9441,14 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xml-crypto@6.1.2:
     resolution: {integrity: sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==}
     engines: {node: '>=16'}
@@ -9458,6 +9536,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.1.8:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
@@ -13501,7 +13582,31 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/blob@2.8.0':
+    dependencies:
+      '@vercel/oidc': 3.8.5
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.28.0
+
+  '@vercel/cli-config@0.2.4':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.1':
+    dependencies:
+      execa: 5.1.1
+
   '@vercel/oidc@3.1.0': {}
+
+  '@vercel/oidc@3.8.5':
+    dependencies:
+      '@vercel/cli-config': 0.2.4
+      '@vercel/cli-exec': 1.0.1
+      jose: 5.10.0
 
   '@vitejs/plugin-react@5.2.0(vite@6.4.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -13777,6 +13882,10 @@ snapshots:
   astring@1.9.0: {}
 
   async-exit-hook@2.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   async@3.2.6: {}
 
@@ -15518,6 +15627,8 @@ snapshots:
     dependencies:
       binary-extensions: 2.3.0
 
+  is-buffer@2.0.5: {}
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
@@ -15605,6 +15716,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jiti@2.7.0: {}
+
+  jose@5.10.0: {}
 
   jose@6.1.3: {}
 
@@ -16608,6 +16721,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  os-paths@4.4.0: {}
+
   outvariant@1.4.3: {}
 
   p-cancelable@2.1.1: {}
@@ -17119,6 +17234,8 @@ snapshots:
       signal-exit: 4.1.0
 
   retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   rettime@0.11.11: {}
 
@@ -18170,6 +18287,15 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xml-crypto@6.1.2:
     dependencies:
       '@xmldom/is-dom-node': 1.0.1
@@ -18237,6 +18363,8 @@ snapshots:
       zod: 4.3.6
 
   zod@3.25.76: {}
+
+  zod@4.1.11: {}
 
   zod@4.1.8: {}
 


### PR DESCRIPTION
PR evidence currently expands traces and screenshots into a long comment and replaces earlier runs when publishing the next test. This adds a private Vercel review app that composes existing test records and DocShot receipts into one report, with a compact GitHub link and details available on demand.

- One versioned runtime schema supplies the TypeScript types. Sections reference assertions and images by stable IDs; all sources must match the PR commit. Reference images have no implied pass/fail result, and skipped tests, pending judgments, failures, and declared gaps stay visible.
- Existing publication commands accept multiple runs or `--all`. Publication performs no test runs, captures, or model calls. Images are deduplicated, the manifest uploads last, and a changed PR head or failed upload preserves existing evidence. Reporting libraries load only when publishing.
- A separate optional workflow consumes completed CI artifacts. It is not a release dependency; existing required test checks are unchanged. The review app has its own checks only when its files change.

Validation on `56468d344e99d5ce7ddb32a9ec2b3d7c11e57184`:

- `pnpm --filter @openwork/review-app build` — passed.
- `node --test evals/packages/test-artifacts/test/*.test.ts evals/bin/evals.test.mjs` — 25 passed, 0 failed.
- `OPENWORK_EVAL_REVIEW=1 pnpm evals:pr specs/evidence-review.test.ts` — Passed: 1 passed, 0 failed, 0 skipped. Placement: local, isolated production review app. Verifies composed reports, accurate failure/incomplete/reference states, password-free preview pages/media/source records, production rejection, and missing-resource behavior through HTTP.
- Browser layout verification on prior commit `ecfbc37fb` (the UI is unchanged): disclosure controls work; desktop and 390px mobile layouts render with loaded images and no horizontal overflow. Example report contents are explicitly synthetic fixtures.
- Hosted access verification: anonymous requests to home, report, JSON, and image routes receive a Vercel sign-in redirect (302). Requests authenticated through `vercel curl` reach the app with no Basic header: home 200, missing report/assets 404.

A local assembly measurement for two runs and a DocShot was 6.7 ms, producing a 2.5 KB manifest and one deduplicated image. This excludes network upload time, which stays outside required CI.

[App preview](https://openwork-review-jqvsx0grh-prologe.vercel.app) uses Vercel Authentication for Preview and private Blob storage. Teammates use their Vercel accounts with project access; the app password and its Preview environment variable were removed. Deployments outside Preview return 503. Automatic publication is now enabled through the repository review URL and private Blob secret. [A verified report](https://openwork-review-jqvsx0grh-prologe.vercel.app/r/516b650a8605481986be5d327095cfe7) is published; authenticated page/JSON reads and anonymous Vercel protection were verified. The optional publisher also completed for #4647 and correctly reported that its source workflow uploaded no test records. Production deployment access remains disabled. Setup and the shared format are documented in `apps/review/README.md`.

<details>
<summary>Repository-wide checks compared with a clean base</summary>

The broad eval typecheck and existing layer/channel/boundary guards fail identically on clean base `7874bf927` and this branch. The new review journey adds no guard violation. Commands: `pnpm --dir evals exec tsc --noEmit --pretty false`, `node evals/scripts/spec-boundary-ratchet.mjs`, `node evals/scripts/spec-channel-ratchet.mjs`, and the dependency-cruiser layer check under supported Node 24. Typecheck diagnostics match exactly; the layer check reports the same 38 existing violations. Focused app build/typechecking and publisher tests pass.

</details>

