### PR TITLE
fix(ci): keep Warden advisories out of review threads

### DIFF
--- a/.github/workflows/warden-clearance.yml
+++ b/.github/workflows/warden-clearance.yml
@@ -135,7 +135,7 @@ jobs:
           set -euo pipefail
           BODY="**Warden security clearance: clear.** No blocking findings (security or desktop↔den sync) in this diff (\`$HEAD_SHA\`)."
           if [[ "$ADVISORY" =~ ^[0-9]+$ ]] && [ "$ADVISORY" -gt 0 ]; then
-            BODY="$BODY $ADVISORY advisory desktop↔den sync note(s) were posted as review comments; they do not affect clearance."
+            BODY="$BODY $ADVISORY advisory desktop↔den sync note(s) are listed in Warden check summaries instead of creating new review threads."
           fi
           BODY="$BODY Automated clearance satisfies the required-review gate only — a human still reviews and merges. [Analysis run]($RUN_URL)"
           gh api "repos/$REPO/pulls/$PR/reviews" \

--- a/warden.toml
+++ b/warden.toml
@@ -2,9 +2,9 @@ version = 1
 
 # Warden gates clearance on blocking findings from three skills:
 # diff-security-review and confidentiality-review (all findings block) and
-# desktop-den-sync-review (only high findings block; medium findings are
-# advisory). The clearance itself is granted by
-# .github/workflows/warden-clearance.yml.
+# desktop-den-sync-review (only high findings block). Provenance and medium/low
+# sync advisories remain in Warden check summaries but create no new threads.
+# Clearance itself is granted by .github/workflows/warden-clearance.yml.
 
 [defaults]
 reportOn = "low"
@@ -50,6 +50,7 @@ type = "local"
 
 [[skills]]
 name = "spec-provenance-review"
+reportOn = "off"
 paths = ["evals/specs/**", "evals/worlds/**"]
 
 [[skills.triggers]]
@@ -61,6 +62,7 @@ type = "local"
 
 [[skills]]
 name = "desktop-den-sync-review"
+reportOn = "high"
 paths = [
   "apps/app/**",
   "apps/desktop/**",


### PR DESCRIPTION
## Summary
- Keep provenance and medium/low desktop-den sync advisories in Warden check summaries without creating new review threads.
- Continue reporting and enforcing medium/low security and confidentiality findings, plus high desktop-den sync findings.
- Update clearance copy to describe the new advisory routing.
- Leave models, triggers, pins, full analysis, clearance counts, and security guard logic unchanged; use the existing pinned Warden native per-skill `reportOn` setting.
- Existing advisory threads are not automatically resolved.

## Verification
**Verdict: Incomplete** — hosted runtime verification is still required. These structural checks passed but are not runtime PR evidence:
- `git diff --check`
- Python 3.12 policy assertions: defaults=low; security/confidentiality inherit low; provenance=off; desktop-den-sync=high.

No existing journey test observes GitHub review routing, so no unrelated journey was run and no new spec was invented.

## Missing hosted proof
- Positive: an advisory-only run shows findings in check summaries and creates no new review threads.
- Negative: a mixed run confirms medium/low security and confidentiality findings and high desktop-den sync findings are still reported and enforced.

This PR changes guarded review machinery (`warden.toml` and a workflow), so the unchanged security guard intentionally withholds Warden auto-approval. Independent review is required. Keep the PR draft until the missing runtime proof is available; passing builds alone do not satisfy it.