### PR TITLE
fix(session): stop foreground tasks before follow-up turns

### DIFF
--- a/apps/app/src/app/lib/opencode-interruption.ts
+++ b/apps/app/src/app/lib/opencode-interruption.ts
@@ -1,0 +1,161 @@
+import type { Client } from "../types";
+import { isPromptAdmissionUnknown, unwrap } from "./opencode";
+
+type Turn = {
+  generation: number;
+  submissions: Set<Promise<unknown>>;
+  interruption?: Promise<void>;
+  stopping: boolean;
+  needsStop: boolean;
+  listeners: Set<() => void>;
+};
+const turns = new Map<string, Turn>();
+
+function turnFor(baseUrl: string, sessionID: string) {
+  const key = JSON.stringify([baseUrl.replace(/\/+$/, ""), sessionID]);
+  let turn = turns.get(key);
+  if (!turn) {
+    turn = { generation: 0, submissions: new Set(), stopping: false, needsStop: false, listeners: new Set() };
+    turns.set(key, turn);
+  }
+  return turn;
+}
+
+/** Shared by visible panes and the background queue. A successor cannot enter
+ * the engine while Stop is still cancelling its predecessor's children. */
+export async function submitAfterInterruption<T>(baseUrl: string, sessionID: string, send: (afterStop: boolean) => Promise<T>): Promise<T> {
+  const turn = turnFor(baseUrl, sessionID);
+  const generation = turn.generation;
+  const interruption = turn.interruption;
+  await interruption;
+  if (turn.generation !== generation) throw new Error("Send cancelled by Stop.");
+  const pending = send(interruption !== undefined);
+  turn.submissions.add(pending);
+  try {
+    return await pending;
+  } finally {
+    turn.submissions.delete(pending);
+  }
+}
+
+export function sessionNeedsStop(baseUrl: string, sessionID: string): boolean {
+  return turnFor(baseUrl, sessionID).needsStop;
+}
+
+export function subscribeSessionInterruption(baseUrl: string, sessionID: string, listener: () => void): () => void {
+  const turn = turnFor(baseUrl, sessionID);
+  turn.listeners.add(listener);
+  return () => { turn.listeners.delete(listener); };
+}
+
+/** Keep a failed interruption fenced until the user retries Stop. Forgetting
+ * it on failure would silently steer the next message into the old run. */
+export function interruptSessionTurn(
+  baseUrl: string,
+  client: Client,
+  sessionID: string,
+  directory?: string,
+  options: { timeoutMs?: number; admissionUnknown?: boolean; onStopped?: () => void } = {},
+): Promise<void> {
+  const turn = turnFor(baseUrl, sessionID);
+  if (turn.stopping && turn.interruption) return turn.interruption;
+  turn.generation += 1;
+  turn.stopping = true;
+  turn.needsStop = true;
+  const pending = [...turn.submissions];
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("Stopping the previous turn timed out. Retry Stop before sending.")), options.timeoutMs ?? 15_000);
+  const deadline = new Promise<never>((_, reject) => {
+    controller.signal.addEventListener("abort", () => reject(controller.signal.reason), { once: true });
+  });
+  const interruption = Promise.race([
+    stopForegroundTree(client, sessionID, directory, pending, controller.signal, options.admissionUnknown === true),
+    deadline,
+  ]).then(() => {
+    // Reconcile the old admission before releasing waiting successor sends.
+    options.onStopped?.();
+    turn.interruption = undefined;
+    turn.needsStop = false;
+  }).finally(() => {
+    clearTimeout(timer);
+    turn.stopping = false;
+    for (const listener of turn.listeners) listener();
+  });
+  turn.interruption = interruption;
+  for (const listener of turn.listeners) listener();
+  // Retain rejection for future submissions without an unhandled rejection.
+  void interruption.catch(() => {});
+  return interruption;
+}
+
+async function stopForegroundTree(
+  client: Client,
+  rootID: string,
+  directory: string | undefined,
+  pending: readonly Promise<unknown>[],
+  signal: AbortSignal,
+  admissionUnknown: boolean,
+) {
+  const options = { signal };
+  const children = async (sessionID: string) => {
+    signal.throwIfAborted();
+    const messages = unwrap(await client.session.messages({ sessionID, directory }, options));
+    const turnStart = messages.findLastIndex(({ info }) => info.role === "user");
+    return messages.slice(Math.max(0, turnStart)).flatMap(({ parts }) => parts.flatMap((part) => {
+      if (part.type !== "tool" || !["task", "subagent"].includes(part.tool)
+        || part.state.status === "completed" || part.state.input.background === true) return [];
+      const metadata = "metadata" in part.state ? part.state.metadata : undefined;
+      if (metadata?.background === true) return [];
+      const id = metadata?.sessionId ?? metadata?.sessionID;
+      return typeof id === "string" && id !== sessionID ? [id] : [];
+    }));
+  };
+  const abort = async (sessionID: string) => {
+    signal.throwIfAborted();
+    // A false acknowledgement may mean the native cascade already stopped a
+    // child. Only the final authoritative idle check establishes settlement.
+    unwrap(await client.session.abort({ sessionID, directory }, options));
+  };
+  const root = unwrap(await client.session.get({ sessionID: rootID, directory }, options));
+  if (root.id !== rootID || (directory !== undefined && root.directory !== directory)) {
+    throw new Error("Could not verify the conversation's workspace. Stop was not confirmed.");
+  }
+  const targets = new Set<string>();
+  const stop = async (sessionID: string, knownChildren: string[] = []) => {
+    signal.throwIfAborted();
+    if (targets.has(sessionID)) return;
+    if (targets.size >= 256) throw new Error("Too many delegated sessions to confirm Stop.");
+    targets.add(sessionID);
+    const before = await children(sessionID);
+    await abort(sessionID);
+    // Cancellation can race task metadata publication. Read again after the
+    // parent stops; include cancelled tool parts, but never completed or
+    // explicitly background tasks, nor descendants from an older user turn.
+    const ids = new Set([...knownChildren, ...before, ...await children(sessionID)]);
+    for (const id of ids) {
+      signal.throwIfAborted();
+      const child = unwrap(await client.session.get({ sessionID: id, directory }, options));
+      if (child.parentID !== sessionID || child.directory !== root.directory) {
+        throw new Error("Could not verify the delegated session owner. Stop was not confirmed.");
+      }
+      await stop(id);
+    }
+  };
+  const before = await children(rootID);
+  // Stop active work promptly, even if an older shell/send has not returned.
+  await abort(rootID);
+  const settled = await Promise.allSettled(pending);
+  signal.throwIfAborted();
+  await stop(rootID, before);
+  // A lost admission response is not proof that the old POST cannot arrive
+  // later. Do not claim a clean handoff or replay that prompt.
+  if (admissionUnknown || settled.some((result) => result.status === "rejected" && isPromptAdmissionUnknown(result.reason))) {
+    throw new Error("The previous message's acceptance is still unknown. Check acceptance, then retry Stop.");
+  }
+  while (true) {
+    signal.throwIfAborted();
+    const statuses = unwrap(await client.session.status({ directory }, options));
+    if ([...targets].every((id) => !statuses[id] || statuses[id].type === "idle")) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+}

--- a/apps/app/src/react-app/domains/session/surface/queued-drain-machine.ts
+++ b/apps/app/src/react-app/domains/session/surface/queued-drain-machine.ts
@@ -67,6 +67,7 @@ export type QueuedDrainState = {
 
 export type QueuedDrainEvent =
   | { type: "send_started"; itemId: string; steer?: boolean }
+  | { type: "stop_confirmed" }
   | { type: "send_result"; itemId: string; outcome: "sent" | "accepted" | "blocked" | "cancelled"; at: number }
   | { type: "send_error"; itemId: string }
   | { type: "send_unknown"; itemId: string; messageID: string; at: number }
@@ -103,6 +104,12 @@ function resolved(
 export function reduceQueuedDrain(state: QueuedDrainState, event: QueuedDrainEvent): QueuedDrainState {
   const { phase } = state;
   switch (event.type) {
+    case "stop_confirmed":
+      // A replacement may already hold the send slot while awaiting Stop.
+      // Keep that claim, but discard activity belonging to its predecessor.
+      if (phase.kind === "sending") return { ...state, phase: { ...phase, busySeen: false } };
+      if (phase.kind === "admission_unknown") return state;
+      return { ...INITIAL_QUEUED_DRAIN_STATE, lastResolution: state.lastResolution };
     case "send_started": {
       if (phase.kind !== "ready") {
         if (!event.steer) return state;

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -7,9 +7,9 @@ import { Check, CirclePause, Minimize2 } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
 
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
+import { interruptSessionTurn, sessionNeedsStop, submitAfterInterruption, subscribeSessionInterruption } from "@/app/lib/opencode-interruption";
 import { createClient, createPromptMessageID, hasAcceptedPromptMessage, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
-import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
 import { setThemeMode } from "@/app/theme";
 import { t } from "@/i18n";
@@ -1300,7 +1300,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const liveStatus = statusState ?? snapshot?.status ?? IDLE_STATUS;
   const preparingCloudTools = props.cloudMcpSubmissionState.status === "checking" ||
     props.cloudMcpSubmissionState.status === "repairing";
-  const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
+  const needsStop = useSyncExternalStore(
+    useCallback((listener) => subscribeSessionInterruption(props.opencodeBaseUrl, props.sessionId, listener), [props.opencodeBaseUrl, props.sessionId]),
+    useCallback(() => sessionNeedsStop(props.opencodeBaseUrl, props.sessionId), [props.opencodeBaseUrl, props.sessionId]),
+  );
+  const chatStreaming = needsStop || sending || liveStatus.type === "busy" || liveStatus.type === "retry";
   // A busy status is a claim that decays: the sync layer revalidates it
   // continuously against /session/status, and once that validation keeps
   // failing (network drop, sleep, dead engine) the transcript must present
@@ -1864,7 +1868,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setPendingSendSessions([...pendingSendsRef.current.values()]);
     setError(null);
     try {
-      const result = await props.onSendDraft({ ...nextDraft, messageId }, props.sessionId);
+      const result = await submitAfterInterruption(props.opencodeBaseUrl, props.sessionId,
+        () => props.onSendDraft({ ...nextDraft, messageId }, props.sessionId));
       dispatchQueuedDrain(props.sessionId, { type: "send_result", itemId, outcome: result.outcome, at: Date.now() });
       if (getQueuedSendGeneration(props.sessionId) !== generation) return result;
       if (result.outcome === "blocked" || result.outcome === "cancelled") return result;
@@ -1899,7 +1904,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       pendingSendsRef.current.delete(submissionId);
       setPendingSendSessions([...pendingSendsRef.current.values()]);
     }
-  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length, sessionOwner, setError]);
+  }, [appendComposerHistory, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, renderedMessages.length, sessionOwner, setError]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);
@@ -2073,23 +2078,20 @@ export function SessionSurface(props: SessionSurfaceProps) {
     // passes the workspace root), so the abort must target the same scope —
     // without it the server resolves the default project, finds no live run,
     // and answers `200: false` while the stream keeps going (#2014).
-    const aborted = await abortSessionSafe(
-      opencodeClient,
-      props.sessionId,
-      props.workspaceRoot.trim() || undefined,
-      {
-        source: "composer.stop",
-        initiator: "user",
-        reason: "stop active session run",
-      },
-    );
-    if (!aborted) {
-      setError({ message: t("session.stop_failed") });
-      return;
+    try {
+      await interruptSessionTurn(props.opencodeBaseUrl, opencodeClient, props.sessionId,
+        props.workspaceRoot.trim() || undefined, {
+          admissionUnknown: phase.kind === "admission_unknown",
+          onStopped: () => dispatchQueuedDrain(props.sessionId, { type: "stop_confirmed" }),
+        });
+    } catch (error) {
+      setError({ message: error instanceof Error ? error.message : t("session.stop_failed") });
+      return false;
     }
     captureAnalyticsEvent("task_run_stopped", {});
     await snapshotQuery.refetch();
-  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, snapshotQuery.refetch, setError]);
+    return true;
+  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.opencodeBaseUrl, props.sessionId, props.workspaceRoot, snapshotQuery.refetch, setError]);
 
   const checkUnknownAdmission = useCallback(async (notify = false) => {
     const phase = getQueuedDrainState(props.sessionId).phase;
@@ -2396,10 +2398,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     sideEffect: "mutation",
     disabled: !chatStreaming && queuedDrainState.phase.kind !== "sending" && queuedDrainState.phase.kind !== "admission_unknown",
     targetRef: composerShellRef,
-    execute: async () => {
-      await handleAbort();
-      return true;
-    },
+    execute: handleAbort,
   }), [chatStreaming, handleAbort, queuedDrainState.phase.kind]);
   useControlAction(props.isControlTarget ? composerStopControlAction : null);
 
@@ -3077,7 +3076,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onSend={handleSend}
         onSteer={handleSteer}
         onQueue={handleQueue}
-        onStop={handleAbort}
+        onStop={async () => { await handleAbort(); }}
         busy={chatStreaming}
         steering={steering}
         submissionPreparing={preparingCloudTools || sending}

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
@@ -3,6 +3,8 @@ import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 import { markTaskRunStart } from "@/app/lib/analytics";
 import { createClient, createPromptMessageID, hasAcceptedPromptMessage, isPromptAdmissionUnknown } from "@/app/lib/opencode";
 import { shellInSession } from "@/app/lib/opencode-session";
+import { submitAfterInterruption } from "@/app/lib/opencode-interruption";
+import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
 import type { ComposerDraft, ModelRef } from "@/app/types";
 import { readStoredDefaultModel } from "@/react-app/kernel/model-config";
@@ -101,7 +103,8 @@ async function performQueuedDraftSend(
   const sessionModelSelection = getSessionModelSelection(sessionId);
   const sendModel = sessionModelSelection?.model ?? readStoredDefaultModelSafely() ?? context.model;
   const sendVariant = sessionModelSelection ? sessionModelSelection.variant : context.variant;
-  const opencodeClient = createClient(
+  const createEngineClient = isOpencodeV2BaseUrl(context.opencodeBaseUrl) ? createClientV2 : createClient;
+  const opencodeClient = createEngineClient(
     context.opencodeBaseUrl,
     context.workspaceRoot || undefined,
     { token: context.openworkToken, mode: "openwork" },
@@ -347,7 +350,8 @@ async function attemptDrain(sessionId: string) {
   useComposerStateStore.getState().removeQueuedDraft(sessionId, nextItem.id);
 
   try {
-    await performQueuedDraftSend(context, sessionId, draft, generation);
+    await submitAfterInterruption(context.opencodeBaseUrl, sessionId,
+      () => performQueuedDraftSend(context, sessionId, draft, generation));
     dispatchQueuedDrain(sessionId, {
       type: "send_result",
       itemId: nextItem.id,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -18,7 +18,7 @@ import { buildDiagnosticsBundleJson } from "@/app/lib/diagnostics-bundle";
 import { downloadTextAsFile } from "@/app/lib/download";
 import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
 import { createClient, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
-import { isOpencodeV2BaseUrl, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
+import { createClientV2, isOpencodeV2BaseUrl, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession, unrevertSession } from "@/app/lib/opencode-session";
 import { getNativeSessionMessages } from "@/app/lib/opencode-session-native";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -1612,7 +1612,8 @@ export function SessionRoute() {
     }
 
     const workspaceRoot = paneEndpoint.workspaceRoot;
-    const workspaceOpencodeClient = createClient(
+    const createEngineClient = isOpencodeV2BaseUrl(endpoint.opencodeBaseUrl) ? createClientV2 : createClient;
+    const workspaceOpencodeClient = createEngineClient(
       endpoint.opencodeBaseUrl,
       workspaceRoot || undefined,
       { token: endpoint.token, mode: "openwork" },

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
-import { createClient, createPromptMessageID, hasAcceptedPromptMessage, type FieldsResult } from "../src/app/lib/opencode";
+import { createClient, createPromptMessageID, hasAcceptedPromptMessage, unwrap, type FieldsResult } from "../src/app/lib/opencode";
+import { interruptSessionTurn, sessionNeedsStop, submitAfterInterruption } from "../src/app/lib/opencode-interruption";
+import { createClientV2 } from "../src/app/lib/opencode-v2-adapter";
 import {
   composeNativeSessionSnapshot,
   deleteNativeSession,
@@ -54,6 +56,41 @@ function operations(overrides: Partial<NativeSessionOperations> = {}): NativeSes
     delete: async () => result(true),
     ...overrides,
   };
+}
+
+async function withSessionFetch(
+  respond: (request: Request) => Response | Promise<Response>,
+  run: (requests: Request[]) => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+  const requests: Request[] = [];
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      return Promise.resolve(respond(request));
+    },
+  });
+  try {
+    await run(requests);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function delegatedTool(childID: string, state: Record<string, unknown> = {}, tool = "task") {
+  return {
+    type: "tool", tool, id: `part_${childID}`, callID: `call_${childID}`,
+    state: { status: "running", input: {}, metadata: { sessionId: childID }, time: { start: 1 }, ...state },
+  };
+}
+
+function turnMessages(sessionID: string, parts: ReturnType<typeof delegatedTool>[] = [], messageID = "msg_current") {
+  return [
+    { info: { id: messageID, sessionID, role: "user", time: { created: 1 } }, parts: [] },
+    { info: { id: `${messageID}_reply`, sessionID, role: "assistant", time: { created: 2 } }, parts },
+  ];
 }
 
 describe("native OpenCode session operations", () => {
@@ -166,5 +203,374 @@ describe("native OpenCode session operations", () => {
         todo: async () => failedResult({ code: "engine_unavailable" }, 503),
       }),
     })).rejects.toMatchObject({ status: 503, code: "engine_unavailable" });
+  });
+});
+
+describe("native Stop and follow-up handoff", () => {
+  test("v2 interrupts the native subagent before admitting the next prompt", async () => {
+    const baseUrl = endpoint.opencodeBaseUrl.replace("opencode", "opencode2");
+    const rootID = "ses_v2_stop";
+    const childID = "ses_v2_child";
+    const events: string[] = [];
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      const [, id, action] = path.match(/\/api\/session\/([^/]+)(?:\/([^/]+))?$/) ?? [];
+      if (id === "active") return Response.json({ data: {} });
+      if (!action) return Response.json({ data: {
+        id, title: "Native turn", location: { directory: session.directory }, time: { created: 1, updated: 2 },
+        ...(id === childID ? { parentID: rootID } : {}),
+      } });
+      if (action === "message") return Response.json({ data: [
+        { id: "msg_user", type: "user", time: { created: 1 }, content: [] },
+        { id: "msg_assistant", type: "assistant", time: { created: 2 }, content: id === rootID ? [{
+          type: "tool", id: "call_child", name: "subagent", time: { created: 2, ran: 2 },
+          state: { status: "running", input: { agent: "explore" }, metadata: { sessionID: childID } },
+        }] : [] },
+      ] });
+      if (action === "interrupt") { events.push(`interrupt:${id}`); return Response.json({ data: { interrupted: true } }); }
+      if (action === "model") return Response.json({ data: {} });
+      if (action === "prompt") { events.push(`prompt:${id}`); return Response.json({ data: {} }); }
+      throw new Error(`Unexpected v2 request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClientV2(baseUrl, session.directory, { token: endpoint.token, mode: "openwork" });
+      const stop = interruptSessionTurn(baseUrl, client, rootID, session.directory);
+      const next = submitAfterInterruption(baseUrl, rootID, async () => unwrap(await client.session.promptAsync({
+        sessionID: rootID, model: { providerID: "mock", modelID: "mock" }, parts: [{ type: "text", text: "new turn" }],
+      })));
+      await Promise.all([stop, next]);
+      expect(events).toEqual([`interrupt:${rootID}`, `interrupt:${rootID}`, `interrupt:${childID}`, `prompt:${rootID}`]);
+      expect(requests.every((request) => new URL(request.url).pathname.includes("/opencode2/api/"))).toBe(true);
+    });
+  });
+
+  test("unknown admission stays fenced even after the visible run stops", async () => {
+    const root = { ...session, id: "ses_unknown_stop" };
+    let sends = 0;
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith("/message")) return Response.json(turnMessages(root.id));
+      if (path.endsWith("/abort")) return Response.json(true);
+      if (path.endsWith("/status")) return Response.json({});
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClient(endpoint.opencodeBaseUrl, root.directory);
+      await expect(interruptSessionTurn(endpoint.opencodeBaseUrl, client, root.id, root.directory, { admissionUnknown: true }))
+        .rejects.toThrow("acceptance is still unknown");
+      await expect(submitAfterInterruption(endpoint.opencodeBaseUrl, root.id, async () => { sends += 1; }))
+        .rejects.toThrow("acceptance is still unknown");
+      expect(sends).toBe(0);
+      expect(requests.filter((request) => request.method === "POST")).toHaveLength(2);
+      expect(sessionNeedsStop(endpoint.opencodeBaseUrl, root.id)).toBe(true);
+    });
+  });
+
+  test("stops only the current foreground tree and holds follow-up through delayed child abort and authoritative idle", async () => {
+    const root = { ...session, id: "ses_tree" };
+    const baseUrl = endpoint.opencodeBaseUrl;
+    const childAbort = Promise.withResolvers<Response>();
+    const childReached = Promise.withResolvers<void>();
+    const idle = Promise.withResolvers<Response>();
+    const idleReached = Promise.withResolvers<void>();
+    const aborted: string[] = [];
+    const sent: boolean[] = [];
+    let admissionReconciled = false;
+    let statusReads = 0;
+    const sessions: Record<string, Session> = {
+      [root.id]: root,
+      ses_child: { ...session, id: "ses_child", parentID: root.id },
+      ses_nested: { ...session, id: "ses_nested", parentID: "ses_child" },
+      ses_late: { ...session, id: "ses_late", parentID: root.id },
+    };
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/status")) {
+        if (++statusReads === 1) return Response.json({ ses_nested: { type: "busy" }, ses_unrelated: { type: "busy" } });
+        idleReached.resolve();
+        return idle.promise;
+      }
+      const [, id, action] = path.match(/\/session\/([^/]+)(?:\/([^/]+))?$/) ?? [];
+      if (request.method === "POST" && action === "prompt_async") return new Response(null, { status: 204 });
+      if (request.method === "POST" && action === "abort" && id) {
+        aborted.push(id);
+        if (id === "ses_child") { childReached.resolve(); return childAbort.promise; }
+        return Response.json(true);
+      }
+      if (action === "message" && id === root.id) return Response.json([
+        ...turnMessages(root.id, [delegatedTool("ses_old")], "msg_old"),
+        ...turnMessages(root.id, [
+          delegatedTool("ses_child"),
+          delegatedTool("ses_completed", { status: "completed", output: "done" }),
+          delegatedTool("ses_background_input", { input: { background: true } }),
+          delegatedTool("ses_background_metadata", { metadata: { sessionID: "ses_background_metadata", background: true } }),
+          delegatedTool("ses_not_a_task", {}, "read"),
+          delegatedTool(root.id),
+          ...(aborted.includes(root.id) ? [delegatedTool("ses_late", { status: "error", error: "cancelled" })] : []),
+        ]),
+      ]);
+      if (action === "message" && id === "ses_child") return Response.json(turnMessages(id, [
+        delegatedTool("ses_nested", { metadata: { sessionID: "ses_nested" } }, "subagent"),
+      ]));
+      if (action === "message" && id && sessions[id]) return Response.json(turnMessages(id));
+      if (!action && id && sessions[id]) return Response.json(sessions[id]);
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClient(baseUrl, root.directory, { token: endpoint.token, mode: "openwork" });
+      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, {
+        timeoutMs: 1_000, onStopped: () => { admissionReconciled = true; },
+      });
+      const followUp = submitAfterInterruption(baseUrl, root.id, async (afterStop) => {
+        expect(admissionReconciled).toBe(true);
+        sent.push(afterStop);
+        return unwrap(await client.session.promptAsync({ sessionID: root.id, parts: [{ type: "text", text: "follow-up" }] }));
+      });
+      try {
+        await childReached.promise;
+        expect(sent).toEqual([]);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(true);
+        childAbort.resolve(Response.json(true));
+        await idleReached.promise;
+        expect(aborted).toEqual([root.id, root.id, "ses_child", "ses_nested", "ses_late"]);
+        expect(sent).toEqual([]);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(true);
+        // Busy sessions outside this turn must neither be stopped nor hold the fence.
+        idle.resolve(Response.json({ [root.id]: { type: "idle" }, ses_unrelated: { type: "busy" }, ses_old: { type: "busy" } }));
+        await Promise.all([stop, followUp]);
+        expect(sent).toEqual([true]);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(false);
+        expect(requests.filter((request) => /\/session\/ses_[^/]+$/.test(new URL(request.url).pathname))
+          .map((request) => new URL(request.url).pathname.split("/").at(-1)))
+          .toEqual([root.id, "ses_child", "ses_nested", "ses_late"]);
+        for (const request of requests) {
+          expect(request.url.startsWith(`${baseUrl}/session/`)).toBe(true);
+          expect(request.headers.get("Authorization")).toBe(`Bearer ${endpoint.token}`);
+          if (!request.url.endsWith("/prompt_async")) expect(new URL(request.url).searchParams.get("directory")).toBe(root.directory);
+        }
+      } finally {
+        childAbort.resolve(Response.json(true));
+        idle.resolve(Response.json({}));
+        await Promise.allSettled([stop, followUp]);
+      }
+    });
+  });
+
+  test("refuses cross-directory and wrong-parent children without aborting them or admitting follow-up", async () => {
+    for (const mismatch of ["directory", "parentID"]) {
+      const root = { ...session, id: `ses_owner_${mismatch}` };
+      const child = { ...session, id: "ses_foreign", parentID: root.id, [mismatch]: "other-owner" };
+      const sent: boolean[] = [];
+      await withSessionFetch((request) => {
+        const path = new URL(request.url).pathname;
+        if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+        if (path.endsWith(`/session/${child.id}`)) return Response.json(child);
+        if (path.endsWith(`/session/${root.id}/message`)) return Response.json(turnMessages(root.id, [delegatedTool(child.id)]));
+        if (path.endsWith(`/session/${root.id}/abort`)) return Response.json(true);
+        throw new Error(`Unexpected request: ${request.method} ${path}`);
+      }, async (requests) => {
+        const client = createClient(endpoint.opencodeBaseUrl, root.directory);
+        await expect(interruptSessionTurn(endpoint.opencodeBaseUrl, client, root.id, root.directory, { timeoutMs: 1_000 }))
+          .rejects.toThrow("Could not verify the delegated session owner");
+        expect(sessionNeedsStop(endpoint.opencodeBaseUrl, root.id)).toBe(true);
+        await expect(submitAfterInterruption(endpoint.opencodeBaseUrl, root.id, async (afterStop) => { sent.push(afterStop); }))
+          .rejects.toThrow("Could not verify the delegated session owner");
+        expect(sent).toEqual([]);
+        expect(requests.filter((request) => request.method === "POST").map((request) => new URL(request.url).pathname))
+          .toEqual(Array(2).fill(`/workspace/ws-native/opencode/session/${root.id}/abort`));
+      });
+    }
+  });
+
+  test("false abort with authoritative busy times out, keeps sends blocked, and releases only on explicit Stop retry", async () => {
+    const root = { ...session, id: "ses_retry" };
+    const baseUrl = endpoint.opencodeBaseUrl;
+    const sent: boolean[] = [];
+    let busy = true;
+    let statusReads = 0;
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith("/message")) return Response.json(turnMessages(root.id));
+      if (path.endsWith("/abort")) return Response.json(false);
+      if (path.endsWith("/status")) { statusReads += 1; return Response.json({ [root.id]: { type: busy ? "busy" : "idle" } }); }
+      if (path.endsWith("/prompt_async")) return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClient(baseUrl, root.directory);
+      const send = async (afterStop: boolean) => {
+        sent.push(afterStop);
+        return unwrap(await client.session.promptAsync({ sessionID: root.id, parts: [{ type: "text", text: "follow-up" }] }));
+      };
+      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 25 });
+      const followUp = submitAfterInterruption(baseUrl, root.id, send);
+      for (const outcome of await Promise.allSettled([stop, followUp])) {
+        if (outcome.status !== "rejected" || !(outcome.reason instanceof Error)) {
+          throw new Error("Stop and follow-up must both reject on timeout");
+        }
+        expect(outcome.reason.message).toContain("timed out. Retry Stop before sending");
+      }
+      expect(statusReads).toBeGreaterThan(0);
+      expect(sessionNeedsStop(baseUrl, root.id)).toBe(true);
+      busy = false;
+      await expect(submitAfterInterruption(baseUrl, root.id, send)).rejects.toThrow("Retry Stop before sending");
+      expect(sent).toEqual([]);
+      expect(requests.filter((request) => request.url.endsWith("/prompt_async"))).toHaveLength(0);
+      const retry = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+      const retriedFollowUp = submitAfterInterruption(baseUrl, root.id, send);
+      await Promise.all([retry, retriedFollowUp]);
+      expect(sessionNeedsStop(baseUrl, root.id)).toBe(false);
+      expect(sent).toEqual([true]);
+      expect(requests.filter((request) => request.url.endsWith("/prompt_async"))).toHaveLength(1);
+    });
+  });
+
+  test("drains old preflight before follow-up and cancels sends that had not entered preflight at Stop", async () => {
+    const root = { ...session, id: "ses_preflight" };
+    const baseUrl = endpoint.opencodeBaseUrl;
+    const preflight = Promise.withResolvers<Response>();
+    const preflightReached = Promise.withResolvers<void>();
+    const firstAbort = Promise.withResolvers<void>();
+    const events: string[] = [];
+    await withSessionFetch(async (request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/todo")) { preflightReached.resolve(); return preflight.promise; }
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith("/message")) return Response.json(turnMessages(root.id));
+      if (path.endsWith("/abort")) { events.push("abort"); firstAbort.resolve(); return Response.json(true); }
+      if (path.endsWith("/status")) { events.push("idle"); return Response.json({}); }
+      if (path.endsWith("/prompt_async")) {
+        const body = await request.json();
+        events.push(body.messageID);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async () => {
+      const client = createClient(baseUrl, root.directory);
+      const send = async (messageID: string) => unwrap(await client.session.promptAsync({ sessionID: root.id, messageID, parts: [] }));
+      const old = submitAfterInterruption(baseUrl, root.id, async () => {
+        unwrap(await client.session.todo({ sessionID: root.id }));
+        return send("msg_old_preflight");
+      });
+      await preflightReached.promise;
+      const notStarted = submitAfterInterruption(baseUrl, root.id, () => send("msg_never_started"));
+      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+      const cancelled = expect(notStarted).rejects.toThrow("Send cancelled by Stop");
+      const followUp = submitAfterInterruption(baseUrl, root.id, () => send("msg_follow_up"));
+      try {
+        await firstAbort.promise;
+        await cancelled;
+        expect(events).toEqual(["abort"]);
+        preflight.resolve(Response.json([]));
+        await Promise.all([old, stop, followUp]);
+        expect(events).toEqual(["abort", "msg_old_preflight", "abort", "idle", "msg_follow_up"]);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(false);
+      } finally {
+        preflight.resolve(Response.json([]));
+        await Promise.allSettled([old, stop, followUp, notStarted]);
+      }
+    });
+  });
+
+  test("re-aborts a mid-send predecessor admitted after the first abort before allowing follow-up", async () => {
+    const root = { ...session, id: "ses_mid_send" };
+    const baseUrl = endpoint.opencodeBaseUrl;
+    const admission = Promise.withResolvers<Response>();
+    const dispatched = Promise.withResolvers<void>();
+    const firstAbort = Promise.withResolvers<void>();
+    const events: string[] = [];
+    let busy = false;
+    await withSessionFetch(async (request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith("/message")) return Response.json(turnMessages(root.id));
+      if (path.endsWith("/abort")) { busy = false; events.push("abort"); firstAbort.resolve(); return Response.json(true); }
+      if (path.endsWith("/status")) { events.push("status"); return Response.json({ [root.id]: { type: busy ? "busy" : "idle" } }); }
+      if (path.endsWith("/prompt_async")) {
+        const body = await request.json();
+        if (body.messageID === "msg_old") {
+          events.push("old-dispatched");
+          dispatched.resolve();
+          const response = await admission.promise;
+          busy = true;
+          events.push("old-admitted");
+          return response;
+        }
+        events.push("follow-up");
+        busy = true;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async () => {
+      const client = createClient(baseUrl, root.directory);
+      const send = async (messageID: string) => unwrap(await client.session.promptAsync({ sessionID: root.id, messageID, parts: [] }));
+      const old = submitAfterInterruption(baseUrl, root.id, () => send("msg_old"));
+      await dispatched.promise;
+      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+      const followUp = submitAfterInterruption(baseUrl, root.id, () => send("msg_follow_up"));
+      try {
+        await firstAbort.promise;
+        expect(events).toEqual(["old-dispatched", "abort"]);
+        admission.resolve(new Response(null, { status: 204 }));
+        await Promise.all([old, stop, followUp]);
+        expect(events).toEqual(["old-dispatched", "abort", "old-admitted", "abort", "status", "follow-up"]);
+        expect(busy).toBe(true);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(false);
+      } finally {
+        admission.resolve(new Response(null, { status: 204 }));
+        await Promise.allSettled([old, stop, followUp]);
+      }
+    });
+  });
+
+  test("shares duplicate Stop across clients and trailing slashes without fencing another workspace, engine, or session", async () => {
+    const root = { ...session, id: "ses_scope" };
+    const baseUrl = endpoint.opencodeBaseUrl;
+    const idle = Promise.withResolvers<Response>();
+    const idleReached = Promise.withResolvers<void>();
+    const sent: string[] = [];
+    const targets = [
+      { baseUrl: baseUrl.replace("ws-native", "ws-other"), sessionID: root.id },
+      { baseUrl: baseUrl.replace("worker.example", "engine.example"), sessionID: root.id },
+      { baseUrl, sessionID: "ses_other" },
+    ];
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith("/message")) return Response.json(turnMessages(root.id));
+      if (path.endsWith("/abort")) return Response.json(true);
+      if (path.endsWith("/status")) { idleReached.resolve(); return idle.promise; }
+      if (path.endsWith("/prompt_async")) { sent.push(request.url); return new Response(null, { status: 204 }); }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClient(baseUrl, root.directory);
+      const otherClient = createClient(baseUrl, root.directory);
+      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+      expect(interruptSessionTurn(`${baseUrl}/`, otherClient, root.id, root.directory, { timeoutMs: 1_000 })).toBe(stop);
+      const followUp = submitAfterInterruption(`${baseUrl}/`, root.id, async (afterStop) => {
+        expect(afterStop).toBe(true);
+        return unwrap(await otherClient.session.promptAsync({ sessionID: root.id, parts: [] }));
+      });
+      try {
+        await idleReached.promise;
+        expect(sessionNeedsStop(`${baseUrl}/`, root.id)).toBe(true);
+        for (const target of targets) {
+          expect(sessionNeedsStop(target.baseUrl, target.sessionID)).toBe(false);
+          const independentClient = createClient(target.baseUrl, root.directory);
+          await submitAfterInterruption(target.baseUrl, target.sessionID, async (afterStop) => {
+            expect(afterStop).toBe(false);
+            return unwrap(await independentClient.session.promptAsync({ sessionID: target.sessionID, parts: [] }));
+          });
+        }
+        expect(sent).toEqual(targets.map((target) => `${target.baseUrl}/session/${target.sessionID}/prompt_async`));
+        expect(requests.filter((request) => new URL(request.url).pathname.endsWith("/abort"))).toHaveLength(2);
+        idle.resolve(Response.json({}));
+        await Promise.all([stop, followUp]);
+        expect(sent.at(-1)).toBe(`${baseUrl}/session/${root.id}/prompt_async`);
+        expect(sent).toHaveLength(4);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(false);
+      } finally {
+        idle.resolve(Response.json({}));
+        await Promise.allSettled([stop, followUp]);
+      }
+    });
   });
 });

--- a/apps/app/tests/queued-drain-admission-wedge.test.ts
+++ b/apps/app/tests/queued-drain-admission-wedge.test.ts
@@ -25,6 +25,25 @@ import {
 
 const t0 = 1_000_000;
 
+test("an immediate follow-up cannot inherit its interrupted predecessor's busy observation", () => {
+  let state = reduceQueuedDrain(INITIAL_QUEUED_DRAIN_STATE, { type: "send_started", itemId: "old" });
+  state = reduceQueuedDrain(state, { type: "busy_observed" });
+  state = reduceQueuedDrain(state, { type: "send_result", itemId: "old", outcome: "sent", at: t0 });
+  expect(canAdmitNextQueuedItem(reduceQueuedDrain(state, { type: "stop_confirmed" }))).toBe(true);
+  state = reduceQueuedDrain(state, { type: "send_started", itemId: "new", steer: true });
+  state = reduceQueuedDrain(state, { type: "busy_observed" });
+  expect(state.phase).toEqual({ kind: "sending", itemId: "new", busySeen: true });
+  state = reduceQueuedDrain(state, { type: "stop_confirmed" });
+  expect(state.phase).toEqual({ kind: "sending", itemId: "new", busySeen: false });
+  state = reduceQueuedDrain(state, { type: "send_result", itemId: "new", outcome: "sent", at: t0 + 10 });
+  expect(state.phase).toEqual({ kind: "awaiting_observation", itemId: "new", admittedAt: t0 + 10 });
+  expect(reduceQueuedDrain(state, { type: "idle_reconciled", observedAt: t0 })).toBe(state);
+  expect(canAdmitNextQueuedItem(state)).toBe(false);
+  state = reduceQueuedDrain(state, { type: "busy_observed" });
+  state = reduceQueuedDrain(state, { type: "idle_reconciled", observedAt: t0 + 20 });
+  expect(canAdmitNextQueuedItem(state)).toBe(true);
+});
+
 function admit(state: QueuedDrainState, itemId: string, at: number): QueuedDrainState {
   const sending = reduceQueuedDrain(state, { type: "send_started", itemId });
   expect(sending.phase).toEqual({ kind: "sending", itemId, busySeen: false });

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -176,7 +176,7 @@ stopTest("retry recovery and stopping a permission leave other requests and fres
 });
 
 const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
-questionTest("a parent answers its real child question without settling an unrelated root question", { timeout: 1_200_000 }, async ({ world, user, probe, step }) => {
+questionTest("a parent answers and stops real child questions, then finishes fresh work without settling an unrelated root question", { timeout: 1_200_000 }, async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";
   const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
   const sessionPath = (id: string) => `/session/${encodeURIComponent(id)}`;
@@ -260,7 +260,7 @@ questionTest("a parent answers its real child question without settling an unrel
     return request;
   });
 
-  const child = await step("the parent displays only its delegated child's question", async () => {
+  const delegate = async () => {
     await open(world.root.sessionId, "Delegated question parent");
     await user.notSee({ text: world.unrelated.question });
     await send(world.root.prompt);
@@ -282,13 +282,15 @@ questionTest("a parent answers its real child question without settling an unrel
     expect(owner[v2 ? "location" : "directory"]).toEqual(root[v2 ? "location" : "directory"]);
     expect(other[v2 ? "location" : "directory"]).toEqual(root[v2 ? "location" : "directory"]);
     await user.see({ text: world.child.question }, { timeoutMs: 30_000 });
+    await user.see({ role: "button", label: /^Child checklist/ });
     await user.notSee({ text: world.unrelated.question });
     await user.notSee({ role: "button", label: /^Unrelated outline/ });
     expect(await probe.hash()).toContain(`/session/${world.root.sessionId}`);
     expect((await transcript(request.sessionID)).find((message) => message.id === request.messageID)?.tools)
       .toContainEqual(expect.objectContaining({ callID: request.callID, name: "question", status: "running" }));
     return request;
-  });
+  };
+  const child = await step("the parent displays only its delegated child's question", delegate);
 
   await step("reloading the parent restores the same unanswered requests", async () => {
     await user.reload();
@@ -333,7 +335,63 @@ questionTest("a parent answers its real child question without settling an unrel
     return { parent: parentFinished, child: childFinished };
   });
 
-  await step("the unrelated root remains answerable without changing the parent's result", async () => {
+  const stopped = await step("the parent waits on another foreground child while the unrelated question stays pending", delegate);
+  expect(stopped.sessionID).not.toBe(child.sessionID);
+  expect(stopped.id).not.toBe(child.id);
+  const parentBeforeStop = await transcript(world.root.sessionId);
+  const delegation = parentBeforeStop.flatMap((message) => message.tools)
+    .filter((part) => part.name === world.delegationTool && part.status === "running");
+  expect(delegation).toHaveLength(1);
+  const oldRequests = () => Promise.all([world.root.prompt, world.child.prompt]
+    .map((promptMarker) => world.mock.agentRequests({ promptMarker })));
+  const requestsBeforeStop = await oldRequests();
+
+  const recovered = await step("Stop immediately followed by fresh work interrupts the child and completes only the new turn once", async () => {
+    await user.click({ role: "button", label: "Stop" });
+    // No reload or cleanup polling between Stop and sending the next user turn.
+    await send(world.followup.prompt);
+    await user.see({ text: world.followup.reply }, { timeoutMs: 60_000 });
+    await user.notSee({ role: "button", label: /^Child checklist/ });
+    await user.notSee({ role: "button", label: "Stop" });
+    expect(await probe.hash()).toContain(`/session/${world.root.sessionId}`);
+    await probe.eventually(pending, {
+      within: 30_000, label: "interruption removes only the stopped child's question",
+      until: (items) => items.length === 1 && items[0]?.id === unrelated.id,
+    });
+    expect(await pending()).toEqual([unrelated]);
+    const interrupted = await probe.eventually(() => transcript(stopped.sessionID), {
+      within: 30_000, label: "the original child question tool is interrupted, not answered",
+      until: (messages) => messages.some((message) => message.id === stopped.messageID
+        && message.tools.some((part) => part.callID === stopped.callID && part.status === "error")),
+    });
+    expect(interrupted.flatMap((message) => message.tools).some((part) => part.status === "completed")).toBe(false);
+    expect(interrupted.map((message) => message.text).join("\n")).not.toContain(world.followup.reply);
+    const parent = await probe.eventually(() => transcript(world.root.sessionId), {
+      within: 30_000, label: "the fresh parent response completes after its old delegation is interrupted",
+      until: (messages) => messages.some((message) => message.completed && message.text === world.followup.reply)
+        && messages.some((message) => message.tools.some((part) => part.callID === delegation[0]?.callID && part.status === "error")),
+    });
+    const newReplies = parent.filter((message) => message.text
+      && !parentBeforeStop.some((previous) => previous.id === message.id));
+    expect(newReplies).toHaveLength(1);
+    expect(newReplies[0]).toMatchObject({ completed: true, text: world.followup.reply, tools: [] });
+    expect((await world.mock.agentRequests({ promptMarker: world.followup.prompt })).map((call) => call.kind)).toEqual(["final"]);
+    expect(await oldRequests()).toEqual(requestsBeforeStop);
+    expect((await world.mock.agentRequests({ promptMarker: world.unrelated.prompt })).some((call) => call.kind === "final")).toBe(false);
+    if (v2) {
+      await probe.eventually(() => read(sessionPath(stopped.sessionID)), {
+        within: 15_000, label: "the stopped child retains the native interrupted outcome",
+        until: (value) => record(value).outcome === "interrupted",
+      });
+      await probe.eventually(() => read(sessionPath(world.root.sessionId)), {
+        within: 15_000, label: "only the fresh parent turn succeeds",
+        until: (value) => record(value).outcome === "succeeded",
+      });
+    }
+    return { parent, interrupted };
+  });
+
+  await step("the unrelated root remains answerable without resuming the stopped child or duplicating the follow-up", async () => {
     await open(unrelated.sessionID, "Unrelated question root");
     await user.see({ text: world.unrelated.question });
     await user.notSee({ text: world.child.question });
@@ -341,8 +399,12 @@ questionTest("a parent answers its real child question without settling an unrel
     await complete(unrelated.sessionID, world.unrelated.prompt, "question", `"${world.unrelated.question}"="${world.unrelated.answer}"`, world.child.answer);
     await user.see({ text: /User has answered your questions:.*="Unrelated outline"/ });
     expect(await pending()).toEqual([]);
-    expect(await transcript(world.root.sessionId)).toEqual(finished.parent);
+    expect(await transcript(world.root.sessionId)).toEqual(recovered.parent);
     expect(await transcript(child.sessionID)).toEqual(finished.child);
+    expect(await transcript(stopped.sessionID)).toEqual(recovered.interrupted);
+    expect(await oldRequests()).toEqual(requestsBeforeStop);
+    expect((await world.mock.agentRequests({ promptMarker: world.followup.prompt })).map((call) => call.kind)).toEqual(["final"]);
+    if (v2) expect(record(await read(sessionPath(stopped.sessionID))).outcome).toBe("interrupted");
     await user.screenshot();
   });
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -277,6 +277,7 @@ export async function delegatedQuestionHandoff(seed: Seed) {
     answer: "Unrelated outline",
     alternative: "Unrelated checklist",
   };
+  const followup = { prompt: "Leave the delegated task stopped and prepare a fresh summary", reply: "Fresh summary finished after stopping the child." };
   const base = await splitPaneQuestions(seed, "delegated-question-handoff", [
     {
       promptMarker: rootPrompt, latestUserTurn: true,
@@ -298,6 +299,7 @@ export async function delegatedQuestionHandoff(seed: Seed) {
         ],
       }] } }],
     })),
+    { promptMarker: followup.prompt, latestUserTurn: true, finalReply: followup.reply, steps: [] },
   ], {
     permission: { question: "allow", task: "allow" },
     // Both engines deny questions for general by default; v2 migrates task to subagent.
@@ -305,7 +307,7 @@ export async function delegatedQuestionHandoff(seed: Seed) {
   });
   const root = await seedSessionRetry(seed, base.app, { title: "Delegated question parent" });
   const other = await seedSessionRetry(seed, base.app, { title: "Unrelated question root" });
-  return { ...base, engine, delegationTool, root: { ...root, prompt: rootPrompt }, child, unrelated: { ...other, ...unrelated } };
+  return { ...base, engine, delegationTool, followup, root: { ...root, prompt: rootPrompt }, child, unrelated: { ...other, ...unrelated } };
 }
 
 /** Real native permissions and a provider retry, without synthetic UI events. */


### PR DESCRIPTION
## Summary

- Make composer Stop cancel the current foreground task tree, verify each child belongs to the same parent/workspace, and confirm native idle before releasing the next user turn.
- Share the interruption boundary across visible panes and queued sends. Settle older in-flight submissions and stop late admissions before sending the follow-up; keep Stop available if cancellation fails or admission remains unknown.
- Reconcile the old queue admission before the successor starts, without inheriting predecessor busy state. Use the matching v1/v2 client for queued and other-workspace-pane submissions.
- Extend the existing parent/child permission journey with Stop followed immediately by fresh work, interrupted-child assertions, single follow-up completion, and unrelated-session isolation. Preserve explicit background tasks and normal steering semantics.

## Verification — Incomplete

Head: `3f708af7f34b24ae4895e632e971c8a355d73ec0`, rebased onto `dev` at `60494f2055c80f4f8694e53c8a8ac41aeac6b654`.

| Check | Result |
| --- | --- |
| Focused regression tests | Exit 0: 24 passed, 0 failed, 0 skipped; 251 assertions |
| App typecheck | Exit 0; no diagnostics |
| Diff whitespace check | Passed |
| Real-engine v1/v2 journey | Not run; exact-head runtime evidence and publication remain outstanding |

Commands run on this head:
```sh
pnpm --filter @openwork/app exec bun test ./tests/opencode-session-native.test.ts ./tests/queued-drain-admission-wedge.test.ts
pnpm --filter @openwork/app typecheck
git diff origin/dev...HEAD --check
```

The focused tests use controlled HTTP responses through the actual v1/v2 clients. They cover delayed child interruption, nested ownership, background/historical exclusions, timeout and retry fencing, late admissions, duplicate Stop, and endpoint isolation. They are not real-engine or desktop proof. This PR is open for review, not a claim of merge readiness. End-to-end execution was deferred from the local candidate pass; no runtime placement or passing end-to-end verdict is claimed.

Remaining proof on the pushed head:
```sh
OPENWORK_EVAL_REF=3f708af7f34b24ae4895e632e971c8a355d73ec0 OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e parent-child-permission-approval
OPENWORK_EVAL_REF=3f708af7f34b24ae4895e632e971c8a355d73ec0 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e parent-child-permission-approval
```
Publish those saved runs after completion; any missing or skipped claims keep the verdict Incomplete.

## Related work

- #4640 adds archive-specific cancellation/admission guards; reconcile shared logic when integrating. This change does not include archive behavior.
- #4599 contains the same global-drainer v2 client-selection correction. Only that necessary correction overlaps; its larger test changes and history are not included.

No merge, release, deployment, or installer change is included.