### PR TITLE
fix(mcp): preserve OAuth callback failure diagnostics

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -192,25 +192,26 @@ const PROVIDER_CODE_FIELDS = ["code", "error"]
 const PROVIDER_REQUEST_ID_FIELDS = ["requestId", "request_id", "transactionId", "transaction_id"]
 const URL_ELICITATION_REQUIRED_JSON_RPC_CODE = -32042
 
-const TYPED_OAUTH_ERROR_NAMES = new Set([
-  "InvalidClientError",
-  "UnauthorizedClientError",
-  "InvalidClientMetadataError",
-  "InvalidGrantError",
-  "InvalidRequestError",
-  "InvalidScopeError",
-  "InvalidTargetError",
-  "InvalidTokenError",
-  "InsufficientScopeError",
-  "MethodNotAllowedError",
-  "TooManyRequestsError",
-  "UnsupportedTokenTypeError",
-  "AccessDeniedError",
-  "UnsupportedGrantTypeError",
-  "UnsupportedResponseTypeError",
-  "TemporarilyUnavailableError",
-  "ServerError",
+const TYPED_OAUTH_ERROR_NAMES_BY_CODE = new Map([
+  ["invalid_client", "InvalidClientError"],
+  ["unauthorized_client", "UnauthorizedClientError"],
+  ["invalid_client_metadata", "InvalidClientMetadataError"],
+  ["invalid_grant", "InvalidGrantError"],
+  ["invalid_request", "InvalidRequestError"],
+  ["invalid_scope", "InvalidScopeError"],
+  ["invalid_target", "InvalidTargetError"],
+  ["invalid_token", "InvalidTokenError"],
+  ["insufficient_scope", "InsufficientScopeError"],
+  ["method_not_allowed", "MethodNotAllowedError"],
+  ["too_many_requests", "TooManyRequestsError"],
+  ["unsupported_token_type", "UnsupportedTokenTypeError"],
+  ["access_denied", "AccessDeniedError"],
+  ["unsupported_grant_type", "UnsupportedGrantTypeError"],
+  ["unsupported_response_type", "UnsupportedResponseTypeError"],
+  ["temporarily_unavailable", "TemporarilyUnavailableError"],
+  ["server_error", "ServerError"],
 ])
+const TYPED_OAUTH_ERROR_NAMES = new Set(TYPED_OAUTH_ERROR_NAMES_BY_CODE.values())
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -661,6 +662,20 @@ function errorName(value: unknown): string {
   return name && SAFE_ERROR_NAMES.has(name) ? name : "Error"
 }
 
+function typedOAuthErrorName(error: unknown): string | undefined {
+  let current: unknown = error
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    const name = errorName(current)
+    if (TYPED_OAUTH_ERROR_NAMES.has(name)) return name
+    if (name === "OAuthError") {
+      const mappedName = TYPED_OAUTH_ERROR_NAMES_BY_CODE.get(stringProperty(current, "code") ?? "")
+      if (mappedName) return mappedName
+    }
+    current = errorCause(current)
+  }
+  return undefined
+}
+
 function oauthProviderDetail(error: unknown): string | undefined {
   let current: unknown = error
   const seen = new Set<unknown>()
@@ -668,9 +683,11 @@ function oauthProviderDetail(error: unknown): string | undefined {
     seen.add(current)
     const name = errorName(current)
     if (TYPED_OAUTH_ERROR_NAMES.has(name) || name === "OAuthError" || name === "CustomOAuthError") {
+      // SDK v2 embeds raw response bodies in OAuthError.message. Only legacy
+      // typed errors use message as the provider description.
       const description = stringProperty(current, "error_description")
-        ?? (current instanceof Error ? current.message : stringProperty(current, "message"))
-      if (!description) return name
+        ?? (TYPED_OAUTH_ERROR_NAMES.has(name) ? stringProperty(current, "message") : undefined)
+      if (!description) return undefined
       const prefix = `${name}: `
       const redacted = redactSensitiveString(description).slice(
         0,
@@ -748,7 +765,10 @@ export function safeExternalMcpCauseChain(error: unknown): ExternalMcpSafeCause[
     const rawCode = stringOrNumberProperty(current, "code")
     const code = typeof rawCode === "number" && Number.isSafeInteger(rawCode)
       ? String(rawCode).slice(0, 16)
-      : typeof rawCode === "string" && SAFE_NATIVE_ERROR_CODES.has(rawCode)
+      : typeof rawCode === "string" && (
+          SAFE_NATIVE_ERROR_CODES.has(rawCode)
+          || (errorName(current) === "OAuthError" && TYPED_OAUTH_ERROR_NAMES_BY_CODE.has(rawCode))
+        )
         ? rawCode
         : undefined
     const errno = stringOrNumberProperty(current, "errno")
@@ -866,7 +886,12 @@ function safeBaseMessageFor(input: {
     return "The authorization server rejected the OAuth client configured for this connection; the saved client was kept for an administrator to review."
   }
   if (input.phase === "AUTH_TOKEN_ACQUISITION" || input.phase === "CONTINUITY_REFRESH") {
-    return "The authorization server rejected the code or token refresh exchange."
+    if (input.code === "MCP_OAUTH_INVALID_GRANT" || input.category === "oauth_request_rejected") {
+      return "The authorization server rejected the code or token refresh exchange."
+    }
+    return input.phase === "CONTINUITY_REFRESH"
+      ? "OpenWork could not complete the OAuth token refresh."
+      : "OpenWork could not complete the OAuth token exchange."
   }
   if (input.phase === "AUTH_USER_OR_WORKLOAD") {
     return input.code === "MCP_OAUTH_ACCESS_DENIED"
@@ -1026,9 +1051,9 @@ function httpClassification(input: {
   }
   if ((status === 401 || status === 403) && phase.startsWith("MCP_") && input.hasAuthorization) {
     // A 401 is itself an authentication challenge. A 403 is ambiguous for
-    // enterprise providers: only a Bearer/insufficient_scope challenge means
-    // token validation; an ordinary tools/* 403 is usually an ACL/role denial.
-    if (status === 401 || input.bearerChallenge || input.insufficientScope) {
+    // enterprise providers: initialization rejects access to the resource,
+    // while an ordinary tools/* 403 is usually an ACL/role denial.
+    if (status === 401 || phase === "MCP_INITIALIZE" || input.bearerChallenge || input.insufficientScope) {
       return {
         phase: "AUTH_RESOURCE_VALIDATION",
         category: input.insufficientScope ? "oauth_insufficient_scope" : "oauth_resource_rejected",
@@ -1037,7 +1062,9 @@ function httpClassification(input: {
         actionOwner: input.insufficientScope ? "organization_admin" : "member",
         operatorAction: input.insufficientScope
           ? "Grant the provider scopes required by this MCP resource and reconnect."
-          : "Reconnect the provider account and verify token audience, tenant, and resource binding.",
+          : status === 403 && !input.bearerChallenge
+            ? "Verify provider access policy and token audience, tenant, and resource binding before reconnecting."
+            : "Reconnect the provider account and verify token audience, tenant, and resource binding.",
       }
     }
     if (status === 403 && (phase === "MCP_TOOL_DISCOVERY" || phase === "MCP_TOOL_EXECUTION")) {
@@ -1342,7 +1369,7 @@ function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase
   }
   if (numericCode !== undefined) return providerDeclaredErrorClassification()
 
-  const name = errorName(error)
+  const name = typedOAuthErrorName(error)
   const redirectUriRejectionCode = namedOAuthRedirectUriRejectionCode(error, fallbackPhase)
   if (redirectUriRejectionCode) return oauthRedirectUriNotAllowedClassification(redirectUriRejectionCode)
   if (name === "InvalidClientError" || name === "UnauthorizedClientError" || name === "InvalidClientMetadataError") {
@@ -1491,10 +1518,12 @@ function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase
     category,
     code: `MCP_${phase}`,
     retryable: phase === "NETWORK_TCP" || phase === "MCP_TRANSPORT",
-    actionOwner: phase.startsWith("AUTH_") ? "organization_admin" : "provider_admin",
-    operatorAction: phase.startsWith("AUTH_")
-      ? "Verify the endpoint's OAuth metadata and provider application configuration."
-      : "Inspect the provider's MCP logs using the diagnostic reference and retry after correcting the named layer.",
+    actionOwner: isOAuthTokenPhase(phase) ? "openwork" : phase.startsWith("AUTH_") ? "organization_admin" : "provider_admin",
+    operatorAction: isOAuthTokenPhase(phase)
+      ? "Inspect OpenWork's OAuth diagnostics using the reference to identify where the exchange failed before retrying."
+      : phase.startsWith("AUTH_")
+        ? "Verify the endpoint's OAuth metadata and provider application configuration."
+        : "Inspect the provider's MCP logs using the diagnostic reference and retry after correcting the named layer.",
   }
 }
 
@@ -1738,7 +1767,7 @@ export class ExternalMcpDiagnosticTracker {
       || sourceCode === "MCP_LIFECYCLE_DEADLINE"
     const classified = this.forcedClassification
       && (this.forcedClassification.code === "MCP_OAUTH_REDIRECT_URI_NOT_ALLOWED" || (
-        !TYPED_OAUTH_ERROR_NAMES.has(errorName(source.error))
+        !typedOAuthErrorName(source.error)
         && !sourceIsApplicationOwnedOAuthFailure
         && inferredClassification.phase !== "MCP_VERSION"
       ))

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { exchangeAuthorization, OAuthError, parseErrorResponse } from "@modelcontextprotocol/client"
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
 import {
@@ -14,6 +15,7 @@ import {
   externalMcpDiagnosticForLog,
   safeExternalMcpEndpointForLog,
   safeExternalMcpCauseChain,
+  type ExternalMcpDiagnosticPhase,
 } from "../src/capability-sources/external-mcp-diagnostics.js"
 import { PrivateUrlError } from "../src/capability-sources/url-guard.js"
 import { connectCallbackPage } from "../src/capability-sources/oauth-callback-page.js"
@@ -338,6 +340,27 @@ describe("external MCP diagnostics", () => {
     expect(safeExternalMcpCauseChain(error)).toEqual([{ name: "Error" }])
   })
 
+  test("does not promote unrecognized OAuth codes or arbitrary string codes", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_unknown_oauth_code")
+    tracker.begin("AUTH_TOKEN_ACQUISITION")
+    for (const error of [
+      new OAuthError("private-provider-code", "raw-body-secret"),
+      new OAuthError("constructor", "raw-body-secret"),
+      Object.assign(new Error("raw-body-secret"), { code: "invalid_grant" }),
+    ]) {
+      const diagnosticError = tracker.error(error)
+      expect(diagnosticError.diagnostic).toMatchObject({
+        code: "MCP_AUTH_TOKEN_ACQUISITION",
+        actionOwner: "openwork",
+      })
+      expect(diagnosticError.safeCauseChain).toEqual([{ name: error.name }])
+      const logged = JSON.stringify(externalMcpDiagnosticForLog(diagnosticError, "ignored", "AUTH_TOKEN_ACQUISITION"))
+      expect(logged).not.toContain("raw-body-secret")
+      expect(logged).not.toContain("private-provider-code")
+      expect(logged).not.toContain("invalid_grant")
+    }
+  })
+
   test("safe endpoint logs omit credentials, query parameters, and fragments", () => {
     const endpoint = safeExternalMcpEndpointForLog("https://user:password@mcp.example.invalid/tenant/server?token=secret#fragment")
     expect(endpoint).toEqual({ origin: "https://mcp.example.invalid", pathHash: "sha256:8ab7ab56bba09945" })
@@ -477,6 +500,42 @@ describe("external MCP diagnostics", () => {
       phase: "AUTH_RESOURCE_VALIDATION",
       code: "MCP_OAUTH_INSUFFICIENT_SCOPE",
     })
+  })
+
+  test.each([401, 403])("classifies callback token-only resource verification HTTP %s without claiming missing state", async (status) => {
+    for (const method of ["server/discover", "initialize"]) {
+      const tracker = new ExternalMcpDiagnosticTracker("req_callback_resource", {
+        authType: "oauth",
+        credentialMode: "per_member",
+      })
+      tracker.passed("AUTH_TOKEN_ACQUISITION")
+      const diagnosticFetch = createExternalMcpDiagnosticFetch({
+        endpoint: "https://mcp.example.invalid/mcp",
+        tracker,
+        fetch: async () => new Response(null, { status }),
+      })
+      await diagnosticFetch("https://mcp.example.invalid/mcp", {
+        method: "POST",
+        headers: { authorization: "Bearer callback-token-secret", "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: {} }),
+      })
+      const error = tracker.error(new Error("Token-only verification failed"), "MCP_INITIALIZE")
+      expect(error.diagnostic).toMatchObject({
+        phase: "AUTH_RESOURCE_VALIDATION",
+        operationPhase: "MCP_INITIALIZE",
+        code: `MCP_OAUTH_HTTP_${status}`,
+        category: "oauth_resource_rejected",
+        highestPassed: "reachable",
+        actionOwner: "member",
+        retryable: status === 401,
+        httpStatus: status,
+        message: "The MCP resource rejected the supplied authorization.",
+      })
+      expect(error.diagnostic.code).not.toBe("MCP_OAUTH_AUTHORIZATION_MISSING")
+      expect(error.diagnostic.message).not.toContain("authorization server")
+      expect(JSON.stringify(externalMcpDiagnosticForLog(error, "ignored", "AUTH_TOKEN_ACQUISITION")))
+        .not.toContain("callback-token-secret")
+    }
   })
 
   test("classifies allowlisted provider tool results with bounded provider text", () => {
@@ -1109,6 +1168,148 @@ describe("external MCP diagnostics", () => {
       code: "MCP_PROVIDER_TOOL_ERROR",
       payloadBytes: 0,
     })
+  })
+
+  for (const status of [undefined, 400, 401]) {
+    test.each([
+      ["invalid_client", "AUTH_CLIENT_REGISTRATION", "oauth_client_registration", "MCP_OAUTH_CLIENT_REJECTED", "organization_admin", false],
+      ["unauthorized_client", "AUTH_CLIENT_REGISTRATION", "oauth_client_registration", "MCP_OAUTH_CLIENT_REJECTED", "organization_admin", false],
+      ["invalid_client_metadata", "AUTH_CLIENT_REGISTRATION", "oauth_client_registration", "MCP_OAUTH_CLIENT_REJECTED", "organization_admin", false],
+      ["invalid_grant", "AUTH_TOKEN_ACQUISITION", "oauth_token_failure", "MCP_OAUTH_INVALID_GRANT", "member", false],
+      ["invalid_request", "AUTH_TOKEN_ACQUISITION", "oauth_request_rejected", "MCP_OAUTH_INVALID_REQUEST", "organization_admin", false],
+      ["invalid_scope", "AUTH_USER_OR_WORKLOAD", "oauth_invalid_scope", "MCP_OAUTH_INVALID_SCOPE", "organization_admin", false],
+      ["invalid_target", "AUTH_RESOURCE_VALIDATION", "oauth_invalid_target", "MCP_OAUTH_INVALID_TARGET", "organization_admin", false],
+      ["invalid_token", "AUTH_RESOURCE_VALIDATION", "oauth_invalid_token", "MCP_OAUTH_INVALID_TOKEN", "member", false],
+      ["insufficient_scope", "AUTH_RESOURCE_VALIDATION", "oauth_insufficient_scope", "MCP_OAUTH_INSUFFICIENT_SCOPE", "organization_admin", false],
+      ["method_not_allowed", "AUTH_TOKEN_ACQUISITION", "oauth_method_not_allowed", "MCP_OAUTH_METHOD_NOT_ALLOWED", "provider_admin", false],
+      ["too_many_requests", "AUTH_TOKEN_ACQUISITION", "oauth_provider_throttled", "MCP_OAUTH_TOO_MANY_REQUESTS", "provider_admin", true],
+      ["unsupported_token_type", "AUTH_TOKEN_ACQUISITION", "oauth_unsupported_token_type", "MCP_OAUTH_UNSUPPORTED_TOKEN_TYPE", "provider_admin", false],
+      ["access_denied", "AUTH_USER_OR_WORKLOAD", "oauth_access_denied", "MCP_OAUTH_ACCESS_DENIED", "member", false],
+      ["unsupported_grant_type", "AUTH_TOKEN_ACQUISITION", "oauth_request_rejected", "MCP_OAUTH_UNSUPPORTED_GRANT_TYPE", "organization_admin", false],
+      ["unsupported_response_type", "AUTH_TOKEN_ACQUISITION", "oauth_request_rejected", "MCP_OAUTH_UNSUPPORTED_RESPONSE_TYPE", "organization_admin", false],
+      ["temporarily_unavailable", "AUTH_TOKEN_ACQUISITION", "oauth_provider_unavailable", "MCP_OAUTH_TEMPORARILY_UNAVAILABLE", "provider_admin", true],
+      ["server_error", "AUTH_TOKEN_ACQUISITION", "oauth_provider_unavailable", "MCP_OAUTH_SERVER_ERROR", "provider_admin", true],
+    ])(`classifies SDK v2 %s with ${status === undefined ? "no captured HTTP response" : `HTTP ${status}`}`, async (oauthCode, phase, category, code, actionOwner, retryable) => {
+      const tracker = new ExternalMcpDiagnosticTracker(`req_v2_${oauthCode}`)
+      tracker.begin("AUTH_TOKEN_ACQUISITION")
+      const fetchToken = async () => Response.json({
+        error: oauthCode,
+        error_description: "Token exchange failed; client_secret=description-secret",
+        private_detail: "sdk-raw-body-secret",
+        access_token: "response-token-secret",
+      }, { status: status ?? 400 })
+      const diagnosticFetch = createExternalMcpDiagnosticFetch({
+        endpoint: "https://mcp.example.invalid/mcp",
+        tracker,
+        fetch: fetchToken,
+      })
+      let sdkError: unknown
+      try {
+        await exchangeAuthorization("https://login.example.invalid", {
+          metadata: {
+            issuer: "https://login.example.invalid",
+            authorization_endpoint: "https://login.example.invalid/authorize",
+            token_endpoint: "https://login.example.invalid/token",
+            response_types_supported: ["code"],
+          },
+          clientInformation: { client_id: "diagnostic-client" },
+          authorizationCode: "request-code-secret",
+          codeVerifier: "request-pkce-secret",
+          redirectUri: "https://den.example.invalid/callback",
+          fetchFn: status === undefined
+            ? fetchToken
+            : (url, init) => diagnosticFetch(typeof url === "string" || url instanceof URL ? url : url.url, init),
+        })
+      } catch (error) {
+        sdkError = error
+      }
+      expect(sdkError).toBeInstanceOf(OAuthError)
+      if (!(sdkError instanceof OAuthError)) throw new Error("The SDK did not return an OAuthError")
+      expect(sdkError.name).toBe("OAuthError")
+      expect(sdkError.code).toBe(oauthCode)
+      expect(sdkError.message).toContain("description-secret")
+
+      for (const source of [sdkError, new EnterpriseMcpClientError({
+        operationPhase: "authorization-callback",
+        requestPhase: "oauth-token-exchange",
+        cause: sdkError,
+      })]) {
+        const error = tracker.error(source)
+        expect(error.diagnostic).toMatchObject({ phase, category, code, actionOwner, retryable })
+        expect(error.diagnostic.httpStatus).toBe(status)
+        expect(error.safeCauseChain).toContainEqual({ name: "OAuthError", code: oauthCode })
+        const logged = externalMcpDiagnosticForLog(error, "ignored", "AUTH_TOKEN_ACQUISITION")
+        const html = connectCallbackPage({ ok: false, name: "Diagnostic MCP", message: error.message, referenceId: error.diagnostic.referenceId })
+        const serialized = `${JSON.stringify(logged)} ${html}`
+        for (const secret of ["description-secret", "sdk-raw-body-secret", "response-token-secret", "request-code-secret", "request-pkce-secret"]) {
+          expect(serialized).not.toContain(secret)
+        }
+        if (status !== undefined) {
+          expect(error.diagnostic.providerResponseExcerpt).toContain("client_secret=[redacted]")
+        }
+      }
+
+      if (oauthCode === "invalid_grant") {
+        const refresh = new ExternalMcpDiagnosticTracker("req_v2_refresh", { authType: "oauth", credentialMode: "shared" })
+        expect(refresh.error(sdkError, "CONTINUITY_REFRESH").diagnostic).toMatchObject({
+          phase: "CONTINUITY_REFRESH",
+          code: "MCP_OAUTH_INVALID_GRANT",
+          actionOwner: "organization_admin",
+          operatorAction: "Reconnect the organization-managed provider account, then retry.",
+        })
+      }
+    })
+  }
+
+  test.each([undefined, 400, 401])("does not expose SDK v2 raw OAuth parse-error bodies with HTTP %s", async (status) => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_oauth_parse_error")
+    tracker.begin("AUTH_TOKEN_ACQUISITION")
+    const fetchToken = async () => Response.json({ private_detail: "sdk-raw-body-secret" }, { status: status ?? 400 })
+    const diagnosticFetch = createExternalMcpDiagnosticFetch({
+      endpoint: "https://mcp.example.invalid/mcp",
+      tracker,
+      fetch: fetchToken,
+    })
+    const response = status === undefined ? await fetchToken() : await diagnosticFetch("https://login.example.invalid/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ grant_type: "authorization_code", code: "request-code-secret" }),
+    })
+    const sdkError = await parseErrorResponse(response)
+    expect(sdkError).toBeInstanceOf(OAuthError)
+    expect(sdkError.message).toContain("sdk-raw-body-secret")
+    const error = tracker.error(sdkError)
+    expect(error.diagnostic).toMatchObject({
+      phase: "AUTH_TOKEN_ACQUISITION",
+      code: "MCP_OAUTH_SERVER_ERROR",
+      message: "OpenWork could not complete the OAuth token exchange.",
+    })
+    expect(error.diagnostic.httpStatus).toBe(status)
+    expect(error.safeCauseChain).toEqual([{ name: "OAuthError", code: "server_error" }])
+    const logged = JSON.stringify(externalMcpDiagnosticForLog(error, "ignored", "AUTH_TOKEN_ACQUISITION"))
+    expect(logged).not.toContain("sdk-raw-body-secret")
+    expect(logged).not.toContain("request-code-secret")
+  })
+
+  test.each(["AUTH_TOKEN_ACQUISITION", "CONTINUITY_REFRESH"] satisfies ExternalMcpDiagnosticPhase[])("keeps a local %s failure neutral before any fetch", (phase) => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_local_oauth", { authType: "oauth", credentialMode: "shared" })
+    tracker.begin(phase)
+    const error = tracker.error(new TypeError("Local setup failed with local-secret"))
+    expect(error.diagnostic).toMatchObject({
+      phase,
+      code: `MCP_${phase}`,
+      highestPassed: "configured",
+      actionOwner: "openwork",
+      retryable: false,
+      message: phase === "CONTINUITY_REFRESH"
+        ? "OpenWork could not complete the OAuth token refresh."
+        : "OpenWork could not complete the OAuth token exchange.",
+    })
+    expect(error.diagnostic.httpStatus).toBeUndefined()
+    expect(error.diagnostic.outbound).toBeUndefined()
+    expect(error.diagnostic.message).not.toContain("rejected")
+    expect(error.diagnostic.operatorAction).toContain("OpenWork's OAuth diagnostics")
+    expect(JSON.stringify(externalMcpDiagnosticForLog(error, "ignored", phase))).not.toContain("local-secret")
   })
 
   test("typed OAuth token errors override generic HTTP 400 classification", async () => {

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -10,6 +10,12 @@ export interface MockAuthorizeRequest {
   path: string;
   url: string;
   at: string;
+  status?: number;
+  grantType?: string;
+  /** Non-secret fingerprint, shared by token issuance and resource validation witnesses. */
+  tokenId?: string | null;
+  refreshTokenIssued?: boolean;
+  oauthError?: string;
 }
 
 /** A tool invocation the connector actually served, and which credential served it. */
@@ -99,6 +105,13 @@ export interface MockMcpHandle {
   releaseAgentReply(promptMarker: string, count?: number): Promise<MockAgentReplyState>;
   handshakes(opts?: { timeoutMs?: number; atLeast?: number; sinceIso?: string }): Promise<MockAuthorizeRequest[]>;
   configureOAuthRedirectUris(redirectUris: readonly string[]): Promise<void>;
+  /** Replace callback faults; an empty object restores normal token/resource responses. */
+  configureOAuthCallback(options: {
+    issueRefreshToken?: boolean;
+    resourceStatus?: 401 | 403;
+    /** Return HTTP 400 invalid_grant after validating the authorization code and PKCE. */
+    tokenErrorDescription?: string;
+  }): Promise<void>;
   resetOAuth(): Promise<void>;
   /** Expire access tokens and hold refresh replies until explicitly released. */
   holdRefreshResponses(): Promise<void>;
@@ -177,7 +190,14 @@ function parseRequest(value: unknown): MockAuthorizeRequest | null {
     || typeof value.url !== "string"
     || typeof value.at !== "string"
   ) return null;
-  return { method: value.method, path: value.path, url: value.url, at: value.at };
+  return {
+    method: value.method, path: value.path, url: value.url, at: value.at,
+    ...(typeof value.status === "number" ? { status: value.status } : {}),
+    ...(typeof value.grantType === "string" ? { grantType: value.grantType } : {}),
+    ...(typeof value.tokenId === "string" || value.tokenId === null ? { tokenId: value.tokenId } : {}),
+    ...(typeof value.refreshTokenIssued === "boolean" ? { refreshTokenIssued: value.refreshTokenIssued } : {}),
+    ...(typeof value.oauthError === "string" ? { oauthError: value.oauthError } : {}),
+  };
 }
 
 function parseRequests(value: unknown): MockAuthorizeRequest[] {
@@ -384,6 +404,9 @@ async function startEnterpriseProfileMock(options: StartMockMcpOptions): Promise
       await stop();
       redirectUris = [...nextRedirectUris];
       await boot();
+    },
+    async configureOAuthCallback() {
+      throw new Error("Callback fault controls are only supported by the legacy OAuth MCP mock.");
     },
     async resetOAuth() {
       await stop();
@@ -609,6 +632,15 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     },
     async configureOAuthRedirectUris() {
       throw new Error("The legacy mock must receive preregistered redirect URIs before startup.");
+    },
+    async configureOAuthCallback(options) {
+      const response = await fetch(`${url}/admin/oauth-callback`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(options),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) throw new Error(`Mock OAuth callback configuration failed: HTTP ${response.status}`);
     },
     async resetOAuth() {
       const response = await fetch(`${url}/admin/expire-oauth-tokens`, { method: "POST" });

--- a/evals/specs/mcp-oauth-response-issuer.test.ts
+++ b/evals/specs/mcp-oauth-response-issuer.test.ts
@@ -469,3 +469,143 @@ test("Den keeps an administrator-supplied OAuth client when the provider rejects
   expect(await detail(id)).toMatchObject({ oauthClientConfigured: true, oauthClientId: "admin-configured-client" });
   evidence.recordAssertionEvidence("Den-created registrations are still discarded and re-registered", "The dynamically registered connection lost its client after the same rejection and registered a fresh client on the next sign-in, while the administrator-configured connection kept its client.", true);
 });
+
+test("Den OAuth callback distinguishes resource rejection from token exchange failure without restarting interactive authorization", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun"] });
+  await using den = await server({
+    place, web: false,
+    mocks: { connector: mcpMock({ authorizationResponseIssuerSupported: true }) },
+    org: { name: `OAuth Callback Boundaries ${Date.now()}`, members: {} },
+  });
+  const provider = den.mocks.connector;
+  const headers = { authorization: `Bearer ${den.admin.token}` };
+  const secret = "synthetic-callback-secret";
+  for (const fault of ["resource-401", "resource-403", "token-400"]) {
+    const resourceStatus = fault === "resource-401" ? 401 : fault === "resource-403" ? 403 : undefined;
+    const expectedCode = resourceStatus === 401 ? "MCP_OAUTH_HTTP_401"
+      : resourceStatus === 403 ? "MCP_OAUTH_INSUFFICIENT_SCOPE" : "MCP_OAUTH_INVALID_GRANT";
+    const expectedPhase = resourceStatus === undefined ? "AUTH_TOKEN_ACQUISITION" : "AUTH_RESOURCE_VALIDATION";
+    await provider.configureOAuthCallback({
+      issueRefreshToken: resourceStatus !== undefined,
+      ...(resourceStatus === undefined
+        ? { tokenErrorDescription: `Synthetic code rejected; client_secret=${secret}` }
+        : { resourceStatus }),
+    });
+    const firstRequest = (await provider.requests()).length;
+    const created = await denFetch(den.admin, "/v1/mcp-connections", {
+      method: "POST", headers,
+      body: JSON.stringify({ name: `Callback ${fault}`, url: provider.mcpUrl, authType: "oauth", credentialMode: "shared", access: { orgWide: true } }),
+    });
+    expect(created.response.status).toBe(200);
+    if (!isRecord(created.body) || typeof created.body.id !== "string") throw new Error("Connection id missing");
+    expect(created.body.connected).toBe(false);
+    const id = created.body.id;
+    const started = await denFetch(den.admin, `/v1/mcp-connections/${id}/connect/start`, { headers });
+    expect(started.response.status).toBe(200);
+    if (!isRecord(started.body) || typeof started.body.authorizeUrl !== "string") throw new Error("Authorization URL missing");
+    expect(started.body.status).toBe("needs_auth");
+    const redirect = await fetch(started.body.authorizeUrl, { redirect: "manual", signal: AbortSignal.timeout(15_000) });
+    expect(redirect.status).toBe(302);
+    const location = redirect.headers.get("location");
+    if (!location) throw new Error("OAuth callback location missing");
+    const callback = new URL(location);
+    expect(callback.searchParams.get("iss")).toBe(provider.url);
+    expect(Boolean(callback.searchParams.get("code") && callback.searchParams.get("state"))).toBe(true);
+    const before = await provider.requests();
+    const setup = before.slice(firstRequest);
+    expect(setup.filter((entry) => entry.path === "/register").length).toBe(1);
+    expect(setup.filter((entry) => entry.path === "/authorize").length).toBe(1);
+    expect(setup.filter((entry) => entry.path === "/token").length).toBe(0);
+    evidence.recordAssertionEvidence(`${fault}: real authorization reaches a valid issuer callback`,
+      "Created a disconnected shared connection; connect/start returned needs_auth; one registration and authorization produced HTTP 302 with code, state, and the expected issuer; no exchange yet.", true);
+
+    const completed = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+    const html = await completed.text();
+    const referenceId = html.match(/Diagnostic reference:\s*<code>([^<]+)<\/code>/)?.[1];
+    const callbackRejected = completed.status === 400
+      && completed.headers.get("content-type")?.startsWith("text/html") === true
+      && html.includes('role="alert"') && html.includes("Connection failed")
+      && html.includes(resourceStatus === undefined
+        ? "The authorization server rejected the code or token refresh exchange."
+        : "The MCP resource rejected the supplied authorization.")
+      && !html.includes("Connection complete") && Boolean(referenceId);
+    evidence.recordAssertionEvidence(`${fault}: callback explains the failing boundary`,
+      `HTTP ${completed.status}; expected an HTML failure alert with a diagnostic reference and a ${expectedPhase} message, not a success page.`, callbackRejected);
+    expect(callbackRejected).toBe(true);
+    if (!referenceId) throw new Error("Callback diagnostic reference missing");
+
+    // Callback HTML exposes only a message/reference; connection JSON has no diagnostic.
+    // Match the real callback's structured log, never a fabricated JSON callback response.
+    const diagnostic = await eventually(async () => {
+      for (const line of (await den.apiLog()).split("\n")) {
+        if (!line.includes(referenceId)) continue;
+        let entry: unknown;
+        try { entry = JSON.parse(line); } catch { continue; }
+        if (!isRecord(entry) || entry.connection_id !== id
+          || entry.message !== "external_mcp_connect_callback_token_exchange_failed"
+          || !isRecord(entry.diagnostic) || entry.diagnostic.referenceId !== referenceId) continue;
+        return {
+          classified: entry.diagnostic.code === expectedCode && entry.diagnostic.phase === expectedPhase
+            && entry.diagnostic.httpStatus === (resourceStatus ?? 400),
+          missingAuthorizationId: line.includes("MCP_OAUTH_AUTHORIZATION_ID_REQUIRED"),
+          sdkInvalidGrant: Array.isArray(entry.causeChain) && entry.causeChain.some((cause) =>
+            isRecord(cause) && cause.name === "OAuthError" && cause.code === "invalid_grant"),
+          sanitized: !line.includes(secret),
+        };
+      }
+    }, { within: 5_000, intervalMs: 100, label: `${fault} callback diagnostic` });
+    if (!diagnostic) throw new Error("Callback diagnostic missing");
+    const classified = diagnostic.classified && !diagnostic.missingAuthorizationId
+      && (resourceStatus !== undefined || diagnostic.sdkInvalidGrant);
+    evidence.recordAssertionEvidence(`${fault}: reports ${expectedCode} in ${expectedPhase}`,
+      `Reference-matched Den diagnostic must carry HTTP ${resourceStatus ?? 400}, not a missing authorization ID; token failure must retain SDK v2 OAuthError.code=invalid_grant.`, classified);
+    expect(classified).toBe(true);
+
+    const connection = await denFetch(den.admin, `/v1/mcp-connections/${id}`, { headers });
+    expect(connection.response.status).toBe(200);
+    if (!isRecord(connection.body)) throw new Error("Connection missing after callback");
+    const disconnected = connection.body.connected === false && connection.body.connectedForMe === false
+      && connection.body.connectedAt === null && connection.body.oauthClientConfigured === true;
+    evidence.recordAssertionEvidence(`${fault}: failed callback does not commit a connected credential`,
+      "Connection GET reports connected=false, connectedForMe=false, connectedAt=null; the OAuth client registration remains configured.", disconnected);
+    expect(disconnected).toBe(true);
+
+    const observed = (await provider.requests()).slice(firstRequest);
+    const tokenRequests = observed.filter((entry) => entry.path === "/token");
+    const attempts = {
+      registrations: observed.filter((entry) => entry.path === "/register").length,
+      authorizations: observed.filter((entry) => entry.path === "/authorize" || entry.path === "/approve").length,
+      exchanges: tokenRequests.filter((entry) => entry.grantType === "authorization_code").length,
+      refreshes: tokenRequests.filter((entry) => entry.grantType === "refresh_token").length,
+      tokenRequests: tokenRequests.length,
+    };
+    const expectedExchanges = fault === "token-400" ? 2 : 1;
+    const bounded = attempts.registrations === 1 && attempts.authorizations === 1
+      && attempts.exchanges === expectedExchanges && attempts.refreshes === 0 && attempts.tokenRequests === expectedExchanges;
+    evidence.recordAssertionEvidence(`${fault}: bounded code exchange without interactive restart or refresh`,
+      `${JSON.stringify(attempts)}; ${fault === "token-400" ? "One SDK token-exchange retry is expected" : "Resource rejection must not retry the code exchange"}; no additional registration, interactive authorization, or refresh.`, bounded);
+    expect(bounded).toBe(true);
+    const exchange = tokenRequests[0];
+    if (!exchange) throw new Error("Code exchange witness missing");
+    const resources = observed.slice(before.length - firstRequest).filter((entry) => entry.path === "/mcp");
+    const providerRejected = resourceStatus === undefined
+      ? tokenRequests.every((entry) => entry.status === 400 && entry.oauthError === "invalid_grant"
+        && entry.tokenId === undefined) && resources.length === 0
+      : exchange.status === 200 && exchange.refreshTokenIssued === true
+        && typeof exchange.tokenId === "string" && resources.length > 0
+        && resources.every((entry) => entry.tokenId === exchange.tokenId && entry.status === resourceStatus
+          && entry.oauthError === (resourceStatus === 403 ? "insufficient_scope" : "invalid_token"));
+    evidence.recordAssertionEvidence(`${fault}: provider witnesses the actual rejection`,
+      resourceStatus === undefined
+        ? "Both code-exchange responses returned HTTP 400 invalid_grant; neither issued a candidate and no resource validation request followed."
+        : `Code exchange returned HTTP 200 with a refresh token; ${resources.length} resource requests used the issued candidate fingerprint and all returned HTTP ${resourceStatus}; none succeeded.`, providerRejected);
+    expect(providerRejected).toBe(true);
+
+    const sanitized = diagnostic.sanitized && !html.includes(secret) && !connection.text.includes(secret)
+      && !html.includes("mock-access-") && !html.includes("mock-refresh-")
+      && !html.includes(callback.href) && !html.includes(callback.searchParams.get("state")!);
+    evidence.recordAssertionEvidence(`${fault}: failure output excludes credentials and callback state`,
+      "Callback HTML, connection JSON, and the reference-matched diagnostic exclude the synthetic secret. HTML excludes token prefixes and the full callback/state; evidence retains only counts and booleans.", sanitized);
+    expect(sanitized).toBe(true);
+  }
+});

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -285,7 +285,11 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
         })
       : undefined
     const transport = new StreamableHTTPClientTransport(serverUrl, {
-      authProvider: oauthProvider,
+      // Callback validation may use the staged token, but must never start OAuth
+      // again (including refresh or scope step-up) when the resource rejects it.
+      authProvider: input.flow.kind === "callback" && oauthProvider
+        ? { token: async () => (await oauthProvider.tokens())?.access_token }
+        : oauthProvider,
       fetch: observer.fetch,
       requestInit: requestInit(input.connection.authorization),
     })
@@ -386,7 +390,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
         kind: "operation",
         connectionId: input.connection.id,
         operationPhase: input.operationPhase,
-        requestPhase: failureRequestPhase(session.observer),
+        requestPhase: wrapped.requestPhase,
         outcome: "failed",
         durationMs: clock.now() - startedAt,
       })
@@ -540,7 +544,14 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
           let exchangedTokens = false
           let operationFailed = false
           try {
-            await session.transport.finishAuth(code, input.responseIssuer)
+            if (!session.oauthProvider) throw new UnauthorizedError("OAuth callback requires an OAuthClientProvider")
+            const authResult = await auth(session.oauthProvider, {
+              serverUrl: session.serverUrl,
+              authorizationCode: code,
+              iss: input.responseIssuer,
+              fetchFn: session.observer.fetch,
+            })
+            if (authResult !== "AUTHORIZED") throw new UnauthorizedError("Failed to authorize")
             exchangedTokens = true
             await connectWithProtocolNegotiation({
               session,
@@ -550,9 +561,11 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
             if (session.client.getServerCapabilities()?.tools) {
               await session.client.listTools(undefined, session.requestOptions)
             }
-            await session.oauthProvider?.commitPendingAuthorizationCodeCredential()
+            await session.oauthProvider.commitPendingAuthorizationCodeCredential()
           } catch (error) {
             operationFailed = true
+            // Preserve the rejection phase before cleanup or close can change it.
+            const requestPhase = failureRequestPhase(session.observer)
             let credentialCleanupError: unknown = null
             if (exchangedTokens && credentialPort) {
               try {
@@ -572,14 +585,18 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
             if (credentialCleanupError) {
               throw new EnterpriseMcpClientError({
                 operationPhase: "authorization-callback",
-                requestPhase: session.observer.lastRequestPhase(),
+                requestPhase,
                 cause: new AggregateError(
                   [error, credentialCleanupError],
                   "Post-authorization validation failed and the exchanged credentials could not be invalidated.",
                 ),
               })
             }
-            throw error
+            throw error instanceof EnterpriseMcpClientError ? error : new EnterpriseMcpClientError({
+              operationPhase: "authorization-callback",
+              requestPhase,
+              cause: error,
+            })
           } finally {
             try {
               await closeWithinDeadline(() => session.client.close(), closeTimeoutMs)

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -27,7 +27,7 @@ import {
   assertEnterpriseMcpResourceResult,
   collectEnterpriseMcpResources,
 } from "../src/resource-catalog.js"
-import { selectClientAuthMethod } from "@modelcontextprotocol/client"
+import { InsufficientScopeError, selectClientAuthMethod, UnauthorizedError } from "@modelcontextprotocol/client"
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/client"
 
 const rpcRequestSchema = z.object({
@@ -169,6 +169,11 @@ function sendJson(response: ServerResponse, status: number, body: unknown, heade
 }
 
 async function sendMcpResponse(request: IncomingMessage, response: ServerResponse, options: { rejectToolsList?: boolean } = {}): Promise<void> {
+  if (request.method === "GET") {
+    response.writeHead(200, { "content-type": "text/event-stream" })
+    response.end()
+    return
+  }
   const parsed: unknown = JSON.parse(await requestBody(request))
   const rpc = rpcRequestSchema.parse(parsed)
   if (rpc.method === "notifications/initialized") {
@@ -208,6 +213,7 @@ async function sendMcpResponse(request: IncomingMessage, response: ServerRespons
 async function startOAuthMcpServer(options: {
   rejectAuthenticatedMcp?: boolean
   rejectAuthenticatedToolsList?: boolean
+  omitRefreshToken?: boolean
   clientMetadataSupported?: boolean
   scopeLessChallenge?: boolean
   advertisedScopes?: string[]
@@ -270,7 +276,7 @@ async function startOAuthMcpServer(options: {
         }
         sendJson(response, 200, {
           access_token: "enterprise-access-token",
-          refresh_token: "enterprise-refresh-token",
+          ...(options.omitRefreshToken ? {} : { refresh_token: "enterprise-refresh-token" }),
           token_type: "Bearer",
           expires_in: 3600,
           scope: "tools.read",
@@ -2146,6 +2152,105 @@ describe("enterprise MCP OAuth persistence contract", () => {
     assert.equal(persistence.credential?.tokens.access_token, "first-refreshed-access-token")
     assert.equal(persistence.credential?.tokens.refresh_token, "first-rotated-refresh-token")
   })
+
+  for (const method of ["server/discover", "tools/list"]) {
+    for (const status of [401, 403]) {
+      it(`preserves a ${status} ${method} rejection after exchange without restarting OAuth`, async (t) => {
+        const server = await startOAuthMcpServer({ omitRefreshToken: status === 401 })
+        try {
+          const persistence = new MemoryOAuthPersistence()
+          const saveCredential = t.mock.method(persistence.credentials, "save")
+          const state = t.mock.method(EnterpriseMcpOAuthProvider.prototype, "state")
+          const saveCodeVerifier = t.mock.method(EnterpriseMcpOAuthProvider.prototype, "saveCodeVerifier")
+          const redirect = t.mock.method(EnterpriseMcpOAuthProvider.prototype, "redirectToAuthorization")
+          const events: EnterpriseMcpDiagnosticEvent[] = []
+          let rejectedRequests = 0
+          const client = createEnterpriseMcpClient({
+            operationTimeoutMs: 5_000,
+            diagnosticSink: (event) => events.push(event),
+            fetch: async (url, init) => {
+              if (new URL(url).pathname === "/mcp"
+                && new Headers(init?.headers).get("authorization") === "Bearer enterprise-access-token"
+                && requestText(init?.body)) {
+                const request = rpcRequestSchema.parse(JSON.parse(requestText(init?.body)))
+                if (request.method === method) {
+                  rejectedRequests += 1
+                  return Response.json({ error: status === 401 ? "invalid_token" : "insufficient_scope" }, {
+                    status,
+                    headers: {
+                      "www-authenticate": status === 401
+                        ? `Bearer resource_metadata="${server.origin}/.well-known/oauth-protected-resource/mcp"`
+                        : 'Bearer error="insufficient_scope", scope="tools.read tools.write"',
+                    },
+                  })
+                }
+              }
+              return fetch(url, init)
+            },
+          })
+          const connection: EnterpriseMcpConnection = {
+            id: "oauth-candidate-rejection",
+            serverUrl: `${server.origin}/mcp`,
+            authorization: { type: "oauth", persistence },
+          }
+          const redirectUri = "https://den.example.test/oauth-candidate-rejection"
+          const authorizationId = "signed-candidate-state"
+          const started = await client.connect({ connection, redirectUri, authorizationId })
+          assert.equal(started.status, "needs_auth")
+          if (started.status !== "needs_auth") throw new Error("Expected OAuth authorization to be required.")
+          assert.equal(new URL(started.authorizeUrl).searchParams.get("state"), authorizationId)
+          const transaction = persistence.authorizationRecords.get(authorizationId)
+          assert.ok(transaction)
+          const registration = persistence.registration
+          const requestPhase = method === "server/discover" ? "mcp-discovery" : "mcp-tool-discovery"
+
+          await assert.rejects(client.completeAuthorization({
+            connection,
+            redirectUri,
+            code: "approved-code",
+            authorizationId,
+          }), (error: unknown) => {
+            assert.ok(error instanceof EnterpriseMcpClientError)
+            assert.equal(error.code, "MCP_AUTHORIZATION_CALLBACK_FAILED")
+            assert.equal(error.operationPhase, "authorization-callback")
+            assert.ok(!(error.cause instanceof EnterpriseMcpOAuthContractError))
+            if (status === 401) {
+              assert.ok(error.cause instanceof UnauthorizedError)
+            } else {
+              assert.ok(error.cause instanceof InsufficientScopeError)
+              assert.equal(error.cause.requiredScope, "tools.read tools.write")
+            }
+            assert.equal(error.requestPhase, requestPhase)
+            return true
+          })
+
+          assert.equal(rejectedRequests, 1)
+          assert.equal(state.mock.callCount(), 1)
+          assert.equal(saveCodeVerifier.mock.callCount(), 1)
+          assert.equal(redirect.mock.callCount(), 1)
+          assert.equal(saveCredential.mock.callCount(), 0)
+          assert.equal(persistence.invalidationCount, 1)
+          assert.equal(persistence.credential, undefined)
+          assert.equal(persistence.registration, registration)
+          assert.equal(persistence.authorizationRecords.get(authorizationId), transaction)
+          const callbackRequests = events.filter((event) => event.kind === "request"
+            && event.operationPhase === "authorization-callback")
+          assert.deepEqual(callbackRequests.filter((event) => event.kind === "request"
+            && event.outcome === "started" && event.requestPhase?.startsWith("oauth-"))
+            .map((event) => event.requestPhase), ["oauth-token-exchange"])
+          assert.ok(callbackRequests.some((event) => event.kind === "request"
+            && event.requestPhase === "oauth-token-exchange" && event.outcome === "succeeded"))
+          assert.ok(callbackRequests.some((event) => event.kind === "request"
+            && event.requestPhase === requestPhase && event.outcome === "failed" && event.httpStatus === status))
+          assert.ok(events.some((event) => event.kind === "operation"
+            && event.operationPhase === "authorization-callback" && event.outcome === "failed"
+            && event.requestPhase === requestPhase))
+        } finally {
+          await server.close()
+        }
+      })
+    }
+  }
 
   it("invalidates exchanged tokens when callback validation cannot initialize MCP", async () => {
     const server = await startOAuthMcpServer({ rejectAuthenticatedMcp: true })

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -83,6 +83,7 @@ const AGENT_REPLY_GATE_TIMEOUT_MS = 60_000;
 let agentRepliesHeld = false;
 const heldAgentReplies = new Set();
 let configuredTools = [];
+let oauthCallback = {};
 
 const gmailThreadId = "thread-q3-launch";
 
@@ -646,7 +647,7 @@ async function readForm(req) {
   return Object.fromEntries(new URLSearchParams(raw));
 }
 
-function record(req, url) {
+function record(req, url, res) {
   const entry = {
     id: requests.length + 1,
     method: req.method,
@@ -655,6 +656,7 @@ function record(req, url) {
     at: new Date().toISOString(),
   };
   requests.push(entry);
+  res.once("finish", () => { entry.status = res.statusCode; });
   console.log(`[mock-oauth-mcp] ${entry.method} ${entry.path}`);
   return entry;
 }
@@ -897,6 +899,7 @@ async function issueToken(req, res, entry) {
   if (grantType === "authorization_code") {
     const grant = codes.get(form.code);
     if (!grant) {
+      entry.oauthError = "invalid_grant";
       json(res, 400, { error: "invalid_grant" });
       return;
     }
@@ -914,6 +917,12 @@ async function issueToken(req, res, entry) {
         json(res, 400, { error: "invalid_grant", error_description: "PKCE verification failed" });
         return;
       }
+    }
+    if (oauthCallback.tokenErrorDescription !== undefined) {
+      codes.delete(form.code);
+      entry.oauthError = "invalid_grant";
+      json(res, 400, { error: "invalid_grant", error_description: oauthCallback.tokenErrorDescription });
+      return;
     }
   } else if (grantType === "refresh_token") {
     if (!requirePreregisteredTokenClient(req, res, form, null)) {
@@ -936,10 +945,13 @@ async function issueToken(req, res, entry) {
   const accessToken = `mock-access-${randomUUID()}`;
   tokens.add(accessToken);
   const refreshToken = `mock-refresh-${randomUUID()}`;
-  refreshTokens.add(refreshToken);
+  const issueRefreshToken = oauthCallback.issueRefreshToken !== false;
+  if (issueRefreshToken) refreshTokens.add(refreshToken);
+  entry.tokenId = createHash("sha256").update(accessToken).digest("hex").slice(0, 12);
+  entry.refreshTokenIssued = issueRefreshToken;
   await respond(200, {
     access_token: accessToken,
-    refresh_token: refreshToken,
+    ...(issueRefreshToken ? { refresh_token: refreshToken } : {}),
     token_type: "Bearer",
     expires_in: 3600,
     scope: grantedScope,
@@ -1186,6 +1198,17 @@ async function handleMcp(req, res, entry) {
     .map((message) => message.method);
 
   const authorized = isAuthorized(req);
+  entry.tokenId = tokenFingerprint(req);
+  if (tokens.has(bearerToken(req)) && oauthCallback.resourceStatus !== undefined) {
+    const error = oauthCallback.resourceStatus === 403 ? "insufficient_scope" : "invalid_token";
+    entry.oauthError = error;
+    json(res, oauthCallback.resourceStatus, { error }, {
+      "www-authenticate": oauthCallback.resourceStatus === 403
+        ? 'Bearer error="insufficient_scope", scope="mcp:read mcp:write"'
+        : `Bearer resource_metadata="${issuer}/.well-known/oauth-protected-resource"`,
+    });
+    return;
+  }
   if (!authorized) {
     json(res, 401, { error: "missing_mcp_token" }, {
       "www-authenticate": `Bearer resource_metadata="${issuer}/.well-known/oauth-protected-resource"`,
@@ -1205,7 +1228,6 @@ async function handleMcp(req, res, entry) {
   // Arguments + a token fingerprint make the connector the AUTHORITY on who
   // called it: a spec can prove two members each invoked a tool with their own
   // credential, without trusting the app's own UI state.
-  entry.tokenId = tokenFingerprint(req);
   entry.toolCalls = messages
     .filter((message) => message && typeof message === "object" && message.method === "tools/call" && typeof message.params?.name === "string")
     .map((message) => ({
@@ -1233,7 +1255,7 @@ async function handleMcp(req, res, entry) {
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url || "/", issuer);
-    const entry = record(req, url);
+    const entry = record(req, url, res);
 
     if (req.method === "OPTIONS") {
       json(res, 204, {});
@@ -1247,6 +1269,22 @@ const server = http.createServer(async (req, res) => {
 
     if (url.pathname === "/requests") {
       json(res, 200, { requests });
+      return;
+    }
+
+    if (url.pathname === "/admin/oauth-callback" && req.method === "POST") {
+      const body = await readJson(req);
+      if (!body || typeof body !== "object" || Array.isArray(body)
+        || Object.keys(body).some((key) => !["issueRefreshToken", "resourceStatus", "tokenErrorDescription"].includes(key))
+        || (body.issueRefreshToken !== undefined && typeof body.issueRefreshToken !== "boolean")
+        || (body.resourceStatus !== undefined && ![401, 403].includes(body.resourceStatus))
+        || (body.tokenErrorDescription !== undefined && (typeof body.tokenErrorDescription !== "string"
+          || !body.tokenErrorDescription || body.tokenErrorDescription.length > 512))) {
+        json(res, 400, { error: "invalid_oauth_callback_options" });
+        return;
+      }
+      oauthCallback = body;
+      json(res, 200, { configured: true });
       return;
     }
 


### PR DESCRIPTION
## Problem

An OAuth code exchange could succeed, then a rejected MCP validation request would start authorization again inside the callback. That secondary flow reported `MCP_OAUTH_AUTHORIZATION_ID_REQUIRED` even though the original signed transaction was present, hiding the resource rejection.

Separately, the diagnostic classifier recognized legacy OAuth error subclasses but not SDK v2 `OAuthError.code`. Unknown local failures could incorrectly claim the authorization server rejected a token request.

## Change

- Exchange the code using the full OAuth provider, then validate MCP with a token-only provider. Resource rejection cannot trigger fresh authorization, refresh, DCR, or scope step-up during callback validation.
- Capture the original failure phase before cleanup and transport shutdown.
- Classify allowlisted SDK v2 OAuth codes ahead of generic HTTP failures, retaining legacy compatibility and sanitized cause codes.
- Use neutral wording and OpenWork-owned investigation guidance when an unknown token failure does not establish provider rejection. Never log raw SDK error bodies.

Signed state, PKCE, issuer checks, registered callbacks, credential commit/cleanup behavior, and normal runtime refresh remain unchanged. This does not make a provider-rejected credential valid or resolve the provider's underlying configuration.

## Conflict resolution

Reconstructed the intended change on current `dev`, preserving the newer redirect-URI rejection classification, administrator-supplied client retention, revision-fenced credential invalidation, refresh-response gates, and all added OAuth journey cases. Resource-401 and resource-403 scenarios now receive a refresh token and still assert zero refresh requests, addressing the review's missing negative witness.

## Verification

**Verdict: Passed.** [Exact-head assertion evidence for all ten tests](https://github.com/different-ai/openwork/pull/4656#issuecomment-5593848491) is published inline: **62 passed recorded assertions**, zero failures, skips, or pending judgments.

Head: `a3087a6026f0de4594e09eec36ad35784c6bdb5a`; base: `23143497940c871bda4a9aaebb82bd86c3f95530`.

- `pnpm evals:pr specs/mcp-oauth-response-issuer.test.ts` — exit 0; **10 passed, 0 failed, 0 skipped**, 182.07 seconds. Direct Vitest PR lane, local cold-boot Den instances and isolated databases; no attached Den or real OAuth providers.
- From `ee/apps/den-api`: `bun test --conditions development test/external-mcp-diagnostics.test.ts test/slack-mcp-diagnostic-compat.test.ts` — **154 passed, 0 failed**. Run before the final rebase; the rebase changed unrelated browser/proxy files, not the tested source or dependencies.
- Focused conflict review and `git diff --check` passed. The final commit is signed.

An earlier invocation exceeded the shell's two-minute deadline; it is not used for this verdict. The complete run above used a sufficient command timeout. Previous-head package/typecheck results are historical, not current-head proof.

Deferred: real-provider reproduction and broad cross-platform suites. Auto-merge is requested subject to normal repository checks; no manual deployment or release is included.
