### PR TITLE
fix(den-web): keep a preset's auth type over discovery in quick add

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -2408,8 +2408,13 @@ function AddConnectionDialog({
 
   function applyDiscoveredRequirements(result: McpRequirementsDiscovery) {
     setRequirements(result);
-    if (result.authentication.kind === "none") setAuthType("none");
-    else if (result.authentication.kind === "oauth") setAuthType("oauth");
+    // A curated preset's auth type stays authoritative over the live probe,
+    // matching the smart-add rule: an API-key server that also advertises
+    // OAuth metadata (or initializes anonymously) must not lose its key field.
+    if (!preset) {
+      if (result.authentication.kind === "none") setAuthType("none");
+      else if (result.authentication.kind === "oauth") setAuthType("oauth");
+    }
     const servers = result.authentication.authorizationServers;
     setAuthorizationServerIssuer(servers.length === 1 ? servers[0].issuer : "");
     setRequestedScopes(result.authentication.recommendedScopes);

--- a/evals/specs/connector-quick-add-preset-auth.e2e.test.ts
+++ b/evals/specs/connector-quick-add-preset-auth.e2e.test.ts
@@ -31,6 +31,9 @@ test("an API-key quick add keeps its key field while a custom OAuth-only server 
     };
   };
 
+  // Den's own discovery disagreed with the preset before the dialog opened;
+  // without that conflict the key field surviving would prove nothing.
+  expect(world.discovered.kind).toBe("oauth");
   await user.navigate(`${world.den.ref.webUrl}/dashboard/mcp-connections?quickAdd=${API_KEY_PRESET_ID}`);
   await user.see({ testId: "add-mcp-connection-dialog" }, { timeoutMs: 90_000 });
   await user.see({ text: `Add ${world.presetName}` });
@@ -48,8 +51,8 @@ test("an API-key quick add keeps its key field while a custom OAuth-only server 
   expect(quickAddOk, JSON.stringify({ alert: quickAdd.alert, keyField: quickAdd.keyField, clientIdField: quickAdd.clientIdField, credentialMode: quickAdd.credentialMode })).toBe(true);
   await user.screenshot();
   evidence.recordAssertionEvidence(
-    "The API-key quick add still asks for the org key after the hosted server's OAuth challenge was discovered",
-    `quickAdd=${API_KEY_PRESET_ID} against ${world.presetUrl}: Add connection enabled once a key was typed; key field present, no OAuth app, client ID, or credential-mode fields`,
+    "The API-key quick add still asks for the org key although Den's discovery classified the server as OAuth",
+    `Den discovery for ${world.presetUrl}: kind=${world.discovered.kind}, registration=${world.discovered.registration}. quickAdd=${API_KEY_PRESET_ID}: Add connection enabled once a key was typed; key field present, no OAuth app, client ID, or credential-mode fields`,
     quickAddOk,
   );
   await user.click({ role: "button", label: "Cancel" });

--- a/evals/specs/connector-quick-add-preset-auth.e2e.test.ts
+++ b/evals/specs/connector-quick-add-preset-auth.e2e.test.ts
@@ -1,0 +1,85 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { API_KEY_PRESET_ID, connectorQuickAddPresetAuth } from "../worlds/connector-quick-add.ts";
+
+// An admin who picks an API-key quick add must be asked for that key even when
+// the hosted server also advertises OAuth metadata; the live probe still
+// decides the auth type for a custom server URL.
+const test = spec.world(connectorQuickAddPresetAuth, { timeout: 600_000 });
+
+test("an API-key quick add keeps its key field while a custom OAuth-only server still switches to OAuth", async ({ world, user, probe, evidence }) => {
+  // The connections page behind the dialog also mentions API keys, so every
+  // field claim reads the dialog itself rather than the whole page.
+  const DIALOG = '[data-testid="add-mcp-connection-dialog"]';
+  const dialog = async () => {
+    const [root, keyField, clientIdField, alert, enabledButtons] = await Promise.all([
+      probe.dom(DIALOG),
+      probe.dom(`${DIALOG} input[name="mcp-api-key"]`),
+      probe.dom(`${DIALOG} input[name="mcp-oauth-client-id"]`),
+      probe.dom(`${DIALOG} [role="alert"]`),
+      probe.dom(`${DIALOG} button:not([disabled])`),
+    ]);
+    const text = root.elements[0]?.text;
+    if (text === undefined) return null;
+    return {
+      text,
+      alert: alert.elements.length > 0,
+      keyField: keyField.elements.length > 0,
+      clientIdField: clientIdField.elements.length > 0,
+      credentialMode: text.includes("Whose account does the AI use?"),
+      addEnabled: enabledButtons.elements.some(button => button.text === "Add connection"),
+    };
+  };
+
+  await user.navigate(`${world.den.ref.webUrl}/dashboard/mcp-connections?quickAdd=${API_KEY_PRESET_ID}`);
+  await user.see({ testId: "add-mcp-connection-dialog" }, { timeoutMs: 90_000 });
+  await user.see({ text: `Add ${world.presetName}` });
+  await user.type({ placeholder: "sk-..." }, "synthetic-org-api-key");
+  // Discovery must finish (the submit button only enables on a ready probe)
+  // before the claim means anything: an unfinished probe never flips the form.
+  const quickAdd = await probe.eventually(dialog, {
+    within: 60_000,
+    label: "requirements discovery finished for the quick add",
+    until: state => state?.addEnabled === true,
+  });
+  if (!quickAdd) throw new Error("The quick-add dialog disappeared.");
+  const quickAddOk = !quickAdd.alert && quickAdd.keyField && !quickAdd.clientIdField
+    && !quickAdd.text.includes("OAuth app") && !quickAdd.credentialMode;
+  expect(quickAddOk, JSON.stringify({ alert: quickAdd.alert, keyField: quickAdd.keyField, clientIdField: quickAdd.clientIdField, credentialMode: quickAdd.credentialMode })).toBe(true);
+  await user.screenshot();
+  evidence.recordAssertionEvidence(
+    "The API-key quick add still asks for the org key after the hosted server's OAuth challenge was discovered",
+    `quickAdd=${API_KEY_PRESET_ID} against ${world.presetUrl}: Add connection enabled once a key was typed; key field present, no OAuth app, client ID, or credential-mode fields`,
+    quickAddOk,
+  );
+  await user.click({ role: "button", label: "Cancel" });
+  await user.notSee({ testId: "add-mcp-connection-dialog" });
+
+  // Negative half: without a curated preset the probe still drives the form.
+  // The admin first chooses API key by hand; discovering an OAuth server
+  // must override that choice, and the server's own log witnesses the probe.
+  await user.click({ role: "button", label: "Advanced setup" });
+  await user.see({ testId: "add-mcp-connection-dialog" });
+  await user.see({ text: "Add a custom MCP server" });
+  await user.click({ role: "button", label: "API key" });
+  const customBefore = await dialog();
+  if (!customBefore) throw new Error("The custom server dialog disappeared.");
+  expect(customBefore.keyField, "API key chosen by hand before discovery").toBe(true);
+  await user.type({ placeholder: "https://mcp.example.com/mcp" }, world.oauthOnlyServerUrl);
+  const custom = await probe.eventually(dialog, {
+    within: 60_000,
+    label: "requirements discovery switched the custom server to OAuth",
+    until: state => state?.keyField === false && state?.credentialMode === true,
+  });
+  if (!custom) throw new Error("The custom server dialog disappeared.");
+  const probedPaths = (await world.connector.requests()).map(request => request.path).filter(path => path.startsWith("/mcp") || path.includes("/.well-known/"));
+  const customOk = !custom.alert && probedPaths.length > 0;
+  expect(customOk, JSON.stringify({ alert: custom.alert, probedPaths })).toBe(true);
+  await user.screenshot();
+  evidence.recordAssertionEvidence(
+    "A custom OAuth server overrides a hand-picked API key auth type after Den probes it",
+    `Den probed the synthetic server at ${JSON.stringify([...new Set(probedPaths)])}; the dialog dropped the API-key field and asked whose account the AI uses`,
+    customOk,
+  );
+  await user.click({ role: "button", label: "Cancel" });
+});

--- a/evals/worlds/connector-quick-add.ts
+++ b/evals/worlds/connector-quick-add.ts
@@ -1,0 +1,47 @@
+import type { Seed } from "@openwork/env";
+import { SkipError } from "@openwork/env";
+
+/** Curated API-key presets whose hosted server also answers unauthenticated MCP requests with an OAuth challenge. */
+export const API_KEY_PRESET_ID = "render";
+
+/**
+ * The hosted server behind the API-key preset is a third party: the journey
+ * only proves the quick-add form when that server still answers an
+ * unauthenticated initialize with a 401 OAuth challenge. Anything else skips
+ * loudly instead of passing on a probe that never classified the server.
+ */
+async function hostedServerAdvertisesOAuth(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "openwork-eval-probe", version: "0" } } }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    await response.body?.cancel();
+    return response.status === 401 && /resource_metadata=/.test(response.headers.get("www-authenticate") ?? "");
+  } catch {
+    return false;
+  }
+}
+
+export async function connectorQuickAddPresetAuth(seed: Seed) {
+  const den = await seed.den({
+    org: { name: `Quick add preset auth ${Date.now()}`, admin: { name: "Quick Add Admin" } },
+    // A synthetic OAuth-only MCP server whose request log witnesses that Den
+    // really probed it while the custom-server form was open.
+    mocks: { connector: seed.mock() },
+  });
+  const presets = await seed.api(den.admin, "/v1/mcp-connections/presets");
+  const body: unknown = presets.body;
+  if (typeof body !== "object" || body === null || !Array.isArray(Reflect.get(body, "presets"))) throw new Error("Den did not return its connector presets.");
+  const preset: unknown = Reflect.get(body, "presets").find((entry: unknown) => typeof entry === "object" && entry !== null && Reflect.get(entry, "presetId") === API_KEY_PRESET_ID);
+  if (typeof preset !== "object" || preset === null) throw new Error(`Den has no ${API_KEY_PRESET_ID} preset.`);
+  const presetUrl = Reflect.get(preset, "url");
+  const presetName = Reflect.get(preset, "displayName");
+  const presetAuthType = Reflect.get(preset, "authType");
+  if (typeof presetUrl !== "string" || typeof presetName !== "string" || presetAuthType !== "apikey") throw new Error(`The ${API_KEY_PRESET_ID} preset is not an API-key preset.`);
+  if (!await hostedServerAdvertisesOAuth(presetUrl)) throw new SkipError(`${presetUrl} did not answer an unauthenticated initialize with a 401 OAuth challenge`);
+  const web = await seed.web({ den, signedInAs: den.admin, startPath: "/dashboard/mcp-connections", headless: true, viewport: { width: 1440, height: 1400 } });
+  return { den, web, presetUrl, presetName, oauthOnlyServerUrl: den.mocks.connector.mcpUrl, connector: den.mocks.connector };
+}

--- a/evals/worlds/connector-quick-add.ts
+++ b/evals/worlds/connector-quick-add.ts
@@ -1,28 +1,19 @@
 import type { Seed } from "@openwork/env";
 import { SkipError } from "@openwork/env";
 
-/** Curated API-key presets whose hosted server also answers unauthenticated MCP requests with an OAuth challenge. */
+/** Curated API-key preset whose hosted server also answers unauthenticated MCP requests with an OAuth challenge. */
 export const API_KEY_PRESET_ID = "render";
 
-/**
- * The hosted server behind the API-key preset is a third party: the journey
- * only proves the quick-add form when that server still answers an
- * unauthenticated initialize with a 401 OAuth challenge. Anything else skips
- * loudly instead of passing on a probe that never classified the server.
- */
-async function hostedServerAdvertisesOAuth(url: string): Promise<boolean> {
-  try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "openwork-eval-probe", version: "0" } } }),
-      signal: AbortSignal.timeout(15_000),
-    });
-    await response.body?.cancel();
-    return response.status === 401 && /resource_metadata=/.test(response.headers.get("www-authenticate") ?? "");
-  } catch {
-    return false;
-  }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function organizationId(seed: Seed, session: Parameters<Seed["api"]>[0]): Promise<string> {
+  const result = await seed.api(session, "/v1/me/orgs");
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
+  const id = orgs[0]?.id;
+  if (!result.response.ok || typeof id !== "string") throw new Error(`Resolving the active organization failed: HTTP ${result.response.status}`);
+  return id;
 }
 
 export async function connectorQuickAddPresetAuth(seed: Seed) {
@@ -32,16 +23,43 @@ export async function connectorQuickAddPresetAuth(seed: Seed) {
     // really probed it while the custom-server form was open.
     mocks: { connector: seed.mock() },
   });
+  const orgId = await organizationId(seed, den.admin);
   const presets = await seed.api(den.admin, "/v1/mcp-connections/presets");
-  const body: unknown = presets.body;
-  if (typeof body !== "object" || body === null || !Array.isArray(Reflect.get(body, "presets"))) throw new Error("Den did not return its connector presets.");
-  const preset: unknown = Reflect.get(body, "presets").find((entry: unknown) => typeof entry === "object" && entry !== null && Reflect.get(entry, "presetId") === API_KEY_PRESET_ID);
-  if (typeof preset !== "object" || preset === null) throw new Error(`Den has no ${API_KEY_PRESET_ID} preset.`);
-  const presetUrl = Reflect.get(preset, "url");
-  const presetName = Reflect.get(preset, "displayName");
-  const presetAuthType = Reflect.get(preset, "authType");
-  if (typeof presetUrl !== "string" || typeof presetName !== "string" || presetAuthType !== "apikey") throw new Error(`The ${API_KEY_PRESET_ID} preset is not an API-key preset.`);
-  if (!await hostedServerAdvertisesOAuth(presetUrl)) throw new SkipError(`${presetUrl} did not answer an unauthenticated initialize with a 401 OAuth challenge`);
+  const presetList = isRecord(presets.body) && Array.isArray(presets.body.presets) ? presets.body.presets.filter(isRecord) : null;
+  if (!presetList) throw new Error("Den did not return its connector presets.");
+  const preset = presetList.find((entry) => entry.presetId === API_KEY_PRESET_ID);
+  if (!preset) throw new Error(`Den has no ${API_KEY_PRESET_ID} preset.`);
+  const presetUrl = preset.url;
+  const presetName = preset.displayName;
+  if (typeof presetUrl !== "string" || typeof presetName !== "string" || preset.authType !== "apikey") throw new Error(`The ${API_KEY_PRESET_ID} preset is not an API-key preset.`);
+
+  // The preset's hosted server is a third party. Ask the same Den discovery
+  // the dialog uses how it classifies that URL right now: the journey only
+  // proves anything when Den sees a conflicting OAuth requirement, so any
+  // other classification skips loudly instead of passing on a probe that
+  // never disagreed with the preset.
+  const discover = await seed.api(den.admin, "/v1/mcp-connections/discover", {
+    method: "POST",
+    headers: { "x-openwork-org-id": orgId },
+    body: JSON.stringify({ url: presetUrl }),
+  });
+  const authentication = isRecord(discover.body) && isRecord(discover.body.authentication) ? discover.body.authentication : null;
+  const discoveredKind = authentication?.kind;
+  const discoveredRegistration = authentication?.recommendedRegistrationMethod;
+  if (!discover.response.ok || typeof discoveredKind !== "string" || typeof discoveredRegistration !== "string") {
+    throw new SkipError(`Den could not discover ${presetUrl} (HTTP ${discover.response.status})`);
+  }
+  if (discoveredKind !== "oauth") throw new SkipError(`Den classified ${presetUrl} as ${discoveredKind}, not the conflicting oauth requirement this journey needs`);
+
   const web = await seed.web({ den, signedInAs: den.admin, startPath: "/dashboard/mcp-connections", headless: true, viewport: { width: 1440, height: 1400 } });
-  return { den, web, presetUrl, presetName, oauthOnlyServerUrl: den.mocks.connector.mcpUrl, connector: den.mocks.connector };
+  return {
+    den,
+    web,
+    presetUrl,
+    presetName,
+    /** How Den's own requirements discovery classified the preset URL just before the dialog opened. */
+    discovered: { kind: discoveredKind, registration: discoveredRegistration },
+    oauthOnlyServerUrl: den.mocks.connector.mcpUrl,
+    connector: den.mocks.connector,
+  };
 }


### PR DESCRIPTION
## Summary
The prefilled connector quick-add dialog hides the authentication selector and then lets requirements discovery overwrite the curated preset's auth type. An API-key preset whose hosted server also answers unauthenticated requests with an OAuth challenge turned into an OAuth form demanding a pre-registered client ID (with no way back to the key field), and an API-key preset whose server initializes anonymously lost its key field entirely. Presets now stay authoritative inside the dialog, as they already are in the smart bar (`Keep curated preset requirements authoritative over a probe`); custom server URLs keep following the live probe.

## Why
Two curated API-key quick adds (`render`, `exa`) could not be completed as the cards describe. The card promises "Paste your org's API key", but the form that opened asked for OAuth client credentials or nothing at all.

## Issue
No linked issue. Investigation follow-up on connector catalog coverage. Supersedes #4665 (identical tree; that PR's commit was unsigned and the `dev` ruleset requires signed commits).

## Scope
- `ee/apps/den-web/.../mcp-connections-screen.tsx`: `applyDiscoveredRequirements` only derives `authType` from the probe when the dialog has no curated preset (+5/-2 lines).
- `evals/specs/connector-quick-add-preset-auth.e2e.test.ts` + `evals/worlds/connector-quick-add.ts`: new Den-web journey (new user journey: completing an API-key quick add whose provider also advertises OAuth).

## Out of scope
Server-side validation of preset auth types, OAuth start/callback logic, the preset catalog itself, and any live provider connection.

## Testing
### Ran
- `pnpm evals:e2e connector-quick-add-preset-auth --local` on PR head `6ed65b0a2`
- Control: same spec with the component reverted to `dev` (`4d7727740`) → fails at the quick-add claim with `{"keyField":false,"clientIdField":true,"credentialMode":true}` (the OAuth form), proving the spec observes the defect.
- `pnpm --filter @openwork-ee/den-web typecheck` → exit 0
- `pnpm evals:typecheck` → no errors in the new files (pre-existing unrelated errors elsewhere)
- `evals` channel/boundary ratchets and `lint:layers` → no findings for the new files

### Result
- `placement: local (--local)`; **1 passed, 0 failed, 0 skipped**; verdict `passed`.
- Claim 1: `?quickAdd=render` renders the API-key field, `Add connection` enables once a key is typed (discovery reached ready), and no `OAuth app`, client ID, or credential-mode fields appear.
- Claim 2 (negative half): in `Add a custom MCP server`, choosing API key by hand and then entering a synthetic OAuth MCP server URL switches the form to OAuth after Den probes the server; the mock's request log witnesses the `/mcp` and `/.well-known/...` probes.
- The world skips loudly (`needs:`) if the hosted preset server stops answering an unauthenticated initialize with a 401 OAuth challenge, so a third-party change cannot produce a false pass.

## CI status
- pass: pending at PR creation
- code-related failures: none known
- external/env/auth blockers: none known

## Manual verification
1. Den → Connectors → click the `Render` (or `Exa`) quick-add tile.
2. Wait for "Checking…" to finish.
3. Confirm the API key field is still shown and `Add connection` enables after pasting a key; no OAuth client fields appear.
4. `Advanced setup` → paste an OAuth MCP server URL → confirm the form still switches to OAuth.

## Evidence
Test-evidence comment to follow (local lane, testkit run bound to the PR head).

## Risk
Low: UI-only, narrows one state transition to non-preset dialogs. OAuth presets still receive issuer/scope/pre-registered hints from discovery.

## Rollback
Revert this PR.

