### PR TITLE
fix(den): record the shared callback mode for isolated MCP rows with shared registrations

### DIFF
--- a/docs/external-mcp-oauth.md
+++ b/docs/external-mcp-oauth.md
@@ -31,6 +31,13 @@ older per-connection callback. Reconnecting therefore uses the exact redirect
 URI that was registered with the provider and does not rewrite credentials,
 tokens, access grants, or plugin bindings.
 
+One exception keeps stored state truthful: when a row still carries a
+per-connection callback mode but its administrator-supplied client recorded the
+shared callback as its registered redirect, starting authorization records the
+shared mode on that row. The redirect sent to the provider, the client
+registration, credentials, grants, and bindings do not change; only
+transactions signed with the stale mode keep failing closed.
+
 ## Add a connection
 
 In Cloud → Connections, enter the MCP server URL. OpenWork automatically runs

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -22,6 +22,7 @@ import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { declaredPluginMcpAuthType, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
+import { isExternalMcpSharedCallbackRedirectUri } from "./external-mcp-oauth-contract.js"
 import {
   createExternalMcpIdentityBinding,
   normalizeExternalMcpIdentityUrl,
@@ -620,6 +621,63 @@ export async function isolateExternalMcpOAuthCallback(input: {
       connectedAt: null,
       updatedAt,
     }
+  })
+}
+
+/**
+ * Callback isolation kept admin-registered clients, so an isolated row can
+ * still send its client's recorded shared redirect while signing a
+ * per-connection callback mode that the shared route rejects. Record the mode
+ * the registered redirect already uses. The redirect, client, credentials,
+ * grants, and bindings are unchanged; transactions signed with the stale mode
+ * keep failing closed.
+ */
+export async function adoptRegisteredSharedExternalMcpOAuthCallback(input: {
+  organizationId: OrganizationId
+  connectionId: ExternalMcpConnectionId
+}): Promise<ExternalMcpConnectionRow | null> {
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(ExternalMcpConnectionTable)
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const connection = rows[0]
+    if (!connection || connection.authType !== "oauth" || !connection.oauthConfiguration) return null
+    if (connection.oauthConfiguration.callbackMode === "shared-v1") return null
+
+    const clients = await tx
+      .select({ extra: OrgOAuthClientTable.extra })
+      .from(OrgOAuthClientTable)
+      .where(and(
+        eq(OrgOAuthClientTable.organizationId, input.organizationId),
+        eq(OrgOAuthClientTable.providerId, input.connectionId),
+      ))
+      .limit(1)
+    const clientExtra = normalizeOAuthClientExtra(clients[0]?.extra)
+    const registeredRedirectUri = clientExtra?.registeredRedirectUri
+    if (
+      clientExtra?.enterpriseMcpRegistrationSource !== "pre-registered"
+      || typeof registeredRedirectUri !== "string"
+      || !isExternalMcpSharedCallbackRedirectUri(registeredRedirectUri)
+    ) {
+      return null
+    }
+
+    const oauthConfiguration: ExternalMcpOAuthConfiguration = { ...connection.oauthConfiguration, callbackMode: "shared-v1" }
+    const updatedAt = new Date(Math.max(Date.now(), connection.updatedAt.getTime() + 1))
+    await tx
+      .update(ExternalMcpConnectionTable)
+      .set({ oauthConfiguration, updatedAt })
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+    return { ...connection, oauthConfiguration, updatedAt }
   })
 }
 

--- a/ee/apps/den-api/src/capability-sources/external-mcp-oauth-contract.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-oauth-contract.ts
@@ -24,6 +24,19 @@ export function externalMcpLegacyCallbackUrl(connectionId: string): string {
   return publicApiUrl(`/v1/mcp-connections/${encodeURIComponent(connectionId)}/connect/callback`)
 }
 
+/**
+ * Whether a recorded redirect URI lands on the deployment-wide callback route,
+ * on any public host or base path Den has emitted (including the hosted web
+ * proxy, which forwards to the same route).
+ */
+export function isExternalMcpSharedCallbackRedirectUri(redirectUri: string): boolean {
+  try {
+    return new URL(redirectUri).pathname.endsWith("/v1/mcp-connections/oauth/callback")
+  } catch {
+    return false
+  }
+}
+
 function hostedWebProxyUrl(pathname: string): string {
   const url = new URL(`/api/den${pathname}`, env.betterAuthUrl)
   return url.toString()

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -49,6 +49,7 @@ import {
   listExternalMcpTools,
 } from "../../capability-sources/external-mcp-client-runtime.js"
 import {
+  adoptRegisteredSharedExternalMcpOAuthCallback,
   confirmExternalMcpIssuerReview,
   createExternalMcpConnection,
   deleteExternalMcpConnection,
@@ -3087,6 +3088,23 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         const member = connection.credentialMode === "per_member"
           ? { orgMembershipId: payload.currentMember.id }
           : undefined
+        if (connection.oauthConfiguration?.callbackMode !== "shared-v1") {
+          // Rows isolated in July kept their admin-registered client, whose
+          // recorded shared redirect is what the provider still receives.
+          // Sign the mode that redirect actually uses, or the shared callback
+          // route rejects the transaction after provider consent.
+          const adopted = await adoptRegisteredSharedExternalMcpOAuthCallback({
+            organizationId: payload.organization.id,
+            connectionId: externalMcpConnectionId,
+          })
+          if (adopted) {
+            connection = adopted
+            logger.info("external_mcp_oauth_registered_shared_callback_adopted", {
+              connection_id: connection.id,
+              organization_id: payload.organization.id,
+            })
+          }
+        }
         const beginAuthorization = async (target: ExternalMcpConnectionRow) => {
           const callbackMode = target.oauthConfiguration?.callbackMode ?? "legacy-v1"
           const responseIssuerRequired = authorizationResponseIssuerRequired(target)

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -612,6 +612,241 @@ test("connect start keeps the shared callback for a pre-registered confidential 
   }
 })
 
+test("connect start records the shared callback mode for an isolated row whose pre-registered client keeps the shared redirect", async () => {
+  let origin = ""
+  let expectedCodeChallenge = ""
+  const tokenRedirectUris: string[] = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(incoming) {
+      const url = new URL(incoming.url)
+      if (url.pathname === "/.well-known/oauth-protected-resource/mcp") {
+        return Response.json({ resource: `${origin}/mcp`, authorization_servers: [origin], scopes_supported: ["mcp_server"] })
+      }
+      if (url.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code"],
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          code_challenge_methods_supported: ["S256"],
+          scopes_supported: ["mcp_server"],
+        })
+      }
+      if (url.pathname === "/token") {
+        const form = new URLSearchParams(await incoming.text())
+        expect(form.get("client_id")).toBe("kept-preregistered-client")
+        expect(form.get("client_secret")).toBe("kept-preregistered-secret")
+        expect(form.get("code")).toBe("isolated-row-authorization-code")
+        tokenRedirectUris.push(form.get("redirect_uri") ?? "")
+        expect(createHash("sha256").update(form.get("code_verifier") ?? "").digest("base64url")).toBe(expectedCodeChallenge)
+        return Response.json({ access_token: "isolated-row-access-token", token_type: "Bearer", expires_in: 3_600, scope: "mcp_server" })
+      }
+      if (url.pathname === "/mcp") {
+        if (incoming.headers.get("authorization") !== "Bearer isolated-row-access-token") {
+          return new Response(null, {
+            status: 401,
+            headers: { "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp", scope="mcp_server"` },
+          })
+        }
+        if (incoming.method !== "POST") return new Response(null, { status: 405 })
+        const rpc: unknown = await incoming.json()
+        if (!isRecord(rpc)) return Response.json({ error: "invalid_request" }, { status: 400 })
+        if (rpc.method === "notifications/initialized") return new Response(null, { status: 202 })
+        const id = typeof rpc.id === "string" || typeof rpc.id === "number" ? rpc.id : null
+        if (rpc.method === "tools/list") {
+          return Response.json({ jsonrpc: "2.0", id, result: { tools: [{ name: "list-records", description: "Lists records.", inputSchema: { type: "object", properties: {} } }] } })
+        }
+        return Response.json({
+          jsonrpc: "2.0",
+          id,
+          result: { protocolVersion: "2025-06-18", capabilities: { tools: {} }, serverInfo: { name: "isolated-row-test", version: "1.0.0" } },
+        })
+      }
+      return new Response(null, { status: 404 })
+    },
+  })
+  origin = `http://127.0.0.1:${server.port}`
+  const publicOrigin = process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790"
+  const sharedCallback = new URL("/v1/mcp-connections/oauth/callback", publicOrigin).toString()
+
+  try {
+    // Historical sequence: a shared-v1 row with an admin-registered client whose
+    // recorded redirect is the shared callback, then callback isolation, which
+    // kept the pre-registered client while flipping the row to isolated-v1.
+    const connection = await createExternalMcpConnection({
+      organizationId,
+      name: "Isolated row with shared registration",
+      url: `${origin}/mcp`,
+      authType: "oauth",
+      credentialMode: "per_member",
+      createdByOrgMembershipId: memberId,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    })
+    await db
+      .update(schema.ExternalMcpConnectionTable)
+      .set({
+        oauthConfiguration: {
+          version: 1,
+          authorizationServerIssuer: origin,
+          requestedScopes: [],
+          callbackMode: "shared-v1",
+          discovery: {
+            authorizationServerUrl: origin,
+            authorizationServerMetadata: { issuer: origin, authorization_response_iss_parameter_supported: false, code_challenge_methods_supported: ["S256"] },
+            resourceMetadata: { authorization_servers: [origin] },
+          },
+        },
+      })
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
+    await upsertOrgOAuthClient({
+      organizationId,
+      providerId: connection.id,
+      clientId: "kept-preregistered-client",
+      clientSecret: "kept-preregistered-secret",
+      extra: {
+        enterpriseMcpRegistrationSource: "pre-registered",
+        registrationContractVersion: 2,
+        registeredRedirectUri: sharedCallback,
+        authorizationServerIssuer: origin,
+        tokenEndpointAuthMethod: "client_secret_post",
+      },
+      createdByOrgMembershipId: memberId,
+    })
+    const isolated = await isolateExternalMcpOAuthCallback({ organizationId, connectionId: connection.id })
+    expect(isolated.oauthConfiguration?.callbackMode).toBe("isolated-v1")
+    const keptClient = await getOrgOAuthClient(organizationId, connection.id)
+    expect(keptClient?.clientId).toBe("kept-preregistered-client")
+
+    const inconsistentList = await request("/v1/mcp-connections?scope=manageable")
+    const inconsistentBody: unknown = await inconsistentList.json()
+    if (!isRecord(inconsistentBody) || !Array.isArray(inconsistentBody.connections)) throw new Error("Expected manageable connections.")
+    expect(inconsistentBody.connections.find((entry) => isRecord(entry) && entry.id === connection.id))
+      .toMatchObject({ oauthCallbackMode: "isolated-v1", oauthCallbackUrl: sharedCallback, oauthRegistrationSource: "pre-registered" })
+
+    // A transaction signed with the stale row mode still fails closed at the
+    // shared route, before and after the row is reconciled.
+    const staleState = createOAuthStateToken({
+      organizationId,
+      orgMembershipId: regularMemberId,
+      providerId: connection.id,
+      binding: externalMcpIdentityBinding(isolated),
+      version: 2,
+      callbackMode: "isolated-v1",
+      authorizationServerIssuer: origin,
+      authorizationResponseIssuerRequired: false,
+      secret: process.env.BETTER_AUTH_SECRET ?? "",
+    })
+    const staleSharedCallback = new URL(sharedCallback)
+    staleSharedCallback.searchParams.set("code", "stale-code")
+    staleSharedCallback.searchParams.set("state", staleState)
+    const staleRejected = await app.fetch(new Request(staleSharedCallback))
+    expect(staleRejected.status).toBe(400)
+    expect(await staleRejected.json()).toEqual({
+      error: "invalid_request",
+      message: "This authorization callback must use the shared callback selected when authorization started.",
+    })
+
+    // A granted member starts sign-in: the row adopts the shared mode its
+    // registered redirect already uses, and nothing else about the client changes.
+    const started = await principalRequest(regularUserId, `/v1/mcp-connections/${connection.id}/connect/start`)
+    expect(started.status).toBe(200)
+    const startedBody: unknown = await started.json()
+    if (!isRecord(startedBody) || typeof startedBody.authorizeUrl !== "string") throw new Error("Expected an OAuth authorize URL.")
+    const authorizeUrl = new URL(startedBody.authorizeUrl)
+    expect(authorizeUrl.searchParams.get("client_id")).toBe("kept-preregistered-client")
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(sharedCallback)
+    expectedCodeChallenge = authorizeUrl.searchParams.get("code_challenge") ?? ""
+    expect(expectedCodeChallenge.length).toBeGreaterThan(0)
+    const signedState = authorizeUrl.searchParams.get("state") ?? ""
+    expect(verifyOAuthStateToken({ token: signedState, secret: process.env.BETTER_AUTH_SECRET ?? "" })).toMatchObject({
+      providerId: connection.id,
+      orgMembershipId: regularMemberId,
+      callbackMode: "shared-v1",
+      authorizationServerIssuer: origin,
+      authorizationResponseIssuerRequired: false,
+    })
+    const [reconciled] = await db
+      .select()
+      .from(schema.ExternalMcpConnectionTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
+      .limit(1)
+    expect(reconciled?.oauthConfiguration?.callbackMode).toBe("shared-v1")
+    expect(reconciled?.updatedAt.getTime()).toBeGreaterThan(isolated.updatedAt.getTime())
+    expect(await getOrgOAuthClient(organizationId, connection.id)).toMatchObject({
+      clientId: "kept-preregistered-client",
+      clientSecret: "kept-preregistered-secret",
+      extra: { enterpriseMcpRegistrationSource: "pre-registered", registeredRedirectUri: sharedCallback },
+    })
+
+    const staleScopedCallback = new URL(`/v1/mcp-connections/${connection.id}/connect/callback`, publicOrigin)
+    staleScopedCallback.searchParams.set("code", "stale-code")
+    staleScopedCallback.searchParams.set("state", staleState)
+    const staleScopedRejected = await app.fetch(new Request(staleScopedCallback))
+    expect(staleScopedRejected.status).toBe(400)
+    expect(await staleScopedRejected.json()).toMatchObject({ error: "invalid_request", message: expect.stringContaining("changed after authorization started") })
+    expect(tokenRedirectUris).toEqual([])
+
+    const callbackUrl = new URL(sharedCallback)
+    callbackUrl.searchParams.set("code", "isolated-row-authorization-code")
+    callbackUrl.searchParams.set("state", signedState)
+    const callbackResponse = await app.fetch(new Request(callbackUrl))
+    expect(callbackResponse.status).toBe(200)
+    expect(await callbackResponse.text()).toContain("You're connected")
+    expect(tokenRedirectUris).toEqual([sharedCallback])
+    const [account] = await db
+      .select({ accessToken: schema.ConnectedAccountTable.accessToken })
+      .from(schema.ConnectedAccountTable)
+      .where(drizzle.and(
+        drizzle.eq(schema.ConnectedAccountTable.providerId, connection.id),
+        drizzle.eq(schema.ConnectedAccountTable.orgMembershipId, regularMemberId),
+      ))
+      .limit(1)
+    expect(account?.accessToken).toBe("isolated-row-access-token")
+    const connectedList = await request("/v1/mcp-connections?scope=manageable")
+    const connectedBody: unknown = await connectedList.json()
+    if (!isRecord(connectedBody) || !Array.isArray(connectedBody.connections)) throw new Error("Expected manageable connections.")
+    expect(connectedBody.connections.find((entry) => isRecord(entry) && entry.id === connection.id))
+      .toMatchObject({ connected: true, oauthCallbackMode: "shared-v1", oauthCallbackUrl: sharedCallback })
+
+    // Control: a legacy row whose pre-registered client recorded its own
+    // per-connection callback keeps that mode.
+    const legacy = await createExternalMcpConnection({
+      organizationId,
+      name: "Legacy row with scoped registration",
+      url: "http://127.0.0.1:9/legacy-scoped-mcp",
+      authType: "oauth",
+      credentialMode: "shared",
+      createdByOrgMembershipId: memberId,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    })
+    await db
+      .update(schema.ExternalMcpConnectionTable)
+      .set({ oauthConfiguration: { version: 1, authorizationServerIssuer: null, requestedScopes: [], callbackMode: "legacy-v1" } })
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, legacy.id))
+    const legacyCallback = new URL(`/v1/mcp-connections/${legacy.id}/connect/callback`, publicOrigin).toString()
+    await upsertOrgOAuthClient({
+      organizationId,
+      providerId: legacy.id,
+      clientId: "legacy-scoped-client",
+      clientSecret: null,
+      extra: { enterpriseMcpRegistrationSource: "pre-registered", registrationContractVersion: 2, registeredRedirectUri: legacyCallback },
+      createdByOrgMembershipId: memberId,
+    })
+    expect((await request(`/v1/mcp-connections/${legacy.id}/connect/start`)).status).toBe(502)
+    const [legacyRow] = await db
+      .select({ oauthConfiguration: schema.ExternalMcpConnectionTable.oauthConfiguration })
+      .from(schema.ExternalMcpConnectionTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, legacy.id))
+      .limit(1)
+    expect(legacyRow?.oauthConfiguration?.callbackMode).toBe("legacy-v1")
+  } finally {
+    server.stop(true)
+  }
+})
+
 test("connect start repairs a verified stale resource issuer alias before authorization", async () => {
   let authorizationOrigin = ""
   const registeredRedirects: string[][] = []

--- a/evals/specs/mcp-oauth-response-issuer.test.ts
+++ b/evals/specs/mcp-oauth-response-issuer.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
+import { queryDenDatabase } from "@openwork/env";
 import { eventually, mcpMock, needs, server, test } from "@openwork/testkit";
 import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
 
@@ -212,3 +213,77 @@ for (const issuerSupport of [true, false, undefined]) {
     }
   });
 }
+
+// Rows isolated in July kept their admin-registered client, so the provider
+// still receives that client's shared redirect while Den signed a per-connection
+// mode the shared callback route rejects. This journey seeds that stored state
+// through the database (no supported surface produces it today) and signs in.
+test("Den member sign-in recovers an isolated connection whose pre-registered client uses the shared callback", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun"] });
+  await using den = await server({
+    place, web: false,
+    mocks: { connector: mcpMock({ authorizationResponseIssuerSupported: false }) },
+    org: { name: `OAuth Callback Mode ${Date.now()}`, members: { teammate: {} } },
+  });
+  if (!den.database) throw new Error("Seeding the historical callback mode requires the isolated local testkit database");
+  const provider = den.mocks.connector;
+  const adminHeaders = { authorization: `Bearer ${den.admin.token}` };
+  const memberHeaders = { authorization: `Bearer ${den.members.teammate.token}` };
+  const tokenRequests = async () => (await provider.requests()).filter((entry) => entry.path === "/token").length;
+
+  const created = await denFetch(den.admin, "/v1/mcp-connections", {
+    method: "POST", headers: adminHeaders,
+    body: JSON.stringify({
+      name: "Registered shared callback", url: provider.mcpUrl, authType: "oauth", credentialMode: "per_member",
+      oauthClient: { clientId: "mock-preregistered-client", clientSecret: "mock-preregistered-secret", tokenEndpointAuthMethod: "client_secret_post" },
+      access: { orgWide: true },
+    }),
+  });
+  expect(created.response.status, created.text).toBe(200);
+  if (!isRecord(created.body) || typeof created.body.id !== "string" || typeof created.body.oauthCallbackUrl !== "string") throw new Error("Connection id or callback URL missing");
+  const id = created.body.id;
+  const sharedCallback = created.body.oauthCallbackUrl;
+  expect(new URL(sharedCallback).pathname).toBe("/v1/mcp-connections/oauth/callback");
+  expect(created.body).toMatchObject({ oauthCallbackMode: "shared-v1", oauthRegistrationSource: "pre-registered", oauthClientId: "mock-preregistered-client" });
+  await queryDenDatabase(den.database.url, "UPDATE external_mcp_connection SET oauth_configuration = JSON_SET(oauth_configuration, '$.callbackMode', 'isolated-v1') WHERE id = ?", [id]);
+
+  const detail = async () => {
+    const listed = await denFetch(den.admin, "/v1/mcp-connections?scope=manageable", { headers: adminHeaders });
+    expect(listed.response.status, listed.text).toBe(200);
+    if (!isRecord(listed.body) || !Array.isArray(listed.body.connections)) throw new Error("Connections missing");
+    const connection = listed.body.connections.find((entry) => isRecord(entry) && entry.id === id);
+    if (!isRecord(connection)) throw new Error("Seeded connection missing from the manageable list");
+    return connection;
+  };
+  expect(await detail()).toMatchObject({ oauthCallbackMode: "isolated-v1", oauthCallbackUrl: sharedCallback, connected: false });
+  evidence.recordAssertionEvidence("Stored callback mode disagrees with the registered redirect", "Admin detail reported an isolated-v1 callback mode while the effective callback URL was the shared route.", true);
+
+  const started = await denFetch(den.members.teammate, `/v1/mcp-connections/${id}/connect/start`, { headers: memberHeaders });
+  expect(started.response.status, started.text).toBe(200);
+  if (!isRecord(started.body) || typeof started.body.authorizeUrl !== "string") throw new Error("Authorization URL missing");
+  const authorize = new URL(started.body.authorizeUrl);
+  expect(authorize.searchParams.get("client_id")).toBe("mock-preregistered-client");
+  expect(authorize.searchParams.get("redirect_uri")).toBe(sharedCallback);
+  expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
+  expect(await detail()).toMatchObject({ oauthCallbackMode: "shared-v1", oauthCallbackUrl: sharedCallback, oauthClientId: "mock-preregistered-client", oauthRegistrationSource: "pre-registered", connected: false });
+  evidence.recordAssertionEvidence("Member sign-in records the shared callback mode without changing the registration", "connect/start sent the registered shared redirect with the same pre-registered client id; the stored mode now reads shared-v1 and nothing is connected yet.", true);
+
+  const redirect = await fetch(authorize, { redirect: "manual" });
+  expect(redirect.status).toBe(302);
+  const callback = new URL(redirect.headers.get("location")!);
+  expect(`${callback.origin}${callback.pathname}`).toBe(sharedCallback);
+  const before = await tokenRequests();
+  const completed = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+  const html = await completed.text();
+  expect(completed.status, html).toBe(200);
+  expect(html).toContain("connected");
+  expect(await tokenRequests()).toBe(before + 1);
+  expect(await detail()).toMatchObject({ connected: true, oauthCallbackMode: "shared-v1" });
+  const tools = await denFetch(den.members.teammate, `/v1/mcp-connections/${id}/tools`, { headers: memberHeaders });
+  expect(tools.response.status, tools.text).toBe(200);
+  expect(tools.text).toContain("\"tools\"");
+  const replay = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+  expect(replay.status).toBe(400);
+  expect(await tokenRequests()).toBe(before + 1);
+  evidence.recordAssertionEvidence("Shared callback completes sign-in and authenticated discovery after recovery", "The provider redirected to the shared route; the callback returned HTTP 200 with exactly one token exchange, the member listed tools with the new credential, and replaying the callback was rejected without another exchange.", true);
+});


### PR DESCRIPTION
## Problem

Callback isolation (#2868, July) moved qualifying OAuth connections to `isolated-v1` and deleted SDK-registered clients, but kept administrator-supplied (pre-registered) clients together with the shared callback recorded as their `registeredRedirectUri` (#2771). Since #4039 made the recorded redirect authoritative, such a row sends the shared `redirect_uri` to the provider while `connect/start` signs the row's `isolated-v1` mode. After provider consent, the shared callback route rejects the transaction:

> This authorization callback must use the shared callback selected when authorization started.

Every sign-in on an affected connection fails at OpenWork's own callback. No supported surface creates this state today; only rows from the July window carry it.

## Change

- `connect/start`: when a row is not `shared-v1` and its **pre-registered** client recorded a redirect on the shared callback route (`/v1/mcp-connections/oauth/callback` on any public host or base path Den emitted), record `shared-v1` on that row inside a `FOR UPDATE` transaction before signing state, and log `external_mcp_oauth_registered_shared_callback_adopted`.
- The redirect sent to the provider does not change (it was already the shared URL). Client id/secret, `registeredRedirectUri`, tokens, grants, and plugin bindings are untouched. The reconciled row gets the posture a newly created connection for the same provider has today (`pinned-transaction` mix-up defense without RFC 9207 `iss`, `response-issuer` with it).
- Callback route validation is unchanged: the shared route still requires `shared-v1`, the scoped route still rejects it, and stale transactions signed with the old mode keep failing closed on both routes. SDK-registered clients, rows whose registered redirect is their own scoped callback, and rows with no registered redirect are not touched.
- `docs/external-mcp-oauth.md`: one paragraph describing the exception.

Out of scope: broad start-time diagnostics for unrelated registered redirects, CORS on error responses, provider approval policies, and the docs hostname for the hosted callback URL (separate follow-up).

## Verification

**Verdict: Passed.** [Exact-head assertion evidence for all seven tests](https://github.com/different-ai/openwork/pull/4663#issuecomment-5595753798) is published inline. Head `26fcf20525f79e67e72ce6bde6d02d3613ac0bdf` (base `4d7727740d222f2291ebb2e6e9005c8bd86b2e16`). Direct Vitest PR lane, local cold-boot Den with an isolated MySQL database and the synthetic OAuth+MCP mock; no attached Den, no real provider.

- `pnpm evals:pr specs/mcp-oauth-response-issuer.test.ts` — **7 passed, 0 failed, 0 skipped** (108 s). The new journey `Den member sign-in recovers an isolated connection whose pre-registered client uses the shared callback` seeds the historical state (pre-registered client via `POST /v1/mcp-connections`, row flipped to `isolated-v1` through the testkit database), then asserts: admin detail shows `isolated-v1` with the shared callback URL; a granted member's `connect/start` sends the registered shared `redirect_uri` with the same client id and the detail now reads `shared-v1` with an unchanged client; the provider redirect lands on the shared route and the callback returns HTTP 200 with exactly one token exchange; the member lists tools with the new credential; replaying the callback is rejected without another exchange. The same spec fails on the base commit at the post-start detail assertion (mode stays `isolated-v1`).
- Boundary suite `ee/apps/den-api/test/mcp-connections-connect-start.test.ts` — **22 pass, 0 fail** (`bun test --conditions development`). New test reproduces the historical sequence through `isolateExternalMcpOAuthCallback` itself, asserts the stale-mode state is rejected by the shared route with the exact message before and after reconciliation and by the scoped route with "connection changed", verifies the token exchange used the shared redirect with the preserved client secret, and keeps a legacy row whose pre-registered client recorded its own scoped callback on `legacy-v1`. On the base commit this test fails at the signed state (`callbackMode: "isolated-v1"`).
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit -p .` — clean. `pnpm --filter @openwork-ee/den-api test` — 24 pass.
- Pre-existing, unrelated on the same base: `mcp-connections-edit.test.ts` › "marketplace bindings protect identity…" (identityManagedBy provenance) and the Den-as-authorization-server refresh suites fail identically with this change stashed; `evals` boundary/channel ratchets and `lint:layers` report the same pre-existing debt on base.

Live provider behaviour after deployment (consent, token issuance, reviewed-client policy) remains a separate gate; this PR only makes Den's stored callback mode agree with the redirect it already sends.