### PR TITLE
fix(v1): preserve composer drafts and verify instant sends

### DIFF
--- a/apps/app/src/app/lib/opencode-session-native.ts
+++ b/apps/app/src/app/lib/opencode-session-native.ts
@@ -9,6 +9,12 @@ import type { ResolvedWorkspaceEndpoint } from "./workspace-endpoint";
 type NativeSessionEndpoint = Pick<ResolvedWorkspaceEndpoint, "opencodeBaseUrl" | "token">;
 type RequestOptions = { signal?: AbortSignal };
 
+export type NativeSessionSnapshotTarget = {
+  owner: string;
+  endpoint: NativeSessionEndpoint;
+  sessionId: string;
+};
+
 export type NativeSessionOperations = {
   get: (sessionId: string, options?: RequestOptions) => Promise<FieldsResult<Session>>;
   messages: (sessionId: string, limit: number | undefined, options?: RequestOptions) => Promise<FieldsResult<Array<{ info: Message; parts: Part[] }>>>;
@@ -19,7 +25,36 @@ export type NativeSessionOperations = {
 
 export type NativeSessionDependencies = {
   createOperations?: (endpoint: NativeSessionEndpoint) => NativeSessionOperations;
+  waitForSnapshotRetry?: (delayMs: number, signal: AbortSignal) => Promise<void>;
 };
+
+const SNAPSHOT_RETRY_DELAYS_MS = [100, 250, 500];
+
+function waitForSnapshotRetry(delayMs: number, signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function readOwnedSnapshotTarget(
+  expectedOwner: string,
+  readCurrentTarget: () => NativeSessionSnapshotTarget,
+) {
+  const target = readCurrentTarget();
+  if (target.owner !== expectedOwner) {
+    throw new Error("Session snapshot owner changed before the local read completed.");
+  }
+  return target;
+}
 
 function createNativeOperations(endpoint: NativeSessionEndpoint): NativeSessionOperations {
   const client = isOpencodeV2BaseUrl(endpoint.opencodeBaseUrl)
@@ -93,6 +128,39 @@ export async function composeNativeSessionSnapshot(
   const todos = unwrapSessionResult(todoResult, "session_not_found");
   const statuses = unwrapSessionResult(statusResult);
   return { session, messages, todos, status: statuses[sessionId] ?? { type: "idle" } };
+}
+
+export async function composeNativeSessionSnapshotWithRetry(
+  expectedOwner: string,
+  readCurrentTarget: () => NativeSessionSnapshotTarget,
+  options: RequestOptions & { limit?: number },
+  dependencies?: NativeSessionDependencies,
+): Promise<OpenworkSessionSnapshot> {
+  const signal = options.signal ?? new AbortController().signal;
+  const waitForRetry = dependencies?.waitForSnapshotRetry ?? waitForSnapshotRetry;
+  let attempt = 0;
+  while (true) {
+    signal.throwIfAborted();
+    const target = readOwnedSnapshotTarget(expectedOwner, readCurrentTarget);
+    try {
+      const snapshot = await composeNativeSessionSnapshot(
+        target.endpoint,
+        target.sessionId,
+        options,
+        dependencies,
+      );
+      signal.throwIfAborted();
+      readOwnedSnapshotTarget(expectedOwner, readCurrentTarget);
+      return snapshot;
+    } catch (error) {
+      signal.throwIfAborted();
+      readOwnedSnapshotTarget(expectedOwner, readCurrentTarget);
+      const delayMs = SNAPSHOT_RETRY_DELAYS_MS[attempt];
+      if (delayMs === undefined) throw error;
+      attempt += 1;
+      await waitForRetry(delayMs, signal);
+    }
+  }
 }
 
 export async function deleteNativeSession(

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
 
 import type { CloudImportedPlugin } from "@/app/cloud/import-state";
@@ -10,6 +10,10 @@ import { t } from "@/i18n";
 import type { ComposerSettingsSection } from "@/react-app/domains/settings/library";
 import { ReactSessionComposer } from "@/react-app/domains/session/surface/composer/composer";
 import { WorkspaceRunModeMenu } from "@/react-app/domains/session/surface/composer/workspace-run-mode-menu";
+import {
+  snapshotComposerSessionState,
+  type ComposerSessionState,
+} from "@/react-app/domains/session/surface/composer-state-store";
 import { encodeComposerMentionValue, type ComposerMentionKind } from "@/react-app/domains/session/surface/composer/mention-encoding";
 import {
   createPastedTextChip,
@@ -33,6 +37,8 @@ import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/
 export type NewTaskComposerContext = {
   client: OpenworkServerClient | null;
   workspaceId: string | null;
+  /** Stable identity for draft ownership across workspace, endpoint, and account changes. */
+  draftOwnerKey?: string;
   selectedModel: ModelRef;
   modelOptions?: readonly ModelOption[];
   modelUnavailable?: boolean;
@@ -63,11 +69,36 @@ export type NewTaskComposerProps = {
   draft: string;
   onDraftChange: (value: string) => void;
   /** Called with a non-empty draft and in-memory attachments; the caller creates the session (and workspace if needed). */
-  onRunTask: (resolvedDraft: string, attachments: ComposerAttachment[]) => void | Promise<void>;
+  onRunTask: (
+    resolvedDraft: string,
+    attachments: ComposerAttachment[],
+    handoff?: NewTaskComposerHandoff,
+  ) => void | Promise<void>;
   /** Disable submission while a default workspace is being prepared. */
   busy: boolean;
   context: NewTaskComposerContext | null;
 };
+
+export type NewTaskComposerHandoff = {
+  submitted: ComposerSessionState;
+  getContinuation: () => ComposerSessionState;
+};
+
+type NewTaskContinuationHolder = {
+  ownerKey: string;
+  state: ComposerSessionState;
+  frozen: boolean;
+};
+
+function emptyNewTaskComposerState(): ComposerSessionState {
+  return {
+    draft: "",
+    attachments: [],
+    mentions: {},
+    pasteParts: [],
+    revertMessageId: null,
+  };
+}
 
 const noop = () => {};
 const emptyAgents = async (): Promise<Agent[]> => [];
@@ -83,6 +114,8 @@ const FALLBACK_MODEL: ModelRef = { providerID: "", modelID: "" };
  * created session, where the normal send path uploads them into the workspace.
  */
 export function NewTaskComposer(props: NewTaskComposerProps) {
+  const context = props.context;
+  const draftOwnerKey = context?.draftOwnerKey ?? "legacy";
   const [mentions, setMentions] = useState<Record<string, ComposerMentionKind>>({});
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [skills, setSkills] = useState<SkillCard[]>([]);
@@ -96,15 +129,95 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [preparingAttachments, setPreparingAttachments] = useState(false);
   const [submissionError, setSubmissionError] = useState<string | null>(null);
-  const [failedSubmission, setFailedSubmission] = useState<{ text: string; attachments: ComposerAttachment[]; pastedText: PastedTextChip[] } | null>(null);
+  const [failedSubmission, setFailedSubmission] = useState<ComposerSessionState | null>(null);
   const draftRef = useRef(props.draft);
+  const continuationHolderRef = useRef<NewTaskContinuationHolder>({
+    ownerKey: draftOwnerKey,
+    state: { ...emptyNewTaskComposerState(), draft: props.draft },
+    frozen: false,
+  });
+  const mountedDraftOwnerKeyRef = useRef(draftOwnerKey);
+  const currentHolder = continuationHolderRef.current;
+  if (currentHolder.ownerKey !== draftOwnerKey) {
+    currentHolder.frozen = true;
+    continuationHolderRef.current = {
+      ownerKey: draftOwnerKey,
+      state: snapshotComposerSessionState({ ...currentHolder.state, draft: props.draft }),
+      frozen: false,
+    };
+  } else if (!currentHolder.frozen) {
+    currentHolder.state = { ...currentHolder.state, draft: props.draft };
+  }
   draftRef.current = props.draft;
   const skillsConnectPushRef = useRef(0);
   const mcpConnectPushRef = useRef(0);
   const pluginConnectPushRef = useRef(0);
-  const context = props.context;
   const workspaceClient = context?.client ?? null;
   const workspaceId = context?.workspaceId ?? null;
+
+  useEffect(() => {
+    const holder = continuationHolderRef.current;
+    holder.frozen = false;
+    if (mountedDraftOwnerKeyRef.current !== draftOwnerKey) {
+      mountedDraftOwnerKeyRef.current = draftOwnerKey;
+      holder.state = emptyNewTaskComposerState();
+      draftRef.current = "";
+      submittingRef.current = false;
+      props.onDraftChange("");
+      setAttachments([]);
+      setMentions({});
+      setPastedText([]);
+      setPendingPrompt(null);
+      setPreparingAttachments(false);
+      setSubmissionError(null);
+      setFailedSubmission(null);
+    }
+    return () => {
+      holder.frozen = true;
+    };
+  }, [draftOwnerKey]);
+
+  const updateDraft = (value: string) => {
+    const holder = continuationHolderRef.current;
+    if (holder.frozen) return;
+    draftRevisionRef.current += 1;
+    draftRef.current = value;
+    holder.state = { ...holder.state, draft: value };
+    props.onDraftChange(value);
+  };
+
+  const updateAttachments = (next: ComposerAttachment[]) => {
+    const holder = continuationHolderRef.current;
+    if (holder.frozen) return;
+    holder.state = { ...holder.state, attachments: next };
+    setAttachments(next);
+  };
+
+  const updateMentions = (next: Record<string, ComposerMentionKind>) => {
+    const holder = continuationHolderRef.current;
+    if (holder.frozen) return;
+    holder.state = { ...holder.state, mentions: next };
+    setMentions(next);
+  };
+
+  const updatePasteParts = (next: PastedTextChip[]) => {
+    const holder = continuationHolderRef.current;
+    if (holder.frozen) return;
+    holder.state = { ...holder.state, pasteParts: next };
+    setPastedText(next);
+  };
+
+  const restoreComposer = (state: ComposerSessionState) => {
+    const holder = continuationHolderRef.current;
+    if (holder.frozen) return;
+    const restored = snapshotComposerSessionState(state);
+    holder.state = restored;
+    draftRef.current = restored.draft;
+    props.onDraftChange(restored.draft);
+    setAttachments(restored.attachments);
+    setMentions(restored.mentions);
+    setPastedText(restored.pasteParts);
+  };
 
   const listSkills = workspaceClient && workspaceId
     ? async (): Promise<SkillCard[]> => {
@@ -181,48 +294,47 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     // @agent mentions switch the pending task's agent instead of inserting a
     // mention token (mirrors the session composer, #2101).
     if (kind === "agent") {
-      props.onDraftChange(props.draft.replace(/@([^\s@]*)$/, ""));
+      updateDraft(continuationHolderRef.current.state.draft.replace(/@([^\s@]*)$/, ""));
       context?.onSelectAgent(value);
       return;
     }
-    props.onDraftChange(props.draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
-    setMentions((previous) => ({ ...previous, [value]: kind }));
+    updateDraft(continuationHolderRef.current.state.draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
+    updateMentions({ ...continuationHolderRef.current.state.mentions, [value]: kind });
   };
 
   const handlePasteText = (text: string) => {
     const pasted = createPastedTextChip(text);
-    setPastedText((current) => [...current, pasted]);
-    props.onDraftChange(`${props.draft}[pasted text ${pasted.label}]`);
+    updatePasteParts([...continuationHolderRef.current.state.pasteParts, pasted]);
+    updateDraft(`${continuationHolderRef.current.state.draft}[pasted text ${pasted.label}]`);
   };
 
   const handleExpandPastedText = (id: string) => {
-    const pasted = pastedText.find((item) => item.id === id);
+    const pasted = continuationHolderRef.current.state.pasteParts.find((item) => item.id === id);
     if (!pasted) return;
-    props.onDraftChange(props.draft.replace(`[pasted text ${pasted.label}]`, pasted.text));
-    setPastedText((current) => current.filter((item) => item.id !== id));
+    updateDraft(continuationHolderRef.current.state.draft.replace(`[pasted text ${pasted.label}]`, pasted.text));
+    updatePasteParts(continuationHolderRef.current.state.pasteParts.filter((item) => item.id !== id));
   };
 
   const handleRemovePastedText = (id: string) => {
-    const pasted = pastedText.find((item) => item.id === id);
+    const pasted = continuationHolderRef.current.state.pasteParts.find((item) => item.id === id);
     if (!pasted) return;
-    props.onDraftChange(props.draft.replace(`[pasted text ${pasted.label}]`, ""));
-    setPastedText((current) => current.filter((item) => item.id !== id));
+    updateDraft(continuationHolderRef.current.state.draft.replace(`[pasted text ${pasted.label}]`, ""));
+    updatePasteParts(continuationHolderRef.current.state.pasteParts.filter((item) => item.id !== id));
   };
 
   const handleDraftChange = (value: string) => {
-    draftRevisionRef.current += 1;
-    props.onDraftChange(value);
     const idsInDraft = new Set(
       [...value.matchAll(/\[attachment ([^\]]+)\]/g)].map((match) => match[1]).filter((id): id is string => Boolean(id)),
     );
-    setAttachments((current) => {
-      const retained = current.filter((attachment) => idsInDraft.has(attachment.id));
-      if (retained.length === current.length) return current;
-      for (const attachment of current) {
+    const currentAttachments = continuationHolderRef.current.state.attachments;
+    const retained = currentAttachments.filter((attachment) => idsInDraft.has(attachment.id));
+    if (retained.length !== currentAttachments.length) {
+      for (const attachment of currentAttachments) {
         if (!idsInDraft.has(attachment.id)) revokeAttachmentPreview(attachment);
       }
-      return retained;
-    });
+      updateAttachments(retained);
+    }
+    updateDraft(value);
   };
 
   const handleAttachFiles = (files: File[]) => {
@@ -239,47 +351,50 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
         previewUrl: metadata.kind === "image" ? URL.createObjectURL(file) : undefined,
       };
     });
-    setAttachments((current) => [...current, ...next]);
-    props.onDraftChange(`${props.draft}${next.map((attachment) => `[attachment ${attachment.id}]`).join("")}`);
+    updateAttachments([...continuationHolderRef.current.state.attachments, ...next]);
+    updateDraft(`${continuationHolderRef.current.state.draft}${next.map((attachment) => `[attachment ${attachment.id}]`).join("")}`);
   };
 
   const handleRemoveAttachment = (id: string) => {
-    setAttachments((current) => {
-      const target = current.find((item) => item.id === id);
-      if (target) revokeAttachmentPreview(target);
-      return current.filter((item) => item.id !== id);
-    });
-    props.onDraftChange(props.draft.replaceAll(`[attachment ${id}]`, ""));
+    const target = continuationHolderRef.current.state.attachments.find((item) => item.id === id);
+    if (target) revokeAttachmentPreview(target);
+    updateAttachments(continuationHolderRef.current.state.attachments.filter((item) => item.id !== id));
+    updateDraft(continuationHolderRef.current.state.draft.replaceAll(`[attachment ${id}]`, ""));
   };
 
   const handleRunTask = async () => {
     if (submittingRef.current || props.busy || failedSubmission || (!props.draft.trim() && !attachments.length)) return;
     submittingRef.current = true;
-    const originalDraft = props.draft;
+    const submissionHolder = continuationHolderRef.current;
+    const originalDraft = submissionHolder.state.draft;
     const revision = draftRevisionRef.current;
-    const resolved = resolvePastedTextPlaceholders(originalDraft, pastedText);
-    const saved = { text: originalDraft, attachments, pastedText };
-    if (!attachments.length) setPendingPrompt(resolved.replace(/\[attachment [^\]]+\]/g, ""));
-    setPreparingAttachments(attachments.length > 0);
+    const submitted = snapshotComposerSessionState({ ...submissionHolder.state, draft: originalDraft });
+    const resolved = resolvePastedTextPlaceholders(originalDraft, submitted.pasteParts);
+    if (!submitted.attachments.length) setPendingPrompt(resolved.replace(/\[attachment [^\]]+\]/g, ""));
+    setPreparingAttachments(submitted.attachments.length > 0);
     setSubmissionError(null);
     // Attachment drafts stay visible through session creation and are handed
     // to the session composer, which clears them only after preparation.
-    if (!attachments.length) {
+    if (!submitted.attachments.length) {
       props.onDraftChange("");
       draftRef.current = "";
+      submissionHolder.state = emptyNewTaskComposerState();
       setAttachments([]);
+      setMentions({});
       setPastedText([]);
     }
     try {
-      await props.onRunTask(resolved, attachments);
+      await props.onRunTask(resolved, submitted.attachments, {
+        submitted,
+        getContinuation: () => snapshotComposerSessionState(submissionHolder.state),
+      });
     } catch (error) {
-      if (!attachments.length) {
+      if (continuationHolderRef.current !== submissionHolder || submissionHolder.frozen) return;
+      if (!submitted.attachments.length) {
         if (draftRevisionRef.current === revision && !draftRef.current) {
-          props.onDraftChange(originalDraft);
-          setAttachments(saved.attachments);
-          setPastedText(saved.pastedText);
+          restoreComposer(submitted);
         } else {
-          setFailedSubmission(saved);
+          setFailedSubmission(submitted);
         }
       }
       setSubmissionError(error instanceof Error ? error.message : "Could not create the conversation. Try again.");
@@ -291,7 +406,8 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
 
   const handleUnsupportedFileLinks = (links: string[]) => {
     if (!links.length) return;
-    props.onDraftChange(`${props.draft}${props.draft && !props.draft.endsWith("\n") ? "\n" : ""}${links.join("\n")}`);
+    const currentDraft = continuationHolderRef.current.state.draft;
+    updateDraft(`${currentDraft}${currentDraft && !currentDraft.endsWith("\n") ? "\n" : ""}${links.join("\n")}`);
   };
 
   return (
@@ -301,9 +417,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     </div> : null}
     {submissionError ? <div role="alert" className="mb-2 text-sm text-red-11">{submissionError}</div> : null}
     {failedSubmission ? <button type="button" disabled={Boolean(props.draft || attachments.length)} className="mb-2 text-sm disabled:opacity-50" onClick={() => {
-      props.onDraftChange(failedSubmission.text);
-      setAttachments(failedSubmission.attachments);
-      setPastedText(failedSubmission.pastedText);
+      restoreComposer(failedSubmission);
       setFailedSubmission(null);
     }}>Clear the current draft to restore the unsent message</button> : null}
     <ReactSessionComposer

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -15,7 +15,11 @@ import {
   useOpenWorkModelsPromoEligibility,
 } from "@/react-app/domains/cloud/openwork-models-promo";
 import { usePlatform } from "@/react-app/kernel/platform";
-import { NewTaskComposer, type NewTaskComposerContext } from "./new-task-composer";
+import {
+  NewTaskComposer,
+  type NewTaskComposerContext,
+  type NewTaskComposerHandoff,
+} from "./new-task-composer";
 
 type HeroSuggestion = {
   title: string;
@@ -51,7 +55,11 @@ export type SessionEmptyHeroProps = {
   /** Disable submission while a default workspace is being prepared. */
   busy?: boolean;
   /** Called with the task prompt and attachments; the caller creates the session (and workspace if needed). */
-  onRunTask: (prompt: string, attachments: ComposerAttachment[]) => void | Promise<void>;
+  onRunTask: (
+    prompt: string,
+    attachments: ComposerAttachment[],
+    handoff?: NewTaskComposerHandoff,
+  ) => void | Promise<void>;
   onOpenProviderAuth?: () => void;
   /** Workspace-scoped wiring for the full composer (skills, agents, models). */
   composer?: NewTaskComposerContext | null;
@@ -101,10 +109,14 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     })
     : DEFAULT_SUGGESTIONS;
 
-  const submit = (resolvedPrompt: string, attachments: ComposerAttachment[]) => {
+  const submit = (
+    resolvedPrompt: string,
+    attachments: ComposerAttachment[],
+    handoff?: NewTaskComposerHandoff,
+  ) => {
     const trimmedPrompt = resolvedPrompt.trim();
     if ((!trimmedPrompt && !attachments.length) || props.busy) return;
-    return props.onRunTask(trimmedPrompt, attachments);
+    return props.onRunTask(trimmedPrompt, attachments, handoff);
   };
 
   const fillPrompt = (value: string) => {

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -62,7 +62,7 @@ import {
 } from "@/components/ui/resizable";
 import { ShareWorkspaceModal } from "../../workspace/share-workspace-modal";
 import { SessionEmptyHero } from "./session-empty-hero";
-import type { NewTaskComposerContext } from "./new-task-composer";
+import type { NewTaskComposerContext, NewTaskComposerHandoff } from "./new-task-composer";
 import type { SessionCloudMcpMaintenanceState } from "../../connections/use-session-mcp-maintenance";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
@@ -159,7 +159,12 @@ export type SessionPageSidebarProps = {
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
   onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
-  onCreateTaskWithPrompt?: (workspaceId: string, prompt: string, attachments?: ComposerAttachment[]) => Promise<void>;
+  onCreateTaskWithPrompt?: (
+    workspaceId: string,
+    prompt: string,
+    attachments?: ComposerAttachment[],
+    handoff?: NewTaskComposerHandoff,
+  ) => Promise<void>;
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;
   onRevealWorkspace: (workspaceId: string) => void;
@@ -1903,8 +1908,8 @@ export function SessionPage(props: SessionPageProps) {
                     <div className="flex flex-1 items-center justify-center py-16">
                       <SessionEmptyHero
                         providerCount={providerCount}
-                        onRunTask={(prompt, attachments) =>
-                          props.sidebar.onCreateTaskWithPrompt?.(props.selectedWorkspaceId, prompt, attachments)
+                        onRunTask={(prompt, attachments, handoff) =>
+                          props.sidebar.onCreateTaskWithPrompt?.(props.selectedWorkspaceId, prompt, attachments, handoff)
                         }
                         onOpenProviderAuth={props.onOpenProviderAuth}
                         composer={props.newTaskComposer}

--- a/apps/app/src/react-app/domains/session/surface/composer-auto-send.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-auto-send.ts
@@ -1,21 +1,70 @@
 /**
  * One-step "Run task" from the empty-state hero: the route seeds the created
- * session's draft and marks it here; the session surface consumes the mark
- * and fires its normal send path once the composer is ready. If the send
- * conditions are never met (e.g. no usable model), the mark simply expires
- * with the surface and the seeded draft stays for manual sending.
+ * session's continuation draft and marks the submitted draft here; the
+ * session surface consumes the mark and fires its normal send path once the
+ * composer is ready.
  */
-const pendingAutoSendSessionIds = new Set<string>();
+import { snapshotComposerSessionState, type ComposerSessionState } from "./composer-state-store";
 
-export function markComposerAutoSend(sessionId: string) {
+export type ComposerAutoSendPayload = {
+  scopeKey: string;
+  composer: ComposerSessionState;
+};
+
+export function composerAutoSendScopeKey(input: {
+  draftScope: string | null;
+  opencodeBaseUrl: string;
+  workspaceId: string;
+  sessionId: string;
+}) {
+  return JSON.stringify([input.draftScope, input.opencodeBaseUrl, input.workspaceId, input.sessionId]);
+}
+
+const pendingLegacyAutoSendSessionIds = new Set<string>();
+const pendingScopedAutoSends = new Map<string, Map<string, ComposerAutoSendPayload>>();
+
+export function markComposerAutoSend(sessionId: string, payload?: ComposerAutoSendPayload) {
   const id = sessionId.trim();
-  if (id) pendingAutoSendSessionIds.add(id);
+  if (!id) return;
+  if (!payload) {
+    pendingLegacyAutoSendSessionIds.add(id);
+    return;
+  }
+  const scoped = pendingScopedAutoSends.get(id) ?? new Map<string, ComposerAutoSendPayload>();
+  scoped.set(payload.scopeKey, {
+    scopeKey: payload.scopeKey,
+    composer: snapshotComposerSessionState(payload.composer),
+  });
+  pendingScopedAutoSends.set(id, scoped);
 }
 
-export function consumeComposerAutoSend(sessionId: string): boolean {
-  return pendingAutoSendSessionIds.delete(sessionId.trim());
+export function consumeComposerAutoSend(sessionId: string, scopeKey?: string): boolean {
+  const id = sessionId.trim();
+  if (scopeKey === undefined) return pendingLegacyAutoSendSessionIds.delete(id);
+  const scoped = pendingScopedAutoSends.get(id);
+  if (!scoped) return false;
+  if (!scoped.delete(scopeKey)) return false;
+  if (scoped.size === 0) pendingScopedAutoSends.delete(id);
+  return true;
 }
 
-export function hasComposerAutoSend(sessionId: string): boolean {
-  return pendingAutoSendSessionIds.has(sessionId.trim());
+export function getComposerAutoSendPayload(sessionId: string, scopeKey: string): ComposerAutoSendPayload | null {
+  return pendingScopedAutoSends.get(sessionId.trim())?.get(scopeKey) ?? null;
+}
+
+export function consumeComposerAutoSendPayload(sessionId: string, scopeKey: string): ComposerAutoSendPayload | null {
+  const payload = getComposerAutoSendPayload(sessionId, scopeKey);
+  if (!payload) return null;
+  const id = sessionId.trim();
+  const scoped = pendingScopedAutoSends.get(id);
+  scoped?.delete(scopeKey);
+  if (scoped?.size === 0) pendingScopedAutoSends.delete(id);
+  return payload;
+}
+
+export function hasComposerAutoSend(sessionId: string, scopeKey?: string): boolean {
+  const id = sessionId.trim();
+  if (scopeKey === undefined) return pendingLegacyAutoSendSessionIds.has(id);
+  const scoped = pendingScopedAutoSends.get(id);
+  return scoped?.has(scopeKey) === true;
 }

--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -24,6 +24,16 @@ export type ComposerSessionState = {
   revertMessageId: string | null;
 };
 
+export function snapshotComposerSessionState(state: ComposerSessionState): ComposerSessionState {
+  return {
+    draft: state.draft,
+    attachments: state.attachments.map((attachment) => ({ ...attachment })),
+    mentions: { ...state.mentions },
+    pasteParts: state.pasteParts.map((part) => ({ ...part })),
+    revertMessageId: state.revertMessageId,
+  };
+}
+
 export type ComposerStateStore = {
   failedDrafts: Record<string, ComposerSessionState[]>;
   pendingMessages: Record<string, { draft: ComposerDraft & { messageId: string }; previousMessageIds: string[] }[]>;

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -116,6 +116,7 @@ import {
   getComposerRevertMessageId,
   getComposerSessionDraftScope,
   persistableComposerDraftText,
+  type ComposerSessionState,
   useComposerStateStore,
 } from "./composer-state-store";
 import { MessageList } from "@/components/chat/message-list";
@@ -146,7 +147,13 @@ import {
   readCloudInventoryScope,
 } from "@/react-app/domains/connections/cloud-inventory-cache";
 import { connectPluginsForComposer, EMPTY_CONNECT_CAPABILITY_INVENTORY } from "@/react-app/domains/session/surface/connect-capability-inventory";
-import { consumeComposerAutoSend, hasComposerAutoSend } from "./composer-auto-send";
+import {
+  composerAutoSendScopeKey,
+  consumeComposerAutoSend,
+  consumeComposerAutoSendPayload,
+  getComposerAutoSendPayload,
+  hasComposerAutoSend,
+} from "./composer-auto-send";
 import { useOrgMcpConnections } from "@/react-app/domains/connections/use-org-mcp-connections";
 import { buildConnectorToolIdentities } from "@/react-app/domains/connections/connector-tool-identity";
 
@@ -947,6 +954,16 @@ function withoutRevertTarget(draft: ComposerDraft | null): ComposerDraft | null 
   return { ...draft, revertMessageId: undefined };
 }
 
+function composerSessionHasContent(state: ComposerSessionState | undefined) {
+  return Boolean(state && (
+    state.draft
+    || state.attachments.length
+    || Object.keys(state.mentions).length
+    || state.pasteParts.length
+    || state.revertMessageId
+  ));
+}
+
 function hiddenMessageCount(snapshot: OpenworkSessionSnapshot, revertMessageId: string): number {
   const index = snapshot.messages.findIndex((message) => message.info.id === revertMessageId);
   return index < 0 ? snapshot.messages.length : snapshot.messages.length - index;
@@ -1101,7 +1118,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
     : Boolean(props.modelUnavailable);
   // This surface is retained across navigation. Async completions must keep
   // their original owner, including when different servers reuse session IDs.
-  const sessionOwner = JSON.stringify([props.draftScope, props.opencodeBaseUrl, props.workspaceId, props.sessionId]);
+  const sessionOwner = composerAutoSendScopeKey({
+    draftScope: props.draftScope,
+    opencodeBaseUrl: props.opencodeBaseUrl,
+    workspaceId: props.workspaceId,
+    sessionId: props.sessionId,
+  });
   const activeSessionOwnerRef = useRef(sessionOwner);
   activeSessionOwnerRef.current = sessionOwner;
   const [ownedError, setOwnedError] = useState<{ owner: string; error: SessionError } | null>(null);
@@ -1350,7 +1372,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
   const pendingMessages = useComposerStateStore((state) => state.pendingMessages[sessionOwner]);
   const failedDraft = useComposerStateStore((state) => state.failedDrafts[sessionOwner]?.[0]);
-  const autoSending = hasComposerAutoSend(props.sessionId) && !sessionModelUnavailable && attachments.length === 0;
+  const autoSendPayload = getComposerAutoSendPayload(props.sessionId, sessionOwner);
+  const autoSending = (Boolean(autoSendPayload)
+    || (hasComposerAutoSend(props.sessionId) && attachments.length === 0))
+    && !sessionModelUnavailable;
   const unmatchedPendingMessages = useMemo(() => {
     const matchedIds = new Set<string>();
     const remaining = (pendingMessages ?? []).filter(({ draft: pending, previousMessageIds }) => {
@@ -1381,13 +1406,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
       role: "user",
       parts: [{ type: "text", text: item.resolvedText ?? item.text }],
     }));
-    if (autoSending && draft.trim()) pending.push({
-      id: `${props.sessionId}:first-send`,
-      role: "user",
-      parts: [{ type: "text", text: resolvePastedTextPlaceholders(draft, pasteParts).replace(/\[attachment [^\]]+\]/g, "") }],
-    });
+    if (autoSending) {
+      const pendingComposer = autoSendPayload?.composer;
+      const pendingText = pendingComposer?.draft ?? draft;
+      const pendingPasteParts = pendingComposer?.pasteParts ?? pasteParts;
+      if (pendingText.trim() || (pendingComposer?.attachments.length ?? attachments.length)) pending.push({
+        id: `${props.sessionId}:first-send`,
+        role: "user",
+        parts: [{ type: "text", text: resolvePastedTextPlaceholders(pendingText, pendingPasteParts).replace(/\[attachment [^\]]+\]/g, "") }],
+      });
+    }
     return [...baseRenderedMessages, ...pending, ...evalMarkdownMessages];
-  }, [autoSending, baseRenderedMessages, draft, evalMarkdownMessages, pasteParts, props.sessionId, unmatchedPendingMessages]);
+  }, [attachments.length, autoSendPayload, autoSending, baseRenderedMessages, draft, evalMarkdownMessages, pasteParts, props.sessionId, unmatchedPendingMessages]);
   const renderedMessagesRef = useRef(renderedMessages);
   useEffect(() => {
     renderedMessagesRef.current = renderedMessages;
@@ -1757,7 +1787,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     renderedSessionId: renderedMessages.length > 0 || snapshot ? props.sessionId : null,
     hasSnapshot: Boolean(snapshot) || renderedMessages.length > 0,
     isFetching: snapshotQuery.isFetching,
-    isError: snapshotQuery.isError || Boolean(error),
+    // A failed send stays visible for composer recovery; only snapshot failure invalidates the session transition.
+    isError: snapshotQuery.isError,
   });
   const failSessionSnapshotControlAction = useMemo<OpenworkControlAction | null>(() => {
     if (!import.meta.env.DEV) return null;
@@ -1776,7 +1807,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId, snapshotQuery.refetch]);
   useControlAction(props.isControlTarget ? failSessionSnapshotControlAction : null);
 
-  const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
+  const buildDraft = useCallback((
+    text: string,
+    nextAttachments: ComposerAttachment[],
+    sourceComposer?: ComposerSessionState,
+  ): ComposerDraft => {
+    const sourceMentions = sourceComposer?.mentions ?? mentions;
+    const sourcePasteParts = sourceComposer?.pasteParts ?? pasteParts;
     const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment, index, segments) => {
       if (!segment) return [] as ComposerDraft["parts"];
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
@@ -1786,7 +1823,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       }
       const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
       if (pasteMatch) {
-        const target = pasteParts.find((item) => item.label === pasteMatch[1]);
+        const target = sourcePasteParts.find((item) => item.label === pasteMatch[1]);
         if (target) {
           return [{ type: "paste", id: target.id, label: target.label, text: target.text, lines: target.lines } satisfies ComposerDraft["parts"][number]];
         }
@@ -1801,7 +1838,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       }
       if (segment.startsWith("@")) {
         const value = decodeComposerMentionValue(segment.slice(1));
-        const kind = mentions[value];
+        const kind = sourceMentions[value];
         if (isComputerTarget(value) && (!kind || kind === "computer") && (index <= 1 && !segments[0] || /\s$/.test(segments[index - 1] ?? ""))) {
           return [{ type: "computer", target: value } satisfies ComposerDraft["parts"][number]];
         }
@@ -1813,14 +1850,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
     });
     // Expand paste placeholders in resolvedText so the model receives
     // the actual pasted content instead of "[pasted text <label>]".
-    let resolved = resolvePastedTextPlaceholders(text, pasteParts);
+    let resolved = resolvePastedTextPlaceholders(text, sourcePasteParts);
     resolved = resolved.replace(/\[attachment [^\]]+\]/g, "");
     resolved = resolved.replace(/\[connect-skill [^\]]+\]/g, (match) => {
       const token = parseConnectSkillToken(match);
       return token ? `/${token.slug}` : match;
     });
     resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
-    for (const value of Object.keys(mentions)) {
+    for (const value of Object.keys(sourceMentions)) {
       resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
     }
     // A selected Connect skill is a mention, even though its label starts with /.
@@ -1832,7 +1869,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
       text,
       resolvedText: resolved,
       command: slashCommand ?? undefined,
-      revertMessageId: getComposerRevertMessageId(useComposerStateStore.getState(), props.sessionId) ?? undefined,
+      revertMessageId: sourceComposer
+        ? sourceComposer.revertMessageId ?? undefined
+        : getComposerRevertMessageId(useComposerStateStore.getState(), props.sessionId) ?? undefined,
     };
   }, [mentions, pasteParts, props.sessionId]);
 
@@ -1913,22 +1952,28 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   // Initial send (agent idle) and explicit "Steer" follow-up (agent busy)
   // share the same immediate path.
-  const handleSend = useCallback(async () => {
+  const handleSend = useCallback(async (sourceComposer?: ComposerSessionState) => {
     if ([...pendingSendsRef.current.values()].includes(sessionOwner)) return;
-    const originalDraft = draft;
+    const originalDraft = sourceComposer?.draft ?? draft;
+    const sourceAttachments = sourceComposer?.attachments ?? attachments;
     const text = originalDraft.trim();
-    if (!text && attachments.length === 0) return;
-    const nextDraft = { ...buildDraft(text, attachments), messageId: createPromptMessageID() };
+    if (!text && sourceAttachments.length === 0) return;
+    const nextDraft = {
+      ...buildDraft(text, sourceAttachments, sourceComposer),
+      messageId: createPromptMessageID(),
+    };
     // Immediate sends and queued sends share the same slot across all panes.
     dispatchQueuedDrain(props.sessionId, { type: "user_retry" });
     if (!claimQueuedSend(props.sessionId, nextDraft.messageId, true)) return;
-    const sentAttachments = attachments;
-    const savedComposer = useComposerStateStore.getState().sessions[props.sessionId];
+    const sentAttachments = sourceAttachments;
+    const composerCheckpoint = useComposerStateStore.getState().sessions[props.sessionId];
+    const savedComposer = sourceComposer ?? composerCheckpoint;
     let clearedComposer: typeof savedComposer;
     let composerCleared = false;
     const markPrepared = () => {
       // Do not erase edits made while attachments were being prepared.
-      if (useComposerStateStore.getState().sessions[props.sessionId] === savedComposer
+      if ((!sourceComposer || sentAttachments.length > 0)
+        && useComposerStateStore.getState().sessions[props.sessionId] === composerCheckpoint
         && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
         clearComposer();
         clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
@@ -1953,8 +1998,22 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }));
     const restore = () => {
       removePending();
-      if (!composerCleared) return;
       const state = useComposerStateStore.getState();
+      if (!composerCleared) {
+        if (!sourceComposer || sentAttachments.length > 0 || !savedComposer) return;
+        if (state.sessions[props.sessionId] === composerCheckpoint
+          && !composerSessionHasContent(composerCheckpoint)
+          && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
+          useComposerStateStore.setState({ sessions: { ...state.sessions, [props.sessionId]: savedComposer } });
+          props.onDraftChange(nextDraft);
+        } else {
+          useComposerStateStore.setState({ failedDrafts: {
+            ...state.failedDrafts,
+            [sessionOwner]: [...(state.failedDrafts[sessionOwner] ?? []), savedComposer],
+          } });
+        }
+        return;
+      }
       // Identity, not text equality: typing and then deleting is still a newer edit.
       if (savedComposer && state.sessions[props.sessionId] === clearedComposer
         && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
@@ -1985,19 +2044,26 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
   }, [attachments, baseRenderedMessages, buildDraft, clearComposer, draft, persistedDraftKey, props.onDraftChange, props.sessionId, sendDraft, sessionOwner]);
 
-  // One-step run from the empty-state hero: the route seeds this session's
-  // draft and marks it for auto-send. Fire the same send path as the send
-  // button once the composer is usable; if these conditions never hold
-  // (e.g. no usable model), the mark is never consumed and the seeded
-  // draft stays for manual sending.
+  // One-step run from the empty-state hero: the route keeps the continuation
+  // in this session's composer and marks the submitted snapshot for auto-send.
+  // Fire the same send path as the send button once the composer is usable;
+  // until then, leave both the scoped mark and continuation untouched.
   useEffect(() => {
     if (model.transitionState !== "idle") return;
     if (chatStreaming) return;
     if (sessionModelUnavailable) return;
+    const sourceComposer = autoSendPayload?.composer;
+    if (sourceComposer) {
+      if (!sourceComposer.draft.trim() && !sourceComposer.attachments.length) return;
+      const payload = consumeComposerAutoSendPayload(props.sessionId, sessionOwner);
+      if (!payload) return;
+      void handleSend(payload.composer);
+      return;
+    }
     if (!draft.trim() && !attachments.length) return;
     if (!consumeComposerAutoSend(props.sessionId)) return;
     void handleSend();
-  }, [attachments.length, chatStreaming, draft, handleSend, model.transitionState, sessionModelUnavailable, props.sessionId]);
+  }, [attachments.length, autoSendPayload, chatStreaming, draft, handleSend, model.transitionState, sessionModelUnavailable, props.sessionId, sessionOwner]);
 
   const handleSteer = useCallback(async () => {
     setSteering(true);
@@ -3084,16 +3150,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
         )))}
         <ReactSessionComposer
           runModeControl={<WorkspaceRunModeMenu client={props.client} workspaceId={props.workspaceId} busy={chatStreaming || preparingCloudTools || Boolean(props.activePermission || props.activeQuestion)} />}
-          draft={autoSending ? "" : draft}
+          draft={autoSendPayload ? draft : autoSending ? "" : draft}
           mentions={mentions}
           onDraftChange={handleComposerDraftChange}
-        onSend={handleSend}
+        onSend={() => handleSend()}
         onSteer={handleSteer}
         onQueue={handleQueue}
         onStop={async () => { await handleAbort(); }}
         busy={chatStreaming}
         steering={steering}
-        submissionPreparing={preparingCloudTools || sending}
+        submissionPreparing={preparingCloudTools || sending || autoSending}
         queuedCount={queuedItems.length}
         disabled={model.transitionState !== "idle" || sessionModelUnavailable || queuedDrainState.phase.kind === "admission_unknown"}
         modelUnavailable={sessionModelUnavailable}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2035,15 +2035,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const savedComposer = sourceComposer ?? composerCheckpoint;
     let clearedComposer: typeof savedComposer;
     let composerCleared = false;
-    const markPrepared = () => {
-      // Do not erase edits made while attachments were being prepared.
-      if ((!sourceComposer || sentAttachments.length > 0)
-        && useComposerStateStore.getState().sessions[props.sessionId] === composerCheckpoint
-        && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
-        clearComposer();
-        clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
-        composerCleared = true;
-      }
+    let pendingRegistered = false;
+    const registerPending = () => {
+      if (pendingRegistered) return;
+      pendingRegistered = true;
       useComposerStateStore.setState((state) => ({
         pendingMessages: {
           ...state.pendingMessages,
@@ -2053,6 +2048,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
           }],
         },
       }));
+    };
+    const markPrepared = () => {
+      // Do not erase edits made while attachments were being prepared.
+      if (!sourceComposer
+        && useComposerStateStore.getState().sessions[props.sessionId] === composerCheckpoint
+        && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
+        clearComposer();
+        clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
+        composerCleared = true;
+      }
+      registerPending();
       setAttachmentsUploading(false);
     };
     const removePending = () => useComposerStateStore.setState((state) => ({
@@ -2065,7 +2071,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       removePending();
       const state = useComposerStateStore.getState();
       if (!composerCleared) {
-        if (!sourceComposer || sentAttachments.length > 0 || !savedComposer) return;
+        if (!sourceComposer || !savedComposer) return;
         if (state.sessions[props.sessionId] === composerCheckpoint
           && !composerSessionHasContent(composerCheckpoint)
           && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
@@ -2091,6 +2097,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         } });
       }
     };
+    if (sourceComposer && sentAttachments.length) registerPending();
     if (sentAttachments.length) setAttachmentsUploading(true);
     else markPrepared();
     try {
@@ -2101,7 +2108,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       }
       if (result.outcome !== "unknown" && (nextDraft.command || nextDraft.mode === "shell")) removePending();
       const retained = useComposerStateStore.getState().sessions[props.sessionId]?.attachments ?? [];
-      sentAttachments.filter((attachment) => !retained.includes(attachment)).forEach(revokeAttachmentPreview);
+      sentAttachments.filter((attachment) => !retained.some((item) => item.id === attachment.id)).forEach(revokeAttachmentPreview);
     } catch {
       restore();
     } finally {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -10,7 +10,9 @@ import { captureAnalyticsEvent } from "@/app/lib/analytics";
 import { interruptSessionTurn, sessionNeedsStop, submitAfterInterruption, subscribeSessionInterruption } from "@/app/lib/opencode-interruption";
 import { createClient, createPromptMessageID, hasAcceptedPromptMessage, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
-import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
+import * as opencodeSessionNative from "@/app/lib/opencode-session-native";
+import type { NativeSessionSnapshotTarget } from "@/app/lib/opencode-session-native";
+import { isDesktopRuntime } from "@/app/lib/runtime-env";
 import { setThemeMode } from "@/app/theme";
 import { t } from "@/i18n";
 import type { ComposerSettingsSection } from "@/react-app/domains/settings/library";
@@ -22,6 +24,7 @@ import type {
   OpenworkServerClient,
   OpenworkSessionSnapshot,
 } from "@/app/lib/openwork-server";
+import { isLoopbackOpenworkServerUrl } from "@/app/lib/openwork-server";
 import type {
   ComposerAttachment,
   ComposerDraft,
@@ -161,6 +164,16 @@ const EMPTY_TRANSCRIPT: UIMessage[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
 const DEFAULT_COMPOSER_CONTROL_TEXT = "Help me outline the next OpenWork task.";
 const SESSION_SURFACE_SELECTOR = "[data-session-surface-id]";
+
+function sanitizedInspectorDiagnosticText(value: string) {
+  return value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, "[url]")
+    .replace(/\b(Bearer|Basic)\s+[^\s"'<>]+/gi, "$1 [redacted]")
+    .replace(/\b(authorization|ownerToken|clientToken|openworkToken|accessToken|apiKey|token)\b\s*[=:]\s*[^\s,;]+/gi, "$1=[redacted]")
+    .replace(/[\r\n\t]+/g, " ")
+    .slice(0, 240);
+}
+
 const MARKDOWN_PRIMITIVE_EVAL_TEXT = `# Markdown proof heading
 
 This shared renderer keeps **bold proof text**, inline \`renderMarkdownHtml\`, and [OpenWork link](https://openworklabs.com) readable in one message.
@@ -1126,6 +1139,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
   const activeSessionOwnerRef = useRef(sessionOwner);
   activeSessionOwnerRef.current = sessionOwner;
+  const snapshotTargetRef = useRef<NativeSessionSnapshotTarget>({
+    owner: sessionOwner,
+    endpoint: { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
+    sessionId: props.sessionId,
+  });
+  snapshotTargetRef.current = {
+    owner: sessionOwner,
+    endpoint: { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
+    sessionId: props.sessionId,
+  };
   const [ownedError, setOwnedError] = useState<{ owner: string; error: SessionError } | null>(null);
   const error = ownedError?.owner === sessionOwner ? ownedError.error : null;
   const setError = useCallback((nextError: SessionError | null) => {
@@ -1199,6 +1222,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     () => reactStatusKey(props.workspaceId, props.sessionId),
     [props.workspaceId, props.sessionId],
   );
+  const useDesktopLoopbackSnapshotRetry = isDesktopRuntime()
+    && isLoopbackOpenworkServerUrl(props.opencodeBaseUrl);
   const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
     queryKey: snapshotQueryKey,
     queryFn: async ({ signal }) => {
@@ -1206,19 +1231,36 @@ export function SessionSurface(props: SessionSurfaceProps) {
         throw new Error("eval: forced session snapshot failure");
       }
       const startedAt = Date.now();
-      const item = await composeNativeSessionSnapshot(
-        { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
-        props.sessionId,
-        { limit: 140, signal },
-      );
+      const item = useDesktopLoopbackSnapshotRetry
+        ? await opencodeSessionNative.composeNativeSessionSnapshotWithRetry(
+          sessionOwner,
+          () => snapshotTargetRef.current,
+          { limit: 140, signal },
+        )
+        : await opencodeSessionNative.composeNativeSessionSnapshot(
+          { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
+          props.sessionId,
+          { limit: 140, signal },
+        );
       markSessionSnapshotFetchStart(item, startedAt);
       return item;
     },
     staleTime: 500,
-    retry: (failureCount) => !evalSnapshotFailureRef.current && failureCount < 3,
+    networkMode: useDesktopLoopbackSnapshotRetry ? "always" : undefined,
+    retry: useDesktopLoopbackSnapshotRetry
+      ? false
+      : (failureCount) => !evalSnapshotFailureRef.current && failureCount < 3,
   });
 
   const currentSnapshot = snapshotQuery.data?.session.id === props.sessionId ? snapshotQuery.data : null;
+  const inspectorOpencodeBaseUrl = useMemo(() => {
+    try {
+      const url = new URL(props.opencodeBaseUrl);
+      return { origin: url.origin, pathname: url.pathname };
+    } catch {
+      return { origin: null, pathname: null };
+    }
+  }, [props.opencodeBaseUrl]);
   const transcriptState = useSharedQueryState<UIMessage[]>(transcriptQueryKey, EMPTY_TRANSCRIPT);
   const statusQuery = useQuery<SessionStatus, Error, SessionStatus, readonly unknown[]>({
     queryKey: statusQueryKey,
@@ -1285,6 +1327,20 @@ export function SessionSurface(props: SessionSurfaceProps) {
         code: props.cloudMcpSubmissionState.issue?.code ?? null,
         stage: props.cloudMcpSubmissionState.issue?.stage ?? null,
       },
+      snapshotQuery: {
+        status: snapshotQuery.status,
+        fetchStatus: snapshotQuery.fetchStatus,
+        isPaused: snapshotQuery.isPaused,
+        failureCount: snapshotQuery.failureCount,
+        errorName: snapshotQuery.error ? sanitizedInspectorDiagnosticText(snapshotQuery.error.name) : null,
+        errorMessage: snapshotQuery.error ? sanitizedInspectorDiagnosticText(snapshotQuery.error.message) : null,
+        dataSessionId: snapshotQuery.data?.session.id ?? null,
+        dataMessageCount: snapshotQuery.data?.messages.length ?? null,
+        currentSnapshotId: currentSnapshot?.session.id ?? null,
+        intendedSessionId: props.sessionId,
+        opencodeBaseUrl: inspectorOpencodeBaseUrl,
+        tokenPresent: props.openworkToken.length > 0,
+      },
       error,
     }));
     return dispose;
@@ -1294,10 +1350,19 @@ export function SessionSurface(props: SessionSurfaceProps) {
     error,
     mentions,
     pasteParts,
+    currentSnapshot,
+    inspectorOpencodeBaseUrl,
+    props.openworkToken,
     props.sessionId,
     props.workspaceId,
     props.cloudMcpSubmissionState,
     sending,
+    snapshotQuery.data,
+    snapshotQuery.error,
+    snapshotQuery.failureCount,
+    snapshotQuery.fetchStatus,
+    snapshotQuery.isPaused,
+    snapshotQuery.status,
   ]);
 
   useEffect(() => {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -109,7 +109,10 @@ import { DashboardPage } from "@/react-app/domains/dashboard/dashboard-page";
 import { useDashboardDeploymentAvailability } from "@/react-app/domains/dashboard/dashboard-availability";
 import { useAutomationDeploymentEnabled } from "@/react-app/domains/automations/automation-availability";
 import { automationsStateChangedEvent } from "@/react-app/domains/automations/automation-events";
-import type { NewTaskComposerContext } from "@/react-app/domains/session/chat/new-task-composer";
+import type {
+  NewTaskComposerContext,
+  NewTaskComposerHandoff,
+} from "@/react-app/domains/session/chat/new-task-composer";
 import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
@@ -136,7 +139,10 @@ import {
   useModelCollectionsStore,
 } from "@/react-app/domains/session/models/model-collections-store";
 import { openModelPickerEvent, openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
-import { markComposerAutoSend } from "@/react-app/domains/session/surface/composer-auto-send";
+import {
+  composerAutoSendScopeKey,
+  markComposerAutoSend,
+} from "@/react-app/domains/session/surface/composer-auto-send";
 import { sendWithRevertRollback } from "@/react-app/domains/session/surface/safe-edit-resend";
 import { assertQueuedSendCurrent, getQueuedSendGeneration } from "@/react-app/domains/session/surface/queued-drain-machine";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
@@ -208,6 +214,8 @@ import {
 } from "@/react-app/domains/session/sync/draft-store";
 import {
   claimComposerSessionDraftScope,
+  persistableComposerDraftText,
+  snapshotComposerSessionState,
   useComposerStateStore,
 } from "@/react-app/domains/session/surface/composer-state-store";
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
@@ -355,6 +363,14 @@ function singlePickedDirectory(selection: string | string[] | null) {
       : null;
 }
 
+function focusedWorkbenchPaneOwner() {
+  const workbench = useWorkbenchStore.getState();
+  const focused = workbench.focusedPane === "secondary" ? workbench.secondary : workbench.primary;
+  return focused
+    ? JSON.stringify([workbench.focusedPane, focused.workspaceId, focused.sessionId])
+    : null;
+}
+
 export function SessionRoute() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -497,6 +513,29 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
+  const routeNavigationRef = useRef({ locationKey: location.key, generation: 0 });
+  if (routeNavigationRef.current.locationKey !== location.key) {
+    routeNavigationRef.current = {
+      locationKey: location.key,
+      generation: routeNavigationRef.current.generation + 1,
+    };
+  }
+  const selectedConversationRef = useRef({
+    workspaceId: selectedWorkspaceId,
+    sessionId: selectedSessionId,
+    draftScope: sessionDraftScope,
+    location: `${location.pathname}${location.search}`,
+    locationKey: location.key,
+    navigationGeneration: routeNavigationRef.current.generation,
+  });
+  selectedConversationRef.current = {
+    workspaceId: selectedWorkspaceId,
+    sessionId: selectedSessionId,
+    draftScope: sessionDraftScope,
+    location: `${location.pathname}${location.search}`,
+    locationKey: location.key,
+    navigationGeneration: routeNavigationRef.current.generation,
+  };
   const archiveDisabledReason = isOpencodeV2BaseUrl(opencodeBaseUrl) ? V2_SESSION_ARCHIVE_UNAVAILABLE : undefined;
   // The dashboard is user-scoped while MCP servers are workspace-scoped: the
   // selected workspace's runtime is primary, and every other available one is
@@ -1869,6 +1908,11 @@ export function SessionRoute() {
     return {
       client,
       workspaceId: selectedWorkspaceId || null,
+      draftOwnerKey: JSON.stringify([
+        sessionDraftScope,
+        selectedWorkspaceEndpoint?.opencodeBaseUrl ?? null,
+        selectedWorkspaceId || null,
+      ]),
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
       modelOptions: organizationAssignedModelOptions,
       modelUnavailable: selectedModelUnavailable,
@@ -1952,8 +1996,10 @@ export function SessionRoute() {
     selectedAgent,
     selectedModelUnavailable,
     selectedWorkspace,
+    selectedWorkspaceEndpoint,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
+    sessionDraftScope,
     sessionProviderAuthStore,
     setSelectedAgent,
   ]);
@@ -3420,44 +3466,90 @@ export function SessionRoute() {
         onCreateSplitTaskInWorkspace: (workspaceId) => {
           void handleCreateSplitTaskInWorkspace(workspaceId);
         },
-        onCreateTaskWithPrompt: async (workspaceId, prompt, attachments) => {
+        onCreateTaskWithPrompt: async (
+          workspaceId,
+          prompt,
+          attachments,
+          handoff?: NewTaskComposerHandoff,
+        ) => {
+          const navigationOwner = {
+            ...selectedConversationRef.current,
+            paneOwner: focusedWorkbenchPaneOwner(),
+          };
           const workspace = workspaces.find((item) => item.id === workspaceId);
           if (!workspace) throw new Error("Workspace is unavailable. Try again.");
           const endpoint = endpointForWorkspace(workspace);
           if (!endpoint?.token) throw new Error("Workspace is disconnected. Reconnect and try again.");
           const session = await createRouteSession(endpoint, workspace.path?.trim() || undefined);
+          const continuation = handoff
+            ? snapshotComposerSessionState(handoff.getContinuation())
+            : null;
           if (workspaceId === selectedWorkspaceId) {
             void refreshCloudProviderSync("new_chat");
           }
           const firstTaskPrompt = prompt.trim();
           if (firstTaskPrompt || attachments?.length) {
             const firstTaskAttachments = attachments ?? [];
-            // Attachment chips only survive in-memory (File objects), so the
-            // persisted fallback draft drops their tokens.
-            saveSessionDraft(sessionDraftScope, workspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
-            claimComposerSessionDraftScope(
-              session.id,
-              sessionDraftScopeKey(sessionDraftScope, workspaceId, session.id),
-            );
-            // The composer reads its draft from the composer state store,
-            // not the persisted draft store — seed both.
-            useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
-            if (firstTaskAttachments.length) {
-              useComposerStateStore.getState().setAttachments(session.id, firstTaskAttachments);
+            const destinationScopeKey = sessionDraftScopeKey(sessionDraftScope, workspaceId, session.id);
+            if (handoff && continuation) {
+              // The source composer remains live while session creation is in
+              // flight. Seed its latest continuation in the destination, but
+              // send the immutable submitted snapshot through the scoped mark.
+              saveSessionDraft(sessionDraftScope, workspaceId, session.id, {
+                text: persistableComposerDraftText(continuation.draft),
+                mode: "prompt",
+              });
+              claimComposerSessionDraftScope(session.id, destinationScopeKey);
+              useComposerStateStore.setState((state) => ({
+                sessions: {
+                  ...state.sessions,
+                  [session.id]: continuation,
+                },
+              }));
+              markComposerAutoSend(session.id, {
+                scopeKey: composerAutoSendScopeKey({
+                  draftScope: sessionDraftScope,
+                  opencodeBaseUrl: endpoint.opencodeBaseUrl,
+                  workspaceId,
+                  sessionId: session.id,
+                }),
+                composer: handoff.submitted,
+              });
+            } else {
+              // Attachment chips only survive in-memory (File objects), so the
+              // persisted fallback draft drops their tokens.
+              saveSessionDraft(sessionDraftScope, workspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
+              claimComposerSessionDraftScope(session.id, destinationScopeKey);
+              // The composer reads its draft from the composer state store,
+              // not the persisted draft store — seed both.
+              useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
+              if (firstTaskAttachments.length) {
+                useComposerStateStore.getState().setAttachments(session.id, firstTaskAttachments);
+              }
+              // Legacy callers still seed the submitted draft directly.
+              markComposerAutoSend(session.id);
             }
-            // One-step run: the session surface sends the seeded draft itself.
-            markComposerAutoSend(session.id);
           }
-          writeActiveWorkspaceId(workspaceId || null);
-          writeLastSessionFor(workspaceId, session.id);
           rememberPendingCreatedSession(workspaceId, session.id);
           applyLastUsedModelToSession(session.id);
           setSessionsByWorkspaceId((current) => ({
             ...current,
             [workspaceId]: mergeWorkspaceRouteSession(current[workspaceId] ?? [], session),
           }));
-          navigateToWorkspaceSession(workspaceId, session.id);
-          focusPromptSoon();
+          const stillOwnsNavigation = navigationOwner.workspaceId === workspaceId
+            && selectedConversationRef.current.workspaceId === navigationOwner.workspaceId
+            && selectedConversationRef.current.sessionId === navigationOwner.sessionId
+            && selectedConversationRef.current.draftScope === navigationOwner.draftScope
+            && selectedConversationRef.current.location === navigationOwner.location
+            && selectedConversationRef.current.locationKey === navigationOwner.locationKey
+            && selectedConversationRef.current.navigationGeneration === navigationOwner.navigationGeneration
+            && focusedWorkbenchPaneOwner() === navigationOwner.paneOwner;
+          if (stillOwnsNavigation) {
+            writeActiveWorkspaceId(workspaceId || null);
+            writeLastSessionFor(workspaceId, session.id);
+            navigateToWorkspaceSession(workspaceId, session.id);
+            focusPromptSoon();
+          }
         },
         onOpenRenameWorkspace: handleOpenRenameWorkspace,
         onShareWorkspace: handleShareWorkspace,

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -377,9 +377,18 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(sentDrafts).toHaveLength(4);
 
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    const scopedFile = new File(["scoped image"], "scoped.png", { type: "image/png" });
+    const scopedAttachment: ComposerAttachment = {
+      id: "scoped-image",
+      name: "scoped.png",
+      mimeType: "image/png",
+      size: scopedFile.size,
+      kind: "image",
+      file: scopedFile,
+    };
     const submittedComposer = {
-      draft: "First [pasted text handoff]",
-      attachments: [],
+      draft: "First [pasted text handoff][attachment scoped-image]",
+      attachments: [scopedAttachment],
       mentions: {},
       pasteParts: [{ id: "submitted-paste", label: "handoff", text: "submitted body", lines: 1 }],
       revertMessageId: null,
@@ -409,12 +418,35 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(sentDrafts[4]?.resolvedText).toBe("First submitted body");
     expect(editor.textContent).toBe("Continuation B");
     expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationComposer);
+    const scopedPendingRows = () => [...container.querySelectorAll('[data-message-role="user"]')]
+      .filter((row) => row.textContent === "First submitted body");
+    expect(scopedPendingRows()).toHaveLength(1);
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Continuation B before preparation"));
+    expect(editor.textContent).toBe("Continuation B before preparation");
+    const continuationBeforePreparation = useComposerStateStore.getState().sessions[sessionId];
+    expect(prepareSubmission).toBeFunction();
+    await act(async () => prepareSubmission?.());
+    expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationBeforePreparation);
+    expect(scopedPendingRows()).toHaveLength(1);
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Continuation B after preparation"));
+    expect(editor.textContent).toBe("Continuation B after preparation");
+    const continuationAfterPreparation = useComposerStateStore.getState().sessions[sessionId];
     await act(async () => submission.reject(new Error("Scoped submission unavailable")));
-    expect(editor.textContent).toBe("Continuation B");
-    expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationComposer);
+    expect(editor.textContent).toBe("Continuation B after preparation");
+    expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationAfterPreparation);
     expect(Object.values(useComposerStateStore.getState().failedDrafts).flat().map((item) => item.draft)).toEqual([
-      "First [pasted text handoff]",
+      "First [pasted text handoff][attachment scoped-image]",
     ]);
+    expect(Object.values(useComposerStateStore.getState().failedDrafts).flat()[0]?.attachments[0]?.file).toBe(scopedFile);
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, ""));
+    await act(async () => {
+      const restore = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent === "Restore unsent message");
+      expect(restore?.disabled).toBe(false);
+      restore?.click();
+    });
+    expect(useComposerStateStore.getState().sessions[sessionId]?.attachments[0]?.file).toBe(scopedFile);
 
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
     let creation = Promise.withResolvers<void>();

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -10,6 +10,10 @@ import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import type { ComposerAttachment, ComposerDraft } from "../src/app/types";
 import type { CloudMcpSubmissionResult } from "../src/react-app/domains/connections/cloud-mcp-submit-readiness";
+import type {
+  NewTaskComposerContext,
+  NewTaskComposerHandoff,
+} from "../src/react-app/domains/session/chat/new-task-composer";
 
 const workspaceId = "workspace-focus-continuity";
 const sessionId = "session-focus-continuity";
@@ -34,6 +38,29 @@ function createSnapshot(status: SessionStatus, updated: number): OpenworkSession
     }],
     todos: [],
     status,
+  };
+}
+
+function newTaskComposerContext(draftOwnerKey: string): NewTaskComposerContext {
+  return {
+    client: null,
+    workspaceId: null,
+    draftOwnerKey,
+    selectedModel: { providerID: "test", modelID: "test-model" },
+    modelPickerOpen: false,
+    onModelPickerOpenChange: () => {},
+    onModelChange: () => {},
+    modelVariantLabel: "Default",
+    modelVariant: null,
+    onModelVariantChange: () => {},
+    agentLabel: "OpenWork",
+    selectedAgent: null,
+    listAgents: async () => [],
+    onSelectAgent: () => {},
+    listCommands: async () => [],
+    searchFiles: async () => [],
+    isRemoteWorkspace: false,
+    isSandboxWorkspace: false,
   };
 }
 
@@ -270,6 +297,11 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
       restore?.click();
     });
     expect(editor.textContent).toBe(draft);
+    const restoredRun = container.querySelector<HTMLButtonElement>('button[aria-label="Run task"]');
+    expect(container.textContent).toContain("Submission unavailable");
+    expect(restoredRun?.disabled).toBe(false);
+    expect(sentDrafts).toHaveLength(1);
+    expect(editor.textContent).toBe(draft);
 
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
     await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Dismiss error"]')?.click());
@@ -278,7 +310,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(editor.textContent).toBe(draft);
 
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
-    const { markComposerAutoSend } = await import("../src/react-app/domains/session/surface/composer-auto-send");
+    const { composerAutoSendScopeKey, markComposerAutoSend } = await import("../src/react-app/domains/session/surface/composer-auto-send");
     await act(async () => {
       markComposerAutoSend(sessionId);
       useComposerStateStore.getState().setDraft(sessionId, "First message auto-send");
@@ -344,15 +376,60 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(editor.textContent).toBe("Newer uncertain draft");
     expect(sentDrafts).toHaveLength(4);
 
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    const submittedComposer = {
+      draft: "First [pasted text handoff]",
+      attachments: [],
+      mentions: {},
+      pasteParts: [{ id: "submitted-paste", label: "handoff", text: "submitted body", lines: 1 }],
+      revertMessageId: null,
+    };
+    const continuationComposer = {
+      draft: "Continuation B",
+      attachments: [],
+      mentions: {},
+      pasteParts: [{ id: "continuation-paste", label: "handoff", text: "wrong continuation metadata", lines: 1 }],
+      revertMessageId: null,
+    };
+    await act(async () => {
+      markComposerAutoSend(sessionId, {
+        scopeKey: composerAutoSendScopeKey({
+          draftScope: "local",
+          opencodeBaseUrl: "http://127.0.0.1:1/opencode",
+          workspaceId,
+          sessionId,
+        }),
+        composer: submittedComposer,
+      });
+      useComposerStateStore.setState((state) => ({
+        sessions: { ...state.sessions, [sessionId]: continuationComposer },
+      }));
+    });
+    await waitFor(() => sentDrafts.length === 5, "scoped first-message auto-send");
+    expect(sentDrafts[4]?.resolvedText).toBe("First submitted body");
+    expect(editor.textContent).toBe("Continuation B");
+    expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationComposer);
+    await act(async () => submission.reject(new Error("Scoped submission unavailable")));
+    expect(editor.textContent).toBe("Continuation B");
+    expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationComposer);
+    expect(Object.values(useComposerStateStore.getState().failedDrafts).flat().map((item) => item.draft)).toEqual([
+      "First [pasted text handoff]",
+    ]);
+
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
     let creation = Promise.withResolvers<void>();
     let creations = 0;
+    let capturedHandoff: NewTaskComposerHandoff | null = null;
     let updateHeroDraft = (_text: string) => {};
+    let updateDraftOwner = (_owner: string) => {};
     function Hero() {
       const [text, setText] = useState("First hero message");
+      const [draftOwner, setDraftOwner] = useState("owner-a");
       updateHeroDraft = setText;
-      return <NewTaskComposer draft={text} onDraftChange={setText} busy={false} context={null} onRunTask={() => {
+      updateDraftOwner = setDraftOwner;
+      return <NewTaskComposer draft={text} onDraftChange={setText} busy={false} context={newTaskComposerContext(draftOwner)} onRunTask={(_resolved, _attachments, handoff) => {
         creations++;
+        capturedHandoff = handoff ?? null;
         return creation.promise;
       }} />;
     }
@@ -362,6 +439,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("");
     expect(container.querySelector('[data-message-role="user"]')?.textContent).toBe("First hero message");
     await act(async () => updateHeroDraft("Newer hero draft"));
+    expect(capturedHandoff?.getContinuation().draft).toBe("Newer hero draft");
     await act(async () => creation.reject(new Error("Session creation failed")));
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Newer hero draft");
     expect(container.textContent).toContain("Session creation failed");
@@ -387,6 +465,29 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     await act(async () => creation.reject(new Error("Image session creation failed")));
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toContain("First hero message");
     expect(container.querySelector('[data-attachment-id]')).not.toBeNull();
+
+    await act(async () => updateDraftOwner("owner-b"));
+    await waitFor(
+      () => container.querySelector('[data-lexical-editor="true"]')?.textContent === "",
+      "the next draft owner to start empty after attachment recovery",
+    );
+    creation = Promise.withResolvers<void>();
+    await act(async () => updateHeroDraft("Owner B submission"));
+    await act(async () => send());
+    expect(creations).toBe(3);
+    const ownerBHandoff = capturedHandoff;
+    if (!ownerBHandoff) throw new Error("Expected the owner B handoff");
+    await act(async () => updateHeroDraft("Owner B continuation"));
+    expect(ownerBHandoff.getContinuation().draft).toBe("Owner B continuation");
+    await act(async () => updateDraftOwner("owner-c"));
+    await waitFor(
+      () => container.querySelector('[data-lexical-editor="true"]')?.textContent === "",
+      "the new draft owner to start empty",
+    );
+    await act(async () => updateHeroDraft("Foreign owner draft"));
+    expect(ownerBHandoff.getContinuation().draft).toBe("Owner B continuation");
+    await act(async () => creation.resolve());
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Foreign owner draft");
   } finally {
     await act(async () => root.unmount());
     resetQueuedDrainForTests();

--- a/apps/app/tests/composer-state-store.test.ts
+++ b/apps/app/tests/composer-state-store.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { ComposerDraft } from "../src/app/types";
+import type { ComposerAttachment, ComposerDraft } from "../src/app/types";
+import {
+  consumeComposerAutoSend,
+  consumeComposerAutoSendPayload,
+  getComposerAutoSendPayload,
+  hasComposerAutoSend,
+  markComposerAutoSend,
+} from "../src/react-app/domains/session/surface/composer-auto-send";
 import {
   composerDraftNeedsHydration,
   getComposerQueuedDrafts,
   getComposerRevertMessageId,
+  type ComposerSessionState,
   useComposerStateStore,
 } from "../src/react-app/domains/session/surface/composer-state-store";
 
@@ -135,5 +143,63 @@ describe("composer state store", () => {
       currentText: storedText,
       storedText,
     })).toBe(true);
+  });
+
+  test("keeps auto-send payloads immutable and scoped while preserving legacy marks", () => {
+    const file = new File(["image"], "submitted.png", { type: "image/png" });
+    const attachment: ComposerAttachment = {
+      id: "attachment-a",
+      name: "submitted.png",
+      mimeType: "image/png",
+      size: file.size,
+      kind: "image",
+      file,
+      previewUrl: "blob:submitted-preview",
+    };
+    const submitted: ComposerSessionState = {
+      draft: "submitted",
+      attachments: [attachment],
+      mentions: { source: "file" },
+      pasteParts: [{ id: "paste-a", label: "A", text: "submitted paste", lines: 1 }],
+      revertMessageId: null,
+    };
+    markComposerAutoSend("scoped-session", { scopeKey: "owner-a", composer: submitted });
+    submitted.draft = "mutated after mark";
+    submitted.mentions.source = "app";
+    const submittedPaste = submitted.pasteParts[0];
+    if (!submittedPaste) throw new Error("Expected submitted paste metadata");
+    submittedPaste.text = "mutated paste";
+    attachment.name = "mutated.png";
+    attachment.previewUrl = "blob:mutated-preview";
+
+    expect(hasComposerAutoSend("scoped-session", "owner-b")).toBe(false);
+    expect(getComposerAutoSendPayload("scoped-session", "owner-b")).toBeNull();
+    expect(consumeComposerAutoSend("scoped-session", "owner-b")).toBe(false);
+    const capturedAttachment = getComposerAutoSendPayload("scoped-session", "owner-a")?.composer.attachments[0];
+    expect(capturedAttachment?.name).toBe("submitted.png");
+    expect(capturedAttachment?.previewUrl).toBe("blob:submitted-preview");
+    expect(capturedAttachment?.file).toBe(file);
+    expect(capturedAttachment).not.toBe(attachment);
+    expect(getComposerAutoSendPayload("scoped-session", "owner-a")?.composer.mentions.source).toBe("file");
+    expect(getComposerAutoSendPayload("scoped-session", "owner-a")?.composer.pasteParts[0]?.text).toBe("submitted paste");
+    markComposerAutoSend("scoped-session", {
+      scopeKey: "owner-b",
+      composer: { ...submitted, draft: "submitted by B" },
+    });
+    expect(hasComposerAutoSend("scoped-session")).toBe(false);
+    expect(consumeComposerAutoSend("scoped-session")).toBe(false);
+    expect(getComposerAutoSendPayload("scoped-session", "owner-a")?.composer.draft).toBe("submitted");
+    expect(getComposerAutoSendPayload("scoped-session", "owner-b")?.composer.draft).toBe("submitted by B");
+
+    markComposerAutoSend("scoped-session");
+    expect(hasComposerAutoSend("scoped-session")).toBe(true);
+    expect(getComposerAutoSendPayload("scoped-session", "owner-a")?.composer.draft).toBe("submitted");
+    expect(getComposerAutoSendPayload("scoped-session", "owner-b")?.composer.draft).toBe("submitted by B");
+    expect(consumeComposerAutoSend("scoped-session")).toBe(true);
+    expect(hasComposerAutoSend("scoped-session")).toBe(false);
+    expect(consumeComposerAutoSendPayload("scoped-session", "owner-a")?.composer.draft).toBe("submitted");
+    expect(getComposerAutoSendPayload("scoped-session", "owner-b")?.composer.draft).toBe("submitted by B");
+    expect(consumeComposerAutoSendPayload("scoped-session", "owner-b")?.composer.draft).toBe("submitted by B");
+    expect(hasComposerAutoSend("scoped-session")).toBe(false);
   });
 });

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { focusManager } from "@tanstack/react-query";
 import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, createPromptMessageID, hasAcceptedPromptMessage, unwrap, type FieldsResult } from "../src/app/lib/opencode";
@@ -6,6 +7,7 @@ import { interruptSessionTurn, sessionNeedsStop, submitAfterInterruption } from 
 import { createClientV2 } from "../src/app/lib/opencode-v2-adapter";
 import {
   composeNativeSessionSnapshot,
+  composeNativeSessionSnapshotWithRetry,
   deleteNativeSession,
   getNativeSession,
   getNativeSessionMessages,
@@ -203,6 +205,96 @@ describe("native OpenCode session operations", () => {
         todo: async () => failedResult({ code: "engine_unavailable" }, 503),
       }),
     })).rejects.toMatchObject({ status: 503, code: "engine_unavailable" });
+  });
+
+  test("retries a failed local snapshot read without waiting for query focus or issuing writes", async () => {
+    const calls: string[] = [];
+    const endpointTokens: string[] = [];
+    let currentEndpoint = endpoint;
+    let attempt = 0;
+    focusManager.setFocused(false);
+    try {
+      const snapshot = await composeNativeSessionSnapshotWithRetry("owner-a", () => ({
+        owner: "owner-a",
+        endpoint: currentEndpoint,
+        sessionId: session.id,
+      }), { limit: 140 }, {
+        createOperations: (target) => {
+          attempt += 1;
+          endpointTokens.push(target.token);
+          const track = <T>(name: string, value: FieldsResult<T>) => {
+            calls.push(name);
+            return Promise.resolve(value);
+          };
+          return operations({
+            get: async () => track("get", attempt === 1
+              ? failedResult({ code: "engine_reloading" }, 503)
+              : result(session)),
+            messages: async () => track("messages", result(messages)),
+            todo: async () => track("todo", result(todos)),
+            status: async () => track("status", result<Record<string, SessionStatus>>({})),
+            delete: async () => {
+              calls.push("delete");
+              return result(true);
+            },
+          });
+        },
+        waitForSnapshotRetry: async () => {
+          currentEndpoint = { ...endpoint, token: "rotated-workspace-token" };
+        },
+      });
+
+      expect(snapshot.session.id).toBe(session.id);
+      expect(attempt).toBe(2);
+      expect(endpointTokens).toEqual([endpoint.token, "rotated-workspace-token"]);
+      expect(calls).toEqual(["get", "messages", "todo", "status", "get", "messages", "todo", "status"]);
+      expect(calls).not.toContain("delete");
+      expect(calls).not.toContain("prompt");
+    } finally {
+      focusManager.setFocused(undefined);
+    }
+  });
+
+  test("rejects the final local snapshot read error after four attempts", async () => {
+    let attempt = 0;
+    const delays: number[] = [];
+    const promise = composeNativeSessionSnapshotWithRetry("owner-a", () => ({
+      owner: "owner-a",
+      endpoint,
+      sessionId: session.id,
+    }), {}, {
+      createOperations: () => {
+        attempt += 1;
+        return operations({
+          get: async () => failedResult({ code: `engine_unavailable_${attempt}` }, 503),
+        });
+      },
+      waitForSnapshotRetry: async (delayMs) => { delays.push(delayMs); },
+    });
+
+    await expect(promise).rejects.toMatchObject({ status: 503, code: "engine_unavailable_4" });
+    expect(attempt).toBe(4);
+    expect(delays).toEqual([100, 250, 500]);
+  });
+
+  test("aborting a local snapshot retry prevents the next read attempt", async () => {
+    const controller = new AbortController();
+    const aborted = new Error("snapshot read cancelled");
+    let attempt = 0;
+    const promise = composeNativeSessionSnapshotWithRetry("owner-a", () => ({
+      owner: "owner-a",
+      endpoint,
+      sessionId: session.id,
+    }), { signal: controller.signal }, {
+      createOperations: () => {
+        attempt += 1;
+        return operations({ get: async () => failedResult({ code: "engine_reloading" }, 503) });
+      },
+      waitForSnapshotRetry: async () => { controller.abort(aborted); },
+    });
+
+    await expect(promise).rejects.toBe(aborted);
+    expect(attempt).toBe(1);
   });
 });
 

--- a/evals/packages/cdp/src/browser-globals.d.ts
+++ b/evals/packages/cdp/src/browser-globals.d.ts
@@ -36,6 +36,22 @@ declare global {
       };
     };
     __openwork: {
+      slice(name: "composer"): {
+        snapshotQuery: {
+          status: "pending" | "error" | "success";
+          fetchStatus: "fetching" | "paused" | "idle";
+          isPaused: boolean;
+          failureCount: number;
+          errorName: string | null;
+          errorMessage: string | null;
+          dataSessionId: string | null;
+          dataMessageCount: number | null;
+          currentSnapshotId: string | null;
+          intendedSessionId: string;
+          opencodeBaseUrl: { origin: string | null; pathname: string | null };
+          tokenPresent: boolean;
+        };
+      };
       slice(name: "route"): {
         selectedWorkspaceId: string | null;
         workspaces: { id: string; name?: string; displayName?: string; displayNameResolved?: string; loading?: boolean; error?: string | null }[];

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -7,6 +7,7 @@ const definitions = {
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
   'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },
+  'workspace-new-task-hit-target.e2e.test.ts': { name: 'Keep new tasks and sends instantly responsive', placement: 'local' },
 };
 
 export async function catalog(root = new URL('../specs/', import.meta.url)) {

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -45,6 +45,12 @@ test('changed additional journey joins critical selection; manual filters work f
   const handoff = selectJourneys(entries, { only: 'cross-server-handoff-atomic-commit' });
   assert.equal(handoff.length, 1);
   assert.equal(handoff[0].placement, 'local');
+  const instantSend = selectJourneys(entries, { only: 'workspace-new-task-hit-target' });
+  assert.equal(instantSend.length, 1);
+  assert.equal(instantSend[0].name, 'Keep new tasks and sends instantly responsive');
+  assert.equal(instantSend[0].placement, 'local');
+  assert.equal(instantSend[0].model, 'mock');
+  assert.equal(instantSend[0].critical, false);
   assert.equal(selectJourneys(entries, { only: 'does-not-exist' }).length, 0);
 });
 

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -3,105 +3,707 @@ import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { workspaceNewTask } from "../worlds/session-shell.ts";
 
-const test = spec.world(workspaceNewTask);
+const sampleCount = 12;
+const newTaskLimitMs = 500;
+const sendLimitMs = 100;
+const boundaryHoldMs = 1_500;
+const test = spec.world(workspaceNewTask, { timeout: 900_000 });
+
+type TimingSample = {
+  index: number;
+  elapsedMs: number | null;
+  trusted: boolean;
+  frames: number;
+  mutations: number;
+  consecutiveFrames: number;
+  beforeEngine: boolean;
+  firstHoldMs: number;
+  secondHoldMs: number;
+  firstHeldCount: number;
+  secondHeldCount: number;
+  exact: boolean;
+  typedWithoutClick: boolean;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-test("workspace New task opens an editable composer immediately and creates one task on submit", async ({ world, user, agent, probe, step, evidence }) => {
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function occurrences(text: string, marker: string): number {
+  return marker ? text.split(marker).length - 1 : 0;
+}
+
+function percentile(values: readonly number[], fraction: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? null;
+}
+
+function timingReport(samples: readonly TimingSample[]) {
+  const completed = samples.flatMap((sample) => sample.elapsedMs === null ? [] : [sample.elapsedMs]);
+  const value = (number: number | null) => number === null ? null : round(number);
+  return {
+    count: samples.length,
+    failures: samples.filter((sample) => sample.elapsedMs === null).map((sample) => sample.index),
+    p50Ms: value(percentile(completed, 0.5)),
+    p95Ms: value(percentile(completed, 0.95)),
+    maxMs: value(completed.length === 0 ? null : Math.max(...completed)),
+    samples: samples.map((sample) => ({
+      i: sample.index,
+      ms: value(sample.elapsedMs),
+      beforeEngine: sample.beforeEngine,
+      holds: [{ count: sample.firstHeldCount, ms: round(sample.firstHoldMs) }, { count: sample.secondHeldCount, ms: round(sample.secondHoldMs) }],
+      trusted: sample.trusted,
+      frames: sample.frames,
+      consecutiveFrames: sample.consecutiveFrames,
+      mutations: sample.mutations,
+      exact: sample.exact,
+      typedWithoutClick: sample.typedWithoutClick,
+    })),
+  };
+}
+
+test("workspace New task is instantly typable and every v1 send paints before engine work", async ({ world, user, agent, probe, step, evidence }) => {
+  await using faults = world.boundary;
   const workspaceName = world.workspacePath.split("/").at(-1) ?? world.workspacePath;
-  await user.hover({ role: "button", label: workspaceName });
+  const newTaskSamples: TimingSample[] = [];
+  const lazySendSamples: TimingSample[] = [];
+  const existingSendSamples: TimingSample[] = [];
+  const typingDiagnostics: { index: number; beforeText: string; afterText: string }[] = [];
+  let lastFaultCounts = { creation: 0, prompt: 0 };
+  const negatives = {
+    rapidDuplicateEnter: false,
+    successDraftB: false,
+    creationFailureComposerReady: false,
+    creationFailureARecoverable: false,
+    creationFailureDraftBSurvives: false,
+    creationFailureNoFallbackSession: false,
+    promptFailureComposerReady: false,
+    promptFailureARecoverable: false,
+    promptFailureDraftBSurvives: false,
+    promptFailureNoFallbackSession: false,
+    navigationIsolation: false,
+    responseSseReconciliation: false,
+    exactAfterReload: false,
+  };
 
-  await step("the plus remains the topmost hit target", async () => {
-    // TODO(primitive): probe.hitTarget should identify the painted element at a visible control's center.
-    const hit = await probe.eval(browserScript((workspaceId) => {
-      const plus = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`);
-      if (!(plus instanceof HTMLElement)) return { hitPlus: false, hitTitle: false, tag: "" };
-      const rect = plus.getBoundingClientRect();
-      const node = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
-      const title = plus.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>(".ow-fade-truncate");
-      return {
-        hitPlus: plus.contains(node),
-        hitTitle: Boolean(title && node instanceof Node && title.contains(node)),
-        tag: node instanceof Element ? node.tagName.toLowerCase() : "",
-      };
-    }, [world.workspace.workspaceId]));
-    if (!isRecord(hit)) throw new Error(`New task plus returned malformed hit facts: ${JSON.stringify(hit)}`);
-    expect(hit.hitPlus).toBe(true);
-    expect(hit.hitTitle).toBe(false);
-    evidence.recordAssertionEvidence(
-      "The workspace New task plus remains clickable over a long workspace name",
-      "The painted element at the plus center belongs to the plus, not the truncated title.", true,
-    );
-  });
-
-  const before = (await agent.list()).map((session) => session.sessionId).sort();
-  const requests = () => probe.eval(() => (window.__newTaskRequests));
-  // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
-  const expandedBefore = await probe.eval(browserScript((workspaceId) => (document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`)
-    ?.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>("[aria-expanded]")?.getAttribute("aria-expanded")), [world.workspace.workspaceId]));
-  // TODO(primitive): probe.paintTiming should measure input-to-visible-content in the renderer.
-  await probe.eval(browserScript((workspaceId) => {
-    const button = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`);
-    if (!button) throw new Error("Missing new task button");
-    button.addEventListener("click", () => {
-      const started = performance.now();
-      const observer = new MutationObserver(() => {
-        const heading = [...document.querySelectorAll<HTMLElement>("h2")]
-          .find((node) => node.textContent === "What do you need done?" && node.getClientRects().length);
-        if (!heading) return;
-        window.__newTaskOpenedAfterMs = performance.now() - started;
-        observer.disconnect();
-      });
-      observer.observe(document.body, { subtree: true, childList: true });
-    }, { once: true, capture: true });
+  const sessionTarget = async (sessionId: string): Promise<{ role: "button"; label: string; nth: number }> => {
+    const target = await probe.eventually(() => probe.eval(browserScript((sessionId) => {
+      const row = document.querySelector<HTMLElement>(`[data-session-tab-id="${sessionId}"]`);
+      row?.scrollIntoView({ block: "center" });
+      const label = row?.getAttribute("aria-label") ?? "";
+      const candidates = [...document.querySelectorAll<HTMLElement>('button, [role="button"]')]
+        .filter((node) => node.getAttribute("aria-label") === label);
+      return { label, nth: row ? candidates.indexOf(row) : -1 };
+    }, [sessionId])), {
+      within: 15_000,
+      label: `session ${sessionId} has a native sidebar target`,
+      until: (value) => value.label.length > 0 && value.nth >= 0,
+    });
+    return { role: "button", label: target.label, nth: target.nth };
+  };
+  const activeSessionId = () => probe.eval(browserScript((workspaceId) => {
+    if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) return "";
+    const persistedPrefix = `#/workspace/${workspaceId}/session/`;
+    if (!location.hash.startsWith(persistedPrefix)) return "";
+    const sessionId = location.hash.slice(persistedPrefix.length);
+    if (!sessionId.startsWith("ses_") || /[/?#]/.test(sessionId)) return "";
+    const visible = (node: HTMLElement) => {
+      const rect = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+        && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
+        && style.display !== "none" && style.visibility !== "hidden";
+    };
+    const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')].find(visible);
+    const ownsRoute = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+      .some((surface) => surface.dataset.sessionSurfaceId === sessionId && visible(surface));
+    return ownsRoute ? sessionId : "";
   }, [world.workspace.workspaceId]));
-  await user.click({ role: "button", label: `New session · ${workspaceName}` });
-  await user.see({ text: "What do you need done?" });
-  const openedAfterMs = await probe.eval(() => (window.__newTaskOpenedAfterMs));
-  expect(openedAfterMs).toBeLessThan(1000);
-  expect(await probe.hash()).not.toContain("/session/ses_");
-  expect(await requests()).toEqual([]);
-  expect((await agent.list()).map((session) => session.sessionId).sort()).toEqual(before);
-  evidence.recordAssertionEvidence(
-    "New task opens without waiting for engine session creation",
-    `The visible composer appeared ${openedAfterMs} ms after clicking; the limit was 1000 ms. Session POSTs were delayed 5000 ms, but opening issued none and left all existing session IDs unchanged.`, true,
-  );
-
-  await step("the empty composer accepts and keeps a draft without creating a session", async () => {
-    await user.type({ placeholder: "Describe your task..." }, world.prompt, { verify: true });
-    await user.hover({ role: "button", label: workspaceName });
-    await user.click({ role: "button", label: `New session · ${workspaceName}` });
-    expect(await probe.eval(() => (document.querySelector<HTMLElement>('[contenteditable="true"]')?.textContent))).toBe(world.prompt);
-    expect(await requests()).toEqual([]);
-    evidence.recordAssertionEvidence(
-      "The empty composer accepts a draft and preserves it on another New task click",
-      "Typing was verified in the visible editor; clicking New task again retained the exact draft text and still issued no session creation request.", true,
-    );
-  });
-  await user.see({ text: "New task model" });
-  await user.click({ placeholder: "Describe your task..." });
-  await user.press("Enter");
-  await probe.eventually(() => agent.list(), {
+  const openSession = async (session: { sessionId: string }) => {
+    if (await activeSessionId() !== session.sessionId) await user.click(await sessionTarget(session.sessionId));
+    await probe.eventually(activeSessionId, {
+      within: 30_000,
+      label: `session ${session.sessionId} owns the primary pane`,
+      until: (sessionId) => sessionId === session.sessionId,
+    });
+  };
+  const expanded = () => probe.eval(browserScript((workspaceId) => document
+    .querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`)
+    ?.closest("[data-workspace-actions]")?.parentElement
+    ?.querySelector<HTMLElement>("[aria-expanded]")?.getAttribute("aria-expanded") ?? null, [world.workspace.workspaceId]));
+  const visibleFacts = (marker: string) => probe.eval(browserScript((marker, workspaceId) => {
+    const visible = (node: HTMLElement) => {
+      const rect = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+        && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
+        && style.display !== "none" && style.visibility !== "hidden";
+    };
+    let root: HTMLElement | null = null;
+    if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId) {
+      const sessionlessRoute = `#/workspace/${workspaceId}/session`;
+      if (location.hash === sessionlessRoute) {
+        const heading = [...document.querySelectorAll<HTMLElement>("h2")]
+          .find((candidate) => candidate.textContent?.trim() === "What do you need done?" && visible(candidate));
+        const headingMain = heading?.closest<HTMLElement>("main") ?? null;
+        const main = headingMain && visible(headingMain) ? headingMain
+          : [...document.querySelectorAll<HTMLElement>("main")].filter(visible)
+              .find((candidate) => [...candidate.querySelectorAll<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"], [data-message-role]')]
+                .some(visible)) ?? null;
+        const persistedSurfaceVisible = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")].some(visible);
+        if (main && !persistedSurfaceVisible) root = main;
+      } else {
+        const persistedPrefix = `#/workspace/${workspaceId}/session/`;
+        const sessionId = location.hash.startsWith(persistedPrefix) ? location.hash.slice(persistedPrefix.length) : "";
+        if (sessionId.startsWith("ses_") && !/[/?#]/.test(sessionId)) {
+          const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')].find(visible) ?? null;
+          const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+            .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId && visible(candidate));
+          if (pane && surface) root = pane;
+        }
+      }
+    }
+    const editor = root?.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]');
+    const rows = [...(root?.querySelectorAll<HTMLElement>('[data-message-role="user"]') ?? [])]
+      .filter((row) => visible(row) && row.innerText.includes(marker)
+        && !(editor && (editor.contains(row) || row.contains(editor))));
+    return {
+      rowCount: rows.length,
+      markerOccurrences: marker ? rows.reduce((total, row) => total + row.innerText.split(marker).length - 1, 0) : 0,
+      composerText: editor?.innerText ?? "",
+      composerEditable: Boolean(editor?.isContentEditable),
+      focusedEditor: Boolean(editor && (document.activeElement === editor || editor.contains(document.activeElement))),
+      sessionId: root?.querySelector<HTMLElement>("[data-session-surface-id]")?.dataset.sessionSurfaceId ?? "",
+      route: location.hash,
+    };
+  }, [marker, world.workspace.workspaceId]));
+  const surfaceContains = (text: string) => probe.eval(browserScript((text, workspaceId) => {
+    const visible = (node: HTMLElement) => {
+      const rect = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+        && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
+        && style.display !== "none" && style.visibility !== "hidden";
+    };
+    if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) return false;
+    let root: HTMLElement | null = null;
+    const sessionlessRoute = `#/workspace/${workspaceId}/session`;
+    if (location.hash === sessionlessRoute) {
+      const heading = [...document.querySelectorAll<HTMLElement>("h2")]
+        .find((candidate) => candidate.textContent?.trim() === "What do you need done?" && visible(candidate));
+      const headingMain = heading?.closest<HTMLElement>("main") ?? null;
+      const main = headingMain && visible(headingMain) ? headingMain
+        : [...document.querySelectorAll<HTMLElement>("main")].filter(visible)
+            .find((candidate) => [...candidate.querySelectorAll<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"], [data-message-role]')]
+              .some(visible)) ?? null;
+      const persistedSurfaceVisible = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")].some(visible);
+      if (main && !persistedSurfaceVisible) root = main;
+    } else {
+      const persistedPrefix = `#/workspace/${workspaceId}/session/`;
+      const sessionId = location.hash.startsWith(persistedPrefix) ? location.hash.slice(persistedPrefix.length) : "";
+      if (sessionId.startsWith("ses_") && !/[/?#]/.test(sessionId)) {
+        const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')].find(visible) ?? null;
+        const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+          .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId && visible(candidate));
+        if (pane && surface) root = pane;
+      }
+    }
+    return root?.innerText.includes(text) ?? false;
+  }, [text, world.workspace.workspaceId]));
+  const accessibleRunTask = () => probe.eventually(() => world.accessibleRunTaskReady(), {
+    within: 15_000,
+    label: "the current pane exposes an enabled, native-accessible Run task control",
+    until: (ready) => ready,
+  }).then(() => true, () => false);
+  const waitReply = (reply: string) => probe.eventually(() => surfaceContains(reply), {
     within: 60_000,
-    label: "submitting creates exactly one session after the slow engine responds",
-    until: (sessions) => sessions.length === before.length + 1,
+    label: `the deterministic v1 reply ${reply.slice(0, 32)} is visible`,
+    until: (visible) => visible,
   });
-  await user.see({ text: world.reply });
-  expect(await probe.hash()).toContain("/session/ses_");
-  const creationRequests = await requests();
-  expect(Array.isArray(creationRequests) && creationRequests.length).toBe(1);
-  expect(JSON.stringify(creationRequests)).toContain(world.workspace.workspaceId);
-  const after = (await agent.list()).map((session) => session.sessionId);
-  expect(after.length).toBe(before.length + 1);
-  expect(after).toEqual(expect.arrayContaining(before));
-  // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
-  const expandedAfter = await probe.eval(browserScript((workspaceId) => (document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`)
-    ?.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>("[aria-expanded]")?.getAttribute("aria-expanded")), [world.workspace.workspaceId]));
-  expect(expandedAfter).toBe(expandedBefore);
-  evidence.recordAssertionEvidence(
-    "Submitting creates exactly one task in the intended workspace and receives the mock reply",
-    "The mock model was visible before submission and its reply appeared afterward. Exactly one session POST targeted the selected workspace, one session was added, every existing session remained, and the workspace expansion state was unchanged.", true,
-  );
+  const waitBackendMarker = (sessionId: string, marker: string) => probe.eventually(() => world.messageFacts(sessionId, marker), {
+    within: 30_000,
+    label: `the real v1 transcript contains one ${marker.slice(0, 32)} turn`,
+    until: (facts) => facts.markerOccurrences > 0,
+  });
+  const readFaults = () => {
+    lastFaultCounts = faults.read();
+    return lastFaultCounts;
+  };
+  type Gate = ReturnType<typeof faults.holdNext>;
+  const waitHeld = (gate: Gate) => probe.eventually(() => gate.read(), {
+    within: 20_000,
+    label: `${gate.read().kind} ${gate.read().stage} is held for ${boundaryHoldMs} ms`,
+    until: (state) => state.held > 0 && state.elapsedMs >= boundaryHoldMs,
+  });
+  type RendererObserver = Awaited<ReturnType<typeof world.observeRenderer>>;
+  const waitRenderer = (observer: RendererObserver) => probe.eventually(() => observer.read(), {
+    within: 12_000,
+    label: "two consecutive renderer frames observe the target",
+    until: (state) => state.elapsedMs !== null || state.expired,
+  });
+  const sample = (
+    index: number,
+    state: Awaited<ReturnType<RendererObserver["read"]>>,
+    options: Partial<Pick<TimingSample, "beforeEngine" | "firstHoldMs" | "secondHoldMs" | "firstHeldCount" | "secondHeldCount" | "exact" | "typedWithoutClick">> = {},
+  ): TimingSample => ({
+    index,
+    elapsedMs: state.elapsedMs,
+    trusted: state.trusted,
+    frames: state.frames,
+    mutations: state.mutations,
+    consecutiveFrames: state.consecutiveFrames,
+    beforeEngine: options.beforeEngine ?? true,
+    firstHoldMs: options.firstHoldMs ?? 0,
+    secondHoldMs: options.secondHoldMs ?? 0,
+    firstHeldCount: options.firstHeldCount ?? 0,
+    secondHeldCount: options.secondHeldCount ?? 0,
+    exact: options.exact ?? true,
+    typedWithoutClick: options.typedWithoutClick ?? true,
+  });
+  const updateRendererSample = (entry: TimingSample, state: Awaited<ReturnType<RendererObserver["read"]>>) => {
+    entry.elapsedMs = state.elapsedMs;
+    entry.trusted = state.trusted;
+    entry.frames = state.frames;
+    entry.mutations = state.mutations;
+    entry.consecutiveFrames = state.consecutiveFrames;
+  };
+  const pendingMeasurement: { current: { observer: RendererObserver; sample: TimingSample } | null } = { current: null };
+  let journeyCompleted = false;
+  let diagnosticError: string | null = null;
+
+  try {
+    await user.hover({ role: "button", label: workspaceName });
+    await step("the plus remains the topmost hit target over the long workspace name", async () => {
+      const hit = await probe.eval(browserScript((workspaceId) => {
+        const plus = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`);
+        if (!(plus instanceof HTMLElement)) return { hitPlus: false, hitTitle: false, tag: "" };
+        const rect = plus.getBoundingClientRect();
+        const node = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        const title = plus.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>(".ow-fade-truncate");
+        return {
+          hitPlus: plus.contains(node),
+          hitTitle: Boolean(title && node instanceof Node && title.contains(node)),
+          tag: node instanceof Element ? node.tagName.toLowerCase() : "",
+        };
+      }, [world.workspace.workspaceId]));
+      if (!isRecord(hit)) throw new Error(`New task plus returned malformed hit facts: ${JSON.stringify(hit)}`);
+      expect(hit.hitPlus).toBe(true);
+      expect(hit.hitTitle).toBe(false);
+      evidence.recordAssertionEvidence(
+        "The workspace New task plus remains clickable over a long workspace name",
+        "The painted element at the plus center belongs to the plus, not the truncated title.", true,
+      );
+    });
+
+    const expandedBefore = await expanded();
+    await user.see({ text: world.existingHistory });
+
+    await step("twelve populated-session New task clicks and twelve lazy first sends retain every renderer sample", async () => {
+      for (let index = 0; index < sampleCount; index += 1) {
+        const scenario = world.lazySamples[index];
+        if (!scenario) throw new Error(`Missing lazy sample ${index + 1}`);
+        await openSession(world.existing);
+        await user.see({ text: world.existingHistory });
+        const serverBeforeOpen = await world.sessionIds();
+        const agentBeforeOpen = (await agent.list()).map((session) => session.sessionId).sort();
+        const requestsBeforeOpen = readFaults();
+        await user.hover({ role: "button", label: workspaceName });
+        const readyObserver = await world.observeRenderer("new-task");
+        await user.click({ role: "button", label: `New session · ${workspaceName}` });
+        const readySample = sample(index + 1, await readyObserver.read(), { exact: false, typedWithoutClick: false });
+        newTaskSamples.push(readySample);
+        pendingMeasurement.current = { observer: readyObserver, sample: readySample };
+        const ready = await waitRenderer(readyObserver);
+        updateRendererSample(readySample, ready);
+        await readyObserver[Symbol.asyncDispose]();
+        pendingMeasurement.current = null;
+        const serverAfterOpen = await world.sessionIds();
+        const agentAfterOpen = (await agent.list()).map((session) => session.sessionId).sort();
+        const requestsAfterOpen = readFaults();
+        const openingStayedLazy = JSON.stringify(serverAfterOpen) === JSON.stringify(serverBeforeOpen)
+          && JSON.stringify(agentAfterOpen) === JSON.stringify(agentBeforeOpen)
+          && requestsAfterOpen.creation === requestsBeforeOpen.creation
+          && requestsAfterOpen.prompt === requestsBeforeOpen.prompt
+          && !(await probe.hash()).includes("/session/ses_");
+        if (index === 0) await user.see({ text: "What do you need done?" });
+        const typed = await world.insertFocusedText(scenario.marker);
+        typingDiagnostics.push({ index: index + 1, beforeText: typed.beforeText, afterText: typed.afterText });
+        const normalizedBeforeText = /^\s*$/.test(typed.beforeText) ? "" : typed.beforeText;
+        const typedWithoutClick = normalizedBeforeText === "" && typed.afterText === scenario.marker;
+        readySample.exact = openingStayedLazy;
+        readySample.typedWithoutClick = typedWithoutClick;
+
+        const requestBeforeSend = readFaults();
+        const createGate = faults.holdNext("creation", "request");
+        const promptGate = faults.holdNext("prompt", "request");
+        const rowObserver = await world.observeRenderer("user-row", scenario.marker);
+        await user.press("Enter");
+        if (index === 0) await user.press("Enter");
+        const lazySample = sample(index + 1, await rowObserver.read(), {
+          beforeEngine: false,
+          exact: false,
+          typedWithoutClick,
+        });
+        lazySendSamples.push(lazySample);
+        pendingMeasurement.current = { observer: rowObserver, sample: lazySample };
+        const creationHeld = await waitHeld(createGate);
+        const beforeEngineState = await rowObserver.read();
+        updateRendererSample(lazySample, beforeEngineState);
+        lazySample.beforeEngine = beforeEngineState.elapsedMs !== null && beforeEngineState.elapsedMs < sendLimitMs;
+        lazySample.firstHoldMs = creationHeld.elapsedMs;
+        lazySample.firstHeldCount = creationHeld.held;
+        const heldInventory = await world.sessionIds();
+        let successDraftTyped = true;
+        if (index === 0) {
+          const draft = await world.insertFocusedText(world.failure.pendingB);
+          successDraftTyped = draft.afterText.endsWith(world.failure.pendingB);
+        }
+        await createGate.release();
+        const createdIds = await probe.eventually(async () => (await world.sessionIds())
+          .filter((sessionId) => !serverBeforeOpen.includes(sessionId)), {
+          within: 30_000,
+          label: `lazy sample ${index + 1} creates a real v1 session after release`,
+          until: (sessionIds) => sessionIds.length > 0,
+        });
+        const createdSessionId = createdIds[0];
+        if (!createdSessionId) throw new Error(`Lazy sample ${index + 1} did not expose its created session id.`);
+        const promptHeld = await waitHeld(promptGate);
+        lazySample.secondHoldMs = promptHeld.elapsedMs;
+        lazySample.secondHeldCount = promptHeld.held;
+        const backendBeforePromptRelease = await Promise.all(createdIds.map((sessionId) => world.messageFacts(sessionId, scenario.marker)));
+        await promptGate.release();
+        await waitReply(scenario.reply);
+        const rendered = await waitRenderer(rowObserver);
+        updateRendererSample(lazySample, rendered);
+        await rowObserver[Symbol.asyncDispose]();
+        pendingMeasurement.current = null;
+        const active = await activeSessionId();
+        const visible = await visibleFacts(scenario.marker);
+        const backend = await probe.eventually(() => Promise.all(createdIds.map((sessionId) => world.messageFacts(sessionId, scenario.marker))), {
+          within: 30_000,
+          label: `lazy sample ${index + 1} reaches one real v1 transcript`,
+          until: (facts) => facts.reduce((total, entry) => total + entry.markerOccurrences, 0) > 0,
+        });
+        const requestAfterSend = readFaults();
+        const serverAfterSend = await world.sessionIds();
+        const exact = createdIds.length === 1
+          && heldInventory.length === serverBeforeOpen.length
+          && backendBeforePromptRelease.every((facts) => facts.markerCount === 0 && facts.markerOccurrences === 0)
+          && backend.reduce((total, facts) => total + facts.markerCount, 0) === 1
+          && backend.reduce((total, facts) => total + facts.markerOccurrences, 0) === 1
+          && requestAfterSend.creation - requestBeforeSend.creation === 1
+          && requestAfterSend.prompt - requestBeforeSend.prompt === 1
+          && serverAfterSend.length === serverBeforeOpen.length + 1
+          && active === createdSessionId
+          && visible.rowCount === 1 && visible.markerOccurrences === 1;
+        lazySample.exact = exact;
+
+        if (index === 0) {
+          const draftAfterSuccess = await visibleFacts(world.failure.pendingB);
+          negatives.successDraftB = successDraftTyped && draftAfterSuccess.composerText === world.failure.pendingB;
+          negatives.rapidDuplicateEnter = exact && createGate.read().held === 1 && promptGate.read().held === 1;
+          await user.reload();
+          await probe.eventually(activeSessionId, {
+            within: 30_000,
+            label: "the first lazy session remains selected after reload",
+            until: (sessionId) => sessionId === createdSessionId,
+          });
+          const reloaded = await visibleFacts(scenario.marker);
+          const afterReloadRequests = readFaults();
+          const reloadedBackend = await probe.eventually(() => world.messageFacts(createdSessionId, scenario.marker), {
+            within: 30_000,
+            label: `reloaded v1 transcript ${createdSessionId} is readable with exactly one marker`,
+            until: (facts) => facts.markerCount === 1 && facts.markerOccurrences === 1,
+          });
+          negatives.exactAfterReload = reloaded.rowCount === 1
+            && reloaded.markerOccurrences === 1
+            && afterReloadRequests.creation - requestBeforeSend.creation === 1
+            && afterReloadRequests.prompt - requestBeforeSend.prompt === 1
+            && reloadedBackend.markerCount === 1 && reloadedBackend.markerOccurrences === 1;
+        }
+      }
+    });
+
+    await step("twelve existing-session sends paint before each real prompt request", async () => {
+      await openSession(world.existing);
+      for (let index = 0; index < sampleCount; index += 1) {
+        const scenario = world.existingSamples[index];
+        if (!scenario) throw new Error(`Missing existing-session sample ${index + 1}`);
+        await user.type({ placeholder: "Describe your task..." }, scenario.marker, { replace: true, verify: true });
+        const requestBefore = readFaults();
+        const inventoryBefore = await world.sessionIds();
+        const promptGate = faults.holdNext("prompt", "request");
+        const rowObserver = await world.observeRenderer("user-row", scenario.marker);
+        await user.press("Enter");
+        const existingSample = sample(index + 1, await rowObserver.read(), { beforeEngine: false, exact: false });
+        existingSendSamples.push(existingSample);
+        pendingMeasurement.current = { observer: rowObserver, sample: existingSample };
+        const held = await waitHeld(promptGate);
+        const beforeEngineState = await rowObserver.read();
+        updateRendererSample(existingSample, beforeEngineState);
+        existingSample.beforeEngine = beforeEngineState.elapsedMs !== null && beforeEngineState.elapsedMs < sendLimitMs;
+        existingSample.firstHoldMs = held.elapsedMs;
+        existingSample.firstHeldCount = held.held;
+        const backendBefore = await world.messageFacts(world.existing.sessionId, scenario.marker);
+        await promptGate.release();
+        await waitReply(scenario.reply);
+        const rendered = await waitRenderer(rowObserver);
+        updateRendererSample(existingSample, rendered);
+        await rowObserver[Symbol.asyncDispose]();
+        pendingMeasurement.current = null;
+        const backendAfter = await waitBackendMarker(world.existing.sessionId, scenario.marker);
+        const visible = await visibleFacts(scenario.marker);
+        const requestAfter = readFaults();
+        const inventoryAfter = await world.sessionIds();
+        existingSample.exact = backendBefore.markerCount === 0 && backendBefore.markerOccurrences === 0
+          && backendAfter.markerCount === 1 && backendAfter.markerOccurrences === 1
+          && visible.rowCount === 1 && visible.markerOccurrences === 1
+          && requestAfter.prompt - requestBefore.prompt === 1
+          && requestAfter.creation === requestBefore.creation
+          && JSON.stringify(inventoryAfter) === JSON.stringify(inventoryBefore);
+      }
+    });
+
+    await step("creation and prompt failures preserve submitted work and the next draft", async () => {
+      await openSession(world.existing);
+      const beforeCreationFailure = await world.sessionIds();
+      const creationRequestsBefore = readFaults();
+      await user.hover({ role: "button", label: workspaceName });
+      await user.click({ role: "button", label: `New session · ${workspaceName}` });
+      await probe.eventually(() => visibleFacts(""), {
+        within: 10_000,
+        label: "failed-creation composer is focused",
+        until: (facts) => facts.focusedEditor,
+      });
+      await world.insertFocusedText(world.failure.creationA);
+      const creationGate = faults.holdNext("creation", "request");
+      const creationRow = await world.observeRenderer("user-row", world.failure.creationA);
+      await user.press("Enter");
+      await waitHeld(creationGate);
+      await world.insertFocusedText(world.failure.creationB);
+      await creationGate.fail();
+      const creationRunTask = await accessibleRunTask();
+      const creationFacts = await probe.eventually(() => visibleFacts(world.failure.creationA), {
+        within: 15_000,
+        label: "creation failure keeps the current pane editable with draft B",
+        until: (facts) => facts.composerEditable && occurrences(facts.composerText, world.failure.creationB) === 1,
+      }).catch(() => visibleFacts(world.failure.creationA));
+      const afterCreationFailure = await world.sessionIds();
+      const creationRequestsAfter = readFaults();
+      negatives.creationFailureComposerReady = creationRunTask && creationFacts.composerEditable;
+      negatives.creationFailureARecoverable = (creationFacts.rowCount === 1 && creationFacts.markerOccurrences === 1)
+        || occurrences(creationFacts.composerText, world.failure.creationA) === 1;
+      negatives.creationFailureDraftBSurvives = occurrences(creationFacts.composerText, world.failure.creationB) === 1;
+      negatives.creationFailureNoFallbackSession = !creationFacts.route.includes("/session/ses_")
+        && JSON.stringify(afterCreationFailure) === JSON.stringify(beforeCreationFailure)
+        && creationRequestsAfter.creation - creationRequestsBefore.creation === 1
+        && creationRequestsAfter.prompt === creationRequestsBefore.prompt;
+      await creationRow[Symbol.asyncDispose]();
+
+      await openSession(world.existing);
+      await user.type({ placeholder: "Describe your task..." }, world.failure.promptA, { replace: true, verify: true });
+      const beforePromptFailure = await world.sessionIds();
+      const promptRequestsBefore = readFaults();
+      const promptGate = faults.holdNext("prompt", "request");
+      const promptRow = await world.observeRenderer("user-row", world.failure.promptA);
+      await user.press("Enter");
+      await waitHeld(promptGate);
+      await world.insertFocusedText(world.failure.promptB);
+      await promptGate.fail();
+      const promptRunTask = await accessibleRunTask();
+      const promptFacts = await probe.eventually(() => visibleFacts(world.failure.promptA), {
+        within: 15_000,
+        label: "prompt failure keeps the current pane editable with draft B",
+        until: (facts) => facts.composerEditable && occurrences(facts.composerText, world.failure.promptB) === 1,
+      }).catch(() => visibleFacts(world.failure.promptA));
+      const promptBackend = await world.messageFacts(world.existing.sessionId, world.failure.promptA);
+      const afterPromptFailure = await world.sessionIds();
+      const promptRequestsAfter = readFaults();
+      negatives.promptFailureComposerReady = promptRunTask && promptFacts.composerEditable;
+      negatives.promptFailureARecoverable = (promptFacts.rowCount === 1 && promptFacts.markerOccurrences === 1)
+        || occurrences(promptFacts.composerText, world.failure.promptA) === 1;
+      negatives.promptFailureDraftBSurvives = occurrences(promptFacts.composerText, world.failure.promptB) === 1;
+      negatives.promptFailureNoFallbackSession = promptFacts.sessionId === world.existing.sessionId
+        && promptBackend.markerCount === 0 && promptBackend.markerOccurrences === 0
+        && JSON.stringify(afterPromptFailure) === JSON.stringify(beforePromptFailure)
+        && promptRequestsAfter.prompt - promptRequestsBefore.prompt === 1
+        && promptRequestsAfter.creation === promptRequestsBefore.creation;
+      await promptRow[Symbol.asyncDispose]();
+    });
+
+    await step("navigation while a send is held cannot leak, clear the next draft, navigate late, or steal focus", async () => {
+      await openSession(world.existing);
+      await user.type({ placeholder: "Describe your task..." }, world.navigation.marker, { replace: true, verify: true });
+      const requestsBefore = readFaults();
+      const promptGate = faults.holdNext("prompt", "request");
+      const rowObserver = await world.observeRenderer("user-row", world.navigation.marker);
+      await user.press("Enter");
+      await waitHeld(promptGate);
+      await world.insertFocusedText(world.failure.navigationB);
+      await openSession(world.unrelated);
+      await user.see({ text: world.unrelatedHistory });
+      await user.click({ placeholder: "Describe your task..." });
+      const unrelatedBefore = await visibleFacts(world.navigation.marker);
+      await promptGate.release();
+      await waitBackendMarker(world.existing.sessionId, world.navigation.marker);
+      await probe.eventually(() => world.messageFacts(world.existing.sessionId, world.navigation.reply), {
+        within: 60_000,
+        label: "held navigation send completes in its originating v1 session",
+        until: (facts) => facts.markerOccurrences > 0,
+      });
+      const unrelatedAfter = await visibleFacts(world.navigation.marker);
+      const stayedUnrelated = unrelatedAfter.sessionId === world.unrelated.sessionId && unrelatedAfter.focusedEditor;
+      await openSession(world.existing);
+      const originAfter = await visibleFacts(world.navigation.marker);
+      const navigationBackend = await world.messageFacts(world.existing.sessionId, world.navigation.marker);
+      const navigationReplyBackend = await world.messageFacts(world.existing.sessionId, world.navigation.reply);
+      const requestsAfter = readFaults();
+      negatives.navigationIsolation = unrelatedBefore.rowCount === 0 && unrelatedBefore.markerOccurrences === 0
+        && !unrelatedBefore.composerText.includes(world.failure.navigationB)
+        && unrelatedAfter.rowCount === 0 && unrelatedAfter.markerOccurrences === 0
+        && !unrelatedAfter.composerText.includes(world.failure.navigationB)
+        && stayedUnrelated
+        && originAfter.rowCount === 1 && originAfter.markerOccurrences === 1
+        && occurrences(originAfter.composerText, world.failure.navigationB) === 1
+        && navigationBackend.markerCount === 1 && navigationBackend.markerOccurrences === 1
+        && navigationReplyBackend.markerCount === 1 && navigationReplyBackend.markerOccurrences === 1
+        && requestsAfter.prompt - requestsBefore.prompt === 1;
+      await rowObserver[Symbol.asyncDispose]();
+    });
+
+    await step("a separately held real response reconciles from SSE without duplicate rows", async () => {
+      await openSession(world.existing);
+      await user.type({ placeholder: "Describe your task..." }, world.responseHold.marker, { replace: true, verify: true });
+      const inventoryBefore = await world.sessionIds();
+      const requestsBefore = readFaults();
+      const responseGate = faults.holdNext("prompt", "response");
+      const rowObserver = await world.observeRenderer("user-row", world.responseHold.marker);
+      await user.press("Enter");
+      const responseHeld = await waitHeld(responseGate);
+      const sseBeforeResponse = await probe.eventually(async () => {
+        const visible = await visibleFacts(world.responseHold.marker);
+        const userBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.marker);
+        const replyBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.reply);
+        return {
+          ready: visible.rowCount > 0 && visible.markerOccurrences > 0 && await surfaceContains(world.responseHold.reply)
+            && userBackend.markerOccurrences > 0 && replyBackend.markerOccurrences > 0,
+          responseStillHeld: !responseGate.read().released,
+        };
+      }, {
+        within: 20_000,
+        label: "SSE renders the real operation while its HTTP response remains held",
+        until: (facts) => facts.ready && facts.responseStillHeld,
+      }).then((facts) => facts.ready && facts.responseStillHeld, () => false);
+      await responseGate.release();
+      await waitReply(world.responseHold.reply);
+      await waitRenderer(rowObserver);
+      await rowObserver[Symbol.asyncDispose]();
+      const beforeReload = await visibleFacts(world.responseHold.marker);
+      await user.reload();
+      await probe.eventually(activeSessionId, {
+        within: 30_000,
+        label: "response-stage session remains selected after reload",
+        until: (sessionId) => sessionId === world.existing.sessionId,
+      });
+      const afterReload = await probe.eventually(() => visibleFacts(world.responseHold.marker), {
+        within: 30_000,
+        label: "reloaded SSE-reconciled row remains exactly once",
+        until: (facts) => facts.rowCount > 0 && facts.markerOccurrences > 0,
+      });
+      const backend = await world.messageFacts(world.existing.sessionId, world.responseHold.marker);
+      const replyBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.reply);
+      const requestsAfter = readFaults();
+      negatives.responseSseReconciliation = sseBeforeResponse
+        && responseHeld.elapsedMs >= boundaryHoldMs
+        && beforeReload.rowCount === 1 && beforeReload.markerOccurrences === 1
+        && afterReload.rowCount === 1 && afterReload.markerOccurrences === 1
+        && backend.markerCount === 1 && backend.markerOccurrences === 1
+        && replyBackend.markerCount === 1 && replyBackend.markerOccurrences === 1
+        && requestsAfter.prompt - requestsBefore.prompt === 1
+        && requestsAfter.creation === requestsBefore.creation
+        && JSON.stringify(await world.sessionIds()) === JSON.stringify(inventoryBefore);
+    });
+
+    const expandedAfter = await expanded();
+    const newTaskPass = newTaskSamples.length === sampleCount && newTaskSamples.every((entry) => entry.elapsedMs !== null
+      && entry.elapsedMs < newTaskLimitMs && entry.trusted && entry.consecutiveFrames >= 2
+      && entry.exact && entry.typedWithoutClick);
+    const lazySendPass = lazySendSamples.length === sampleCount && lazySendSamples.every((entry) => entry.elapsedMs !== null
+      && entry.elapsedMs < sendLimitMs && entry.trusted && entry.consecutiveFrames >= 2 && entry.beforeEngine
+      && entry.firstHoldMs >= boundaryHoldMs && entry.secondHoldMs >= boundaryHoldMs
+      && entry.firstHeldCount === 1 && entry.secondHeldCount === 1 && entry.exact && entry.typedWithoutClick);
+    const existingSendPass = existingSendSamples.length === sampleCount && existingSendSamples.every((entry) => entry.elapsedMs !== null
+      && entry.elapsedMs < sendLimitMs && entry.trusted && entry.consecutiveFrames >= 2 && entry.beforeEngine
+      && entry.firstHoldMs >= boundaryHoldMs && entry.firstHeldCount === 1 && entry.exact);
+    const negativePass = Object.values(negatives).every(Boolean);
+    const expansionPass = expandedAfter === expandedBefore;
+
+    evidence.recordAssertionEvidence(
+      "Twelve New task clicks expose a focused, unobstructed composer within 500 ms",
+      JSON.stringify({ definition: "trusted click capture to the second consecutive requestAnimationFrame that sees the exact sessionless workspace route, visible new-task heading, no old primary-pane session surface, and the focused viewport-intersecting center-hit-testable editor; CDP polling roundtrip excluded; this is a conservative frame opportunity, not a literal pixel-presentation timestamp", limitMs: newTaskLimitMs, report: timingReport(newTaskSamples) }),
+      newTaskPass,
+    );
+    evidence.recordAssertionEvidence(
+      "Twelve lazy and twelve existing-session sends expose their visible user row within 100 ms before v1 engine work",
+      JSON.stringify({ definition: "trusted Enter keydown capture to the second consecutive requestAnimationFrame that sees the marker in a viewport-intersecting data-message-role=user row outside the composer; CDP polling roundtrip excluded", limitMs: sendLimitMs, lazy: timingReport(lazySendSamples), existing: timingReport(existingSendSamples) }),
+      lazySendPass && existingSendPass,
+    );
+    evidence.recordAssertionEvidence(
+      "Held, failed, navigated, SSE-reconciled, and reloaded sends remain singular and preserve drafts",
+      JSON.stringify({ negatives, expansionUnchanged: expansionPass }),
+      negativePass && expansionPass,
+    );
+    if (!newTaskPass || !lazySendPass || !existingSendPass || !negativePass || !expansionPass) await user.screenshot();
+    expect({
+      newTaskSamples: newTaskSamples.length === sampleCount,
+      newTaskEverySampleUnder500Ms: newTaskPass,
+      lazySamples: lazySendSamples.length === sampleCount,
+      lazyEverySampleUnder100MsBeforeEngine: lazySendPass,
+      existingSamples: existingSendSamples.length === sampleCount,
+      existingEverySampleUnder100MsBeforeEngine: existingSendPass,
+      negativeHalves: negativePass,
+      workspaceExpansionUnchanged: expansionPass,
+    }).toEqual({
+      newTaskSamples: true,
+      newTaskEverySampleUnder500Ms: true,
+      lazySamples: true,
+      lazyEverySampleUnder100MsBeforeEngine: true,
+      existingSamples: true,
+      existingEverySampleUnder100MsBeforeEngine: true,
+      negativeHalves: true,
+      workspaceExpansionUnchanged: true,
+    });
+    journeyCompleted = true;
+  } catch (error) {
+    diagnosticError = (error instanceof Error ? error.message : String(error)).slice(0, 500);
+    await user.screenshot().catch(() => undefined);
+    throw error;
+  } finally {
+    const pending = pendingMeasurement.current;
+    if (pending) {
+      try { updateRendererSample(pending.sample, await pending.observer.read()); } catch {}
+      try { await pending.observer[Symbol.asyncDispose](); } catch {}
+      pendingMeasurement.current = null;
+    }
+    try { lastFaultCounts = faults.read(); } catch {}
+    evidence.recordAssertionEvidence(
+      "Instant-send partial and final diagnostics retain every attempted sample",
+      JSON.stringify({
+        completed: journeyCompleted,
+        error: diagnosticError,
+        faultCounts: lastFaultCounts,
+        typing: typingDiagnostics,
+        negatives,
+        newTask: timingReport(newTaskSamples),
+        lazy: timingReport(lazySendSamples),
+        existing: timingReport(existingSendSamples),
+      }),
+      journeyCompleted,
+    );
+  }
 });

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -411,13 +411,39 @@ test("workspace New task is instantly typable and every v1 send paints before en
           const draftAfterSuccess = await visibleFacts(world.failure.pendingB);
           negatives.successDraftB = successDraftTyped && draftAfterSuccess.composerText === world.failure.pendingB;
           negatives.rapidDuplicateEnter = exact && createGate.read().held === 1 && promptGate.read().held === 1;
+          await user.see({ text: scenario.marker }, { timeoutMs: 30_000 });
+          await user.see({ text: scenario.reply }, { timeoutMs: 30_000 });
+          const beforeReloadObservedPair = await probe.eventually(async () => {
+            const [visibleUser, visibleReply] = await Promise.all([
+              world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
+              world.visibleMessageFacts(createdSessionId, "assistant", scenario.reply),
+            ]);
+            return { visibleUser, visibleReply };
+          }, {
+            within: 30_000,
+            label: `normal user observation exposes the first lazy user and reply before reloading ${createdSessionId}`,
+            until: ({ visibleUser, visibleReply }) => visibleUser.rowCount > 0 && visibleUser.markerOccurrences > 0
+              && visibleReply.rowCount > 0 && visibleReply.markerOccurrences > 0,
+          });
+          const beforeReloadNativePair = await probe.eventually(async () => {
+            const [nativeUser, nativeReply] = await Promise.all([
+              world.messageFacts(createdSessionId, scenario.marker),
+              world.messageFacts(createdSessionId, scenario.reply),
+            ]);
+            return { nativeUser, nativeReply };
+          }, {
+            within: 30_000,
+            label: `the first lazy user and reply are persisted before reloading ${createdSessionId}`,
+            until: ({ nativeUser, nativeReply }) => nativeUser.markerOccurrences > 0
+              && nativeReply.markerOccurrences > 0,
+          });
           const beforeReload = {
             providerRequestCount: await world.providerRequestCount(scenario.marker),
             sessionIds: await world.sessionIds(),
-            nativeUser: await world.messageFacts(createdSessionId, scenario.marker),
-            nativeReply: await world.messageFacts(createdSessionId, scenario.reply),
-            visibleUser: await world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
-            visibleReply: await world.visibleMessageFacts(createdSessionId, "assistant", scenario.reply),
+            nativeUser: beforeReloadNativePair.nativeUser,
+            nativeReply: beforeReloadNativePair.nativeReply,
+            visibleUser: beforeReloadObservedPair.visibleUser,
+            visibleReply: beforeReloadObservedPair.visibleReply,
           };
           await faults.suspend();
           await user.reload();
@@ -442,7 +468,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
           });
           await user.see({ text: scenario.marker }, { timeoutMs: 30_000 });
           await user.see({ text: scenario.reply }, { timeoutMs: 30_000 });
-          const reloadedState = await probe.eventually(async () => {
+          const postReloadObservedPair = await probe.eventually(async () => {
             const [reloaded, visibleUser, visibleReply] = await Promise.all([
               visibleFacts(scenario.marker),
               world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
@@ -451,13 +477,13 @@ test("workspace New task is instantly typable and every v1 send paints before en
             return { reloaded, visibleUser, visibleReply };
           }, {
             within: 30_000,
-            label: `the reloaded v1 user and reply can be viewed exactly once in ${createdSessionId}`,
-            until: ({ reloaded, visibleUser, visibleReply }) => reloaded.rowCount === 1
-              && reloaded.markerOccurrences === 1
-              && visibleUser.rowCount === 1 && visibleUser.markerOccurrences === 1
-              && visibleReply.rowCount === 1 && visibleReply.markerOccurrences === 1,
+            label: `normal user observation exposes the reloaded v1 user and reply in ${createdSessionId}`,
+            until: ({ reloaded, visibleUser, visibleReply }) => reloaded.rowCount > 0
+              && reloaded.markerOccurrences > 0
+              && visibleUser.rowCount > 0 && visibleUser.markerOccurrences > 0
+              && visibleReply.rowCount > 0 && visibleReply.markerOccurrences > 0,
           });
-          const { reloaded } = reloadedState;
+          const { reloaded } = postReloadObservedPair;
           const reloadedBackend = await probe.eventually(() => world.messageFacts(createdSessionId, scenario.marker), {
             within: 30_000,
             label: `reloaded v1 transcript ${createdSessionId} is readable with exactly one marker`,
@@ -468,8 +494,8 @@ test("workspace New task is instantly typable and every v1 send paints before en
             providerRequestCount: await world.providerRequestCount(scenario.marker),
             sessionIds: await world.sessionIds(),
             nativeReply: await world.messageFacts(createdSessionId, scenario.reply),
-            visibleUser: reloadedState.visibleUser,
-            visibleReply: reloadedState.visibleReply,
+            visibleUser: postReloadObservedPair.visibleUser,
+            visibleReply: postReloadObservedPair.visibleReply,
           };
           negatives.exactAfterReload = reloaded.rowCount === 1
             && reloaded.markerOccurrences === 1
@@ -491,6 +517,22 @@ test("workspace New task is instantly typable and every v1 send paints before en
             && afterReload.visibleReply.rowCount === 1 && afterReload.visibleReply.markerOccurrences === 1
             && afterReload.visibleReply.totalRowCount === 1;
           evidence.recordJsonArtifact("First reload proof", {
+            checks: {
+              afterReloadUserExact: reloaded.rowCount === 1 && reloaded.markerOccurrences === 1,
+              creationRequestExact: afterReloadRequests.creation - requestBeforeSend.creation === 1,
+              promptRequestExact: afterReloadRequests.prompt - requestBeforeSend.prompt === 1,
+              providerBeforeExact: beforeReload.providerRequestCount === 1,
+              providerCountStable: afterReload.providerRequestCount === beforeReload.providerRequestCount,
+              inventoryStableAcrossReload: JSON.stringify(afterReload.sessionIds) === JSON.stringify(beforeReload.sessionIds),
+              beforeNativeUserExact: beforeReload.nativeUser.markerCount === 1 && beforeReload.nativeUser.markerOccurrences === 1,
+              beforeNativeReplyExact: beforeReload.nativeReply.markerCount === 1 && beforeReload.nativeReply.markerOccurrences === 1,
+              beforeVisibleUserExact: beforeReload.visibleUser.rowCount === 1 && beforeReload.visibleUser.markerOccurrences === 1 && beforeReload.visibleUser.totalRowCount === 1,
+              beforeVisibleReplyExact: beforeReload.visibleReply.rowCount === 1 && beforeReload.visibleReply.markerOccurrences === 1 && beforeReload.visibleReply.totalRowCount === 1,
+              afterNativeUserExact: reloadedBackend.markerCount === 1 && reloadedBackend.markerOccurrences === 1,
+              afterNativeReplyExact: afterReload.nativeReply.markerCount === 1 && afterReload.nativeReply.markerOccurrences === 1,
+              afterVisibleUserExact: afterReload.visibleUser.rowCount === 1 && afterReload.visibleUser.markerOccurrences === 1 && afterReload.visibleUser.totalRowCount === 1,
+              afterVisibleReplyExact: afterReload.visibleReply.rowCount === 1 && afterReload.visibleReply.markerOccurrences === 1 && afterReload.visibleReply.totalRowCount === 1,
+            },
             claim: "The exact user message and reply can be viewed after reload without duplicates.",
             visibleUserCount: afterReload.visibleUser.rowCount,
             visibleReplyCount: afterReload.visibleReply.rowCount,
@@ -498,6 +540,26 @@ test("workspace New task is instantly typable and every v1 send paints before en
             providerCountAfter: afterReload.providerRequestCount,
             providerCountEqual: afterReload.providerRequestCount === beforeReload.providerRequestCount,
             inventoryEqual: JSON.stringify(afterReload.sessionIds) === JSON.stringify(beforeReload.sessionIds),
+            nativeBefore: {
+              user: { count: beforeReload.nativeUser.markerCount, occurrences: beforeReload.nativeUser.markerOccurrences },
+              reply: { count: beforeReload.nativeReply.markerCount, occurrences: beforeReload.nativeReply.markerOccurrences },
+            },
+            visibleBefore: {
+              user: { rows: beforeReload.visibleUser.rowCount, occurrences: beforeReload.visibleUser.markerOccurrences, totalRows: beforeReload.visibleUser.totalRowCount },
+              reply: { rows: beforeReload.visibleReply.rowCount, occurrences: beforeReload.visibleReply.markerOccurrences, totalRows: beforeReload.visibleReply.totalRowCount },
+            },
+            nativeAfter: {
+              user: { count: reloadedBackend.markerCount, occurrences: reloadedBackend.markerOccurrences },
+              reply: { count: afterReload.nativeReply.markerCount, occurrences: afterReload.nativeReply.markerOccurrences },
+            },
+            visibleAfter: {
+              user: { rows: afterReload.visibleUser.rowCount, occurrences: afterReload.visibleUser.markerOccurrences, totalRows: afterReload.visibleUser.totalRowCount },
+              reply: { rows: afterReload.visibleReply.rowCount, occurrences: afterReload.visibleReply.markerOccurrences, totalRows: afterReload.visibleReply.totalRowCount },
+            },
+            requestDelta: {
+              creation: afterReloadRequests.creation - requestBeforeSend.creation,
+              prompt: afterReloadRequests.prompt - requestBeforeSend.prompt,
+            },
           });
           await faults.resume();
         }
@@ -810,6 +872,19 @@ test("workspace New task is instantly typable and every v1 send paints before en
       const unrelatedAfter = await visibleFacts(world.navigation.marker);
       const stayedUnrelated = unrelatedAfter.sessionId === world.unrelated.sessionId && unrelatedAfter.focusedEditor;
       await openSession(world.existing);
+      await probe.eventually(async () => {
+        const [renderedUser, renderedReply] = await Promise.all([
+          world.visibleMessageFacts(world.existing.sessionId, "user", world.navigation.marker),
+          world.visibleMessageFacts(world.existing.sessionId, "assistant", world.navigation.reply),
+        ]);
+        return { renderedUser, renderedReply };
+      }, {
+        within: 30_000,
+        label: "the navigation origin renders its user and reply rows after return",
+        until: ({ renderedUser, renderedReply }) => renderedUser.totalRowCount > 0 && renderedReply.totalRowCount > 0,
+      });
+      await user.see({ text: world.navigation.marker }, { timeoutMs: 30_000 });
+      await user.see({ text: world.navigation.reply }, { timeoutMs: 30_000 });
       const originAfter = await visibleFacts(world.navigation.marker);
       const navigationBackend = await world.messageFacts(world.existing.sessionId, world.navigation.marker);
       const navigationReplyBackend = await world.messageFacts(world.existing.sessionId, world.navigation.reply);

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -69,7 +69,6 @@ function timingReport(samples: readonly TimingSample[]) {
 
 test("workspace New task is instantly typable and every v1 send paints before engine work", async ({ world, user, agent, probe, step, evidence }) => {
   await using faults = world.boundary;
-  const workspaceName = world.workspacePath.split("/").at(-1) ?? world.workspacePath;
   const newTaskSamples: TimingSample[] = [];
   const lazySendSamples: TimingSample[] = [];
   const existingSendSamples: TimingSample[] = [];
@@ -91,21 +90,6 @@ test("workspace New task is instantly typable and every v1 send paints before en
     exactAfterReload: false,
   };
 
-  const sessionTarget = async (sessionId: string): Promise<{ role: "button"; label: string; nth: number }> => {
-    const target = await probe.eventually(() => probe.eval(browserScript((sessionId) => {
-      const row = document.querySelector<HTMLElement>(`[data-session-tab-id="${sessionId}"]`);
-      row?.scrollIntoView({ block: "center" });
-      const label = row?.getAttribute("aria-label") ?? "";
-      const candidates = [...document.querySelectorAll<HTMLElement>('button, [role="button"]')]
-        .filter((node) => node.getAttribute("aria-label") === label);
-      return { label, nth: row ? candidates.indexOf(row) : -1 };
-    }, [sessionId])), {
-      within: 15_000,
-      label: `session ${sessionId} has a native sidebar target`,
-      until: (value) => value.label.length > 0 && value.nth >= 0,
-    });
-    return { role: "button", label: target.label, nth: target.nth };
-  };
   const activeSessionId = () => probe.eval(browserScript((workspaceId) => {
     if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) return "";
     const persistedPrefix = `#/workspace/${workspaceId}/session/`;
@@ -125,7 +109,8 @@ test("workspace New task is instantly typable and every v1 send paints before en
     return ownsRoute ? sessionId : "";
   }, [world.workspace.workspaceId]));
   const openSession = async (session: { sessionId: string }) => {
-    if (await activeSessionId() !== session.sessionId) await user.click(await sessionTarget(session.sessionId));
+    // Untimed setup navigation uses the client boundary; pointer navigation is a separate journey.
+    if (await activeSessionId() !== session.sessionId) await agent.run("session.open", { sessionId: session.sessionId });
     await probe.eventually(activeSessionId, {
       within: 30_000,
       label: `session ${session.sessionId} owns the primary pane`,
@@ -172,10 +157,11 @@ test("workspace New task is instantly typable and every v1 send paints before en
     const rows = [...(root?.querySelectorAll<HTMLElement>('[data-message-role="user"]') ?? [])]
       .filter((row) => visible(row) && row.innerText.includes(marker)
         && !(editor && (editor.contains(row) || row.contains(editor))));
+    const rawComposerText = editor?.innerText ?? "";
     return {
       rowCount: rows.length,
       markerOccurrences: marker ? rows.reduce((total, row) => total + row.innerText.split(marker).length - 1, 0) : 0,
-      composerText: editor?.innerText ?? "",
+      composerText: /^\s*$/.test(rawComposerText) ? "" : rawComposerText,
       composerEditable: Boolean(editor?.isContentEditable),
       focusedEditor: Boolean(editor && (document.activeElement === editor || editor.contains(document.activeElement))),
       sessionId: root?.querySelector<HTMLElement>("[data-session-surface-id]")?.dataset.sessionSurfaceId ?? "",
@@ -215,11 +201,11 @@ test("workspace New task is instantly typable and every v1 send paints before en
     }
     return root?.innerText.includes(text) ?? false;
   }, [text, world.workspace.workspaceId]));
-  const accessibleRunTask = () => probe.eventually(() => world.accessibleRunTaskReady(), {
+  const accessibleRunTask = (expectedText: string, label: string) => probe.eventually(() => world.accessibleRunTaskReady(expectedText), {
     within: 15_000,
-    label: "the current pane exposes an enabled, native-accessible Run task control",
-    until: (ready) => ready,
-  }).then(() => true, () => false);
+    label,
+    until: (state) => state.ready,
+  });
   const waitReply = (reply: string) => probe.eventually(() => surfaceContains(reply), {
     within: 60_000,
     label: `the deterministic v1 reply ${reply.slice(0, 32)} is visible`,
@@ -277,20 +263,19 @@ test("workspace New task is instantly typable and every v1 send paints before en
   let diagnosticError: string | null = null;
 
   try {
-    await user.hover({ role: "button", label: workspaceName });
+    const initialNewTaskPoint = await world.prepareWorkspaceNewTask();
     await step("the plus remains the topmost hit target over the long workspace name", async () => {
-      const hit = await probe.eval(browserScript((workspaceId) => {
+      const hit = await probe.eval(browserScript((workspaceId, x, y) => {
         const plus = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`);
         if (!(plus instanceof HTMLElement)) return { hitPlus: false, hitTitle: false, tag: "" };
-        const rect = plus.getBoundingClientRect();
-        const node = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        const node = document.elementFromPoint(x, y);
         const title = plus.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>(".ow-fade-truncate");
         return {
           hitPlus: plus.contains(node),
           hitTitle: Boolean(title && node instanceof Node && title.contains(node)),
           tag: node instanceof Element ? node.tagName.toLowerCase() : "",
         };
-      }, [world.workspace.workspaceId]));
+      }, [world.workspace.workspaceId, initialNewTaskPoint.x, initialNewTaskPoint.y]));
       if (!isRecord(hit)) throw new Error(`New task plus returned malformed hit facts: ${JSON.stringify(hit)}`);
       expect(hit.hitPlus).toBe(true);
       expect(hit.hitTitle).toBe(false);
@@ -312,9 +297,9 @@ test("workspace New task is instantly typable and every v1 send paints before en
         const serverBeforeOpen = await world.sessionIds();
         const agentBeforeOpen = (await agent.list()).map((session) => session.sessionId).sort();
         const requestsBeforeOpen = readFaults();
-        await user.hover({ role: "button", label: workspaceName });
+        const newTaskPoint = await world.prepareWorkspaceNewTask();
         const readyObserver = await world.observeRenderer("new-task");
-        await user.click({ role: "button", label: `New session · ${workspaceName}` });
+        await world.clickWorkspaceNewTask(newTaskPoint);
         const readySample = sample(index + 1, await readyObserver.read(), { exact: false, typedWithoutClick: false });
         newTaskSamples.push(readySample);
         pendingMeasurement.current = { observer: readyObserver, sample: readySample };
@@ -325,11 +310,24 @@ test("workspace New task is instantly typable and every v1 send paints before en
         const serverAfterOpen = await world.sessionIds();
         const agentAfterOpen = (await agent.list()).map((session) => session.sessionId).sort();
         const requestsAfterOpen = readFaults();
-        const openingStayedLazy = JSON.stringify(serverAfterOpen) === JSON.stringify(serverBeforeOpen)
-          && JSON.stringify(agentAfterOpen) === JSON.stringify(agentBeforeOpen)
-          && requestsAfterOpen.creation === requestsBeforeOpen.creation
-          && requestsAfterOpen.prompt === requestsBeforeOpen.prompt
-          && !(await probe.hash()).includes("/session/ses_");
+        const routeAfterOpen = await probe.hash();
+        const openingSubfacts = {
+          backendInventoryUnchanged: JSON.stringify(serverAfterOpen) === JSON.stringify(serverBeforeOpen),
+          cachedIdsRetained: agentBeforeOpen.every((sessionId) => agentAfterOpen.includes(sessionId)),
+          cachedIdsAuthoritative: [...agentBeforeOpen, ...agentAfterOpen]
+            .every((sessionId) => serverBeforeOpen.includes(sessionId)),
+          zeroCreationPosts: requestsAfterOpen.creation === requestsBeforeOpen.creation,
+          zeroPromptPosts: requestsAfterOpen.prompt === requestsBeforeOpen.prompt,
+          sessionlessRoute: !routeAfterOpen.includes("/session/ses_"),
+        };
+        const openingStayedLazy = Object.values(openingSubfacts).every(Boolean);
+        if (!openingStayedLazy) {
+          evidence.recordAssertionEvidence(
+            `Lazy New task sample ${index + 1} opening invariants`,
+            JSON.stringify({ index: index + 1, ...openingSubfacts, serverBeforeOpen, serverAfterOpen, agentBeforeOpen, agentAfterOpen, requestsBeforeOpen, requestsAfterOpen, routeAfterOpen }),
+            false,
+          );
+        }
         if (index === 0) await user.see({ text: "What do you need done?" });
         const typed = await world.insertFocusedText(scenario.marker);
         typingDiagnostics.push({ index: index + 1, beforeText: typed.beforeText, afterText: typed.afterText });
@@ -338,6 +336,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         readySample.exact = openingStayedLazy;
         readySample.typedWithoutClick = typedWithoutClick;
 
+        await accessibleRunTask(scenario.marker, `lazy sample ${index + 1} exposes an enabled Run task control for its typed payload`);
         const requestBeforeSend = readFaults();
         const createGate = faults.holdNext("creation", "request");
         const promptGate = faults.holdNext("prompt", "request");
@@ -407,12 +406,22 @@ test("workspace New task is instantly typable and every v1 send paints before en
           const draftAfterSuccess = await visibleFacts(world.failure.pendingB);
           negatives.successDraftB = successDraftTyped && draftAfterSuccess.composerText === world.failure.pendingB;
           negatives.rapidDuplicateEnter = exact && createGate.read().held === 1 && promptGate.read().held === 1;
+          const beforeReload = {
+            providerRequestCount: await world.providerRequestCount(scenario.marker),
+            sessionIds: await world.sessionIds(),
+            nativeUser: await world.messageFacts(createdSessionId, scenario.marker),
+            nativeReply: await world.messageFacts(createdSessionId, scenario.reply),
+            visibleUser: await world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
+            visibleReply: await world.visibleMessageFacts(createdSessionId, "assistant", scenario.reply),
+          };
+          await faults.suspend();
           await user.reload();
           await probe.eventually(activeSessionId, {
             within: 30_000,
             label: "the first lazy session remains selected after reload",
             until: (sessionId) => sessionId === createdSessionId,
           });
+          await faults.resume();
           const reloaded = await visibleFacts(scenario.marker);
           const afterReloadRequests = readFaults();
           const reloadedBackend = await probe.eventually(() => world.messageFacts(createdSessionId, scenario.marker), {
@@ -420,14 +429,52 @@ test("workspace New task is instantly typable and every v1 send paints before en
             label: `reloaded v1 transcript ${createdSessionId} is readable with exactly one marker`,
             until: (facts) => facts.markerCount === 1 && facts.markerOccurrences === 1,
           });
+          const afterReload = {
+            providerRequestCount: await world.providerRequestCount(scenario.marker),
+            sessionIds: await world.sessionIds(),
+            nativeReply: await world.messageFacts(createdSessionId, scenario.reply),
+            visibleUser: await world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
+            visibleReply: await world.visibleMessageFacts(createdSessionId, "assistant", scenario.reply),
+          };
           negatives.exactAfterReload = reloaded.rowCount === 1
             && reloaded.markerOccurrences === 1
             && afterReloadRequests.creation - requestBeforeSend.creation === 1
             && afterReloadRequests.prompt - requestBeforeSend.prompt === 1
-            && reloadedBackend.markerCount === 1 && reloadedBackend.markerOccurrences === 1;
+            && beforeReload.providerRequestCount === 1
+            && afterReload.providerRequestCount === beforeReload.providerRequestCount
+            && JSON.stringify(afterReload.sessionIds) === JSON.stringify(beforeReload.sessionIds)
+            && beforeReload.nativeUser.markerCount === 1 && beforeReload.nativeUser.markerOccurrences === 1
+            && beforeReload.nativeReply.markerCount === 1 && beforeReload.nativeReply.markerOccurrences === 1
+            && beforeReload.visibleUser.rowCount === 1 && beforeReload.visibleUser.markerOccurrences === 1
+            && beforeReload.visibleReply.rowCount === 1 && beforeReload.visibleReply.markerOccurrences === 1
+            && reloadedBackend.markerCount === 1 && reloadedBackend.markerOccurrences === 1
+            && afterReload.nativeReply.markerCount === 1 && afterReload.nativeReply.markerOccurrences === 1
+            && afterReload.visibleUser.rowCount === 1 && afterReload.visibleUser.markerOccurrences === 1
+            && afterReload.visibleReply.rowCount === 1 && afterReload.visibleReply.markerOccurrences === 1;
         }
       }
     });
+
+    const newTaskTiming = timingReport(newTaskSamples);
+    const newTaskFailureIndices = newTaskSamples.filter((entry) => entry.elapsedMs === null
+      || entry.elapsedMs >= newTaskLimitMs || !entry.trusted || entry.consecutiveFrames < 2
+      || !entry.exact || !entry.typedWithoutClick).map((entry) => entry.index);
+    evidence.recordAssertionEvidence(
+      "Twelve New task clicks expose a focused, unobstructed composer within 500 ms",
+      JSON.stringify({ metric: "trusted click to second consecutive qualifying animation frame", limitMs: newTaskLimitMs, count: newTaskTiming.count, expectedCount: sampleCount, p50Ms: newTaskTiming.p50Ms, p95Ms: newTaskTiming.p95Ms, maxMs: newTaskTiming.maxMs, failureIndices: newTaskFailureIndices }),
+      newTaskTiming.count === sampleCount && newTaskFailureIndices.length === 0,
+    );
+    const lazyTiming = timingReport(lazySendSamples);
+    const lazyFailureIndices = lazySendSamples.filter((entry) => entry.elapsedMs === null
+      || entry.elapsedMs >= sendLimitMs || !entry.trusted || entry.consecutiveFrames < 2 || !entry.beforeEngine
+      || entry.firstHoldMs < boundaryHoldMs || entry.secondHoldMs < boundaryHoldMs
+      || entry.firstHeldCount !== 1 || entry.secondHeldCount !== 1 || !entry.exact || !entry.typedWithoutClick)
+      .map((entry) => entry.index);
+    evidence.recordAssertionEvidence(
+      "Twelve lazy first sends paint before engine work within 100 ms",
+      JSON.stringify({ metric: "trusted Enter to second consecutive visible-row frame before held engine requests", limitMs: sendLimitMs, count: lazyTiming.count, expectedCount: sampleCount, p50Ms: lazyTiming.p50Ms, p95Ms: lazyTiming.p95Ms, maxMs: lazyTiming.maxMs, failureIndices: lazyFailureIndices }),
+      lazyTiming.count === sampleCount && lazyFailureIndices.length === 0,
+    );
 
     await step("twelve existing-session sends paint before each real prompt request", async () => {
       await openSession(world.existing);
@@ -435,6 +482,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         const scenario = world.existingSamples[index];
         if (!scenario) throw new Error(`Missing existing-session sample ${index + 1}`);
         await user.type({ placeholder: "Describe your task..." }, scenario.marker, { replace: true, verify: true });
+        await accessibleRunTask(scenario.marker, `existing sample ${index + 1} exposes an enabled Run task control for its typed payload`);
         const requestBefore = readFaults();
         const inventoryBefore = await world.sessionIds();
         const promptGate = faults.holdNext("prompt", "request");
@@ -469,44 +517,150 @@ test("workspace New task is instantly typable and every v1 send paints before en
       }
     });
 
-    await step("creation and prompt failures preserve submitted work and the next draft", async () => {
+    const existingTiming = timingReport(existingSendSamples);
+    const existingFailureIndices = existingSendSamples.filter((entry) => entry.elapsedMs === null
+      || entry.elapsedMs >= sendLimitMs || !entry.trusted || entry.consecutiveFrames < 2 || !entry.beforeEngine
+      || entry.firstHoldMs < boundaryHoldMs || entry.firstHeldCount !== 1 || !entry.exact)
+      .map((entry) => entry.index);
+    evidence.recordAssertionEvidence(
+      "Twelve existing-session sends paint before engine work within 100 ms",
+      JSON.stringify({ metric: "trusted Enter to second consecutive visible-row frame before held engine request", limitMs: sendLimitMs, count: existingTiming.count, expectedCount: sampleCount, p50Ms: existingTiming.p50Ms, p95Ms: existingTiming.p95Ms, maxMs: existingTiming.maxMs, failureIndices: existingFailureIndices }),
+      existingTiming.count === sampleCount && existingFailureIndices.length === 0,
+    );
+
+    const creationRestoreLabel = "Clear the current draft to restore the unsent message";
+    const existingRestoreLabel = "Restore unsent message";
+    const originalFailureMessage = "The request was rejected before admission.";
+    const recoveryUiFacts = (restoreLabel: string, expectedFailureText: string) => probe.eval(browserScript((workspaceId, restoreLabel, expectedFailureText) => {
+      const visible = (node: HTMLElement) => {
+        const rect = node.getBoundingClientRect();
+        let ancestor: HTMLElement | null = node;
+        while (ancestor) {
+          const style = getComputedStyle(ancestor);
+          if (style.display === "none" || style.visibility === "hidden" || Number(style.opacity) === 0) return false;
+          ancestor = ancestor.parentElement;
+        }
+        return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+          && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight;
+      };
+      let root: HTMLElement | null = null;
+      const sessionlessRoute = `#/workspace/${workspaceId}/session`;
+      if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId) {
+        if (location.hash === sessionlessRoute) {
+          const heading = [...document.querySelectorAll<HTMLElement>("h2")]
+            .find((candidate) => candidate.textContent?.trim() === "What do you need done?" && visible(candidate));
+          const main = heading?.closest<HTMLElement>("main") ?? null;
+          const persistedSurfaceVisible = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")].some(visible);
+          if (main && visible(main) && !persistedSurfaceVisible) root = main;
+        } else {
+          const persistedPrefix = `#/workspace/${workspaceId}/session/`;
+          const sessionId = location.hash.startsWith(persistedPrefix) ? location.hash.slice(persistedPrefix.length) : "";
+          const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')].find(visible) ?? null;
+          const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+            .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId && visible(candidate));
+          if (sessionId.startsWith("ses_") && !/[/?#]/.test(sessionId) && pane && surface) root = pane;
+        }
+      }
+      const alerts = [...(root?.querySelectorAll<HTMLElement>('[role="alert"]') ?? [])]
+        .filter(visible).map((alert) => alert.innerText.trim()).filter(Boolean);
+      const inlineFailures = [...(root?.querySelectorAll<Element>("*") ?? [])]
+        .filter((candidate): candidate is HTMLElement => candidate instanceof HTMLElement
+          && candidate.innerText.trim() === expectedFailureText && visible(candidate)
+          && !candidate.closest('[contenteditable="true"][data-lexical-editor="true"], [data-message-role="user"]')
+          && ![...candidate.querySelectorAll<Element>("*")]
+            .some((descendant) => descendant instanceof HTMLElement
+              && descendant.innerText.trim() === expectedFailureText && visible(descendant)))
+        .map((candidate) => candidate.innerText.trim());
+      const restore = [...(root?.querySelectorAll<HTMLButtonElement>("button") ?? [])]
+        .find((button) => button.innerText.trim() === restoreLabel && visible(button)) ?? null;
+      return {
+        failureMessage: [...new Set([...alerts, ...inlineFailures])].join(" | "),
+        restoreVisible: Boolean(restore),
+        restoreDisabled: restore?.disabled ?? null,
+      };
+    }, [world.workspace.workspaceId, restoreLabel, expectedFailureText]));
+
+    await step("creation and prompt failures preserve submitted work and the next draft through explicit recovery", async () => {
       await openSession(world.existing);
       const beforeCreationFailure = await world.sessionIds();
       const creationRequestsBefore = readFaults();
-      await user.hover({ role: "button", label: workspaceName });
-      await user.click({ role: "button", label: `New session · ${workspaceName}` });
+      const newTaskPoint = await world.prepareWorkspaceNewTask();
+      await world.clickWorkspaceNewTask(newTaskPoint);
       await probe.eventually(() => visibleFacts(""), {
         within: 10_000,
         label: "failed-creation composer is focused",
         until: (facts) => facts.focusedEditor,
       });
       await world.insertFocusedText(world.failure.creationA);
+      await accessibleRunTask(world.failure.creationA, "the failed-creation payload has an enabled Run task control before Enter");
       const creationGate = faults.holdNext("creation", "request");
       const creationRow = await world.observeRenderer("user-row", world.failure.creationA);
       await user.press("Enter");
       await waitHeld(creationGate);
       await world.insertFocusedText(world.failure.creationB);
       await creationGate.fail();
-      const creationRunTask = await accessibleRunTask();
-      const creationFacts = await probe.eventually(() => visibleFacts(world.failure.creationA), {
+      const creationFailure = await probe.eventually(async () => ({
+        composer: await visibleFacts(world.failure.creationA),
+        recovery: await recoveryUiFacts(creationRestoreLabel, originalFailureMessage),
+      }), {
         within: 15_000,
-        label: "creation failure keeps the current pane editable with draft B",
-        until: (facts) => facts.composerEditable && occurrences(facts.composerText, world.failure.creationB) === 1,
-      }).catch(() => visibleFacts(world.failure.creationA));
+        label: "creation failure preserves editable draft B, the original failure, and a guarded restore action",
+        until: (state) => state.composer.composerEditable
+          && state.composer.composerText === world.failure.creationB
+          && state.recovery.failureMessage.includes(originalFailureMessage)
+          && state.recovery.restoreVisible && state.recovery.restoreDisabled === true,
+      });
+      const creationRequestsAtFailure = readFaults();
+      await user.click({ placeholder: "Describe your task..." });
+      await user.press(world.app.handle.hostKind !== "daytona" && process.platform === "darwin" ? "Meta+A" : "Control+A");
+      await user.press("Backspace");
+      await probe.eventually(async () => ({
+        composer: await visibleFacts(world.failure.creationA),
+        recovery: await recoveryUiFacts(creationRestoreLabel, originalFailureMessage),
+      }), {
+        within: 10_000,
+        label: "clearing new-task draft B by keyboard enables its restore action",
+        until: (state) => state.composer.composerText === ""
+          && state.recovery.restoreVisible && state.recovery.restoreDisabled === false,
+      });
+      await user.click({ role: "button", label: creationRestoreLabel });
+      const creationRestored = await probe.eventually(async () => ({
+        composer: await visibleFacts(world.failure.creationA),
+        recovery: await recoveryUiFacts(creationRestoreLabel, originalFailureMessage),
+      }), {
+        within: 10_000,
+        label: "the real new-task restore action restores exactly failed payload A",
+        until: (state) => state.composer.composerEditable
+          && state.composer.composerText === world.failure.creationA
+          && state.composer.rowCount === 0 && state.composer.markerOccurrences === 0
+          && !state.recovery.restoreVisible,
+      });
       const afterCreationFailure = await world.sessionIds();
       const creationRequestsAfter = readFaults();
-      negatives.creationFailureComposerReady = creationRunTask && creationFacts.composerEditable;
-      negatives.creationFailureARecoverable = (creationFacts.rowCount === 1 && creationFacts.markerOccurrences === 1)
-        || occurrences(creationFacts.composerText, world.failure.creationA) === 1;
-      negatives.creationFailureDraftBSurvives = occurrences(creationFacts.composerText, world.failure.creationB) === 1;
-      negatives.creationFailureNoFallbackSession = !creationFacts.route.includes("/session/ses_")
+      negatives.creationFailureComposerReady = creationFailure.composer.composerEditable
+        && creationFailure.recovery.failureMessage.includes(originalFailureMessage)
+        && creationFailure.recovery.restoreVisible && creationFailure.recovery.restoreDisabled === true;
+      negatives.creationFailureARecoverable = creationRestored.composer.composerText === world.failure.creationA
+        && creationRestored.composer.rowCount === 0 && creationRestored.composer.markerOccurrences === 0
+        && !creationRestored.recovery.restoreVisible
+        && creationRequestsAfter.creation === creationRequestsAtFailure.creation
+        && creationRequestsAfter.prompt === creationRequestsAtFailure.prompt;
+      negatives.creationFailureDraftBSurvives = creationFailure.composer.composerText === world.failure.creationB;
+      negatives.creationFailureNoFallbackSession = !creationRestored.composer.route.includes("/session/ses_")
         && JSON.stringify(afterCreationFailure) === JSON.stringify(beforeCreationFailure)
         && creationRequestsAfter.creation - creationRequestsBefore.creation === 1
         && creationRequestsAfter.prompt === creationRequestsBefore.prompt;
+      evidence.recordAssertionEvidence(
+        "Failed new-task creation preserves draft B and restores exact payload A only after explicit recovery",
+        JSON.stringify({ failureMessage: creationFailure.recovery.failureMessage, restoreDisabledWithDraftB: creationFailure.recovery.restoreDisabled, requestsBefore: creationRequestsBefore, requestsAtFailure: creationRequestsAtFailure, requestsAfterRestore: creationRequestsAfter }),
+        negatives.creationFailureComposerReady && negatives.creationFailureARecoverable
+          && negatives.creationFailureDraftBSurvives && negatives.creationFailureNoFallbackSession,
+      );
       await creationRow[Symbol.asyncDispose]();
 
       await openSession(world.existing);
       await user.type({ placeholder: "Describe your task..." }, world.failure.promptA, { replace: true, verify: true });
+      await accessibleRunTask(world.failure.promptA, "the failed-prompt payload has an enabled Run task control before Enter");
       const beforePromptFailure = await world.sessionIds();
       const promptRequestsBefore = readFaults();
       const promptGate = faults.holdNext("prompt", "request");
@@ -515,24 +669,70 @@ test("workspace New task is instantly typable and every v1 send paints before en
       await waitHeld(promptGate);
       await world.insertFocusedText(world.failure.promptB);
       await promptGate.fail();
-      const promptRunTask = await accessibleRunTask();
-      const promptFacts = await probe.eventually(() => visibleFacts(world.failure.promptA), {
+      const promptFailure = await probe.eventually(async () => ({
+        composer: await visibleFacts(world.failure.promptA),
+        recovery: await recoveryUiFacts(existingRestoreLabel, originalFailureMessage),
+      }), {
         within: 15_000,
-        label: "prompt failure keeps the current pane editable with draft B",
-        until: (facts) => facts.composerEditable && occurrences(facts.composerText, world.failure.promptB) === 1,
-      }).catch(() => visibleFacts(world.failure.promptA));
+        label: "prompt failure preserves editable draft B, the original failure, and a guarded restore action",
+        until: (state) => state.composer.composerEditable
+          && state.composer.composerText === world.failure.promptB
+          && state.recovery.failureMessage.includes(originalFailureMessage)
+          && state.recovery.restoreVisible && state.recovery.restoreDisabled === true,
+      });
+      const promptRequestsAtFailure = readFaults();
+      await user.click({ placeholder: "Describe your task..." });
+      await user.press(world.app.handle.hostKind !== "daytona" && process.platform === "darwin" ? "Meta+A" : "Control+A");
+      await user.press("Backspace");
+      await probe.eventually(async () => ({
+        composer: await visibleFacts(world.failure.promptA),
+        recovery: await recoveryUiFacts(existingRestoreLabel, originalFailureMessage),
+      }), {
+        within: 10_000,
+        label: "clearing existing-session draft B by keyboard enables its restore action",
+        until: (state) => state.composer.composerText === ""
+          && state.recovery.restoreVisible && state.recovery.restoreDisabled === false,
+      });
+      await user.click({ role: "button", label: existingRestoreLabel });
+      const promptRestored = await probe.eventually(async () => ({
+        composer: await visibleFacts(world.failure.promptA),
+        recovery: await recoveryUiFacts(existingRestoreLabel, originalFailureMessage),
+      }), {
+        within: 10_000,
+        label: "the real existing-session restore action restores exactly failed payload A",
+        until: (state) => state.composer.composerEditable
+          && state.composer.composerText === world.failure.promptA
+          && state.composer.rowCount === 0 && state.composer.markerOccurrences === 0
+          && !state.recovery.restoreVisible,
+      });
+      const recoveredRunTask = await accessibleRunTask(
+        world.failure.promptA,
+        "the existing-session composer returns to enabled Run task after explicit recovery",
+      );
       const promptBackend = await world.messageFacts(world.existing.sessionId, world.failure.promptA);
       const afterPromptFailure = await world.sessionIds();
       const promptRequestsAfter = readFaults();
-      negatives.promptFailureComposerReady = promptRunTask && promptFacts.composerEditable;
-      negatives.promptFailureARecoverable = (promptFacts.rowCount === 1 && promptFacts.markerOccurrences === 1)
-        || occurrences(promptFacts.composerText, world.failure.promptA) === 1;
-      negatives.promptFailureDraftBSurvives = occurrences(promptFacts.composerText, world.failure.promptB) === 1;
-      negatives.promptFailureNoFallbackSession = promptFacts.sessionId === world.existing.sessionId
+      negatives.promptFailureComposerReady = promptFailure.composer.composerEditable
+        && promptFailure.recovery.failureMessage.includes(originalFailureMessage)
+        && promptFailure.recovery.restoreVisible && promptFailure.recovery.restoreDisabled === true
+        && recoveredRunTask.ready;
+      negatives.promptFailureARecoverable = promptRestored.composer.composerText === world.failure.promptA
+        && promptRestored.composer.rowCount === 0 && promptRestored.composer.markerOccurrences === 0
+        && !promptRestored.recovery.restoreVisible
+        && promptRequestsAfter.creation === promptRequestsAtFailure.creation
+        && promptRequestsAfter.prompt === promptRequestsAtFailure.prompt;
+      negatives.promptFailureDraftBSurvives = promptFailure.composer.composerText === world.failure.promptB;
+      negatives.promptFailureNoFallbackSession = promptRestored.composer.sessionId === world.existing.sessionId
         && promptBackend.markerCount === 0 && promptBackend.markerOccurrences === 0
         && JSON.stringify(afterPromptFailure) === JSON.stringify(beforePromptFailure)
         && promptRequestsAfter.prompt - promptRequestsBefore.prompt === 1
         && promptRequestsAfter.creation === promptRequestsBefore.creation;
+      evidence.recordAssertionEvidence(
+        "Failed existing-session prompt preserves draft B and restores exact payload A without retry",
+        JSON.stringify({ failureMessage: promptFailure.recovery.failureMessage, restoreDisabledWithDraftB: promptFailure.recovery.restoreDisabled, requestsBefore: promptRequestsBefore, requestsAtFailure: promptRequestsAtFailure, requestsAfterRestore: promptRequestsAfter }),
+        negatives.promptFailureComposerReady && negatives.promptFailureARecoverable
+          && negatives.promptFailureDraftBSurvives && negatives.promptFailureNoFallbackSession,
+      );
       await promptRow[Symbol.asyncDispose]();
     });
 
@@ -604,12 +804,22 @@ test("workspace New task is instantly typable and every v1 send paints before en
       await waitRenderer(rowObserver);
       await rowObserver[Symbol.asyncDispose]();
       const beforeReload = await visibleFacts(world.responseHold.marker);
+      const beforeReloadProof = {
+        providerRequestCount: await world.providerRequestCount(world.responseHold.marker),
+        sessionIds: await world.sessionIds(),
+        nativeUser: await world.messageFacts(world.existing.sessionId, world.responseHold.marker),
+        nativeReply: await world.messageFacts(world.existing.sessionId, world.responseHold.reply),
+        visibleUser: await world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
+        visibleReply: await world.visibleMessageFacts(world.existing.sessionId, "assistant", world.responseHold.reply),
+      };
+      await faults.suspend();
       await user.reload();
       await probe.eventually(activeSessionId, {
         within: 30_000,
         label: "response-stage session remains selected after reload",
         until: (sessionId) => sessionId === world.existing.sessionId,
       });
+      await faults.resume();
       const afterReload = await probe.eventually(() => visibleFacts(world.responseHold.marker), {
         within: 30_000,
         label: "reloaded SSE-reconciled row remains exactly once",
@@ -617,13 +827,28 @@ test("workspace New task is instantly typable and every v1 send paints before en
       });
       const backend = await world.messageFacts(world.existing.sessionId, world.responseHold.marker);
       const replyBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.reply);
+      const afterReloadProof = {
+        providerRequestCount: await world.providerRequestCount(world.responseHold.marker),
+        sessionIds: await world.sessionIds(),
+        visibleUser: await world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
+        visibleReply: await world.visibleMessageFacts(world.existing.sessionId, "assistant", world.responseHold.reply),
+      };
       const requestsAfter = readFaults();
       negatives.responseSseReconciliation = sseBeforeResponse
         && responseHeld.elapsedMs >= boundaryHoldMs
         && beforeReload.rowCount === 1 && beforeReload.markerOccurrences === 1
         && afterReload.rowCount === 1 && afterReload.markerOccurrences === 1
+        && beforeReloadProof.providerRequestCount === 1
+        && afterReloadProof.providerRequestCount === beforeReloadProof.providerRequestCount
+        && JSON.stringify(afterReloadProof.sessionIds) === JSON.stringify(beforeReloadProof.sessionIds)
+        && beforeReloadProof.nativeUser.markerCount === 1 && beforeReloadProof.nativeUser.markerOccurrences === 1
+        && beforeReloadProof.nativeReply.markerCount === 1 && beforeReloadProof.nativeReply.markerOccurrences === 1
+        && beforeReloadProof.visibleUser.rowCount === 1 && beforeReloadProof.visibleUser.markerOccurrences === 1
+        && beforeReloadProof.visibleReply.rowCount === 1 && beforeReloadProof.visibleReply.markerOccurrences === 1
         && backend.markerCount === 1 && backend.markerOccurrences === 1
         && replyBackend.markerCount === 1 && replyBackend.markerOccurrences === 1
+        && afterReloadProof.visibleUser.rowCount === 1 && afterReloadProof.visibleUser.markerOccurrences === 1
+        && afterReloadProof.visibleReply.rowCount === 1 && afterReloadProof.visibleReply.markerOccurrences === 1
         && requestsAfter.prompt - requestsBefore.prompt === 1
         && requestsAfter.creation === requestsBefore.creation
         && JSON.stringify(await world.sessionIds()) === JSON.stringify(inventoryBefore);
@@ -643,16 +868,6 @@ test("workspace New task is instantly typable and every v1 send paints before en
     const negativePass = Object.values(negatives).every(Boolean);
     const expansionPass = expandedAfter === expandedBefore;
 
-    evidence.recordAssertionEvidence(
-      "Twelve New task clicks expose a focused, unobstructed composer within 500 ms",
-      JSON.stringify({ definition: "trusted click capture to the second consecutive requestAnimationFrame that sees the exact sessionless workspace route, visible new-task heading, no old primary-pane session surface, and the focused viewport-intersecting center-hit-testable editor; CDP polling roundtrip excluded; this is a conservative frame opportunity, not a literal pixel-presentation timestamp", limitMs: newTaskLimitMs, report: timingReport(newTaskSamples) }),
-      newTaskPass,
-    );
-    evidence.recordAssertionEvidence(
-      "Twelve lazy and twelve existing-session sends expose their visible user row within 100 ms before v1 engine work",
-      JSON.stringify({ definition: "trusted Enter keydown capture to the second consecutive requestAnimationFrame that sees the marker in a viewport-intersecting data-message-role=user row outside the composer; CDP polling roundtrip excluded", limitMs: sendLimitMs, lazy: timingReport(lazySendSamples), existing: timingReport(existingSendSamples) }),
-      lazySendPass && existingSendPass,
-    );
     evidence.recordAssertionEvidence(
       "Held, failed, navigated, SSE-reconciled, and reloaded sends remain singular and preserve drafts",
       JSON.stringify({ negatives, expansionUnchanged: expansionPass }),
@@ -692,18 +907,37 @@ test("workspace New task is instantly typable and every v1 send paints before en
     }
     try { lastFaultCounts = faults.read(); } catch {}
     evidence.recordAssertionEvidence(
-      "Instant-send partial and final diagnostics retain every attempted sample",
+      "Instant-send run diagnostics retain the terminal state without combining timing payloads",
       JSON.stringify({
         completed: journeyCompleted,
         error: diagnosticError,
         faultCounts: lastFaultCounts,
         typing: typingDiagnostics,
         negatives,
-        newTask: timingReport(newTaskSamples),
-        lazy: timingReport(lazySendSamples),
-        existing: timingReport(existingSendSamples),
       }),
       journeyCompleted,
+    );
+    evidence.recordAssertionEvidence(
+      "Raw New task timing samples are retained, including any pending partial sample",
+      JSON.stringify(timingReport(newTaskSamples)),
+      newTaskSamples.length === sampleCount && newTaskSamples.every((entry) => entry.elapsedMs !== null
+        && entry.elapsedMs < newTaskLimitMs && entry.trusted && entry.consecutiveFrames >= 2
+        && entry.exact && entry.typedWithoutClick),
+    );
+    evidence.recordAssertionEvidence(
+      "Raw lazy-send timing samples are retained, including any pending partial sample",
+      JSON.stringify(timingReport(lazySendSamples)),
+      lazySendSamples.length === sampleCount && lazySendSamples.every((entry) => entry.elapsedMs !== null
+        && entry.elapsedMs < sendLimitMs && entry.trusted && entry.consecutiveFrames >= 2 && entry.beforeEngine
+        && entry.firstHoldMs >= boundaryHoldMs && entry.secondHoldMs >= boundaryHoldMs
+        && entry.firstHeldCount === 1 && entry.secondHeldCount === 1 && entry.exact && entry.typedWithoutClick),
+    );
+    evidence.recordAssertionEvidence(
+      "Raw existing-send timing samples are retained, including any pending partial sample",
+      JSON.stringify(timingReport(existingSendSamples)),
+      existingSendSamples.length === sampleCount && existingSendSamples.every((entry) => entry.elapsedMs !== null
+        && entry.elapsedMs < sendLimitMs && entry.trusted && entry.consecutiveFrames >= 2 && entry.beforeEngine
+        && entry.firstHoldMs >= boundaryHoldMs && entry.firstHeldCount === 1 && entry.exact),
     );
   }
 });

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -74,6 +74,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
   const existingSendSamples: TimingSample[] = [];
   const typingDiagnostics: { index: number; beforeText: string; afterText: string }[] = [];
   let lastFaultCounts = { creation: 0, prompt: 0 };
+  let expectedSessionId: string | null = world.existing.sessionId;
   const negatives = {
     rapidDuplicateEnter: false,
     successDraftB: false,
@@ -109,6 +110,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
     return ownsRoute ? sessionId : "";
   }, [world.workspace.workspaceId]));
   const openSession = async (session: { sessionId: string }) => {
+    expectedSessionId = session.sessionId;
     // Untimed setup navigation uses the client boundary; pointer navigation is a separate journey.
     if (await activeSessionId() !== session.sessionId) await agent.run("session.open", { sessionId: session.sessionId });
     await probe.eventually(activeSessionId, {
@@ -294,11 +296,12 @@ test("workspace New task is instantly typable and every v1 send paints before en
         if (!scenario) throw new Error(`Missing lazy sample ${index + 1}`);
         await openSession(world.existing);
         await user.see({ text: world.existingHistory });
-        const serverBeforeOpen = await world.sessionIds();
-        const agentBeforeOpen = (await agent.list()).map((session) => session.sessionId).sort();
+        const targetNativeBeforeOpen = await world.sessionIds();
+        const globalUiBeforeOpen = (await agent.list()).map((session) => session.sessionId).sort();
         const requestsBeforeOpen = readFaults();
         const newTaskPoint = await world.prepareWorkspaceNewTask();
         const readyObserver = await world.observeRenderer("new-task");
+        expectedSessionId = null;
         await world.clickWorkspaceNewTask(newTaskPoint);
         const readySample = sample(index + 1, await readyObserver.read(), { exact: false, typedWithoutClick: false });
         newTaskSamples.push(readySample);
@@ -307,27 +310,28 @@ test("workspace New task is instantly typable and every v1 send paints before en
         updateRendererSample(readySample, ready);
         await readyObserver[Symbol.asyncDispose]();
         pendingMeasurement.current = null;
-        const serverAfterOpen = await world.sessionIds();
-        const agentAfterOpen = (await agent.list()).map((session) => session.sessionId).sort();
+        const targetNativeAfterOpen = await world.sessionIds();
+        const globalUiAfterOpen = (await agent.list()).map((session) => session.sessionId).sort();
         const requestsAfterOpen = readFaults();
         const routeAfterOpen = await probe.hash();
         const openingSubfacts = {
-          backendInventoryUnchanged: JSON.stringify(serverAfterOpen) === JSON.stringify(serverBeforeOpen),
-          cachedIdsRetained: agentBeforeOpen.every((sessionId) => agentAfterOpen.includes(sessionId)),
-          cachedIdsAuthoritative: [...agentBeforeOpen, ...agentAfterOpen]
-            .every((sessionId) => serverBeforeOpen.includes(sessionId)),
-          zeroCreationPosts: requestsAfterOpen.creation === requestsBeforeOpen.creation,
-          zeroPromptPosts: requestsAfterOpen.prompt === requestsBeforeOpen.prompt,
+          globalUiRetained: globalUiBeforeOpen.every((sessionId) => globalUiAfterOpen.includes(sessionId)),
+          targetNativeStable: JSON.stringify(targetNativeAfterOpen) === JSON.stringify(targetNativeBeforeOpen),
+          zeroTargetCreationPosts: requestsAfterOpen.creation === requestsBeforeOpen.creation,
+          zeroTargetPromptPosts: requestsAfterOpen.prompt === requestsBeforeOpen.prompt,
           sessionlessRoute: !routeAfterOpen.includes("/session/ses_"),
         };
         const openingStayedLazy = Object.values(openingSubfacts).every(Boolean);
-        if (!openingStayedLazy) {
-          evidence.recordAssertionEvidence(
-            `Lazy New task sample ${index + 1} opening invariants`,
-            JSON.stringify({ index: index + 1, ...openingSubfacts, serverBeforeOpen, serverAfterOpen, agentBeforeOpen, agentAfterOpen, requestsBeforeOpen, requestsAfterOpen, routeAfterOpen }),
-            false,
-          );
-        }
+        evidence.recordJsonArtifact(`Lazy New task sample ${index + 1} opening invariants`, {
+          checks: openingSubfacts,
+          globalUi: { before: globalUiBeforeOpen, after: globalUiAfterOpen, retained: openingSubfacts.globalUiRetained },
+          targetNative: { before: targetNativeBeforeOpen, after: targetNativeAfterOpen, stable: openingSubfacts.targetNativeStable },
+          requestDelta: {
+            creation: requestsAfterOpen.creation - requestsBeforeOpen.creation,
+            prompt: requestsAfterOpen.prompt - requestsBeforeOpen.prompt,
+          },
+          routeAfterOpen,
+        });
         if (index === 0) await user.see({ text: "What do you need done?" });
         const typed = await world.insertFocusedText(scenario.marker);
         typingDiagnostics.push({ index: index + 1, beforeText: typed.beforeText, afterText: typed.afterText });
@@ -364,13 +368,14 @@ test("workspace New task is instantly typable and every v1 send paints before en
         }
         await createGate.release();
         const createdIds = await probe.eventually(async () => (await world.sessionIds())
-          .filter((sessionId) => !serverBeforeOpen.includes(sessionId)), {
+          .filter((sessionId) => !targetNativeBeforeOpen.includes(sessionId)), {
           within: 30_000,
           label: `lazy sample ${index + 1} creates a real v1 session after release`,
           until: (sessionIds) => sessionIds.length > 0,
         });
         const createdSessionId = createdIds[0];
         if (!createdSessionId) throw new Error(`Lazy sample ${index + 1} did not expose its created session id.`);
+        expectedSessionId = createdSessionId;
         const promptHeld = await waitHeld(promptGate);
         lazySample.secondHoldMs = promptHeld.elapsedMs;
         lazySample.secondHeldCount = promptHeld.held;
@@ -391,13 +396,13 @@ test("workspace New task is instantly typable and every v1 send paints before en
         const requestAfterSend = readFaults();
         const serverAfterSend = await world.sessionIds();
         const exact = createdIds.length === 1
-          && heldInventory.length === serverBeforeOpen.length
+          && heldInventory.length === targetNativeBeforeOpen.length
           && backendBeforePromptRelease.every((facts) => facts.markerCount === 0 && facts.markerOccurrences === 0)
           && backend.reduce((total, facts) => total + facts.markerCount, 0) === 1
           && backend.reduce((total, facts) => total + facts.markerOccurrences, 0) === 1
           && requestAfterSend.creation - requestBeforeSend.creation === 1
           && requestAfterSend.prompt - requestBeforeSend.prompt === 1
-          && serverAfterSend.length === serverBeforeOpen.length + 1
+          && serverAfterSend.length === targetNativeBeforeOpen.length + 1
           && active === createdSessionId
           && visible.rowCount === 1 && visible.markerOccurrences === 1;
         lazySample.exact = exact;
@@ -421,6 +426,22 @@ test("workspace New task is instantly typable and every v1 send paints before en
             label: "the first lazy session remains selected after reload",
             until: (sessionId) => sessionId === createdSessionId,
           });
+          await probe.eventually(async () => {
+            const [renderedUser, renderedReply, renderer] = await Promise.all([
+              world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
+              world.visibleMessageFacts(createdSessionId, "assistant", scenario.reply),
+              world.rendererDiagnostic(createdSessionId),
+            ]);
+            return { renderedUser, renderedReply, renderer };
+          }, {
+            within: 30_000,
+            label: `the correct-owner reloaded v1 transcript ${createdSessionId} renders its user and reply rows`,
+            until: ({ renderedUser, renderedReply, renderer }) => renderer.ownerWorkspaceId === world.workspace.workspaceId
+              && renderer.ownerSessionId === createdSessionId
+              && renderedUser.totalRowCount > 0 && renderedReply.totalRowCount > 0,
+          });
+          await user.see({ text: scenario.marker }, { timeoutMs: 30_000 });
+          await user.see({ text: scenario.reply }, { timeoutMs: 30_000 });
           const reloadedState = await probe.eventually(async () => {
             const [reloaded, visibleUser, visibleReply] = await Promise.all([
               visibleFacts(scenario.marker),
@@ -430,11 +451,11 @@ test("workspace New task is instantly typable and every v1 send paints before en
             return { reloaded, visibleUser, visibleReply };
           }, {
             within: 30_000,
-            label: `reloaded v1 transcript ${createdSessionId} renders its user and reply rows`,
-            until: ({ reloaded, visibleUser, visibleReply }) => reloaded.rowCount > 0
-              && reloaded.markerOccurrences > 0
-              && visibleUser.rowCount > 0 && visibleUser.markerOccurrences > 0
-              && visibleReply.rowCount > 0 && visibleReply.markerOccurrences > 0,
+            label: `the reloaded v1 user and reply can be viewed exactly once in ${createdSessionId}`,
+            until: ({ reloaded, visibleUser, visibleReply }) => reloaded.rowCount === 1
+              && reloaded.markerOccurrences === 1
+              && visibleUser.rowCount === 1 && visibleUser.markerOccurrences === 1
+              && visibleReply.rowCount === 1 && visibleReply.markerOccurrences === 1,
           });
           const { reloaded } = reloadedState;
           const reloadedBackend = await probe.eventually(() => world.messageFacts(createdSessionId, scenario.marker), {
@@ -460,12 +481,17 @@ test("workspace New task is instantly typable and every v1 send paints before en
             && beforeReload.nativeUser.markerCount === 1 && beforeReload.nativeUser.markerOccurrences === 1
             && beforeReload.nativeReply.markerCount === 1 && beforeReload.nativeReply.markerOccurrences === 1
             && beforeReload.visibleUser.rowCount === 1 && beforeReload.visibleUser.markerOccurrences === 1
+            && beforeReload.visibleUser.totalRowCount === 1
             && beforeReload.visibleReply.rowCount === 1 && beforeReload.visibleReply.markerOccurrences === 1
+            && beforeReload.visibleReply.totalRowCount === 1
             && reloadedBackend.markerCount === 1 && reloadedBackend.markerOccurrences === 1
             && afterReload.nativeReply.markerCount === 1 && afterReload.nativeReply.markerOccurrences === 1
             && afterReload.visibleUser.rowCount === 1 && afterReload.visibleUser.markerOccurrences === 1
-            && afterReload.visibleReply.rowCount === 1 && afterReload.visibleReply.markerOccurrences === 1;
+            && afterReload.visibleUser.totalRowCount === 1
+            && afterReload.visibleReply.rowCount === 1 && afterReload.visibleReply.markerOccurrences === 1
+            && afterReload.visibleReply.totalRowCount === 1;
           evidence.recordJsonArtifact("First reload proof", {
+            claim: "The exact user message and reply can be viewed after reload without duplicates.",
             visibleUserCount: afterReload.visibleUser.rowCount,
             visibleReplyCount: afterReload.visibleReply.rowCount,
             providerCountBefore: beforeReload.providerRequestCount,
@@ -608,6 +634,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
       const beforeCreationFailure = await world.sessionIds();
       const creationRequestsBefore = readFaults();
       const newTaskPoint = await world.prepareWorkspaceNewTask();
+      expectedSessionId = null;
       await world.clickWorkspaceNewTask(newTaskPoint);
       await probe.eventually(() => visibleFacts(""), {
         within: 10_000,
@@ -797,6 +824,26 @@ test("workspace New task is instantly typable and every v1 send paints before en
         && navigationBackend.markerCount === 1 && navigationBackend.markerOccurrences === 1
         && navigationReplyBackend.markerCount === 1 && navigationReplyBackend.markerOccurrences === 1
         && requestsAfter.prompt - requestsBefore.prompt === 1;
+      evidence.recordJsonArtifact("Navigation isolation conjuncts", {
+        checks: {
+          unrelatedBeforeRowsAbsent: unrelatedBefore.rowCount === 0 && unrelatedBefore.markerOccurrences === 0,
+          unrelatedBeforeDraftIsolated: !unrelatedBefore.composerText.includes(world.failure.navigationB),
+          unrelatedAfterRowsAbsent: unrelatedAfter.rowCount === 0 && unrelatedAfter.markerOccurrences === 0,
+          unrelatedAfterDraftIsolated: !unrelatedAfter.composerText.includes(world.failure.navigationB),
+          stayedUnrelated,
+          originRowExact: originAfter.rowCount === 1 && originAfter.markerOccurrences === 1,
+          originDraftBExact: occurrences(originAfter.composerText, world.failure.navigationB) === 1,
+          nativeUserExact: navigationBackend.markerCount === 1 && navigationBackend.markerOccurrences === 1,
+          nativeReplyExact: navigationReplyBackend.markerCount === 1 && navigationReplyBackend.markerOccurrences === 1,
+          promptRequestExact: requestsAfter.prompt - requestsBefore.prompt === 1,
+        },
+        unrelatedBefore: { rows: unrelatedBefore.rowCount, occurrences: unrelatedBefore.markerOccurrences, sessionId: unrelatedBefore.sessionId, focused: unrelatedBefore.focusedEditor },
+        unrelatedAfter: { rows: unrelatedAfter.rowCount, occurrences: unrelatedAfter.markerOccurrences, sessionId: unrelatedAfter.sessionId, focused: unrelatedAfter.focusedEditor },
+        originAfter: { rows: originAfter.rowCount, occurrences: originAfter.markerOccurrences, draftBOccurrences: occurrences(originAfter.composerText, world.failure.navigationB), sessionId: originAfter.sessionId, focused: originAfter.focusedEditor },
+        nativeUser: { count: navigationBackend.markerCount, occurrences: navigationBackend.markerOccurrences },
+        nativeReply: { count: navigationReplyBackend.markerCount, occurrences: navigationReplyBackend.markerOccurrences },
+        requestDelta: { creation: requestsAfter.creation - requestsBefore.creation, prompt: requestsAfter.prompt - requestsBefore.prompt },
+      });
       await rowObserver[Symbol.asyncDispose]();
     });
 
@@ -810,32 +857,45 @@ test("workspace New task is instantly typable and every v1 send paints before en
       const rowObserver = await world.observeRenderer("user-row", world.responseHold.marker);
       await user.press("Enter");
       const responseHeld = await waitHeld(responseGate);
-      const sseBeforeResponse = await probe.eventually(async () => {
-        const visible = await visibleFacts(world.responseHold.marker);
+      await probe.eventually(async () => {
         const userBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.marker);
         const replyBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.reply);
         return {
-          ready: visible.rowCount > 0 && visible.markerOccurrences > 0 && await surfaceContains(world.responseHold.reply)
-            && userBackend.markerOccurrences > 0 && replyBackend.markerOccurrences > 0,
+          ready: userBackend.markerOccurrences > 0 && replyBackend.markerOccurrences > 0,
           responseStillHeld: !responseGate.read().released,
         };
       }, {
         within: 20_000,
-        label: "SSE renders the real operation while its HTTP response remains held",
+        label: "SSE delivers the real operation while its HTTP response remains held",
         until: (facts) => facts.ready && facts.responseStillHeld,
-      }).then((facts) => facts.ready && facts.responseStillHeld, () => false);
+      });
+      await user.see({ text: world.responseHold.reply });
+      const sseVisiblePair = await probe.eventually(async () => {
+        const [visibleUser, visibleReply] = await Promise.all([
+          world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
+          world.visibleMessageFacts(world.existing.sessionId, "assistant", world.responseHold.reply),
+        ]);
+        return { visibleUser, visibleReply, responseStillHeld: !responseGate.read().released };
+      }, {
+        within: 20_000,
+        label: "normal user observation exposes the SSE user and reply while the response remains held",
+        until: (facts) => facts.visibleUser.rowCount > 0 && facts.visibleUser.markerOccurrences > 0
+          && facts.visibleReply.rowCount > 0 && facts.visibleReply.markerOccurrences > 0
+          && facts.responseStillHeld,
+      });
+      const sseBeforeResponse = sseVisiblePair.responseStillHeld;
       await responseGate.release();
       await waitReply(world.responseHold.reply);
       await waitRenderer(rowObserver);
       await rowObserver[Symbol.asyncDispose]();
-      const beforeReload = await visibleFacts(world.responseHold.marker);
+      const beforeReload = sseVisiblePair.visibleUser;
       const beforeReloadProof = {
         providerRequestCount: await world.providerRequestCount(world.responseHold.marker),
         sessionIds: await world.sessionIds(),
         nativeUser: await world.messageFacts(world.existing.sessionId, world.responseHold.marker),
         nativeReply: await world.messageFacts(world.existing.sessionId, world.responseHold.reply),
-        visibleUser: await world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
-        visibleReply: await world.visibleMessageFacts(world.existing.sessionId, "assistant", world.responseHold.reply),
+        visibleUser: sseVisiblePair.visibleUser,
+        visibleReply: sseVisiblePair.visibleReply,
       };
       await faults.suspend();
       await user.reload();
@@ -847,14 +907,16 @@ test("workspace New task is instantly typable and every v1 send paints before en
       let finalReloadDiagnostic: unknown = null;
       let finalReloadPolls = 0;
       const finalReloadStartedAt = Date.now();
-      const afterReloadState = await (async () => {
+      const afterReloadRenderedState = await (async () => {
         try {
           return await probe.eventually(async () => {
             finalReloadPolls += 1;
-            const [renderedUser, native, exactNonUtilityModelInvocations] = await Promise.all([
+            const [renderedUser, renderedReply, native, exactNonUtilityModelInvocations, renderer] = await Promise.all([
               world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
+              world.visibleMessageFacts(world.existing.sessionId, "assistant", world.responseHold.reply),
               world.messageFacts(world.existing.sessionId, world.responseHold.marker, world.responseHold.reply),
               world.providerRequestCount(world.responseHold.marker),
+              world.rendererDiagnostic(world.existing.sessionId),
             ]);
             const interceptorState = faults.read();
             const responseGateState = responseGate.read();
@@ -869,8 +931,16 @@ test("workspace New task is instantly typable and every v1 send paints before en
                 surfaces: renderedUser.surfaceCount,
                 visibleSurfaces: renderedUser.visibleSurfaceCount,
               },
+              renderedReply: {
+                total: renderedReply.totalRowCount,
+                viewport: renderedReply.rowCount,
+                offscreen: renderedReply.offscreenRowCount,
+                surfaces: renderedReply.surfaceCount,
+                visibleSurfaces: renderedReply.visibleSurfaceCount,
+              },
               labels: { loaders: renderedUser.loaderLabels, errors: renderedUser.errorLabels },
               browserNetwork: renderedUser.network,
+              renderer,
               exactNonUtilityModelInvocations,
               interceptor: {
                 enabled: interceptorState.enabled,
@@ -883,27 +953,46 @@ test("workspace New task is instantly typable and every v1 send paints before en
                 gateReleased: responseGateState.released,
               },
             };
-            return { renderedUser };
+            return { renderedUser, renderedReply, renderer };
           }, {
             within: 30_000,
-            label: "reloaded SSE-reconciled row remains exactly once",
-            until: (state) => state.renderedUser.rowCount > 0 && state.renderedUser.markerOccurrences > 0,
+            label: "the correct-owner reloaded SSE transcript renders its user and reply rows",
+            until: (state) => state.renderer.ownerWorkspaceId === world.workspace.workspaceId
+              && state.renderer.ownerSessionId === world.existing.sessionId
+              && state.renderedUser.totalRowCount > 0 && state.renderedReply.totalRowCount > 0,
           });
         } catch (error) {
           evidence.recordJsonArtifact("Final reload diagnostic", finalReloadDiagnostic ?? { capture: "unavailable" });
           throw error;
         }
       })();
-      const afterReload = afterReloadState.renderedUser;
+      await user.see({ text: world.responseHold.marker }, { timeoutMs: 30_000 });
+      await user.see({ text: world.responseHold.reply }, { timeoutMs: 30_000 });
+      const afterReloadVisible = await probe.eventually(async () => {
+        const [visibleUser, visibleReply] = await Promise.all([
+          world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
+          world.visibleMessageFacts(world.existing.sessionId, "assistant", world.responseHold.reply),
+        ]);
+        return { visibleUser, visibleReply };
+      }, {
+        within: 30_000,
+        label: "the reloaded SSE user and reply can be viewed exactly once",
+        until: ({ visibleUser, visibleReply }) => visibleUser.rowCount === 1 && visibleUser.markerOccurrences === 1
+          && visibleUser.totalRowCount === 1
+          && visibleReply.rowCount === 1 && visibleReply.markerOccurrences === 1
+          && visibleReply.totalRowCount === 1,
+      });
+      const afterReload = afterReloadVisible.visibleUser;
       const backend = await world.messageFacts(world.existing.sessionId, world.responseHold.marker);
       const replyBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.reply);
       const afterReloadProof = {
         providerRequestCount: await world.providerRequestCount(world.responseHold.marker),
         sessionIds: await world.sessionIds(),
-        visibleUser: await world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
-        visibleReply: await world.visibleMessageFacts(world.existing.sessionId, "assistant", world.responseHold.reply),
+        visibleUser: afterReloadVisible.visibleUser,
+        visibleReply: afterReloadVisible.visibleReply,
       };
       const requestsAfter = readFaults();
+      const inventoryEqual = JSON.stringify(await world.sessionIds()) === JSON.stringify(inventoryBefore);
       negatives.responseSseReconciliation = sseBeforeResponse
         && responseHeld.elapsedMs >= boundaryHoldMs
         && beforeReload.rowCount === 1 && beforeReload.markerOccurrences === 1
@@ -914,14 +1003,68 @@ test("workspace New task is instantly typable and every v1 send paints before en
         && beforeReloadProof.nativeUser.markerCount === 1 && beforeReloadProof.nativeUser.markerOccurrences === 1
         && beforeReloadProof.nativeReply.markerCount === 1 && beforeReloadProof.nativeReply.markerOccurrences === 1
         && beforeReloadProof.visibleUser.rowCount === 1 && beforeReloadProof.visibleUser.markerOccurrences === 1
+        && beforeReloadProof.visibleUser.totalRowCount === 1
         && beforeReloadProof.visibleReply.rowCount === 1 && beforeReloadProof.visibleReply.markerOccurrences === 1
+        && beforeReloadProof.visibleReply.totalRowCount === 1
         && backend.markerCount === 1 && backend.markerOccurrences === 1
         && replyBackend.markerCount === 1 && replyBackend.markerOccurrences === 1
         && afterReloadProof.visibleUser.rowCount === 1 && afterReloadProof.visibleUser.markerOccurrences === 1
+        && afterReloadProof.visibleUser.totalRowCount === 1
         && afterReloadProof.visibleReply.rowCount === 1 && afterReloadProof.visibleReply.markerOccurrences === 1
+        && afterReloadProof.visibleReply.totalRowCount === 1
         && requestsAfter.prompt - requestsBefore.prompt === 1
         && requestsAfter.creation === requestsBefore.creation
-        && JSON.stringify(await world.sessionIds()) === JSON.stringify(inventoryBefore);
+        && inventoryEqual;
+      evidence.recordJsonArtifact("SSE reconciliation conjuncts", {
+        checks: {
+          sseBeforeResponse,
+          responseHeldLongEnough: responseHeld.elapsedMs >= boundaryHoldMs,
+          beforeReloadUserExact: beforeReload.rowCount === 1 && beforeReload.markerOccurrences === 1,
+          afterReloadUserExact: afterReload.rowCount === 1 && afterReload.markerOccurrences === 1,
+          providerBeforeExact: beforeReloadProof.providerRequestCount === 1,
+          providerCountStable: afterReloadProof.providerRequestCount === beforeReloadProof.providerRequestCount,
+          inventoryStableAcrossReload: JSON.stringify(afterReloadProof.sessionIds) === JSON.stringify(beforeReloadProof.sessionIds),
+          beforeNativeUserExact: beforeReloadProof.nativeUser.markerCount === 1 && beforeReloadProof.nativeUser.markerOccurrences === 1,
+          beforeNativeReplyExact: beforeReloadProof.nativeReply.markerCount === 1 && beforeReloadProof.nativeReply.markerOccurrences === 1,
+          beforeVisibleUserExact: beforeReloadProof.visibleUser.rowCount === 1 && beforeReloadProof.visibleUser.markerOccurrences === 1 && beforeReloadProof.visibleUser.totalRowCount === 1,
+          beforeVisibleReplyExact: beforeReloadProof.visibleReply.rowCount === 1 && beforeReloadProof.visibleReply.markerOccurrences === 1 && beforeReloadProof.visibleReply.totalRowCount === 1,
+          afterNativeUserExact: backend.markerCount === 1 && backend.markerOccurrences === 1,
+          afterNativeReplyExact: replyBackend.markerCount === 1 && replyBackend.markerOccurrences === 1,
+          afterVisibleUserExact: afterReloadProof.visibleUser.rowCount === 1 && afterReloadProof.visibleUser.markerOccurrences === 1 && afterReloadProof.visibleUser.totalRowCount === 1,
+          afterVisibleReplyExact: afterReloadProof.visibleReply.rowCount === 1 && afterReloadProof.visibleReply.markerOccurrences === 1 && afterReloadProof.visibleReply.totalRowCount === 1,
+          promptRequestExact: requestsAfter.prompt - requestsBefore.prompt === 1,
+          creationRequestsStable: requestsAfter.creation === requestsBefore.creation,
+          inventoryEqual,
+        },
+        sseBeforeResponse,
+        claim: "The exact SSE-reconciled user message and reply can be viewed after reload without duplicates.",
+        responseHoldMs: round(responseHeld.elapsedMs),
+        renderedBeforeObservation: {
+          userRows: afterReloadRenderedState.renderedUser.totalRowCount,
+          replyRows: afterReloadRenderedState.renderedReply.totalRowCount,
+        },
+        beforeReload: { rows: beforeReload.rowCount, occurrences: beforeReload.markerOccurrences },
+        afterReload: { rows: afterReload.rowCount, occurrences: afterReload.markerOccurrences },
+        provider: { before: beforeReloadProof.providerRequestCount, after: afterReloadProof.providerRequestCount },
+        nativeBefore: {
+          user: { count: beforeReloadProof.nativeUser.markerCount, occurrences: beforeReloadProof.nativeUser.markerOccurrences },
+          reply: { count: beforeReloadProof.nativeReply.markerCount, occurrences: beforeReloadProof.nativeReply.markerOccurrences },
+        },
+        visibleBefore: {
+          user: { rows: beforeReloadProof.visibleUser.rowCount, occurrences: beforeReloadProof.visibleUser.markerOccurrences },
+          reply: { rows: beforeReloadProof.visibleReply.rowCount, occurrences: beforeReloadProof.visibleReply.markerOccurrences },
+        },
+        nativeAfter: {
+          user: { count: backend.markerCount, occurrences: backend.markerOccurrences },
+          reply: { count: replyBackend.markerCount, occurrences: replyBackend.markerOccurrences },
+        },
+        visibleAfter: {
+          user: { rows: afterReloadProof.visibleUser.rowCount, occurrences: afterReloadProof.visibleUser.markerOccurrences },
+          reply: { rows: afterReloadProof.visibleReply.rowCount, occurrences: afterReloadProof.visibleReply.markerOccurrences },
+        },
+        inventoryEquality: { reload: JSON.stringify(afterReloadProof.sessionIds) === JSON.stringify(beforeReloadProof.sessionIds), final: inventoryEqual },
+        requestDelta: { creation: requestsAfter.creation - requestsBefore.creation, prompt: requestsAfter.prompt - requestsBefore.prompt },
+      });
       if (negatives.responseSseReconciliation) await faults.resume();
     });
 
@@ -940,7 +1083,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
     const expansionPass = expandedAfter === expandedBefore;
 
     evidence.recordAssertionEvidence(
-      "Held, failed, navigated, SSE-reconciled, and reloaded sends remain singular and preserve drafts",
+      "Held, failed, navigated, and SSE-reconciled sends remain singular, can be viewed after reload, and preserve drafts",
       JSON.stringify({ negatives, expansionUnchanged: expansionPass }),
       negativePass && expansionPass,
     );
@@ -967,6 +1110,8 @@ test("workspace New task is instantly typable and every v1 send paints before en
     journeyCompleted = true;
   } catch (error) {
     diagnosticError = (error instanceof Error ? error.message : String(error)).slice(0, 500);
+    const renderer = await world.rendererDiagnostic(expectedSessionId).catch(() => ({ capture: "unavailable" }));
+    evidence.recordJsonArtifact("Renderer failure diagnostic", renderer);
     await user.screenshot().catch(() => undefined);
     throw error;
   } finally {

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -711,6 +711,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
       await waitHeld(creationGate);
       await world.insertFocusedText(world.failure.creationB);
       await creationGate.fail();
+      await user.see({ text: originalFailureMessage }, { timeoutMs: 15_000 });
       const creationFailure = await probe.eventually(async () => ({
         composer: await visibleFacts(world.failure.creationA),
         recovery: await recoveryUiFacts(creationRestoreLabel, originalFailureMessage),
@@ -781,6 +782,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
       await waitHeld(promptGate);
       await world.insertFocusedText(world.failure.promptB);
       await promptGate.fail();
+      await user.see({ text: originalFailureMessage }, { timeoutMs: 15_000 });
       const promptFailure = await probe.eventually(async () => ({
         composer: await visibleFacts(world.failure.promptA),
         recovery: await recoveryUiFacts(existingRestoreLabel, originalFailureMessage),

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -421,20 +421,34 @@ test("workspace New task is instantly typable and every v1 send paints before en
             label: "the first lazy session remains selected after reload",
             until: (sessionId) => sessionId === createdSessionId,
           });
-          await faults.resume();
-          const reloaded = await visibleFacts(scenario.marker);
-          const afterReloadRequests = readFaults();
+          const reloadedState = await probe.eventually(async () => {
+            const [reloaded, visibleUser, visibleReply] = await Promise.all([
+              visibleFacts(scenario.marker),
+              world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
+              world.visibleMessageFacts(createdSessionId, "assistant", scenario.reply),
+            ]);
+            return { reloaded, visibleUser, visibleReply };
+          }, {
+            within: 30_000,
+            label: `reloaded v1 transcript ${createdSessionId} renders its user and reply rows`,
+            until: ({ reloaded, visibleUser, visibleReply }) => reloaded.rowCount > 0
+              && reloaded.markerOccurrences > 0
+              && visibleUser.rowCount > 0 && visibleUser.markerOccurrences > 0
+              && visibleReply.rowCount > 0 && visibleReply.markerOccurrences > 0,
+          });
+          const { reloaded } = reloadedState;
           const reloadedBackend = await probe.eventually(() => world.messageFacts(createdSessionId, scenario.marker), {
             within: 30_000,
             label: `reloaded v1 transcript ${createdSessionId} is readable with exactly one marker`,
             until: (facts) => facts.markerCount === 1 && facts.markerOccurrences === 1,
           });
+          const afterReloadRequests = readFaults();
           const afterReload = {
             providerRequestCount: await world.providerRequestCount(scenario.marker),
             sessionIds: await world.sessionIds(),
             nativeReply: await world.messageFacts(createdSessionId, scenario.reply),
-            visibleUser: await world.visibleMessageFacts(createdSessionId, "user", scenario.marker),
-            visibleReply: await world.visibleMessageFacts(createdSessionId, "assistant", scenario.reply),
+            visibleUser: reloadedState.visibleUser,
+            visibleReply: reloadedState.visibleReply,
           };
           negatives.exactAfterReload = reloaded.rowCount === 1
             && reloaded.markerOccurrences === 1
@@ -451,6 +465,15 @@ test("workspace New task is instantly typable and every v1 send paints before en
             && afterReload.nativeReply.markerCount === 1 && afterReload.nativeReply.markerOccurrences === 1
             && afterReload.visibleUser.rowCount === 1 && afterReload.visibleUser.markerOccurrences === 1
             && afterReload.visibleReply.rowCount === 1 && afterReload.visibleReply.markerOccurrences === 1;
+          evidence.recordJsonArtifact("First reload proof", {
+            visibleUserCount: afterReload.visibleUser.rowCount,
+            visibleReplyCount: afterReload.visibleReply.rowCount,
+            providerCountBefore: beforeReload.providerRequestCount,
+            providerCountAfter: afterReload.providerRequestCount,
+            providerCountEqual: afterReload.providerRequestCount === beforeReload.providerRequestCount,
+            inventoryEqual: JSON.stringify(afterReload.sessionIds) === JSON.stringify(beforeReload.sessionIds),
+          });
+          await faults.resume();
         }
       }
     });
@@ -739,6 +762,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
     await step("navigation while a send is held cannot leak, clear the next draft, navigate late, or steal focus", async () => {
       await openSession(world.existing);
       await user.type({ placeholder: "Describe your task..." }, world.navigation.marker, { replace: true, verify: true });
+      await accessibleRunTask(world.navigation.marker, "the navigation payload has an enabled Run task control before Enter");
       const requestsBefore = readFaults();
       const promptGate = faults.holdNext("prompt", "request");
       const rowObserver = await world.observeRenderer("user-row", world.navigation.marker);
@@ -779,6 +803,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
     await step("a separately held real response reconciles from SSE without duplicate rows", async () => {
       await openSession(world.existing);
       await user.type({ placeholder: "Describe your task..." }, world.responseHold.marker, { replace: true, verify: true });
+      await accessibleRunTask(world.responseHold.marker, "the response-held payload has an enabled Run task control before Enter");
       const inventoryBefore = await world.sessionIds();
       const requestsBefore = readFaults();
       const responseGate = faults.holdNext("prompt", "response");
@@ -819,12 +844,57 @@ test("workspace New task is instantly typable and every v1 send paints before en
         label: "response-stage session remains selected after reload",
         until: (sessionId) => sessionId === world.existing.sessionId,
       });
-      await faults.resume();
-      const afterReload = await probe.eventually(() => visibleFacts(world.responseHold.marker), {
-        within: 30_000,
-        label: "reloaded SSE-reconciled row remains exactly once",
-        until: (facts) => facts.rowCount > 0 && facts.markerOccurrences > 0,
-      });
+      let finalReloadDiagnostic: unknown = null;
+      let finalReloadPolls = 0;
+      const finalReloadStartedAt = Date.now();
+      const afterReloadState = await (async () => {
+        try {
+          return await probe.eventually(async () => {
+            finalReloadPolls += 1;
+            const [renderedUser, native, exactNonUtilityModelInvocations] = await Promise.all([
+              world.visibleMessageFacts(world.existing.sessionId, "user", world.responseHold.marker),
+              world.messageFacts(world.existing.sessionId, world.responseHold.marker, world.responseHold.reply),
+              world.providerRequestCount(world.responseHold.marker),
+            ]);
+            const interceptorState = faults.read();
+            const responseGateState = responseGate.read();
+            finalReloadDiagnostic = {
+              elapsedMs: Date.now() - finalReloadStartedAt,
+              polls: finalReloadPolls,
+              native: native.diagnostic,
+              renderedUser: {
+                total: renderedUser.totalRowCount,
+                viewport: renderedUser.rowCount,
+                offscreen: renderedUser.offscreenRowCount,
+                surfaces: renderedUser.surfaceCount,
+                visibleSurfaces: renderedUser.visibleSurfaceCount,
+              },
+              labels: { loaders: renderedUser.loaderLabels, errors: renderedUser.errorLabels },
+              browserNetwork: renderedUser.network,
+              exactNonUtilityModelInvocations,
+              interceptor: {
+                enabled: interceptorState.enabled,
+                creationRequests: interceptorState.creation,
+                promptRequests: interceptorState.prompt,
+                activeGateCount: interceptorState.activeGateCount,
+                activeHeldRequestCount: interceptorState.activeHeldRequestCount,
+                gateHeldCount: responseGateState.held,
+                activeHeldCount: responseGateState.released ? 0 : responseGateState.held,
+                gateReleased: responseGateState.released,
+              },
+            };
+            return { renderedUser };
+          }, {
+            within: 30_000,
+            label: "reloaded SSE-reconciled row remains exactly once",
+            until: (state) => state.renderedUser.rowCount > 0 && state.renderedUser.markerOccurrences > 0,
+          });
+        } catch (error) {
+          evidence.recordJsonArtifact("Final reload diagnostic", finalReloadDiagnostic ?? { capture: "unavailable" });
+          throw error;
+        }
+      })();
+      const afterReload = afterReloadState.renderedUser;
       const backend = await world.messageFacts(world.existing.sessionId, world.responseHold.marker);
       const replyBackend = await world.messageFacts(world.existing.sessionId, world.responseHold.reply);
       const afterReloadProof = {
@@ -852,6 +922,7 @@ test("workspace New task is instantly typable and every v1 send paints before en
         && requestsAfter.prompt - requestsBefore.prompt === 1
         && requestsAfter.creation === requestsBefore.creation
         && JSON.stringify(await world.sessionIds()) === JSON.stringify(inventoryBefore);
+      if (negatives.responseSseReconciliation) await faults.resume();
     });
 
     const expandedAfter = await expanded();

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1,10 +1,11 @@
-import { browserScript } from "@openwork/cdp";
+import { allocateFreePort, browserScript, evaluate, locate, type Surface, typeText } from "@openwork/cdp";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { mkdir, rm } from "node:fs/promises";
 import { engineSessionProbe, observeSidebarExpansion, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
-import { resolveEvalEngine } from "@openwork/env";
-import type { Seed } from "@openwork/env";
+import { resolveEvalEngine, SkipError } from "@openwork/env";
+import type { Place, Seed } from "@openwork/env";
 import { daytonaSandbox, desktop as launchDesktop } from "@openwork/hosts";
+import { startMockMcp } from "@openwork/labs";
 
 const stormProviderId = "active-session-storm-mock";
 const stormModelId = "mock-agent-workload-model";
@@ -27,6 +28,348 @@ export interface StormPlan extends ShellSession, ShellWorkspace {
   slowMarker: string;
   easyMarker: string;
   finalReply: string;
+}
+
+type InstantMetricKind = "new-task" | "user-row";
+type InstantBoundaryKind = "creation" | "prompt";
+type InstantBoundaryStage = "request" | "response";
+
+type InstantRendererState = {
+  kind: InstantMetricKind;
+  started: boolean;
+  trusted: boolean;
+  elapsedMs: number | null;
+  frames: number;
+  mutations: number;
+  consecutiveFrames: number;
+  expired: boolean;
+};
+
+declare global {
+  interface Window {
+    __instantSendMetric?: { state: InstantRendererState; stop(): void };
+  }
+}
+
+function instantDeferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Renderer-only timing: trusted input capture through two consecutive animation-frame samples. */
+async function observeInstantRenderer(
+  seed: Seed,
+  app: Surface,
+  workspaceId: string,
+  kind: InstantMetricKind,
+  marker = "",
+) {
+  await seed.evalIn(app, browserScript((workspaceId, kind, marker) => {
+    if (window.__instantSendMetric) throw new Error("An instant-send renderer observer is already active");
+    const state: InstantRendererState = {
+      kind, started: false, trusted: false, elapsedMs: null, frames: 0,
+      mutations: 0, consecutiveFrames: 0, expired: false,
+    };
+    let startedAt = 0;
+    let frame = 0;
+
+    const visibleInViewport = (node: HTMLElement) => {
+      const rect = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+        && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
+        && style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity) > 0;
+    };
+    const surfaceRoot = () => {
+      if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) return null;
+      const sessionlessRoute = `#/workspace/${workspaceId}/session`;
+      if (location.hash === sessionlessRoute) {
+        const heading = [...document.querySelectorAll<HTMLElement>("h2")]
+          .find((candidate) => candidate.textContent?.trim() === "What do you need done?" && visibleInViewport(candidate));
+        const headingMain = heading?.closest<HTMLElement>("main") ?? null;
+        const main = headingMain && visibleInViewport(headingMain) ? headingMain
+          : [...document.querySelectorAll<HTMLElement>("main")].filter(visibleInViewport)
+              .find((candidate) => [...candidate.querySelectorAll<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"], [data-message-role]')]
+                .some(visibleInViewport)) ?? null;
+        const persistedSurfaceVisible = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")]
+          .some(visibleInViewport);
+        return main && !persistedSurfaceVisible
+          ? { kind: "new-task", root: main, headingVisible: Boolean(heading && main.contains(heading)) }
+          : null;
+      }
+      const persistedPrefix = `#/workspace/${workspaceId}/session/`;
+      if (!location.hash.startsWith(persistedPrefix)) return null;
+      const sessionId = location.hash.slice(persistedPrefix.length);
+      if (!sessionId.startsWith("ses_") || /[/?#]/.test(sessionId)) return null;
+      const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')]
+        .find(visibleInViewport);
+      const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+        .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId && visibleInViewport(candidate));
+      return pane && surface ? { kind: "persisted", root: pane, headingVisible: false } : null;
+    };
+    const editor = () => surfaceRoot()?.root.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]') ?? null;
+    const ready = () => {
+      const surface = surfaceRoot();
+      if (!surface) return false;
+      if (kind === "new-task") {
+        if (surface.kind !== "new-task" || !surface.headingVisible) return false;
+        const node = editor();
+        if (!node || !node.isContentEditable || !visibleInViewport(node)
+          || !(document.activeElement === node || node.contains(document.activeElement))) return false;
+        const rect = node.getBoundingClientRect();
+        const x = Math.min(innerWidth - 1, Math.max(0, rect.left + rect.width / 2));
+        const y = Math.min(innerHeight - 1, Math.max(0, rect.top + Math.min(rect.height / 2, 24)));
+        const hit = document.elementFromPoint(x, y);
+        return hit instanceof Node && node.contains(hit);
+      }
+      const composer = editor();
+      return [...surface.root.querySelectorAll<HTMLElement>('[data-message-role="user"]')]
+        .some((row) => visibleInViewport(row) && row.innerText.includes(marker)
+          && !(composer?.contains(row) || row.contains(composer)));
+    };
+    const sample = () => {
+      if (!state.started || state.elapsedMs !== null) return;
+      state.frames += 1;
+      state.consecutiveFrames = ready() ? state.consecutiveFrames + 1 : 0;
+      if (state.consecutiveFrames >= 2) state.elapsedMs = performance.now() - startedAt;
+    };
+    const paint = () => { sample(); frame = requestAnimationFrame(paint); };
+    const capture = (event: Event) => {
+      if (state.started || !event.isTrusted) return;
+      if (kind === "new-task") {
+        const target = event.target;
+        if (event.type !== "click" || !(target instanceof Element)
+          || !target.closest(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`)) return;
+      } else {
+        if (!(event instanceof KeyboardEvent) || event.key !== "Enter") return;
+        const node = editor();
+        if (!node || !(event.target instanceof Node) || !(event.target === node || node.contains(event.target))) return;
+      }
+      state.started = true;
+      state.trusted = true;
+      startedAt = performance.now();
+    };
+    const eventName = kind === "new-task" ? "click" : "keydown";
+    window.addEventListener(eventName, capture, true);
+    const observer = new MutationObserver(() => { state.mutations += 1; });
+    observer.observe(document.documentElement, { subtree: true, childList: true, characterData: true, attributes: true });
+    frame = requestAnimationFrame(paint);
+    const timer = setTimeout(() => { state.expired = true; stop(); }, 10_000);
+    function stop() {
+      clearTimeout(timer);
+      observer.disconnect();
+      cancelAnimationFrame(frame);
+      window.removeEventListener(eventName, capture, true);
+    }
+    window.__instantSendMetric = { state, stop };
+  }, [workspaceId, kind, marker]));
+  let disposed = false;
+  return {
+    async read(): Promise<InstantRendererState> {
+      const value = await seed.evalIn(app, () => window.__instantSendMetric?.state ?? null);
+      if (!isRecord(value) || (value.kind !== "new-task" && value.kind !== "user-row")
+        || typeof value.started !== "boolean" || typeof value.trusted !== "boolean"
+        || !(value.elapsedMs === null || typeof value.elapsedMs === "number")
+        || typeof value.frames !== "number" || typeof value.mutations !== "number"
+        || typeof value.consecutiveFrames !== "number" || typeof value.expired !== "boolean") {
+        throw new Error(`Instant renderer timing state was malformed: ${JSON.stringify(value)}`);
+      }
+      return {
+        kind: value.kind,
+        started: value.started,
+        trusted: value.trusted,
+        elapsedMs: value.elapsedMs,
+        frames: value.frames,
+        mutations: value.mutations,
+        consecutiveFrames: value.consecutiveFrames,
+        expired: value.expired,
+      };
+    },
+    async [Symbol.asyncDispose]() {
+      if (disposed) return;
+      disposed = true;
+      await seed.evalIn(app, () => {
+        window.__instantSendMetric?.stop();
+        delete window.__instantSendMetric;
+      });
+    },
+  };
+}
+
+type InstantGateState = {
+  kind: InstantBoundaryKind;
+  stage: InstantBoundaryStage;
+  requestIds: Set<string>;
+  heldAt: number | null;
+  released: boolean;
+  failed: boolean;
+  expired: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+
+/** Disposable CDP Fetch gate. It reports only compact counts and never request headers or bodies. */
+async function instantBoundaryController(app: Surface, workspaceId: string) {
+  const endpoint = app.client.webSocketDebuggerUrl;
+  if (!endpoint) throw new Error("Instant-send boundary observer requires the desktop CDP endpoint");
+  const baseUrl = await evaluate(app.client, async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    return info?.running && info.baseUrl ? String(info.baseUrl) : "";
+  }, { awaitPromise: true });
+  if (typeof baseUrl !== "string" || !baseUrl) throw new Error("OpenWork server URL was unavailable to the boundary observer");
+  const origin = new URL(baseUrl).origin;
+  const encodedWorkspaceId = encodeURIComponent(workspaceId);
+  const sessionBases = ["workspace", "w"].map((mount) => `/${mount}/${encodedWorkspaceId}/opencode/session`);
+  const socket = new WebSocket(endpoint);
+  const ready = instantDeferred();
+  const commands = new Map<number, ReturnType<typeof instantDeferred>>();
+  const gates: InstantGateState[] = [];
+  const counts = { creation: 0, prompt: 0 };
+  let nextId = 1;
+  let disposed = false;
+  let failure: Error | undefined;
+
+  const command = async (method: string, params: Record<string, unknown> = {}) => {
+    const id = nextId++;
+    const result = instantDeferred();
+    commands.set(id, result);
+    const timer = setTimeout(() => result.reject(new Error(`Instant-send boundary command timed out: ${method}`)), 15_000);
+    try {
+      socket.send(JSON.stringify({ id, method, params }));
+      await result.promise;
+    } finally {
+      clearTimeout(timer);
+      commands.delete(id);
+    }
+  };
+  const loseConnection = () => {
+    if (disposed) return;
+    failure = new Error("Instant-send boundary observer lost its CDP connection");
+    ready.reject(failure);
+    for (const result of commands.values()) result.reject(failure);
+  };
+  const classify = (method: string, url: string): InstantBoundaryKind | null => {
+    if (method.toUpperCase() !== "POST") return null;
+    const path = new URL(url).pathname;
+    if (sessionBases.includes(path)) return "creation";
+    return sessionBases.some((base) => path.startsWith(`${base}/`) && path.endsWith("/prompt_async")) ? "prompt" : null;
+  };
+  const finishGate = async (gate: InstantGateState, fail: boolean) => {
+    if (gate.released) return;
+    gate.released = true;
+    gate.failed = fail;
+    if (gate.timer) clearTimeout(gate.timer);
+    gate.timer = null;
+    const method = fail ? "Fetch.failRequest" : gate.stage === "response" ? "Fetch.continueResponse" : "Fetch.continueRequest";
+    const interceptResponse = !fail && gate.stage === "request"
+      && gates.some((candidate) => candidate.kind === gate.kind && candidate.stage === "response" && !candidate.released);
+    await Promise.all([...gate.requestIds].map((requestId) => command(method, fail
+      ? { requestId, errorReason: "Failed" }
+      : { requestId, ...(interceptResponse ? { interceptResponse: true } : {}) })));
+  };
+
+  socket.addEventListener("open", () => ready.resolve());
+  socket.addEventListener("error", loseConnection);
+  socket.addEventListener("close", loseConnection);
+  socket.addEventListener("message", (event) => {
+    const message: unknown = JSON.parse(String(event.data));
+    if (!isRecord(message)) return;
+    if (typeof message.id === "number") {
+      const result = commands.get(message.id);
+      if ("error" in message) result?.reject(new Error("Instant-send boundary CDP command failed"));
+      else result?.resolve();
+    }
+    if (message.method !== "Fetch.requestPaused" || !isRecord(message.params)) return;
+    const params = message.params;
+    if (typeof params.requestId !== "string" || !isRecord(params.request)
+      || typeof params.request.method !== "string" || typeof params.request.url !== "string") return;
+    const stage: InstantBoundaryStage = typeof params.responseStatusCode === "number" || typeof params.responseErrorReason === "string"
+      ? "response" : "request";
+    const continueMethod = stage === "response" ? "Fetch.continueResponse" : "Fetch.continueRequest";
+    const kind = classify(params.request.method, params.request.url);
+    if (!kind) {
+      void command(continueMethod, { requestId: params.requestId }).catch((error: Error) => { failure = error; });
+      return;
+    }
+    if (stage === "request") counts[kind] += 1;
+    const gate = gates.find((candidate) => candidate.kind === kind && candidate.stage === stage && !candidate.released);
+    if (!gate) {
+      const interceptResponse = stage === "request"
+        && gates.some((candidate) => candidate.kind === kind && candidate.stage === "response" && !candidate.released);
+      void command(continueMethod, {
+        requestId: params.requestId,
+        ...(interceptResponse ? { interceptResponse: true } : {}),
+      }).catch((error: Error) => { failure = error; });
+      return;
+    }
+    gate.requestIds.add(params.requestId);
+    if (gate.heldAt === null) {
+      gate.heldAt = performance.now();
+      gate.timer = setTimeout(() => {
+        gate.expired = true;
+        void finishGate(gate, false).catch((error: Error) => { failure = error; });
+      }, 30_000);
+    }
+  });
+  const connectionTimer = setTimeout(() => ready.reject(new Error("Instant-send boundary observer could not connect")), 15_000);
+  try {
+    await ready.promise;
+    await command("Network.enable");
+    await command("Fetch.enable", {
+      patterns: sessionBases.map((path) => ({ urlPattern: `${origin}${path}*`, requestStage: "Request" })),
+    });
+  } catch (error) {
+    disposed = true;
+    socket.close();
+    throw error;
+  } finally {
+    clearTimeout(connectionTimer);
+  }
+
+  const arm = (kind: InstantBoundaryKind, stage: InstantBoundaryStage) => {
+    if (disposed) throw new Error("Instant-send boundary observer is disposed");
+    const state: InstantGateState = {
+      kind, stage, requestIds: new Set(), heldAt: null, released: false,
+      failed: false, expired: false, timer: null,
+    };
+    gates.push(state);
+    let gateDisposed = false;
+    const read = () => {
+      if (failure) throw failure;
+      return {
+        kind, stage, held: state.requestIds.size,
+        elapsedMs: state.heldAt === null ? 0 : performance.now() - state.heldAt,
+        released: state.released, failed: state.failed, expired: state.expired,
+      };
+    };
+    return {
+      read,
+      release: () => finishGate(state, false),
+      fail: () => finishGate(state, true),
+      async [Symbol.asyncDispose]() {
+        if (gateDisposed) return;
+        gateDisposed = true;
+        await finishGate(state, false);
+      },
+    };
+  };
+  return {
+    holdNext: arm,
+    read() {
+      if (failure) throw failure;
+      return { creation: counts.creation, prompt: counts.prompt };
+    },
+    async [Symbol.asyncDispose]() {
+      if (disposed) return;
+      for (const gate of gates) await finishGate(gate, false);
+      try { await command("Fetch.disable"); }
+      finally { disposed = true; socket.close(); }
+    },
+  };
 }
 
 function closeServer(server: Server): Promise<void> {
@@ -245,40 +588,265 @@ export async function sidebarWorkspaceTitles(seed: Seed) {
   return { app, shortName, longName, shortWorkspace };
 }
 
-export async function workspaceNewTask(seed: Seed) {
+export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) {
+  if (place.kind !== "local") throw new SkipError("local renderer performance contract (OPENWORK_WORLD_PLACE=local and --local)");
+  if (resolveEvalEngine() !== "v1") throw new SkipError("native v1 instant-send contract (OPENWORK_EVAL_ENGINE=v1)");
   const providerId = "new-task-mock";
   const modelId = "new-task-model";
-  const prompt = "Confirm the new task is ready";
-  const reply = "The new task is ready.";
-  const mock = seed.mock({ agentWorkloads: [{ promptMarker: prompt, finalReply: reply, steps: [] }] });
-  const den = await seed.den({ mocks: { agent: mock }, provision: false });
+  const nonce = `${Date.now().toString(36)}-${process.pid}`;
+  const lazySamples = Array.from({ length: 12 }, (_, index) => ({
+    marker: `INSTANT-LAZY-${String(index + 1).padStart(2, "0")}-${nonce}`,
+    reply: `Lazy task ${String(index + 1).padStart(2, "0")} completed ${nonce}.`,
+  }));
+  const existingSamples = Array.from({ length: 12 }, (_, index) => ({
+    marker: `INSTANT-EXISTING-${String(index + 1).padStart(2, "0")}-${nonce}`,
+    reply: `Existing task ${String(index + 1).padStart(2, "0")} completed ${nonce}.`,
+  }));
+  const navigation = { marker: `INSTANT-NAVIGATION-A-${nonce}`, reply: `Navigation task completed ${nonce}.` };
+  const responseHold = { marker: `INSTANT-RESPONSE-HOLD-${nonce}`, reply: `Response hold completed ${nonce}.` };
+  const workloads = [...lazySamples, ...existingSamples, navigation, responseHold]
+    .map(({ marker, reply }) => ({ promptMarker: marker, latestUserTurn: true, finalReply: reply, steps: [] }));
+  await using setup = new AsyncDisposableStack();
+  const mock = setup.use(await startMockMcp({ port: await allocateFreePort(), agentWorkloads: workloads }));
   const app = await seed.desktop({ name: "workspace-new-task", model: `${providerId}/${modelId}` });
   const workspacePath = seed.tmpPath(`openwork-workspace-new-task-long-name-${Date.now()}`);
   const workspace = await seed.workspace(app, workspacePath, { create: true });
   await configureWorkspaceProvider(seed, app, [workspace.workspaceId], {
-    providerId, modelId, modelName: "New task model", baseUrl: `${den.mocks.agent.url}/v1`,
+    providerId, modelId, modelName: "New task model", baseUrl: `${mock.url}/v1`,
   });
   const selectedModel = await selectModel(app, modelId);
   if (!selectedModel.selected) throw new Error("The mock task model was not selected.");
-  const sessions = await seed.sessions(app, ["Existing task"]);
-  // TODO(primitive): seed.networkFault should delay and observe renderer requests.
-  // Keep real session creation behind a slow transport boundary. Opening the
-  // composer must not reach this boundary; submitting must reach it only once.
-  await seed.evalIn(app, () => {
-    window.__newTaskRequests = [];
-    const originalFetch = window.fetch;
-    window.fetch = async function (...args) {
-      const request = args[0];
-      const url = request instanceof Request ? request.url : String(request);
-      const method = args[1]?.method ?? (request instanceof Request ? request.method : "GET");
-      if (method.toUpperCase() === "POST" && new URL(url, location.href).pathname.endsWith("/session")) {
-        window.__newTaskRequests.push(url);
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-      }
-      return originalFetch.apply(this, args);
-    };
+  const [unrelated, existing] = await seed.sessions(app, ["Unrelated populated task", "Existing populated task"]);
+  if (!unrelated || !existing) throw new Error("Instant-send world did not create both real v1 sessions.");
+
+  const serverInfo = await seed.evalIn(app, async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    return info?.running && info.baseUrl
+      ? { baseUrl: String(info.baseUrl), token: String(info.ownerToken ?? info.clientToken ?? "") }
+      : null;
+  }, { awaitPromise: true, timeoutMs: 30_000 });
+  if (!isRecord(serverInfo) || typeof serverInfo.baseUrl !== "string" || typeof serverInfo.token !== "string" || !serverInfo.token) {
+    throw new Error("Instant-send world could not reach the real local v1 engine.");
+  }
+  const serverUrl = serverInfo.baseUrl;
+  const serverToken = serverInfo.token;
+  const engine = engineSessionProbe({
+    engine: "v1",
+    surface: app,
+    workspaceId: workspace.workspaceId,
   });
-  return { app, workspace, workspacePath, sessions, prompt, reply };
+  const existingHistory = `EXISTING-HISTORY-${nonce}`;
+  const unrelatedHistory = `UNRELATED-HISTORY-${nonce}`;
+  const persistUserMessage = async (sessionId: string, text: string) => {
+    const base = serverUrl.replace(/\/+$/, "");
+    const response = await fetch(`${base}/workspace/${encodeURIComponent(workspace.workspaceId)}/opencode/session/${encodeURIComponent(sessionId)}/message`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${serverToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        noReply: true,
+        model: { providerID: providerId, modelID: modelId },
+        parts: [{ type: "text", text }],
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) throw new Error(`Real v1 history setup returned HTTP ${response.status}`);
+  };
+  await persistUserMessage(unrelated.sessionId, unrelatedHistory);
+  await persistUserMessage(existing.sessionId, existingHistory);
+  await waitFor(app, browserScript((marker, workspaceId, sessionId) => {
+    if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId
+      || location.hash !== `#/workspace/${workspaceId}/session/${sessionId}`) return false;
+    const pane = document.querySelector<HTMLElement>('[data-workbench-pane="primary"]');
+    const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+      .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId);
+    return [...(surface?.querySelectorAll<HTMLElement>('[data-message-role="user"]') ?? [])]
+      .some((row) => row.innerText.includes(marker));
+  }, [existingHistory, workspace.workspaceId, existing.sessionId]), {
+    timeoutMs: 30_000,
+    label: "existing populated task is visible before performance sampling",
+  });
+
+  const boundary = await instantBoundaryController(app, workspace.workspaceId);
+  const sessionIds = async () => {
+    const result = await engine.list();
+    if (!result.ok) throw new Error(`Real v1 session inventory returned HTTP ${result.status}`);
+    return result.data.map((session) => session.id).sort();
+  };
+  const sanitizedDiagnosticText = (value: string) => value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, "[url]")
+    .replace(/\bBearer\s+[^\s"'<>]+/gi, "Bearer [redacted]")
+    .replace(/\b(ownerToken|clientToken|token)\b\s*[=:]\s*[^\s,;]+/gi, "$1=[redacted]")
+    .replace(/[\r\n\t]+/g, " ")
+    .slice(0, 240);
+  const sanitizedErrorField = (value: unknown, field: "name" | "message") => {
+    const pending: unknown[] = [value];
+    for (let index = 0; index < pending.length && index < 8; index += 1) {
+      const candidate = pending[index];
+      if (field === "message" && typeof candidate === "string" && candidate) return sanitizedDiagnosticText(candidate);
+      if (Array.isArray(candidate)) {
+        pending.push(...candidate);
+        continue;
+      }
+      if (!isRecord(candidate)) continue;
+      const fieldNames = field === "name" ? ["name", "code", "error"] : ["message", "detail", "error"];
+      for (const fieldName of fieldNames) {
+        const direct = candidate[fieldName];
+        if (typeof direct !== "string" || !direct) continue;
+        return sanitizedDiagnosticText(direct);
+      }
+      for (const key of ["error", "data", "cause", "validation", "issues", "errors"]) {
+        if (key in candidate) pending.push(candidate[key]);
+      }
+    }
+    return "unavailable";
+  };
+  const messageFacts = async (sessionId: string, marker: string) => {
+    const result = await engine.messages(sessionId, 100).catch((error: unknown) => {
+      const errorName = sanitizedErrorField(error, "name");
+      const errorMessage = sanitizedErrorField(error, "message");
+      throw new Error(`Real v1 messages read failed for session ${sessionId}: error name=${errorName}; message=${errorMessage}`);
+    });
+    if (!result.ok) {
+      const errorName = sanitizedErrorField(result.body, "name");
+      const errorMessage = sanitizedErrorField(result.body, "message");
+      throw new Error(`Real v1 messages read failed for session ${sessionId}: HTTP ${result.status}; validation/error name=${errorName}; message=${errorMessage}`);
+    }
+    const texts = result.data.map((message) => message.parts.map((part) => part.text).join("\n"));
+    const matching = marker ? texts.filter((text) => text.includes(marker)) : [];
+    return {
+      messages: texts.length,
+      markerCount: matching.length,
+      markerOccurrences: marker ? matching.reduce((total, text) => total + text.split(marker).length - 1, 0) : 0,
+    };
+  };
+  const readInstantComposer = () => seed.evalIn(app, browserScript((workspaceId) => {
+    const visible = (node: HTMLElement) => {
+      const rect = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+        && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
+        && style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity) > 0;
+    };
+    if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) {
+      return { rootKind: "", focused: false, editable: false, text: "" };
+    }
+    let root: HTMLElement | null = null;
+    let rootKind = "";
+    const sessionlessRoute = `#/workspace/${workspaceId}/session`;
+    if (location.hash === sessionlessRoute) {
+      const heading = [...document.querySelectorAll<HTMLElement>("h2")]
+        .find((candidate) => candidate.textContent?.trim() === "What do you need done?" && visible(candidate));
+      const headingMain = heading?.closest<HTMLElement>("main") ?? null;
+      const main = headingMain && visible(headingMain) ? headingMain
+        : [...document.querySelectorAll<HTMLElement>("main")].filter(visible)
+            .find((candidate) => [...candidate.querySelectorAll<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"], [data-message-role]')]
+              .some(visible)) ?? null;
+      const persistedSurfaceVisible = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")].some(visible);
+      if (main && !persistedSurfaceVisible) { root = main; rootKind = "new-task"; }
+    } else {
+      const persistedPrefix = `#/workspace/${workspaceId}/session/`;
+      const sessionId = location.hash.startsWith(persistedPrefix) ? location.hash.slice(persistedPrefix.length) : "";
+      if (sessionId.startsWith("ses_") && !/[/?#]/.test(sessionId)) {
+        const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')].find(visible) ?? null;
+        const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+          .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId && visible(candidate));
+        if (pane && surface) { root = pane; rootKind = "persisted"; }
+      }
+    }
+    const editor = root?.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]') ?? null;
+    return {
+      rootKind,
+      focused: Boolean(editor && (document.activeElement === editor || editor.contains(document.activeElement))),
+      editable: Boolean(editor?.isContentEditable && visible(editor)),
+      text: editor?.innerText ?? "",
+    };
+  }, [workspace.workspaceId]));
+  const insertFocusedText = async (text: string) => {
+    const before = await readInstantComposer();
+    if (!isRecord(before) || (before.rootKind !== "new-task" && before.rootKind !== "persisted")
+      || before.focused !== true || before.editable !== true || typeof before.text !== "string") {
+      throw new Error(`Focused composer was unavailable for native insertText: ${JSON.stringify(before)}`);
+    }
+    await typeText(app, text);
+    const deadline = Date.now() + 5_000;
+    let after = await readInstantComposer();
+    while (Date.now() < deadline && !after.text.endsWith(text)) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      after = await readInstantComposer();
+    }
+    if (!after.text.endsWith(text)) throw new Error("Focused composer did not retain native insertText");
+    return { beforeText: before.text, afterText: after.text };
+  };
+  const accessibleRunTaskReady = async () => {
+    const located = await locate(app, { role: "button", label: "Run task" });
+    if (!located.visible || !located.hitTestOk) return false;
+    return seed.evalIn(app, browserScript((x, y, workspaceId) => {
+      const hit = document.elementFromPoint(x, y);
+      const button = hit instanceof Element ? hit.closest("button") : null;
+      const visible = (node: HTMLElement) => {
+        const rect = node.getBoundingClientRect();
+        const style = getComputedStyle(node);
+        return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+          && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
+          && style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity) > 0;
+      };
+      if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) return false;
+      let root: HTMLElement | null = null;
+      const sessionlessRoute = `#/workspace/${workspaceId}/session`;
+      if (location.hash === sessionlessRoute) {
+        const heading = [...document.querySelectorAll<HTMLElement>("h2")]
+          .find((candidate) => candidate.textContent?.trim() === "What do you need done?" && visible(candidate));
+        const headingMain = heading?.closest<HTMLElement>("main") ?? null;
+        const main = headingMain && visible(headingMain) ? headingMain
+          : [...document.querySelectorAll<HTMLElement>("main")].filter(visible)
+              .find((candidate) => [...candidate.querySelectorAll<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"], [data-message-role]')]
+                .some(visible)) ?? null;
+        const persistedSurfaceVisible = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")].some(visible);
+        if (main && !persistedSurfaceVisible) root = main;
+      } else {
+        const persistedPrefix = `#/workspace/${workspaceId}/session/`;
+        const sessionId = location.hash.startsWith(persistedPrefix) ? location.hash.slice(persistedPrefix.length) : "";
+        if (sessionId.startsWith("ses_") && !/[/?#]/.test(sessionId)) {
+          const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')].find(visible) ?? null;
+          const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
+            .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId && visible(candidate));
+          if (pane && surface) root = pane;
+        }
+      }
+      return button instanceof HTMLButtonElement && !button.disabled
+        && Boolean(root?.contains(button));
+    }, [located.center.x, located.center.y, workspace.workspaceId]));
+  };
+
+  const resources = setup.move();
+  return {
+    app,
+    workspace,
+    workspacePath,
+    existing,
+    unrelated,
+    existingHistory,
+    unrelatedHistory,
+    lazySamples,
+    existingSamples,
+    navigation,
+    responseHold,
+    failure: {
+      creationA: `INSTANT-CREATE-FAIL-A-${nonce}`,
+      creationB: `INSTANT-CREATE-FAIL-B-${nonce}`,
+      promptA: `INSTANT-PROMPT-FAIL-A-${nonce}`,
+      promptB: `INSTANT-PROMPT-FAIL-B-${nonce}`,
+      pendingB: `INSTANT-PENDING-DRAFT-B-${nonce}`,
+      navigationB: `INSTANT-NAVIGATION-DRAFT-B-${nonce}`,
+    },
+    boundary,
+    sessionIds,
+    messageFacts,
+    insertFocusedText,
+    accessibleRunTaskReady,
+    observeRenderer: (kind: InstantMetricKind, marker = "") => observeInstantRenderer(seed, app, workspace.workspaceId, kind, marker),
+    [Symbol.asyncDispose]: () => resources.disposeAsync(),
+  };
 }
 
 export async function pinnedSessions(seed: Seed) {

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1,4 +1,4 @@
-import { allocateFreePort, browserScript, clickAt, evaluate, hoverAt, type Point, type Surface, typeText } from "@openwork/cdp";
+import { allocateFreePort, browserScript, clickAt, evaluate, hoverAt, reload, type Point, type Surface, typeText } from "@openwork/cdp";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { mkdir, rm } from "node:fs/promises";
 import { engineSessionProbe, observeSidebarExpansion, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
@@ -655,9 +655,20 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
     marker: `INSTANT-EXISTING-${String(index + 1).padStart(2, "0")}-${nonce}`,
     reply: `Existing task ${String(index + 1).padStart(2, "0")} completed ${nonce}.`,
   }));
+  const existingHistory = `EXISTING-HISTORY-${nonce}`;
+  const existingHistoryReply = `The existing startup task finished successfully ${nonce}.`;
+  const unrelatedHistory = `UNRELATED-HISTORY-${nonce}`;
+  const unrelatedHistoryReply = `The unrelated startup task finished successfully ${nonce}.`;
   const navigation = { marker: `INSTANT-NAVIGATION-A-${nonce}`, reply: `Navigation task completed ${nonce}.` };
   const responseHold = { marker: `INSTANT-RESPONSE-HOLD-${nonce}`, reply: `Response hold completed ${nonce}.` };
-  const workloads = [...lazySamples, ...existingSamples, navigation, responseHold]
+  const workloads = [
+    { marker: existingHistory, reply: existingHistoryReply },
+    { marker: unrelatedHistory, reply: unrelatedHistoryReply },
+    ...lazySamples,
+    ...existingSamples,
+    navigation,
+    responseHold,
+  ]
     .map(({ marker, reply }) => ({ promptMarker: marker, latestUserTurn: true, finalReply: reply, steps: [] }));
   await using setup = new AsyncDisposableStack();
   const mock = setup.use(await startMockMcp({ port: await allocateFreePort(), agentWorkloads: workloads }));
@@ -667,6 +678,13 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
   await configureWorkspaceProvider(seed, app, [workspace.workspaceId], {
     providerId, modelId, modelName: "New task model", baseUrl: `${mock.url}/v1`,
   });
+  await reload(app, { timeoutMs: 60_000 });
+  await waitFor(app, () => Boolean(window.__openworkControl?.listActions()
+    .some((entry) => entry.id === "session.model_picker.open" && entry.disabled === false)), {
+    timeoutMs: 60_000,
+    label: "reloaded renderer model picker is interactive",
+  });
+  await readAvailableModels(app);
   const selectedModel = await selectModel(app, modelId);
   if (!selectedModel.selected) throw new Error("The mock task model was not selected.");
   const [unrelated, existing] = await seed.sessions(app, ["Unrelated populated task", "Existing populated task"]);
@@ -688,35 +706,89 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
     surface: app,
     workspaceId: workspace.workspaceId,
   });
-  const existingHistory = `EXISTING-HISTORY-${nonce}`;
-  const unrelatedHistory = `UNRELATED-HISTORY-${nonce}`;
-  const persistUserMessage = async (sessionId: string, text: string) => {
+  const submitNativePrompt = async (sessionId: string, text: string) => {
     const base = serverUrl.replace(/\/+$/, "");
     const response = await fetch(`${base}/workspace/${encodeURIComponent(workspace.workspaceId)}/opencode/session/${encodeURIComponent(sessionId)}/message`, {
       method: "POST",
       headers: { Authorization: `Bearer ${serverToken}`, "Content-Type": "application/json" },
       body: JSON.stringify({
-        noReply: true,
         model: { providerID: providerId, modelID: modelId },
         parts: [{ type: "text", text }],
       }),
       signal: AbortSignal.timeout(30_000),
     });
-    if (!response.ok) throw new Error(`Real v1 history setup returned HTTP ${response.status}`);
+    const body = await response.text();
+    if (!response.ok) throw new Error(`Real v1 history setup returned HTTP ${response.status}: ${body.slice(0, 300)}`);
   };
-  await persistUserMessage(unrelated.sessionId, unrelatedHistory);
-  await persistUserMessage(existing.sessionId, existingHistory);
-  await waitFor(app, browserScript((marker, workspaceId, sessionId) => {
+  await Promise.all([
+    submitNativePrompt(unrelated.sessionId, unrelatedHistory),
+    submitNativePrompt(existing.sessionId, existingHistory),
+  ]);
+  const readNativeHistory = async (sessionId: string, marker: string, reply: string) => {
+    const base = serverUrl.replace(/\/+$/, "");
+    const mount = `${base}/workspace/${encodeURIComponent(workspace.workspaceId)}/opencode`;
+    const headers = { Authorization: `Bearer ${serverToken}` };
+    const [messagesResponse, statusResponse] = await Promise.all([
+      fetch(`${mount}/session/${encodeURIComponent(sessionId)}/message?limit=20`, {
+        headers,
+        signal: AbortSignal.timeout(10_000),
+      }),
+      fetch(`${mount}/session/status`, { headers, signal: AbortSignal.timeout(10_000) }),
+    ]);
+    if (!messagesResponse.ok || !statusResponse.ok) {
+      throw new Error(`Real v1 history readiness returned messages=${messagesResponse.status}, status=${statusResponse.status}`);
+    }
+    const messagesBody: unknown = await messagesResponse.json();
+    const statusBody: unknown = await statusResponse.json();
+    const messages = Array.isArray(messagesBody)
+      ? messagesBody
+      : isRecord(messagesBody) && Array.isArray(messagesBody.data) ? messagesBody.data : [];
+    const nativeMessages = messages.flatMap((message) => {
+      if (!isRecord(message)) return [];
+      const info = isRecord(message.info) ? message.info : message;
+      const parts = Array.isArray(message.parts) ? message.parts : [];
+      return [{
+        role: typeof info.role === "string" ? info.role : "",
+        text: parts.map((part) => isRecord(part) && typeof part.text === "string" ? part.text : "").join("\n"),
+      }];
+    });
+    const statuses = isRecord(statusBody) && isRecord(statusBody.data) ? statusBody.data : statusBody;
+    const status = isRecord(statuses) ? statuses[sessionId] : undefined;
+    return {
+      userPersisted: nativeMessages.some((message) => message.role === "user" && message.text.includes(marker)),
+      assistantPersisted: nativeMessages.some((message) => message.role === "assistant" && message.text.includes(reply)),
+      idle: status === undefined || (isRecord(status) && status.type === "idle"),
+    };
+  };
+  const historyDeadline = Date.now() + 60_000;
+  let historyReadiness = await Promise.all([
+    readNativeHistory(unrelated.sessionId, unrelatedHistory, unrelatedHistoryReply),
+    readNativeHistory(existing.sessionId, existingHistory, existingHistoryReply),
+  ]);
+  while (!historyReadiness.every((state) => state.userPersisted && state.assistantPersisted && state.idle)) {
+    if (Date.now() >= historyDeadline) {
+      throw new Error(`Real v1 completed history did not become idle: ${JSON.stringify(historyReadiness)}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    historyReadiness = await Promise.all([
+      readNativeHistory(unrelated.sessionId, unrelatedHistory, unrelatedHistoryReply),
+      readNativeHistory(existing.sessionId, existingHistory, existingHistoryReply),
+    ]);
+  }
+  await waitFor(app, browserScript((marker, reply, workspaceId, sessionId) => {
     if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId
       || location.hash !== `#/workspace/${workspaceId}/session/${sessionId}`) return false;
     const pane = document.querySelector<HTMLElement>('[data-workbench-pane="primary"]');
     const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
       .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId);
-    return [...(surface?.querySelectorAll<HTMLElement>('[data-message-role="user"]') ?? [])]
+    const userVisible = [...(surface?.querySelectorAll<HTMLElement>('[data-message-role="user"]') ?? [])]
       .some((row) => row.innerText.includes(marker));
-  }, [existingHistory, workspace.workspaceId, existing.sessionId]), {
+    const assistantVisible = [...(surface?.querySelectorAll<HTMLElement>('[data-message-role="assistant"]') ?? [])]
+      .some((row) => row.innerText.includes(reply));
+    return userVisible && assistantVisible;
+  }, [existingHistory, existingHistoryReply, workspace.workspaceId, existing.sessionId]), {
     timeoutMs: 30_000,
-    label: "existing populated task is visible before performance sampling",
+    label: "existing completed task is visible before performance sampling",
   });
 
   const boundary = await instantBoundaryController(app, workspace.workspaceId);

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -924,7 +924,7 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
   };
   const providerRequestCount = async (promptMarker: string) => (await mock.agentRequests({ promptMarker }))
     .filter((request) => request.promptMarker === promptMarker && request.kind !== "utility").length;
-  const visibleMessageFacts = (sessionId: string, role: "user" | "assistant", marker: string) => seed.evalIn(app, browserScript((sessionId, role, marker, workspaceId) => {
+  const visibleMessageFacts = (sessionId: string, role: "user" | "assistant", marker: string) => seed.evalIn(app, browserScript((sessionId, role, marker) => {
     const visible = (node: HTMLElement) => {
       const rect = node.getBoundingClientRect();
       const style = getComputedStyle(node);
@@ -942,11 +942,10 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
       .map((node) => (node.getAttribute("aria-label") ?? node.innerText).replace(/\s+/g, " ").trim().slice(0, 120))
       .filter((label, index, values) => Boolean(label) && values.indexOf(label) === index)
       .slice(0, 5);
-    const resourcePrefixes = ["workspace", "w"].map((mount) => `/${mount}/${encodeURIComponent(workspaceId)}/opencode`);
     const network = performance.getEntriesByType("resource").flatMap((entry) => {
       if (!(entry instanceof PerformanceResourceTiming)) return [];
+      if (entry.initiatorType !== "fetch" && entry.initiatorType !== "xmlhttprequest") return [];
       const url = new URL(entry.name);
-      if (!resourcePrefixes.some((prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`))) return [];
       return [{
         path: url.pathname,
         limit: url.searchParams.get("limit"),
@@ -965,7 +964,38 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
       errorLabels: labels('[role="alert"]'),
       network,
     };
-  }, [sessionId, role, marker, workspace.workspaceId]));
+  }, [sessionId, role, marker]));
+  const rendererDiagnostic = (expectedSessionId: string | null) => seed.evalIn(app, browserScript((expectedWorkspaceId, expectedSessionId) => {
+    const composer = window.__openwork?.slice("composer") ?? null;
+    const ownerWorkspaceId: unknown = composer ? Reflect.get(composer, "workspaceId") : null;
+    const ownerSessionId: unknown = composer ? Reflect.get(composer, "sessionId") : null;
+    return {
+      expectedWorkspaceId,
+      expectedSessionId,
+      expectedRoute: expectedSessionId
+        ? `#/workspace/${expectedWorkspaceId}/session/${expectedSessionId}`
+        : `#/workspace/${expectedWorkspaceId}/session`,
+      actualRoute: location.hash,
+      ownerWorkspaceId: typeof ownerWorkspaceId === "string" ? ownerWorkspaceId : null,
+      ownerSessionId: typeof ownerSessionId === "string" ? ownerSessionId : null,
+      snapshotQuery: composer ? {
+        status: composer.snapshotQuery.status,
+        fetchStatus: composer.snapshotQuery.fetchStatus,
+        isPaused: composer.snapshotQuery.isPaused,
+        failureCount: composer.snapshotQuery.failureCount,
+        errorName: composer.snapshotQuery.errorName,
+        errorMessage: composer.snapshotQuery.errorMessage,
+        dataSessionId: composer.snapshotQuery.dataSessionId,
+        dataMessageCount: composer.snapshotQuery.dataMessageCount,
+        currentSnapshotId: composer.snapshotQuery.currentSnapshotId,
+        intendedSessionId: composer.snapshotQuery.intendedSessionId,
+        opencodeBaseUrl: composer.snapshotQuery.opencodeBaseUrl,
+        tokenPresent: composer.snapshotQuery.tokenPresent,
+      } : null,
+      navigatorOnline: navigator.onLine,
+      documentHasFocus: document.hasFocus(),
+    };
+  }, [workspace.workspaceId, expectedSessionId]));
   const readInstantComposer = () => seed.evalIn(app, browserScript((workspaceId) => {
     const visible = (node: HTMLElement) => {
       const rect = node.getBoundingClientRect();
@@ -1233,6 +1263,7 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
     messageFacts,
     providerRequestCount,
     visibleMessageFacts,
+    rendererDiagnostic,
     insertFocusedText,
     prepareWorkspaceNewTask,
     clickWorkspaceNewTask,

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1,4 +1,4 @@
-import { allocateFreePort, browserScript, evaluate, locate, type Surface, typeText } from "@openwork/cdp";
+import { allocateFreePort, browserScript, clickAt, evaluate, hoverAt, type Point, type Surface, typeText } from "@openwork/cdp";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { mkdir, rm } from "node:fs/promises";
 import { engineSessionProbe, observeSidebarExpansion, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
@@ -212,6 +212,8 @@ type InstantGateState = {
   timer: ReturnType<typeof setTimeout> | null;
 };
 
+const INSTANT_BOUNDARY_REJECTION_MESSAGE = "The request was rejected before admission.";
+
 /** Disposable CDP Fetch gate. It reports only compact counts and never request headers or bodies. */
 async function instantBoundaryController(app: Surface, workspaceId: string) {
   const endpoint = app.client.webSocketDebuggerUrl;
@@ -224,6 +226,7 @@ async function instantBoundaryController(app: Surface, workspaceId: string) {
   const origin = new URL(baseUrl).origin;
   const encodedWorkspaceId = encodeURIComponent(workspaceId);
   const sessionBases = ["workspace", "w"].map((mount) => `/${mount}/${encodedWorkspaceId}/opencode/session`);
+  const fetchPatterns = sessionBases.map((path) => ({ urlPattern: `${origin}${path}*`, requestStage: "Request" }));
   const socket = new WebSocket(endpoint);
   const ready = instantDeferred();
   const commands = new Map<number, ReturnType<typeof instantDeferred>>();
@@ -231,6 +234,8 @@ async function instantBoundaryController(app: Surface, workspaceId: string) {
   const counts = { creation: 0, prompt: 0 };
   let nextId = 1;
   let disposed = false;
+  let fetchEnabled = false;
+  let cleanupPromise: Promise<void> | null = null;
   let failure: Error | undefined;
 
   const command = async (method: string, params: Record<string, unknown> = {}) => {
@@ -264,11 +269,17 @@ async function instantBoundaryController(app: Surface, workspaceId: string) {
     gate.failed = fail;
     if (gate.timer) clearTimeout(gate.timer);
     gate.timer = null;
-    const method = fail ? "Fetch.failRequest" : gate.stage === "response" ? "Fetch.continueResponse" : "Fetch.continueRequest";
+    const method = fail ? "Fetch.fulfillRequest" : gate.stage === "response" ? "Fetch.continueResponse" : "Fetch.continueRequest";
     const interceptResponse = !fail && gate.stage === "request"
       && gates.some((candidate) => candidate.kind === gate.kind && candidate.stage === "response" && !candidate.released);
     await Promise.all([...gate.requestIds].map((requestId) => command(method, fail
-      ? { requestId, errorReason: "Failed" }
+      ? {
+          requestId,
+          responseCode: 400,
+          responsePhrase: "Bad Request",
+          responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+          body: Buffer.from(JSON.stringify({ error: { message: INSTANT_BOUNDARY_REJECTION_MESSAGE } }), "utf8").toString("base64"),
+        }
       : { requestId, ...(interceptResponse ? { interceptResponse: true } : {}) })));
   };
 
@@ -319,9 +330,8 @@ async function instantBoundaryController(app: Surface, workspaceId: string) {
   try {
     await ready.promise;
     await command("Network.enable");
-    await command("Fetch.enable", {
-      patterns: sessionBases.map((path) => ({ urlPattern: `${origin}${path}*`, requestStage: "Request" })),
-    });
+    await command("Fetch.enable", { patterns: fetchPatterns });
+    fetchEnabled = true;
   } catch (error) {
     disposed = true;
     socket.close();
@@ -363,11 +373,38 @@ async function instantBoundaryController(app: Surface, workspaceId: string) {
       if (failure) throw failure;
       return { creation: counts.creation, prompt: counts.prompt };
     },
+    async suspend() {
+      if (disposed) throw new Error("Instant-send boundary observer is disposed");
+      if (failure) throw failure;
+      const activelyHeld = gates.filter((gate) => !gate.released && gate.requestIds.size > 0);
+      if (activelyHeld.length > 0) {
+        throw new Error(`Instant-send boundary observer cannot suspend with ${activelyHeld.length} actively held gate(s)`);
+      }
+      if (!fetchEnabled) return;
+      await command("Fetch.disable");
+      fetchEnabled = false;
+    },
+    async resume() {
+      if (disposed) throw new Error("Instant-send boundary observer is disposed");
+      if (failure) throw failure;
+      if (fetchEnabled) return;
+      await command("Fetch.enable", { patterns: fetchPatterns });
+      fetchEnabled = true;
+    },
     async [Symbol.asyncDispose]() {
-      if (disposed) return;
-      for (const gate of gates) await finishGate(gate, false);
-      try { await command("Fetch.disable"); }
-      finally { disposed = true; socket.close(); }
+      if (cleanupPromise) return cleanupPromise;
+      cleanupPromise = (async () => {
+        if (disposed) return;
+        try {
+          for (const gate of gates) await finishGate(gate, false);
+          if (fetchEnabled) await command("Fetch.disable");
+        } finally {
+          fetchEnabled = false;
+          disposed = true;
+          socket.close();
+        }
+      })();
+      return cleanupPromise;
     },
   };
 }
@@ -719,6 +756,25 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
       markerOccurrences: marker ? matching.reduce((total, text) => total + text.split(marker).length - 1, 0) : 0,
     };
   };
+  const providerRequestCount = async (promptMarker: string) => (await mock.agentRequests({ promptMarker }))
+    .filter((request) => request.promptMarker === promptMarker && request.kind !== "utility").length;
+  const visibleMessageFacts = (sessionId: string, role: "user" | "assistant", marker: string) => seed.evalIn(app, browserScript((sessionId, role, marker) => {
+    const visible = (node: HTMLElement) => {
+      const rect = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return node.getClientRects().length > 0 && rect.width > 0 && rect.height > 0
+        && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
+        && style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity) > 0;
+    };
+    const surfaces = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")]
+      .filter((surface) => surface.dataset.sessionSurfaceId === sessionId && visible(surface));
+    const rows = surfaces.flatMap((surface) => [...surface.querySelectorAll<HTMLElement>("[data-message-role]")])
+      .filter((row) => row.dataset.messageRole === role && visible(row) && row.innerText.includes(marker));
+    return {
+      rowCount: rows.length,
+      markerOccurrences: marker ? rows.reduce((total, row) => total + row.innerText.split(marker).length - 1, 0) : 0,
+    };
+  }, [sessionId, role, marker]));
   const readInstantComposer = () => seed.evalIn(app, browserScript((workspaceId) => {
     const visible = (node: HTMLElement) => {
       const rect = node.getBoundingClientRect();
@@ -777,12 +833,135 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
     if (!after.text.endsWith(text)) throw new Error("Focused composer did not retain native insertText");
     return { beforeText: before.text, afterText: after.text };
   };
-  const accessibleRunTaskReady = async () => {
-    const located = await locate(app, { role: "button", label: "Run task" });
-    if (!located.visible || !located.hitTestOk) return false;
-    return seed.evalIn(app, browserScript((x, y, workspaceId) => {
-      const hit = document.elementFromPoint(x, y);
-      const button = hit instanceof Element ? hit.closest("button") : null;
+  const newTaskGeometry = (point: Point) => seed.evalIn(app, browserScript((workspaceId, x, y) => {
+    const matchingWorkspaces = [...document.querySelectorAll<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"]`)];
+    const matchingPlusNodes = matchingWorkspaces.flatMap((candidate) => [...candidate.querySelectorAll<HTMLElement>("[data-workspace-new-task]")]);
+    const matchingHeaderNodes = new Set(matchingPlusNodes.map((candidate) => candidate.closest<HTMLElement>("[data-workspace-actions]")?.parentElement).filter((candidate) => candidate !== null));
+    const workspace = matchingWorkspaces[0] ?? null;
+    const plus = workspace?.querySelector<HTMLElement>("[data-workspace-new-task]") ?? null;
+    const actions = plus?.closest<HTMLElement>("[data-workspace-actions]") ?? null;
+    const header = actions?.parentElement ?? null;
+    const actionsStyle = actions ? getComputedStyle(actions) : null;
+    const correctWorkspace = Boolean(workspace && plus?.closest("[data-sidebar-workspace-id]") === workspace);
+    const rect = plus?.getBoundingClientRect() ?? null;
+    let hiddenBy = "";
+    let current: Element | null = plus ?? null;
+    while (current instanceof Element && !hiddenBy) {
+      const style = getComputedStyle(current);
+      if (style.display === "none" || style.visibility !== "visible" || Number(style.opacity) <= 0) {
+        hiddenBy = `${current.tagName.toLowerCase()}:${style.display}/${style.visibility}/${style.opacity}`;
+      }
+      current = current.parentElement;
+    }
+    const centerX = rect ? rect.left + rect.width / 2 : 0;
+    const centerY = rect ? rect.top + rect.height / 2 : 0;
+    const centered = Math.abs(centerX - x) < 0.5 && Math.abs(centerY - y) < 0.5;
+    const inViewport = x >= 0 && y >= 0 && x < innerWidth && y < innerHeight;
+    const hit = inViewport ? document.elementFromPoint(x, y) : null;
+    const hitPlus = Boolean(plus && hit instanceof Node && plus.contains(hit));
+    return {
+      ready: Boolean(correctWorkspace && plus && rect && rect.width > 0 && rect.height > 0
+        && !hiddenBy && centered && inViewport && hitPlus),
+      found: Boolean(plus),
+      point: [Math.round(x), Math.round(y)],
+      center: [Math.round(centerX), Math.round(centerY)],
+      centerX,
+      centerY,
+      rect: rect ? [Math.round(rect.x), Math.round(rect.y), Math.round(rect.width), Math.round(rect.height)] : [],
+      correctWorkspace,
+      hiddenBy,
+      hitPlus,
+      headerHover: header?.matches(":hover") ?? false,
+      plusHover: plus?.matches(":hover") ?? false,
+      hoverHover: matchMedia("(hover: hover)").matches,
+      anyHoverHover: matchMedia("(any-hover: hover)").matches,
+      pointerFine: matchMedia("(pointer: fine)").matches,
+      maxTouchPoints: navigator.maxTouchPoints,
+      documentHasFocus: document.hasFocus(),
+      actionsClassName: actions?.className ?? "",
+      headerClassName: header?.className ?? "",
+      actionsOpacity: actionsStyle?.opacity ?? "",
+      actionsTransitionDuration: actionsStyle?.transitionDuration ?? "",
+      multipleMatchingPlus: matchingPlusNodes.length > 1,
+      multipleMatchingHeaders: matchingHeaderNodes.size > 1,
+      covering: hitPlus || !(hit instanceof Element) ? "" : hit.tagName.toLowerCase(),
+    };
+  }, [workspace.workspaceId, point.x, point.y]));
+  const prepareWorkspaceNewTask = async (): Promise<Point> => {
+    const deadline = Date.now() + 5_000;
+    const reset = await seed.evalIn(app, browserScript((workspaceId) => {
+      const workspace = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"]`);
+      const plus = workspace?.querySelector<HTMLElement>("[data-workspace-new-task]") ?? null;
+      const header = plus?.closest<HTMLElement>("[data-workspace-actions]")?.parentElement ?? null;
+      if (!workspace || !plus || !header || plus.closest("[data-sidebar-workspace-id]") !== workspace) {
+        return { ready: false, point: [0, 0], plus: [], header: [], hitHeader: false, x: 0, y: 0 };
+      }
+      let rect = plus.getBoundingClientRect();
+      if (rect.left < 0 || rect.top < 0 || rect.right > innerWidth || rect.bottom > innerHeight) {
+        plus.scrollIntoView({ block: "nearest", inline: "nearest" });
+        rect = plus.getBoundingClientRect();
+      }
+      const headerRect = header.getBoundingClientRect();
+      const left = Math.max(0, headerRect.left);
+      const right = Math.min(innerWidth, headerRect.right);
+      const top = Math.max(0, headerRect.top);
+      const bottom = Math.min(innerHeight, headerRect.bottom);
+      const x = left + Math.min(8, Math.max(1, (right - left) / 4));
+      const y = top + (bottom - top) / 2;
+      let headerVisible = true;
+      let current: Element | null = header;
+      while (current instanceof Element && headerVisible) {
+        const style = getComputedStyle(current);
+        headerVisible = style.display !== "none" && style.visibility === "visible" && Number(style.opacity) > 0;
+        current = current.parentElement;
+      }
+      const hit = x >= 0 && y >= 0 && x < innerWidth && y < innerHeight ? document.elementFromPoint(x, y) : null;
+      const hitHeader = hit instanceof Node && header.contains(hit) && !plus.contains(hit);
+      const plusX = rect.left + rect.width / 2;
+      const plusY = rect.top + rect.height / 2;
+      const different = Math.abs(x - plusX) >= 1 || Math.abs(y - plusY) >= 1;
+      return {
+        ready: headerVisible && right > left && bottom > top && hitHeader && different,
+        point: [Math.round(x), Math.round(y)],
+        plus: [Math.round(rect.x), Math.round(rect.y), Math.round(rect.width), Math.round(rect.height)],
+        header: [Math.round(headerRect.x), Math.round(headerRect.y), Math.round(headerRect.width), Math.round(headerRect.height)],
+        hitHeader,
+        x,
+        y,
+      };
+    }, [workspace.workspaceId]));
+    if (!reset.ready || !Number.isFinite(reset.x) || !Number.isFinite(reset.y)) {
+      throw new Error(`New task header reset point was unavailable before click: ${JSON.stringify(reset)}`);
+    }
+    await hoverAt(app, { x: reset.x, y: reset.y });
+    let readiness = await newTaskGeometry({ x: reset.x, y: reset.y });
+    while (!readiness.headerHover && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      readiness = await newTaskGeometry({ x: reset.x, y: reset.y });
+    }
+    if (!readiness.headerHover || !readiness.correctWorkspace
+      || !Number.isFinite(readiness.centerX) || !Number.isFinite(readiness.centerY)) {
+      throw new Error(`New task header did not rearm hover before click: ${JSON.stringify(readiness)}`);
+    }
+    let point: Point = { x: readiness.centerX, y: readiness.centerY };
+    await hoverAt(app, point);
+    readiness = await newTaskGeometry(point);
+    while (!readiness.ready && Date.now() < deadline) {
+      if (readiness.correctWorkspace && Number.isFinite(readiness.centerX) && Number.isFinite(readiness.centerY)
+        && (Math.abs(readiness.centerX - point.x) >= 0.5 || Math.abs(readiness.centerY - point.y) >= 0.5)) {
+        point = { x: readiness.centerX, y: readiness.centerY };
+        await hoverAt(app, point);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      readiness = await newTaskGeometry(point);
+    }
+    if (!readiness.ready) {
+      throw new Error(`New task plus was not ready before click: ${JSON.stringify(readiness)}`);
+    }
+    return point;
+  };
+  const clickWorkspaceNewTask = (point: Point) => clickAt(app, point);
+  const accessibleRunTaskReady = async (expectedText: string) => seed.evalIn(app, browserScript((workspaceId, expectedText) => {
       const visible = (node: HTMLElement) => {
         const rect = node.getBoundingClientRect();
         const style = getComputedStyle(node);
@@ -790,8 +969,11 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
           && rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight
           && style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity) > 0;
       };
-      if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) return false;
+      if ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") !== workspaceId) {
+        return { ready: false, rootKind: "", composerText: "", focusedEditor: false, buttonFound: false, buttonDisabled: null, buttonHit: false };
+      }
       let root: HTMLElement | null = null;
+      let rootKind = "";
       const sessionlessRoute = `#/workspace/${workspaceId}/session`;
       if (location.hash === sessionlessRoute) {
         const heading = [...document.querySelectorAll<HTMLElement>("h2")]
@@ -802,7 +984,7 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
               .find((candidate) => [...candidate.querySelectorAll<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"], [data-message-role]')]
                 .some(visible)) ?? null;
         const persistedSurfaceVisible = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")].some(visible);
-        if (main && !persistedSurfaceVisible) root = main;
+        if (main && !persistedSurfaceVisible) { root = main; rootKind = "new-task"; }
       } else {
         const persistedPrefix = `#/workspace/${workspaceId}/session/`;
         const sessionId = location.hash.startsWith(persistedPrefix) ? location.hash.slice(persistedPrefix.length) : "";
@@ -810,13 +992,29 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
           const pane = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="primary"]')].find(visible) ?? null;
           const surface = [...(pane?.querySelectorAll<HTMLElement>("[data-session-surface-id]") ?? [])]
             .find((candidate) => candidate.dataset.sessionSurfaceId === sessionId && visible(candidate));
-          if (pane && surface) root = pane;
+          if (pane && surface) { root = pane; rootKind = "persisted"; }
         }
       }
-      return button instanceof HTMLButtonElement && !button.disabled
-        && Boolean(root?.contains(button));
-    }, [located.center.x, located.center.y, workspace.workspaceId]));
-  };
+      const editor = [...(root?.querySelectorAll<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]') ?? [])]
+        .find(visible) ?? null;
+      const button = [...(root?.querySelectorAll<HTMLButtonElement>('button[aria-label="Run task"]') ?? [])]
+        .find(visible) ?? null;
+      const rect = button?.getBoundingClientRect() ?? null;
+      const hit = rect ? document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2) : null;
+      const buttonHit = Boolean(button && hit instanceof Node && button.contains(hit));
+      const focusedEditor = Boolean(editor && (document.activeElement === editor || editor.contains(document.activeElement)));
+      const composerText = editor?.innerText ?? "";
+      return {
+        ready: Boolean(root && editor?.isContentEditable && visible(editor) && focusedEditor
+          && composerText === expectedText && button && !button.disabled && buttonHit),
+        rootKind,
+        composerText,
+        focusedEditor,
+        buttonFound: Boolean(button),
+        buttonDisabled: button?.disabled ?? null,
+        buttonHit,
+      };
+    }, [workspace.workspaceId, expectedText]));
 
   const resources = setup.move();
   return {
@@ -842,7 +1040,11 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
     boundary,
     sessionIds,
     messageFacts,
+    providerRequestCount,
+    visibleMessageFacts,
     insertFocusedText,
+    prepareWorkspaceNewTask,
+    clickWorkspaceNewTask,
     accessibleRunTaskReady,
     observeRenderer: (kind: InstantMetricKind, marker = "") => observeInstantRenderer(seed, app, workspace.workspaceId, kind, marker),
     [Symbol.asyncDispose]: () => resources.disposeAsync(),

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -218,10 +218,14 @@ const INSTANT_BOUNDARY_REJECTION_MESSAGE = "The request was rejected before admi
 async function instantBoundaryController(app: Surface, workspaceId: string) {
   const endpoint = app.client.webSocketDebuggerUrl;
   if (!endpoint) throw new Error("Instant-send boundary observer requires the desktop CDP endpoint");
-  const baseUrl = await evaluate(app.client, async () => {
+  const runtime = await evaluate(app.client, async () => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
-    return info?.running && info.baseUrl ? String(info.baseUrl) : "";
+    return {
+      baseUrl: info?.running && info.baseUrl ? String(info.baseUrl) : "",
+      rendererOrigin: window.location.origin,
+    };
   }, { awaitPromise: true });
+  const { baseUrl, rendererOrigin } = runtime;
   if (typeof baseUrl !== "string" || !baseUrl) throw new Error("OpenWork server URL was unavailable to the boundary observer");
   const origin = new URL(baseUrl).origin;
   const encodedWorkspaceId = encodeURIComponent(workspaceId);
@@ -277,8 +281,13 @@ async function instantBoundaryController(app: Surface, workspaceId: string) {
           requestId,
           responseCode: 400,
           responsePhrase: "Bad Request",
-          responseHeaders: [{ name: "Content-Type", value: "application/json" }],
-          body: Buffer.from(JSON.stringify({ error: { message: INSTANT_BOUNDARY_REJECTION_MESSAGE } }), "utf8").toString("base64"),
+          responseHeaders: [
+            { name: "Content-Type", value: "application/json" },
+            { name: "Access-Control-Allow-Origin", value: rendererOrigin },
+            { name: "Access-Control-Allow-Credentials", value: "true" },
+            { name: "Vary", value: "Origin" },
+          ],
+          body: Buffer.from(JSON.stringify(INSTANT_BOUNDARY_REJECTION_MESSAGE), "utf8").toString("base64"),
         }
       : { requestId, ...(interceptResponse ? { interceptResponse: true } : {}) })));
   };
@@ -371,7 +380,14 @@ async function instantBoundaryController(app: Surface, workspaceId: string) {
     holdNext: arm,
     read() {
       if (failure) throw failure;
-      return { creation: counts.creation, prompt: counts.prompt };
+      const activelyHeld = gates.filter((gate) => !gate.released && gate.requestIds.size > 0);
+      return {
+        creation: counts.creation,
+        prompt: counts.prompt,
+        enabled: fetchEnabled,
+        activeGateCount: activelyHeld.length,
+        activeHeldRequestCount: activelyHeld.reduce((total, gate) => total + gate.requestIds.size, 0),
+      };
     },
     async suspend() {
       if (disposed) throw new Error("Instant-send boundary observer is disposed");
@@ -737,7 +753,156 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
     }
     return "unavailable";
   };
-  const messageFacts = async (sessionId: string, marker: string) => {
+  const messageFacts = async (sessionId: string, marker: string, diagnosticReplyMarker?: string) => {
+    if (diagnosticReplyMarker !== undefined) {
+      let currentServerInfo: { baseUrl: string; ownerAccessToken: string; clientAccessToken: string } | null = null;
+      let serverInfoError: string | null = null;
+      try {
+        currentServerInfo = await seed.evalIn(app, async () => {
+          const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+          if (!info?.running || !info.baseUrl) return null;
+          return {
+            baseUrl: String(info.baseUrl),
+            ownerAccessToken: String(info.ownerToken ?? ""),
+            clientAccessToken: String(info.clientToken ?? ""),
+          };
+        }, { awaitPromise: true, timeoutMs: 5_000 });
+      } catch (error) {
+        serverInfoError = sanitizedErrorField(error, "message");
+      }
+      const unavailable = (error: string) => ({
+        messages: 0,
+        markerCount: 0,
+        markerOccurrences: 0,
+        diagnostic: {
+          transport: "node",
+          user: { count: 0, occurrences: 0 },
+          reply: { count: 0, occurrences: 0 },
+          ownerSnapshot: Object.fromEntries(["session", "messages", "todo", "status"]
+            .map((name) => [name, { status: 0, durationMs: 0, errorName: "unavailable", errorMessage: error }])),
+          clientSnapshot: null,
+          health: { status: 0, durationMs: 0, errorName: "unavailable", errorMessage: error, actualV1Version: null },
+          preview: { status: 0, durationMs: 0, errorName: "unavailable", errorMessage: error, enabled: null, chatRouting: null },
+        },
+      });
+      if (!currentServerInfo?.ownerAccessToken) return unavailable(serverInfoError ?? "current owner server credential unavailable");
+
+      const base = currentServerInfo.baseUrl.replace(/\/+$/, "");
+      const nodeGet = async (path: string, accessToken: string) => {
+        const startedAt = performance.now();
+        try {
+          const response = await fetch(`${base}${path}`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+            signal: AbortSignal.timeout(5_000),
+          });
+          const text = await response.text();
+          let body: unknown = text;
+          try { body = text ? JSON.parse(text) : null; } catch {}
+          return {
+            ok: response.ok,
+            status: response.status,
+            durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
+            body,
+            transportErrorName: null,
+            transportErrorMessage: null,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            status: 0,
+            durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
+            body: null,
+            transportErrorName: sanitizedErrorField(error, "name"),
+            transportErrorMessage: sanitizedErrorField(error, "message"),
+          };
+        }
+      };
+      const responseFacts = (response: Awaited<ReturnType<typeof nodeGet>>) => ({
+        status: response.status,
+        durationMs: response.durationMs,
+        errorName: response.ok ? null : response.transportErrorName ?? sanitizedErrorField(response.body, "name"),
+        errorMessage: response.ok ? null : response.transportErrorMessage ?? sanitizedErrorField(response.body, "message"),
+      });
+      const mount = `/workspace/${encodeURIComponent(workspace.workspaceId)}/opencode`;
+      const encodedSessionId = encodeURIComponent(sessionId);
+      const snapshotPaths = {
+        session: `${mount}/session/${encodedSessionId}`,
+        messages: `${mount}/session/${encodedSessionId}/message?limit=140`,
+        todo: `${mount}/session/${encodedSessionId}/todo`,
+        status: `${mount}/session/status`,
+      };
+      const snapshotProbe = async (accessToken: string) => {
+        const [session, messages, todo, status] = await Promise.all([
+          nodeGet(snapshotPaths.session, accessToken),
+          nodeGet(snapshotPaths.messages, accessToken),
+          nodeGet(snapshotPaths.todo, accessToken),
+          nodeGet(snapshotPaths.status, accessToken),
+        ]);
+        return {
+          responses: { session, messages, todo, status },
+          facts: {
+            session: responseFacts(session),
+            messages: responseFacts(messages),
+            todo: responseFacts(todo),
+            status: responseFacts(status),
+          },
+        };
+      };
+      const compareClient = Boolean(currentServerInfo.clientAccessToken
+        && currentServerInfo.clientAccessToken !== currentServerInfo.ownerAccessToken);
+      const [ownerSnapshot, clientSnapshot, healthResponse, previewResponse] = await Promise.all([
+        snapshotProbe(currentServerInfo.ownerAccessToken),
+        compareClient ? snapshotProbe(currentServerInfo.clientAccessToken) : Promise.resolve(null),
+        nodeGet(`${mount}/global/health`, currentServerInfo.ownerAccessToken),
+        nodeGet("/experimental/engine-v2-preview/status", currentServerInfo.ownerAccessToken),
+      ]);
+      const messageResponse = ownerSnapshot.responses.messages;
+      const responseItems = Array.isArray(messageResponse.body)
+        ? messageResponse.body
+        : isRecord(messageResponse.body) && Array.isArray(messageResponse.body.data)
+          ? messageResponse.body.data
+          : [];
+      const nativeMessages = responseItems.flatMap((message) => {
+        if (!isRecord(message)) return [];
+        const info = isRecord(message.info) ? message.info : message;
+        const parts = Array.isArray(message.parts) ? message.parts : [];
+        return [{
+          role: typeof info.role === "string" ? info.role : "",
+          text: parts.map((part) => isRecord(part) && typeof part.text === "string" ? part.text : "").join("\n"),
+        }];
+      });
+      const markerFacts = (role: "user" | "assistant", value: string) => {
+        const matching = nativeMessages.filter((message) => message.role === role && message.text.includes(value));
+        return {
+          count: matching.length,
+          occurrences: value ? matching.reduce((total, message) => total + message.text.split(value).length - 1, 0) : 0,
+        };
+      };
+      const user = markerFacts("user", marker);
+      const reply = markerFacts("assistant", diagnosticReplyMarker);
+      const actualV1Version = isRecord(healthResponse.body) && typeof healthResponse.body.version === "string"
+        ? sanitizedDiagnosticText(healthResponse.body.version) : null;
+      return {
+        messages: nativeMessages.length,
+        markerCount: user.count,
+        markerOccurrences: user.occurrences,
+        diagnostic: {
+          transport: "node",
+          user,
+          reply,
+          ownerSnapshot: ownerSnapshot.facts,
+          clientSnapshot: clientSnapshot?.facts ?? null,
+          health: { ...responseFacts(healthResponse), actualV1Version },
+          preview: {
+            ...responseFacts(previewResponse),
+            enabled: isRecord(previewResponse.body) && typeof previewResponse.body.enabled === "boolean"
+              ? previewResponse.body.enabled : null,
+            chatRouting: isRecord(previewResponse.body) && typeof previewResponse.body.chatRouting === "boolean"
+              ? previewResponse.body.chatRouting : null,
+          },
+        },
+      };
+    }
     const result = await engine.messages(sessionId, 100).catch((error: unknown) => {
       const errorName = sanitizedErrorField(error, "name");
       const errorMessage = sanitizedErrorField(error, "message");
@@ -754,11 +919,12 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
       messages: texts.length,
       markerCount: matching.length,
       markerOccurrences: marker ? matching.reduce((total, text) => total + text.split(marker).length - 1, 0) : 0,
+      diagnostic: null,
     };
   };
   const providerRequestCount = async (promptMarker: string) => (await mock.agentRequests({ promptMarker }))
     .filter((request) => request.promptMarker === promptMarker && request.kind !== "utility").length;
-  const visibleMessageFacts = (sessionId: string, role: "user" | "assistant", marker: string) => seed.evalIn(app, browserScript((sessionId, role, marker) => {
+  const visibleMessageFacts = (sessionId: string, role: "user" | "assistant", marker: string) => seed.evalIn(app, browserScript((sessionId, role, marker, workspaceId) => {
     const visible = (node: HTMLElement) => {
       const rect = node.getBoundingClientRect();
       const style = getComputedStyle(node);
@@ -767,14 +933,39 @@ export async function workspaceNewTask(seed: Seed, { place }: { place: Place }) 
         && style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity) > 0;
     };
     const surfaces = [...document.querySelectorAll<HTMLElement>("[data-session-surface-id]")]
-      .filter((surface) => surface.dataset.sessionSurfaceId === sessionId && visible(surface));
+      .filter((surface) => surface.dataset.sessionSurfaceId === sessionId);
     const rows = surfaces.flatMap((surface) => [...surface.querySelectorAll<HTMLElement>("[data-message-role]")])
-      .filter((row) => row.dataset.messageRole === role && visible(row) && row.innerText.includes(marker));
+      .filter((row) => row.dataset.messageRole === role && row.innerText.includes(marker));
+    const viewportRows = rows.filter(visible);
+    const labels = (selector: string) => [...document.querySelectorAll<HTMLElement>(selector)]
+      .filter(visible)
+      .map((node) => (node.getAttribute("aria-label") ?? node.innerText).replace(/\s+/g, " ").trim().slice(0, 120))
+      .filter((label, index, values) => Boolean(label) && values.indexOf(label) === index)
+      .slice(0, 5);
+    const resourcePrefixes = ["workspace", "w"].map((mount) => `/${mount}/${encodeURIComponent(workspaceId)}/opencode`);
+    const network = performance.getEntriesByType("resource").flatMap((entry) => {
+      if (!(entry instanceof PerformanceResourceTiming)) return [];
+      const url = new URL(entry.name);
+      if (!resourcePrefixes.some((prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`))) return [];
+      return [{
+        path: url.pathname,
+        limit: url.searchParams.get("limit"),
+        responseStatus: entry.responseStatus,
+        durationMs: Math.round(entry.duration * 100) / 100,
+      }];
+    }).slice(-30);
     return {
-      rowCount: rows.length,
-      markerOccurrences: marker ? rows.reduce((total, row) => total + row.innerText.split(marker).length - 1, 0) : 0,
+      rowCount: viewportRows.length,
+      markerOccurrences: marker ? viewportRows.reduce((total, row) => total + row.innerText.split(marker).length - 1, 0) : 0,
+      totalRowCount: rows.length,
+      offscreenRowCount: rows.length - viewportRows.length,
+      surfaceCount: surfaces.length,
+      visibleSurfaceCount: surfaces.filter(visible).length,
+      loaderLabels: labels('[role="status"], [data-session-loading-indicator]'),
+      errorLabels: labels('[role="alert"]'),
+      network,
     };
-  }, [sessionId, role, marker]));
+  }, [sessionId, role, marker, workspace.workspaceId]));
   const readInstantComposer = () => seed.evalIn(app, browserScript((workspaceId) => {
     const visible = (node: HTMLElement) => {
       const rect = node.getBoundingClientRect();


### PR DESCRIPTION
## Production fixes
Builds on the immediate-message implementation already merged in #4631; it does not duplicate that work.
- Keep immutable submitted draft A separate from editable continuation B while a new conversation is created and sent, including attachment preparation and explicit failure recovery.
- Do not classify a rejected send as a failed session transition; keep the error visible without permanently disabling the valid composer.
- Bound desktop-loopback snapshot read retries so a transient read does not remain paused indefinitely. Retries are cancellable reads, preserve ownership, and do not resend prompts.
- Preserve current admission-unknown, interruption, and queue protections from dev.

## Performance proof
Final tested head: `f5a009ef1e4214c399e6be05e819b69a33bde43c`.
`OPENWORK_WORLD_PLACE=local OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_MAX_WORKERS=1 pnpm evals:e2e workspace-new-task-hit-target --local`

**Passed: 1 test, 36/36 timing samples, 11/11 evidence assertion groups, 0 failures, 0 skips, 0 pending judgments.** Placement: `local (--local)`; isolated real Electron/v1 with a deterministic standalone model witness.

| Metric | Samples | Required | Observed max |
|---|---:|---:|---:|
| New task to focused, editable composer | 12 | <500ms | 103.1ms |
| First send to user row | 12 | <100ms | 14.8ms |
| Existing-session send to user row | 12 | <100ms | 24.2ms |

Timing runs from trusted renderer input to two consecutive qualifying animation frames, excluding CDP roundtrip. Creation/prompt requests are held before engine forwarding for at least 1500ms. Every sample is retained; these are renderer-frame opportunities, not hardware pixel-presentation telemetry.

The existing journey is extended rather than adding a new spec file. It checks no empty-session creation on opening, single submission, continuation preservation, known-rejection/Restore behavior, navigation isolation, SSE-before-HTTP response, and exact-once messages/model calls across reload. Its required local placement is declared in the journey catalog. Most of the diff is fixture instrumentation and evidence diagnostics.

## Additional checks
- App typecheck: passed.
- Focused native-session, composer-focus, and composer-state checks: 21 + 1 + 7 passed in separate invocations.
- Journey selection/reporting checks: 12 passed.
- Targeted strict TypeScript and browser callback checks: passed.

Final-head evidence is published below. Historical interrupted/red runs are not used as passing proof. This is a v1 local composer/performance slice, not certification of v2, live LLMs, hundreds of sessions, or the full safety baseline. No merge or release requested by this PR.