### PR TITLE
fix(session): keep Stop responsive and recover stalled sends

### DIFF
--- a/apps/app/src/app/lib/opencode-interruption.ts
+++ b/apps/app/src/app/lib/opencode-interruption.ts
@@ -1,9 +1,15 @@
 import type { Client } from "../types";
 import { isPromptAdmissionUnknown, unwrap } from "./opencode";
 
+type Submission = {
+  messageID?: string;
+  settled: boolean;
+  error?: unknown;
+  cancel: () => void;
+};
 type Turn = {
   generation: number;
-  submissions: Set<Promise<unknown>>;
+  submissions: Set<Submission>;
   interruption?: Promise<void>;
   stopping: boolean;
   needsStop: boolean;
@@ -23,18 +29,28 @@ function turnFor(baseUrl: string, sessionID: string) {
 
 /** Shared by visible panes and the background queue. A successor cannot enter
  * the engine while Stop is still cancelling its predecessor's children. */
-export async function submitAfterInterruption<T>(baseUrl: string, sessionID: string, send: (afterStop: boolean) => Promise<T>): Promise<T> {
+export async function submitAfterInterruption<T>(baseUrl: string, sessionID: string, send: (afterStop: boolean) => Promise<T>, messageID?: string): Promise<T> {
   const turn = turnFor(baseUrl, sessionID);
   const generation = turn.generation;
   const interruption = turn.interruption;
   await interruption;
   if (turn.generation !== generation) throw new Error("Send cancelled by Stop.");
-  const pending = send(interruption !== undefined);
-  turn.submissions.add(pending);
+  let cancel!: () => void;
+  const cancelled = new Promise<never>((_, reject) => {
+    cancel = () => reject(new Error("Send cancelled by Stop."));
+  });
+  const submission: Submission = {
+    messageID, settled: false, cancel,
+  };
+  const pending = send(interruption !== undefined).then(
+    (result) => { submission.settled = true; return result; },
+    (error: unknown) => { submission.settled = true; submission.error = error; throw error; },
+  );
+  turn.submissions.add(submission);
   try {
-    return await pending;
+    return await Promise.race([pending, cancelled]);
   } finally {
-    turn.submissions.delete(pending);
+    turn.submissions.delete(submission);
   }
 }
 
@@ -58,8 +74,10 @@ export function interruptSessionTurn(
   options: { timeoutMs?: number; admissionUnknown?: boolean; onStopped?: () => void } = {},
 ): Promise<void> {
   const turn = turnFor(baseUrl, sessionID);
-  if (turn.stopping && turn.interruption) return turn.interruption;
+  // Share the cancellation request, not permission for intervening sends to
+  // survive another explicit Stop.
   turn.generation += 1;
+  if (turn.stopping && turn.interruption) return turn.interruption;
   turn.stopping = true;
   turn.needsStop = true;
   const pending = [...turn.submissions];
@@ -78,6 +96,7 @@ export function interruptSessionTurn(
     turn.needsStop = false;
   }).finally(() => {
     clearTimeout(timer);
+    controller.abort(new Error("Stop operation finished."));
     turn.stopping = false;
     for (const listener of turn.listeners) listener();
   });
@@ -92,7 +111,7 @@ async function stopForegroundTree(
   client: Client,
   rootID: string,
   directory: string | undefined,
-  pending: readonly Promise<unknown>[],
+  pending: readonly Submission[],
   signal: AbortSignal,
   admissionUnknown: boolean,
 ) {
@@ -116,7 +135,20 @@ async function stopForegroundTree(
     // child. Only the final authoritative idle check establishes settlement.
     unwrap(await client.session.abort({ sessionID, directory }, options));
   };
-  const root = unwrap(await client.session.get({ sessionID: rootID, directory }, options));
+  // Stop must reach the engine even when session/transcript reads are broken.
+  // Read concurrently to retain child references, but never gate the root abort
+  // on discovery. Failed discovery still prevents claiming a complete handoff.
+  const [aborted, rootResult, childResult] = await Promise.allSettled([
+    abort(rootID),
+    client.session.get({ sessionID: rootID, directory }, options).then(unwrap),
+    children(rootID),
+  ]);
+  // Do not let a fast discovery failure cancel an abort still in flight.
+  if (aborted.status === "rejected") throw aborted.reason;
+  if (rootResult.status === "rejected") throw rootResult.reason;
+  if (childResult.status === "rejected") throw childResult.reason;
+  const root = rootResult.value;
+  const before = childResult.value;
   if (root.id !== rootID || (directory !== undefined && root.directory !== directory)) {
     throw new Error("Could not verify the conversation's workspace. Stop was not confirmed.");
   }
@@ -141,15 +173,42 @@ async function stopForegroundTree(
       await stop(id);
     }
   };
-  const before = await children(rootID);
-  // Stop active work promptly, even if an older shell/send has not returned.
-  await abort(rootID);
-  const settled = await Promise.allSettled(pending);
+  const waiting = new Set(pending);
+  const reconciled = new Set<Submission>();
+  while (waiting.size > 0) {
+    signal.throwIfAborted();
+    for (const submission of waiting) if (submission.settled) waiting.delete(submission);
+    if (waiting.size === 0) break;
+    if ([...waiting].some((submission) => submission.messageID !== undefined)) {
+      const messages = unwrap(await client.session.messages({ sessionID: rootID, directory }, options));
+      const statuses = unwrap(await client.session.status({ directory }, options));
+      signal.throwIfAborted();
+      if (!statuses[rootID] || statuses[rootID].type === "idle") {
+        for (const submission of waiting) {
+          const id = submission.messageID;
+          if (id === undefined) continue;
+          const admitted = messages.some(({ info }) => info.id === id && info.sessionID === rootID && info.role === "user");
+          const terminal = messages.some(({ info, parts }) => info.role === "assistant" && info.sessionID === rootID
+            && info.parentID === id && typeof info.time.completed === "number" && info.finish !== "tool-calls"
+            && !parts.some((part) => part.type === "tool" && ["pending", "running"].includes(part.state.status)));
+          // Exact terminal evidence reconciles a lost response, not an absent
+          // message or an idle snapshot on its own. Reject only the UI wait;
+          // never replay the request, and still stop/verify the child tree below.
+          if (admitted && terminal) {
+            reconciled.add(submission);
+            submission.cancel();
+            waiting.delete(submission);
+          }
+        }
+      }
+    }
+    if (waiting.size > 0) await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
   signal.throwIfAborted();
   await stop(rootID, before);
   // A lost admission response is not proof that the old POST cannot arrive
   // later. Do not claim a clean handoff or replay that prompt.
-  if (admissionUnknown || settled.some((result) => result.status === "rejected" && isPromptAdmissionUnknown(result.reason))) {
+  if (admissionUnknown || pending.some((submission) => !reconciled.has(submission) && isPromptAdmissionUnknown(submission.error))) {
     throw new Error("The previous message's acceptance is still unknown. Check acceptance, then retry Stop.");
   }
   while (true) {

--- a/apps/app/src/app/lib/opencode-session.ts
+++ b/apps/app/src/app/lib/opencode-session.ts
@@ -195,9 +195,9 @@ export async function shellInSession(
   client: Client,
   sessionID: string,
   command: string,
-  options?: { model?: { providerID: string; modelID: string }; agent?: string; variant?: string },
+  options?: { model?: { providerID: string; modelID: string }; agent?: string; variant?: string; messageID?: string },
 ): Promise<void> {
-  const result = await client.session.shell({ sessionID, command });
+  const result = await client.session.shell({ sessionID, command, messageID: options?.messageID });
   assertNoClientError(result);
 }
 

--- a/apps/app/src/react-app/domains/session/surface/safe-edit-resend.ts
+++ b/apps/app/src/react-app/domains/session/surface/safe-edit-resend.ts
@@ -25,12 +25,17 @@ export async function sendWithRevertRollback(input: SafeEditResendInput): Promis
   await input.abort();
   input.assertCurrent?.();
   await input.revert(revertMessageId);
+  let promptStarted = false;
   try {
     input.assertCurrent?.();
+    promptStarted = true;
     await input.prompt();
   } catch (error) {
     // The replacement may already exist. Unrevert would mutate its history.
     if (isPromptAdmissionUnknown(error)) throw error;
+    // Stop may have reconciled this send from native evidence while its HTTP
+    // response was still pending. A late failure must not undo a newer turn.
+    if (promptStarted) input.assertCurrent?.();
     try {
       await input.unrevert();
     } catch (unrevertError) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1869,7 +1869,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setError(null);
     try {
       const result = await submitAfterInterruption(props.opencodeBaseUrl, props.sessionId,
-        () => props.onSendDraft({ ...nextDraft, messageId }, props.sessionId, onPrepared));
+        () => props.onSendDraft({ ...nextDraft, messageId }, props.sessionId, onPrepared), messageId);
       dispatchQueuedDrain(props.sessionId, { type: "send_result", itemId, outcome: result.outcome, at: Date.now() });
       if (getQueuedSendGeneration(props.sessionId) !== generation) return result;
       if (result.outcome === "blocked" || result.outcome === "cancelled") return result;

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
@@ -111,13 +111,14 @@ async function performQueuedDraftSend(
   );
 
   if (draft.mode === "shell") {
-    await shellInSession(opencodeClient, sessionId, text);
+    await shellInSession(opencodeClient, sessionId, text, { messageID: draft.messageId });
     return;
   }
 
   if (draft.command) {
     const result = await opencodeClient.session.command({
       sessionID: sessionId,
+      messageID: draft.messageId,
       command: draft.command.name,
       arguments: draft.command.arguments,
     });
@@ -149,6 +150,7 @@ async function performQueuedDraftSend(
     if (isPromptAdmissionUnknown(result.error)) throw result.error;
     throw new Error(serializeSDKError(result.error));
   }
+  assertQueuedSendCurrent(sessionId, generation);
   if (sendModel) {
     useSessionModelStore.getState().setModel(sessionId, sendModel, sendVariant ?? null);
   }
@@ -351,7 +353,7 @@ async function attemptDrain(sessionId: string) {
 
   try {
     await submitAfterInterruption(context.opencodeBaseUrl, sessionId,
-      () => performQueuedDraftSend(context, sessionId, draft, generation));
+      () => performQueuedDraftSend(context, sessionId, draft, generation), draft.messageId);
     dispatchQueuedDrain(sessionId, {
       type: "send_result",
       itemId: nextItem.id,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1374,7 +1374,7 @@ export function SessionRoute() {
 
                 if (draft.mode === "shell") {
                   onPrepared?.();
-                  await shellInSession(opencodeClient, targetSessionId, text);
+                  await shellInSession(opencodeClient, targetSessionId, text, { messageID: draft.messageId });
                   return;
                 }
 
@@ -1382,6 +1382,7 @@ export function SessionRoute() {
                   onPrepared?.();
                   const result = await opencodeClient.session.command({
                     sessionID: targetSessionId,
+                    messageID: draft.messageId,
                     command: draft.command.name,
                     arguments: draft.command.arguments,
                   });
@@ -1415,7 +1416,7 @@ export function SessionRoute() {
                 }
                 // Remember what this conversation used last so returning to it
                 // (or splitting it beside another session) keeps its own model.
-                if (sendModel) {
+                if (sendModel && getQueuedSendGeneration(targetSessionId) === generation) {
                   useSessionModelStore.getState().setModel(targetSessionId, sendModel, sendVariant ?? null);
                 }
               },
@@ -1709,13 +1710,14 @@ export function SessionRoute() {
                 trackTaskStarted(targetSessionId, telemetryDimensions);
                 if (draft.mode === "shell") {
                   onPrepared?.();
-                  await shellInSession(workspaceOpencodeClient, targetSessionId, text);
+                  await shellInSession(workspaceOpencodeClient, targetSessionId, text, { messageID: draft.messageId });
                   return;
                 }
                 if (draft.command) {
                   onPrepared?.();
                   const result = await workspaceOpencodeClient.session.command({
                     sessionID: targetSessionId,
+                    messageID: draft.messageId,
                     command: draft.command.name,
                     arguments: draft.command.arguments,
                   });
@@ -1744,7 +1746,7 @@ export function SessionRoute() {
                   if (isPromptAdmissionUnknown(result.error)) throw result.error;
                   throw new Error(serializeSDKError(result.error));
                 }
-                if (sendModel) {
+                if (sendModel && getQueuedSendGeneration(targetSessionId) === generation) {
                   useSessionModelStore.getState().setModel(targetSessionId, sendModel, sendVariant ?? null);
                 }
               },

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -207,6 +207,210 @@ describe("native OpenCode session operations", () => {
 });
 
 describe("native Stop and follow-up handoff", () => {
+  test("dispatches root abort before failed or hanging discovery reads can block Stop", async () => {
+    for (const action of ["get", "message"]) {
+      for (const failure of ["failed", "hanging"]) {
+        const root = { ...session, id: `ses_discovery_${action}_${failure}` };
+        const discovery = Promise.withResolvers<Response>();
+        const reached = Promise.withResolvers<void>();
+        await withSessionFetch((request) => {
+          const path = new URL(request.url).pathname;
+          if (path.endsWith("/abort")) return Response.json(true);
+          if (path.endsWith(action === "get" ? `/session/${root.id}` : "/message")) {
+            reached.resolve();
+            return discovery.promise;
+          }
+          if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+          if (path.endsWith("/message")) return Response.json(turnMessages(root.id));
+          throw new Error(`Unexpected request: ${request.method} ${path}`);
+        }, async (requests) => {
+          const client = createClient(endpoint.opencodeBaseUrl, root.directory);
+          const stop = interruptSessionTurn(endpoint.opencodeBaseUrl, client, root.id, root.directory, { timeoutMs: 100 });
+          const outcome = stop.then(() => undefined, (error: unknown) => error);
+          try {
+            await reached.promise;
+            expect(requests.filter((request) => request.method === "POST").map((request) => new URL(request.url).pathname))
+              .toEqual([`/workspace/ws-native/opencode/session/${root.id}/abort`]);
+            if (failure === "failed") discovery.resolve(Response.json({ message: "Discovery failed" }, { status: 503 }));
+            const error = await outcome;
+            expect(error).toBeInstanceOf(Error);
+            expect(error).toMatchObject({ message: expect.stringContaining(failure === "hanging" ? "timed out" : "Discovery failed") });
+            expect(sessionNeedsStop(endpoint.opencodeBaseUrl, root.id)).toBe(true);
+          } finally {
+            discovery.resolve(Response.json(action === "get" ? root : []));
+            await outcome;
+          }
+        });
+      }
+    }
+  });
+
+  test("a duplicate Stop cancels the intervening follow-up but admits one queued after it", async () => {
+    const root = { ...session, id: "ses_duplicate_generation" };
+    const baseUrl = endpoint.opencodeBaseUrl;
+    const idle = Promise.withResolvers<Response>();
+    const reached = Promise.withResolvers<void>();
+    const sent: string[] = [];
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith("/message")) return Response.json(turnMessages(root.id));
+      if (path.endsWith("/abort")) return Response.json(true);
+      if (path.endsWith("/status")) { reached.resolve(); return idle.promise; }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClient(baseUrl, root.directory);
+      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+      const intervening = submitAfterInterruption(baseUrl, root.id, async () => { sent.push("cancelled"); });
+      const outcome = intervening.then(() => undefined, (error: unknown) => error);
+      expect(interruptSessionTurn(baseUrl, client, root.id, root.directory)).toBe(stop);
+      const followUp = submitAfterInterruption(baseUrl, root.id, async (afterStop) => {
+        expect(afterStop).toBe(true);
+        sent.push("follow-up");
+      });
+      try {
+        await reached.promise;
+        expect(sent).toEqual([]);
+        idle.resolve(Response.json({}));
+        await Promise.all([stop, followUp]);
+        expect(await outcome).toMatchObject({ message: expect.stringContaining("Send cancelled by Stop") });
+        expect(sent).toEqual(["follow-up"]);
+        expect(requests.filter((request) => request.method === "POST")).toHaveLength(2);
+      } finally {
+        idle.resolve(Response.json({}));
+        await Promise.allSettled([stop, outcome, followUp]);
+      }
+    });
+  });
+
+  test("terminal native evidence cancels a hung send before tree cleanup and ignores its late HTTP response", async () => {
+    const root = { ...session, id: "ses_terminal_admission" };
+    const child = { ...session, id: "ses_terminal_child", parentID: root.id };
+    const baseUrl = endpoint.opencodeBaseUrl;
+    const messageID = "msg_terminal_admission";
+    const admission = Promise.withResolvers<Response>();
+    const dispatched = Promise.withResolvers<void>();
+    const returned = Promise.withResolvers<void>();
+    const childAbort = Promise.withResolvers<Response>();
+    const childReached = Promise.withResolvers<void>();
+    const sent: string[] = [];
+    const native = turnMessages(root.id, [delegatedTool(child.id, { status: "error", error: "cancelled" })], messageID)
+      .map((message) => message.info.role === "assistant" ? {
+        ...message, info: { ...message.info, parentID: messageID, finish: "stop", time: { created: 2, completed: 3 } },
+      } : message);
+    await withSessionFetch(async (request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith(`/session/${child.id}`)) return Response.json(child);
+      if (path.endsWith(`/session/${root.id}/message`)) return Response.json(native);
+      if (path.endsWith(`/session/${child.id}/message`)) return Response.json(turnMessages(child.id));
+      if (path.endsWith(`/session/${child.id}/abort`)) { childReached.resolve(); return childAbort.promise.then((response) => response.clone()); }
+      if (path.endsWith("/abort")) return Response.json(true);
+      if (path.endsWith("/status")) return Response.json({ [root.id]: { type: "idle" } });
+      if (path.endsWith("/prompt_async")) {
+        const body = await request.json();
+        sent.push(body.messageID);
+        if (body.messageID === messageID) { dispatched.resolve(); return admission.promise; }
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClient(baseUrl, root.directory);
+      const send = async (id: string) => unwrap(await client.session.promptAsync({ sessionID: root.id, messageID: id, parts: [] }));
+      const old = submitAfterInterruption(baseUrl, root.id, async () => {
+        const response = await send(messageID);
+        returned.resolve();
+        return response;
+      }, messageID);
+      const outcome = old.then(() => undefined, (error: unknown) => error);
+      await dispatched.promise;
+      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+      const followUp = submitAfterInterruption(baseUrl, root.id, () => send("msg_after_terminal"));
+      try {
+        // Race with Stop so a broken implementation fails at its bounded deadline.
+        const error = await Promise.race([outcome, stop]);
+        expect(error).toMatchObject({ message: expect.stringContaining("Send cancelled by Stop") });
+        await Promise.race([childReached.promise, stop]);
+        expect(sent).toEqual([messageID]);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(true);
+        childAbort.resolve(Response.json(true));
+        await Promise.all([stop, followUp]);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(false);
+        expect(requests.filter((request) => new URL(request.url).pathname.endsWith(`/session/${root.id}/abort`))).toHaveLength(2);
+        // Another Stop must finish even while the old HTTP response is still held.
+        await interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+        admission.resolve(new Response(null, { status: 204 }));
+        await returned.promise;
+        await submitAfterInterruption(baseUrl, root.id, () => send("msg_after_late_response"));
+        await interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 1_000 });
+        expect(await outcome).toBe(error);
+        expect(sent).toEqual([messageID, "msg_after_terminal", "msg_after_late_response"]);
+        expect(sessionNeedsStop(baseUrl, root.id)).toBe(false);
+      } finally {
+        admission.resolve(new Response(null, { status: 204 }));
+        childAbort.resolve(Response.json(true));
+        await Promise.allSettled([old, stop, followUp]);
+      }
+    });
+  });
+
+  test("unknown, nonmatching, nonterminal, tool-calls, and busy evidence cannot release pending admission", async () => {
+    for (const variant of ["unknown", "absent", "wrong-message", "wrong-user-session", "wrong-reply-session", "wrong-parent", "unfinished", "tool-calls", "running-tool", "busy"]) {
+      const root = { ...session, id: `ses_pending_${variant}` };
+      const baseUrl = endpoint.opencodeBaseUrl;
+      const messageID = "msg_pending";
+      const admission = Promise.withResolvers<Response>();
+      const dispatched = Promise.withResolvers<void>();
+      const observedID = variant === "wrong-message" ? "msg_other" : messageID;
+      const native = turnMessages(root.id, variant === "running-tool" ? [delegatedTool("ses_unused", {}, "read")] : [], observedID)
+        .map((message) => ({
+          ...message,
+          info: message.info.role === "user" ? {
+            ...message.info, sessionID: variant === "wrong-user-session" ? "ses_other" : root.id,
+          } : {
+            ...message.info,
+            sessionID: variant === "wrong-reply-session" ? "ses_other" : root.id,
+            parentID: variant === "wrong-parent" ? "msg_other" : observedID,
+            finish: variant === "tool-calls" ? "tool-calls" : "stop",
+            time: { created: 2, ...(variant === "unfinished" ? {} : { completed: 3 }) },
+          },
+        }));
+      let settled = false;
+      let followUpSent = false;
+      await withSessionFetch((request) => {
+        const path = new URL(request.url).pathname;
+        if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+        if (path.endsWith("/message")) return Response.json(variant === "absent" ? [] : native);
+        if (path.endsWith("/abort")) return Response.json(true);
+        if (path.endsWith("/status")) return Response.json({ [root.id]: { type: variant === "busy" ? "busy" : "idle" } });
+        if (path.endsWith("/prompt_async")) { dispatched.resolve(); return admission.promise; }
+        throw new Error(`Unexpected request: ${request.method} ${path}`);
+      }, async () => {
+        const client = createClient(baseUrl, root.directory);
+        const old = submitAfterInterruption(baseUrl, root.id, async () => unwrap(await client.session.promptAsync({
+          sessionID: root.id, messageID, parts: [],
+        })), variant === "unknown" ? undefined : messageID);
+        const outcome = old.then(() => { settled = true; }, () => { settled = true; });
+        await dispatched.promise;
+        const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, { timeoutMs: 25 });
+        const followUp = submitAfterInterruption(baseUrl, root.id, async () => { followUpSent = true; });
+        try {
+          for (const result of await Promise.allSettled([stop, followUp])) {
+            expect(result.status).toBe("rejected");
+            if (result.status !== "rejected" || !(result.reason instanceof Error)) throw new Error("Expected cancellation timeout");
+            expect(result.reason.message).toContain("timed out");
+          }
+          expect(settled).toBe(false);
+          expect(followUpSent).toBe(false);
+          expect(sessionNeedsStop(baseUrl, root.id)).toBe(true);
+        } finally {
+          admission.resolve(new Response(null, { status: 204 }));
+          await Promise.allSettled([outcome, stop, followUp]);
+        }
+      });
+    }
+  });
+
   test("v2 interrupts the native subagent before admitting the next prompt", async () => {
     const baseUrl = endpoint.opencodeBaseUrl.replace("opencode", "opencode2");
     const rootID = "ses_v2_stop";

--- a/apps/app/tests/safe-edit-resend.test.ts
+++ b/apps/app/tests/safe-edit-resend.test.ts
@@ -5,6 +5,30 @@ import { PromptAdmissionUnknownError } from "../src/app/lib/opencode";
 import { assertQueuedSendCurrent, dispatchQueuedDrain, getQueuedSendGeneration, resetQueuedDrainForTests } from "../src/react-app/domains/session/surface/queued-drain-machine";
 
 describe("safe edit resend", () => {
+  test("a late response failure after Stop cannot roll back the successor's history", async () => {
+    resetQueuedDrainForTests();
+    const sessionId = "ses_late_revert_response";
+    const generation = getQueuedSendGeneration(sessionId);
+    const response = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<void>();
+    const calls: string[] = [];
+    const old = sendWithRevertRollback({
+      assertCurrent: () => assertQueuedSendCurrent(sessionId, generation),
+      revertMessageId: "msg_original",
+      abort: async () => {},
+      revert: async () => { calls.push("old-revert"); },
+      prompt: async () => { started.resolve(); await response.promise; },
+      unrevert: async () => { calls.push("unrevert"); },
+    });
+    await started.promise;
+    dispatchQueuedDrain(sessionId, { type: "queue_cleared" });
+    calls.push("successor-revert");
+    response.reject(new Error("Late HTTP 502"));
+    await expect(old).rejects.toThrow("Send cancelled by Stop.");
+    expect(calls).toEqual(["old-revert", "successor-revert"]);
+    resetQueuedDrainForTests();
+  });
+
   test("sends a normal draft without history mutation", async () => {
     const calls: string[] = [];
     await sendWithRevertRollback({

--- a/evals/specs/app-smoke.e2e.test.ts
+++ b/evals/specs/app-smoke.e2e.test.ts
@@ -14,7 +14,14 @@ test("app boots with a control route and meaningful visible content", async ({ w
       until: (hash) => /^#\/workspace\/[^/]+\/session$/.test(hash),
     });
     await user.see("composer", { editable: true, text: "" });
-    expect(await world.packagedRuntime()).toEqual({
+    // The IPC/health round trip can overlap a startup route or composer
+    // remount. Observe readiness after that round trip, not just before it.
+    const runtime = await probe.eventually(() => world.packagedRuntime(), {
+      within: 30_000,
+      label: "packaged empty session is ready after runtime health check",
+      until: (state) => state.emptySession === true,
+    });
+    expect(runtime).toEqual({
       bridge: true, protocol: "file:", health: 200, emptySession: true, signedOut: true, onboarding: false, crash: false,
     });
     await user.see("Run task");


### PR DESCRIPTION
## Summary

Follow-up to #4649 for the three interruption edge cases found in code review:

- Dispatch the scoped root abort immediately alongside discovery. Failed or slow session/transcript reads no longer prevent requesting cancellation; discovery failure still prevents claiming that the whole tree stopped.
- Invalidate waiting submissions on every explicit Stop, including a second click that shares an in-flight cancellation request. Only follow-ups submitted after the latest Stop may continue.
- Reconcile a hung submission response using its exact native user-message ID, completed same-session assistant reply, and idle status. Cancel the obsolete UI wait without replaying the request, then finish foreground-tree cleanup. Absent, mismatched, unfinished, tool-calls, or busy evidence does not release the fence.
- Carry message IDs through command and shell sends. Guard late model updates and edit/resend rollback so an old response cannot overwrite newer turn state.
- Resolve the overlap with #4652 by preserving both the attachment-preparation callback and interruption message identity.
- Bound the packaged smoke readiness observation after its IPC/health round trip. Retain all existing assertions, including empty editable workspace, signed-out state, health, and shipped tools.

No archive behavior, automatic retry, or background-task policy changes.

## Verification — CI green; interruption runtime proof Incomplete

Final PR head: `1c736677c91a7f3c8f915994aedbeb1aaa1c61c9`, rebased onto `dev` at `be2be81f6ad1dcda561385d0db913cd80c5f6544`.

- CI: 21 checks passed, 0 failed, 0 pending; 6 conditional/optional checks skipped or neutral.
- [Build and core checks](https://github.com/different-ai/openwork/actions/runs/34288005646): successful on the final head, including core product regressions, packaged-desktop smoke, and the required aggregate gate.
- CodeQL, Warden, i18n, and configured preview checks passed.
- Local checks after conflict resolution: 34 interruption/edit-resend regression tests passed (362 assertions), plus 1 attachment-focus test passed (67 assertions). No failures or skips. App typecheck and diff whitespace checks passed.

Local commands:
```sh
pnpm --filter @openwork/app exec bun test ./tests/opencode-session-native.test.ts ./tests/queued-drain-admission-wedge.test.ts ./tests/safe-edit-resend.test.ts
pnpm --filter @openwork/app exec bun test ./tests/composer-focus-continuity.test.tsx
pnpm --filter @openwork/app typecheck
git diff origin/dev...HEAD --check
```

The earlier packaged smoke failure sampled `emptySession: false` after the composer assertion had passed. Its bounded readiness wait now passes in CI without removing any assertion. Packaged smoke ran with `placement: local (--local)` inside CI; that boot proof does not establish interruption fault behavior.

### Remaining runtime proof

The added fault regressions use controlled client/helper responses. The full Stop/follow-up journey and fault coverage have not been run against both real engines or published as interruption evidence. That narrower proof verdict remains **Incomplete**, independently of green CI and the merge.

```sh
OPENWORK_EVAL_REF=1c736677c91a7f3c8f915994aedbeb1aaa1c61c9 OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e parent-child-permission-approval
OPENWORK_EVAL_REF=1c736677c91a7f3c8f915994aedbeb1aaa1c61c9 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e parent-child-permission-approval
```

Requests without correlatable terminal evidence remain blocked rather than being guessed complete. GitHub records this PR merged on September 8 at 22:54:55 UTC as `e0232b606f6d540616abb159aca5dc266140d7ba`; deployment is not asserted.