### PR TITLE
fix(app): keep subtasks with their original message

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -91,7 +91,7 @@ import { CodeModeTool } from "@/components/chat/code-mode-tool"
 import { codeModeToolCalls } from "@/lib/code-mode-tools"
 import { hasPreservedMcpAppResult, McpAppFrame } from "@/components/chat/mcp-app-frame"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
-import { ActiveSubagentTasksContext, SubagentRunLine } from "@/components/chat/subagent-run-line"
+import { SubagentRunLine } from "@/components/chat/subagent-run-line"
 import { ToolAggregateGroup } from "@/components/chat/tool-aggregate-group"
 import {
   CurrentToolLifecycleProvider,
@@ -117,7 +117,7 @@ import {
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
 import { useSessionActivityStore, type SessionActivityStatus } from "@/react-app/domains/session/status/session-activity-store"
-import { activeDelegatedTasks, delegatedActivityTitle, hasNoNewActivity, lastTaskProgressAt } from "@/react-app/domains/session/status/session-progress"
+import { activeDelegatedTasks, hasNoNewActivity, lastTaskProgressAt } from "@/react-app/domains/session/status/session-progress"
 import { revalidateWorkspaceSessionSync } from "@/react-app/domains/session/sync/session-sync"
 import { useWorkspaceMaybe } from "@/react-app/shell/workspace-provider"
 import { formatElapsedSeconds, formatToolCallDuration } from "@/lib/tool-call-duration"
@@ -135,6 +135,8 @@ const SEARCH_HIGHLIGHT_MARK_CLASS = "rounded px-0.5 bg-amber-4/70 text-current"
 
 /** Above this many step rows a finished turn folds into one summary line. */
 const COLLAPSED_STEP_RUN_MIN_ROWS = 4
+
+const ParentRunActiveContext = React.createContext(true)
 
 function MessageTimestamp({ message, className }: { message: UIMessage; className?: string }) {
   const created = getMessageCreated(message)
@@ -187,11 +189,12 @@ class ToolMessage extends React.Component<ToolMessageProps, { failed: boolean }>
 
 const ToolMessageInner = ({ part }: ToolMessageProps) => {
   const { connectorIdentities, onMcpReconnect, onMcpReopenAuthorization, onMcpRetry } = useMessageList()
+  const parentActive = React.useContext(ParentRunActiveContext)
   const resolveLifecycle = useCurrentToolLifecycleResolver()
   const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
 
   // Delegated work has its own lifecycle, even after a parent follow-up/error.
-  if (isTaskToolPart(part)) return <SubagentRunLine part={part} />
+  if (isTaskToolPart(part)) return <SubagentRunLine part={part} parentActive={parentActive} />
 
   if (part.type === "dynamic-tool") {
     const calls = codeModeToolCalls(part)
@@ -1479,7 +1482,6 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
   const { workspaceId, sessionId } = useMessageList()
   const workspace = useWorkspaceMaybe()
   const tasks = React.useMemo(() => activeDelegatedTasks(messages), [messages])
-  const carriedTaskIds = React.useMemo(() => new Set(tasks.map((part) => part.toolCallId)), [tasks])
   const [observedAt] = React.useState(() => Date.now())
   const lastProgressAt = useSessionActivityStore((state) => {
     const records = state.recordsByWorkspaceId[workspaceId]
@@ -1496,7 +1498,6 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
   const runActive = status === "submitted" || status === "streaming" || status === "retrying"
   const syncDegraded = syncHealth?.degraded === true
   const activityActive = runActive || tasks.length > 0
-  const delegationTitle = useSessionActivityStore((state) => delegatedActivityTitle(tasks, state.recordsByWorkspaceId[workspaceId], syncDegraded, runActive))
   const runStartedAtRef = React.useRef<number | null>(null)
   const [runElapsedSeconds, setRunElapsedSeconds] = React.useState(0)
   // Anchor the counter to the user message that started the run (server
@@ -1560,7 +1561,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
   )
 
   return (
-    <ActiveSubagentTasksContext.Provider value={carriedTaskIds}>
+    <ParentRunActiveContext.Provider value={runActive}>
     <CurrentToolLifecycleProvider
       activityStatus={activityStatus}
       currentToolCallIds={currentToolCallIds}
@@ -1595,12 +1596,6 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
         )
         })}
 
-        {tasks.length > 0 ? (
-          <Message data-testid="active-subagents" className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
-            <div className="text-sm font-medium">{delegationTitle}</div>
-            {tasks.map((part) => <SubagentRunLine key={part.toolCallId} part={part} liveSummary parentActive={runActive} />)}
-          </Message>
-        ) : null}
         {noNewActivity ? (
           <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-1 px-2 md:px-10">
             <div data-loading-message="no-new-activity" role="status" className="text-sm text-amber-11">No new activity</div>
@@ -1614,6 +1609,6 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
         {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
       </div>
     </CurrentToolLifecycleProvider>
-    </ActiveSubagentTasksContext.Provider>
+    </ParentRunActiveContext.Provider>
   )
 }

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { ArrowUpRight, ShieldAlert } from "lucide-react"
 
 import {
@@ -20,12 +20,9 @@ import { statusKey } from "@/react-app/domains/session/sync/session-sync"
 import { useQueryCacheState } from "@/react-app/infra/query-cache-state"
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
 
-export const ActiveSubagentTasksContext = createContext<ReadonlySet<string>>(new Set())
-
 type SubagentRunLineProps = {
   part: TaskToolPart
   className?: string
-  liveSummary?: boolean
   parentActive?: boolean
 }
 
@@ -69,12 +66,10 @@ function agentName(slug: string): string {
  * session in the main chat surface. Without that route, details stay limited
  * to safe task/output labels, never raw prompts or payloads.
  */
-export function SubagentRunLine({ part, className, liveSummary = false, parentActive = true }: SubagentRunLineProps) {
+export function SubagentRunLine({ part, className, parentActive = true }: SubagentRunLineProps) {
   const [open, setOpen] = useState(false)
   const { onOpenSubagentSession, syncDegraded, workspaceId } = useMessageList()
   const childSessionId = taskChildSessionId(part)
-  const carriedTasks = useContext(ActiveSubagentTasksContext)
-  const history = !liveSummary && carriedTasks.has(part.toolCallId)
   const child = useSessionActivityStore((state) => (
     childSessionId
       ? state.recordsByWorkspaceId[workspaceId]?.[childSessionId]
@@ -104,14 +99,14 @@ export function SubagentRunLine({ part, className, liveSummary = false, parentAc
   useEffect(() => {
     // While run liveness is unconfirmed the counter must not tick; the
     // module-scoped anchor resumes the true elapsed time on recovery.
-    if (!inFlight || startedAt === null || syncDegraded || history) return
+    if (!inFlight || startedAt === null || syncDegraded) return
     const update = () => {
       setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)))
     }
     update()
     const interval = window.setInterval(update, 1000)
     return () => window.clearInterval(interval)
-  }, [inFlight, startedAt, part.toolCallId, syncDegraded, history])
+  }, [inFlight, startedAt, part.toolCallId, syncDegraded])
   const title = part.input?.description?.trim().slice(0, 160) || "Sub-agent task"
   const agent = agentName(part.input?.subagent_type ?? "")
   const status = permissionPending
@@ -128,15 +123,6 @@ export function SubagentRunLine({ part, className, liveSummary = false, parentAc
     : isFailed
       ? "Task failed"
       : "Completed"
-
-  if (history) {
-    return (
-      <div data-subagent-history={part.toolCallId} className={cn("flex min-w-0 max-w-full flex-col gap-0.5 text-sm text-muted-foreground", className)}>
-        <span className="truncate">{title} · {agent} agent</span>
-        <span className="text-xs text-muted-foreground/70">Delegated task - activity below</span>
-      </div>
-    )
-  }
 
   const lines = (
     <>

--- a/apps/app/src/react-app/domains/session/status/session-progress.ts
+++ b/apps/app/src/react-app/domains/session/status/session-progress.ts
@@ -17,25 +17,6 @@ export function activeDelegatedTasks(messages: UIMessage[]): TaskToolPart[] {
   return [...calls.values()].filter(isToolPartInFlight);
 }
 
-export function delegatedActivityTitle(tasks: TaskToolPart[], children: Record<string, {
-  runActive: boolean; runStatusAt: number; retrying: boolean; errorActive: boolean;
-  waitingPermissionIds: string[]; waitingQuestionIds: string[];
-}> | undefined, disconnected: boolean, parentActive = true): string {
-  const count = tasks.length;
-  const noun = count === 1 ? "subagent" : "subagents";
-  if (disconnected) return `Checking ${count} ${noun}`;
-  const running = tasks.filter((task) => {
-    const id = taskChildSessionId(task);
-    const child = id ? children?.[id] : undefined;
-    return (!child && parentActive) || (child && !child.errorActive && !child.retrying
-      && child.waitingPermissionIds.length === 0 && child.waitingQuestionIds.length === 0
-      && (child.runActive || (parentActive && child.runStatusAt === 0)));
-  }).length;
-  if (running === count) return `Running ${count} ${noun}`;
-  if (running > 0) return `Running ${running} ${running === 1 ? "subagent" : "subagents"} · ${count - running} waiting`;
-  return `Subagent activity · ${count} ${count === 1 ? "task" : "tasks"}`;
-}
-
 /** Fixed tool categories keep context useful without reflecting arguments or payloads. */
 function safeToolActivity(part: UIMessage["parts"][number]): string {
   if (!isToolUIPart(part)) return "Tool activity received";

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -453,9 +453,9 @@ function createSessionErrorEvalMessages(sessionId: string, error: unknown = SESS
   ];
 }
 
-function createSubagentActivityEvalMessages(sessionId: string, childSessionId?: string): UIMessage[] {
+function createSubagentActivityEvalMessages(sessionId: string, childSessionId?: string, withFollowup = false): UIMessage[] {
   const now = Date.now();
-  return [
+  const messages: UIMessage[] = [
     {
       id: `${sessionId}:eval-subagent-user`,
       role: "user",
@@ -482,6 +482,15 @@ function createSubagentActivityEvalMessages(sessionId: string, childSessionId?: 
       metadata: { opencode: { created: now + 1 } },
     },
   ];
+  if (withFollowup) {
+    messages.push({
+      id: `${sessionId}:eval-subagent-followup`,
+      role: "user",
+      parts: [{ type: "text", text: "What is the update?" }],
+      metadata: { opencode: { created: now + 2 } },
+    });
+  }
+  return messages;
 }
 
 function createChatLoadingEvalMessages(sessionId: string): UIMessage[] {
@@ -1556,13 +1565,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
       description: "Dev-only eval hook that renders a deterministic running delegated-task row.",
       sideEffect: "mutation",
       disabled: !props.sessionId,
-      args: [{ name: "childSessionId", type: "string", description: "Optional child session represented by the task row." }],
+      args: [
+        { name: "childSessionId", type: "string", description: "Optional child session represented by the task row." },
+        { name: "withFollowup", type: "boolean", description: "Include a user follow-up after the delegated task." },
+      ],
       execute: (args) => {
         const rawChildSessionId = args && typeof args === "object" ? Reflect.get(args, "childSessionId") : undefined;
         const childSessionId = typeof rawChildSessionId === "string" && rawChildSessionId.trim()
           ? rawChildSessionId.trim()
           : undefined;
-        setEvalMarkdownMessages(createSubagentActivityEvalMessages(props.sessionId, childSessionId));
+        const withFollowup = Boolean(args && typeof args === "object" && Reflect.get(args, "withFollowup") === true);
+        setEvalMarkdownMessages(createSubagentActivityEvalMessages(props.sessionId, childSessionId, withFollowup));
         useSessionActivityStore.getState().setRunStatus(
           props.workspaceId,
           props.sessionId,

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -100,14 +100,14 @@ const delegated: UIMessage = { id: "assistant", role: "assistant", parts: [task]
 const followup: UIMessage = { id: "followup", role: "user", parts: [{ type: "text", text: "What is the update?" }] };
 
 describe("task-linked meaningful progress", () => {
-  test("carries old active tasks below the latest user follow-up without a second live card", () => {
+  test.each<ThreadStatus>(["streaming", "ready"])("keeps delegated tasks before the follow-up while the parent is %s", (status) => {
     const messages = [userMessage, delegated, followup];
     expect(activeDelegatedTasks(messages)).toEqual([task]);
-    const html = renderList(messages, "streaming");
-    expect(html).toContain("Running 1 subagent");
-    expect(html.indexOf('data-testid="active-subagents"')).toBeGreaterThan(html.indexOf("What is the update?"));
+    const html = renderList(messages, status);
     expect(html.match(/data-subagent-run="delegation"/g)).toHaveLength(1);
-    expect(html).toContain('data-subagent-history="delegation"');
+    expect(html.indexOf('data-subagent-run="delegation"')).toBeLessThan(html.indexOf("What is the update?"));
+    expect(html).not.toContain('data-testid="active-subagents"');
+    expect(html).not.toContain("data-subagent-history");
     expect(html).not.toContain('data-loading-message="working"');
     expect(html).not.toContain("PRIVATE TASK PROMPT");
   });
@@ -116,15 +116,17 @@ describe("task-linked meaningful progress", () => {
     expect(activeDelegatedTasks([delegated, delegated, followup])).toEqual([task]);
     const completed: UIMessage = { ...delegated, parts: [{ ...task, state: "output-available", output: "PRIVATE RESULT" }] };
     expect(activeDelegatedTasks([delegated, followup, completed])).toEqual([]);
-    const html = renderList([userMessage, completed], "ready");
+    const html = renderList([userMessage, completed, followup], "ready");
     expect(html).not.toContain('data-testid="active-subagents"');
     expect(html).toContain("Completed");
+    expect(html.match(/data-subagent-run="delegation"/g)).toHaveLength(1);
+    expect(html.indexOf('data-subagent-run="delegation"')).toBeLessThan(html.indexOf("What is the update?"));
     expect(html).not.toContain("PRIVATE RESULT");
   });
 
   test("does not claim an unobserved child is running after its parent stops", () => {
     const html = renderList([userMessage, delegated, followup], "ready");
-    expect(html).toContain("Subagent activity · 1 task");
+    expect(html).toContain('data-subagent-activity="waiting-result"');
     expect(html).toContain("Waiting for task result");
     expect(html).not.toContain("Running 1 subagent");
     expect(html).not.toContain("Completed");
@@ -165,12 +167,12 @@ describe("task-linked meaningful progress", () => {
       expect(html).not.toContain('data-testid="session-error-resume"');
       expect(revalidate).toHaveBeenCalledTimes(1);
       expect(revalidate).toHaveBeenCalledWith({ workspaceId: "ws", baseUrl: "http://localhost/test-engine" });
-      const inspect = container.querySelector<HTMLButtonElement>('[data-testid="active-subagents"] button');
+      const inspect = container.querySelector<HTMLButtonElement>('[data-subagent-run="delegation"] button');
       if (!inspect) throw new Error("Missing child inspection button");
       await act(async () => { inspect.click(); });
       expect(inspectChild).toHaveBeenCalledTimes(1);
       expect(inspectChild).toHaveBeenCalledWith("child");
-      expect(container.querySelectorAll('[data-subagent-history] button')).toHaveLength(0);
+      expect(container.querySelectorAll('[data-subagent-history], [data-testid="active-subagents"]')).toHaveLength(0);
       await act(async () => { root.render(view()); });
       expect(revalidate).toHaveBeenCalledTimes(1);
       await act(async () => { store.observeTranscript("ws", "child", [output]); });
@@ -178,7 +180,7 @@ describe("task-linked meaningful progress", () => {
       expect(lastTaskProgressAt(1_000, [task], records)).toBe(62_000);
       html = container.innerHTML;
       expect(html).not.toContain('data-loading-message="no-new-activity"');
-      expect(html).toContain("Running 1 subagent");
+      expect(html).toContain('data-subagent-activity="shimmer"');
       expect(html).not.toContain("PRIVATE OUTPUT");
       expect(html).toContain("Last activity: Response updated");
       clock.mockReturnValue(123_000);
@@ -198,7 +200,7 @@ describe("task-linked meaningful progress", () => {
       expect(container.innerHTML).not.toContain('data-loading-message="no-new-activity"');
       expect(container.innerHTML).toContain("Retrying");
       await act(async () => { store.setRunStatus("ws", "child", { type: "idle" }); });
-      expect(container.innerHTML).toContain("Subagent activity · 1 task");
+      expect(container.innerHTML).toContain('data-subagent-activity="waiting-result"');
       expect(container.innerHTML).not.toContain("Completed");
       expect(container.innerHTML).toContain("Waiting for task result");
     } finally {

--- a/evals/specs/task-activity-shimmer.e2e.test.ts
+++ b/evals/specs/task-activity-shimmer.e2e.test.ts
@@ -4,17 +4,23 @@ import { taskActivity } from "../worlds/chat.ts";
 
 const test = spec.world(taskActivity);
 
-test("running delegated-task activity uses a quiet shimmer without a spinner", async ({ user, probe }) => {
-  await user.see({ testId: "active-subagents" }, { text: /Running 1 subagent/ });
+test("delegated-task activity stays with its original message after a follow-up", async ({ user, probe }) => {
+  await user.see({ text: "Build isolated Azure repro" });
+  await user.see({ text: "What is the update?" });
   // TODO(primitive): inspect the visual treatment classes on a delegated-task status row.
   const rendered = await probe.eval(() => {
     const row = document.querySelector<HTMLElement>('[data-subagent-activity="shimmer"]');
+    const original = document.querySelector<HTMLElement>('[data-message-id$=":eval-subagent-assistant"]');
+    const followup = document.querySelector<HTMLElement>('[data-message-id$=":eval-subagent-followup"]');
     return {
       text: row instanceof HTMLElement ? row.innerText.replace(/\s+/g, " ").trim() : "",
       hasSpinner: Boolean(row?.querySelector<HTMLElement>(".animate-spin")),
       hasShimmer: Boolean(row?.querySelector<HTMLElement>(".ow-text-shimmer")),
       liveCards: document.querySelectorAll('[data-subagent-run="eval-subagent-activity"]').length,
       historyEntries: document.querySelectorAll('[data-subagent-history="eval-subagent-activity"]').length,
+      carriedSummaries: document.querySelectorAll('[data-testid="active-subagents"]').length,
+      staysWithOriginalMessage: Boolean(row && original?.contains(row)),
+      precedesFollowup: Boolean(row && followup && (row.compareDocumentPosition(followup) & Node.DOCUMENT_POSITION_FOLLOWING)),
       rawPromptVisible: document.body.innerText.includes("Reproduce the Azure failure in isolation."),
     };
   });
@@ -23,7 +29,10 @@ test("running delegated-task activity uses a quiet shimmer without a spinner", a
     hasSpinner: false,
     hasShimmer: true,
     liveCards: 1,
-    historyEntries: 1,
+    historyEntries: 0,
+    carriedSummaries: 0,
+    staysWithOriginalMessage: true,
+    precedesFollowup: true,
     rawPromptVisible: false,
   });
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1633,7 +1633,7 @@ export async function taskActivity(seed: Seed) {
   const app = await seed.desktop({ name: "task-activity-shimmer" });
   const workspace = await seed.workspace(app, seed.tmpPath("task-activity-shimmer"));
   const session = await seedSessionRetry(seed, app);
-  await arrangeControl(seed, app, "eval.task_activity.seed");
+  await arrangeControl(seed, app, "eval.task_activity.seed", { withFollowup: true });
   return { app, workspace, session };
 }
 


### PR DESCRIPTION
## Summary

A follow-up should not move earlier delegated tasks beneath the new message. This reverts only the subtask carry-forward display from #4635, not the rest of that PR.

- Keep each task card at its original transcript message; remove the trailing summary and historical placeholder.
- Preserve parent-liveness handling, child-chat navigation, waiting/retry/error feedback, meaningful-progress checks, and all send-admission and recovery safeguards.
- Leave restart recovery from #4636 unchanged.
- Extend the existing task-activity journey with a follow-up, original-message ownership, and no-duplicate assertions. No new test files.

## Verification — Incomplete

Passed on the unchanged source tree included in this commit:

```sh
pnpm --filter @openwork/app exec bun test --isolate tests/message-list-loading.test.tsx tests/subagent-run-line.test.tsx tests/current-turn-tool-activity.test.ts
# exit 0: 22 passed, 0 failed, no skips reported

git diff --check
# passed
```

These are focused regression checks, not real-app runtime proof. They cover task placement while the parent is active or stopped, settled-task placement, stopped-parent status, child navigation, and existing progress feedback.

Deferred: the updated `task-activity-shimmer` journey has not been executed or published for this head. Run it on the exact PR commit with `OPENWORK_EVAL_REF=<PR-head-SHA> pnpm evals:e2e task-activity-shimmer` and publish that run before treating runtime verification as Passed. The deterministic display fixture does not certify native child cancellation or follow-up delivery.

The branch is based on freshly fetched canonical `dev` at `0857e81d8`. No merge, release, or deployment is included.