### PR TITLE
fix(den): restore skill verification and reduce editing prompts

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -113,13 +113,13 @@ export function hasPluginArchCapability(context: PluginArchActorContext, capabil
   return isPluginArchOrgAdmin(context)
 }
 
-function ensureFreshPluginArchAdmin(context: PluginArchActorContext) {
+function ensureFreshPluginArchAdmin(context: PluginArchActorContext, sessionMaxAgeMs?: number) {
   if (context.apiKey === true || context.automation === true) {
     // Session freshness is a step-up check for interactive humans. API keys and connector automation
     // are non-interactive principals authorized by their scoped organization membership.
     return
   }
-  if (!isPluginArchOrgAdmin(context) || hasFreshPrivilegedSession({ session: context.session })) {
+  if (!isPluginArchOrgAdmin(context) || hasFreshPrivilegedSession({ session: context.session }, new Date(), sessionMaxAgeMs)) {
     return
   }
 
@@ -459,12 +459,13 @@ export async function requirePluginArchCapability(context: PluginArchActorContex
 export async function requirePluginArchResourceRole(input: {
   context: PluginArchActorContext
   requireFreshSession?: boolean
+  sessionMaxAgeMs?: number
   resourceId: ConfigObjectId | ConnectorInstanceId | MarketplaceId | PluginId
   resourceKind: PluginArchResourceKind
   role: PluginArchRole
 }) {
   if (input.role !== "viewer" && input.requireFreshSession !== false) {
-    ensureFreshPluginArchAdmin(input.context)
+    ensureFreshPluginArchAdmin(input.context, input.sessionMaxAgeMs)
   }
 
   const resolved = await resolvePluginArchResourceRole(input as RequireResourceRoleInput)

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -30,6 +30,7 @@ import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { hasSkillFrontmatterName, parseSkillMarkdown } from "@openwork-ee/utils"
 import type { PluginArchActorContext, PluginArchResourceKind, PluginArchRole } from "./access.js"
 import { isPluginArchOrgAdmin, PluginArchAuthorizationError, pluginArchResourceHasExpandedAudience, requirePluginArchResourceRole, resolvePluginArchGrantRole, resolvePluginArchResourceRole } from "./access.js"
+import { CONTENT_EDIT_SESSION_MAX_AGE_MS } from "../shared.js"
 import { clampCodePoints, clampUtf8Bytes, PROJECTION_TEXT_MAX_BYTES, PROJECTION_TITLE_MAX_CHARS } from "./projection-text.js"
 import {
   AGENT_PLUGIN_V1_VERSION,
@@ -1306,6 +1307,7 @@ async function ensureEditablePlugin(
   context: PluginArchActorContext,
   pluginId: PluginId,
   requireFreshSession?: boolean,
+  sessionMaxAgeMs?: number,
 ) {
   const row = await getPluginRow(context.organizationContext.organization.id, pluginId)
   if (!row) {
@@ -1314,6 +1316,7 @@ async function ensureEditablePlugin(
   await requirePluginArchResourceRole({
     context,
     requireFreshSession,
+    sessionMaxAgeMs,
     resourceId: row.id,
     resourceKind: "plugin",
     role: "editor",
@@ -1672,7 +1675,8 @@ export async function createConfigObject(input: {
     pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: pluginId, resourceKind: "plugin" })))
   const requireFreshSession = input.requireFreshSession ?? targetExposure.some(Boolean)
   for (const pluginId of input.pluginIds ?? []) {
-    await ensureEditablePlugin(input.context, pluginId, requireFreshSession)
+    await ensureEditablePlugin(input.context, pluginId, requireFreshSession,
+      input.objectType === "skill" ? CONTENT_EDIT_SESSION_MAX_AGE_MS : undefined)
   }
 
   const now = new Date()
@@ -1804,7 +1808,10 @@ export async function createConfigObjectVersion(input: { context: PluginArchActo
     throw new PluginArchRouteFailure(404, "config_object_not_found", "Config object not found.")
   }
   const requireFreshSession = await pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: row.id, resourceKind: "config_object" })
-  await requirePluginArchResourceRole({ context: input.context, requireFreshSession, resourceId: row.id, resourceKind: "config_object", role: "editor" })
+  await requirePluginArchResourceRole({
+    context: input.context, requireFreshSession, resourceId: row.id, resourceKind: "config_object", role: "editor",
+    sessionMaxAgeMs: row.objectType === "skill" ? CONTENT_EDIT_SESSION_MAX_AGE_MS : undefined,
+  })
 
   const now = new Date()
   const projection = deriveProjection({ objectType: row.objectType, value: input.value })
@@ -2890,7 +2897,7 @@ export async function createPluginBundle(input: {
 
 export async function updatePlugin(input: { context: PluginArchActorContext; description?: string | null; name?: string; pluginId: PluginId }) {
   const requireFreshSession = await pluginArchResourceHasExpandedAudience({ context: input.context, resourceId: input.pluginId, resourceKind: "plugin" })
-  const row = await ensureEditablePlugin(input.context, input.pluginId, requireFreshSession)
+  const row = await ensureEditablePlugin(input.context, input.pluginId, requireFreshSession, CONTENT_EDIT_SESSION_MAX_AGE_MS)
   const updatedAt = new Date()
   await db.update(PluginTable).set({
     description: input.description === undefined ? row.description : normalizeOptionalString(input.description ?? undefined),

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -24,6 +24,9 @@ export type OrgRouteVariables =
   & Partial<MemberTeamsContext>
 
 export const PRIVILEGED_SESSION_MAX_AGE_MS = 15 * 60 * 1000
+// Reuse confirmation during content editing; access, credentials, publishing,
+// and destructive changes retain the shorter privileged window.
+export const CONTENT_EDIT_SESSION_MAX_AGE_MS = 60 * 60 * 1000
 export const CONNECTIONS_READ_SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000
 export const WORKSPACE_REAUTH_SECURITY_MESSAGE = "For security, confirm it's you before changing workspace settings."
 

--- a/ee/apps/den-api/test/org-identity-access.test.ts
+++ b/ee/apps/den-api/test/org-identity-access.test.ts
@@ -92,6 +92,14 @@ test("privileged actions require a fresh session", () => {
   }, now)).toBe(false)
 
   expect(sharedModule.hasFreshPrivilegedSession({ session: null }, now)).toBe(false)
+
+  for (const ageMs of [20 * 60_000, 60 * 60_000, 60 * 60_000 + 1]) {
+    const session = { createdAt: new Date(now.getTime() - ageMs) }
+    expect(sharedModule.hasFreshPrivilegedSession({ session }, now)).toBe(false)
+    expect(sharedModule.hasFreshPrivilegedSession(
+      { session }, now, sharedModule.CONTENT_EDIT_SESSION_MAX_AGE_MS,
+    )).toBe(ageMs <= 60 * 60_000)
+  }
 })
 
 test("read-only connection settings accept a login from the last 24 hours", () => {

--- a/ee/apps/den-api/test/plugin-system-access-list-freshness.test.ts
+++ b/ee/apps/den-api/test/plugin-system-access-list-freshness.test.ts
@@ -110,7 +110,7 @@ test("stale-session authoring follows the private versus exposed route matrix", 
   const exposedVersionId = createDenTypeId("configObjectVersion")
   const marketplaceId = createDenTypeId("marketplace")
   const now = new Date()
-  const staleCreatedAt = new Date(now.getTime() - 20 * 60_000)
+  const staleCreatedAt = new Date(now.getTime() - 65 * 60_000)
   const organizationContext: PluginArchActorContext["organizationContext"] = {
     organization: {
       id: organizationId,
@@ -324,6 +324,35 @@ test("stale-session authoring follows the private versus exposed route matrix", 
         message: "For security, confirm it's you before changing workspace settings.",
       })
     }
+    // Content editing gets a longer window; extending it must not extend grants
+    // or deletion, or permit editing other config types such as MCP settings.
+    staleCreatedAt.setTime(Date.now() - 20 * 60_000)
+    expect((await request("PATCH", `/v1/plugins/${exposedPluginId}`, { name: "Exposed Plugin" })).status).toBe(200)
+    const sharedSkill = await request("POST", "/v1/config-objects", {
+      type: "skill", pluginIds: [exposedPluginId], sourceMode: "cloud",
+      input: { rawSourceText: "---\nname: editing-window\ndescription: Editing window fixture.\n---\nInstructions." },
+    })
+    expect(sharedSkill.status).toBe(201)
+    const sharedSkillId = String(responseItem(await sharedSkill.json()).id)
+    expect((await request("POST", `/v1/config-objects/${sharedSkillId}/versions`, {
+      input: { rawSourceText: "---\nname: editing-window\ndescription: Editing window fixture.\n---\nUpdated instructions." },
+    })).status).toBe(201)
+    await expectFreshAuthRequired(await request("POST", `/v1/plugins/${privatePluginId}/access`, { orgWide: true, role: "viewer" }))
+    await expectFreshAuthRequired(await request("POST", `/v1/config-objects/${sharedSkillId}/delete`, {}))
+    await expectFreshAuthRequired(await request("POST", "/v1/config-objects", {
+      type: "mcp", pluginIds: [exposedPluginId], sourceMode: "cloud",
+      input: { rawSourceText: '{"mcpServers":{"fixture":{"url":"https://example.test/mcp"}}}' },
+    }))
+    const sharedVersions = await database.select().from(ConfigObjectVersionTable)
+      .where(eq(ConfigObjectVersionTable.configObjectId, sharedSkillId))
+    expect(sharedVersions).toHaveLength(2)
+    const sharedRows = await database.select().from(ConfigObjectTable).where(eq(ConfigObjectTable.id, sharedSkillId))
+    expect(sharedRows[0]?.deletedAt).toBeNull()
+    const privateGrants = await database.select().from(PluginAccessGrantTable).where(and(
+      eq(PluginAccessGrantTable.pluginId, privatePluginId), eq(PluginAccessGrantTable.orgWide, true),
+    ))
+    expect(privateGrants).toHaveLength(0)
+    staleCreatedAt.setTime(Date.now() - 65 * 60_000)
     const blockedPluginName = `Blocked Org-wide ${organizationId}`
     const blockedSkillName = `blocked-exposed-${organizationId.slice(-8)}`
     const blockedCases = [

--- a/ee/apps/den-web/app/(den)/dashboard/_components/skill-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/skill-data.tsx
@@ -113,25 +113,31 @@ export function useSkill(pluginId: string, skillId: string) {
 
 export function useCreateSkill(pluginId: string) {
   const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
 
   return useMutation({
     mutationFn: async (draft: SkillDraft): Promise<DenSkill> => {
-      const { response, payload } = await requestJson(
-        "/v1/config-objects",
-        {
-          method: "POST",
-          body: JSON.stringify(createSkillPayload(pluginId, draft)),
-        },
-        15000,
-      );
-      if (!response.ok) {
-        throw getRequestError(payload, response, `Failed to create skill (${response.status}).`);
-      }
-      const skill = parseSkillResponse(payload);
-      if (!skill) {
-        throw new Error("Skill create response was incomplete.");
-      }
-      return skill;
+      const result: { skill?: DenSkill } = {};
+      await runReauthableAction("create-skill", async () => {
+        const { response, payload } = await requestJson(
+          "/v1/config-objects",
+          {
+            method: "POST",
+            body: JSON.stringify(createSkillPayload(pluginId, draft)),
+          },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to create skill (${response.status}).`);
+        }
+        const skill = parseSkillResponse(payload);
+        if (!skill) {
+          throw new Error("Skill create response was incomplete.");
+        }
+        result.skill = skill;
+      });
+      if (!result.skill) throw new Error("Skill save response was incomplete.");
+      return result.skill;
     },
     onSuccess: async () => {
       await Promise.all([
@@ -144,28 +150,34 @@ export function useCreateSkill(pluginId: string) {
 
 export function useUpdateSkill(pluginId: string) {
   const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
 
   return useMutation({
     mutationFn: async (input: { skillId: string; draft: SkillDraft }): Promise<DenSkill> => {
-      const { response, payload } = await requestJson(
-        `/v1/config-objects/${encodeURIComponent(input.skillId)}/versions`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            input: { rawSourceText: skillSourceFromDraft(input.draft) },
-            reason: "Updated from Den Web",
-          }),
-        },
-        15000,
-      );
-      if (!response.ok) {
-        throw getRequestError(payload, response, `Failed to save skill (${response.status}).`);
-      }
-      const skill = parseSkillResponse(payload);
-      if (!skill) {
-        throw new Error("Skill update response was incomplete.");
-      }
-      return skill;
+      const result: { skill?: DenSkill } = {};
+      await runReauthableAction("update-skill", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/config-objects/${encodeURIComponent(input.skillId)}/versions`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              input: { rawSourceText: skillSourceFromDraft(input.draft) },
+              reason: "Updated from Den Web",
+            }),
+          },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to save skill (${response.status}).`);
+        }
+        const skill = parseSkillResponse(payload);
+        if (!skill) {
+          throw new Error("Skill update response was incomplete.");
+        }
+        result.skill = skill;
+      });
+      if (!result.skill) throw new Error("Skill save response was incomplete.");
+      return result.skill;
     },
     onSuccess: async () => {
       await Promise.all([

--- a/ee/apps/den-web/app/(den)/dashboard/_components/skill-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/skill-editor-screen.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { ArrowLeft, FileText } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
@@ -15,6 +15,7 @@ const SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; skillId?: string }) {
   const router = useRouter();
+  const submittingRef = useRef(false);
   const { orgSlug } = useOrgDashboard();
   const skillQuery = useSkill(pluginId, skillId ?? "");
   const createSkill = useCreateSkill(pluginId);
@@ -38,6 +39,7 @@ export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; ski
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (submittingRef.current) return;
     const draft = { name: name.trim(), description: description.trim(), body: body.trim() };
     if (!SKILL_NAME_PATTERN.test(draft.name) || draft.name.length > 64) {
       setValidationError("Name must use lowercase letters, numbers, and single hyphens only.");
@@ -53,6 +55,7 @@ export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; ski
     }
 
     setValidationError(null);
+    submittingRef.current = true;
     try {
       const saved = skillId
         ? await updateSkill.mutateAsync({ skillId, draft })
@@ -60,6 +63,8 @@ export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; ski
       router.push(getPluginSkillRoute(orgSlug, pluginId, saved.id));
     } catch {
       // React Query exposes the request error in the form below.
+    } finally {
+      submittingRef.current = false;
     }
   }
 

--- a/evals/specs/reauth-popup.e2e.test.ts
+++ b/evals/specs/reauth-popup.e2e.test.ts
@@ -117,6 +117,34 @@ test("workspace SSO verifies through a real popup and safely recovers from inter
   const skillBody = { role: "textbox", label: /Skill body/ } as const;
   await step("shared content editing reuses confirmation beyond fifteen minutes", async () => {
     await world.ageSession(20);
+    const headers = { "x-openwork-org-id": world.organizationId };
+    const renamed = await probe.api(world.den.admin, `/v1/plugins/${world.pluginId}`, {
+      method: "PATCH", headers, body: JSON.stringify({ name: "Shared editing updated" }),
+    });
+    expect(renamed.response.status).toBe(200);
+    expect(JSON.stringify(renamed.body)).toContain("Shared editing updated");
+    const accessBefore = await probe.api(world.den.admin, `/v1/plugins/${world.pluginId}/access`, { headers });
+    expect(accessBefore.response.status).toBe(200);
+    const grant = await probe.api(world.den.admin, `/v1/plugins/${world.pluginId}/access`, {
+      method: "POST", headers, body: JSON.stringify({ orgWide: true, role: "editor" }),
+    });
+    const deletion = await probe.api(world.den.admin, `/v1/config-objects/${world.skillId}/delete`, {
+      method: "POST", headers, body: "{}",
+    });
+    const mcp = await probe.api(world.den.admin, "/v1/config-objects", {
+      method: "POST", headers, body: JSON.stringify({
+        type: "mcp", sourceMode: "cloud", pluginIds: [world.pluginId],
+        input: { rawSourceText: '{"mcpServers":{"fixture":{"url":"https://example.test/mcp"}}}' },
+      }),
+    });
+    for (const blocked of [grant, deletion, mcp]) {
+      expect(blocked.response.status).toBe(403);
+      expect(blocked.body).toMatchObject({ error: "reauth", reason: "fresh_auth_required" });
+    }
+    const accessAfter = await probe.api(world.den.admin, `/v1/plugins/${world.pluginId}/access`, { headers });
+    expect(accessAfter.body).toEqual(accessBefore.body);
+    expect((await world.skillSnapshot()).versions).toBe(1);
+    evidence.recordAssertionEvidence("The content editing window accepts plugin metadata while access, deletion, and MCP changes still require recent authentication", "At twenty minutes the plugin rename succeeded; grants, skill deletion and MCP creation returned fresh_auth_required; access grants and skill versions stayed unchanged.", true);
     await user.navigate(editUrl);
     await user.see({ text: "Edit shared-editing" }, { timeoutMs: 60_000 });
     await user.type(skillBody, "Saved within the content editing window.", { replace: true });

--- a/evals/specs/reauth-popup.e2e.test.ts
+++ b/evals/specs/reauth-popup.e2e.test.ts
@@ -112,4 +112,70 @@ test("workspace SSO verifies through a real popup and safely recovers from inter
     popup.client.close();
     evidence.recordAssertionEvidence("Real OIDC verification closes both surfaces and resumes a server-validated settings mutation", "A session aged beyond 15 minutes could not save; signed-token approval refreshed authentication, showed completion, closed the popup/dialog, and persisted the new workspace name across reload.", true);
   });
+
+  const editUrl = new URL(`/dashboard/plugins/${world.pluginId}/skills/${world.skillId}/edit`, world.den.ref.webUrl).toString();
+  const skillBody = { role: "textbox", label: /Skill body/ } as const;
+  await step("shared content editing reuses confirmation beyond fifteen minutes", async () => {
+    await world.ageSession(20);
+    await user.navigate(editUrl);
+    await user.see({ text: "Edit shared-editing" }, { timeoutMs: 60_000 });
+    await user.type(skillBody, "Saved within the content editing window.", { replace: true });
+    await user.click("Save changes");
+    await user.see({ text: "Complete skill body" }, { timeoutMs: 30_000 });
+    expect(await probe.eval(() => document.querySelector('[role="dialog"]') === null)).toBe(true);
+    const stored = await world.skillSnapshot();
+    expect(stored.source).toContain("Saved within the content editing window.");
+    expect(stored.versions).toBe(2);
+    evidence.recordAssertionEvidence("A twenty-minute-old session can save shared skill content without another prompt", "The UI saved and navigated to the skill; exactly one new version persisted without a verification dialog. Workspace security settings above still required verification at twenty minutes.", true);
+  });
+
+  await step("expired skill edits retain their draft through cancellation and resume once after real verification", async () => {
+    await world.ageSession(65);
+    await user.navigate(editUrl);
+    await user.see({ text: "Edit shared-editing" }, { timeoutMs: 60_000 });
+    const draft = "Keep this draft through verification.";
+    await user.type(skillBody, draft, { replace: true });
+    await user.click("Save changes");
+    await user.see({ role: "button", label: "Continue with SSO" });
+    await world.duplicateSkillSubmit();
+    expect((await world.skillSnapshot()).versions).toBe(2);
+    await user.click({ role: "button", label: "Close security check" });
+    await user.see(skillBody, { value: draft });
+    expect((await world.skillSnapshot()).versions).toBe(2);
+    await user.click("Save changes");
+    await user.see({ role: "button", label: "Continue with SSO" });
+    await user.click({ role: "button", label: "Continue with SSO" });
+    const popup = await waiting();
+    await user.on(popup).click({ role: "button", label: "Approve sign-in" });
+    await user.see({ text: "Complete skill body" }, { timeoutMs: 60_000 });
+    const stored = await world.skillSnapshot();
+    expect(stored.source).toContain(draft);
+    expect(stored.versions).toBe(3);
+    expect(await probe.eval(() => document.querySelector('[role="dialog"]') === null)).toBe(true);
+    await user.reload();
+    await user.see({ text: draft }, { timeoutMs: 60_000 });
+    popup.client.close();
+    evidence.recordAssertionEvidence("Expired skill edits open verification, survive cancellation, and save the draft exactly once after SSO", "At sixty-five minutes the server blocked the save; cancellation and duplicate submit made no versions; real SSO saved one new version with the retained draft, visible after reload.", true);
+    await user.screenshot();
+  });
+
+  await step("expired skill creation also offers verification and resumes", async () => {
+    await world.ageSession(65);
+    await user.navigate(new URL(`/dashboard/plugins/${world.pluginId}/skills/new`, world.den.ref.webUrl).toString());
+    await user.see({ text: "Create a skill" }, { timeoutMs: 60_000 });
+    await user.type({ placeholder: "e.g. customer-research" }, "created-after-verification");
+    await user.type({ placeholder: "When should an agent use this skill?" }, "Synthetic creation recovery.");
+    await user.type(skillBody, "Created after confirming identity.");
+    await user.click("Create skill");
+    await user.see({ role: "button", label: "Continue with SSO" });
+    await user.click({ role: "button", label: "Continue with SSO" });
+    const popup = await waiting();
+    await user.on(popup).click({ role: "button", label: "Approve sign-in" });
+    await user.see({ text: "Complete skill body" }, { timeoutMs: 60_000 });
+    await user.reload();
+    await user.see({ text: "Created after confirming identity." }, { timeoutMs: 60_000 });
+    expect(await probe.eval(() => document.querySelector('[role="dialog"]') === null)).toBe(true);
+    popup.client.close();
+    evidence.recordAssertionEvidence("Creating a shared skill resumes after verification", "An expired session opened SSO from the create form; verification completed creation and the new skill persisted across reload.", true);
+  });
 });

--- a/evals/specs/reauth-popup.e2e.test.ts
+++ b/evals/specs/reauth-popup.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
 import { spec } from "@openwork/testkit";
 import { reauthPopup } from "../worlds/reauth-popup.ts";
 
@@ -117,21 +118,21 @@ test("workspace SSO verifies through a real popup and safely recovers from inter
   const skillBody = { role: "textbox", label: /Skill body/ } as const;
   await step("shared content editing reuses confirmation beyond fifteen minutes", async () => {
     await world.ageSession(20);
-    const headers = { "x-openwork-org-id": world.organizationId };
-    const renamed = await probe.api(world.den.admin, `/v1/plugins/${world.pluginId}`, {
+    const headers = { "x-openwork-org-id": world.organizationId, authorization: `Bearer ${world.den.admin.token}` };
+    const renamed = await denFetch(world.den.admin, `/v1/plugins/${world.pluginId}`, {
       method: "PATCH", headers, body: JSON.stringify({ name: "Shared editing updated" }),
     });
     expect(renamed.response.status).toBe(200);
     expect(JSON.stringify(renamed.body)).toContain("Shared editing updated");
     const accessBefore = await probe.api(world.den.admin, `/v1/plugins/${world.pluginId}/access`, { headers });
     expect(accessBefore.response.status).toBe(200);
-    const grant = await probe.api(world.den.admin, `/v1/plugins/${world.pluginId}/access`, {
+    const grant = await denFetch(world.den.admin, `/v1/plugins/${world.pluginId}/access`, {
       method: "POST", headers, body: JSON.stringify({ orgWide: true, role: "editor" }),
     });
-    const deletion = await probe.api(world.den.admin, `/v1/config-objects/${world.skillId}/delete`, {
+    const deletion = await denFetch(world.den.admin, `/v1/config-objects/${world.skillId}/delete`, {
       method: "POST", headers, body: "{}",
     });
-    const mcp = await probe.api(world.den.admin, "/v1/config-objects", {
+    const mcp = await denFetch(world.den.admin, "/v1/config-objects", {
       method: "POST", headers, body: JSON.stringify({
         type: "mcp", sourceMode: "cloud", pluginIds: [world.pluginId],
         input: { rawSourceText: '{"mcpServers":{"fixture":{"url":"https://example.test/mcp"}}}' },

--- a/evals/worlds/reauth-popup.ts
+++ b/evals/worlds/reauth-popup.ts
@@ -38,6 +38,19 @@ with open("/tmp/reauth-idp.log", "ab", buffering=0) as log:
 PY`);
   const orgResult = await seed.api(den.admin, "/v1/org");
   const organizationId = text(record(record(orgResult.body).organization).id);
+  const plugin = await seed.api(den.admin, "/v1/plugins", {
+    method: "POST", body: JSON.stringify({ name: "Shared editing", orgWide: true }),
+  });
+  if (!plugin.response.ok) throw new Error(`Plugin setup: ${plugin.response.status}`);
+  const pluginId = text(record(record(plugin.body).item).id);
+  const skill = await seed.api(den.admin, "/v1/config-objects", {
+    method: "POST", body: JSON.stringify({
+      type: "skill", sourceMode: "cloud", pluginIds: [pluginId],
+      input: { rawSourceText: "---\nname: shared-editing\ndescription: Synthetic shared instructions.\n---\n\nOriginal skill body." },
+    }),
+  });
+  if (!skill.response.ok) throw new Error(`Skill setup: ${skill.response.status}`);
+  const skillId = text(record(record(skill.body).item).id);
   const signIn = await seed.api(den.admin, "/api/auth/sign-in/email", { method: "POST", body: JSON.stringify({ email: den.admin.email, password: den.admin.password }) });
   if (!signIn.response.ok) throw new Error(`Fixture login: ${signIn.response.status}`);
   const sessionCookie = text(signIn.response.headers.getSetCookie().find((value) => value.includes("session_token=")));
@@ -64,7 +77,7 @@ PY`);
   const appliedCookie = await web.client.send("Network.setCookie", { name: cookie.slice(0, separator), value: cookie.slice(separator + 1), domain: `.${cookieDomain.replace(/^\./, "")}`, path: "/", url: den.ref.webUrl, httpOnly: true, secure: true });
   if (record(appliedCookie).success !== true) throw new Error("Could not apply the fixture session cookie");
   return {
-    den, web, originalName, testUrl, issuer, organizationId, otherEmail: `other@${domain}`,
+    den, web, originalName, testUrl, issuer, organizationId, pluginId, skillId, otherEmail: `other@${domain}`,
     async [Symbol.asyncDispose]() {
       await web.stop();
       await host.stop();
@@ -73,8 +86,21 @@ PY`);
       const result = await seed.api(den.admin, "/v1/sso/enable", { method: "POST", headers, body: "{}" });
       if (result.response.status !== 204) throw new Error(`SSO enable: ${result.response.status} ${result.text}`);
     },
-    async ageSession() {
-      await sql(`UPDATE session SET created_at=DATE_SUB(NOW(3), INTERVAL 20 MINUTE) WHERE user_id IN (SELECT id FROM user WHERE email=${sqlString(den.admin.email)});`);
+    async ageSession(minutes = 20) {
+      if (!Number.isSafeInteger(minutes) || minutes < 0) throw new Error("Invalid session age");
+      await sql(`UPDATE session SET created_at=DATE_SUB(NOW(3), INTERVAL ${minutes} MINUTE) WHERE user_id IN (SELECT id FROM user WHERE email=${sqlString(den.admin.email)});`);
+    },
+    async skillSnapshot() {
+      const detail = await seed.api(den.admin, `/v1/config-objects/${skillId}`);
+      const versions = await seed.api(den.admin, `/v1/config-objects/${skillId}/versions`);
+      const items = record(versions.body).items;
+      if (!detail.response.ok || !versions.response.ok || !Array.isArray(items)) throw new Error("Could not read stored skill");
+      return { source: text(record(record(record(detail.body).item).latestVersion).rawSourceText), versions: items.length };
+    },
+    async duplicateSkillSubmit() {
+      await evaluate(web.client, browserScript(() => {
+        document.querySelector("textarea")?.closest("form")?.requestSubmit();
+      }, []));
     },
     async storedName() {
       return (await sql(`SELECT name FROM organization WHERE id=${sqlString(organizationId)};`)).trim();


### PR DESCRIPTION
## Summary

Skill creation and saves could show “confirm it's you” without opening verification. Route both through the existing dialog so drafts survive cancellation and the pending save resumes after sign-in, with duplicate submissions blocked.

Shared skill edits and plugin name/description edits now accept authentication from the preceding hour. Access grants, MCP configuration, publishing, destructive actions, and workspace security settings retain their 15-minute checks.

## Why

The skill editor was missing the dashboard's reauthentication wrapper, while content editing used the same short confirmation window as security changes.

## Issue

Reported workspace verification dead end and frequent prompts; no linked issue.

## Scope

Den web skill creation/editing, server freshness policy for shared skill content and plugin metadata, and regression assertions in the existing SSO journey.

## Out of scope

Changing sign-in methods, granting super-admin exemptions, or extending the security-action window.

## Testing

### Ran

- `OPENWORK_EVAL_REF=ee57e6fa62a3354257a49f429aa9e41eb4b204d4 pnpm evals:e2e reauth-popup`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --dir ee/apps/den-api exec bun test --conditions development test/org-identity-access.test.ts`
- `pnpm --dir evals exec tsc --noEmit --pretty false`
- `pnpm --dir ee/apps/den-api exec bun test --conditions development --timeout 30000 test/plugin-system-access-list-freshness.test.ts`

### Result

- Browser journey: **Passed**, `placement: daytona (daytona CLI authenticated)`; 1 test, 11 recorded assertions, no failures or skips. Real OIDC sign-in verifies draft preservation, cancellation, exactly one resumed save, creation recovery, and content/security freshness boundaries.
- Den web typecheck passed. Identity/freshness tests: 7 passed, 32 assertions.
- Evaluation typecheck: 358 diagnostics, matching clean base `54a7f0fa9` after normalizing checkout paths and line offsets.
- Supplementary local route suite: 3 passed, 1 failed on MySQL `ETIMEDOUT`, reproduced on the same clean base. The passing Daytona journey separately exercises the relevant API boundaries.

## CI status

GitHub checks pending. Baseline typecheck and local MySQL limitations are documented above.

## Manual verification

The automated browser journey performs these checks against an isolated Den and test identity provider:

1. A 20-minute-old session saves shared content without another prompt; access grants, deletion, and MCP changes remain blocked.
2. At 65 minutes, saving opens verification. Cancel retains the draft; signing in resumes exactly one save.
3. Creating a shared skill also resumes after verification and persists across reload.

## Evidence

The test-evidence comment records all 11 assertions for PR head `ee57e6fa62a3354257a49f429aa9e41eb4b204d4` and includes available screenshots.

## Risk

The authenticated editing window intentionally increases from 15 to 60 minutes for shared skill content and plugin metadata. Authorization and server validation on retries remain enforced. A stolen but otherwise valid admin session could modify that shared content during the additional 45 minutes. This is the bounded security/usability tradeoff of reducing repeated confirmation during editing. The one-hour limit is selected by server code, cannot be supplied by an API client, and does not extend the 15-minute checks for access grants, MCP configuration, publishing, deletion, or workspace security settings.

## Rollback

Revert this PR to restore the previous editing window and skill mutation handlers.

