### PR TITLE
docs: correct hosted MCP OAuth callback URL

### DIFF
--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -62,11 +62,11 @@ New MCP connections on one Den instance share this redirect URL:
 
 For the hosted OpenWork Cloud instance, the dashboard is
 `https://app.openworklabs.com` and its public Den API origin is
-`https://api.app.openworklabs.com`. Register this exact redirect URL with the OAuth
+`https://api.openworklabs.com`. Register this exact redirect URL with the OAuth
 provider:
 
 ```text
-https://api.app.openworklabs.com/v1/mcp-connections/oauth/callback
+https://api.openworklabs.com/v1/mcp-connections/oauth/callback
 ```
 
 For a self-hosted instance whose public Den API is


### PR DESCRIPTION
## Summary
- Correct the hosted Den API origin and OAuth callback example to use `api.openworklabs.com`.

## Verification
- `git diff --check` — passed.
- Reviewed the complete diff: two URL corrections in one documentation page.
- Runtime journey proof skipped: documentation-only change; no runtime behavior changed.