### PR TITLE
fix(composer): wait for image readiness before showing sent text

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -94,7 +94,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const submittingRef = useRef(false);
   const draftRevisionRef = useRef(0);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
-  const [pendingAttachmentNames, setPendingAttachmentNames] = useState<string[]>([]);
+  const [preparingAttachments, setPreparingAttachments] = useState(false);
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [failedSubmission, setFailedSubmission] = useState<{ text: string; attachments: ComposerAttachment[]; pastedText: PastedTextChip[] } | null>(null);
   const draftRef = useRef(props.draft);
@@ -259,26 +259,32 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     const revision = draftRevisionRef.current;
     const resolved = resolvePastedTextPlaceholders(originalDraft, pastedText);
     const saved = { text: originalDraft, attachments, pastedText };
-    setPendingPrompt(resolved.replace(/\[attachment [^\]]+\]/g, ""));
-    setPendingAttachmentNames(attachments.map((attachment) => attachment.name));
+    if (!attachments.length) setPendingPrompt(resolved.replace(/\[attachment [^\]]+\]/g, ""));
+    setPreparingAttachments(attachments.length > 0);
     setSubmissionError(null);
-    props.onDraftChange("");
-    draftRef.current = "";
-    setAttachments([]);
-    setPastedText([]);
+    // Attachment drafts stay visible through session creation and are handed
+    // to the session composer, which clears them only after preparation.
+    if (!attachments.length) {
+      props.onDraftChange("");
+      draftRef.current = "";
+      setAttachments([]);
+      setPastedText([]);
+    }
     try {
       await props.onRunTask(resolved, attachments);
     } catch (error) {
-      if (draftRevisionRef.current === revision && !draftRef.current) {
-        props.onDraftChange(originalDraft);
-        setAttachments(saved.attachments);
-        setPastedText(saved.pastedText);
-      } else {
-        setFailedSubmission(saved);
+      if (!attachments.length) {
+        if (draftRevisionRef.current === revision && !draftRef.current) {
+          props.onDraftChange(originalDraft);
+          setAttachments(saved.attachments);
+          setPastedText(saved.pastedText);
+        } else {
+          setFailedSubmission(saved);
+        }
       }
       setSubmissionError(error instanceof Error ? error.message : "Could not create the conversation. Try again.");
       setPendingPrompt(null);
-      setPendingAttachmentNames([]);
+      setPreparingAttachments(false);
       submittingRef.current = false;
     }
   };
@@ -292,14 +298,6 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     <>
     {pendingPrompt !== null ? <div className="mb-4 whitespace-pre-wrap rounded-xl bg-muted px-4 py-3 text-sm" data-message-role="user">
       {pendingPrompt}
-      {pendingAttachmentNames.length > 0 ? <div role="status" className="mt-2 flex flex-wrap gap-2">
-        {pendingAttachmentNames.map((name, index) => (
-          <span key={index} className="inline-flex max-w-full items-center gap-2 rounded-xl border border-border/70 px-2 py-1 text-xs text-muted-foreground" data-attachment-status="preparing">
-            <span className="truncate" title={name}>{name}</span>
-            <span className="shrink-0">Preparing attachment...</span>
-          </span>
-        ))}
-      </div> : null}
     </div> : null}
     {submissionError ? <div role="alert" className="mb-2 text-sm text-red-11">{submissionError}</div> : null}
     {failedSubmission ? <button type="button" disabled={Boolean(props.draft || attachments.length)} className="mb-2 text-sm disabled:opacity-50" onClick={() => {
@@ -319,7 +317,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onStop={noop}
       busy={false}
       steering={false}
-      submissionPreparing={props.busy || pendingPrompt !== null || failedSubmission !== null}
+      submissionPreparing={props.busy || pendingPrompt !== null || preparingAttachments || failedSubmission !== null}
       queuedCount={0}
       disabled={Boolean(context?.modelUnavailable)}
       modelUnavailable={context?.modelUnavailable}
@@ -335,7 +333,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onModelPickerOpenChange={context?.onModelPickerOpenChange ?? noop}
       onModelChange={context?.onModelChange ?? noop}
       attachments={attachments}
-      attachmentsUploading={props.busy && attachments.length > 0}
+      attachmentsUploading={preparingAttachments}
       onAttachFiles={handleAttachFiles}
       onRemoveAttachment={handleRemoveAttachment}
       attachmentsEnabled

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -581,7 +581,7 @@ export type SessionSurfaceProps = {
   onRefreshOrganizationModels?: () => void | Promise<void>;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef, variant?: string | null) => void;
-  onSendDraft: (draft: ComposerDraft, sessionId: string) => Promise<CloudMcpSubmissionResult>;
+  onSendDraft: (draft: ComposerDraft, sessionId: string, onPrepared?: () => void) => Promise<CloudMcpSubmissionResult>;
   cloudMcpSubmissionState: CloudMcpSubmissionGateState;
   onOpenConnect: () => void;
   onDraftChange: (draft: ComposerDraft) => void;
@@ -1350,7 +1350,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
   const pendingMessages = useComposerStateStore((state) => state.pendingMessages[sessionOwner]);
   const failedDraft = useComposerStateStore((state) => state.failedDrafts[sessionOwner]?.[0]);
-  const autoSending = hasComposerAutoSend(props.sessionId) && !sessionModelUnavailable;
+  const autoSending = hasComposerAutoSend(props.sessionId) && !sessionModelUnavailable && attachments.length === 0;
   const unmatchedPendingMessages = useMemo(() => {
     const matchedIds = new Set<string>();
     const remaining = (pendingMessages ?? []).filter(({ draft: pending, previousMessageIds }) => {
@@ -1860,7 +1860,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Core sender shared by initial send and steered follow-ups. OpenCode
   // accepts follow-up user turns mid-run (steering) — the running loop picks
   // up the new message — so this is safe to call while the agent is busy.
-  const sendDraft = useCallback(async (nextDraft: ComposerDraft, itemId: string): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
+  const sendDraft = useCallback(async (nextDraft: ComposerDraft, itemId: string, onPrepared?: () => void): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
     const messageId = nextDraft.messageId ?? createPromptMessageID();
     const generation = getQueuedSendGeneration(props.sessionId);
     const submissionId = Symbol();
@@ -1869,7 +1869,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setError(null);
     try {
       const result = await submitAfterInterruption(props.opencodeBaseUrl, props.sessionId,
-        () => props.onSendDraft({ ...nextDraft, messageId }, props.sessionId));
+        () => props.onSendDraft({ ...nextDraft, messageId }, props.sessionId, onPrepared));
       dispatchQueuedDrain(props.sessionId, { type: "send_result", itemId, outcome: result.outcome, at: Date.now() });
       if (getQueuedSendGeneration(props.sessionId) !== generation) return result;
       if (result.outcome === "blocked" || result.outcome === "cancelled") return result;
@@ -1924,8 +1924,27 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!claimQueuedSend(props.sessionId, nextDraft.messageId, true)) return;
     const sentAttachments = attachments;
     const savedComposer = useComposerStateStore.getState().sessions[props.sessionId];
-    clearComposer();
-    const clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
+    let clearedComposer: typeof savedComposer;
+    let composerCleared = false;
+    const markPrepared = () => {
+      // Do not erase edits made while attachments were being prepared.
+      if (useComposerStateStore.getState().sessions[props.sessionId] === savedComposer
+        && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
+        clearComposer();
+        clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
+        composerCleared = true;
+      }
+      useComposerStateStore.setState((state) => ({
+        pendingMessages: {
+          ...state.pendingMessages,
+          [sessionOwner]: [...(state.pendingMessages[sessionOwner] ?? []), {
+            draft: nextDraft,
+            previousMessageIds: baseRenderedMessages.map((message) => message.id),
+          }],
+        },
+      }));
+      setAttachmentsUploading(false);
+    };
     const removePending = () => useComposerStateStore.setState((state) => ({
       pendingMessages: {
         ...state.pendingMessages,
@@ -1934,6 +1953,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }));
     const restore = () => {
       removePending();
+      if (!composerCleared) return;
       const state = useComposerStateStore.getState();
       // Identity, not text equality: typing and then deleting is still a newer edit.
       if (savedComposer && state.sessions[props.sessionId] === clearedComposer
@@ -1947,24 +1967,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
         } });
       }
     };
-    useComposerStateStore.setState((state) => ({
-      pendingMessages: {
-        ...state.pendingMessages,
-        [sessionOwner]: [...(state.pendingMessages[sessionOwner] ?? []), {
-          draft: nextDraft,
-          previousMessageIds: baseRenderedMessages.map((message) => message.id),
-        }],
-      },
-    }));
     if (sentAttachments.length) setAttachmentsUploading(true);
+    else markPrepared();
     try {
-      const result = await sendDraft(nextDraft, nextDraft.messageId);
+      const result = await sendDraft(nextDraft, nextDraft.messageId, sentAttachments.length ? markPrepared : undefined);
       if (result.outcome === "blocked" || result.outcome === "cancelled") {
         restore();
         return;
       }
       if (result.outcome !== "unknown" && (nextDraft.command || nextDraft.mode === "shell")) removePending();
-      sentAttachments.forEach(revokeAttachmentPreview);
+      const retained = useComposerStateStore.getState().sessions[props.sessionId]?.attachments ?? [];
+      sentAttachments.filter((attachment) => !retained.includes(attachment)).forEach(revokeAttachmentPreview);
     } catch {
       restore();
     } finally {
@@ -2004,13 +2017,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Queue: hold the draft locally and clear the composer. The drain effect
   // sends it once the session reports idle.
   const handleQueue = useCallback(() => {
+    if ([...pendingSendsRef.current.values()].includes(sessionOwner)) return;
     const text = draft.trim();
     if (!text && attachments.length === 0) return;
     const queuedDraft = withoutRevertTarget(buildDraft(text, attachments));
     if (!queuedDraft) return;
     appendQueuedDraft(props.sessionId, queuedDraft);
     clearComposer();
-  }, [appendQueuedDraft, attachments, buildDraft, clearComposer, draft, props.sessionId]);
+  }, [appendQueuedDraft, attachments, buildDraft, clearComposer, draft, props.sessionId, sessionOwner]);
 
   const removeQueuedDraft = useCallback((id: string) => {
     const target = queuedItems.find((item) => item.id === id);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1300,7 +1300,7 @@ export function SessionRoute() {
           openSettings: handleOpenSettings,
         });
       },
-      onSendDraft: async (draft: ComposerDraft, sessionId: string): Promise<CloudMcpSubmissionResult> => {
+      onSendDraft: async (draft: ComposerDraft, sessionId: string, onPrepared?: () => void): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || selectedSessionId;
         if (!targetSessionId) return { outcome: "cancelled", reason: "context_changed" };
         const generation = getQueuedSendGeneration(targetSessionId);
@@ -1373,11 +1373,13 @@ export function SessionRoute() {
                 trackTaskStarted(targetSessionId, telemetryDimensions);
 
                 if (draft.mode === "shell") {
+                  onPrepared?.();
                   await shellInSession(opencodeClient, targetSessionId, text);
                   return;
                 }
 
                 if (draft.command) {
+                  onPrepared?.();
                   const result = await opencodeClient.session.command({
                     sessionID: targetSessionId,
                     command: draft.command.name,
@@ -1397,6 +1399,7 @@ export function SessionRoute() {
                   runtimeKey: environmentRuntimeKey,
                 });
                 assertCurrent();
+                onPrepared?.();
                 const result = await opencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
                   messageID: draft.messageId,
@@ -1654,7 +1657,7 @@ export function SessionRoute() {
       isSandboxWorkspace: isSandboxWorkspace(workspace),
       environmentRuntimeKey: workspace.workspaceType === "remote" ? null : environmentRuntimeKey,
       onApplyEnvironmentChanges: undefined,
-      onSendDraft: async (draft: ComposerDraft, sessionId: string): Promise<CloudMcpSubmissionResult> => {
+      onSendDraft: async (draft: ComposerDraft, sessionId: string, onPrepared?: () => void): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || session.sessionId;
         const generation = getQueuedSendGeneration(targetSessionId);
         const assertCurrent = () => assertQueuedSendCurrent(targetSessionId, generation);
@@ -1705,10 +1708,12 @@ export function SessionRoute() {
                 trackSessionActive(targetSessionId, telemetryDimensions);
                 trackTaskStarted(targetSessionId, telemetryDimensions);
                 if (draft.mode === "shell") {
+                  onPrepared?.();
                   await shellInSession(workspaceOpencodeClient, targetSessionId, text);
                   return;
                 }
                 if (draft.command) {
+                  onPrepared?.();
                   const result = await workspaceOpencodeClient.session.command({
                     sessionID: targetSessionId,
                     command: draft.command.name,
@@ -1725,6 +1730,7 @@ export function SessionRoute() {
                   runtimeKey: workspace.workspaceType === "remote" ? null : environmentRuntimeKey,
                 });
                 assertCurrent();
+                onPrepared?.();
                 const result = await workspaceOpencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
                   messageID: draft.messageId,

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -8,7 +8,7 @@ import { createRoot } from "react-dom/client";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
-import type { ComposerDraft } from "../src/app/types";
+import type { ComposerAttachment, ComposerDraft } from "../src/app/types";
 import type { CloudMcpSubmissionResult } from "../src/react-app/domains/connections/cloud-mcp-submit-readiness";
 
 const workspaceId = "workspace-focus-continuity";
@@ -128,6 +128,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
   const draft = "Keep this draft while the task finishes";
   let submission = Promise.withResolvers<CloudMcpSubmissionResult>();
   const sentDrafts: ComposerDraft[] = [];
+  let prepareSubmission: (() => void) | undefined;
 
   try {
     await act(async () => {
@@ -151,8 +152,9 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
                 selectedModel={{ providerID: "test", modelID: "test-model" }}
                 onModelPickerOpenChange={() => {}}
                 onModelChange={() => {}}
-                onSendDraft={(value) => {
+                onSendDraft={(value, _sessionId, onPrepared) => {
                   sentDrafts.push(value);
+                  prepareSubmission = onPrepared;
                   return submission.promise;
                 }}
                 cloudMcpSubmissionState={IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE}
@@ -211,6 +213,43 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
       button.click();
       button.click();
     };
+    const attachment: ComposerAttachment = { id: "image-ready", name: "photo.png", mimeType: "image/png", size: 3, kind: "image",
+      file: new File(["png"], "photo.png", { type: "image/png" }) };
+    await act(async () => {
+      useComposerStateStore.getState().setAttachments(sessionId, [attachment]);
+      useComposerStateStore.getState().setDraft(sessionId, `${draft}[attachment image-ready]`);
+    });
+    await act(async () => send());
+    expect(sentDrafts).toHaveLength(1);
+    expect(editor.textContent).toContain(draft);
+    expect(container.querySelector('[data-attachment-status="uploading"]')).not.toBeNull();
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
+    await act(async () => {
+      editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true, bubbles: true }));
+    });
+    expect(sentDrafts).toHaveLength(1);
+    expect(useComposerStateStore.getState().queuedDrafts[sessionId]).toBeUndefined();
+    await act(async () => submission.reject(new Error("Image preparation failed")));
+    expect(editor.textContent).toContain(draft);
+    expect(useComposerStateStore.getState().sessions[sessionId]?.attachments).toEqual([attachment]);
+    expect(Object.values(useComposerStateStore.getState().failedDrafts).flat()).toHaveLength(0);
+
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Dismiss error"]')?.click());
+    await act(async () => send());
+    expect(prepareSubmission).toBeFunction();
+    await act(async () => prepareSubmission?.());
+    expect(editor.textContent).toBe("");
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
+    await act(async () => submission.resolve({ outcome: "cancelled", reason: "context_changed" }));
+    expect(editor.textContent).toContain(draft);
+    await act(async () => {
+      useComposerStateStore.getState().setAttachments(sessionId, []);
+      useComposerStateStore.getState().setDraft(sessionId, draft);
+    });
+    sentDrafts.length = 0;
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
     await act(async () => send());
     expect(sentDrafts).toHaveLength(1);
     expect(editor.textContent).toBe("");
@@ -306,7 +345,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(sentDrafts).toHaveLength(4);
 
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
-    const creation = Promise.withResolvers<void>();
+    let creation = Promise.withResolvers<void>();
     let creations = 0;
     let updateHeroDraft = (_text: string) => {};
     function Hero() {
@@ -333,6 +372,21 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     });
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("First hero message");
     expect(creations).toBe(1);
+    creation = Promise.withResolvers<void>();
+    await act(async () => {
+      const input = container.querySelector<HTMLInputElement>('input[type="file"][multiple]');
+      if (!input) throw new Error("Expected the attachment input");
+      Object.defineProperty(input, "files", { configurable: true, value: [attachment.file] });
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await act(async () => send());
+    expect(creations).toBe(2);
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toContain("First hero message");
+    expect(container.querySelector('[data-message-role="user"]')).toBeNull();
+    expect(container.querySelector('[data-attachment-status="uploading"]')).not.toBeNull();
+    await act(async () => creation.reject(new Error("Image session creation failed")));
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toContain("First hero message");
+    expect(container.querySelector('[data-attachment-id]')).not.toBeNull();
   } finally {
     await act(async () => root.unmount());
     resetQueuedDrainForTests();

--- a/evals/specs/attachment-upload-loading-state.e2e.test.ts
+++ b/evals/specs/attachment-upload-loading-state.e2e.test.ts
@@ -13,7 +13,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-test("attaching an image shows its chip instantly and sends with a visible uploading state", async ({ world, user, seed, probe, step }) => {
+for (const entryPoint of ["existing chat", "new task"]) {
+test(`attaching an image in ${entryPoint} retains the draft until the upload is ready`, async ({ world, user, seed, probe, step }) => {
   await step("manual approval exempts only chat-attachment inbox uploads", async () => {
     expect(world.uploadStatus).toBe(200);
     expect(world.uploadElapsedMs).toBeLessThan(world.approvalTimeoutMs);
@@ -21,9 +22,10 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
     expect(world.writeElapsedMs).toBeGreaterThanOrEqual(world.approvalTimeoutMs - 100);
   });
 
+  if (entryPoint === "new task") await user.click({ role: "button", label: /^New task$/ });
   await user.type("composer", "Describe the attached image.");
   // TODO(primitive): attach an in-memory file through the composer's file chooser.
-  const attached = await seed.evalIn(world.app, browserScript(async (attachmentName) => {
+  const attached = await seed.evalIn(world.app, browserScript(async (attachmentName: string) => {
       const canvas = document.createElement("canvas");
       canvas.width = 2400;
       canvas.height = 2400;
@@ -88,15 +90,30 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
     record();
     return true;
   });
+  await world.holdUploads();
   await user.click("Run task");
 
   // TODO(primitive): await a transient attachment-status witness.
-  expect(await probe.eventually(() => probe.eval(() => (globalThis.__attachmentUploadingSeen === true)), {
+  expect(await probe.eventually(() => probe.eval(() => (globalThis.__attachmentUploadingSeen === true && window.__openworkSubmissionFault?.attempts === 1)), {
     within: 30_000,
     intervalMs: 50,
     label: "attachment uploading state observed",
     until: (value) => value === true,
   })).toBe(true);
+  await step("the draft is not sent while its image is preparing", async () => {
+    await user.see("composer", { text: /Describe the attached image\./ });
+    expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(0);
+    await user.click("composer");
+    await user.press("Enter");
+    await user.press("Meta+Enter");
+    await user.see("composer", { text: /Describe the attached image\./ });
+    expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(0);
+    await user.notSee({ text: /1 queued/ });
+  });
+  await world.releaseUploads();
+  await user.see({ text: "attachment upload loading proof" });
+  await user.see("composer", { text: "" });
+  expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(1);
   await user.notSee({ text: /1 queued/ });
   expect((await probe.hash()).includes("/session/ses_")).toBe(true);
   // TODO(primitive): inspect attachment cleanup and error-toast state after send.
@@ -112,3 +129,4 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   expect(await probe.eval(() => (document.querySelectorAll<HTMLButtonElement>('button[title="Open pasted-recording.mp4 in Artifacts"]').length))).toBe(1);
   await user.screenshot();
 });
+}

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -616,6 +616,33 @@ export async function attachmentUpload(seed: Seed) {
       app,
       workspace,
       session,
+      async holdUploads() {
+        await seed.evalIn(app, () => {
+          const originalFetch = window.fetch;
+          let release = () => {};
+          const gate = new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error("Attachment upload gate timed out")), 60_000);
+            release = () => { clearTimeout(timer); resolve(); };
+          });
+          const fault = {
+            attempts: 0,
+            release: () => { release(); window.fetch = originalFetch; },
+          };
+          window.__openworkSubmissionFault = fault;
+          window.fetch = async (input, init) => {
+            const url = input instanceof Request ? input.url : String(input);
+            const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+            if (method === "POST" && /\/inbox\?/.test(url) && url.includes("chat-attachments")) {
+              fault.attempts++;
+              await gate;
+            }
+            return originalFetch(input, init);
+          };
+        });
+      },
+      async releaseUploads() {
+        await seed.evalIn(app, () => window.__openworkSubmissionFault?.release());
+      },
       approvalTimeoutMs,
       uploadStatus: uploadResponse.status,
       uploadElapsedMs,


### PR DESCRIPTION
## Summary
- Keep attachment-bearing drafts in the composer until compression and upload finish, rather than showing an optimistic text message during preparation.
- Block duplicate sends and keyboard queueing during preparation, retain drafts on preparation failure, and preserve newer edits.
- Apply the same behavior to new-task handoff. Text-only messages still send immediately.
- Extend the existing attachment upload journey for existing chats and new tasks.

## Verification — Incomplete
- Passed: pnpm --filter @openwork/app exec bun test --isolate ./tests/composer-focus-continuity.test.tsx (exit 0; 1 passed, 0 failed; 67 assertions), rerun on head a6f61060f after rebase.
- Passed: git diff --check.
- Failed: pnpm evals:check-browser (exit 1; diagnostics include DesktopShotSurface.workspaceId and implicit parameter types across eval tooling). Not classified as pre-existing without a clean control.
- Deferred: pnpm evals:e2e attachment-upload-loading-state. Remote infrastructure was not provisioned; no runtime placement or published journey evidence is claimed. Required CI remains unchanged.

## Manual reproduction
1. Attach a large image and type a message in an existing conversation or new task.
2. Send while attachment preparation is slow. Text and image should remain in the composer with the upload indicator, without a user message appearing yet.
3. Press Enter and Cmd/Ctrl+Enter during preparation: no duplicate submission or queued message should appear.
4. Once preparation finishes, the composer clears and the complete message appears.
5. If preparation fails, the draft remains available to retry.
