### PR TITLE
Keep model defaults and saved settings consistent

### DIFF
--- a/apps/app/src/app/lib/model-behavior.ts
+++ b/apps/app/src/app/lib/model-behavior.ts
@@ -14,21 +14,10 @@ const WELL_KNOWN_VARIANT_ORDER = [
   "max",
 ] as const;
 
-const VARIANT_DEFAULT_TARGET = 3;
-const VARIANT_DEFAULT_SCORE: Record<string, number> = {
-  none: 0,
-  minimal: 1,
-  low: 2,
-  medium: VARIANT_DEFAULT_TARGET,
-  high: 4,
-  xhigh: 5,
-  max: 6,
-};
-
 function defaultBehaviorOption(): ModelBehaviorOption {
   return {
     value: null,
-    label: t("settings.provider_default_label"),
+    label: t("settings.default_label"),
     description: t("settings.provider_default_desc"),
   };
 }
@@ -39,13 +28,7 @@ export const normalizeModelBehaviorValue = (value: string | null) => {
   return value?.trim() ? value : null;
 };
 
-const getVariantKeys = (model: ProviderModel) => {
-  const keys = Object.keys(model.variants ?? {}).flatMap((key) => {
-    const normalized = normalizeModelBehaviorValue(key);
-    return normalized ? [normalized] : [];
-  });
-  return Array.from(new Set(keys));
-};
+const getVariantKeys = (model: ProviderModel | undefined) => Object.keys(model?.variants ?? {});
 
 const sortVariantKeys = (keys: string[]) =>
   keys.slice().sort((a, b) => {
@@ -58,30 +41,6 @@ const sortVariantKeys = (keys: string[]) =>
     }
     return a.localeCompare(b);
   });
-
-const getDefaultVariantKey = (keys: string[]) => {
-  let selected: string | null = null;
-  let selectedScore: number | null = null;
-
-  for (const key of keys) {
-    const score = VARIANT_DEFAULT_SCORE[key];
-    if (score == null) continue;
-    if (selectedScore == null) {
-      selected = key;
-      selectedScore = score;
-      continue;
-    }
-
-    const distance = Math.abs(score - VARIANT_DEFAULT_TARGET);
-    const selectedDistance = Math.abs(selectedScore - VARIANT_DEFAULT_TARGET);
-    if (distance < selectedDistance || (distance === selectedDistance && score > selectedScore)) {
-      selected = key;
-      selectedScore = score;
-    }
-  }
-
-  return selected ?? keys[0] ?? null;
-};
 
 const providerFamily = (providerID: string, providerName?: string | null) => {
   const normalizedId = providerID.trim().toLowerCase();
@@ -99,7 +58,7 @@ const providerFamily = (providerID: string, providerName?: string | null) => {
 
 const getBehaviorTitle = (
   providerID: string,
-  model: ProviderModel,
+  model: ProviderModel | undefined,
   variantKeys: string[],
   providerName?: string | null,
 ) => {
@@ -116,7 +75,7 @@ const getBehaviorTitle = (
     }
     return t("app.model_behavior_title");
   }
-  if (model.capabilities?.reasoning) return t("model_behavior.title_builtin_reasoning");
+  if (model?.capabilities?.reasoning) return t("model_behavior.title_builtin_reasoning");
   return t("model_behavior.title_standard_generation");
 };
 
@@ -128,25 +87,25 @@ export const formatGenericBehaviorLabel = (value: string | null) => {
   return getVariantLabel(normalized);
 };
 
-/** Return the next explicit thinking/reasoning variant, wrapping at the end. */
+/** Cycle supplied choices, including the provider's Default (null). */
 export const nextModelBehaviorValue = (
   options: readonly Pick<ModelBehaviorOption, "value">[],
   current: string | null,
 ) => {
-  const values = options.flatMap((option) => option.value == null ? [] : [option.value]);
+  const values = options.map((option) => option.value);
   if (values.length < 2) return null;
-  const currentIndex = current == null ? -1 : values.indexOf(current);
+  const currentIndex = values.indexOf(current);
   return values[(currentIndex + 1) % values.length] ?? null;
 };
 
-/** Return the previous explicit thinking/reasoning variant, wrapping at the start. */
+/** Cycle supplied choices backward, including Default. */
 export const previousModelBehaviorValue = (
   options: readonly Pick<ModelBehaviorOption, "value">[],
   current: string | null,
 ) => {
-  const values = options.flatMap((option) => option.value == null ? [] : [option.value]);
+  const values = options.map((option) => option.value);
   if (values.length < 2) return null;
-  const currentIndex = current == null ? -1 : values.indexOf(current);
+  const currentIndex = values.indexOf(current);
   if (currentIndex === -1) return values[values.length - 1] ?? null;
   return values[(currentIndex - 1 + values.length) % values.length] ?? null;
 };
@@ -175,74 +134,55 @@ const getVariantDescription = (
 
 export const getModelBehaviorOptions = (
   providerID: string,
-  model: ProviderModel,
+  model: ProviderModel | undefined,
   providerName?: string | null,
 ): ModelBehaviorOption[] => {
   const variantKeys = sortVariantKeys(getVariantKeys(model));
-  if (!variantKeys.length) return [];
-  return variantKeys.map((key) => {
+  return [defaultBehaviorOption(), ...variantKeys.map((key) => {
     const label = getVariantLabel(key);
     return {
       value: key,
       label,
       description: getVariantDescription(providerID, key, label, providerName),
     };
-  });
+  })];
 };
 
-const getDefaultModelBehaviorValue = (model: ProviderModel) =>
-  getDefaultVariantKey(sortVariantKeys(getVariantKeys(model)));
-
+/** For an explicit model switch only; never sanitize a saved same-model choice. */
 export const sanitizeModelBehaviorValue = (
   providerID: string,
   model: ProviderModel,
   value: string | null,
   providerName?: string | null,
 ) => {
-  const normalized = normalizeModelBehaviorValue(value);
-  if (!normalized) return null;
-  return getModelBehaviorOptions(providerID, model, providerName).some((option) => option.value === normalized)
-    ? normalized
+  return getModelBehaviorOptions(providerID, model, providerName).some((option) => option.value === value)
+    ? value
     : null;
+};
+
+/** Describe a saved choice without changing it or treating missing metadata as rejection. */
+export const getModelBehaviorSelection = (
+  suppliedOptions: readonly { value: string | null; label: string; description?: string }[],
+  value: string | null,
+) => {
+  const options = [defaultBehaviorOption(), ...suppliedOptions.filter((option) => option.value !== null)
+    .map((option) => ({ ...option, description: option.description ?? "" }))];
+  const selected = options.find((option) => option.value === value);
+  return {
+    value,
+    label: selected?.label ?? `${JSON.stringify(value)} (not in current catalog)`,
+    description: selected?.description ?? "This saved setting is not listed in the current model configuration. It is kept unchanged; choose Default or a listed setting to replace it.",
+    options,
+  };
 };
 
 export const getModelBehaviorSummary = (
   providerID: string,
-  model: ProviderModel,
+  model: ProviderModel | undefined,
   value: string | null,
   providerName?: string | null,
 ) => {
   const options = getModelBehaviorOptions(providerID, model, providerName);
-  const sanitized = sanitizeModelBehaviorValue(providerID, model, value, providerName);
-  const selectedValue = sanitized ?? getDefaultModelBehaviorValue(model);
-  const selected = options.find((option) => option.value === selectedValue) ?? options[0] ?? null;
   const title = getBehaviorTitle(providerID, model, getVariantKeys(model), providerName);
-
-  if (options.length > 0) {
-    return {
-      title,
-      label: selected?.label ?? defaultBehaviorOption().label,
-      description: selected?.description ?? defaultBehaviorOption().description,
-      value: selected?.value ?? null,
-      options,
-    };
-  }
-
-  if (model.capabilities?.reasoning) {
-    return {
-      title,
-      label: t("model_behavior.label_builtin"),
-      description: t("model_behavior.desc_builtin"),
-      value: null,
-      options,
-    };
-  }
-
-  return {
-    title,
-    label: t("model_behavior.label_standard"),
-    description: t("model_behavior.desc_standard"),
-    value: null,
-    options,
-  };
+  return { title, ...getModelBehaviorSelection(options, value) };
 };

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Check, ChevronDown, ChevronLeft, ChevronRight, Settings2, Star } from "lucide-react";
 
 import type { ModelBehaviorOption, ModelOption, ModelRef } from "@/app/types";
-import { getModelBehaviorSummary } from "@/app/lib/model-behavior";
+import { getModelBehaviorSelection, getModelBehaviorSummary } from "@/app/lib/model-behavior";
 import { ProviderIcon } from "@/react-app/design-system/provider-icon";
 import {
   Popover,
@@ -173,7 +173,8 @@ function isSameModel(a: ModelRef, b: ModelRef) {
 }
 
 function thinkingOptionsFor(option: ModelOption): ModelBehaviorOption[] {
-  return (option.behaviorOptions ?? []).filter((item) => item.value != null);
+  if (option.behaviorValue == null && !option.behaviorOptions?.some((item) => item.value !== null)) return [];
+  return getModelBehaviorSelection(option.behaviorOptions ?? [], option.behaviorValue ?? null).options;
 }
 
 function overlaySelectedBehavior(
@@ -181,24 +182,18 @@ function overlaySelectedBehavior(
   value: ModelRef,
   behavior: {
     value: string | null;
-    label?: string;
     options: { value: string | null; label: string }[];
   },
 ): ModelOption[] {
   return options.map((option) => {
     if (!isSameModel(value, option)) return option;
-    const fallbackOptions: ModelBehaviorOption[] = behavior.options.map((item) => ({
-      value: item.value,
-      label: item.label,
-      description: "",
-    }));
+    const selected = getModelBehaviorSelection(option.behaviorOptions ?? behavior.options, behavior.value);
     return {
       ...option,
-      behaviorValue: behavior.value ?? option.behaviorValue,
-      behaviorLabel: behavior.label ?? option.behaviorLabel,
-      behaviorOptions: (option.behaviorOptions?.length ?? 0) > 0
-        ? option.behaviorOptions
-        : fallbackOptions,
+      behaviorValue: selected.value,
+      behaviorLabel: selected.label,
+      behaviorDescription: selected.description,
+      behaviorOptions: selected.options,
     };
   });
 }
@@ -251,10 +246,9 @@ export function ModelSelect({
   const modelOptions = React.useMemo(
     () => overlaySelectedBehavior(catalogOptions, value, {
       value: behaviorValue,
-      label: behaviorLabel,
       options: behaviorOptions,
     }),
-    [behaviorLabel, behaviorOptions, behaviorValue, catalogOptions, value],
+    [behaviorOptions, behaviorValue, catalogOptions, value],
   );
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const canAddProviders = !checkDesktopRestriction({ restriction: "allowCustomProviders" });
@@ -333,7 +327,7 @@ export function ModelSelect({
     return [...quickGroups, ...groupByProvider(modelOptions)];
   }, [favoriteOptions, modelOptions, recentOptions]);
   const selectedThinkingOptions = selectedOption ? thinkingOptionsFor(selectedOption) : [];
-  const effectiveBehaviorLabel = behaviorLabel ?? selectedOption?.behaviorLabel ?? "Default";
+  const effectiveBehaviorLabel = selectedOption?.behaviorLabel ?? behaviorLabel ?? "Default";
   const currentFavorite = favoriteOptions.find((option) => isSameModel(value, option)) ?? favoriteOptions[0] ?? null;
   const nextFavorite = nextFavoriteModel(favorites, value);
   const showBehavior = !hideValue
@@ -365,7 +359,7 @@ export function ModelSelect({
   const thinkingOptions = thinkingFor ? thinkingOptionsFor(thinkingFor) : [];
   const thinkingValue =
     thinkingFor && isSameModel(value, thinkingFor)
-      ? (behaviorValue ?? thinkingFor.behaviorValue)
+      ? behaviorValue
       : (thinkingFor?.behaviorValue ?? null);
 
   const applyThinking = (option: ModelBehaviorOption) => {
@@ -387,7 +381,7 @@ export function ModelSelect({
     const thinking = thinkingOptionsFor(option);
     const compatibleBehavior = thinking.some((entry) => entry.value === behaviorValue)
       ? behaviorValue
-      : option.behaviorValue ?? null;
+      : null;
     applyModel(option, compatibleBehavior);
   };
 
@@ -546,14 +540,17 @@ export function ModelSelect({
                 <span className="block truncate text-xs text-muted-foreground">{thinkingFor.title}</span>
               </span>
             </button>
+            <p role="status" className="px-3 py-2 text-xs text-muted-foreground">
+              {getModelBehaviorSelection(thinkingOptions, thinkingValue).description}
+            </p>
             <div className="min-h-0 flex-1 overflow-y-auto p-1">
               {thinkingOptions.map((option) => {
-                const selected = option.value === thinkingValue
-                  || (thinkingValue == null && option.value === thinkingOptions[0]?.value);
+                const selected = option.value === thinkingValue;
                 return (
                   <button
-                    key={option.value}
+                    key={option.value === null ? "default" : `variant-${option.value}`}
                     type="button"
+                    aria-pressed={selected}
                     className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
                     onClick={() => applyThinking(option)}
                   >

--- a/apps/app/src/react-app/domains/automations/automation-editor.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-editor.tsx
@@ -306,9 +306,12 @@ export function AutomationEditor(props: AutomationEditorProps) {
             onSelect={(model) => {
               setInput((current) => ({
                 ...current,
-                // A different model has its own reasoning levels, so the old
-                // variant cannot carry over.
-                model: { providerId: model.providerID, modelId: model.modelID, variant: null },
+                model: {
+                  providerId: model.providerID,
+                  modelId: model.modelID,
+                  variant: current.model.providerId === model.providerID && current.model.modelId === model.modelID
+                    ? current.model.variant : null,
+                },
               }))
               setPickerOpen(false)
             }}

--- a/apps/app/src/react-app/domains/automations/automation-model-options.ts
+++ b/apps/app/src/react-app/domains/automations/automation-model-options.ts
@@ -153,24 +153,22 @@ export function automationPickerOptions(input: {
     const isSelected = option.providerId === input.selected.providerId
       && option.modelId === input.selected.modelId
     const model = input.catalog[option.providerId]?.[option.modelId]
-    const summary = model
-      ? getModelBehaviorSummary(
-        option.providerId,
-        model,
-        isSelected ? input.selected.variant ?? null : null,
-        option.providerName,
-      )
-      : null
+    const summary = getModelBehaviorSummary(
+      option.providerId,
+      model,
+      isSelected ? input.selected.variant ?? null : null,
+      option.providerName,
+    )
     return {
       providerID: option.providerId,
       modelID: option.modelId,
       title: option.modelName,
       description: option.providerName,
-      behaviorTitle: summary?.title ?? "Reasoning",
-      behaviorLabel: summary?.label ?? "Default",
-      behaviorDescription: summary?.description ?? "",
-      behaviorValue: summary?.value ?? null,
-      behaviorOptions: summary?.options ?? [],
+      behaviorTitle: summary.title,
+      behaviorLabel: summary.label,
+      behaviorDescription: summary.description,
+      behaviorValue: summary.value,
+      behaviorOptions: summary.options,
       isFree: option.accessKind === "free",
     }
   })

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { t } from "@/i18n";
 import { readDenSettings } from "@/app/lib/den";
+import { getModelBehaviorSelection } from "@/app/lib/model-behavior";
 import { modelEquals, resolveProviderDisplayName } from "../../../../app/utils";
 import type { ModelOption, ModelRef } from "../../../../app/types";
 import { isRecommendedModel } from "../../../../app/defaults";
@@ -49,6 +50,7 @@ export type ModelPickerModalProps = {
   subtitle?: string;
   target: "default" | "session";
   current: ModelRef;
+  currentBehaviorValue?: string | null;
   onSelect: (model: ModelRef) => void;
   onBehaviorChange: (model: ModelRef, value: string | null) => void;
   onToggleProvider?: (providerId: string, enabled: boolean) => void;
@@ -128,6 +130,9 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     () => new Set(props.disabledProviders ?? []),
     [props.disabledProviders],
   );
+  const currentOption = props.options.find((option) => modelEquals(option, props.current));
+  const currentBehavior = getModelBehaviorSelection(currentOption?.behaviorOptions ?? [],
+    props.currentBehaviorValue !== undefined ? props.currentBehaviorValue : currentOption?.behaviorValue ?? null);
 
   // Reset on open
   useEffect(() => {
@@ -319,6 +324,22 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
 
           {/* Content */}
           <div className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1 -mr-1">
+            {currentOption && !disabledSet.has(currentOption.providerID) ? (
+              <section aria-label={`Settings for ${currentOption.title}`} className="mb-3 rounded-xl border border-dls-border p-3" data-testid="current-model-settings">
+                <div className="text-xs font-medium">{currentOption.title} · {currentBehavior.label}</div>
+                <p role="status" className="mt-1 text-xs text-muted-foreground">{currentBehavior.description}</p>
+                <div role="group" aria-label="Thinking and effort" className="mt-2 flex flex-wrap gap-2">
+                  {currentBehavior.options.map((option) => (
+                    <Button key={option.value === null ? "default" : `variant-${option.value}`} type="button" size="sm"
+                      variant={option.value === currentBehavior.value ? "secondary" : "outline"}
+                      aria-pressed={option.value === currentBehavior.value}
+                      onClick={() => props.onBehaviorChange(props.current, option.value)}>
+                      {option.label}
+                    </Button>
+                  ))}
+                </div>
+              </section>
+            ) : null}
             {emptyState ? (
               <div className="space-y-3 rounded-2xl border border-dls-border bg-dls-hover/30 px-4 py-6 text-center">
                 <div className="text-sm text-dls-secondary">

--- a/apps/app/src/react-app/domains/session/surface/session-model-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-model-store.ts
@@ -6,7 +6,7 @@
 import { useMemo } from "react";
 import { create } from "zustand";
 
-import { formatGenericBehaviorLabel, getModelBehaviorSummary } from "@/app/lib/model-behavior";
+import { getModelBehaviorSummary } from "@/app/lib/model-behavior";
 import type { ModelRef } from "@/app/types";
 
 type BehaviorOption = { value: string | null; label: string };
@@ -158,15 +158,13 @@ export function useSessionModelSelection(input: UseSessionModelSelectionInput): 
       };
     }
     const providerModel = providerCatalog?.[selection.model.providerID]?.[selection.model.modelID];
-    const summary = providerModel
-      ? getModelBehaviorSummary(selection.model.providerID, providerModel, selection.variant)
-      : null;
+    const summary = getModelBehaviorSummary(selection.model.providerID, providerModel, selection.variant);
     return {
       selectedModel: selection.model,
       modelLabel: providerModel?.name || resolveModelDisplayName(selection.model.modelID),
-      modelVariant: summary ? summary.value : selection.variant,
-      modelVariantLabel: summary?.label ?? formatGenericBehaviorLabel(selection.variant),
-      modelBehaviorOptions: summary?.options ?? [],
+      modelVariant: summary.value,
+      modelVariantLabel: summary.label,
+      modelBehaviorOptions: summary.options,
       hasSessionOverride: true,
       setModel,
       setVariant: (value: string | null) => useSessionModelStore.getState().setVariant(sessionId, value),

--- a/apps/app/src/react-app/domains/session/surface/use-model-behavior.ts
+++ b/apps/app/src/react-app/domains/session/surface/use-model-behavior.ts
@@ -50,13 +50,6 @@ export function useModelBehavior(input: UseModelBehaviorInput) {
       };
     }
     const model = providerCatalog[defaultModel.providerID]?.[defaultModel.modelID];
-    if (!model) {
-      return {
-        modelVariantLabel: variant ?? t("settings.default_label"),
-        modelBehaviorOptions: emptyModelBehaviorOptions,
-        modelVariantValue: variant,
-      };
-    }
     const summary = getModelBehaviorSummary(defaultModel.providerID, model, variant);
     return {
       modelVariantLabel: summary.label,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -130,7 +130,7 @@ import {
 import { draftToParts } from "@/react-app/domains/session/sync/draft-parts";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
-import { getModelBehaviorSummary, nextModelBehaviorValue, previousModelBehaviorValue } from "@/app/lib/model-behavior";
+import { getModelBehaviorSummary, nextModelBehaviorValue, previousModelBehaviorValue, sanitizeModelBehaviorValue } from "@/app/lib/model-behavior";
 import { computeModelAvailability, createUnavailableConfirmationGate, type ModelAvailability } from "@/react-app/domains/session/surface/model-availability";
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
@@ -1020,6 +1020,9 @@ export function SessionRoute() {
   // the picker edits the global default (e.g. opened from the new-providers
   // toast). Composer "All models" carries the session id on the open event.
   const [modelPickerSessionId, setModelPickerSessionId] = useState<string | null>(null);
+  const modelPickerSelection = useSessionModelStore((state) =>
+    modelPickerSessionId ? state.bySessionId[modelPickerSessionId] ?? null : null,
+  );
   useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<{ sessionId?: string }>).detail;
@@ -2397,10 +2400,10 @@ export function SessionRoute() {
       : null;
     const options = selection ? (summary?.options ?? []) : modelBehaviorOptions;
     const current = selection ? (summary?.value ?? selection.variant) : modelVariantValue;
+    if (options.length < 2) return null;
     const next = direction === "reverse"
       ? previousModelBehaviorValue(options, current)
       : nextModelBehaviorValue(options, current);
-    if (!next) return null;
 
     if (activeSessionId && selection) {
       useSessionModelStore.getState().setVariant(activeSessionId, next);
@@ -2434,10 +2437,9 @@ export function SessionRoute() {
     if (!next) return null;
 
     const providerModel = providerCatalog?.[next.providerID]?.[next.modelID];
-    const summary = providerModel
-      ? getModelBehaviorSummary(next.providerID, providerModel, selection?.variant ?? modelVariantValue)
+    const variant = providerModel
+      ? sanitizeModelBehaviorValue(next.providerID, providerModel, selection ? selection.variant : modelVariantValue)
       : null;
-    const variant = summary && summary.options.length > 0 ? summary.value : null;
     if (activeSessionId) {
       useSessionModelStore.getState().setModel(activeSessionId, next, variant);
     }
@@ -3840,7 +3842,7 @@ export function SessionRoute() {
       setQuery={modelPicker.setQuery}
       subtitle={
         resolveModelAvailability(
-          (modelPickerSessionId ? getSessionModelSelection(modelPickerSessionId)?.model : null)
+          modelPickerSelection?.model
             ?? local.prefs.defaultModel
             ?? null,
         ).status === "unavailable"
@@ -3848,8 +3850,11 @@ export function SessionRoute() {
           : undefined
       }
       target="default"
+      currentBehaviorValue={modelPickerSelection
+        ? modelPickerSelection.variant
+        : local.prefs.modelVariant ?? null}
       current={
-        (modelPickerSessionId ? getSessionModelSelection(modelPickerSessionId)?.model : null)
+        modelPickerSelection?.model
           ?? local.prefs.defaultModel
           ?? ({ providerID: "", modelID: "" } satisfies ModelRef)
       }
@@ -3859,7 +3864,15 @@ export function SessionRoute() {
         modelPicker.setOpen(false);
       }}
       disabledProviders={disabledProviderIds}
-      onBehaviorChange={() => {}}
+      onBehaviorChange={(model, value) => {
+        if (modelPickerSessionId) {
+          const store = useSessionModelStore.getState();
+          store.setModel(modelPickerSessionId, model, value);
+          // Same-model selection preserves settings; explicit effort edits do not.
+          store.setVariant(modelPickerSessionId, value);
+        }
+        local.setPrefs((previous) => ({ ...previous, modelVariant: value }));
+      }}
       onToggleProvider={async (providerId, enable) => {
         if (!opencodeClient) return;
         try {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2856,6 +2856,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         query={modelPicker.query}
         setQuery={modelPicker.setQuery}
         target="default"
+        currentBehaviorValue={local.prefs.modelVariant ?? null}
         current={
           local.prefs.defaultModel ?? { providerID: "", modelID: "" }
         }
@@ -2869,7 +2870,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           }));
           modelPicker.setOpen(false);
         }}
-        onBehaviorChange={() => {}}
+        onBehaviorChange={(_model, value) => local.setPrefs((previous) => ({ ...previous, modelVariant: value }))}
         onOpenSettings={() => {}}
         onClose={() => modelPicker.setOpen(false)}
       />

--- a/apps/app/tests/automation-model-options.test.ts
+++ b/apps/app/tests/automation-model-options.test.ts
@@ -112,9 +112,26 @@ describe("Automation model options", () => {
     expect(selected?.behaviorOptions?.map((option) => option.value)).toContain("low")
     expect(selected?.isFree).toBe(false)
     // The free starter model is absent from the local catalog here, so it
-    // still lists — just without reasoning levels.
+    // still lists with a Default recovery path, without invented reasoning levels.
     expect(free?.isFree).toBe(true)
-    expect(free?.behaviorOptions).toEqual([])
+    expect(free?.behaviorOptions?.map((option) => option.value)).toEqual([null])
+  })
+
+  test("preserves unknown saved settings only on the selected identity, even before runtime metadata arrives", () => {
+    const options = automationModelOptions([
+      provider({ id: "lpr_one", source: "custom", name: "One",
+        models: [{ id: "same-model", name: "One model", config: {}, createdAt: null }] }),
+      provider({ id: "lpr_two", source: "custom", name: "Two",
+        models: [{ id: "same-model", name: "Two model", config: {}, createdAt: null }] }),
+    ])
+    const selected = { providerId: "lpr_one", modelId: "same-model", variant: "retired" }
+    const picker = automationPickerOptions({ options, catalog: {}, selected })
+    expect(picker.find((option) => option.providerID === "lpr_one")).toMatchObject({
+      behaviorValue: "retired", behaviorLabel: '"retired" (not in current catalog)',
+    })
+    expect(picker.find((option) => option.providerID === "lpr_one")?.behaviorOptions?.map((option) => option.value)).toEqual([null])
+    expect(picker.find((option) => option.providerID === "lpr_two")?.behaviorValue).toBeNull()
+    expect(selected.variant).toBe("retired")
   })
 })
 

--- a/apps/app/tests/composer-model-controls.test.ts
+++ b/apps/app/tests/composer-model-controls.test.ts
@@ -36,6 +36,17 @@ describe("composer model controls", () => {
     expect(modelSelectSource).not.toContain("setThinkingOpen(true)");
     expect(modelSelectSource).toContain('data-slot="model-thinking-submenu"');
     expect(modelSelectSource).not.toContain("onMouseEnter");
+    const sessionRouteSource = readFileSync(sessionRoutePath, "utf8");
+    const fullPicker = sessionRouteSource.slice(sessionRouteSource.indexOf("<ModelPickerModal"));
+    expect(fullPicker).toContain("currentBehaviorValue={modelPickerSelection");
+    expect(fullPicker).toContain("store.setModel(modelPickerSessionId, model, value)");
+    expect(fullPicker).toContain("store.setVariant(modelPickerSessionId, value)");
+    const behaviorCallback = fullPicker.slice(fullPicker.indexOf("onBehaviorChange="), fullPicker.indexOf("onToggleProvider="));
+    expect(behaviorCallback).toContain("modelVariant: value");
+    expect(behaviorCallback).not.toContain("defaultModel:");
+    const favoriteCycle = sessionRouteSource.slice(sessionRouteSource.indexOf("const cycleFavoriteModel ="), sessionRouteSource.indexOf("const cycleFavoriteModelControlAction"));
+    expect(favoriteCycle).toContain("sanitizeModelBehaviorValue(next.providerID, providerModel, selection ? selection.variant : modelVariantValue)");
+    expect(favoriteCycle).not.toContain("getModelBehaviorSummary");
   });
 
   test("tracks steering until the active run stops streaming", () => {

--- a/apps/app/tests/model-behavior.test.ts
+++ b/apps/app/tests/model-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   getModelBehaviorOptions,
   getModelBehaviorSummary,
   normalizeModelBehaviorValue,
+  sanitizeModelBehaviorValue,
   nextModelBehaviorValue,
   previousModelBehaviorValue,
 } from "../src/app/lib/model-behavior";
@@ -70,7 +71,7 @@ const model: ProviderModel = {
 describe("model behavior options", () => {
   test("preserves opaque variant IDs through selection and saved-value normalization", () => {
     const custom = { ...model, variants: { CustomExact: {}, default: {}, high: {} } };
-    expect(getModelBehaviorOptions("openai", custom).map((option) => option.value)).toEqual(["high", "CustomExact", "default"]);
+    expect(getModelBehaviorOptions("openai", custom).map((option) => option.value)).toEqual([null, "high", "CustomExact", "default"]);
     for (const value of ["CustomExact", "default"]) {
       const restored = normalizeModelBehaviorValue(value);
       expect(restored).toBe(value);
@@ -84,6 +85,7 @@ describe("model behavior options", () => {
     const options = getModelBehaviorOptions("openai", model);
 
     expect(options.map(({ value, label }) => ({ value, label }))).toEqual([
+      { value: null, label: "Default" },
       { value: "none", label: "None" },
       { value: "low", label: "Low" },
       { value: "medium", label: "Medium" },
@@ -93,11 +95,11 @@ describe("model behavior options", () => {
     ]);
   });
 
-  test("cycles explicit effort values and wraps", () => {
+  test("cycles effort values through Default and wraps", () => {
     const options = getModelBehaviorOptions("openai", model);
 
     expect(nextModelBehaviorValue(options, "low")).toBe("medium");
-    expect(nextModelBehaviorValue(options, "max")).toBe("none");
+    expect(nextModelBehaviorValue(options, "max")).toBeNull();
     expect(nextModelBehaviorValue(options, null)).toBe("none");
   });
 
@@ -110,12 +112,53 @@ describe("model behavior options", () => {
     const options = getModelBehaviorOptions("openai", model);
 
     expect(previousModelBehaviorValue(options, "medium")).toBe("low");
-    expect(previousModelBehaviorValue(options, "none")).toBe("max");
+    expect(previousModelBehaviorValue(options, "none")).toBeNull();
     expect(previousModelBehaviorValue(options, null)).toBe("max");
   });
 
   test("does not cycle backward with fewer than two effort values", () => {
     expect(previousModelBehaviorValue([], null)).toBeNull();
     expect(previousModelBehaviorValue([{ value: "high" }], "high")).toBeNull();
+  });
+
+  test("Default is not replaced with a guessed medium effort", () => {
+    for (const value of [null, "high", null]) {
+      const summary = getModelBehaviorSummary("openwork", model, value);
+      expect(summary.value).toBe(value);
+      expect(summary.label).toBe(value === null ? "Default" : "High");
+      expect(summary.options.filter((option) => option.value === value)).toHaveLength(1);
+    }
+    const single = getModelBehaviorOptions("openwork", { ...model, variants: { high: {} } });
+    expect(nextModelBehaviorValue(single, null)).toBe("high");
+    expect(nextModelBehaviorValue(single, "high")).toBeNull();
+  });
+
+  test("preserves stale and malformed same-model settings with a visible advisory and Default recovery", () => {
+    for (const configuration of [model, { ...model, variants: {} }, undefined]) {
+      for (const value of ["retired-effort", " High ", "", "\n"]) {
+        const summary = getModelBehaviorSummary("openwork", configuration, value);
+        expect(summary.value).toBe(value);
+        expect(summary.label).toContain(JSON.stringify(value));
+        expect(summary.label).toContain("not in current catalog");
+        expect(summary.description).toContain("kept unchanged");
+        expect(summary.description).not.toContain("reject");
+        expect(summary.options[0]).toMatchObject({ value: null, label: "Default" });
+        expect(summary.options.some((option) => option.value === value)).toBe(false);
+      }
+    }
+  });
+
+  test("explicit model switches only carry variants supplied by the target configuration", () => {
+    const target = { ...model, variants: { low: {}, CustomEffort: {} } };
+    for (const provider of ["openwork", "lpr_custom"]) {
+      expect(sanitizeModelBehaviorValue(provider, target, "high")).toBeNull();
+      expect(sanitizeModelBehaviorValue(provider, target, null)).toBeNull();
+      expect(sanitizeModelBehaviorValue(provider, target, "low")).toBe("low");
+      expect(sanitizeModelBehaviorValue(provider, target, "CustomEffort")).toBe("CustomEffort");
+      expect(getModelBehaviorOptions(provider, target).map((option) => option.value)).toEqual([null, "low", "CustomEffort"]);
+    }
+    expect(sanitizeModelBehaviorValue("openwork", { ...model, variants: {} }, "high")).toBeNull();
+    expect(getModelBehaviorOptions("openwork", { ...model, id: "future-model", variants: { newEffort: {} } })
+      .map((option) => option.value)).toEqual([null, "newEffort"]);
   });
 });

--- a/apps/app/tests/model-picker-modal.test.ts
+++ b/apps/app/tests/model-picker-modal.test.ts
@@ -1,19 +1,197 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createElement, useState } from "react";
+import type { CreateAutomation } from "@openwork/types/automations";
+import type { AutomationProviderCatalog, AutomationModelOption } from "../src/react-app/domains/automations/automation-model-options";
+import type { ModelOption } from "../src/app/types";
 
-import {
-  MODEL_PICKER_DEFAULT_SUBTITLE,
-  MODEL_PICKER_UNAVAILABLE_SUBTITLE,
-  resolveModelPickerSubtitle,
-} from "../src/react-app/domains/session/modals/model-picker-modal";
+// Base UI detects DOM support when its module loads.
+GlobalRegistrator.register({ url: "http://localhost" });
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+afterAll(async () => { await GlobalRegistrator.unregister(); });
+const { createRoot } = await import("react-dom/client");
+const auth = await import("../src/react-app/domains/cloud/den-auth-provider");
+const { createDefaultPlatform, PlatformProvider } = await import("../src/react-app/kernel/platform");
+const { ModelPickerModal, MODEL_PICKER_DEFAULT_SUBTITLE, MODEL_PICKER_UNAVAILABLE_SUBTITLE, resolveModelPickerSubtitle } = await import("../src/react-app/domains/session/modals/model-picker-modal");
 
 describe("model picker subtitle", () => {
   test("keeps the normal session subtitle by default", () => {
     expect(resolveModelPickerSubtitle(undefined)).toBe(MODEL_PICKER_DEFAULT_SUBTITLE);
   });
-
   test("supports the unavailable-model recovery subtitle", () => {
     expect(resolveModelPickerSubtitle(MODEL_PICKER_UNAVAILABLE_SUBTITLE)).toBe(
       "The model you were using is no longer available, please select a different model for this session.",
     );
   });
+});
+
+test("full picker preserves a stale effort until an explicit choice and never selects a model during effort editing", async () => {
+  const authSpy = spyOn(auth, "useDenAuth").mockReturnValue({ status: "signed_out", user: null, verifiedIdentity: null, isSignedIn: false, error: null, refresh: async () => undefined });
+  const current = { providerID: "fixture", modelID: "first" };
+  const options: ModelOption[] = [{ ...current, title: "Fixture model", description: "Fixture",
+    behaviorOptions: [{ value: null, label: "Default", description: "" }, { value: "low", label: "Low", description: "" }], isFree: false }];
+  const selected: unknown[] = [];
+  const changes: unknown[] = [];
+  function Picker() {
+    const [value, setValue] = useState<string | null>("retired");
+    return createElement(ModelPickerModal, { open: true, options, current, currentBehaviorValue: value,
+      target: "session", query: "", setQuery: () => undefined, onSelect: (model) => selected.push(model),
+      onBehaviorChange: (model, next) => { changes.push({ model, value: next }); setValue(next); },
+      onOpenSettings: () => undefined, onClose: () => undefined });
+  }
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  try {
+    await act(async () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children: createElement(Picker) })));
+    expect(document.querySelector('[data-testid="current-model-settings"]')?.textContent).toContain('"retired" (not in current catalog)');
+    expect(document.querySelector('[data-testid="current-model-settings"] [aria-pressed="true"]')).toBeNull();
+    for (const label of ["Default", "Low", "Default"]) {
+      const button = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="current-model-settings"] button')).find((item) => item.textContent === label);
+      if (!button) throw new Error(`Missing effort ${label}`);
+      await act(async () => button.click());
+      expect(document.querySelector('[data-testid="current-model-settings"] [aria-pressed="true"]')?.textContent).toBe(label);
+    }
+    expect(changes).toEqual([null, "low", null].map((value) => ({ model: current, value })));
+    expect(selected).toEqual([]);
+  } finally {
+    await act(async () => root.unmount());
+    host.remove();
+    authSpy.mockRestore();
+  }
+});
+
+test("compact picker leaves unadvertised effort unavailable but can clear a stale saved value", async () => {
+  const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
+  const { WorkspaceProvider } = await import("../src/react-app/shell/workspace-provider");
+  const { ModelSelect } = await import("../src/components/model-select");
+  const policy = await import("../src/react-app/domains/cloud/desktop-config-provider");
+  const policySpy = spyOn(policy, "useCheckDesktopRestriction").mockReturnValue(() => false);
+  const authSpy = spyOn(auth, "useDenAuth").mockReturnValue({ status: "signed_out", user: null, verifiedIdentity: null, isSignedIn: false, error: null, refresh: async () => undefined });
+  const current = { providerID: "fixture", modelID: "standard" };
+  const options: ModelOption[] = [{ ...current, title: "Standard model", description: "Fixture", isFree: false,
+    behaviorOptions: [{ value: null, label: "Default", description: "" }] }];
+  let value: string | null = null;
+  const selected: unknown[] = [];
+  const changed: Array<string | null> = [];
+  const queryClient = new QueryClient();
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const render = () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children:
+    createElement(QueryClientProvider, { client: queryClient, children:
+      createElement(WorkspaceProvider, { client: null, selectedWorkspaceRoot: "/fixture", children:
+        createElement(ModelSelect, { open: true, value: current, fallbackOptions: options, behaviorValue: value,
+          onOpenChange: () => undefined, onChange: (model) => selected.push(model),
+          onBehaviorChange: (next) => { value = next; changed.push(next); render(); } }) }) }) }));
+  const effortButton = () => Array.from(document.querySelectorAll<HTMLButtonElement>('[data-slot="model-select-root"] button'))
+    .find((button) => button.textContent?.includes("Effort"));
+  try {
+    await act(async () => render());
+    expect(effortButton()?.disabled).toBe(true);
+    expect(effortButton()?.textContent).toContain("Unavailable");
+    value = "retired";
+    await act(async () => render());
+    expect(effortButton()?.disabled).toBe(false);
+    await act(async () => effortButton()?.click());
+    expect(document.querySelector('[data-slot="model-thinking-submenu"]')?.textContent).toContain("kept unchanged");
+    const choices = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-slot="model-thinking-submenu"] button'))
+      .filter((button) => button.hasAttribute("aria-pressed"));
+    expect(choices).toHaveLength(1);
+    expect(choices[0].textContent).toContain("Default");
+    expect(choices[0].getAttribute("aria-pressed")).toBe("false");
+    await act(async () => choices[0].click());
+    expect(changed).toEqual([null]);
+    expect(selected).toEqual([]);
+    expect(effortButton()?.disabled).toBe(true);
+  } finally {
+    await act(async () => root.unmount());
+    host.remove();
+    queryClient.clear();
+    policySpy.mockRestore();
+    authSpy.mockRestore();
+  }
+});
+
+test("Automation preserves same-model settings, recovers Default and saves only on explicit submission", async () => {
+  const { AutomationEditor } = await import("../src/react-app/domains/automations/automation-editor");
+  const authSpy = spyOn(auth, "useDenAuth").mockReturnValue({ status: "signed_out", user: null, verifiedIdentity: null, isSignedIn: false, error: null, refresh: async () => undefined });
+  const modelOptions: AutomationModelOption[] = ["first", "second"].map((modelId) => ({
+    providerId: "lpr_fixture", modelId, providerName: "Fixture provider", modelName: modelId, accessKind: "authorized_custom",
+  }));
+  const catalog: AutomationProviderCatalog = { lpr_fixture: {} };
+  for (const { modelId } of modelOptions) {
+    catalog.lpr_fixture[modelId] = {
+      id: modelId, providerID: "lpr_fixture", name: modelId,
+      api: { id: modelId, url: "https://fixture.invalid", npm: "@ai-sdk/openai-compatible" },
+      capabilities: { temperature: false, reasoning: true, attachment: false, toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false }, interleaved: false },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } }, limit: { context: 1, output: 1 },
+      status: "active", options: {}, headers: {}, release_date: "2026-01-01",
+      variants: modelId === "first" ? { low: {}, high: {} } : { low: {} },
+    };
+  }
+  const initial: CreateAutomation = {
+    name: "Saved instructions", instructions: "Keep these instructions unchanged.",
+    schedule: { kind: "daily", timezone: "UTC", hour: 9, minute: 0 },
+    model: { providerId: "lpr_fixture", modelId: "first", variant: "retired" },
+  };
+  let providerCatalog = catalog;
+  const saved: CreateAutomation[] = [];
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const render = () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children:
+    createElement(AutomationEditor, { initial, initialKey: "revision-one", placement: "desktop", modelOptions,
+      providerCatalog, busy: false, openModelPickerOnMount: true, submitLabel: "Save automation",
+      onCancel: () => undefined, onSave: (input) => { saved.push(input); } }) }));
+  const click = async (selector: string) => {
+    const control = document.querySelector<HTMLElement>(selector);
+    if (!control) throw new Error(`Missing Automation control: ${selector}`);
+    await act(async () => control.click());
+  };
+  const effort = async (label: string) => {
+    const control = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="current-model-settings"] button')).find((button) => button.textContent === label);
+    if (!control) throw new Error(`Missing Automation effort: ${label}`);
+    await act(async () => control.click());
+    expect(document.querySelector('[data-testid="current-model-settings"] [aria-pressed="true"]')?.textContent).toBe(label);
+    expect(saved).toEqual([]);
+  };
+  const selectModel = async (name: string) => {
+    const control = Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent === `${name}${name}`);
+    if (!control) throw new Error(`Missing model ${name}`);
+    await act(async () => control.click());
+  };
+  try {
+    await act(async () => render());
+    expect(document.querySelector('[data-testid="current-model-settings"]')?.textContent).toContain('"retired" (not in current catalog)');
+    await selectModel("first");
+    expect(document.querySelector("#automation-model")?.textContent).toContain("retired");
+    await click("#automation-model");
+    await effort("Default");
+    await effort("High");
+    providerCatalog = {};
+    await act(async () => render());
+    expect(document.querySelector('[data-testid="current-model-settings"]')?.textContent).toContain('"high" (not in current catalog)');
+    expect(document.querySelectorAll('[data-testid="current-model-settings"] button')).toHaveLength(1);
+    await effort("Default");
+    providerCatalog = catalog;
+    await act(async () => render());
+    await effort("High");
+    await selectModel("second");
+    await click("#automation-model");
+    expect(document.querySelector('[data-testid="current-model-settings"] [aria-pressed="true"]')?.textContent).toBe("Default");
+    expect(initial.model.variant).toBe("retired");
+    expect(saved).toEqual([]);
+    const done = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((button) => button.textContent === "Done");
+    if (!done) throw new Error("Missing Done button");
+    await act(async () => done.click());
+    await click('[data-automation-editor] button[type="submit"]');
+    expect(saved).toEqual([{ ...initial, model: { providerId: "lpr_fixture", modelId: "second", variant: null } }]);
+  } finally {
+    await act(async () => root.unmount());
+    host.remove();
+    authSpy.mockRestore();
+  }
 });

--- a/docs/model-setting-continuity.md
+++ b/docs/model-setting-continuity.md
@@ -1,0 +1,41 @@
+# Model setting continuity
+
+This fix is independent of #4629. Discovery, upgrade and free-allowance
+policies are excluded. This change makes the supplied model
+settings behave consistently in the composer, full picker and Automation editor.
+
+- Provider Default is an actual `null` choice. It remains selectable, correctly
+  checked and reachable by forward/backward effort cycling.
+- Options come from the supplied runtime model variants, including custom variant
+  keys. No new client-owned model snapshot, whitelist or price table is introduced.
+- Compact effort stays unavailable when the model advertises no variants and has
+  no saved effort. A stale saved value still exposes Default so it can be cleared.
+- Displaying a saved same-model choice never normalizes or overwrites it merely
+  because metadata is missing or the value is no longer listed. The UI explains
+  that uncertainty and offers Default or a currently supplied choice.
+- Explicitly switching models carries only a setting offered by the target;
+  otherwise it chooses Default. Keyboard and compact favorite cycling agree.
+- The full picker exposes working settings controls for its current model.
+  Automation editing preserves same-model choices and resets on model changes.
+  Editing effort does not replace an unrelated global default model, submit a
+  draft, execute a task, purchase access or change credentials.
+
+Provider acceptance of an unlisted saved value is unknown. This is state/UI
+continuity, not a new gateway enforcement contract or a guarantee that the engine
+or provider can execute an unsupported variant.
+
+The existing catalog JSON, model-maintenance commands and provider materialization
+paths remain unchanged. #4513 owns scheduled mirror freshness. Do not replace
+server-delivered catalog data with compiled client maps as part of this fix.
+
+Supporting checks live in the existing model-behavior, model-picker, Automation
+options/editor and composer-controls tests. The existing
+`composer-model-picker-no-subscribe-promo` journey includes explicit Default
+selection and full-picker settings editing. Component tests cover effort round
+trips and do not replace that journey.
+Automation settings have component coverage; full Automation runtime dispatch is
+outside this change.
+
+This fix targets dev directly without the former parent stack. Prior stack-head
+runtime evidence does not validate this adapted head; fresh exact-head proof is
+required. Budgets, billing, backend catalog delivery and transport are not changed.

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -4,7 +4,10 @@ import { modelPicker, modelPickerEffortWeb } from "../worlds/chat.ts";
 
 const test = spec.world(modelPicker);
 
-test("the composer model pickers keep their controls without the OpenWork Models subscribe promo", async ({ user, step }) => {
+test("the composer model pickers keep their controls without the OpenWork Models subscribe promo", async ({ user, probe, step }) => {
+  const draft = "Keep this draft while editing model settings.";
+  await user.type("composer", draft);
+  const initial = await probe.composer();
   await user.click({ role: "button", label: "Change model" });
   await user.click({ role: "button", label: /^Model\s+Big Pickle/ });
 
@@ -33,6 +36,15 @@ test("the composer model pickers keep their controls without the OpenWork Models
     await user.notSee({ text: "Subscribe to use hosted frontier models in this workspace." });
     await user.notSee({ text: "Sign in to unlock hosted frontier models for your team." });
     await user.notSee({ role: "button", label: "Subscribe" });
+  });
+  await step("provider Default is explicit and editing it preserves the draft and model", async () => {
+    await user.see({ testId: "current-model-settings" });
+    await user.click({ role: "button", label: "Default" });
+    expect((await probe.dom('[data-testid="current-model-settings"] button[aria-pressed="true"]')).elements.map((element) => element.text)).toEqual(["Default"]);
+    await user.click({ role: "button", label: "Done" });
+    await user.see("composer", { text: draft });
+    const current = await probe.composer();
+    expect(current.selectedModelLabel).toBe(initial.selectedModelLabel);
   });
 });
 


### PR DESCRIPTION
## Purpose

Keep provider Default as a real `null` choice, preserve saved same-model effort when metadata is missing or stale, and apply explicit effort edits in the full picker and Automation editor.

- Default stays selectable and checked, including forward/backward keyboard cycling.
- Runtime variant IDs remain exact, including custom keys and the distinct named `default` variant. Unknown saved values are explained, not silently rewritten.
- Explicit favorite/model switches carry only target-compatible effort, otherwise Default. Automation model switches reset effort; reselecting the same model preserves it.
- Full-picker callbacks update effort without replacing an unrelated default model. Automation edits preserve instructions and do not submit until Save.

## Independent dev target

Old head: `d3736d1ce759fe2051a5209e507886c17043cb8c`.
Current signed head: `14fffc4df6962562daf2f2521fcd27a9733ece20`.
Fresh base and verified merge base: `858414c41c63a22eecfe331d17f3f5dd348dfc6f`.

Rebased the single settings increment directly onto current dev. **No parent stack is included.** #4629 and its ancestors are not dependencies. Managed-only discovery, upgrade/allowance policy, free access, onboarding/sign-in changes and parent fixtures remain excluded. Provider-access restrictions, billing, budgets, catalogs and provider materialization are unchanged.

## Current-dev reconciliation

- Keep dev's opaque variant normalization and its regression assertions from #4853. Add explicit `null` Default alongside, not instead of, the exact runtime keys.
- Keep the complete native-v2 `MODEL-01` journey, its custom-effort round trip and its unsupported-model negative assertions. Resolve only the import conflict; do not replace its world or restore parent-stack fixtures.
- Fix an integration regression: injecting Default into the options list must not enable compact effort for a model with no advertised variants and no saved setting. Such models retain disabled **Unavailable** effort. A stale saved value still exposes Default so it can be cleared explicitly, without switching the model.
- Add one compact-picker component regression in the existing model-picker test file. It verifies the unavailable state, stale-value recovery to `null`, and no model-selection callback.

No review threads were present when reviewed. The branch commit is authored by Jalil, signed with the existing signer and verified `G`. Publication used an exact expected-head lease on the existing branch.

## Verification: Incomplete

Passed on the final source tree (exit 0), using frozen offline app dependencies:

```sh
corepack pnpm --filter @openwork/app exec bun test --isolate ./tests/model-behavior.test.ts ./tests/automation-model-options.test.ts ./tests/model-picker-modal.test.ts ./tests/composer-model-controls.test.ts ./tests/automation-editor-state.test.ts
# 32 passed, 0 failed, 0 skipped; 220 assertions
corepack pnpm --filter @openwork/app typecheck
git diff --check origin/dev...HEAD
```

These are supporting checks, not current-head real-engine evidence.

- Failed during iteration, fixed: the new compact-picker fixture initially lacked its desktop-policy context (4 passed, 1 failed). Supplying the fixture's unrestricted policy checker corrected setup without changing production policy or removing assertions. The isolated file then passed all 5 tests, and the final five-file selection passed all 32.
- Skipped/not run: broad suites. No selected test skipped.
- Deferred: fresh exact-head cold-boot runtime evidence, Automation runtime dispatch and manual model-backed review. No paid resources, local E2E or manual review runs were launched.

The covering journey remains `composer-model-picker-no-subscribe-promo`; current dev also contributes its `MODEL-01` native-v2 case. Neither was executed for this head. The full-picker Default assertion does not establish a native-v2 Default round trip or stale-value persistence through a real runtime reload.

Prior evidence at `85e3e7afcdc8930c63fcb102d03558833900b098`, and supporting checks recorded for `d3736d1ce759fe2051a5209e507886c17043cb8c`, are historical. They must not be reused as current-head proof.

This PR remains ready with its incomplete proof stated explicitly. No merge, deployment, review request, branch deletion, live generation or production settings change is included. Details: `docs/model-setting-continuity.md`.
