### PR TITLE
fix(den-web): explain OAuth-start answers the browser cannot read

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
@@ -32,7 +32,8 @@ export function safeMcpAuthorizationUrl(rawUrl: string): string {
 }
 
 export type McpAuthorizationDebugDetails = {
-  httpStatus: number
+  /** "unavailable" when the browser never let the page read a response (network failure or CORS-blocked answer). */
+  httpStatus: number | "unavailable"
   errorCode?: string
   redirectUri?: string
   clientMetadataUrl?: string
@@ -108,7 +109,7 @@ function debugDetailRow(label: string, value: string | number | boolean | undefi
 function technicalDetails(details: McpAuthorizationDebugDetails | undefined): string {
   if (!details) return ""
   const rows = [
-    debugDetailRow("HTTP status", details.httpStatus),
+    debugDetailRow("HTTP status", details.httpStatus === "unavailable" ? "Unavailable — the browser could not read the response" : details.httpStatus),
     debugDetailRow("Error code", details.errorCode, true),
     debugDetailRow("Diagnostic reference", details.diagnosticReference, true),
     debugDetailRow("Redirect URI", details.redirectUri, true),

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { getRequestError, requestJson } from "../../_lib/den-flow";
+import { DenRequestCanceledError, DenRequestTimeoutError, getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
   type ExternalMcpDiagnostic,
@@ -418,6 +418,25 @@ export class McpOAuthConfigurationRequiredError extends McpOAuthStartError {
     super(message, details);
     this.name = "McpOAuthConfigurationRequiredError";
   }
+}
+
+const MCP_OAUTH_START_UNREADABLE_MESSAGE =
+  "OpenWork could not read the answer from its API when starting the sign-in. The browser blocked the response or the request never completed. Try again; if it keeps happening, tell your workspace admin the time of this attempt.";
+
+/**
+ * The browser refused to hand the page a response: a network failure, or an
+ * error answer (often from a proxy) without CORS headers. Without a readable
+ * status the popup would show only the browser's own text ("Failed to fetch"),
+ * so wrap what is known into structured details. Den's own timeout, cancel and
+ * re-authentication errors keep their existing meaning.
+ */
+function mcpOAuthStartUnreadableError(error: unknown): McpOAuthStartError {
+  const browserError = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  return new McpOAuthStartError(MCP_OAUTH_START_UNREADABLE_MESSAGE, {
+    httpStatus: "unavailable",
+    errorCode: "response_unreadable",
+    responseJson: JSON.stringify({ error: "response_unreadable", browserError }, null, 2),
+  });
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -883,11 +902,20 @@ export function useStartMcpConnectionOAuth() {
 
   return useMutation({
     mutationFn: async (connectionId: string): Promise<{ status: "connected" | "needs_auth"; authorizeUrl: string | null }> => {
-      const { response, payload } = await requestJson(
-        `/v1/mcp-connections/${encodeURIComponent(connectionId)}/connect/start`,
-        { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
-        20000,
-      );
+      let response: Response;
+      let payload: unknown;
+      try {
+        ({ response, payload } = await requestJson(
+          `/v1/mcp-connections/${encodeURIComponent(connectionId)}/connect/start`,
+          { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
+          20000,
+        ));
+      } catch (error) {
+        if (isReauthRequiredError(error) || error instanceof DenRequestTimeoutError || error instanceof DenRequestCanceledError) {
+          throw error;
+        }
+        throw mcpOAuthStartUnreadableError(error);
+      }
       if (!response.ok) {
         const details = mcpOAuthStartDebugDetails(payload, response.status);
         const requestError = getRequestError(payload, response, `Failed to start OAuth (${response.status}).`);

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -3,12 +3,12 @@ import { readdir, readFile } from 'node:fs/promises';
 // One home for CI grouping, readable names, and execution requirements.
 // Unlisted specs are discovered automatically as full-regression journeys.
 const definitions = {
+  // Fixes a fault proxy in front of den-api before Den boots; only the local lane can do that.
+  'mcp-oauth-start-unreadable-response.e2e.test.ts': { name: 'Read why a connection sign-in could not start', placement: 'local' },
   'app-smoke.e2e.test.ts': { name: 'Open a working desktop', critical: true },
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
   'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },
-  // Fixes a fault proxy in front of den-api before Den boots; only the local lane can do that.
-  'mcp-oauth-start-unreadable-response.e2e.test.ts': { name: 'Read why a connection sign-in could not start', placement: 'local' },
 };
 
 export async function catalog(root = new URL('../specs/', import.meta.url)) {

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -7,6 +7,8 @@ const definitions = {
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
   'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },
+  // Fixes a fault proxy in front of den-api before Den boots; only the local lane can do that.
+  'mcp-oauth-start-unreadable-response.e2e.test.ts': { name: 'Read why a connection sign-in could not start', placement: 'local' },
 };
 
 export async function catalog(root = new URL('../specs/', import.meta.url)) {

--- a/evals/specs/mcp-oauth-start-browser-readable-errors.test.ts
+++ b/evals/specs/mcp-oauth-start-browser-readable-errors.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import { mcpMock, needs, server, test } from "@openwork/testkit";
+import { isRecord } from "../worlds/openwork-server-cli.ts";
+
+// Journey: a member clicks Connect in the Den web dashboard. The browser sends
+// a credentialed cross-origin GET to den-api's OAuth-start route. Every outcome
+// of that request, including a downstream OAuth handshake failure, must reach
+// the page as a readable response: exactly one Access-Control-Allow-Origin for
+// the trusted web origin, credentials allowed, and nothing for other origins.
+// A response the browser cannot read collapses to "Failed to fetch" in the UI.
+test("Den OAuth-start answers browser preflights, successes and handshake failures with readable CORS headers", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun"] });
+  await using den = await server({
+    place, web: false,
+    mocks: { connector: mcpMock() },
+    org: { name: `OAuth Start CORS ${Date.now()}`, members: {} },
+  });
+  const webOrigin = new URL(den.ref.webUrl).origin;
+  const untrustedOrigin = "https://untrusted.example.test";
+  const headers = { authorization: `Bearer ${den.admin.token}` };
+  // Headers.get() joins repeated headers with ", ", so a duplicate emitted by
+  // two layers shows up as more than one value.
+  const corsOf = (response: Response) => {
+    const allowOrigin = response.headers.get("access-control-allow-origin");
+    return {
+      allowOrigin,
+      allowCredentials: response.headers.get("access-control-allow-credentials"),
+      allowOriginValues: (allowOrigin ?? "").split(",").map((value) => value.trim()).filter(Boolean),
+    };
+  };
+  const expectReadableFor = (response: Response, label: string) => {
+    const cors = corsOf(response);
+    expect(cors.allowOrigin, `${label}: allow-origin`).toBe(webOrigin);
+    expect(cors.allowOriginValues, `${label}: exactly one allow-origin value`).toHaveLength(1);
+    expect(cors.allowCredentials, `${label}: allow-credentials`).toBe("true");
+  };
+
+  const createConnection = async (name: string, mcpUrl: string) => {
+    const created = await denFetch(den.admin, "/v1/mcp-connections", {
+      method: "POST", headers,
+      body: JSON.stringify({ name, url: mcpUrl, authType: "oauth", credentialMode: "per_member", access: { orgWide: true } }),
+    });
+    expect(created.response.status, created.text).toBe(200);
+    if (!isRecord(created.body) || typeof created.body.id !== "string") throw new Error("Connection id missing");
+    return created.body.id;
+  };
+
+  const reachableId = await createConnection("Reachable provider", den.mocks.connector.mcpUrl);
+  const startPath = (id: string) => `/v1/mcp-connections/${id}/connect/start`;
+
+  // 1. Preflight: the browser asks before sending Authorization and the org header.
+  const preflight = await denFetch(den.admin, startPath(reachableId), {
+    method: "OPTIONS",
+    headers: {
+      origin: webOrigin,
+      "access-control-request-method": "GET",
+      "access-control-request-headers": "authorization,x-openwork-org-id,accept",
+    },
+  });
+  expect(preflight.response.status, preflight.text).toBe(204);
+  expectReadableFor(preflight.response, "preflight");
+  const allowHeaders = (preflight.response.headers.get("access-control-allow-headers") ?? "").toLowerCase();
+  expect(allowHeaders).toContain("authorization");
+  expect(allowHeaders).toContain("x-openwork-org-id");
+  expect((preflight.response.headers.get("access-control-allow-methods") ?? "").toUpperCase()).toContain("GET");
+  evidence.recordAssertionEvidence("Preflight for OAuth start is answered for the trusted web origin", `OPTIONS returned HTTP 204 with allow-origin ${webOrigin}, credentials, Authorization and X-OpenWork-Org-Id allowed.`, true);
+
+  // 2. Success: the authorize URL response is readable.
+  const started = await denFetch(den.admin, startPath(reachableId), { headers: { ...headers, origin: webOrigin } });
+  expect(started.response.status, started.text).toBe(200);
+  expect(started.body).toMatchObject({ status: "needs_auth", authorizeUrl: expect.stringContaining(den.mocks.connector.url) });
+  expectReadableFor(started.response, "success");
+  evidence.recordAssertionEvidence("Successful OAuth start is readable from the browser", `HTTP 200 needs_auth carried one allow-origin ${webOrigin} and allow-credentials true.`, true);
+
+  // 3. Downstream failure: the provider disappears after the connection was
+  //    saved. Den must answer its structured 502 with the same CORS headers so
+  //    the dashboard popup can show the diagnostic instead of "Failed to fetch".
+  const { handle: vanishing } = await mcpMock().boot(place);
+  let unreachableId: string;
+  try {
+    unreachableId = await createConnection("Vanishing provider", vanishing.mcpUrl);
+  } finally {
+    await vanishing.stop();
+  }
+  const failed = await denFetch(den.admin, startPath(unreachableId), { headers: { ...headers, origin: webOrigin } });
+  expect(failed.response.status, failed.text).toBe(502);
+  expect(failed.body).toMatchObject({ error: "oauth_handshake_failed", diagnostic: { referenceId: expect.any(String), phase: expect.any(String) } });
+  expect(failed.text).not.toMatch(/code_verifier|client_secret|Bearer /);
+  expectReadableFor(failed.response, "handshake failure");
+  evidence.recordAssertionEvidence("OAuth handshake failure is readable from the browser", `HTTP 502 oauth_handshake_failed with a diagnostic reference carried one allow-origin ${webOrigin} and allow-credentials true; no secrets in the body.`, true);
+
+  // 4. Authentication failure is readable too, so an expired session is not
+  //    reported as a network failure.
+  const unauthenticated = await denFetch(den.admin, startPath(reachableId), { headers: { origin: webOrigin } });
+  expect(unauthenticated.response.status, unauthenticated.text).toBe(401);
+  expectReadableFor(unauthenticated.response, "unauthenticated");
+  evidence.recordAssertionEvidence("Unauthenticated OAuth start is readable from the browser", `HTTP 401 carried allow-origin ${webOrigin} and allow-credentials true.`, true);
+
+  // 5. Negative half: an untrusted origin gets no allow-origin at all, on both
+  //    the preflight and the failing request.
+  const untrustedPreflight = await denFetch(den.admin, startPath(reachableId), {
+    method: "OPTIONS",
+    headers: { origin: untrustedOrigin, "access-control-request-method": "GET", "access-control-request-headers": "authorization" },
+  });
+  expect(untrustedPreflight.response.headers.get("access-control-allow-origin")).toBeNull();
+  const untrustedFailure = await denFetch(den.admin, startPath(unreachableId), { headers: { ...headers, origin: untrustedOrigin } });
+  expect(untrustedFailure.response.status, untrustedFailure.text).toBe(502);
+  // Browsers gate on allow-origin; allow-credentials alone grants nothing.
+  expect(untrustedFailure.response.headers.get("access-control-allow-origin")).toBeNull();
+  evidence.recordAssertionEvidence("Untrusted origins never receive CORS allowance", `Preflight and HTTP 502 for ${untrustedOrigin} carried no allow-origin header.`, true);
+});

--- a/evals/specs/mcp-oauth-start-unreadable-response.e2e.test.ts
+++ b/evals/specs/mcp-oauth-start-unreadable-response.e2e.test.ts
@@ -17,40 +17,66 @@ const connectButton = { role: "button", label: "Connect" } as const;
 test("the connections page explains an OAuth-start answer the browser could not read, then connects once it can", async ({ world, user, probe, evidence, step }) => {
   await user.see({ text: "Synthetic calendar provider" }, { timeoutMs: 90_000 });
   await user.see(connectButton, { timeoutMs: 30_000 });
-  const authorizeRequests = async () => (await world.den.mocks.connector.requests()).filter((entry) => entry.path === "/authorize").length;
   const proxied = async () => (await world.proxy.requestLog()).filter((entry) => entry.path === world.startPath);
-  expect(await authorizeRequests()).toBe(0);
+  expect(await world.authorizeRequests()).toBe(0);
 
-  await step("the OAuth-start answer is withheld from the page", async () => {
-    // The injected answer carries Access-Control-Allow-Origin: * which a
-    // credentialed request may not read, so the page sees only a fetch failure.
-    await world.proxy.faults.status(world.startPath, 502, { times: 1, body: { error: "bad_gateway" } });
+  await step("den-api's own handshake failure is readable and explained", async () => {
+    // The provider disappears after the connection was saved: den-api answers
+    // its structured 502 through the proxy, with CORS headers, so the row shows
+    // the diagnostic reference. This also lets the browser cache the preflight
+    // for this exact URL, so the next fault can land on the GET itself.
+    await world.stopProvider();
     await user.click(connectButton);
-    await user.see({ text: unreadableMessage }, { timeoutMs: 30_000 });
+    await user.see({ text: /Could not connect "Synthetic calendar provider"/ }, { timeoutMs: 30_000 });
+    await user.see({ text: /Reference: / });
+    await user.notSee({ text: unreadableMessage });
     await user.notSee({ text: /Failed to fetch/ });
-    await user.notSee({ text: /provider (rejected|refused)/i });
+    const readable = await proxied();
+    expect(readable.some((entry) => entry.method === "OPTIONS" && !entry.faulted && entry.status === 204)).toBe(true);
+    expect(readable.some((entry) => entry.method === "GET" && !entry.faulted && entry.status === 502)).toBe(true);
     await user.screenshot();
-    const faulted = await proxied();
-    expect(faulted.some((entry) => entry.faulted && entry.status === 502)).toBe(true);
-    expect(await authorizeRequests()).toBe(0);
     evidence.recordAssertionEvidence(
-      "An unreadable OAuth-start answer is explained in plain words",
-      `The proxy answered ${world.startPath} with an injected HTTP 502 the browser could not read; the connection row shows the readability message, not "Failed to fetch", and the provider received no authorization request.`,
+      "A readable handshake failure shows den-api's diagnostic",
+      "With the provider unreachable, the preflight passed (204) and den-api's own HTTP 502 was forwarded unchanged; the connection row shows the structured message with a diagnostic reference, not the readability or browser text.",
       true,
     );
   });
 
-  await step("the same Connect works once the answer is readable", async () => {
-    await world.proxy.faults.clear();
+  await step("an OAuth-start answer the browser cannot read is explained in plain words", async () => {
+    // The injected answer carries Access-Control-Allow-Origin: * which a
+    // credentialed request may not read, so the page sees only a fetch failure.
+    await world.proxy.faults.status(world.startPath, 502, { times: 1, body: { error: "bad_gateway" } });
+    const before = (await proxied()).length;
     await user.click(connectButton);
-    await probe.eventually(authorizeRequests, { within: 60_000, label: "provider authorization request", until: (count) => count >= 1 });
+    await user.see({ text: unreadableMessage }, { timeoutMs: 30_000 });
+    await user.notSee({ text: /Failed to fetch/ });
+    await user.notSee({ text: /Reference: / });
+    await user.screenshot();
+    const faulted = (await proxied()).slice(before).filter((entry) => entry.faulted);
+    expect(faulted).toHaveLength(1);
+    expect(faulted[0]).toMatchObject({ method: "GET", status: 502 });
+    evidence.recordAssertionEvidence(
+      "An unreadable OAuth-start answer is explained in plain words",
+      `The proxy answered the OAuth-start GET (not its preflight) with an injected HTTP 502 the browser could not read; the connection row shows the readability message instead of "Failed to fetch" or a den-api diagnostic.`,
+      true,
+    );
+  });
+
+  await step("the same Connect starts the provider sign-in once the answer is readable", async () => {
+    await world.proxy.faults.clear();
+    await world.restartProvider();
+    expect(await world.authorizeRequests()).toBe(0);
+    const before = (await proxied()).length;
+    await user.click(connectButton);
+    await probe.eventually(() => world.authorizeRequests(), { within: 60_000, label: "provider authorization request", until: (count) => count >= 1 });
     await user.notSee({ text: unreadableMessage });
-    const forwarded = (await proxied()).filter((entry) => !entry.faulted);
-    expect(forwarded.some((entry) => entry.status === 200)).toBe(true);
+    await user.notSee({ text: /Reference: / });
+    const forwarded = (await proxied()).slice(before);
+    expect(forwarded.some((entry) => entry.method === "GET" && !entry.faulted && entry.status === 200)).toBe(true);
     await user.screenshot();
     evidence.recordAssertionEvidence(
       "A readable OAuth-start answer starts the provider sign-in",
-      "With the fault cleared the proxied OAuth-start request returned HTTP 200 and the synthetic provider received an authorization request; the readability message disappeared.",
+      "With the fault cleared and the provider back, the proxied OAuth-start GET returned HTTP 200, the synthetic provider received an authorization request, and neither failure message remained.",
       true,
     );
   });

--- a/evals/specs/mcp-oauth-start-unreadable-response.e2e.test.ts
+++ b/evals/specs/mcp-oauth-start-unreadable-response.e2e.test.ts
@@ -1,0 +1,57 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { oauthStartUnreadableWeb } from "../worlds/mcp-oauth-start-unreadable.ts";
+
+// A member clicks Connect and den-api's OAuth-start answer never reaches the
+// page: the browser withholds a cross-origin error response whose CORS headers
+// do not fit a credentialed request (an edge 502 without them, a wildcard, or
+// no response at all). The dashboard must say so in plain words instead of
+// echoing the browser's "Failed to fetch", and it must not pretend the provider
+// was involved. With the response readable again the same button starts the
+// provider sign-in.
+const test = spec.world(oauthStartUnreadableWeb, { timeout: 600_000, needs: { optIn: ["OPENWORK_EVAL_E2E_TESTS"] } });
+
+const unreadableMessage = /OpenWork could not read the answer from its API when starting the sign-in/;
+const connectButton = { role: "button", label: "Connect" } as const;
+
+test("the connections page explains an OAuth-start answer the browser could not read, then connects once it can", async ({ world, user, probe, evidence, step }) => {
+  await user.see({ text: "Synthetic calendar provider" }, { timeoutMs: 90_000 });
+  await user.see(connectButton, { timeoutMs: 30_000 });
+  const authorizeRequests = async () => (await world.den.mocks.connector.requests()).filter((entry) => entry.path === "/authorize").length;
+  const proxied = async () => (await world.proxy.requestLog()).filter((entry) => entry.path === world.startPath);
+  expect(await authorizeRequests()).toBe(0);
+
+  await step("the OAuth-start answer is withheld from the page", async () => {
+    // The injected answer carries Access-Control-Allow-Origin: * which a
+    // credentialed request may not read, so the page sees only a fetch failure.
+    await world.proxy.faults.status(world.startPath, 502, { times: 1, body: { error: "bad_gateway" } });
+    await user.click(connectButton);
+    await user.see({ text: unreadableMessage }, { timeoutMs: 30_000 });
+    await user.notSee({ text: /Failed to fetch/ });
+    await user.notSee({ text: /provider (rejected|refused)/i });
+    await user.screenshot();
+    const faulted = await proxied();
+    expect(faulted.some((entry) => entry.faulted && entry.status === 502)).toBe(true);
+    expect(await authorizeRequests()).toBe(0);
+    evidence.recordAssertionEvidence(
+      "An unreadable OAuth-start answer is explained in plain words",
+      `The proxy answered ${world.startPath} with an injected HTTP 502 the browser could not read; the connection row shows the readability message, not "Failed to fetch", and the provider received no authorization request.`,
+      true,
+    );
+  });
+
+  await step("the same Connect works once the answer is readable", async () => {
+    await world.proxy.faults.clear();
+    await user.click(connectButton);
+    await probe.eventually(authorizeRequests, { within: 60_000, label: "provider authorization request", until: (count) => count >= 1 });
+    await user.notSee({ text: unreadableMessage });
+    const forwarded = (await proxied()).filter((entry) => !entry.faulted);
+    expect(forwarded.some((entry) => entry.status === 200)).toBe(true);
+    await user.screenshot();
+    evidence.recordAssertionEvidence(
+      "A readable OAuth-start answer starts the provider sign-in",
+      "With the fault cleared the proxied OAuth-start request returned HTTP 200 and the synthetic provider received an authorization request; the readability message disappeared.",
+      true,
+    );
+  });
+});

--- a/evals/specs/mcp-oauth-start-unreadable-response.e2e.test.ts
+++ b/evals/specs/mcp-oauth-start-unreadable-response.e2e.test.ts
@@ -9,7 +9,7 @@ import { oauthStartUnreadableWeb } from "../worlds/mcp-oauth-start-unreadable.ts
 // echoing the browser's "Failed to fetch", and it must not pretend the provider
 // was involved. With the response readable again the same button starts the
 // provider sign-in.
-const test = spec.world(oauthStartUnreadableWeb, { timeout: 600_000, needs: { optIn: ["OPENWORK_EVAL_E2E_TESTS"] } });
+const test = spec.world(oauthStartUnreadableWeb, { timeout: 600_000, needs: { optIn: ["OPENWORK_EVAL_E2E_TESTS"], placement: "local" } });
 
 const unreadableMessage = /OpenWork could not read the answer from its API when starting the sign-in/;
 const connectButton = { role: "button", label: "Connect" } as const;

--- a/evals/worlds/mcp-oauth-start-unreadable.ts
+++ b/evals/worlds/mcp-oauth-start-unreadable.ts
@@ -1,0 +1,43 @@
+import { allocateFreePorts } from "@openwork/cdp";
+import { faultProxy as startFaultProxy, mcpMock } from "@openwork/env";
+import type { Place, Seed } from "@openwork/env";
+
+/**
+ * A member's browser talking to den-api through a proxy that can answer the
+ * OAuth-start request with an error the browser is not allowed to read. The
+ * proxy is fixed in front of den-api before Den boots so DEN_API_PUBLIC_URL
+ * (which den-web hands to the browser as denApiUrl) points at it; the browser
+ * page itself stays on Den's own web origin, which den-api's CORS allowlist
+ * trusts, so every non-faulted request round-trips normally.
+ */
+export async function oauthStartUnreadableWeb(seed: Seed, ctx: { place: Place }) {
+  if (ctx.place.kind !== "local") throw new Error("This world fixes a local fault proxy in front of den-api before boot; run it on the local lane.");
+  const [apiPort, webPort] = await allocateFreePorts(2);
+  const denApiUrl = `http://127.0.0.1:${apiPort}`;
+  const proxy = await startFaultProxy({ apiUrl: denApiUrl, webUrl: denApiUrl }, { place: ctx.place });
+  const den = await seed.den({
+    ports: { api: apiPort, web: webPort },
+    mocks: { connector: mcpMock() },
+    org: { name: `OAuth start readability ${Date.now()}`, admin: { name: "Connections Admin" } },
+    env: { DEN_API_PUBLIC_URL: proxy.ref.webUrl },
+  });
+  const connection = await seed.orgConnection(den.admin, {
+    name: "Synthetic calendar provider",
+    url: den.mocks.connector.mcpUrl,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
+  });
+  const web = await seed.web({
+    den,
+    signedInAs: den.admin,
+    startPath: "/dashboard/your-connections",
+    headless: true,
+    viewport: { width: 1440, height: 1100 },
+  });
+  return Object.assign({ den, proxy, connection, web, startPath: `/v1/mcp-connections/${connection.id}/connect/start` }, {
+    async [Symbol.asyncDispose]() {
+      await proxy[Symbol.asyncDispose]();
+    },
+  });
+}

--- a/evals/worlds/mcp-oauth-start-unreadable.ts
+++ b/evals/worlds/mcp-oauth-start-unreadable.ts
@@ -1,6 +1,6 @@
 import { allocateFreePorts } from "@openwork/cdp";
 import { faultProxy as startFaultProxy, mcpMock } from "@openwork/env";
-import type { Place, Seed } from "@openwork/env";
+import type { MockHandle, Place, Seed } from "@openwork/env";
 
 /**
  * A member's browser talking to den-api through a proxy that can answer the
@@ -9,21 +9,24 @@ import type { Place, Seed } from "@openwork/env";
  * (which den-web hands to the browser as denApiUrl) points at it; the browser
  * page itself stays on Den's own web origin, which den-api's CORS allowlist
  * trusts, so every non-faulted request round-trips normally.
+ *
+ * The synthetic provider runs on a fixed port owned by this world so the spec
+ * can take it away (den-api then fails the handshake itself) and bring it back.
  */
 export async function oauthStartUnreadableWeb(seed: Seed, ctx: { place: Place }) {
   if (ctx.place.kind !== "local") throw new Error("This world fixes a local fault proxy in front of den-api before boot; run it on the local lane.");
-  const [apiPort, webPort] = await allocateFreePorts(2);
+  const [apiPort, webPort, providerPort] = await allocateFreePorts(3);
   const denApiUrl = `http://127.0.0.1:${apiPort}`;
   const proxy = await startFaultProxy({ apiUrl: denApiUrl, webUrl: denApiUrl }, { place: ctx.place });
+  let provider: MockHandle = (await mcpMock({ port: providerPort }).boot(ctx.place)).handle;
   const den = await seed.den({
     ports: { api: apiPort, web: webPort },
-    mocks: { connector: mcpMock() },
     org: { name: `OAuth start readability ${Date.now()}`, admin: { name: "Connections Admin" } },
     env: { DEN_API_PUBLIC_URL: proxy.ref.webUrl },
   });
   const connection = await seed.orgConnection(den.admin, {
     name: "Synthetic calendar provider",
-    url: den.mocks.connector.mcpUrl,
+    url: provider.mcpUrl,
     authType: "oauth",
     credentialMode: "per_member",
     access: { orgWide: true },
@@ -35,8 +38,25 @@ export async function oauthStartUnreadableWeb(seed: Seed, ctx: { place: Place })
     headless: true,
     viewport: { width: 1440, height: 1100 },
   });
-  return Object.assign({ den, proxy, connection, web, startPath: `/v1/mcp-connections/${connection.id}/connect/start` }, {
+  return Object.assign({
+    den,
+    proxy,
+    connection,
+    web,
+    startPath: `/v1/mcp-connections/${connection.id}/connect/start`,
+    /** Authorization requests the synthetic provider has received since it (re)started. */
+    async authorizeRequests(): Promise<number> {
+      return (await provider.requests()).filter((entry) => entry.path === "/authorize").length;
+    },
+    async stopProvider(): Promise<void> {
+      await provider.stop();
+    },
+    async restartProvider(): Promise<void> {
+      provider = (await mcpMock({ port: providerPort }).boot(ctx.place)).handle;
+    },
+  }, {
     async [Symbol.asyncDispose]() {
+      await provider.stop();
       await proxy[Symbol.asyncDispose]();
     },
   });


### PR DESCRIPTION
## Why

A member clicks **Connect** on a Den web connection and the browser's `GET /v1/mcp-connections/:id/connect/start` fails *before the page can read the response*: a cross-origin error answer without usable CORS headers (or no answer at all). Today the connection row and the sign-in popup only echo the browser's own `Failed to fetch`, with no Technical details, so members and support cannot tell a blocked response from a provider problem.

This PR makes that failure readable in the UI and adds boundary proof of den-api's own error-path CORS behaviour. **It does not fix or explain why a given deployment's OAuth-start request returns an error**; that stays an operational investigation (edge vs. den-api logs).

## What changed

- `den-web` `useStartMcpConnectionOAuth`: a pre-response failure (fetch `TypeError`) is wrapped in `McpOAuthStartError` with `httpStatus: "unavailable"`, `errorCode: response_unreadable`, the browser's own error text in the payload, and a plain message. Den's timeout, cancel and re-authentication errors are untouched. The popup's HTTP status row renders "Unavailable — the browser could not read the response" instead of a fake number.
- New boundary spec `evals/specs/mcp-oauth-start-browser-readable-errors.test.ts`: den-api answers OAuth-start preflights, `200`, downstream-failure `502` (`oauth_handshake_failed` + diagnostic reference) and `401` with exactly one `Access-Control-Allow-Origin` for the trusted web origin and `Access-Control-Allow-Credentials: true`; an untrusted origin gets no allow-origin on preflight or on the `502`. (No den-api code change was needed: in the default, non-edge CORS mode the structured `502` already carries the headers.)
- New local-lane journey `evals/specs/mcp-oauth-start-unreadable-response.e2e.test.ts` + world `evals/worlds/mcp-oauth-start-unreadable.ts`: a fault proxy is fixed in front of den-api before Den boots (`DEN_API_PUBLIC_URL` → proxy). Three steps on the Your Connections page in headless Chrome: (1) provider taken away → den-api's own `502` is forwarded with CORS headers and the row shows `Could not connect "…": … Reference: …` (preflight `204` + GET `502` observed at the proxy); (2) the proxy injects an answer the browser may not read on the OAuth-start **GET** (preflight already cached; the log asserts exactly one faulted `GET 502`) → the row shows the readability message, not `Failed to fetch` nor a diagnostic reference; (3) fault cleared and provider back → the same button proxies `GET 200` and the provider receives `/authorize`. Registered in `journey-catalog.mjs` as `placement: 'local'` and declared `needs.placement: "local"`.

## Proof (local lane; Daytona not used by request)

Base `4d7727740`, head `0aa304c6b` (both specs re-run cold on this head). CI note: the Product journeys workflow is withheld for PRs touching `evals/scripts/`, so the journey evidence is the published local run.

```
pnpm evals:pr specs/mcp-oauth-start-browser-readable-errors.test.ts
# ✓ 1 passed (25.9s) — gitSha 0aa304c6b, outcome passed, 5/5 assertion claims

OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/mcp-oauth-start-unreadable-response.e2e.test.ts
# ✓ 1 passed (55.9s) — gitSha 0aa304c6b, outcome passed, steps 3/3, 3 assertion claims, 3 screenshots (unvalidated; no vision key used)

pnpm --filter @openwork-ee/den-web typecheck   # clean
node --test evals/scripts/journey-ci.test.mjs  # 12/12
```

Verdict: **Passed** for the two specs above. Pre-existing, unrelated red on base and head: `ee/apps/den-web tests/cloud-super-admins-role-hierarchy.test.ts` (1 fail, fails identically on `4d7727740`) and `pnpm evals:typecheck` (errors in `apps/server`, `packages/email`, older specs; none in files touched here).

## Notes for reviewers

- Overlaps textually with #4654 in `useStartMcpConnectionOAuth` (that PR adds `attemptId`); the changes are independent and whichever lands second needs a one-line rebase.
- The e2e fault answer uses `Access-Control-Allow-Origin: *`, which a credentialed request may not read — same user-visible outcome as a missing header. The fault lands on the GET (the preflight is cached by the earlier readable failure), as the proxy log assertion shows.
- Not in scope: callback-mode compatibility, token-auth method selection, preset catalog; and no change to den-api CORS middleware (the boundary spec shows none is needed in default mode).
