### PR TITLE
fix(landing): remove in-progress SOC 2 badge from enterprise hero

### DIFF
--- a/ee/apps/landing/components/landing-enterprise.tsx
+++ b/ee/apps/landing/components/landing-enterprise.tsx
@@ -157,7 +157,6 @@ export function LandingEnterprise(props: Props) {
             </div>
             <div className="mt-7 flex flex-wrap gap-2.5">
               <span className="lp-pill-secondary lp-pill-sm !h-9 gap-2 !text-[13px]"><span className="h-2 w-2 rounded-full bg-[#10B981]" />SOC 2 Type I</span>
-              <span className="lp-pill-secondary lp-pill-sm !h-9 gap-2 !text-[13px]"><span className="h-2 w-2 rounded-full bg-[#F59E0B]" />SOC 2 Type II — in progress</span>
               <span className="lp-pill-secondary lp-pill-sm !h-9 !text-[13px]">SAML SSO + SCIM</span>
               <span className="lp-pill-secondary lp-pill-sm !h-9 !text-[13px]">Audit logs</span>
               <span className="lp-pill-secondary lp-pill-sm !h-9 !text-[13px]">Self-host or managed</span>

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -117,6 +117,21 @@ test("visitors can read the trust badge and access every footer link at responsi
     ]);
     evidence.recordAssertionEvidence(`Footer remains readable and complete at ${width}px`, JSON.stringify(facts), true);
   }
+
+  await navigate(browser.client, `${origin}/enterprise`);
+  const hero = await eventually(() => evaluateOnSurface(browser, () => {
+    const section = document.querySelector<HTMLElement>("main > section");
+    if (!section) throw new Error("Enterprise hero missing");
+    return section.innerText;
+  }), {
+    within: 30_000,
+    until: (text) => typeof text === "string" && text.includes("OpenWork Enterprise"),
+  });
+  expect(hero).not.toContain("SOC 2 Type II");
+  for (const badge of ["SOC 2 Type I", "SAML SSO + SCIM", "Audit logs", "Self-host or managed", "White labeling"]) {
+    expect(hero).toContain(badge);
+  }
+  evidence.recordAssertionEvidence("Enterprise hero omits the in-progress Type II badge and retains the other badges", hero, true);
 });
 
 test("download CTAs request the detected installer once and retain the alternative downloads", async ({ evidence }) => {


### PR DESCRIPTION
## Summary
- Remove the “SOC 2 Type II — in progress” badge and its amber dot from the enterprise hero.
- Preserve the SOC 2 Type I badge, all other hero badges, compliance copy, and Trust Center.
- Extend the existing landing-page trust-badge journey to check the removal and retained badges.

## Verification
**Verdict: Incomplete** — the selected browser journey passed; two unrelated tests were excluded by the name filter. No full-suite claim.

- Head: `fd96a6a08`.
- Passed: `git diff --check`.
- Passed: `OPENWORK_EVAL_LANDING_URL=http://127.0.0.1:3418 pnpm evals:pr specs/landing-pricing.test.ts -t "visitors can read the trust badge"` — exit 0, 1 passed, 0 failed, 2 filtered/skipped.
- Placement: local Chrome against a freshly started landing server from this worktree; direct PR-lane Vitest, no E2E placement override.
- The journey checks the enterprise hero and existing footer assertions at 320, 768, 1024, and 1440px.
- Initial collection was blocked by missing `@openwork/paths`; installing the declared `@openwork/world` workspace dependencies resolved it before the passing run.
- Deferred: unrelated pricing and download journeys, broader suite. Required CI remains unchanged.

## Reproduce
Start the landing app with `OPENWORK_DEV_MODE=1 pnpm --filter @openwork-ee/landing exec next dev --hostname 127.0.0.1 --port 3418`, then run the focused command above.

No merge or deployment included.