### PR TITLE
fix(session): confirm Stop for canonical workspace aliases

### DIFF
--- a/apps/app/src/app/lib/opencode-interruption.ts
+++ b/apps/app/src/app/lib/opencode-interruption.ts
@@ -149,8 +149,17 @@ async function stopForegroundTree(
   if (childResult.status === "rejected") throw childResult.reason;
   const root = rootResult.value;
   const before = childResult.value;
-  if (root.id !== rootID || (directory !== undefined && root.directory !== directory)) {
+  if (root.id !== rootID) {
     throw new Error("Could not verify the conversation's workspace. Stop was not confirmed.");
+  }
+  if (directory !== undefined && root.directory !== directory) {
+    // The engine may canonicalize a scoped directory (for example, a symlinked
+    // OS path). Trust the engine's scoped /path result, not a browser-side path
+    // rewrite or the session's claim alone.
+    const canonical = unwrap(await client.path.get({ directory }, options));
+    if (typeof canonical.directory !== "string" || canonical.directory.length === 0 || canonical.directory !== root.directory) {
+      throw new Error("Could not verify the conversation's workspace. Stop was not confirmed.");
+    }
   }
   const targets = new Set<string>();
   const stop = async (sessionID: string, knownChildren: string[] = []) => {

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -561,6 +561,90 @@ describe("native Stop and follow-up handoff", () => {
     });
   });
 
+  test("accepts an engine-confirmed canonical workspace alias before stopping owned children and admitting one follow-up", async () => {
+    const requestedDirectory = "/tmp/openwork-alias";
+    const canonicalDirectory = "/private/tmp/openwork-alias";
+    const root = { ...session, id: "ses_canonical_alias", directory: canonicalDirectory };
+    const child = { ...session, id: "ses_canonical_child", directory: canonicalDirectory, parentID: root.id };
+    const aborted: string[] = [];
+    let sends = 0;
+    await withSessionFetch((request) => {
+      const url = new URL(request.url);
+      const path = url.pathname;
+      if (path.endsWith("/path")) return Response.json({ state: "", config: "", worktree: canonicalDirectory, directory: canonicalDirectory });
+      if (path.endsWith(`/session/${root.id}`)) return Response.json(root);
+      if (path.endsWith(`/session/${child.id}`)) return Response.json(child);
+      if (path.endsWith(`/session/${root.id}/message`)) return Response.json(turnMessages(root.id, [delegatedTool(child.id)]));
+      if (path.endsWith(`/session/${child.id}/message`)) return Response.json(turnMessages(child.id));
+      if (path.endsWith("/abort")) {
+        const id = path.match(/\/session\/([^/]+)\/abort$/)?.[1];
+        if (id) aborted.push(id);
+        return Response.json(true);
+      }
+      if (path.endsWith("/status")) return Response.json({});
+      if (path.endsWith("/prompt_async")) { sends += 1; return new Response(null, { status: 204 }); }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const client = createClient(endpoint.opencodeBaseUrl, requestedDirectory);
+      const stop = interruptSessionTurn(endpoint.opencodeBaseUrl, client, root.id, requestedDirectory, { timeoutMs: 1_000 });
+      const followUp = submitAfterInterruption(endpoint.opencodeBaseUrl, root.id, async () => unwrap(await client.session.promptAsync({
+        sessionID: root.id, parts: [{ type: "text", text: "follow-up" }],
+      })));
+      await Promise.all([stop, followUp]);
+
+      expect(aborted).toEqual([root.id, root.id, child.id]);
+      expect(sends).toBe(1);
+      expect(sessionNeedsStop(endpoint.opencodeBaseUrl, root.id)).toBe(false);
+      const pathRequests = requests.filter((request) => new URL(request.url).pathname.endsWith("/path"));
+      expect(pathRequests).toHaveLength(1);
+      expect(new URL(pathRequests[0]!.url).searchParams.get("directory")).toBe(requestedDirectory);
+    });
+  });
+
+  test("rejects mismatched root identity, invalid canonical workspaces, and failed canonical reads after attempting native abort", async () => {
+    for (const mismatch of ["sessionID", "directory", "canonical-read", "missing-directories", "empty-directories"]) {
+      const requestedDirectory = `/tmp/openwork-${mismatch}`;
+      const rootID = `ses_root_${mismatch}`;
+      const { directory: _sessionDirectory, ...sessionWithoutDirectory } = session;
+      const root = {
+        ...(mismatch === "missing-directories" ? sessionWithoutDirectory : session),
+        id: mismatch === "sessionID" ? "ses_wrong_root" : rootID,
+        ...(mismatch === "missing-directories" ? {} : {
+          directory: mismatch === "sessionID" ? requestedDirectory : mismatch === "empty-directories" ? "" : `/private${requestedDirectory}`,
+        }),
+      };
+      let sends = 0;
+      await withSessionFetch((request) => {
+        const url = new URL(request.url);
+        const path = url.pathname;
+        if (path.endsWith(`/session/${rootID}`)) return Response.json(root);
+        if (path.endsWith(`/session/${rootID}/message`)) return Response.json(turnMessages(rootID));
+        if (path.endsWith("/abort")) return Response.json(true);
+        if (path.endsWith("/path")) {
+          if (mismatch === "canonical-read") return Response.json({ message: "Canonical path unavailable" }, { status: 503 });
+          if (mismatch === "missing-directories") return Response.json({ state: "", config: "", worktree: requestedDirectory });
+          return Response.json({
+            state: "", config: "", worktree: requestedDirectory,
+            directory: mismatch === "empty-directories" ? "" : requestedDirectory,
+          });
+        }
+        if (path.endsWith("/prompt_async")) { sends += 1; return new Response(null, { status: 204 }); }
+        throw new Error(`Unexpected request: ${request.method} ${path}`);
+      }, async (requests) => {
+        const baseUrl = `${endpoint.opencodeBaseUrl}-${mismatch}`;
+        const client = createClient(baseUrl, requestedDirectory);
+        const expectedError = mismatch === "canonical-read" ? "Canonical path unavailable" : "Could not verify the conversation's workspace";
+        await expect(interruptSessionTurn(baseUrl, client, rootID, requestedDirectory, { timeoutMs: 1_000 })).rejects.toThrow(expectedError);
+        await expect(submitAfterInterruption(baseUrl, rootID, async () => { sends += 1; })).rejects.toThrow(expectedError);
+
+        expect(sessionNeedsStop(baseUrl, rootID)).toBe(true);
+        expect(sends).toBe(0);
+        expect(requests.filter((request) => request.method === "POST" && new URL(request.url).pathname.endsWith("/abort"))).toHaveLength(1);
+        expect(requests.filter((request) => new URL(request.url).pathname.endsWith("/path"))).toHaveLength(mismatch === "sessionID" ? 0 : 1);
+      });
+    }
+  });
+
   test("stops only the current foreground tree and holds follow-up through delayed child abort and authoritative idle", async () => {
     const root = { ...session, id: "ses_tree" };
     const baseUrl = endpoint.opencodeBaseUrl;


### PR DESCRIPTION
## Summary
- Confirm equivalent workspace paths through the native engine's scoped `/path` response instead of rejecting aliases such as `/tmp` and `/private/tmp`.
- Preserve exact session identity, child ownership, authoritative idle confirmation, and the failed-Stop submission fence.
- Reject missing/empty canonical paths, foreign workspaces, and failed canonical reads.

## Scope
Two files only: the Stop helper and its existing unit tests. The unfinished app-web fixture, session-switch benchmarks, and child-activity changes are not included.

## Verification
**Merge readiness: Incomplete. Runtime journey verdict: Failed.** This PR is intentionally a draft; unit success is not runtime proof.

- `pnpm --filter @openwork/app exec bun test --isolate ./tests/opencode-session-native.test.ts`: 23 passed, 0 failed, 296 assertions.
- App typecheck and `git diff --check`: passed.
- Final-head runtime command: `OPENWORK_WORLD_PLACE=local OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_MAX_WORKERS=1 pnpm evals:e2e parent-child-permission-approval --local` (inherited preview/remote/alternate-surface overrides cleared).
- Printed placement: `local (--local)`. Exit 1: **1 passed, 3 failed, 0 skipped**.
- Failures before Stop: missing running treatment after child approval; unable to locate the Stop permission conversation; unrelated question still visible after switching. These have not been classified as pre-existing.

Required before marking ready: a successful current-head runtime assertion for canonical-alias Stop and follow-up isolation, plus required CI/review clearance. Earlier prototype runs are not claimed as evidence for this isolated PR.