### PR TITLE
fix(app): remove no-new-activity warning

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -1596,13 +1596,6 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
         )
         })}
 
-        {noNewActivity ? (
-          <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-1 px-2 md:px-10">
-            <div data-loading-message="no-new-activity" role="status" className="text-sm text-amber-11">No new activity</div>
-            <p className="text-xs text-muted-foreground">No new progress has been received for over a minute. The task may still be running.</p>
-            {baseUrl ? <button type="button" className="text-xs underline underline-offset-2" onClick={() => void revalidateWorkspaceSessionSync({ workspaceId, baseUrl })}>Check activity</button> : null}
-          </Message>
-        ) : null}
         {showLoading && <LoadingMessage elapsedSeconds={runElapsedSeconds} />}
         {showReconnecting && <ReconnectingMessage lastConfirmedAt={syncHealth?.lastConfirmedAt ?? null} />}
         {retryStatus ? <RetryMessage status={retryStatus} /> : null}


### PR DESCRIPTION
## Summary
- Remove only the orange "No new activity" warning, explanatory text, and "Check activity" link.
- Preserve inactivity detection, automatic session revalidation, recovery, and all other UI behavior.
- Scope: one file, seven deleted JSX lines.

## Verification
- Passed: `git diff origin/dev...HEAD --check` (exit 0).
- Passed: targeted diff inspection confirms only the warning block changed; monitoring and recovery code remain unchanged.
- Runtime proof: Incomplete. E2E execution and runtime evidence are deferred for this narrowly scoped change; no runtime pass is claimed.
- Based on freshly fetched canonical `dev` at `476b6d49e9498cf96ace44b1fdc74d5de617a319`; no rebase was needed.
