### PR TITLE
fix(session): preserve live progress when switching threads

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/message-merge.ts
+++ b/apps/app/src/react-app/domains/session/sync/message-merge.ts
@@ -12,7 +12,20 @@ function messageSignature(message: UIMessage) {
 }
 
 function mergeMessageParts(snapshotMessage: UIMessage, cachedMessage: UIMessage) {
+  const cachedTools = new Map(cachedMessage.parts.flatMap((part) =>
+    part.type === "dynamic-tool" ? [[part.toolCallId, part] as const] : []));
+  const snapshotToolIds = new Set(snapshotMessage.parts.flatMap((part) =>
+    part.type === "dynamic-tool" ? [part.toolCallId] : []));
   const parts = snapshotMessage.parts.map((part, index) => {
+    if (part.type === "dynamic-tool") {
+      const cached = cachedTools.get(part.toolCallId);
+      // A call cannot return from a terminal result to streaming input. Keep
+      // snapshot authority for terminal-to-terminal updates and other calls.
+      if (cached?.toolName === part.toolName
+        && (cached.state === "output-available" || cached.state === "output-error")
+        && (part.state === "input-streaming" || part.state === "input-available")) return cached;
+      return part;
+    }
     const cachedPart = cachedMessage.parts[index];
     if (!cachedPart) return part;
 
@@ -27,9 +40,9 @@ function mergeMessageParts(snapshotMessage: UIMessage, cachedMessage: UIMessage)
     return part;
   });
 
-  if (cachedMessage.parts.length > snapshotMessage.parts.length) {
-    parts.push(...cachedMessage.parts.slice(snapshotMessage.parts.length));
-  }
+  parts.push(...cachedMessage.parts.filter((part, index) => part.type === "dynamic-tool"
+    ? !snapshotToolIds.has(part.toolCallId)
+    : index >= snapshotMessage.parts.length));
 
   return parts;
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -116,6 +116,7 @@ type DeltaFlushScheduler = (
 const idleStatus: SessionStatus = { type: "idle" };
 const syncs = new Map<string, SyncEntry>();
 const sessionSnapshotFetchStarts = new WeakMap<OpenworkSessionSnapshot, number>();
+const todoSnapshotFirstSeen = new WeakMap<OpenworkSessionSnapshot, number>();
 const workspaceSyncDisposeGraceMs = 2_000;
 const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
@@ -1765,6 +1766,25 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   const queryClient = getReactQueryClient();
   const key = transcriptKey(workspaceId, snapshot.session.id);
   const incoming = snapshotToUIMessages(snapshot);
+  // Commit against the old text before merging a cumulative snapshot, never
+  // append those same queued bytes to the snapshot afterwards.
+  for (const entry of syncs.values()) {
+    if (entry.input.workspaceId !== workspaceId) continue;
+    flushSessionDeltas(entry, workspaceId, snapshot.session.id);
+    for (const message of incoming) {
+      for (const part of message.parts) {
+        if (part.type !== "text" && part.type !== "reasoning") continue;
+        const partId = getPartMetadataId(part);
+        if (!partId) continue;
+        const pending = entry.pendingDeltas.get(partId);
+        if (!pending || pending.messageId !== message.id) continue;
+        // Early deltas and the declaration are cumulative views, as with
+        // message.part.updated. Unrepresented parts remain pending.
+        if (pending.text.length > part.text.length) part.text = pending.text;
+        entry.pendingDeltas.delete(partId);
+      }
+    }
+  }
   const existing = queryClient.getQueryData<UIMessage[]>(key);
 
   const snapshotStartedAt = sessionSnapshotFetchStarts.get(snapshot);
@@ -1806,7 +1826,15 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
     snapshot.session.revert?.messageID ?? null,
   ));
 
-  queryClient.setQueryData(todoKey(workspaceId, snapshot.session.id), snapshot.todos);
+  const todosKey = todoKey(workspaceId, snapshot.session.id);
+  // Remember first observation for unmarked snapshots too, so reselecting a
+  // cached object never makes it newer than a subsequent todo.updated event.
+  const todosStartedAt = snapshotStartedAt ?? todoSnapshotFirstSeen.get(snapshot) ?? Date.now();
+  todoSnapshotFirstSeen.set(snapshot, todosStartedAt);
+  const todosState = queryClient.getQueryState(todosKey);
+  if (!todosState || todosStartedAt > todosState.dataUpdatedAt) {
+    queryClient.setQueryData(todosKey, snapshot.todos, { updatedAt: todosStartedAt });
+  }
   useSessionActivityStore.getState().observeTranscript(workspaceId, snapshot.session.id,
     queryClient.getQueryData<UIMessage[]>(key) ?? [], true);
 }

--- a/apps/app/tests/session-render-state.test.ts
+++ b/apps/app/tests/session-render-state.test.ts
@@ -58,6 +58,39 @@ for (const { name, merge } of [
   { name: "mergeSnapshotIntoCachedMessages", merge: mergeSnapshotIntoCachedMessages },
 ]) {
   describe(name, () => {
+    test("keeps terminal tools by call identity without blocking fresh snapshot output", () => {
+      const running = {
+        id: "tools", role: "assistant", parts: [{
+          type: "dynamic-tool", toolName: "bash", toolCallId: "call-a",
+          state: "input-streaming", input: { command: "pwd" },
+        }],
+      } satisfies UIMessage;
+      for (const terminal of [
+        { state: "output-available", output: "finished" } as const,
+        { state: "output-error", errorText: "failed" } as const,
+      ]) {
+        const completed: UIMessage = {
+          ...running, parts: [{ ...running.parts[0], ...terminal }],
+        };
+        expect(merge([running], [completed])[0]?.parts).toEqual(completed.parts);
+        expect(merge([completed], [running])[0]?.parts).toEqual(completed.parts);
+        const reordered: UIMessage = {
+          ...running, parts: [{
+            type: "dynamic-tool", toolName: "bash", toolCallId: "call-b",
+            state: "input-streaming", input: {},
+          }, ...running.parts],
+        };
+        expect(merge([reordered], [completed])[0]?.parts).toEqual([
+          reordered.parts[0], completed.parts[0],
+        ]);
+        const refreshed: UIMessage = { ...completed, parts: [{
+          type: "dynamic-tool", toolName: "bash", toolCallId: "call-a",
+          state: "output-available", input: {}, output: "fresh snapshot output",
+        }] };
+        expect(merge([refreshed], [completed])[0]?.parts).toEqual(refreshed.parts);
+      }
+    });
+
     for (const historySize of [200, 400, 800]) {
       test(`bounds timestamp reads for a 140-message snapshot over ${historySize} cached messages`, () => {
         let reads = 0;

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -25,6 +25,8 @@ import {
   coalescePendingDeltas,
   ensureWorkspaceSessionSync,
   permissionKey,
+  markSessionSnapshotFetchStart,
+  todoKey,
   questionKey,
   seedPermissionState,
   seedQuestionState,
@@ -692,6 +694,87 @@ describe("session transcript sync", () => {
     const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"));
     expect(transcript?.map((message) => message.id)).toEqual(["msg-user", "msg-assistant"]);
   });
+
+  test("todo hydration rejects old reads and cached reapplication but accepts newer snapshots", () => {
+    const input = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const release = trackWorkspaceSessionSync(input, "session-a");
+    const old = snapshotWithMessages([]);
+    old.todos = [{ id: "todo-a", content: "Check output", status: "pending", priority: "high" }];
+    const completed = old.todos.map((todo) => ({ ...todo, status: "completed" }));
+    const queryClient = getReactQueryClient();
+    try {
+      setSystemTime(100);
+      markSessionSnapshotFetchStart(old, 100);
+      seedSessionState("workspace-a", old);
+      const unmarked = snapshotWithMessages([]);
+      unmarked.todos = old.todos;
+      seedSessionState("workspace-a", unmarked);
+      seedSessionState("workspace-a", snapshotWithMessages([], "session-b"));
+      setSystemTime(200);
+      __applySessionSyncEventForTest(input, {
+        type: "todo.updated", properties: { sessionID: "session-a", todos: completed },
+      });
+      setSystemTime(300);
+      seedSessionState("workspace-a", old);
+      seedSessionState("workspace-a", unmarked);
+      const late = snapshotWithMessages([]);
+      markSessionSnapshotFetchStart(late, 150);
+      seedSessionState("workspace-a", late);
+      expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toEqual(completed);
+      expect(queryClient.getQueryData(todoKey("workspace-a", "session-b"))).toEqual([]);
+      const fresh = snapshotWithMessages([]);
+      markSessionSnapshotFetchStart(fresh, 250);
+      seedSessionState("workspace-a", fresh);
+      expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toEqual([]);
+      seedSessionState("workspace-a", old);
+      expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toEqual([]);
+    } finally { release(); cleanup(); }
+  });
+
+  for (const declared of [true, false]) {
+    test(`snapshot reconciles buffered deltas exactly once (declared=${declared})`, () => {
+      const scheduled: Array<() => void> = [];
+      __setSessionSyncDeltaFlushSchedulerForTest((_lane, run) => {
+        scheduled.push(run);
+        return () => {};
+      });
+      const input = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+      const cleanup = __createWorkspaceSessionSyncForTest(input);
+      const release = trackWorkspaceSessionSync(input, "session-a");
+      const queryClient = getReactQueryClient();
+      const key = transcriptKey("workspace-a", "session-a");
+      try {
+        if (declared) seedSessionState("workspace-a", snapshotWithMessages([
+          { id: "answer", role: "assistant", text: "hello" },
+        ]));
+        const delta = (messageId: string, text: string) => __applySessionSyncEventForTest(input, {
+          type: "message.part.delta", properties: {
+            sessionID: "session-a", messageID: messageId, partID: `part_${messageId}`, delta: text,
+          },
+        });
+        delta("answer", declared ? " world" : "hello world");
+        delta("unknown", "retained");
+        seedSessionState("workspace-a", snapshotWithMessages([
+          { id: "answer", role: "assistant", text: "hello world" },
+        ]));
+        for (const run of scheduled.splice(0)) run();
+        expect(queryClient.getQueryData<UIMessage[]>(key)?.find((m) => m.id === "answer")?.parts[0])
+          .toMatchObject({ text: "hello world" });
+        delta("answer", "!");
+        for (const run of scheduled.splice(0)) run();
+        expect(queryClient.getQueryData<UIMessage[]>(key)?.find((m) => m.id === "answer")?.parts[0])
+          .toMatchObject({ text: "hello world!" });
+        __applySessionSyncEventForTest(input, {
+          type: "message.part.updated", properties: { part: {
+            id: "part_unknown", sessionID: "session-a", messageID: "unknown", type: "text", text: "",
+          } },
+        });
+        expect(queryClient.getQueryData<UIMessage[]>(key)?.find((m) => m.id === "unknown")?.parts[0])
+          .toMatchObject({ text: "retained" });
+      } finally { release(); cleanup(); __setSessionSyncDeltaFlushSchedulerForTest(null); }
+    });
+  }
 
   test("keeps longer live text when an idle snapshot lags the event stream", () => {
     getReactQueryClient().setQueryData(transcriptKey("workspace-a", "session-a"), [


### PR DESCRIPTION
## Summary
Switching back to a cached conversation must not roll back completed work or duplicate streamed text.

- Match dynamic tools by call identity and preserve terminal results against stale input states, while allowing fresh snapshot results.
- Order todo hydration by snapshot fetch time; cached reapplication cannot overwrite newer live updates. Unmarked snapshots retain their first-observed time.
- Flush session deltas against the existing transcript before cumulative hydration. Reconcile early deltas when the snapshot declares their exact part and retain undeclared parts.
- Extend the existing render-state and session-sync tests; no new test files or scheduling changes.

## Verification
**Verdict: Incomplete — runtime journey proof not run.** Opened ready for review as requested; this is not a claim of merge readiness.

Candidate: ac5b478a9, rebased onto dev at bd1b31caf.

Passed (exit 0):
```sh
pnpm --filter @openwork/app exec bun test --isolate ./tests/session-render-state.test.ts ./tests/session-sync-permissions.test.ts
```
60 passed, 0 failed, 0 skipped. Before the fix, the targeted additions produced 5 failures reproducing tool rollback, todo rollback, and duplicate text for declared and undeclared parts. Tests also verify newer snapshots, distinct tool identities, continued deltas, and retention of unknown parts.

Passed: `git diff --check origin/dev...HEAD`.

Deferred: full typecheck, app runtime journey, and evidence publication. No external provisioning was performed. The existing `evals/specs/streamed-markdown-answer.e2e.test.ts` owns the streaming journey; a deterministic mid-stream thread-switch assertion remains missing. Follow-up runtime command: `pnpm evals:e2e streamed-markdown-answer` after extending that assertion. Unit tests are not runtime proof.

## Scope
Existing text-length merge semantics and run-status hydration remain unchanged. No changes to the original checkout, no deployment, and no merge.