### PR TITLE
Use one native desktop connection card for every status response

### DIFF
--- a/apps/app/src/components/chat/connection-card.tsx
+++ b/apps/app/src/components/chat/connection-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import type { DynamicToolUIPart } from "ai"
+import type { ConnectionActionPayload } from "@openwork/types/connection-action-app"
 import { ArrowUpRight, Check, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -9,39 +10,58 @@ import type { ChatToolReconnectAction } from "@/components/tools/error-attributi
 import { useChatToolReconnect } from "@/components/tools/use-chat-tool-reconnect"
 import { useMessageList } from "./message-list-provider"
 
+const ACTION_OWNER = {
+  member: "You",
+  organization_admin: "Your organization admin",
+  provider_admin: "The provider admin",
+  network_admin: "Your network admin",
+  openwork: "OpenWork support",
+}
+
 /** Uses the desktop's signed-in account; credentials never enter an MCP App. */
-export function ConnectionCard({ part, action }: { part: DynamicToolUIPart; action: ChatToolReconnectAction }) {
+export function ConnectionCard({ part, action, connection }: {
+  part: DynamicToolUIPart
+  action: ChatToolReconnectAction | null
+  connection: ConnectionActionPayload | null
+}) {
   const { onMcpReconnect, onMcpReopenAuthorization, connectorIdentities } = useMessageList()
   const { reconnectState, reconnectError, handleReconnect } = useChatToolReconnect(part, {
     onReconnect: onMcpReconnect,
     onReopenAuthorization: onMcpReopenAuthorization,
-  }, action)
+  }, action ?? undefined)
   const [failedIcon, setFailedIcon] = useState<string | null>(null)
-  const icon = connectorIdentities.find(entry => entry.connectionId === action.connectionId)?.iconUrl
-  const connected = reconnectState === "connected"
+  const identity = connection ?? action
+  if (!identity) return null
+  const icon = connectorIdentities.find(entry => entry.connectionId === identity.connectionId)?.iconUrl
+  const connected = connection?.state === "connected" || reconnectState === "connected"
   const opening = reconnectState === "opening"
   const waiting = reconnectState === "authorization_opened"
-  const status = connected ? "Ready to use" : opening ? "Opening sign-in…" : waiting ? "Finish sign-in in your browser" : reconnectState === "failed" ? "Sign-in could not finish" : "Sign in to continue"
-  const label = reconnectState === "failed" ? "Try again" : waiting ? "Open sign-in" : action.label
+  const status = connected ? "Ready to use" : opening ? "Opening sign-in…" : waiting ? "Finish sign-in in your browser" : reconnectState === "failed" ? "Sign-in could not finish" : action ? "Sign in to continue" : connection?.message
+  const label = reconnectState === "failed" ? "Try again" : waiting ? "Open sign-in" : action?.label
 
   return (
-    <section data-testid="desktop-connection-card" aria-label={`${action.connectionName} connection`} aria-live="polite"
+    <section data-testid="desktop-connection-card" aria-label={`${identity.connectionName} connection`} aria-live="polite"
       className="w-96 max-w-full self-start rounded-xl bg-muted/40 px-3 py-2.5 text-sm">
       <div className="flex min-h-10 min-w-0 items-center gap-2.5">
         <span aria-hidden="true" className={cn("flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md", !icon && "bg-muted text-xs font-medium")}>
-          {icon && icon !== failedIcon ? <img src={icon} alt="" className="size-5 object-contain" onError={() => setFailedIcon(icon)} /> : action.connectionName.charAt(0).toUpperCase()}
+          {icon && icon !== failedIcon ? <img src={icon} alt="" className="size-5 object-contain" onError={() => setFailedIcon(icon)} /> : identity.connectionName.charAt(0).toUpperCase()}
         </span>
         <div className="min-w-0 flex-1">
-          <p className="truncate text-[13px] font-medium" title={action.connectionName}>{action.connectionName}</p>
-          <p className="mt-0.5 truncate text-[11px] text-muted-foreground" title={status}>{status}</p>
+          <p className="truncate text-[13px] font-medium" title={identity.connectionName}>{identity.connectionName}</p>
+          <p className={cn("mt-0.5 text-[11px] text-muted-foreground", action && "truncate")} title={status}>{status}</p>
+          {!action && !connected && connection?.action ? (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {connection.actor ? `${ACTION_OWNER[connection.actor]}: ` : ""}{connection.action.label}
+            </p>
+          ) : null}
         </div>
         {connected ? (
           <span className="flex h-7 w-24 shrink-0 items-center justify-center gap-1 text-xs text-muted-foreground"><Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />Connected</span>
-        ) : (
-          <Button variant="ghost" size="sm" disabled={opening} onClick={() => void handleReconnect()} aria-label={`${label} ${action.connectionName}`} className="h-7 w-24 shrink-0 gap-1 rounded-lg px-2 text-xs font-medium hover:bg-background/80">
+        ) : action ? (
+          <Button variant="ghost" size="sm" disabled={opening} onClick={() => void handleReconnect()} aria-label={`${label} ${identity.connectionName}`} className="h-7 w-24 shrink-0 gap-1 rounded-lg px-2 text-xs font-medium hover:bg-background/80">
             {opening ? <><Loader2 className="size-3.5 animate-spin" />Opening</> : <>{label}<ArrowUpRight className="size-3.5 text-muted-foreground" /></>}
           </Button>
-        )}
+        ) : null}
       </div>
       {reconnectError ? <p role="alert" className="mt-2 text-xs leading-relaxed text-destructive">{reconnectError}</p> : null}
     </section>

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -6,10 +6,10 @@ import { AppBridge, PostMessageTransport } from "@modelcontextprotocol/ext-apps/
 import type { McpUiStyles, McpUiStyleVariableKey } from "@modelcontextprotocol/ext-apps"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 
-import { connectorCatalogSchema } from "@openwork/types/connection-action-app"
+import { connectionActionAppResourceUri, connectorCatalogSchema } from "@openwork/types/connection-action-app"
 import { ConnectorCatalogCard } from "./connector-catalog"
 import { ConnectionCard } from "./connection-card"
-import { reconnectActionFromChatToolResult } from "@/components/tools/error-attribution"
+import { connectionCardPayloadFromChatToolResult, reconnectActionFromChatToolResult } from "@/components/tools/error-attribution"
 import { AppChatArtifact } from "@/react-app/domains/apps/app-chat-artifact"
 import { openDesktopUrl } from "@/app/lib/desktop"
 import {
@@ -83,6 +83,7 @@ function preservedResult(part: DynamicToolUIPart): PreservedMcpAppResult | null 
 
 export function hasPreservedMcpAppResult(part: DynamicToolUIPart): boolean {
   return preservedResult(part) !== null || connectorCatalogFromPart(part) !== null
+    || connectionCardPayloadFromChatToolResult(part.toolName, part.output, part.input) !== null
 }
 
 export function connectorCatalogFromPart(part: DynamicToolUIPart) {
@@ -579,9 +580,15 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
 export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
   const result = preservedResult(part)
   const action = reconnectActionFromChatToolResult(part.toolName, result?.structuredContent ?? part.output, part.input)
-  if (action) return <ConnectionCard part={part} action={action} />
+  const connection = connectionCardPayloadFromChatToolResult(part.toolName, result?.structuredContent ?? part.output, part.input)
+  if (action || connection) return <ConnectionCard part={part} action={action} connection={connection} />
   const catalog = connectorCatalogFromPart(part)
   if (catalog) return <ConnectorCatalogCard catalog={catalog} />
+  // First-party connection UI is native, including historical app launches.
+  // Never route an unsupported connection response back into the old iframe.
+  const launch = gatewayMcpAppLaunch(result?._meta)
+  if (part.toolName === "openwork-cloud_connection_action"
+    || (part.toolName.startsWith("openwork-cloud_") && !launch?.connectionId && launch?.resourceUri === connectionActionAppResourceUri)) return null
   return <EmbeddedMcpAppFrame part={part} />
 }
 

--- a/apps/app/src/components/tools/error-attribution.ts
+++ b/apps/app/src/components/tools/error-attribution.ts
@@ -1,4 +1,5 @@
 import { openworkCloudMcpConnectionActionSchema } from "@openwork/types/den/mcp-connection-action"
+import { connectionActionPayloadSchema, type ConnectionActionPayload } from "@openwork/types/connection-action-app"
 
 export type ToolErrorAttribution = {
   label: string
@@ -20,6 +21,7 @@ export type ChatToolReconnectResult = "connected"
 const OPENWORK_CLOUD_CAPABILITY_TOOLS = new Set([
   "openwork-cloud_search_capabilities",
   "openwork-cloud_execute_capability",
+  "openwork-cloud_connection_action",
 ])
 
 const MAX_PARSED_RESULT_LENGTH = 64 * 1_024
@@ -73,13 +75,39 @@ function confirmed(label: string, description: string): ToolErrorAttribution {
   return { label, confidence: "Confirmed", description }
 }
 
+/** Normalize the gateway's search, execution, and status-probe card payloads. */
+export function connectionCardPayloadFromChatToolResult(
+  toolName: string,
+  result: unknown,
+  input?: unknown,
+): ConnectionActionPayload | null {
+  if (!OPENWORK_CLOUD_CAPABILITY_TOOLS.has(toolName)) return null
+  if (toolName === "openwork-cloud_search_capabilities" && (!isRecord(input) || input.intent !== "connect")) return null
+  const parsed = parseResultRecord(result)
+  if (!parsed) return null
+  const candidates = [parsed, parsed.connectionAction, parsed.connectionStatus,
+    ...(Array.isArray(parsed.matches) ? parsed.matches.filter(isRecord).map(match => match.connectionStatus) : []),
+  ]
+  const targets = new Map<string, ConnectionActionPayload>()
+  for (const candidate of candidates) {
+    const payload = connectionActionPayloadSchema.safeParse(
+      isRecord(candidate) && openworkCloudMcpConnectionActionSchema.safeParse(candidate).success
+        ? { ...candidate, schemaVersion: "1" }
+        : candidate,
+    )
+    if (payload.success) targets.set(payload.data.connectionId, payload.data)
+  }
+  if (targets.size !== 1) return null
+  const [payload] = targets.values()
+  return payload
+}
+
 export function reconnectActionFromChatToolResult(
   toolName: string,
   result: unknown,
   input?: unknown,
 ): ChatToolReconnectAction | null {
-  // Tool output is otherwise untrusted. Only the two canonical OpenWork Cloud
-  // capability tools may turn a structured Den response into a UI action.
+  // Only canonical OpenWork Cloud tools may produce a native connection action.
   // Discovery may offer authorization only for an explicit setup request;
   // finding an unavailable connection is not itself a reason to prompt.
   if (!OPENWORK_CLOUD_CAPABILITY_TOOLS.has(toolName)) return null
@@ -97,6 +125,16 @@ export function reconnectActionFromChatToolResult(
         .filter(isRecord)
       : []),
   ]
+  if (candidates.length === 0) {
+    const payload = connectionCardPayloadFromChatToolResult(toolName, parsed, input)
+    if (!payload || payload.actor !== "member" || payload.action?.surface !== "openwork_your_connections"
+      || !((payload.state === "needs_connection" && payload.action.type === "connect")
+        || (payload.state === "reauth_required" && payload.action.type === "reconnect"))) return null
+    // The portable probe omits credential metadata. The signed-in desktop
+    // handler rechecks membership, OAuth, and per-member ownership before auth.
+    return { connectionId: payload.connectionId, connectionName: payload.connectionName,
+      label: payload.state === "needs_connection" ? "Connect" : "Reconnect" }
+  }
   const reconnectTargets = new Map<string, ChatToolReconnectAction>()
   for (const connectionStatus of candidates) {
     const parsedStatus = openworkCloudMcpConnectionActionSchema.safeParse(connectionStatus)

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import type { DynamicToolUIPart } from "ai"
+import { ConnectionCard } from "../src/components/chat/connection-card"
 
 import {
   createOpenworkServerClient,
@@ -13,6 +15,7 @@ import {
   hasPreservedMcpAppResult,
   gatewayMcpAppLaunch,
   isActionableMcpAppResolutionError,
+  McpAppFrame,
   secureMcpAppHtml,
 } from "../src/components/chat/mcp-app-frame"
 
@@ -34,6 +37,31 @@ function fixture(overrides: Partial<OpenworkMcpAppResource> = {}): OpenworkMcpAp
 }
 
 describe("MCP App iframe policy", () => {
+  test("connection status execution renders the native card even without preserved app metadata", () => {
+    const part: DynamicToolUIPart = {
+      type: "dynamic-tool", toolName: "openwork-cloud_execute_capability", toolCallId: "status-probe",
+      state: "output-available", input: { name: "mcp:emc_notes:*" },
+      output: { schemaVersion: "1", connectionId: "emc_notes", connectionName: "Notes", state: "needs_connection",
+        actor: "member", message: "Connect Notes to continue.",
+        action: { type: "connect", label: "Connect Notes", surface: "openwork_your_connections" } },
+    }
+    expect(hasPreservedMcpAppResult(part)).toBe(true)
+    expect(McpAppFrame({ part })?.type).toBe(ConnectionCard)
+    expect(McpAppFrame({ part: { ...part, output: { ...part.output, state: "connected", actor: null, action: null } } })?.type).toBe(ConnectionCard)
+  })
+
+  test("an unsupported first-party connection launch cannot fall back to the legacy iframe", () => {
+    const part: DynamicToolUIPart = {
+      type: "dynamic-tool", toolName: "openwork-cloud_execute_capability", toolCallId: "old-status-probe",
+      state: "output-available", input: {}, output: {},
+      callProviderMetadata: { openwork: { mcpResult: { content: [], _meta: { "openwork/mcpApp": {
+        toolName: "connection_action", resourceUri: "ui://openwork/connection-action/v1/view.html", arguments: { connectionId: "emc_notes" },
+      } } } } },
+    }
+    expect(McpAppFrame({ part })).toBeNull()
+    expect(McpAppFrame({ part: { ...part, toolName: "other_execute_capability" } })).not.toBeNull()
+  })
+
   test("accepts a namespaced gateway launch reference without exposing credentials", () => {
     expect(gatewayMcpAppLaunch({
       source: "provider",

--- a/apps/app/tests/tool-error-attribution.test.ts
+++ b/apps/app/tests/tool-error-attribution.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import {
   attributeChatToolError,
+  connectionCardPayloadFromChatToolResult,
   reconnectActionFromChatToolResult,
 } from "../src/components/tools/error-attribution"
 import { normalizeErrorText } from "../src/lib/error-text"
@@ -26,7 +27,54 @@ function reconnectStatus(connectionId = "emc_knowledge", connectionName = "Knowl
   }
 }
 
+const connectionPayload = {
+  schemaVersion: "1",
+  connectionId: "emc_knowledge",
+  connectionName: "Knowledge Hub",
+  state: "needs_connection",
+  actor: "member",
+  message: "Connect your account to continue.",
+  action: { type: "connect", label: "Connect Knowledge Hub", surface: "openwork_your_connections" },
+}
+
 describe("chat tool error attribution", () => {
+  test("uses the same native action for search attachments and standalone status results", () => {
+    for (const { toolName, payload } of [
+      { toolName: "openwork-cloud_search_capabilities", payload: { connectionAction: connectionPayload } },
+      { toolName: "openwork-cloud_execute_capability", payload: connectionPayload },
+      { toolName: "openwork-cloud_connection_action", payload: connectionPayload },
+    ]) {
+      for (const result of [payload, JSON.stringify(payload)]) {
+        expect(connectionCardPayloadFromChatToolResult(toolName, result, { intent: "connect" })).toEqual(connectionPayload)
+        expect(reconnectActionFromChatToolResult(toolName, result, { intent: "connect" })).toEqual({
+          connectionId: "emc_knowledge", connectionName: "Knowledge Hub", label: "Connect",
+        })
+      }
+    }
+  })
+
+  test("keeps connected and admin states native without offering member authorization", () => {
+    const connected = { ...connectionPayload, state: "connected", actor: null, action: null }
+    const admin = { ...connectionPayload, actor: "organization_admin", action: {
+      type: "update_credentials", label: "Ask an admin", surface: "openwork_organization_connections",
+    } }
+    for (const payload of [connected, admin]) {
+      expect(connectionCardPayloadFromChatToolResult("openwork-cloud_execute_capability", payload)).toEqual(payload)
+      expect(reconnectActionFromChatToolResult("openwork-cloud_execute_capability", payload)).toBeNull()
+    }
+  })
+
+  test("rejects foreign, malformed, ambiguous, and unsolicited portable connection cards", () => {
+    for (const tool of ["malicious_execute_capability", "other_connection_action", "connection_action"]) {
+      expect(connectionCardPayloadFromChatToolResult(tool, connectionPayload)).toBeNull()
+      expect(reconnectActionFromChatToolResult(tool, connectionPayload)).toBeNull()
+    }
+    expect(connectionCardPayloadFromChatToolResult("openwork-cloud_execute_capability", { ...connectionPayload, schemaVersion: "2" })).toBeNull()
+    expect(connectionCardPayloadFromChatToolResult("openwork-cloud_search_capabilities", { connectionAction: connectionPayload })).toBeNull()
+    const matches = [connectionPayload, { ...connectionPayload, connectionId: "emc_second" }].map(connectionStatus => ({ connectionStatus }))
+    expect(connectionCardPayloadFromChatToolResult("openwork-cloud_search_capabilities", { matches }, { intent: "connect" })).toBeNull()
+  })
+
   test("identifies an OpenWork-created capability deadline", () => {
     expect(attributeChatToolError("The capability call exceeded 180s. Retry once.")).toEqual({
       label: "OpenWork timeout",

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -19,8 +19,6 @@ test(`desktop connects through ${entry.name} with one native card and confirms a
   expect(discoveryCalls.filter(call => call.kind === "tool")).toHaveLength(1);
   await user.screenshot();
   evidence.recordAssertionEvidence("Ordinary discovery of an unconnected service stays quiet", "Dashboard capability search completed without a connection card, catalog, Connect button, or provider authorization request", true);
-  await user.click({ role: "button", label: "New session" });
-  await user.see({ role: "button", label: "Run task" });
   expect(entry.prompt).not.toContain(world.connection.id);
   await agent.send(entry.prompt);
   await user.see({ text: connectionActionReply }, { timeoutMs: 120_000 });

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -20,7 +20,7 @@ test(`desktop connects through ${entry.name} with one native card and confirms a
   await user.screenshot();
   evidence.recordAssertionEvidence("Ordinary discovery of an unconnected service stays quiet", "Dashboard capability search completed without a connection card, catalog, Connect button, or provider authorization request", true);
   await user.click({ role: "button", label: "New session" });
-  await user.see({ text: "Try one of these:" });
+  await user.see({ role: "button", label: "Run task" });
   expect(entry.prompt).not.toContain(world.connection.id);
   await agent.send(entry.prompt);
   await user.see({ text: connectionActionReply }, { timeoutMs: 120_000 });

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -1,10 +1,14 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
-import { connectionActionMcpApp, connectionActionPrompt, connectionActionReply, ordinaryDiscoveryPrompt, ordinaryDiscoveryReply } from "../worlds/library.ts";
+import { connectionActionMcpApp, connectionActionPrompt, connectionActionReply, connectionStatusPrompt, ordinaryDiscoveryPrompt, ordinaryDiscoveryReply } from "../worlds/library.ts";
 
 const test = spec.world(connectionActionMcpApp, { timeout: 600_000 });
 
-test("desktop connects an account directly with the provider and confirms authorization in chat", async ({ world, agent, user, probe, evidence }) => {
+for (const entry of [
+  { name: "connection search", prompt: connectionActionPrompt, tools: ["search_capabilities"] },
+  { name: "connection status execution", prompt: connectionStatusPrompt, tools: ["search_capabilities", "execute_capability"] },
+]) {
+test(`desktop connects through ${entry.name} with one native card and confirms authorization in chat`, async ({ world, agent, user, probe, evidence }) => {
   await agent.send(ordinaryDiscoveryPrompt);
   await user.see({ text: ordinaryDiscoveryReply }, { timeoutMs: 120_000 });
   await user.notSee({ testId: "desktop-connection-card" });
@@ -17,26 +21,27 @@ test("desktop connects an account directly with the provider and confirms author
   evidence.recordAssertionEvidence("Ordinary discovery of an unconnected service stays quiet", "Dashboard capability search completed without a connection card, catalog, Connect button, or provider authorization request", true);
   await user.click({ role: "button", label: "New session" });
   await user.see({ text: "Try one of these:" });
-  expect(connectionActionPrompt).not.toContain(world.connection.id);
-  await agent.send(connectionActionPrompt);
+  expect(entry.prompt).not.toContain(world.connection.id);
+  await agent.send(entry.prompt);
   await user.see({ text: connectionActionReply }, { timeoutMs: 120_000 });
   await user.see({ testId: "desktop-connection-card" });
   await user.see({ role: "button", label: "Connect Notion" });
   await user.notSee({ text: "Connected" });
   await user.notSee({ text: "Finish sign-in in your browser" });
-  const calls = await world.den.mocks.connector.agentRequests({ promptMarker: connectionActionPrompt });
-  expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
-  expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);
+  const calls = await world.den.mocks.connector.agentRequests({ promptMarker: entry.prompt });
+  const toolCalls = calls.filter(call => call.kind === "tool");
+  expect(toolCalls).toHaveLength(entry.tools.length);
+  for (const [index, tool] of entry.tools.entries()) expect(toolCalls[index]?.toolName).toMatch(new RegExp(`${tool}$`));
   expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
   const compact = await probe.eval(() => {
     const card = document.querySelector<HTMLElement>('[data-testid="desktop-connection-card"]');
-    return { height: card?.getBoundingClientRect().height, width: card?.getBoundingClientRect().width, hasChecklist: Boolean(card?.querySelector('ol')), embeddedApp: Boolean(document.querySelector<HTMLElement>('[data-mcp-app-resource="ui://openwork/connection-action/v1/view.html"]')) };
+    return { count: document.querySelectorAll('[data-testid="desktop-connection-card"]').length, height: card?.getBoundingClientRect().height, width: card?.getBoundingClientRect().width, hasChecklist: Boolean(card?.querySelector('ol')), embeddedApp: Boolean(document.querySelector<HTMLElement>('[data-mcp-app-resource="ui://openwork/connection-action/v1/view.html"]')) };
   });
-  expect(compact).toMatchObject({ hasChecklist: false, embeddedApp: false });
+  expect(compact).toMatchObject({ count: 1, hasChecklist: false, embeddedApp: false });
   if (!compact || typeof compact !== "object" || !("height" in compact) || typeof compact.height !== "number" || !("width" in compact) || typeof compact.width !== "number") throw new Error("The connection card was not rendered.");
   expect(compact.height).toBeLessThan(88);
   await user.screenshot();
-  evidence.recordAssertionEvidence("Search shows one native connection card without a checklist or embedded setup", JSON.stringify(compact), true);
+  evidence.recordAssertionEvidence(`${entry.name} shows one native connection card without a checklist or embedded setup`, JSON.stringify(compact), true);
   evidence.recordAssertionEvidence("Authorization does not start before the user clicks Connect", "No provider authorization request before Connect", true);
 
   await probe.eval(() => {
@@ -74,3 +79,4 @@ test("desktop connects an account directly with the provider and confirms author
   await user.screenshot();
   evidence.recordAssertionEvidence("Desktop opens the provider directly and confirms completion without a Den screen", "Provider /authorize received the browser handoff; the native card shows Connected and removes Connect", true);
 });
+}

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -960,14 +960,17 @@ export async function connectionActionMcpApp(seed: Seed) {
     mocks: {
       connector: seed.mock({ agentWorkloads: [{
         promptMarker: ordinaryDiscoveryPrompt,
+        latestUserTurn: true,
         finalReply: ordinaryDiscoveryReply,
         steps: [{ tool: "search_capabilities", arguments: { query: "Notion", type: "mcp" } }],
       }, {
         promptMarker: connectionActionPrompt,
+        latestUserTurn: true,
         finalReply: connectionActionReply,
         steps: [{ tool: "search_capabilities", arguments: { query: "Notion", type: "mcp", intent: "connect" } }],
       }, {
         promptMarker: connectionStatusPrompt,
+        latestUserTurn: true,
         finalReply: connectionActionReply,
         steps: [
           { tool: "search_capabilities", arguments: { query: "Notion", type: "mcp", limit: 1 } },

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -945,6 +945,7 @@ export const connectionActionReply = "Connect your Notion account to continue.";
 export const ordinaryDiscoveryPrompt = "Create a dashboard using my notes.";
 export const ordinaryDiscoveryReply = "I found the available capabilities for the dashboard.";
 export const connectionActionPrompt = "I want to connect Notion.";
+export const connectionStatusPrompt = "Check my Notion connection so I can sign in.";
 
 export const allConnectorsPrompt = "Show me all the quick-add connectors.";
 export const allConnectorsReply = "Here are all the connectors available to add.";
@@ -965,6 +966,13 @@ export async function connectionActionMcpApp(seed: Seed) {
         promptMarker: connectionActionPrompt,
         finalReply: connectionActionReply,
         steps: [{ tool: "search_capabilities", arguments: { query: "Notion", type: "mcp", intent: "connect" } }],
+      }, {
+        promptMarker: connectionStatusPrompt,
+        finalReply: connectionActionReply,
+        steps: [
+          { tool: "search_capabilities", arguments: { query: "Notion", type: "mcp", limit: 1 } },
+          { tool: "execute_capability", arguments: {}, argumentsFrom: "capability-search" },
+        ],
       }, {
         promptMarker: connectorCatalogPrompt,
         finalReply: connectorCatalogReply,


### PR DESCRIPTION
## Summary
Executing a connection-status capability could still show the large embedded setup card after #4478 added a native desktop card. Search attachments, execution results, and standalone probes now use the same native connection component; first-party connection launches cannot fall back to the legacy iframe.

## Why
Connecting an account should have one desktop experience regardless of which gateway response opened it.

## Issue
Follow-up to #4478. No linked issue.

## Scope
Normalize trusted connection responses, keep connected and admin-action states native, and preserve signed-in account/access checks before authorization. Extend the existing journey to cover search and status execution within the same task.

## Out of scope
The portable MCP App remains available to other MCP clients. Provider authorization still uses the browser.

## Testing
### Ran
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app exec bun test tests/tool-error-attribution.test.ts tests/mcp-chat-reconnect.test.ts tests/mcp-app-frame.test.ts`
- `OPENWORK_EVAL_DAYTONA_REF=37cb4a5f10ce035e8d007d1bc9ddb42649695f70 OPENWORK_EVAL_REF=37cb4a5f10ce035e8d007d1bc9ddb42649695f70 pnpm evals:e2e connection-action-mcp-app --daytona`

### Result
Typecheck passed; 38 focused tests passed. Placement: `daytona (--daytona)`. Both full journeys passed: **2 passed, 0 failed, 0 skipped**. Each verifies one native card, no embedded connection App, no authorization before clicking Connect, direct provider authorization, automatic Connected status, and stable card dimensions. Provider behavior is mocked through the real gateway.

## CI status
Local focused checks and the Daytona journeys passed on the PR head. GitHub checks are pending.

## Manual verification
1. Ask to connect an available member-owned OAuth service, or execute its connection-status capability.
2. Click Connect on the compact native card and finish provider sign-in.
3. Confirm the same card shows Connected automatically, with no legacy setup screen.

## Evidence
See the test-evidence comment for both passing journeys and their 12 recorded assertions. Screenshots and raw run records are retained locally; automated approval review blocked the artifact upload, so only the audited assertion summary was published.

## Risk
Portable status payloads omit credential metadata. The existing authenticated desktop handler revalidates access, OAuth, per-member ownership, and account scope before starting authorization. Unsupported/admin actions remain descriptive in the native card.

## Rollback
Revert this PR.
