### PR TITLE
Simplify desktop Library add options

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -690,7 +690,7 @@ export default {
   "extensions.kind_plugin_hint": "Skills, commands and servers bundled together.",
   "extensions.kind_mcp": "Organization MCP",
   "extensions.kind_mcp_hint": "Add a remote MCP server to your organization Library.",
-  "extensions.kind_workspace_mcp": "Workspace MCP",
+  "extensions.kind_workspace_mcp": "Local MCP",
   "extensions.kind_workspace_mcp_hint": "Connect an MCP server in this workspace.",
   "extensions.kind_connection": "Connection",
   "extensions.kind_connection_hint": "Browse hosted services and manage setup for this organization in OpenWork Den.",

--- a/apps/app/src/react-app/domains/settings/library.ts
+++ b/apps/app/src/react-app/domains/settings/library.ts
@@ -190,7 +190,7 @@ const LIBRARY_ITEM_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 export function libraryAddKindsForFilter(filter: string): LibraryAddKind[] {
   switch (filter) {
     case "all":
-      return [...LIBRARY_ADD_KINDS];
+      return ["skill", "command", "agent", "workspace-mcp", "connection"];
     case "skill":
       return ["skill"];
     case "command":
@@ -198,9 +198,9 @@ export function libraryAddKindsForFilter(filter: string): LibraryAddKind[] {
     case "agent":
       return ["agent"];
     case "mcp":
-      return ["mcp", "workspace-mcp"];
+      return ["workspace-mcp"];
     case "plugin":
-      return ["plugin"];
+      return [];
     case "connection":
       return ["connection"];
     default:

--- a/apps/app/src/react-app/domains/settings/pages/library-add-kind-picker.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/library-add-kind-picker.tsx
@@ -24,8 +24,6 @@ const PICKER_KIND_ORDER: LibraryAddKind[] = [
   "skill",
   "command",
   "agent",
-  "plugin",
-  "mcp",
   "workspace-mcp",
   "connection",
 ];
@@ -188,17 +186,16 @@ export function LibraryAddKindPicker(props: {
   onClose: () => void;
   onSelect: (kind: LibraryAddKind) => void;
 }) {
-  const firstKind = props.kinds[0];
+  const orderedKinds = PICKER_KIND_ORDER.filter((kind) => props.kinds.includes(kind));
+  const firstKind = orderedKinds[0];
   const [selected, setSelected] = useState<LibraryAddKind | null>(firstKind ?? null);
 
   useEffect(() => {
     if (!props.open) return;
     setSelected((current) => (
-      current && props.kinds.includes(current) ? current : props.kinds[0] ?? null
+      current && PICKER_KIND_ORDER.includes(current) && props.kinds.includes(current) ? current : firstKind ?? null
     ));
-  }, [props.open, props.kinds]);
-
-  const orderedKinds = PICKER_KIND_ORDER.filter((kind) => props.kinds.includes(kind));
+  }, [props.open, props.kinds, firstKind]);
 
   const handleContinue = () => {
     if (!selected) return;

--- a/apps/app/tests/library-add-kind-picker-source.test.ts
+++ b/apps/app/tests/library-add-kind-picker-source.test.ts
@@ -8,9 +8,9 @@ const pickerSource = readFileSync(
 );
 
 describe("Add to your Library picker presentation", () => {
-  test("renders all seven choices in one responsive selection surface", () => {
+  test("renders all five choices in one responsive selection surface", () => {
     expect(pickerSource.match(/role="radiogroup"/g)).toHaveLength(1);
-    expect(pickerSource).toContain('"skill",\n  "command",\n  "agent",\n  "plugin",\n  "mcp",\n  "workspace-mcp",\n  "connection"');
+    expect(pickerSource).toContain('"skill",\n  "command",\n  "agent",\n  "workspace-mcp",\n  "connection"');
     expect(pickerSource).not.toContain("function KindSection");
     expect(pickerSource).not.toContain('t("extensions.add_picker_make")');
     expect(pickerSource).not.toContain('t("extensions.add_picker_connect")');

--- a/apps/app/tests/library-destination.test.ts
+++ b/apps/app/tests/library-destination.test.ts
@@ -119,17 +119,15 @@ describe("library destination", () => {
     expect(libraryAddKindsForFilter("skill")).toEqual(["skill"]);
     expect(libraryAddKindsForFilter("command")).toEqual(["command"]);
     expect(libraryAddKindsForFilter("agent")).toEqual(["agent"]);
-    expect(libraryAddKindsForFilter("mcp")).toEqual(["mcp", "workspace-mcp"]);
-    expect(libraryAddKindsForFilter("plugin")).toEqual(["plugin"]);
+    expect(libraryAddKindsForFilter("mcp")).toEqual(["workspace-mcp"]);
+    expect(libraryAddKindsForFilter("plugin")).toEqual([]);
     expect(libraryAddKindsForFilter("connection")).toEqual(["connection"]);
     expect(libraryAddKindsForFilter("app")).toEqual([]);
     expect(libraryAddKindsForFilter("all")).toEqual([
       "skill",
       "command",
       "agent",
-      "mcp",
       "workspace-mcp",
-      "plugin",
       "connection",
     ]);
   });

--- a/evals/specs/library-add-connector-discovery.e2e.test.ts
+++ b/evals/specs/library-add-connector-discovery.e2e.test.ts
@@ -18,9 +18,7 @@ const expectedChoices = [
   "Skill",
   "Command",
   "Agent",
-  "Plugin",
-  "Organization MCP",
-  "Workspace MCP",
+  "Local MCP",
   "Connection",
 ];
 const expectedConnectorCues = [
@@ -191,7 +189,7 @@ test(title, async ({ evidence, place }) => {
   expect(picker.lightTileBackgrounds).toEqual(expectedConnectorCues.map(() => "rgb(255, 255, 255)"));
   expect(picker.darkTileBackgrounds).toEqual(expectedConnectorCues.map(() => "rgb(255, 255, 255)"));
   evidence.recordAssertionEvidence(
-    "Add to your Library is one responsive seven-choice surface with recognizable hosted-service cues",
+    "Add to your Library is one responsive five-choice surface with recognizable hosted-service cues",
     `At 820×760 the picker rendered ${JSON.stringify(picker)}.`,
     JSON.stringify(picker.choices) === JSON.stringify(expectedChoices)
       && picker.radioGroups === 1
@@ -218,7 +216,7 @@ test(title, async ({ evidence, place }) => {
   {
     const shot = await screenshot(desktop);
     const seen = await validate(shot, [
-      "The Add to your Library dialog presents Skill, Command, Agent, Plugin, Organization MCP, Workspace MCP, and Connection as one continuous selection surface",
+      "The Add to your Library dialog presents Skill, Command, Agent, Local MCP, and Connection as one continuous selection surface",
       "The Connection choice visibly includes a compact row of recognizable service marks for Notion, Slack, Google Workspace, Microsoft 365, and Linear",
       "The dialog has no separate WHAT ARE YOU MAKING or OR CONNECT SOMETHING sections",
       "The dialog, descriptions, connector marks, Cancel button, and Continue button fit within the desktop viewport without clipping",
@@ -263,7 +261,7 @@ test(title, async ({ evidence, place }) => {
       "The Add to your Library dialog is visibly rendered in a dark theme",
       "Connection is the selected choice and remains in the same continuous list as the OpenWork creation and MCP choices",
       "The Connection choice visibly includes recognizable marks for Notion, Slack, Google Workspace, Microsoft 365, and Linear",
-      "The dark-theme dialog, all seven choices, descriptions, connector marks, Cancel button, and Continue button fit within the desktop viewport without clipping",
+      "The dark-theme dialog, all five choices, descriptions, connector marks, Cancel button, and Continue button fit within the desktop viewport without clipping",
     ]);
     expect(seen.ok, seen.why).toBe(true);
   } finally {


### PR DESCRIPTION
The desktop Library Add dialog now offers Skill, Command, Agent, Local MCP, and Connection. Remove Plugin and Organization MCP from the available creation options, including filtered Library views, and rename Workspace MCP to Local MCP.

Validation: 22 focused tests passed. The existing Library connector discovery journey now expects the five choices; Daytona runtime verification passed (1 passed, 0 failed, 0 skipped). Screenshot evidence publication remains incomplete because the configured vision API key returned HTTP 401; the PR stays draft until publication succeeds.

Reproduce: open the desktop Library, click Add, verify the five options and select Local MCP. In the MCP filter, Add should offer only Local MCP; the Plugin filter should have no Add action.
