### PR TITLE
fix(server): retry transient managed policy verification failures

### DIFF
--- a/apps/server/src/managed-desktop-policy.ts
+++ b/apps/server/src/managed-desktop-policy.ts
@@ -9,6 +9,46 @@ import { readGlobalRuntimeOpencodeConfig, writeManagedDesktopPolicy, runtimeProv
 import { policyDenial, policyRequestActions, type ManagedPolicyAction } from "./managed-policy-rules.js";
 
 const services = new WeakMap<ServerConfig, ManagedDesktopPolicy>();
+const DEN_READ_DEADLINE_MS = 5_000;
+const DEN_READ_ATTEMPT_TIMEOUT_MS = 2_500;
+const DEN_READ_MAX_ATTEMPTS = 2;
+const RETRYABLE_DEN_STATUSES = new Set([502, 503, 504]);
+const RETRYABLE_TRANSPORT_CODES = new Set([
+  "ABORT_ERR",
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETRESET",
+  "ENETUNREACH",
+  "EPIPE",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+type DenRetryReason = "http_transient" | "transport_temporary" | "transport_timeout";
+
+function transientTransportReason(error: unknown): DenRetryReason | null {
+  const visited = new Set<object>();
+  let current = error;
+  for (let depth = 0; depth < 6 && isRecord(current) && !visited.has(current); depth += 1) {
+    visited.add(current);
+    if (current.name === "AbortError" || current.name === "TimeoutError" || current.code === "ABORT_ERR"
+      || current.code === "ETIMEDOUT" || current.code === "UND_ERR_CONNECT_TIMEOUT" || current.code === "UND_ERR_HEADERS_TIMEOUT") {
+      return "transport_timeout";
+    }
+    if (current.name === "NetworkError" || (typeof current.code === "string" && RETRYABLE_TRANSPORT_CODES.has(current.code))) {
+      return "transport_temporary";
+    }
+    current = current.cause;
+  }
+  return null;
+}
+
 export function managedDesktopPolicy(config: ServerConfig): ManagedDesktopPolicy {
   const existing = services.get(config);
   if (existing) return existing;
@@ -49,6 +89,48 @@ class ManagedDesktopPolicy {
     void promise.finally(() => { if (this.fetching?.promise === promise) this.fetching = undefined; }).catch(() => undefined);
     return promise;
   }
+  private identityChanged(generation: number): void {
+    if (generation !== this.generation) throw new ApiError(409, "policy_identity_changed", "The signed-in account changed. Retry the action.");
+  }
+  private async readDenJson(session: CloudProviderDenSession, path: string, generation: number): Promise<unknown> {
+    const deadline = performance.now() + DEN_READ_DEADLINE_MS;
+    for (let attempt = 1; attempt <= DEN_READ_MAX_ATTEMPTS; attempt += 1) {
+      this.identityChanged(generation);
+      const remainingMs = Math.floor(deadline - performance.now());
+      if (remainingMs <= 0) throw new Error("Den read deadline exceeded");
+      try {
+        const response = await externalFetch(`${session.baseUrl}${path}`, {
+          headers: { Authorization: `Bearer ${session.token}`, "x-openwork-legacy-org-id": session.orgId },
+          signal: AbortSignal.timeout(Math.min(DEN_READ_ATTEMPT_TIMEOUT_MS, remainingMs)),
+        });
+        this.identityChanged(generation);
+        if (!response.ok) {
+          if (attempt < DEN_READ_MAX_ATTEMPTS && RETRYABLE_DEN_STATUSES.has(response.status)) {
+            console.warn("[openwork:managed-policy] retrying Den verification", {
+              reason: "http_transient", status: response.status, attempt: attempt + 1,
+            });
+            void response.body?.cancel().catch(() => undefined);
+            continue;
+          }
+          throw new Error("Den request failed");
+        }
+        const payload: unknown = await response.json();
+        this.identityChanged(generation);
+        return payload;
+      } catch (error) {
+        this.identityChanged(generation);
+        const reason = transientTransportReason(error);
+        if (attempt < DEN_READ_MAX_ATTEMPTS && reason && performance.now() < deadline) {
+          console.warn("[openwork:managed-policy] retrying Den verification", {
+            reason, status: null, attempt: attempt + 1,
+          });
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error("Den request failed");
+  }
   private async fetchCurrent(): Promise<DesktopConfig | null> {
     const session = this.session;
     if (!session) {
@@ -59,13 +141,9 @@ class ManagedDesktopPolicy {
     const generation = this.generation;
     let policy: DesktopConfig;
     try {
-      const response = await externalFetch(`${session.baseUrl}/v1/me/desktop-config`, {
-        headers: { Authorization: `Bearer ${session.token}`, "x-openwork-legacy-org-id": session.orgId },
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!response.ok) throw new Error("Policy request failed");
-      policy = desktopConfigSchema.parse(await response.json());
-    } catch {
+      policy = desktopConfigSchema.parse(await this.readDenJson(session, "/v1/me/desktop-config", generation));
+    } catch (error) {
+      if (error instanceof ApiError && error.code === "policy_identity_changed") throw error;
       throw new ApiError(403, "policy_unavailable", "Your organization's policy could not be verified. Try again when connected.");
     }
     if (generation !== this.generation) throw new ApiError(409, "policy_identity_changed", "The signed-in account changed. Retry the action.");
@@ -129,17 +207,15 @@ class ManagedDesktopPolicy {
       if (!session) throw new ApiError(403, "policy_unavailable", "Sign in to verify assigned models.");
       let assigned = false;
       try {
-        const response = await externalFetch(`${session.baseUrl}/v1/llm-providers`, {
-          headers: { Authorization: `Bearer ${session.token}`, "x-openwork-legacy-org-id": session.orgId },
-          signal: AbortSignal.timeout(10_000),
-        });
-        if (!response.ok) throw new Error("Catalog unavailable");
-        const catalog: unknown = await response.json();
+        const catalog = await this.readDenJson(session, "/v1/llm-providers", generation);
         if (!isRecord(catalog) || !Array.isArray(catalog.llmProviders)) throw new Error("Invalid catalog");
         assigned = catalog.llmProviders.filter(isRecord).some((item) =>
           (item.source === "openwork" ? "openwork" : item.id) === providerID && Array.isArray(item.models)
           && item.models.filter(isRecord).some((model) => model.id === modelID));
-      } catch { throw new ApiError(403, "policy_unavailable", "Your organization's assigned models could not be verified."); }
+      } catch (error) {
+        if (error instanceof ApiError && error.code === "policy_identity_changed") throw error;
+        throw new ApiError(403, "policy_unavailable", "Your organization's assigned models could not be verified.");
+      }
       if (generation !== this.generation) throw new ApiError(409, "policy_identity_changed", "The signed-in account changed. Retry the action.");
       if (!(assigned && /^(?:lpr_|openwork$)/i.test(providerID) && models && typeof models === "object" && Object.hasOwn(models, modelID))) {
         throw new ApiError(403, "organization_model_denied", "Choose an AI model assigned by your organization.");

--- a/apps/server/src/managed-desktop-policy.ts
+++ b/apps/server/src/managed-desktop-policy.ts
@@ -9,8 +9,9 @@ import { readGlobalRuntimeOpencodeConfig, writeManagedDesktopPolicy, runtimeProv
 import { policyDenial, policyRequestActions, type ManagedPolicyAction } from "./managed-policy-rules.js";
 
 const services = new WeakMap<ServerConfig, ManagedDesktopPolicy>();
-const DEN_READ_DEADLINE_MS = 5_000;
-const DEN_READ_ATTEMPT_TIMEOUT_MS = 2_500;
+// The first cold read previously had 10s; keep two reads under the 15s plugin budget and one read under the 10s session-install budget.
+const DEN_READ_DEADLINE_MS = 6_000;
+const DEN_READ_ATTEMPT_TIMEOUT_MS = 3_500;
 const DEN_READ_MAX_ATTEMPTS = 2;
 const RETRYABLE_DEN_STATUSES = new Set([502, 503, 504]);
 const RETRYABLE_TRANSPORT_CODES = new Set([

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -364,17 +364,28 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
   };
   const latencyEvaluation = async (path: string, evaluation: Record<string, unknown>, times: number) => {
     await world.proxy.faults.clear();
-    await world.proxy.faults.latency(path, 3_000, { times });
+    const start = (await world.proxy.requestLog()).length;
+    await world.proxy.faults.latency(path, 5_000, { times });
     const startedAt = performance.now();
-    const result = await world.evaluate(evaluation);
+    let evaluationComplete = false;
+    const evaluationPromise = world.evaluate(evaluation).finally(() => { evaluationComplete = true; });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const requestsBeforeCompletion = (await world.proxy.requestLog()).slice(start).filter((request) => request.path === path);
+    const completedBeforeRequestProbe = evaluationComplete;
+    const result = await evaluationPromise;
     const elapsedMs = Math.round(performance.now() - startedAt);
+    const logAfterEvaluation = await world.proxy.requestLog();
+    const afterEvaluation = logAfterEvaluation.length;
+    const requests = logAfterEvaluation.slice(start, afterEvaluation).filter((request) => request.path === path);
+    const freshBeforeCompletion = requestsBeforeCompletion.filter((request) => request.faulted === false).length;
+    const freshWithinEvaluation = requests.filter((request) => request.faulted === false).length;
     // Aborted requests are not completed-response log entries. Give every
-    // three-second latency handler a bounded drain window, then prove that a
+    // five-second latency handler a bounded drain window, then prove that a
     // fault-free evaluation is healthy before starting the next case.
-    await new Promise((resolve) => setTimeout(resolve, 3_250));
+    await new Promise((resolve) => setTimeout(resolve, 5_250));
     await world.proxy.faults.clear();
     const healthy = await world.evaluate(evaluation);
-    return { result, healthy, elapsedMs };
+    return { result, healthy, elapsedMs, start, afterEvaluation, requests, completedBeforeRequestProbe, freshBeforeCompletion, freshWithinEvaluation };
   };
 
   await step("the assigned model is materialized and allowed while custom providers are disabled", async () => {
@@ -496,8 +507,12 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
     ]) {
       expect(observed.result.status, name).toBe(200);
       expect(observed.healthy.status, `${name} healthy follow-up`).toBe(200);
-      expect(observed.elapsedMs, name).toBeGreaterThan(2_000);
+      expect(observed.elapsedMs, name).toBeGreaterThan(3_000);
       expect(observed.elapsedMs, name).toBeLessThan(8_000);
+      expect(observed.completedBeforeRequestProbe, name).toBe(false);
+      expect(observed.freshBeforeCompletion, name).toBe(0);
+      expect(observed.freshWithinEvaluation, name).toBe(1);
+      expect(observed.requests.filter((request) => request.faulted === false), name).toMatchObject([{ faulted: false, status: 200 }]);
     }
     for (const { name, observed } of [
       { name: "policy exhaustion", observed: policyExhausted },
@@ -506,16 +521,21 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
       expect(observed.result.status, name).toBe(403);
       expect(code(observed.result.body), name).toBe("policy_unavailable");
       expect(observed.healthy.status, `${name} healthy follow-up`).toBe(200);
-      expect(observed.elapsedMs, name).toBeGreaterThan(4_000);
+      expect(observed.elapsedMs, name).toBeGreaterThan(5_500);
       expect(observed.elapsedMs, name).toBeLessThan(8_000);
+      expect(observed.completedBeforeRequestProbe, name).toBe(false);
+      expect(observed.freshBeforeCompletion, name).toBe(0);
+      expect(observed.freshWithinEvaluation, name).toBe(0);
     }
     evidence.recordAssertionEvidence(
-      "One policy or assigned-model catalog transport timeout recovers after two seconds, repeated timeouts fail closed after four seconds, and every response arrives before eight seconds with a healthy fault-free follow-up",
+      "One policy or assigned-model catalog transport timeout recovers after three seconds, repeated timeouts fail closed after five and a half seconds, and every response arrives before eight seconds with a healthy fault-free follow-up",
       JSON.stringify({ policyRecovered, policyExhausted, catalogRecovered, catalogExhausted }),
       policyRecovered.result.status === 200 && catalogRecovered.result.status === 200
         && code(policyExhausted.result.body) === "policy_unavailable" && code(catalogExhausted.result.body) === "policy_unavailable"
-        && policyRecovered.elapsedMs > 2_000 && catalogRecovered.elapsedMs > 2_000
-        && policyExhausted.elapsedMs > 4_000 && catalogExhausted.elapsedMs > 4_000
+        && policyRecovered.elapsedMs > 3_000 && catalogRecovered.elapsedMs > 3_000
+        && policyExhausted.elapsedMs > 5_500 && catalogExhausted.elapsedMs > 5_500
+        && [policyRecovered, catalogRecovered].every((item) => !item.completedBeforeRequestProbe && item.freshBeforeCompletion === 0 && item.freshWithinEvaluation === 1)
+        && [policyExhausted, catalogExhausted].every((item) => !item.completedBeforeRequestProbe && item.freshBeforeCompletion === 0 && item.freshWithinEvaluation === 0)
         && [policyRecovered, policyExhausted, catalogRecovered, catalogExhausted]
           .every((item) => item.elapsedMs < 8_000 && item.healthy.status === 200),
     );

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 import { selectModel } from "@openwork/behaviors";
 import { spec } from "@openwork/testkit";
-import { defaultPolicyEditorAndMemberDesktop, readDefaultDesktopPolicy, teamAccess } from "../worlds/desktop-policies.ts";
+import { defaultPolicyEditorAndMemberDesktop, managedPolicyRecovery, readDefaultDesktopPolicy, teamAccess } from "../worlds/desktop-policies.ts";
 
 // An organization that wants a vanilla OpenWork picks one decision, Restricted,
 // in the Den policy editor. This spec drives the real editor as the admin and a
@@ -10,16 +10,20 @@ import { defaultPolicyEditorAndMemberDesktop, readDefaultDesktopPolicy, teamAcce
 // collapse to what the policy leaves reachable.
 const defaultJourney = "an admin restricts the default policy and the member desktop enforces it";
 const teamJourney = "team access overrides overlapping grants and restores only selected desktop capabilities";
+const recoveryJourney = "managed policy evaluation bounds transient Den retries and never reuses stale access";
 // Register one fixture extension: Vitest 3 accumulates fixtures when the same
 // base is extended twice. Choose the setup at the test boundary, keeping the
 // worlds framework-free and each sequential journey isolated.
 const test = spec.world(async (seed) => {
   const name = expect.getState().currentTestName;
   if (name?.endsWith(defaultJourney)) {
-    return { defaultPolicy: await defaultPolicyEditorAndMemberDesktop(seed), team: null };
+    return { defaultPolicy: await defaultPolicyEditorAndMemberDesktop(seed), team: null, recovery: null };
   }
   if (name?.endsWith(teamJourney)) {
-    return { defaultPolicy: null, team: await teamAccess(seed) };
+    return { defaultPolicy: null, team: await teamAccess(seed), recovery: null };
+  }
+  if (name?.endsWith(recoveryJourney)) {
+    return { defaultPolicy: null, team: null, recovery: await managedPolicyRecovery(seed) };
   }
   throw new Error(`No desktop policy world selected for ${name}`);
 }, { timeout: 900_000 });
@@ -324,6 +328,82 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Saved to your organization Library as a remote MCP connection.") && !restrictedMcpText.includes("Workspace MCP") && !restrictedMcpText.includes("Add workspace MCP"),
   );
 
+});
+
+test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step, evidence }) => {
+  const world = selectedWorld.recovery;
+  if (!world) throw new Error("Expected the managed-policy recovery world");
+  const policyPath = "/v1/me/desktop-config";
+  const builtInModel = { action: "model", input: { providerID: "opencode", id: "policy-retry-proof" } };
+  const code = (body: unknown) => isRecord(body) && typeof body.code === "string" ? body.code : null;
+  const faultedEvaluation = async (statusCode: number, times: number, body?: unknown) => {
+    await world.proxy.faults.clear();
+    const start = (await world.proxy.requestLog()).length;
+    await world.proxy.faults.status(policyPath, statusCode, { times, body });
+    const result = await world.evaluate(builtInModel);
+    const requests = (await world.proxy.requestLog()).slice(start).filter((request) => request.path === policyPath);
+    return { result, requests };
+  };
+
+  await step("one transient response retries once and applies the live allow", async () => {
+    const recovered = await faultedEvaluation(503, 1);
+    expect(recovered.result.status).toBe(200);
+    expect(recovered.requests).toMatchObject([
+      { status: 503, faulted: true },
+      { status: 200, faulted: false },
+    ]);
+    expect(recovered.requests).toHaveLength(2);
+    evidence.recordAssertionEvidence(
+      "A transient Den failure retries exactly once and the real OpenWork server applies the live allow",
+      JSON.stringify(recovered),
+      recovered.result.status === 200 && recovered.requests.length === 2
+        && recovered.requests[0]?.status === 503 && recovered.requests[1]?.status === 200,
+    );
+  });
+
+  await step("persistent and non-retryable verification failures stay closed", async () => {
+    const outage = await faultedEvaluation(503, 2);
+    expect(outage.result.status).toBe(403);
+    expect(code(outage.result.body)).toBe("policy_unavailable");
+    expect(outage.requests).toHaveLength(2);
+    expect(outage.requests.map((request) => request.status)).toEqual([503, 503]);
+
+    const nonRetryable = [];
+    for (const fault of [
+      { name: "unauthenticated", status: 401 },
+      { name: "forbidden", status: 403 },
+      { name: "rate limited", status: 429 },
+      { name: "invalid schema", status: 200, body: { allowZenModel: "invalid" } },
+    ]) {
+      const observed = await faultedEvaluation(fault.status, 2, fault.body);
+      expect(observed.result.status, fault.name).toBe(403);
+      expect(code(observed.result.body), fault.name).toBe("policy_unavailable");
+      expect(observed.requests, fault.name).toHaveLength(1);
+      nonRetryable.push({ fault: fault.name, ...observed });
+    }
+    evidence.recordAssertionEvidence(
+      "Persistent outage, authentication, authorization, rate limit, and invalid policy responses fail closed without stale access",
+      JSON.stringify({ outage, nonRetryable }),
+      outage.result.status === 403 && code(outage.result.body) === "policy_unavailable" && outage.requests.length === 2
+        && nonRetryable.every((item) => item.result.status === 403 && code(item.result.body) === "policy_unavailable" && item.requests.length === 1),
+    );
+  });
+
+  await step("a retry reads and applies a fresh denial instead of the prior allow", async () => {
+    const updated = await world.updateBuiltInModel(false);
+    expect(updated.response.ok).toBe(true);
+    const denied = await faultedEvaluation(503, 1);
+    expect(denied.result.status).toBe(403);
+    expect(code(denied.result.body)).toBe("organization_policy_denied");
+    expect(denied.requests).toHaveLength(2);
+    expect(denied.requests.map((request) => request.status)).toEqual([503, 200]);
+    evidence.recordAssertionEvidence(
+      "After an earlier allow, the retry uses the fresh Den denial rather than stale policy",
+      JSON.stringify(denied),
+      denied.result.status === 403 && code(denied.result.body) === "organization_policy_denied"
+        && denied.requests.length === 2 && denied.requests[0]?.status === 503 && denied.requests[1]?.status === 200,
+    );
+  });
 });
 
 test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user, agent, probe, step, evidence, seed }) => {

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -1159,7 +1159,7 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
       () => { throw new Error("Expected the browser request to reject under the empty website allowlist"); },
       (error: unknown) => {
         if (!(error instanceof Error)) throw error;
-        expect(error.message).toBe(policyMessage);
+        expect(error.message).toContain(policyMessage);
         return error.message;
       },
     );
@@ -1169,7 +1169,7 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
     await admin.user.reload();
     await admin.user.see({ role: "combobox", label: "Website access" }, { value: "blocked", timeoutMs: 60_000 });
     await admin.user.notSee({ role: "button", label: `Remove ${origin}` });
-    evidence.recordAssertionEvidence("Saving an empty approved-site list persists browsing Blocked and rejects real requests to the formerly approved site only for the assigned team", JSON.stringify({ saved, denied, before, unsaved, blocked, unaffected, controlBefore }), denied.status === 403 && before.reached && unsaved.reached && blocked === policyMessage && unaffected.reached);
+    evidence.recordAssertionEvidence("Saving an empty approved-site list persists browsing Blocked and rejects real requests to the formerly approved site only for the assigned team", JSON.stringify({ saved, denied, before, unsaved, blocked, unaffected, controlBefore }), denied.status === 403 && before.reached && unsaved.reached && blocked.includes(policyMessage) && unaffected.reached);
     await admin.user.looks(["Team Access shows Website access Blocked and says no websites are approved"]);
   });
 

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -334,19 +334,84 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
   const world = selectedWorld.recovery;
   if (!world) throw new Error("Expected the managed-policy recovery world");
   const policyPath = "/v1/me/desktop-config";
+  const catalogPath = "/v1/llm-providers";
   const builtInModel = { action: "model", input: { providerID: "opencode", id: "policy-retry-proof" } };
+  const assignedModel = { action: "model", input: { providerID: world.providerId, id: world.modelId } };
   const code = (body: unknown) => isRecord(body) && typeof body.code === "string" ? body.code : null;
-  const faultedEvaluation = async (statusCode: number, times: number, body?: unknown) => {
+  const runtimeProvider = (body: unknown) => {
+    const providers = isRecord(body) && isRecord(body.provider) ? body.provider : null;
+    const provider = providers?.[world.providerId];
+    return isRecord(provider) ? provider : null;
+  };
+  const statusProvider = (body: unknown) => isRecord(body) && Array.isArray(body.providers)
+    ? body.providers.filter(isRecord).find((provider) => provider.cloudProviderId === world.providerId) ?? null
+    : null;
+  const waitForRequests = async (start: number, path: string, expected: number) => {
+    const deadline = Date.now() + 5_000;
+    while (true) {
+      const requests = (await world.proxy.requestLog()).slice(start).filter((request) => request.path === path);
+      if (requests.length >= expected || Date.now() >= deadline) return requests;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  };
+  const faultedEvaluation = async (
+    path: string,
+    evaluation: Record<string, unknown>,
+    statusCode: number,
+    times: number,
+    body?: unknown,
+  ) => {
     await world.proxy.faults.clear();
     const start = (await world.proxy.requestLog()).length;
-    await world.proxy.faults.status(policyPath, statusCode, { times, body });
-    const result = await world.evaluate(builtInModel);
-    const requests = (await world.proxy.requestLog()).slice(start).filter((request) => request.path === policyPath);
+    await world.proxy.faults.status(path, statusCode, { times, body });
+    const result = await world.evaluate(evaluation);
+    const requests = await waitForRequests(start, path, statusCode === 503 ? 2 : 1);
     return { result, requests };
   };
+  const latencyEvaluation = async (path: string, evaluation: Record<string, unknown>, times: number) => {
+    await world.proxy.faults.clear();
+    await world.proxy.faults.latency(path, 3_000, { times });
+    const startedAt = performance.now();
+    const result = await world.evaluate(evaluation);
+    const elapsedMs = Math.round(performance.now() - startedAt);
+    // Aborted requests are not completed-response log entries. Give every
+    // three-second latency handler a bounded drain window, then prove that a
+    // fault-free evaluation is healthy before starting the next case.
+    await new Promise((resolve) => setTimeout(resolve, 3_250));
+    await world.proxy.faults.clear();
+    const healthy = await world.evaluate(evaluation);
+    return { result, healthy, elapsedMs };
+  };
 
-  await step("one transient response retries once and applies the live allow", async () => {
-    const recovered = await faultedEvaluation(503, 1);
+  await step("the assigned model is materialized and allowed while custom providers are disabled", async () => {
+    const synced = await world.syncProviders();
+    const provider = runtimeProvider(synced.runtime.body);
+    const models = provider && isRecord(provider.models) ? provider.models : null;
+    const status = statusProvider(synced.status.body);
+    const statusModels = status && Array.isArray(status.modelIds) ? status.modelIds : [];
+    const catalog = await world.memberCatalog();
+    const catalogIds = catalog.providers.flatMap((item) => typeof item.id === "string" ? [item.id] : []);
+    const allowed = await world.evaluate(assignedModel);
+    expect(world.providerId).toMatch(/^lpr_/);
+    expect(synced.run.status).toBe(200);
+    expect(synced.runtime.status).toBe(200);
+    expect(synced.status.status).toBe(200);
+    expect(models).not.toBeNull();
+    expect(models && Object.hasOwn(models, world.modelId)).toBe(true);
+    expect(statusModels).toContain(world.modelId);
+    expect(catalog.status).toBe(200);
+    expect(catalogIds).toContain(world.providerId);
+    expect(allowed.status).toBe(200);
+    evidence.recordAssertionEvidence(
+      "A directly assigned lpr_ model is materialized and passes live catalog authorization when custom providers are disabled",
+      JSON.stringify({ providerId: world.providerId, modelId: world.modelId, syncHttp: synced.run.status, runtimeHttp: synced.runtime.status, syncStatusHttp: synced.status.status, statusModels, catalogIds, evaluation: allowed }),
+      /^lpr_/.test(world.providerId) && Boolean(models && Object.hasOwn(models, world.modelId))
+        && statusModels.includes(world.modelId) && catalogIds.includes(world.providerId) && allowed.status === 200,
+    );
+  });
+
+  await step("one transient policy response retries once and applies the live allow", async () => {
+    const recovered = await faultedEvaluation(policyPath, builtInModel, 503, 1);
     expect(recovered.result.status).toBe(200);
     expect(recovered.requests).toMatchObject([
       { status: 503, faulted: true },
@@ -354,15 +419,15 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
     ]);
     expect(recovered.requests).toHaveLength(2);
     evidence.recordAssertionEvidence(
-      "A transient Den failure retries exactly once and the real OpenWork server applies the live allow",
+      "A transient Den policy failure retries exactly once and the real OpenWork server applies the live allow",
       JSON.stringify(recovered),
       recovered.result.status === 200 && recovered.requests.length === 2
         && recovered.requests[0]?.status === 503 && recovered.requests[1]?.status === 200,
     );
   });
 
-  await step("persistent and non-retryable verification failures stay closed", async () => {
-    const outage = await faultedEvaluation(503, 2);
+  await step("persistent and non-retryable policy verification failures stay closed", async () => {
+    const outage = await faultedEvaluation(policyPath, builtInModel, 503, 2);
     expect(outage.result.status).toBe(403);
     expect(code(outage.result.body)).toBe("policy_unavailable");
     expect(outage.requests).toHaveLength(2);
@@ -375,7 +440,7 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
       { name: "rate limited", status: 429 },
       { name: "invalid schema", status: 200, body: { allowZenModel: "invalid" } },
     ]) {
-      const observed = await faultedEvaluation(fault.status, 2, fault.body);
+      const observed = await faultedEvaluation(policyPath, builtInModel, fault.status, 2, fault.body);
       expect(observed.result.status, fault.name).toBe(403);
       expect(code(observed.result.body), fault.name).toBe("policy_unavailable");
       expect(observed.requests, fault.name).toHaveLength(1);
@@ -389,10 +454,118 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
     );
   });
 
+  await step("assigned-model catalog verification has the same bounded retry and fail-closed behavior", async () => {
+    const recovered = await faultedEvaluation(catalogPath, assignedModel, 503, 1);
+    expect(recovered.result.status).toBe(200);
+    expect(recovered.requests).toMatchObject([
+      { status: 503, faulted: true },
+      { status: 200, faulted: false },
+    ]);
+    expect(recovered.requests).toHaveLength(2);
+
+    const outage = await faultedEvaluation(catalogPath, assignedModel, 503, 2);
+    expect(outage.result.status).toBe(403);
+    expect(code(outage.result.body)).toBe("policy_unavailable");
+    expect(outage.requests).toHaveLength(2);
+    expect(outage.requests.map((request) => request.status)).toEqual([503, 503]);
+
+    const nonRetryable = [];
+    for (const fault of [
+      { name: "unauthenticated", status: 401 },
+      { name: "forbidden", status: 403 },
+      { name: "rate limited", status: 429 },
+      { name: "invalid schema", status: 200, body: { llmProviders: "invalid" } },
+    ]) {
+      const observed = await faultedEvaluation(catalogPath, assignedModel, fault.status, 2, fault.body);
+      expect(observed.result.status, fault.name).toBe(403);
+      expect(code(observed.result.body), fault.name).toBe("policy_unavailable");
+      expect(observed.requests, fault.name).toHaveLength(1);
+      nonRetryable.push({ fault: fault.name, ...observed });
+    }
+    evidence.recordAssertionEvidence(
+      "Assigned-model catalog verification recovers from one 503, then fails closed after exactly two persistent attempts or one non-retryable response",
+      JSON.stringify({ recovered, outage, nonRetryable }),
+      recovered.result.status === 200 && recovered.requests.map((request) => request.status).join(",") === "503,200"
+        && outage.result.status === 403 && code(outage.result.body) === "policy_unavailable" && outage.requests.length === 2
+        && nonRetryable.every((item) => item.result.status === 403 && code(item.result.body) === "policy_unavailable" && item.requests.length === 1),
+    );
+  });
+
+  await step("single policy and assigned-model catalog timeouts recover while repeated timeouts exhaust within the shared deadline", async () => {
+    const policyRecovered = await latencyEvaluation(policyPath, builtInModel, 1);
+    const policyExhausted = await latencyEvaluation(policyPath, builtInModel, 2);
+    const catalogRecovered = await latencyEvaluation(catalogPath, assignedModel, 1);
+    const catalogExhausted = await latencyEvaluation(catalogPath, assignedModel, 2);
+    for (const { name, observed } of [
+      { name: "policy recovery", observed: policyRecovered },
+      { name: "catalog recovery", observed: catalogRecovered },
+    ]) {
+      expect(observed.result.status, name).toBe(200);
+      expect(observed.healthy.status, `${name} healthy follow-up`).toBe(200);
+      expect(observed.elapsedMs, name).toBeGreaterThan(2_000);
+      expect(observed.elapsedMs, name).toBeLessThan(8_000);
+    }
+    for (const { name, observed } of [
+      { name: "policy exhaustion", observed: policyExhausted },
+      { name: "catalog exhaustion", observed: catalogExhausted },
+    ]) {
+      expect(observed.result.status, name).toBe(403);
+      expect(code(observed.result.body), name).toBe("policy_unavailable");
+      expect(observed.healthy.status, `${name} healthy follow-up`).toBe(200);
+      expect(observed.elapsedMs, name).toBeGreaterThan(4_000);
+      expect(observed.elapsedMs, name).toBeLessThan(8_000);
+    }
+    evidence.recordAssertionEvidence(
+      "One policy or assigned-model catalog transport timeout recovers after two seconds, repeated timeouts fail closed after four seconds, and every response arrives before eight seconds with a healthy fault-free follow-up",
+      JSON.stringify({ policyRecovered, policyExhausted, catalogRecovered, catalogExhausted }),
+      policyRecovered.result.status === 200 && catalogRecovered.result.status === 200
+        && code(policyExhausted.result.body) === "policy_unavailable" && code(catalogExhausted.result.body) === "policy_unavailable"
+        && policyRecovered.elapsedMs > 2_000 && catalogRecovered.elapsedMs > 2_000
+        && policyExhausted.elapsedMs > 4_000 && catalogExhausted.elapsedMs > 4_000
+        && [policyRecovered, policyExhausted, catalogRecovered, catalogExhausted]
+          .every((item) => item.elapsedMs < 8_000 && item.healthy.status === 200),
+    );
+  });
+
+  await step("revoked catalog access overrides a stale materialized model until the next sync removes it", async () => {
+    await world.proxy.faults.clear();
+    expect(await world.revokeProviderAccess()).toBe(204);
+    const catalog = await world.memberCatalog();
+    const catalogIds = catalog.providers.flatMap((item) => typeof item.id === "string" ? [item.id] : []);
+    expect(catalog.status).toBe(200);
+    expect(catalogIds).not.toContain(world.providerId);
+
+    const stale = await world.readProviderState();
+    const staleProvider = runtimeProvider(stale.runtime.body);
+    const staleModels = staleProvider && isRecord(staleProvider.models) ? staleProvider.models : null;
+    expect(staleModels && Object.hasOwn(staleModels, world.modelId)).toBe(true);
+    expect(statusProvider(stale.status.body)).not.toBeNull();
+
+    const denied = await faultedEvaluation(catalogPath, assignedModel, 503, 1);
+    expect(denied.result.status).toBe(403);
+    expect(code(denied.result.body)).toBe("organization_model_denied");
+    expect(code(denied.result.body)).not.toBe("organization_policy_denied");
+    expect(denied.requests).toHaveLength(2);
+    expect(denied.requests.map((request) => request.status)).toEqual([503, 200]);
+
+    await world.proxy.faults.clear();
+    const synced = await world.syncProviders();
+    expect(synced.run.status).toBe(200);
+    expect(runtimeProvider(synced.runtime.body)).toBeNull();
+    expect(statusProvider(synced.status.body)).toBeNull();
+    evidence.recordAssertionEvidence(
+      "A revoked direct assignment is denied as organization_model_denied even while runtime config is stale, then a fresh sync removes it",
+      JSON.stringify({ providerId: world.providerId, modelId: world.modelId, memberCatalogIds: catalogIds, staleRuntimeModel: Boolean(staleModels && Object.hasOwn(staleModels, world.modelId)), denial: denied, removedFromRuntime: runtimeProvider(synced.runtime.body) === null, removedFromSyncStatus: statusProvider(synced.status.body) === null }),
+      !catalogIds.includes(world.providerId) && Boolean(staleModels && Object.hasOwn(staleModels, world.modelId))
+        && denied.result.status === 403 && code(denied.result.body) === "organization_model_denied"
+        && denied.requests.length === 2 && runtimeProvider(synced.runtime.body) === null && statusProvider(synced.status.body) === null,
+    );
+  });
+
   await step("a retry reads and applies a fresh denial instead of the prior allow", async () => {
     const updated = await world.updateBuiltInModel(false);
     expect(updated.response.ok).toBe(true);
-    const denied = await faultedEvaluation(503, 1);
+    const denied = await faultedEvaluation(policyPath, builtInModel, 503, 1);
     expect(denied.result.status).toBe(403);
     expect(code(denied.result.body)).toBe("organization_policy_denied");
     expect(denied.requests).toHaveLength(2);

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -94,10 +94,7 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     await member.user.see({ text: "Library" }, { timeoutMs: 90_000 });
     await member.user.notSee(manageExtensionsNotice);
     await member.user.click({ role: "button", label: /^MCPs$/ });
-    await member.user.click({ role: "button", label: /^Add$/ });
-    await member.user.see({ text: "Workspace MCP" });
-    await member.user.click({ text: "Workspace MCP" });
-    await member.user.click({ role: "button", label: "Continue" });
+    await member.user.click({ role: "button", label: "Add workspace MCP" });
     await member.user.see({ text: "Add workspace MCP" });
     await member.user.see({ role: "textbox", label: "App name" });
     const localMcpFormText = await member.probe.text();
@@ -296,24 +293,21 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
       label: "built-in extensions notice",
       until: (shown) => shown,
     });
+    await member.user.click({ role: "button", label: /^MCPs$/ });
+    await member.user.notSee({ role: "button", label: "Add workspace MCP" });
+    const mcpFilterText = await member.probe.text();
+    expect(mcpFilterText).not.toContain("Add workspace MCP");
     await member.user.click({ role: "button", label: /^All$/ });
     await member.user.click({ role: "button", label: /^Add$/ });
     await member.user.see({ testId: "library-add-choices" });
-    await member.user.see({ text: "Organization MCP" });
-    await member.user.notSee({ text: "Workspace MCP" });
+    await member.user.see({ text: "Connection" });
+    await member.user.notSee({ text: "Local MCP" });
     const choicesText = await member.probe.text();
-    expect(choicesText).not.toContain("Workspace MCP");
-    await member.user.click({ text: "Organization MCP" });
-    await member.user.click({ role: "button", label: "Continue" });
-    await member.user.see({ text: "Add an MCP server" });
-    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
-    await member.user.notSee({ text: "Add workspace MCP" });
-    const restrictedMcpText = `${choicesText}\n${await member.probe.text()}`;
-    expect(restrictedMcpText).not.toContain("Workspace MCP");
+    expect(choicesText).not.toContain("Local MCP");
+    const restrictedMcpText = `${mcpFilterText}\n${choicesText}`;
     expect(restrictedMcpText).not.toContain("Add workspace MCP");
     await member.user.press("Escape");
-    await member.user.notSee({ text: "Add an MCP server" });
-    await member.user.click({ role: "button", label: /^All$/ });
+    await member.user.notSee({ testId: "library-add-choices" });
     return { libraryHashAfter: await member.probe.hash(), builtInNoticeShown, restrictedMcpText };
   });
   expect(libraryHashAfter).toContain("/extensions");
@@ -323,9 +317,9 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     "A notice says built-in OpenWork extensions are disabled by your organization",
   ]);
   evidence.recordAssertionEvidence(
-    "The Library removes the local workspace MCP add path while the organization MCP add form remains reachable",
-    `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}; add choices and organization form=${restrictedMcpText}`,
-    libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Saved to your organization Library as a remote MCP connection.") && !restrictedMcpText.includes("Workspace MCP") && !restrictedMcpText.includes("Add workspace MCP"),
+    "The Library removes local MCP creation while retaining Connection as a separate picker choice",
+    `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}; MCP filter and All picker=${restrictedMcpText}`,
+    libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Connection") && !restrictedMcpText.includes("Local MCP") && !restrictedMcpText.includes("Add workspace MCP"),
   );
 
 });
@@ -799,25 +793,22 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
     await member.user.click("Library");
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
     await member.user.see({ text: /Need an MCP server or skill/ });
+    await member.user.click({ role: "button", label: /^MCPs$/ });
+    await member.user.notSee({ role: "button", label: "Add workspace MCP" });
+    const mcpFilterText = await member.probe.text();
+    expect(mcpFilterText).not.toContain("Add workspace MCP");
     await member.user.click({ role: "button", label: /^All$/ });
     await member.user.click({ role: "button", label: /^Add$/ });
     await member.user.see({ testId: "library-add-choices" });
-    await member.user.see({ text: "Organization MCP" });
-    await member.user.notSee({ text: "Workspace MCP" });
+    await member.user.see({ text: "Connection" });
+    await member.user.notSee({ text: "Local MCP" });
     const choicesText = await member.probe.text();
-    expect(choicesText).not.toContain("Workspace MCP");
-    await member.user.click({ text: "Organization MCP" });
-    await member.user.click({ role: "button", label: "Continue" });
-    await member.user.see({ text: "Add an MCP server" });
-    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
-    await member.user.notSee({ text: "Add workspace MCP" });
-    const mcpText = `${choicesText}\n${await member.probe.text()}`;
-    expect(mcpText).not.toContain("Workspace MCP");
+    expect(choicesText).not.toContain("Local MCP");
+    const mcpText = `${mcpFilterText}\n${choicesText}`;
     expect(mcpText).not.toContain("Add workspace MCP");
     await member.user.press("Escape");
-    await member.user.notSee({ text: "Add an MCP server" });
-    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path while the organization MCP add form remains reachable", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
-    await member.user.click({ role: "button", label: /^All$/ });
+    await member.user.notSee({ testId: "library-add-choices" });
+    evidence.recordAssertionEvidence("Blocked local tool management removes local MCP creation while retaining Connection as a separate picker choice", mcpText, mcpText.includes("Connection") && !mcpText.includes("Local MCP") && !mcpText.includes("Add workspace MCP"));
     const libraryText = await member.probe.text();
     evidence.recordAssertionEvidence("The locked desktop hides Settings, redirects forbidden routes, and explains how to get an MCP server", JSON.stringify({ redirected, forbiddenRoute, permissionsText, menuText, libraryText }), redirected.includes("/settings/cloud-account") && forbiddenRoute.includes("/settings/cloud-account") && count(permissionsText, "Blocked") === lockedKeys.length && libraryText.includes("Need an MCP server or skill"));
     await member.user.looks(["The Library shows organization restrictions and guidance for requesting an MCP server or skill"]);
@@ -887,31 +878,28 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
     expect(count(permissionsText, "Allowed")).toBe(lockedKeys.length - 1);
     evidence.recordAssertionEvidence("The Custom account permissions tab shows Settings Allowed and tools Blocked", permissionsText, count(permissionsText, "Blocked") === 1 && count(permissionsText, "Allowed") === lockedKeys.length - 1);
     await member.user.looks(["The dedicated App permissions tab shows Change app settings Allowed and Add tools, skills & MCP servers Blocked, without a policy banner"]);
-    // Wait for the Library data, then open Add from the current view. Changing
-    // its inventory filter navigates again and is unrelated to this assertion.
+    // Wait for the Library data before checking its filtered and All add controls.
     await member.user.click({ role: "button", label: "Back to app" });
     await member.user.click("Library");
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
     await member.user.see({ text: world.pluginName }, { timeoutMs: 90_000 });
     await member.user.see({ text: "No MCP servers configured yet." }, { timeoutMs: 90_000 });
+    await member.user.click({ role: "button", label: /^MCPs$/ });
+    await member.user.notSee({ role: "button", label: "Add workspace MCP" });
+    const mcpFilterText = await member.probe.text();
+    expect(mcpFilterText).not.toContain("Add workspace MCP");
+    await member.user.click({ role: "button", label: /^All$/ });
     await member.user.click({ role: "button", label: /^Add$/ });
     await member.user.see({ testId: "library-add-choices" });
-    await member.user.see({ text: "Organization MCP" });
-    await member.user.notSee({ text: "Workspace MCP" });
+    await member.user.see({ text: "Connection" });
+    await member.user.notSee({ text: "Local MCP" });
     const choicesText = await member.probe.text();
-    expect(choicesText).not.toContain("Workspace MCP");
-    await member.user.click({ text: "Organization MCP" });
-    await member.user.click({ role: "button", label: "Continue" });
-    await member.user.see({ text: "Add an MCP server" });
-    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
-    await member.user.notSee({ text: "Add workspace MCP" });
-    const mcpText = `${choicesText}\n${await member.probe.text()}`;
-    expect(mcpText).not.toContain("Workspace MCP");
+    expect(choicesText).not.toContain("Local MCP");
+    const mcpText = `${mcpFilterText}\n${choicesText}`;
     expect(mcpText).not.toContain("Add workspace MCP");
     await member.user.press("Escape");
-    await member.user.notSee({ text: "Add an MCP server" });
-    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path while the organization MCP add form remains reachable", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
-    await member.user.click({ role: "button", label: /^All$/ });
+    await member.user.notSee({ testId: "library-add-choices" });
+    evidence.recordAssertionEvidence("Blocked local tool management removes local MCP creation while retaining Connection as a separate picker choice", mcpText, mcpText.includes("Connection") && !mcpText.includes("Local MCP") && !mcpText.includes("Add workspace MCP"));
     await admin.user.looks(["Tools and connections is Admin managed while AI setup and Settings, workspaces and updates are Allowed"]);
   });
 

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -1154,15 +1154,22 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
     const denied = await member.agent.desktopApi("/managed-policy/evaluate", { method: "POST", body: { action: "browser", input: { url, method: "GET" } } });
     expect(denied.status).toBe(403);
     expect(isRecord(denied.body) && denied.body.code).toBe("organization_policy_denied");
-    const blocked = await member.agent.browserRequest({ url });
+    const policyMessage = "Error invoking remote method 'openwork:browser:openUrl': Error: Your organization does not allow this website.";
+    const blocked = await member.agent.browserRequest({ url }).then(
+      () => { throw new Error("Expected the browser request to reject under the empty website allowlist"); },
+      (error: unknown) => {
+        if (!(error instanceof Error)) throw error;
+        expect(error.message).toBe(policyMessage);
+        return error.message;
+      },
+    );
     const unaffected = await other.browserRequest({ url });
-    expect(blocked.reached).toBe(false);
     expect(unaffected.reached).toBe(true);
     expect(await effective(world.den.members.casey)).toEqual(controlBefore);
     await admin.user.reload();
     await admin.user.see({ role: "combobox", label: "Website access" }, { value: "blocked", timeoutMs: 60_000 });
     await admin.user.notSee({ role: "button", label: `Remove ${origin}` });
-    evidence.recordAssertionEvidence("Saving an empty approved-site list persists browsing Blocked and stops real requests to the formerly approved site only for the assigned team", JSON.stringify({ saved, denied, before, unsaved, blocked, unaffected, controlBefore }), denied.status === 403 && before.reached && unsaved.reached && !blocked.reached && unaffected.reached);
+    evidence.recordAssertionEvidence("Saving an empty approved-site list persists browsing Blocked and rejects real requests to the formerly approved site only for the assigned team", JSON.stringify({ saved, denied, before, unsaved, blocked, unaffected, controlBefore }), denied.status === 403 && before.reached && unsaved.reached && blocked === policyMessage && unaffected.reached);
     await admin.user.looks(["Team Access shows Website access Blocked and says no websites are approved"]);
   });
 

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { selectModel } from "@openwork/behaviors";
-import { spec } from "@openwork/testkit";
+import { spec, type Agent, type User } from "@openwork/testkit";
 import { defaultPolicyEditorAndMemberDesktop, managedPolicyRecovery, readDefaultDesktopPolicy, teamAccess } from "../worlds/desktop-policies.ts";
 
 // An organization that wants a vanilla OpenWork picks one decision, Restricted,
@@ -99,7 +99,7 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     await member.user.see({ role: "textbox", label: "App name" });
     const localMcpFormText = await member.probe.text();
     await member.user.press("Escape");
-    await member.user.notSee({ text: "Add workspace MCP" });
+    await member.user.notSee({ role: "textbox", label: "App name" });
     await member.user.click({ role: "button", label: /^All$/ });
     return { libraryHashBefore: await member.probe.hash(), localMcpFormText };
   });
@@ -578,6 +578,12 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
   if (!world) throw new Error("Expected the Team Access world");
   const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
   const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
+  const openOwnedPolicyTab = async (tabAgent: Agent, tabUser: User, title: string, url: string) => {
+    const sessionId = await tabAgent.createSession(title);
+    const opening = tabAgent.run("browser.open_url", { url, provider: "builtin" });
+    await tabUser.click({ role: "button", label: "Allow origin in this tab" });
+    expect(await opening).toMatchObject({ owner_session_id: sessionId });
+  };
   const effective = async (identity: typeof world.den.admin) => {
     const result = await probe.api(identity, "/v1/me/desktop-config");
     expect(result.response.ok).toBe(true);
@@ -1073,6 +1079,8 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
     expect(deniedExtension.status).toBe(403);
     expect(permittedExtension.status).toBe(200);
     evidence.recordAssertionEvidence("Direct config and extension requests cannot bypass the restricted member's UI", JSON.stringify({ forbiddenConfig, deniedExtension, permittedExtension }), forbiddenConfig.status === 403 && deniedExtension.status === 403 && permittedExtension.status === 200);
+    await openOwnedPolicyTab(member.agent, member.user, "Restricted browsing policy proof", world.den.mocks.witness.url);
+    await openOwnedPolicyTab(other.agent, other.user, "Control browsing policy proof", world.den.mocks.witness.url);
     const allowedBrowser = await member.agent.browserRequest({ url: `${world.den.mocks.witness.url}/health` });
     expect(allowedBrowser.reached).toBe(true);
     const outside = new URL("/health", world.den.ref.apiUrl).toString();
@@ -1128,6 +1136,8 @@ test(teamJourney, { timeout: 20 * 60_000 }, async ({ world: selectedWorld, user,
     const origin = new URL(world.den.mocks.witness.url).origin;
     const url = `${origin}/health`;
     const other = agent.on(world.control);
+    await openOwnedPolicyTab(member.agent, member.user, "Restricted empty-site policy proof", origin);
+    await openOwnedPolicyTab(other, user.on(world.control), "Control empty-site policy proof", origin);
     const controlBefore = await effective(world.den.members.casey);
     const before = await member.agent.browserRequest({ url });
     expect(before.reached).toBe(true);

--- a/evals/worlds/desktop-policies.ts
+++ b/evals/worlds/desktop-policies.ts
@@ -1,6 +1,9 @@
-import { mcpMock } from "@openwork/env";
+import { faultProxy, mcpMock } from "@openwork/env";
 import type { Seed } from "@openwork/env";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
 import { isRecord, records } from "./library.ts";
+import { bootServer, stopChild } from "./openwork-server-cli.ts";
 
 /**
  * The organization's default desktop policy as Den returns it, with the shape
@@ -159,4 +162,99 @@ export async function teamAccess(seed: Seed) {
   const admin = await seed.web({ den, signedInAs: den.admin, startPath: editorPath, headless: true, viewport: { width: 1440, height: 2100 } });
   return { den, member, control, admin, commandProofs, nonce, providerId: llmProvider.id, teamId, grantTeamId, controlTeamId,
     memberId: currentMember.id, controlMemberId: controlMember.id, editorPath, pluginId, pluginName, rawSourceText };
+}
+
+/** A real OpenWork server signed in to Den through a fault proxy, without an
+ * Electron renderer. The journey can therefore count only policy verification
+ * requests caused by each evaluation. */
+export async function managedPolicyRecovery(seed: Seed) {
+  const den = await seed.den({
+    org: {
+      name: `Managed policy recovery ${Date.now()}`,
+      admin: { name: "Policy Recovery Admin" },
+      members: { member: { name: "Policy Recovery Member" } },
+    },
+  });
+  const member = den.members.member;
+  if (!member) throw new Error("Missing policy recovery member session");
+  const org = await seed.api(member, "/v1/org");
+  const organization = isRecord(org.body) && isRecord(org.body.organization) ? org.body.organization : null;
+  if (!org.response.ok || typeof organization?.id !== "string") throw new Error("Missing policy recovery organization ID");
+
+  const stored = await readDefaultDesktopPolicy(seed, den.admin);
+  if (!isRecord(stored.policy) || typeof stored.id !== "string" || typeof stored.policyName !== "string") {
+    throw new Error("Missing default policy for recovery proof");
+  }
+  const allowedPolicy = { ...stored.policy, allowZenModel: true };
+  const updateBuiltInModel = async (allowed: boolean) => seed.api(den.admin, `/v1/desktop-policies/${stored.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ policyName: stored.policyName, policy: { ...allowedPolicy, allowZenModel: allowed } }),
+  });
+  const allowed = await updateBuiltInModel(true);
+  if (!allowed.response.ok) throw new Error(`Allowing the built-in model failed: HTTP ${allowed.response.status}`);
+
+  const root = seed.tmpPath("managed-policy-recovery");
+  const workspace = join(root, "workspace");
+  const home = join(root, "home");
+  await mkdir(workspace, { recursive: true });
+  await mkdir(home, { recursive: true });
+  // The OpenWork server below runs beside Vitest, so its Den fault boundary
+  // must run there too even when Den is on Daytona. Point it at the API origin
+  // directly: unlike browser traffic, server verification has no web Origin.
+  const proxy = await faultProxy({ ...den.ref, webUrl: den.ref.apiUrl });
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
+  const token = "owt_managed_policy_recovery";
+  const booted = bootServer({
+    ...inherited,
+    HOME: home,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    XDG_DATA_HOME: join(home, ".local", "share"),
+    XDG_CACHE_HOME: join(home, ".cache"),
+    XDG_STATE_HOME: join(home, ".local", "state"),
+    OPENWORK_MANAGE_OPENCODE: "0",
+  }, token, workspace, () => {});
+  try {
+    const baseUrl = await booted.listening;
+    const request = async (path: string, input: { method?: string; host?: boolean; body?: unknown } = {}) => {
+      const headers: Record<string, string> = { "content-type": "application/json" };
+      if (input.host) headers["x-openwork-host-token"] = `${token}-host`;
+      else headers.authorization = `Bearer ${token}`;
+      const response = await fetch(`${baseUrl}${path}`, {
+        method: input.method ?? "GET",
+        headers,
+        body: input.body === undefined ? undefined : JSON.stringify(input.body),
+        signal: AbortSignal.timeout(10_000),
+      });
+      const text = await response.text();
+      let body: unknown = null;
+      try { body = text ? JSON.parse(text) : null; }
+      catch { body = text; }
+      return { status: response.status, body };
+    };
+    const session = await request("/den-session", {
+      method: "PUT",
+      host: true,
+      body: { baseUrl: proxy.ref.webUrl, token: member.token, orgId: organization.id },
+    });
+    if (session.status !== 204) throw new Error(`Setting the policy recovery Den session failed: HTTP ${session.status} ${JSON.stringify(session.body)}`);
+    let disposed = false;
+    return {
+      den,
+      proxy,
+      updateBuiltInModel,
+      evaluate: (body: Record<string, unknown>) => request("/managed-policy/evaluate", { method: "POST", body }),
+      async [Symbol.asyncDispose]() {
+        if (disposed) return;
+        disposed = true;
+        await stopChild(booted.child);
+        await proxy[Symbol.asyncDispose]();
+        await rm(root, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    await stopChild(booted.child);
+    await proxy[Symbol.asyncDispose]();
+    await rm(root, { recursive: true, force: true });
+    throw error;
+  }
 }

--- a/evals/worlds/desktop-policies.ts
+++ b/evals/worlds/desktop-policies.ts
@@ -169,6 +169,7 @@ export async function teamAccess(seed: Seed) {
  * requests caused by each evaluation. */
 export async function managedPolicyRecovery(seed: Seed) {
   const den = await seed.den({
+    mocks: { witness: mcpMock({ allowUnauthenticatedMcp: true }) },
     org: {
       name: `Managed policy recovery ${Date.now()}`,
       admin: { name: "Policy Recovery Admin" },
@@ -179,13 +180,56 @@ export async function managedPolicyRecovery(seed: Seed) {
   if (!member) throw new Error("Missing policy recovery member session");
   const org = await seed.api(member, "/v1/org");
   const organization = isRecord(org.body) && isRecord(org.body.organization) ? org.body.organization : null;
-  if (!org.response.ok || typeof organization?.id !== "string") throw new Error("Missing policy recovery organization ID");
+  const currentMember = isRecord(org.body) && isRecord(org.body.currentMember) ? org.body.currentMember : null;
+  if (!org.response.ok || typeof organization?.id !== "string" || typeof currentMember?.id !== "string") {
+    throw new Error("Missing policy recovery organization or member ID");
+  }
+
+  const modelId = "assigned-policy-retry-proof";
+  const created = await seed.api(den.admin, "/v1/llm-providers", {
+    method: "POST",
+    body: JSON.stringify({
+      name: "Assigned policy recovery model",
+      source: "custom",
+      customConfig: {
+        id: "assigned-policy-recovery-provider",
+        name: "Assigned policy recovery model",
+        npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: `${den.mocks.witness.url}/v1` },
+        env: ["ASSIGNED_POLICY_RECOVERY_API_KEY"],
+        models: [{ id: modelId, name: "Assigned policy recovery model" }],
+      },
+      apiKey: "sk-openwork-assigned-policy-recovery-eval-only",
+      allMembers: false,
+      memberIds: [currentMember.id],
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const llmProvider = isRecord(created.body) && isRecord(created.body.llmProvider) ? created.body.llmProvider : null;
+  if (created.response.status !== 201 || typeof llmProvider?.id !== "string" || !/^lpr_/.test(llmProvider.id)) {
+    throw new Error(`Assigned organization model setup failed: HTTP ${created.response.status}`);
+  }
+  const providerId = llmProvider.id;
+  const manageable = await seed.api(den.admin, "/v1/llm-providers?scope=manageable", { signal: AbortSignal.timeout(30_000) });
+  const providers = isRecord(manageable.body) && Array.isArray(manageable.body.llmProviders)
+    ? manageable.body.llmProviders.filter(isRecord)
+    : [];
+  const provider = providers.find((entry) => entry.id === providerId);
+  const access = provider && isRecord(provider.access) ? provider.access : null;
+  const memberAccess = access && Array.isArray(access.members)
+    ? access.members.filter(isRecord).find((entry) => entry.orgMembershipId === currentMember.id)
+    : null;
+  if (!manageable.response.ok || typeof memberAccess?.id !== "string") {
+    throw new Error(`Assigned organization model access lookup failed: HTTP ${manageable.response.status}`);
+  }
+  const accessId = memberAccess.id;
 
   const stored = await readDefaultDesktopPolicy(seed, den.admin);
   if (!isRecord(stored.policy) || typeof stored.id !== "string" || typeof stored.policyName !== "string") {
     throw new Error("Missing default policy for recovery proof");
   }
-  const allowedPolicy = { ...stored.policy, allowZenModel: true };
+  const allowedPolicy = { ...stored.policy, allowCustomProviders: false, allowZenModel: true };
   const updateBuiltInModel = async (allowed: boolean) => seed.api(den.admin, `/v1/desktop-policies/${stored.id}`, {
     method: "PATCH",
     body: JSON.stringify({ policyName: stored.policyName, policy: { ...allowedPolicy, allowZenModel: allowed } }),
@@ -211,6 +255,7 @@ export async function managedPolicyRecovery(seed: Seed) {
     XDG_DATA_HOME: join(home, ".local", "share"),
     XDG_CACHE_HOME: join(home, ".cache"),
     XDG_STATE_HOME: join(home, ".local", "state"),
+    OPENWORK_CLOUD_PROVIDER_SYNC_INTERVAL_MS: "3600000",
     OPENWORK_MANAGE_OPENCODE: "0",
   }, token, workspace, () => {});
   try {
@@ -237,10 +282,40 @@ export async function managedPolicyRecovery(seed: Seed) {
       body: { baseUrl: proxy.ref.webUrl, token: member.token, orgId: organization.id },
     });
     if (session.status !== 204) throw new Error(`Setting the policy recovery Den session failed: HTTP ${session.status} ${JSON.stringify(session.body)}`);
+    const readProviderState = async () => {
+      const runtime = await request("/runtime-config/providers", { host: true });
+      const status = await request("/cloud-provider-sync/status");
+      return { runtime, status };
+    };
+    const syncProviders = async () => {
+      const run = await request("/cloud-provider-sync/run", { method: "POST", host: true, body: { reason: "managed-policy-recovery" } });
+      const { runtime, status } = await readProviderState();
+      return { run, runtime, status };
+    };
+    const memberCatalog = async () => {
+      const result = await seed.api(member, "/v1/llm-providers", { signal: AbortSignal.timeout(30_000) });
+      const items = isRecord(result.body) && Array.isArray(result.body.llmProviders)
+        ? result.body.llmProviders.filter(isRecord)
+        : [];
+      return { status: result.response.status, providers: items };
+    };
+    const revokeProviderAccess = async () => {
+      const result = await seed.api(den.admin, `/v1/llm-providers/${encodeURIComponent(providerId)}/access/${encodeURIComponent(accessId)}`, {
+        method: "DELETE",
+        signal: AbortSignal.timeout(30_000),
+      });
+      return result.response.status;
+    };
     let disposed = false;
     return {
       den,
       proxy,
+      providerId,
+      modelId,
+      memberCatalog,
+      readProviderState,
+      revokeProviderAccess,
+      syncProviders,
       updateBuiltInModel,
       evaluate: (body: Record<string, unknown>) => request("/managed-policy/evaluate", { method: "POST", body }),
       async [Symbol.asyncDispose]() {


### PR DESCRIPTION
## Summary
- Retry fresh managed-policy and assigned-model reads once for selected transient HTTP/transport failures; never reuse cached permissions or replay a tool.
- Keep persistent outages, authentication/authorization errors, invalid responses, and revoked model assignments fail-closed.
- Extend the existing desktop-policy journey with real assigned-provider catalog faults, timeout recovery, and revocation while local runtime configuration is still stale.
- Refresh stale Library/browser test setup so the complete existing journey can execute against the current product.

## Verification — Passed on 17b64378d2fd3921007f6324cfabab73101321ed

Full cold-booted run, with both Den and desktop pinned to the pushed head:

```sh
OPENWORK_EVAL_ENGINE=v1 \
OPENWORK_EVAL_REF=17b64378d2fd3921007f6324cfabab73101321ed \
OPENWORK_EVAL_DAYTONA_REF=17b64378d2fd3921007f6324cfabab73101321ed \
pnpm evals:e2e desktop-policy-restricted-mode
```

Placement: **daytona (daytona CLI authenticated)**. Exit 0; **3 passed, 0 failed, 0 skipped**. All 23 deferred visual expectations subsequently judged successfully; 0 pending. The full run exercises real Electron command/browser enforcement. The recovery case deliberately uses a local OpenWork server and fault proxy against pinned Daytona Den for precise HTTP observations.

| Journey | Published evidence |
| --- | --- |
| Default policy restrictions | [22 expectations passed; 7/7 screenshots](https://github.com/different-ai/openwork/pull/4664#issuecomment-5604667804) |
| Policy and assigned-model recovery | [7 assertion groups passed](https://github.com/different-ai/openwork/pull/4664#issuecomment-5598061628) |
| Team isolation and live revocation | [53 expectations passed; 9/9 screenshots](https://github.com/different-ai/openwork/pull/4664#issuecomment-5604671360) |

Additional checks:
- `pnpm --filter openwork-server typecheck` — passed.
- `pnpm --filter openwork-server test src/no-bare-fetch.test.ts` — 2 passed.
- `git diff --check` — passed.
- GitHub required build/core/security checks — passed.

## Scope and baseline notes
- The implementation uses a 3.5s per-attempt timeout and a 6s budget per Den read (raised from 2.5s/5s after a cold Den read timed out in one setup run; the previous single-attempt timeout was 10s). Timeout-recovery cases now also assert that exactly one fresh non-faulted Den response was observed within the evaluation window, so a cached allow cannot satisfy them. The timeout journey measures end-to-end evaluation and asserts >3s (recovery), >5.5s (exhaustion) and an 8-second upper bound with scheduling/network headroom; it does not independently prove an exact 5-second end-to-end bound. HTTP status-fault cases separately verify exact retry counts for both endpoints.
- `pnpm evals:typecheck` still fails on the branch and clean base5732266c6 with 361 errors each. Matching first failure: `apps/server/src/agent-context-cloud-probe.ts(216,15): TS1294`. The modified world has zero errors; the modified spec has the same 19 normalized diagnostic signatures as the base. This is documented as a reproduced baseline blocker, not a passing check or a reason to change unrelated code.
- This run covers engine v1; no separate engine-v2 run claimed. The precise network/auth failure behind the original incident remains unknown.
- No new journey files or production permission bypasses.