### PR TITLE
test(desktop): wait for the packaged workspace route

### DIFF
--- a/evals/specs/app-smoke.e2e.test.ts
+++ b/evals/specs/app-smoke.e2e.test.ts
@@ -8,6 +8,11 @@ test("app boots with a control route and meaningful visible content", async ({ w
   expect(await probe.hash()).toBeTruthy();
   expect((await probe.text()).trim().length).toBeGreaterThan(40);
   if (world.packaged) {
+    await probe.eventually(() => probe.hash(), {
+      within: 30_000,
+      label: "packaged startup selects its empty workspace route",
+      until: (hash) => /^#\/workspace\/[^/]+\/session$/.test(hash),
+    });
     await user.see("composer", { editable: true, text: "" });
     expect(await world.packagedRuntime()).toEqual({
       bridge: true, protocol: "file:", health: 200, emptySession: true, signedOut: true, onboarding: false, crash: false,


### PR DESCRIPTION
## Summary
- Wait up to 30 seconds for the exact empty-workspace route before checking packaged startup.
- Preserve every existing composer, bridge, file-protocol, health, signed-out, onboarding, crash, empty-session-list, and engine-tool assertion.
- Change only the existing app-smoke journey; no product behavior changes.

## Diagnosis
In dev run 34273199535 at 0857e81d897b97bc7b10b35c0b2193ec3328dab3, the composer assertion passed, but packagedRuntime returned emptySession: false. Other runtime fields matched. The strict route assertion was introduced in #4608 (51c0ab92f51c13f758dbfdfe1e589fd55b639ee2).

The composer can render before asynchronous workspace loading and route normalization finish. Waiting for composer visibility alone therefore does not establish route readiness. This adds the missing bounded synchronization rather than accepting another route or removing an assertion. The failed artifact does not record the actual hash, so this is a plausible race correction, not a confirmed product startup failure or confirmed runtime resolution.

## Verification
Verdict: **Incomplete**.

- Passed: a temporary diagnostic executes the actual spec with stubbed app observations and the real eventually helper. Six checks passed, zero failed, zero skipped: delayed route readiness advances, while a stuck startup route, welcome route, existing session, settings route, and missing workspace ID time out. The diagnostic checks the configured 30-second limit and uses a shortened timeout for its negative cases. This is helper verification only, not packaged runtime evidence.
- Passed: git diff --check origin/dev...HEAD.
- Missing: exact-head Linux packaged desktop smoke and its testkit evidence. The development host is macOS; the packaged smoke script explicitly requires Linux. No remote resources were provisioned and no substitute local E2E run was used.

To complete verification on a Linux runner with the repository-pinned runtimes, workspace/evals dependencies, sidecars, Electron system libraries, and Xvfb prepared, run:

```sh
pnpm exec node apps/desktop/scripts/packaged-smoke.mjs
```

The existing CI build lane runs node apps/desktop/scripts/packaged-smoke.mjs --server-built after server compilation. This packages the binary and runs the app-smoke journey against a fresh isolated packaged profile. A generic source-app app-smoke run without OPENWORK_EVAL_ELECTRON_BINARY does not exercise the changed branch.