### PR TITLE
fix(session): isolate pending deltas during thread hydration

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1168,7 +1168,8 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     if (!isTrackedSession(entry, part.sessionID)) return;
     const [mapped, ...attachments] = toUIParts(part);
     if (!mapped) return;
-    const pending = entry.pendingDeltas.get(part.id);
+    const pendingKey = JSON.stringify([part.sessionID, part.messageID, part.id]);
+    const pending = entry.pendingDeltas.get(pendingKey);
     // Seed the new part with any deltas that arrived before this
     // declaration. We deliberately ignore `pending.reasoning` — it
     // can't be trusted because opencode emits `field: "text"` for
@@ -1194,7 +1195,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     // cumulative text we just wrote, duplicating bytes mid-stream.
     if (entry.deltaFlushBuffer.length > 0) {
       entry.deltaFlushBuffer = entry.deltaFlushBuffer.filter(
-        (item) => item.partId !== part.id,
+        (item) => item.sessionId !== part.sessionID || item.messageId !== part.messageID || item.partId !== part.id,
       );
     }
     queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, part.sessionID), (current = []) => {
@@ -1214,7 +1215,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       }
       return next;
     });
-    if (pending) entry.pendingDeltas.delete(part.id);
+    if (pending) entry.pendingDeltas.delete(pendingKey);
     useSessionActivityStore.getState().observeTranscript(workspaceId, part.sessionID,
       queryClient.getQueryData<UIMessage[]>(transcriptKey(workspaceId, part.sessionID)) ?? []);
     return;
@@ -1323,13 +1324,14 @@ function commitDeltas(entry: SyncEntry, workspaceId: string, items: PendingDelta
           // The declaration event is the source of truth for text versus
           // reasoning. Hold early deltas until that event arrives instead of
           // projecting them into the wrong Markdown surface.
-          const existing = entry.pendingDeltas.get(item.partId) ?? {
+          const pendingKey = JSON.stringify([sessionId, item.messageId, item.partId]);
+          const existing = entry.pendingDeltas.get(pendingKey) ?? {
             messageId: item.messageId,
             reasoning: item.reasoning,
             text: "",
           };
           existing.text += item.delta;
-          entry.pendingDeltas.set(item.partId, existing);
+          entry.pendingDeltas.set(pendingKey, existing);
         }
         return result.messages;
       },
@@ -1771,17 +1773,19 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   for (const entry of syncs.values()) {
     if (entry.input.workspaceId !== workspaceId) continue;
     flushSessionDeltas(entry, workspaceId, snapshot.session.id);
+    if (entry.pendingDeltas.size === 0) continue;
     for (const message of incoming) {
       for (const part of message.parts) {
         if (part.type !== "text" && part.type !== "reasoning") continue;
         const partId = getPartMetadataId(part);
         if (!partId) continue;
-        const pending = entry.pendingDeltas.get(partId);
+        const pendingKey = JSON.stringify([snapshot.session.id, message.id, partId]);
+        const pending = entry.pendingDeltas.get(pendingKey);
         if (!pending || pending.messageId !== message.id) continue;
         // Early deltas and the declaration are cumulative views, as with
         // message.part.updated. Unrepresented parts remain pending.
         if (pending.text.length > part.text.length) part.text = pending.text;
-        entry.pendingDeltas.delete(partId);
+        entry.pendingDeltas.delete(pendingKey);
       }
     }
   }
@@ -1832,7 +1836,8 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   const todosStartedAt = snapshotStartedAt ?? todoSnapshotFirstSeen.get(snapshot) ?? Date.now();
   todoSnapshotFirstSeen.set(snapshot, todosStartedAt);
   const todosState = queryClient.getQueryState(todosKey);
-  if (!todosState || todosStartedAt > todosState.dataUpdatedAt) {
+  // Millisecond ties cannot establish that a snapshot is newer than live data.
+  if (todosState?.data === undefined || todosStartedAt > todosState.dataUpdatedAt) {
     queryClient.setQueryData(todosKey, snapshot.todos, { updatedAt: todosStartedAt });
   }
   useSessionActivityStore.getState().observeTranscript(workspaceId, snapshot.session.id,

--- a/apps/app/tests/session-render-state.test.ts
+++ b/apps/app/tests/session-render-state.test.ts
@@ -72,7 +72,11 @@ for (const { name, merge } of [
         const completed: UIMessage = {
           ...running, parts: [{ ...running.parts[0], ...terminal }],
         };
-        expect(merge([running], [completed])[0]?.parts).toEqual(completed.parts);
+        expect(merge([running], [completed])[0]).toBe(completed);
+        const inputAvailable: UIMessage = {
+          ...running, parts: [{ ...running.parts[0], state: "input-available" }],
+        };
+        expect(merge([inputAvailable], [completed])[0]).toBe(completed);
         expect(merge([completed], [running])[0]?.parts).toEqual(completed.parts);
         const reordered: UIMessage = {
           ...running, parts: [{
@@ -82,6 +86,9 @@ for (const { name, merge } of [
         };
         expect(merge([reordered], [completed])[0]?.parts).toEqual([
           reordered.parts[0], completed.parts[0],
+        ]);
+        expect(merge([running], [reordered])[0]?.parts).toEqual([
+          running.parts[0], reordered.parts[0],
         ]);
         const refreshed: UIMessage = { ...completed, parts: [{
           type: "dynamic-tool", toolName: "bash", toolCallId: "call-a",

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -721,6 +721,9 @@ describe("session transcript sync", () => {
       const late = snapshotWithMessages([]);
       markSessionSnapshotFetchStart(late, 150);
       seedSessionState("workspace-a", late);
+      const tied = snapshotWithMessages([]);
+      markSessionSnapshotFetchStart(tied, 200);
+      seedSessionState("workspace-a", tied);
       expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toEqual(completed);
       expect(queryClient.getQueryData(todoKey("workspace-a", "session-b"))).toEqual([]);
       const fresh = snapshotWithMessages([]);
@@ -744,10 +747,17 @@ describe("session transcript sync", () => {
       const release = trackWorkspaceSessionSync(input, "session-a");
       const queryClient = getReactQueryClient();
       const key = transcriptKey("workspace-a", "session-a");
+      const releaseNeighbor = trackWorkspaceSessionSync(input, "session-b");
       try {
         if (declared) seedSessionState("workspace-a", snapshotWithMessages([
           { id: "answer", role: "assistant", text: "hello" },
         ]));
+        __applySessionSyncEventForTest(input, {
+          type: "message.part.delta", properties: {
+            sessionID: "session-b", messageID: "answer", partID: "part_answer", delta: "neighbor text stays separate",
+          },
+        });
+        for (const run of scheduled.splice(0)) run();
         const delta = (messageId: string, text: string) => __applySessionSyncEventForTest(input, {
           type: "message.part.delta", properties: {
             sessionID: "session-a", messageID: messageId, partID: `part_${messageId}`, delta: text,
@@ -755,13 +765,16 @@ describe("session transcript sync", () => {
         });
         delta("answer", declared ? " world" : "hello world");
         delta("unknown", "retained");
-        seedSessionState("workspace-a", snapshotWithMessages([
-          { id: "answer", role: "assistant", text: "hello world" },
-        ]));
+        const snapshot = snapshotWithMessages([
+          { id: "answer", role: "assistant", text: declared ? "hello world" : "hello" },
+        ]);
+        seedSessionState("workspace-a", snapshot);
+        expect(snapshot.messages[0]?.parts[0]).toMatchObject({ text: declared ? "hello world" : "hello" });
         for (const run of scheduled.splice(0)) run();
         expect(queryClient.getQueryData<UIMessage[]>(key)?.find((m) => m.id === "answer")?.parts[0])
           .toMatchObject({ text: "hello world" });
         delta("answer", "!");
+        seedSessionState("workspace-a", snapshot);
         for (const run of scheduled.splice(0)) run();
         expect(queryClient.getQueryData<UIMessage[]>(key)?.find((m) => m.id === "answer")?.parts[0])
           .toMatchObject({ text: "hello world!" });
@@ -772,7 +785,27 @@ describe("session transcript sync", () => {
         });
         expect(queryClient.getQueryData<UIMessage[]>(key)?.find((m) => m.id === "unknown")?.parts[0])
           .toMatchObject({ text: "retained" });
-      } finally { release(); cleanup(); __setSessionSyncDeltaFlushSchedulerForTest(null); }
+        __applySessionSyncEventForTest(input, {
+          type: "message.part.updated", properties: { part: {
+            id: "part_answer", sessionID: "session-b", messageID: "answer", type: "text", text: "",
+          } },
+        });
+        expect(queryClient.getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-b"))?.[0]?.parts[0])
+          .toMatchObject({ text: "neighbor text stays separate" });
+        __applySessionSyncEventForTest(input, {
+          type: "message.part.delta", properties: {
+            sessionID: "session-b", messageID: "answer", partID: "part_answer", delta: "!",
+          },
+        });
+        __applySessionSyncEventForTest(input, {
+          type: "message.part.updated", properties: { part: {
+            id: "part_answer", sessionID: "session-a", messageID: "answer", type: "text", text: "hello world!",
+          } },
+        });
+        for (const run of scheduled.splice(0)) run();
+        expect(queryClient.getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-b"))?.[0]?.parts[0])
+          .toMatchObject({ text: "neighbor text stays separate!" });
+      } finally { releaseNeighbor(); release(); cleanup(); __setSessionSyncDeltaFlushSchedulerForTest(null); }
     });
   }
 


### PR DESCRIPTION
## Summary
Follow up on #4658, which already landed the original stale-thread hydration fix.

- Key pending deltas by session, message, and part so overlapping identifiers cannot mix text between threads.
- Keep cumulative part updates from discarding another thread’s queued deltas, and skip pending-part reconciliation when the buffer is empty.
- Allow an existing todo query without data to hydrate while keeping conservative timestamp-tie handling.
- Extend existing regression tests for cross-session isolation, unchanged snapshot input, cached reapplication, terminal tool identity, and duplicate-free tool merges.

## Verification: Incomplete
Tested head: `d83be707ab87badbe657c10bf996fa95f6f85899`.
Rebased onto `dev` at `d6eff8a5aeb0ffc44c0890352a36c6775cf7150f`; the already-merged changes from #4658 are not duplicated.

```sh
pnpm --filter @openwork/app exec bun test --isolate ./tests/session-render-state.test.ts ./tests/session-sync-permissions.test.ts
```

- Passed: 60 tests, 0 failed, 0 skipped; exit 0 on the rebased head.
- Passed: `git diff --check origin/dev...HEAD`.
- The added overlapping-identity cases reproduced cross-session text contamination before the scope repair.
- These are deterministic component regressions, not runtime journey proof.
- Deferred: exact-head `@openwork/testkit` runtime evidence. No new runtime resources were provisioned. Broad suites and E2E were not run.
- Missing coverage: the existing `evals/specs/streamed-markdown-answer.e2e.test.ts` needs a mid-stream thread-return assertion that exercises cached hydration, preserves completed tools and todos, and shows each text fragment exactly once without affecting the neighboring thread. The runtime spec is unchanged in this PR.

Runtime verification entry point, once the missing assertion and test resources are available:
```sh
pnpm evals:e2e streamed-markdown-answer
```

Timestamp ties intentionally favor existing todo data; snapshots without a recorded fetch start use their first hydration time.