### PR TITLE
fix(den): preserve renewed MCP credentials on stale rejection

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
@@ -34,7 +34,8 @@ import {
 
 function toEnterpriseConnection(
   connection: ExternalMcpConnectionRow,
-  member?: ExternalMcpMemberContext,
+  member: ExternalMcpMemberContext | undefined,
+  tracker: ExternalMcpDiagnosticTracker,
 ): EnterpriseMcpConnection {
   if (connection.kind !== "external_mcp") {
     throw new Error("Native provider connectors do not expose an MCP server.")
@@ -46,7 +47,7 @@ function toEnterpriseConnection(
       serverUrl: connection.url,
       authorization: {
         type: "oauth",
-        persistence: new DenEnterpriseMcpOAuthPersistence(connection, member),
+        persistence: new DenEnterpriseMcpOAuthPersistence(connection, member, tracker),
         configuration: {
           applicationType: "web",
           // CIMD client identifiers must be HTTPS URLs. Local HTTP development
@@ -106,18 +107,9 @@ function diagnosticSink(tracker: ExternalMcpDiagnosticTracker) {
     // authorization challenges and network causes. Package request events are
     // still available to package consumers, but must not overwrite that richer
     // Den evidence after a response settles.
-    if (event.kind === "request") return
-    if (event.kind === "credential-invalidation") {
-      console.error("external_mcp_credential_invalidated", {
-        referenceId: tracker.referenceId,
-        connectionId: event.connectionId,
-        operationPhase: event.operationPhase,
-        requestPhase: event.requestPhase,
-        httpStatus: event.httpStatus,
-        invalidToken: event.invalidToken,
-      })
-      return
-    }
+    // The persistence boundary logs committed invalidations, including SDK
+    // paths that do not emit the package event. Do not log them twice here.
+    if (event.kind === "request" || event.kind === "credential-invalidation") return
     const phase = diagnosticPhase(event)
     if (event.outcome === "started") {
       tracker.begin(phase)
@@ -239,11 +231,11 @@ async function runEnterpriseMcpOperation<T>(input: {
   lifecycleDeadline?: ExternalMcpLifecycleDeadline
   operationTimeoutMs?: number
   toolCallInspector?: ExternalMcpToolCallInspector
-  operation: (client: EnterpriseMcpClient) => Promise<T>
+  operation: (client: EnterpriseMcpClient, tracker: ExternalMcpDiagnosticTracker) => Promise<T>
 }): Promise<T> {
   const { client, tracker } = createOperationClient(input)
   try {
-    return await input.operation(client)
+    return await input.operation(client, tracker)
   } catch (error) {
     throw translateEnterpriseMcpError(error, tracker)
   }
@@ -259,8 +251,8 @@ export async function connectExternalMcp(
   return runEnterpriseMcpOperation({
     connection,
     diagnosticReferenceId,
-    operation: (client) => client.connect({
-      connection: toEnterpriseConnection(connection, member),
+    operation: (client, tracker) => client.connect({
+      connection: toEnterpriseConnection(connection, member, tracker),
       redirectUri,
       authorizationId: signedState,
     }),
@@ -280,8 +272,8 @@ export async function completeExternalMcpAuth(
   await runEnterpriseMcpOperation({
     connection,
     diagnosticReferenceId,
-    operation: (client) => client.completeAuthorization({
-      connection: toEnterpriseConnection(connection, member),
+    operation: (client, tracker) => client.completeAuthorization({
+      connection: toEnterpriseConnection(connection, member, tracker),
       redirectUri,
       code,
       authorizationId: signedState,
@@ -299,8 +291,8 @@ export async function abandonExternalMcpAuth(
   await runEnterpriseMcpOperation({
     connection,
     diagnosticReferenceId,
-    operation: (client) => client.abandonAuthorization({
-      connection: toEnterpriseConnection(connection, member),
+    operation: (client, tracker) => client.abandonAuthorization({
+      connection: toEnterpriseConnection(connection, member, tracker),
       authorizationId: signedState,
       reason: "provider-rejected",
     }),
@@ -320,8 +312,8 @@ export async function listExternalMcpTools(
     diagnosticReferenceId,
     lifecycleDeadline,
     operationTimeoutMs,
-    operation: (client) => client.listTools({
-      connection: toEnterpriseConnection(connection, member),
+    operation: (client, tracker) => client.listTools({
+      connection: toEnterpriseConnection(connection, member, tracker),
       redirectUri,
     }),
   })
@@ -347,8 +339,8 @@ function runExternalMcpToolCall(
     lifecycleDeadline: input.lifecycleDeadline,
     operationTimeoutMs: EXTERNAL_MCP_TOOL_CALL_TIMEOUT_MS,
     toolCallInspector,
-    operation: (client) => client.callTool({
-      connection: toEnterpriseConnection(input.connection, input.member),
+    operation: (client, tracker) => client.callTool({
+      connection: toEnterpriseConnection(input.connection, input.member, tracker),
       redirectUri: input.redirectUri,
       toolName: input.toolName,
       arguments: input.args,
@@ -366,8 +358,8 @@ export function callExternalMcpToolRaw(input: ExternalMcpToolCallInput) {
     diagnosticReferenceId: input.diagnosticReferenceId,
     lifecycleDeadline: input.lifecycleDeadline,
     operationTimeoutMs: EXTERNAL_MCP_TOOL_CALL_TIMEOUT_MS,
-    operation: (client) => client.callToolRaw({
-      connection: toEnterpriseConnection(input.connection, input.member),
+    operation: (client, tracker) => client.callToolRaw({
+      connection: toEnterpriseConnection(input.connection, input.member, tracker),
       redirectUri: input.redirectUri,
       toolName: input.toolName,
       arguments: input.args,
@@ -388,8 +380,8 @@ export function describeExternalMcpServer(input: ExternalMcpResourceInput) {
     connection: input.connection,
     diagnosticReferenceId: input.diagnosticReferenceId,
     lifecycleDeadline: input.lifecycleDeadline,
-    operation: (client) => client.describeServer({
-      connection: toEnterpriseConnection(input.connection, input.member),
+    operation: (client, tracker) => client.describeServer({
+      connection: toEnterpriseConnection(input.connection, input.member, tracker),
       redirectUri: input.redirectUri,
     }),
   })
@@ -400,8 +392,8 @@ export function listExternalMcpResources(input: ExternalMcpResourceInput) {
     connection: input.connection,
     diagnosticReferenceId: input.diagnosticReferenceId,
     lifecycleDeadline: input.lifecycleDeadline,
-    operation: (client) => client.listResources({
-      connection: toEnterpriseConnection(input.connection, input.member),
+    operation: (client, tracker) => client.listResources({
+      connection: toEnterpriseConnection(input.connection, input.member, tracker),
       redirectUri: input.redirectUri,
     }),
   })
@@ -412,8 +404,8 @@ export function listExternalMcpResourceTemplates(input: ExternalMcpResourceInput
     connection: input.connection,
     diagnosticReferenceId: input.diagnosticReferenceId,
     lifecycleDeadline: input.lifecycleDeadline,
-    operation: (client) => client.listResourceTemplates({
-      connection: toEnterpriseConnection(input.connection, input.member),
+    operation: (client, tracker) => client.listResourceTemplates({
+      connection: toEnterpriseConnection(input.connection, input.member, tracker),
       redirectUri: input.redirectUri,
     }),
   })
@@ -424,8 +416,8 @@ export function readExternalMcpResource(input: ExternalMcpResourceInput & { uri:
     connection: input.connection,
     diagnosticReferenceId: input.diagnosticReferenceId,
     lifecycleDeadline: input.lifecycleDeadline,
-    operation: (client) => client.readResource({
-      connection: toEnterpriseConnection(input.connection, input.member),
+    operation: (client, tracker) => client.readResource({
+      connection: toEnterpriseConnection(input.connection, input.member, tracker),
       redirectUri: input.redirectUri,
       uri: input.uri,
     }),

--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -28,6 +28,7 @@ import {
 } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { z } from "zod"
 import { db } from "../db.js"
+import { appLogger } from "../observability/logger.js"
 import type { ExternalMcpMemberContext } from "./external-mcp-client.js"
 import {
   externalMcpIdentityBinding,
@@ -35,6 +36,11 @@ import {
 } from "./external-mcp-connections.js"
 import { externalMcpCompatibleCallbackUrl } from "./external-mcp-oauth-contract.js"
 import { normalizeConnectedAccountScopes, normalizeOAuthClientExtra } from "./oauth-credentials.js"
+import {
+  externalMcpDiagnosticForLog,
+  safeExternalMcpEndpointForLog,
+  type ExternalMcpDiagnosticTracker,
+} from "./external-mcp-diagnostics.js"
 
 const MAX_PENDING_AUTHORIZATIONS = 8
 
@@ -196,8 +202,13 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
   private connection: ExternalMcpConnectionRow
   private readonly identityBinding: string
   private readonly member?: ExternalMcpMemberContext
+  private loadedRevision: string | undefined
 
-  constructor(connection: ExternalMcpConnectionRow, member?: ExternalMcpMemberContext) {
+  constructor(
+    connection: ExternalMcpConnectionRow,
+    member?: ExternalMcpMemberContext,
+    private readonly diagnosticTracker?: ExternalMcpDiagnosticTracker,
+  ) {
     this.connection = connection
     this.identityBinding = externalMcpIdentityBinding(connection)
     this.member = member
@@ -591,9 +602,11 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
     load: async (context: EnterpriseMcpPersistenceContext) => {
       assertCommitActive(context)
       await this.refreshConnection()
+      this.loadedRevision = undefined
       if (this.isPerMember) {
         const account = await this.memberAccount()
         if (!account?.accessToken) return undefined
+        this.loadedRevision = `${account.id}:${account.updatedAt.getTime()}`
         return {
           tokens: {
             access_token: account.accessToken,
@@ -605,10 +618,11 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
               : {}),
           },
           expiresAt: account.expiresAt?.getTime(),
-          revision: `${account.id}:${account.updatedAt.getTime()}`,
+          revision: this.loadedRevision,
         }
       }
       if (!this.connection.accessToken) return undefined
+      this.loadedRevision = `${this.connection.id}:${this.connection.updatedAt.getTime()}`
       return {
         tokens: {
           access_token: this.connection.accessToken,
@@ -620,7 +634,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
             : {}),
         },
         expiresAt: this.connection.expiresAt?.getTime(),
-        revision: `${this.connection.id}:${this.connection.updatedAt.getTime()}`,
+        revision: this.loadedRevision,
       }
     },
 
@@ -784,7 +798,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
       context: EnterpriseMcpPersistenceContext
       reason: "expired" | "provider-rejected" | "post-authorization-validation-failed"
     }): Promise<void> => {
-      await db.transaction(async (tx) => {
+      const invalidated = await db.transaction(async (tx) => {
         const connections = await tx
           .select()
           .from(ExternalMcpConnectionTable)
@@ -798,6 +812,28 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
         if (!connection) return
         this.assertCurrentIdentity(connection)
         assertCommitActive(input.context)
+        const account = this.isPerMember && this.member
+          ? (await tx.select().from(ConnectedAccountTable).where(and(
+              eq(ConnectedAccountTable.organizationId, connection.organizationId),
+              eq(ConnectedAccountTable.orgMembershipId, this.member.orgMembershipId),
+              eq(ConnectedAccountTable.providerId, connection.id),
+            )).limit(1).for("update"))[0]
+          : undefined
+        const current = this.isPerMember ? account : connection
+        const currentRevision = current ? `${current.id}:${current.updatedAt.getTime()}` : null
+        const snapshot = {
+          loaded_revision: this.loadedRevision ?? null,
+          current_revision: currentRevision,
+          revision_changed: this.loadedRevision !== undefined && this.loadedRevision !== currentRevision,
+          had_access: Boolean(current?.accessToken),
+          had_refresh: Boolean(current?.refreshToken),
+        }
+        // A delayed rejection may belong to credentials that another operation
+        // has already replaced. Only clear the revision this operation read.
+        // Callback validation can also fail before reading any saved credential.
+        if ((snapshot.had_access || snapshot.had_refresh) && this.loadedRevision !== currentRevision) {
+          return { ...snapshot, skipped: true }
+        }
         if (this.isPerMember && this.member) {
           await tx
             .update(ConnectedAccountTable)
@@ -829,7 +865,34 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
             .where(eq(ExternalMcpConnectionTable.id, connection.id))
         }
         assertCommitActive(input.context)
+        return { ...snapshot, skipped: false }
       })
+      if (invalidated) {
+        // Log the committed decision, including requests initiated inside the
+        // SDK. Revision metadata is deliberately separate from secret values.
+        const tracker = this.diagnosticTracker
+        const { skipped, ...snapshot } = invalidated
+        try {
+          appLogger.warn(skipped ? "external_mcp_credential_invalidation_skipped" : "external_mcp_credential_invalidated", {
+            component: "external_mcp_oauth",
+            connection_id: this.connection.id,
+            organization_id: this.connection.organizationId,
+            org_membership_id: this.member?.orgMembershipId ?? null,
+            mode: this.connection.credentialMode,
+            reason: input.reason,
+            connection_endpoint: safeExternalMcpEndpointForLog(this.connection.url),
+            ...snapshot,
+            ...(skipped ? { skip_reason: this.loadedRevision === undefined ? "no-loaded-revision" : "revision-changed" } : {}),
+            ...(tracker ? externalMcpDiagnosticForLog(
+              tracker.error(new Error(skipped ? "Saved OAuth credential invalidation skipped." : "Saved OAuth credentials invalidated.")),
+              tracker.referenceId,
+              tracker.activePhase,
+            ) : {}),
+          })
+        } catch {
+          // Diagnostics must not change the committed credential outcome.
+        }
+      }
       await this.refreshConnection()
     },
   }

--- a/ee/apps/den-api/test/enterprise-mcp-oauth-persistence.test.ts
+++ b/ee/apps/den-api/test/enterprise-mcp-oauth-persistence.test.ts
@@ -1,5 +1,5 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test"
 
 function seedRequiredEnv(): void {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_pr7"
@@ -86,7 +86,7 @@ function context(offsetMs = 30_000) {
 }
 
 describe("Den enterprise MCP OAuth persistence adapter", () => {
-  test("records reconnect-required health when a provider rejects a saved credential", async () => {
+  test("preserves a newer credential and logs rejection only for the revision that was read", async () => {
     const rejected = await createExternalMcpConnection({
       organizationId,
       name: "Enterprise MCP rejected credential",
@@ -104,16 +104,81 @@ describe("Den enterprise MCP OAuth persistence adapter", () => {
       .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, rejected.id))
       .limit(1))[0]
     if (!current) throw new Error("Expected the rejected credential connection.")
-    const persistence = new DenEnterpriseMcpOAuthPersistence(current)
+    const { ExternalMcpDiagnosticTracker, createExternalMcpDiagnosticFetch } = await import("../src/capability-sources/external-mcp-diagnostics.js")
+    const { appLogger } = await import("../src/observability/logger.js")
+    const tracker = new ExternalMcpDiagnosticTracker("invalidation-test-reference")
+    const persistence = new DenEnterpriseMcpOAuthPersistence(current, undefined, tracker)
+    const rejectionContext = { ...context(), connectionId: current.id }
+    const loaded = await persistence.credentials.load(rejectionContext)
+    if (!loaded) throw new Error("Expected the saved credential")
+    const newerUpdatedAt = new Date(current.updatedAt.getTime() + 1_000)
+    await db.update(schema.ExternalMcpConnectionTable).set({
+      accessToken: "newer-access-secret",
+      refreshToken: "newer-refresh-secret",
+      updatedAt: newerUpdatedAt,
+    }).where(drizzle.eq(schema.ExternalMcpConnectionTable.id, current.id))
+    await createExternalMcpDiagnosticFetch({
+      endpoint: current.url,
+      tracker,
+      fetch: async () => Response.json({ error: "invalid_grant", access_token: "provider-access-secret", refresh_token: "provider-refresh-secret" }, { status: 400 }),
+    })("https://identity.example.test/token", { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" }, body: new URLSearchParams({ grant_type: "refresh_token" }) })
+    const logged = spyOn(appLogger, "warn").mockImplementation(() => {})
 
-    await persistence.credentials.invalidate({
-      context: {
-        connectionId: current.id,
-        commitExpiresAt: Date.now() + 30_000,
-        signal: new AbortController().signal,
-      },
-      reason: "provider-rejected",
-    })
+    try {
+      await expect(persistence.credentials.invalidate({
+        context: { ...rejectionContext, commitExpiresAt: Date.now() - 1 },
+        reason: "provider-rejected",
+      })).rejects.toThrow("deadline expired")
+      expect(logged).not.toHaveBeenCalled()
+      await persistence.credentials.invalidate({
+        context: rejectionContext,
+        reason: "provider-rejected",
+      })
+      expect(logged).toHaveBeenCalledTimes(1)
+      expect(logged.mock.calls[0]).toEqual([
+        "external_mcp_credential_invalidation_skipped",
+        expect.objectContaining({
+          connection_id: current.id,
+          organization_id: organizationId,
+          org_membership_id: null,
+          reason: "provider-rejected",
+          loaded_revision: loaded.revision,
+          current_revision: `${current.id}:${newerUpdatedAt.getTime()}`,
+          revision_changed: true,
+          had_access: true,
+          had_refresh: true,
+          skip_reason: "revision-changed",
+          diagnostic: expect.objectContaining({ httpStatus: 400, providerErrorMessage: expect.stringContaining("invalid_grant") }),
+        }),
+      ])
+      expect(JSON.stringify(logged.mock.calls)).not.toMatch(/newer-access-secret|newer-refresh-secret|provider-access-secret|provider-refresh-secret/)
+      const preserved = await persistence.credentials.load(rejectionContext)
+      expect(preserved?.tokens.access_token).toBe("newer-access-secret")
+      expect(preserved?.tokens.refresh_token).toBe("newer-refresh-secret")
+      const withoutRead = new DenEnterpriseMcpOAuthPersistence(current, undefined, tracker)
+      await withoutRead.credentials.invalidate({ context: rejectionContext, reason: "post-authorization-validation-failed" })
+      expect(logged.mock.calls[1]).toEqual([
+        "external_mcp_credential_invalidation_skipped",
+        expect.objectContaining({ skip_reason: "no-loaded-revision", reason: "post-authorization-validation-failed" }),
+      ])
+      expect((await persistence.credentials.load(rejectionContext))?.tokens.access_token).toBe("newer-access-secret")
+      logged.mockClear()
+      logged.mockImplementationOnce(() => { throw new Error("Synthetic log sink failure") })
+      await persistence.credentials.invalidate({ context: rejectionContext, reason: "provider-rejected" })
+      expect(logged).toHaveBeenCalledTimes(1)
+      expect(logged.mock.calls[0]).toEqual([
+        "external_mcp_credential_invalidated",
+        expect.objectContaining({
+          loaded_revision: preserved?.revision,
+          current_revision: preserved?.revision,
+          revision_changed: false,
+          had_access: true,
+          had_refresh: true,
+        }),
+      ])
+    } finally {
+      logged.mockRestore()
+    }
 
     const after = (await db.select()
       .from(schema.ExternalMcpConnectionTable)

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -80,6 +80,10 @@ export interface MockMcpHandle {
   handshakes(opts?: { timeoutMs?: number; atLeast?: number; sinceIso?: string }): Promise<MockAuthorizeRequest[]>;
   configureOAuthRedirectUris(redirectUris: readonly string[]): Promise<void>;
   resetOAuth(): Promise<void>;
+  /** Expire access tokens and hold refresh replies until explicitly released. */
+  holdRefreshResponses(): Promise<void>;
+  pendingRefreshResponses(): Promise<{ id: number; status: number; tokenId: string }[]>;
+  releaseRefreshResponse(id: number): Promise<void>;
   stop(): Promise<void>;
   [Symbol.asyncDispose](): Promise<void>;
 }
@@ -318,6 +322,9 @@ async function startEnterpriseProfileMock(options: StartMockMcpOptions): Promise
       await stop();
       await boot();
     },
+    async holdRefreshResponses() { throw new Error("Refresh response control requires the legacy OAuth mock."); },
+    async pendingRefreshResponses() { throw new Error("Refresh response control requires the legacy OAuth mock."); },
+    async releaseRefreshResponse() { throw new Error("Refresh response control requires the legacy OAuth mock."); },
     stop,
     [Symbol.asyncDispose]: stop,
   };
@@ -518,6 +525,23 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     async resetOAuth() {
       const response = await fetch(`${url}/admin/expire-oauth-tokens`, { method: "POST" });
       if (!response.ok) throw new Error(`Mock OAuth reset failed: HTTP ${response.status}`);
+    },
+    async holdRefreshResponses() {
+      const response = await fetch(`${url}/admin/refresh-responses`, { method: "POST", signal: AbortSignal.timeout(5_000) });
+      if (!response.ok) throw new Error(`Mock refresh hold failed: HTTP ${response.status}`);
+    },
+    async pendingRefreshResponses() {
+      const response = await fetch(`${url}/admin/refresh-responses`, { signal: AbortSignal.timeout(5_000) });
+      const body: unknown = await response.json();
+      if (!response.ok || !isRecord(body) || !Array.isArray(body.responses)) throw new Error("Mock refresh responses missing");
+      return body.responses.map((entry: unknown) => {
+        if (!isRecord(entry) || typeof entry.id !== "number" || typeof entry.status !== "number" || typeof entry.tokenId !== "string") throw new Error("Invalid mock refresh response");
+        return { id: entry.id, status: entry.status, tokenId: entry.tokenId };
+      });
+    },
+    async releaseRefreshResponse(id) {
+      const response = await fetch(`${url}/admin/refresh-responses/${id}/release`, { method: "POST", signal: AbortSignal.timeout(5_000) });
+      if (!response.ok) throw new Error(`Mock refresh release failed: HTTP ${response.status}`);
     },
     stop,
     [Symbol.asyncDispose]: stop,

--- a/evals/specs/mcp-oauth-response-issuer.test.ts
+++ b/evals/specs/mcp-oauth-response-issuer.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
-import { mcpMock, needs, server, test } from "@openwork/testkit";
+import { eventually, mcpMock, needs, server, test } from "@openwork/testkit";
 import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
 
 for (const issuerSupport of [true, false, undefined]) {
@@ -105,10 +105,11 @@ for (const issuerSupport of [true, false, undefined]) {
     if (!isRecord(metadata)) throw new Error("Provider metadata missing");
     expect(metadata.authorization_response_iss_parameter_supported).toBe(issuerSupport);
     const headers = { authorization: `Bearer ${den.admin.token}` };
+    const credentialMode = issuerSupport === true ? "per_member" : "shared";
     for (const mode of issuerSupport === true ? ["mismatch", "valid"] : ["valid"]) {
       const created = await denFetch(den.admin, "/v1/mcp-connections", {
         method: "POST", headers,
-        body: JSON.stringify({ name: `Issuer ${mode}`, url: provider.mcpUrl, authType: "oauth", credentialMode: "shared", access: { orgWide: true } }),
+        body: JSON.stringify({ name: `Issuer ${mode}`, url: provider.mcpUrl, authType: "oauth", credentialMode, access: { orgWide: true } }),
       });
       expect(created.response.status, created.text).toBe(200);
       if (!isRecord(created.body) || typeof created.body.id !== "string") throw new Error("Connection id missing");
@@ -148,6 +149,65 @@ for (const issuerSupport of [true, false, undefined]) {
         expect(reused.body).toMatchObject({ status: "connected", authorizeUrl: null });
         expect((await provider.requests()).filter((entry) => entry.path === "/token").length).toBe(before + 1);
         evidence.recordAssertionEvidence("Den replay preserves usable credentials", "Replay rejected; a subsequent connection check reused saved credentials and remained connected without another token exchange.", true);
+
+        const invalidations = (log: string, message = "external_mcp_credential_invalidated") => log.split(/\r?\n/).flatMap((line) => {
+          const start = line.indexOf("{");
+          if (start < 0) return [];
+          try {
+            const value: unknown = JSON.parse(line.slice(start));
+            return isRecord(value) && value.message === message && value.connection_id === id ? [value] : [];
+          } catch { return []; }
+        });
+        expect(invalidations(await den.apiLog())).toHaveLength(0);
+
+        await provider.holdRefreshResponses();
+        const first = denFetch(den.admin, `/v1/mcp-connections/${id}/tools`, { headers });
+        await eventually(() => provider.pendingRefreshResponses(), { within: 8_000, intervalMs: 50, until: (responses) => responses.length === 1, label: "first refresh response held" });
+        const second = denFetch(den.admin, `/v1/mcp-connections/${id}/tools`, { headers });
+        const pending = await eventually(() => provider.pendingRefreshResponses(), { within: 8_000, intervalMs: 50, until: (responses) => responses.length === 2, label: "two concurrent refresh responses held" });
+        const success = pending.find((response) => response.status === 200);
+        const failure = pending.find((response) => response.status === 400);
+        expect(success).toBeDefined();
+        expect(failure).toBeDefined();
+        if (!success || !failure) throw new Error("Expected one successful rotation and one rejected refresh");
+        expect(failure.tokenId).toBe(success.tokenId);
+        await provider.releaseRefreshResponse(success.id);
+        const refreshed = await first;
+        expect(refreshed.response.status, refreshed.text).toBe(200);
+        await provider.releaseRefreshResponse(failure.id);
+        const recovered = await second;
+        expect(recovered.response.status, recovered.text).toBe(200);
+        const afterRace = await denFetch(den.admin, `/v1/mcp-connections/${id}/tools`, { headers });
+        expect(afterRace.response.status, afterRace.text).toBe(200);
+        const raceLogs = await den.apiLog();
+        expect(invalidations(raceLogs)).toHaveLength(0);
+        const preserved = invalidations(raceLogs, "external_mcp_credential_invalidation_skipped");
+        expect(preserved).toHaveLength(1);
+        expect(preserved[0]).toMatchObject({ mode: credentialMode, reason: "provider-rejected", skip_reason: "revision-changed", revision_changed: true, had_access: true, had_refresh: true });
+        expect(preserved[0].current_revision).not.toBe(preserved[0].loaded_revision);
+        expect(preserved[0].diagnostic).toMatchObject({ httpStatus: 400, providerErrorMessage: expect.stringContaining("invalid_grant") });
+        expect(JSON.stringify(preserved)).not.toMatch(/mock-access-|mock-refresh-|code_verifier|client_secret/);
+        evidence.recordAssertionEvidence(`Den preserves renewed ${credentialMode} credentials after a late rejection`, "Two requests used the same refresh grant. The successful rotation completed before the held invalid_grant was released. A subsequent authenticated tools request succeeded, zero deletion events were logged, and one skipped invalidation named different loaded/current revisions.", true);
+
+        await provider.resetOAuth();
+        const tokenRequestsBefore = (await provider.requests()).filter((entry) => entry.path === "/token").length;
+        const rejected = await denFetch(den.admin, `/v1/mcp-connections/${id}/tools`, { headers });
+        expect(rejected.response.ok).toBe(false);
+        expect((await provider.requests()).filter((entry) => entry.path === "/token").length).toBe(tokenRequestsBefore + 1);
+        const afterRejection = await denFetch(den.admin, "/v1/mcp-connections?scope=manageable", { headers });
+        if (!isRecord(afterRejection.body) || !Array.isArray(afterRejection.body.connections)) throw new Error("Connections missing after rejection");
+        expect(afterRejection.body.connections.find((entry) => isRecord(entry) && entry.id === id)).toMatchObject({ connected: false });
+        const logs = invalidations(await den.apiLog());
+        expect(logs).toHaveLength(1);
+        const [log] = logs;
+        expect(log).toMatchObject({ reason: "provider-rejected", mode: credentialMode, had_access: true, had_refresh: true, revision_changed: false });
+        expect(log.loaded_revision).toEqual(expect.any(String));
+        expect(log.current_revision).toBe(log.loaded_revision);
+        expect(log.org_membership_id).toEqual(credentialMode === "per_member" ? expect.any(String) : null);
+        expect(log.organization_id).toEqual(expect.any(String));
+        expect(log.diagnostic).toMatchObject({ httpStatus: 400, phase: "CONTINUITY_REFRESH", providerErrorMessage: expect.stringContaining("invalid_grant"), referenceId: expect.any(String) });
+        expect(JSON.stringify(log)).not.toMatch(/mock-access-|mock-refresh-|code_verifier|client_secret/);
+        evidence.recordAssertionEvidence(`Den logs committed ${credentialMode} SDK credential invalidation`, "One rejected refresh cleared the connection and produced exactly one structured log with provider error, member scope, and matching loaded/current revisions. Healthy reuse produced no invalidation log; token values and OAuth secrets were absent.", true);
       }
     }
   });

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -12,7 +12,7 @@ const strictOAuth = process.argv.includes("--strict") || process.env.STRICT_OAUT
 // Strict mode rejects refresh tokens this instance did not issue (and
 // rotates on every refresh grant). Off by default: eval flows restart the
 // mock mid-scenario and legitimately present pre-restart refresh tokens.
-const strictRefreshTokens = process.env.STRICT_REFRESH_TOKENS === "1";
+let strictRefreshTokens = process.env.STRICT_REFRESH_TOKENS === "1";
 const mockClientId = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
 const mockClientSecret = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
 const preregisteredRedirectUris = (process.env.MOCK_REDIRECT_URIS || "")
@@ -48,6 +48,9 @@ const clients = new Map();
 const codes = new Map();
 const tokens = new Set();
 const refreshTokens = new Set();
+let holdRefreshResponses = false;
+let nextRefreshResponseId = 0;
+const pendingRefreshResponses = new Map();
 const requests = [];
 const drafts = [];
 let agentWorkloads = [];
@@ -682,6 +685,24 @@ async function issueToken(req, res, entry) {
   const form = await readForm(req);
   const grantType = form.grant_type || "authorization_code";
   if (entry) entry.grantType = grantType;
+  const respond = async (status, body) => {
+    if (grantType === "refresh_token" && holdRefreshResponses) {
+      const id = ++nextRefreshResponseId;
+      await new Promise((resolve) => {
+        const release = () => {
+          clearTimeout(timer);
+          pendingRefreshResponses.delete(id);
+          if (pendingRefreshResponses.size === 0) holdRefreshResponses = false;
+          resolve();
+        };
+        const timer = setTimeout(release, 30_000);
+        pendingRefreshResponses.set(id, {
+          id, status, tokenId: createHash("sha256").update(form.refresh_token || "").digest("hex").slice(0, 16), release,
+        });
+      });
+    }
+    json(res, status, body);
+  };
   let grantedScope = "mcp:read mcp:write";
 
   if (grantType === "authorization_code") {
@@ -711,7 +732,7 @@ async function issueToken(req, res, entry) {
     }
     if (strictRefreshTokens) {
       if (!form.refresh_token || !refreshTokens.has(form.refresh_token)) {
-        json(res, 400, { error: "invalid_grant", error_description: "unknown refresh token" });
+        await respond(400, { error: "invalid_grant", error_description: "unknown refresh token" });
         return;
       }
       // Rotate, like real providers (and the Den) do: the old refresh token
@@ -727,7 +748,7 @@ async function issueToken(req, res, entry) {
   tokens.add(accessToken);
   const refreshToken = `mock-refresh-${randomUUID()}`;
   refreshTokens.add(refreshToken);
-  json(res, 200, {
+  await respond(200, {
     access_token: accessToken,
     refresh_token: refreshToken,
     token_type: "Bearer",
@@ -1134,14 +1155,36 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    // Test hook: invalidate both access and refresh credentials. With
-    // STRICT_REFRESH_TOKENS=1 the next authenticated MCP operation follows
-    // the production-shaped 401 -> refresh -> invalid_grant path.
+    // Hold completed refresh responses so a journey can commit a successful
+    // rotation before delivering another request's rejection of the old grant.
+    if (url.pathname === "/admin/refresh-responses" && req.method === "POST") {
+      tokens.clear();
+      strictRefreshTokens = true;
+      holdRefreshResponses = true;
+      json(res, 200, { holding: true });
+      return;
+    }
+    if (url.pathname === "/admin/refresh-responses" && req.method === "GET") {
+      json(res, 200, { responses: [...pendingRefreshResponses.values()].map(({ id, status, tokenId }) => ({ id, status, tokenId })) });
+      return;
+    }
+    const refreshRelease = url.pathname.match(/^\/admin\/refresh-responses\/(\d+)\/release$/);
+    if (refreshRelease && req.method === "POST") {
+      const pending = pendingRefreshResponses.get(Number(refreshRelease[1]));
+      if (!pending) { json(res, 404, { error: "unknown_refresh_response" }); return; }
+      pending.release();
+      json(res, 200, { released: true });
+      return;
+    }
+
+    // Test hook: revoke both grants and enforce that revocation on refresh,
+    // producing the 401 -> refresh -> invalid_grant path in every test lane.
     if (url.pathname === "/admin/expire-oauth-tokens" && req.method === "POST") {
       const expiredAccessTokens = tokens.size;
       const expiredRefreshTokens = refreshTokens.size;
       tokens.clear();
       refreshTokens.clear();
+      strictRefreshTokens = true;
       json(res, 200, { expiredAccessTokens, expiredRefreshTokens });
       return;
     }


### PR DESCRIPTION
## Summary
A delayed `invalid_grant` from an overlapping refresh could delete credentials another request had already renewed. Den now checks the loaded credential revision inside the invalidation transaction and preserves a newer saved credential. Failed callback cleanup that never read saved credentials also preserves them.

## Why
The MCP SDK can invoke credential invalidation without emitting the enterprise client's diagnostic event. Logging at the persistence boundary covers that path and records the committed decision.

## Issue
Reproduced with a deterministic upstream OAuth fixture; no linked issue.

## Scope
- Den's upstream MCP credential persistence and diagnostic adapter.
- Structured `external_mcp_credential_invalidated` and `external_mcp_credential_invalidation_skipped` events, including request reference, scope, provider diagnostics, and loaded/current revisions. Token values are excluded and diagnostics cannot change the credential outcome.
- Existing OAuth journey and persistence tests, plus mock response controls to deliver a successful rotation before a delayed rejection of the same refresh grant.

## Out of scope
Provider revocation policy and distributed refresh coordination.

## Testing
### Ran
- `OPENWORK_EVAL_MYSQL_URL=mysql://root:password@127.0.0.1:33316 DATABASE_REDIS_URL=redis://127.0.0.1:36379 pnpm evals:pr specs/mcp-oauth-response-issuer.test.ts` — 6 passed, 0 failed, 0 skipped.
- `DATABASE_URL=mysql://root:password@127.0.0.1:33316/mcp_invalidation_units pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/enterprise-mcp-oauth-persistence.test.ts` — 13 passed.
- `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/external-mcp-diagnostics.test.ts` — 84 passed.
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false` — passed.

### Result
Passed on commit `c3c8bb84a345fe4790bc94e8a80dc6f91f28ddfc`. Journeys cold-booted locally against disposable MySQL/Redis; the PR-lane CLI did not print a placement line.

Counterfactual control: unchanged gateway code at `2ce7060e3`, with the same new test witnesses and isolated services, fails the delayed-rejection journey: the second call returns HTTP 502 instead of 200. The fixed journey verifies both calls and a subsequent tools request succeed, no deletion event occurs, and a skipped event records different revisions. A genuine revocation still clears the matching credential with exactly one event.

## CI status
Required core/build CI checks have passed. The Den API image build is still running. Repository-wide evals typecheck and boundary-ratchet failures were also reproduced on unchanged dev; the gateway typecheck passes and this spec adds no boundary-ratchet violations. Details are in the evidence comment.

## Manual verification
Automated server-boundary and database-backed verification used synthetic providers and credentials. No production deployment or live-provider mutation was performed.

## Evidence
Final-commit source records and assertion evidence are published in the [sticky verification comment](https://github.com/different-ai/openwork/pull/4657#issuecomment-5593958978). The private review app is not configured in this environment.

## Risk
Credential revisions use the existing row update timestamp. An overlapping metadata update can conservatively preserve a credential until the next attempt. This change prevents stale deletion; it does not serialize provider refresh requests.

## Rollback
Revert this commit.
