### PR TITLE
feat(den-api): add a kubernetes worker provisioner

### DIFF
--- a/docs/kubernetes-workers.md
+++ b/docs/kubernetes-workers.md
@@ -1,0 +1,100 @@
+# Kubernetes Worker Provisioner
+
+Status: self-host operator guide
+Related: `packaging/helm/openwork-ee`, `ee/apps/den-api/src/workers/kubernetes.ts`, `ee/apps/den-api/src/workers/kubernetes-client.ts`, `packaging/docker/Dockerfile.microsandbox`, `scripts/build-microsandbox-openwork-image.sh`
+
+`PROVISIONER_MODE=kubernetes` makes `den-api` provision every cloud worker directly in your Kubernetes cluster. Each worker becomes a Deployment, a ClusterIP Service, a token Secret, and two PersistentVolumeClaims (`/workspace`, `/data`). This is the fully self-hosted alternative to the hosted Daytona and Render providers: workers run on your nodes, store data in your storage classes, and never leave your network boundary.
+
+## Architecture
+
+```
+den-api (release namespace, ServiceAccount <release>-den-api)
+  │  Kubernetes REST API (in-cluster SA token or KUBERNETES_API_TOKEN)
+  ▼
+worker namespace (default: openwork-workers)
+  ├─ Deployment/<worker-name>            openwork-server + managed opencode
+  ├─ Service/<worker-name>               ClusterIP → pod :8787
+  ├─ Secret/<worker-name>-tokens         OPENWORK_TOKEN, OPENWORK_HOST_TOKEN,
+  │                                      DEN_ACTIVITY_HEARTBEAT_TOKEN (stringData)
+  ├─ PVC/<worker-name>-workspace         mounted at /workspace
+  └─ PVC/<worker-name>-data              mounted at /data (opencode + sidecar state)
+```
+
+Worker names derive from the worker id (`wrk_<base32>` → `wrk-<base32>`, already DNS-1123-safe). den-api waits for the worker's `/health` endpoint before recording the worker healthy, stores the instance URL, and relies on the same reconciler, wake, and idle-stop lifecycle as the other providers.
+
+## Prerequisites
+
+- A Kubernetes cluster (k3s, kubeadm, EKS, GKE, AKS all work) with a default or configured StorageClass that supports `ReadWriteOnce` PVCs.
+- MySQL for den-api (unchanged from the standard chart install).
+- The worker image, built from `packaging/docker/Dockerfile.microsandbox` and pushed to a registry the cluster can pull from:
+
+  ```bash
+  ./scripts/build-microsandbox-openwork-image.sh
+  # tag + push to your registry, then set config.kubernetes.workerImage
+  ```
+
+- Out-of-cluster installs only: `KUBERNETES_API_URL` (+ optional `KUBERNETES_API_TOKEN` / `KUBERNETES_API_CA_FILE`). In-cluster, leave them empty — the ServiceAccount token and CA are used automatically.
+
+## Helm values example
+
+```yaml
+config:
+  provisioner:
+    mode: kubernetes
+    # Only needed if workers must be reachable by hostname outside the cluster.
+    workerUrlTemplate: ""            # e.g. https://{workerId}.workers.example.com
+  kubernetes:
+    workerImage: registry.example.com/openwork-microsandbox:0.18.37
+    workerNamespace: openwork-workers
+    workerStorageClass: ceph-block   # omit for the cluster default
+    workerWorkspaceVolumeSize: "10Gi"
+    workerDataVolumeSize: "10Gi"
+
+workers:
+  kubernetes:
+    createNamespace: true
+    serviceAccount:
+      create: true
+    rbac:
+      create: true
+```
+
+The chart then renders: the `den-api` ServiceAccount, the worker Namespace, and a namespaced Role + RoleBinding. Nothing cluster-scoped is created. The Role is limited to worker-object management (Deployments, Services, Secrets, PVCs) plus pod list/log reads for provisioning diagnostics, and worker pods run with `automountServiceAccountToken: false`.
+
+## RBAC scope
+
+| Resources | Verbs |
+| --- | --- |
+| `apps/deployments` | get, list, create, update, patch, delete |
+| `services`, `secrets`, `persistentvolumeclaims` | get, list, create, delete |
+| `pods` | get, list |
+| `pods/log` | get |
+
+All rules apply to the worker namespace only.
+
+## URLs and ingress
+
+- In-cluster (default): den-api reaches workers at `http://<worker-name>.<worker-namespace>.svc.cluster.local:8787`. No ingress, no public exposure.
+- Public hostnames: set `config.provisioner.workerUrlTemplate` (e.g. `https://{workerId}.workers.example.com`). The `{workerId}` placeholder receives the hyphenated worker NAME. You own the ingress, TLS, and auth for those hosts; the chart does not render worker ingresses.
+- Heartbeats: worker pods call back to den-api (`WORKER_ACTIVITY_BASE_URL`, which follows the internal API URL) for activity heartbeats. Default-deny network policies must therefore allow worker-namespace egress to the den-api Service, plus DNS.
+
+## Lifecycle
+
+- **Provision**: PVCs → token Secret → Deployment → Service, then den-api polls the worker `/health` endpoint until healthy (timeout `KUBERNETES_HEALTHCHECK_TIMEOUT_MS`, default 5m). Health-timeout diagnostics include a redacted pod-log tail.
+- **Idle stop**: the idle loop scales the Deployment to 0 after `CLOUD_IDLE_STOP_MINUTES` (default 30) without activity. PVCs and the token Secret survive.
+- **Wake**: requesting worker tokens (or the reconciler/resume path) scales the Deployment back to 1. If the recorded image version is older than `KUBERNETES_WORKER_IMAGE`, the container image is patched first, so the workspace and data persist across image upgrades.
+- **Deprovision**: deleting the worker removes the Deployment, Service, Secret, and both PVCs. **This is data erasure** — workspace files and opencode state are destroyed with the worker, matching the Daytona deprovision contract.
+
+## Limitations in this release
+
+- The hosted `/v1/cloud/*` browser surface (instance provisioning through the web app) remains Daytona-gated; the Kubernetes provisioner covers worker provisioning via the worker API and desktop flows.
+- Migrating an existing Daytona/Render worker to Kubernetes (or back) is unsupported. Workers are tied to their provisioning mode.
+- No pod-level autoscaling: one worker per user, scaled between 0 and 1 replicas.
+- PVCs use `ReadWriteOnce`; the Deployment uses a Recreate strategy so image updates cannot MultiAttach-stall behind a terminating pod.
+
+## Troubleshooting
+
+- **Worker stuck in `provisioning`**: check `cloud_failure_code`/`cloud_failure_stage` on the worker row and den-api logs (`kubernetes_provisioner` component). Quota or scheduling failures surface through the cloud failure codes; pod log tails appear in health-timeout errors (tokens redacted).
+- **`Multi-Attach` volume errors**: an image patch or rolling update raced a pod termination. The Recreate strategy prevents this; if you see it after manual edits, delete the old pod first.
+- **Health timeout**: `kubectl get pods -n openwork-workers -l openwork.den.worker-id=<workerId>`; the pod may be ImagePullBackOff (bad `workerImage`), CrashLoopBackOff (check `kubectl logs`), or Pending (insufficient resources or unbound PVC — check the StorageClass).
+- **Workers cannot reach den-api**: heartbeats stop, idle-stop may not observe activity. Verify egress from the worker namespace to the den-api Service port and DNS.

--- a/docs/kubernetes-workers.md
+++ b/docs/kubernetes-workers.md
@@ -94,6 +94,49 @@ All rules apply to the worker namespace only.
 - No pod-level autoscaling: one worker per user, scaled between 0 and 1 replicas.
 - PVCs use `ReadWriteOnce`; the Deployment uses a Recreate strategy so image updates cannot MultiAttach-stall behind a terminating pod.
 
+
+## Worker pod customization
+
+All optional — when unset the provisioner builds its default pod shape. Set them under `config.kubernetes` when your cluster needs scheduling, registry, security, or network controls the defaults don't cover.
+
+| Helm value | Purpose |
+| --- | --- |
+| `workerImagePullSecrets` | names of image-pull secrets for a private worker registry (string list) |
+| `workerNodeSelector` | pin workers to a node pool (e.g. GPU nodes) |
+| `workerTolerations` | tolerate taints on those nodes |
+| `workerAffinity` | full affinity rules |
+| `workerTopologySpreadConstraints` | spread workers across zones |
+| `workerPriorityClassName` | priority/preemption class |
+| `workerPodAnnotations` | annotations for monitoring/network-policy/cost tooling |
+| `workerPodLabels` | labels (merged; the provisioner's selector labels always win on collision) |
+| `workerPodSecurityContext` | pod-level `securityContext` (runAsNonRoot, fsGroup, seccomp…) |
+| `workerContainerSecurityContext` | container-level `securityContext` |
+| `workerExtraVolumes` | extra volumes (a `name` colliding with `workspace`/`data` is dropped) |
+| `workerExtraVolumeMounts` | matching mounts (same collision rule) |
+| `workerExtraEnv` | extra env vars (a `name` colliding with a provisioner env var is dropped — worker tokens cannot be overridden) |
+| `workerDnsPolicy` / `workerDnsConfig` | custom pod DNS |
+
+Object/array values are emitted as JSON; den-api parses them. Example:
+
+```yaml
+config:
+  provisioner:
+    mode: kubernetes
+  kubernetes:
+    workerImage: registry.corp/openwork-microsandbox:v1
+    workerImagePullSecrets:
+      - corp-regcred
+    workerNodeSelector:
+      nodepool: gpu
+    workerTolerations:
+      - key: gpu
+        operator: Exists
+    workerPodLabels:
+      team: platform
+```
+
+Collision handling: the provisioner's selector labels (`openwork.den.worker-id`, `openwork.den.provider`), its `workspace`/`data` volumes, and its env vars (worker tokens, runtime config) always win. Operator extras that collide are dropped with a `kubernetes_provisioner` warning rather than failing the provision.
+
 ## Troubleshooting
 
 - **Worker stuck in `provisioning`**: check `cloud_failure_code`/`cloud_failure_stage` on the worker row and den-api logs (`kubernetes_provisioner` component). Quota or scheduling failures surface through the cloud failure codes; pod log tails appear in health-timeout errors (tokens redacted).

--- a/docs/kubernetes-workers.md
+++ b/docs/kubernetes-workers.md
@@ -65,10 +65,12 @@ The chart then renders: the `den-api` ServiceAccount, the worker Namespace, and 
 
 | Resources | Verbs |
 | --- | --- |
-| `apps/deployments` | get, list, create, update, patch, delete |
-| `services`, `secrets`, `persistentvolumeclaims` | get, list, create, delete |
+| `apps/deployments` | get, create, patch, delete |
+| `services`, `secrets`, `persistentvolumeclaims` | get, create, delete |
 | `pods` | get, list |
 | `pods/log` | get |
+
+`pods get` is required because den-api reads the `pods/log` subresource (health-timeout diagnostics) in addition to listing pods by label selector.
 
 All rules apply to the worker namespace only.
 

--- a/ee/apps/den-api/src/automations/cloud-agent-executor.ts
+++ b/ee/apps/den-api/src/automations/cloud-agent-executor.ts
@@ -153,7 +153,7 @@ async function ownerCloudWorker(scope: OwnerScope) {
 }
 
 export async function cloudAgentRuntimeAvailable(scope: OwnerScope): Promise<boolean> {
-  if (env.provisionerMode !== "daytona" || !env.daytona.apiKey) return false
+  if (env.provisionerMode === "daytona" ? !env.daytona.apiKey : env.provisionerMode !== "kubernetes") return false
   const organizationId = normalizeDenTypeId("organization", scope.organizationId)
   const members = await db.select({ id: MemberTable.id }).from(MemberTable).where(and(
     eq(MemberTable.id, normalizeDenTypeId("member", scope.ownerMemberId)),

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -103,7 +103,7 @@ const EnvSchema = z.object({
   CLOUD_IDLE_STOP_MINUTES: z.string().optional(),
   CLOUD_IDLE_LOOP_SECONDS: z.string().optional(),
   CLOUD_IDLE_STOP_BATCH_SIZE: z.string().optional(),
-  PROVISIONER_MODE: z.enum(["stub", "render", "daytona"]).optional(),
+  PROVISIONER_MODE: z.enum(["stub", "render", "daytona", "kubernetes"]).optional(),
   WORKER_URL_TEMPLATE: z.string().optional(),
   WORKER_ACTIVITY_BASE_URL: z.string().optional(),
   DEN_AUTOMATIONS_ENABLED: z.string().optional(),
@@ -179,6 +179,24 @@ const EnvSchema = z.object({
   DAYTONA_DELETE_TIMEOUT_SECONDS: z.string().optional(),
   DAYTONA_STOP_TIMEOUT_SECONDS: z.string().optional(),
   DAYTONA_HEALTHCHECK_TIMEOUT_MS: z.string().optional(),
+  KUBERNETES_API_URL: z.string().optional(),
+  KUBERNETES_API_TOKEN: z.string().optional(),
+  KUBERNETES_API_CA_FILE: z.string().optional(),
+  KUBERNETES_WORKER_NAMESPACE: z.string().optional(),
+  KUBERNETES_WORKER_IMAGE: z.string().optional(),
+  KUBERNETES_WORKER_IMAGE_PULL_POLICY: z.string().optional(),
+  KUBERNETES_WORKER_PORT: z.string().optional(),
+  KUBERNETES_WORKER_APPROVAL_MODE: z.string().optional(),
+  KUBERNETES_WORKER_CPU_REQUEST: z.string().optional(),
+  KUBERNETES_WORKER_CPU_LIMIT: z.string().optional(),
+  KUBERNETES_WORKER_MEMORY_REQUEST: z.string().optional(),
+  KUBERNETES_WORKER_MEMORY_LIMIT: z.string().optional(),
+  KUBERNETES_WORKER_WORKSPACE_VOLUME_SIZE: z.string().optional(),
+  KUBERNETES_WORKER_DATA_VOLUME_SIZE: z.string().optional(),
+  KUBERNETES_WORKER_STORAGE_CLASS: z.string().optional(),
+  KUBERNETES_HEALTHCHECK_TIMEOUT_MS: z.string().optional(),
+  KUBERNETES_POLL_INTERVAL_MS: z.string().optional(),
+  KUBERNETES_WORKER_RECORD_TTL_SECONDS: z.string().optional(),
   DEN_CKPT_INTERVAL_SECONDS: z.string().optional(),
   DEN_CKPT_KEEP: z.string().optional(),
   INFERENCE_PROXY_BASE_URL: z.string().optional(),
@@ -228,6 +246,18 @@ const EnvSchema = z.object({
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `${key} is required when PROVISIONER_MODE=daytona`,
+          path: [key],
+        })
+      }
+    }
+  }
+
+  if (value.PROVISIONER_MODE === "kubernetes") {
+    for (const key of ["KUBERNETES_WORKER_IMAGE"] as const) {
+      if (!value[key]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${key} is required when PROVISIONER_MODE=kubernetes`,
           path: [key],
         })
       }
@@ -915,5 +945,36 @@ export const env = {
     checkpointIntervalSeconds: Number(parsed.DEN_CKPT_INTERVAL_SECONDS ?? "300"),
     checkpointKeep: Number(parsed.DEN_CKPT_KEEP ?? "3"),
     pollIntervalMs: DEN_WORKER_POLL_INTERVAL_MS,
+  },
+  kubernetes: {
+    apiUrl: optionalString(parsed.KUBERNETES_API_URL),
+    apiToken: optionalString(parsed.KUBERNETES_API_TOKEN),
+    apiCaFile: optionalString(parsed.KUBERNETES_API_CA_FILE),
+    workerNamespace:
+      optionalString(parsed.KUBERNETES_WORKER_NAMESPACE) ?? "openwork-workers",
+    workerImage: optionalString(parsed.KUBERNETES_WORKER_IMAGE),
+    workerImagePullPolicy:
+      optionalString(parsed.KUBERNETES_WORKER_IMAGE_PULL_POLICY) ?? "IfNotPresent",
+    workerPort: Number(parsed.KUBERNETES_WORKER_PORT ?? "8787"),
+    workerApprovalMode:
+      optionalString(parsed.KUBERNETES_WORKER_APPROVAL_MODE) ?? "manual",
+    workerResources: {
+      cpuRequest: optionalString(parsed.KUBERNETES_WORKER_CPU_REQUEST) ?? "500m",
+      cpuLimit: optionalString(parsed.KUBERNETES_WORKER_CPU_LIMIT) ?? "2",
+      memoryRequest: optionalString(parsed.KUBERNETES_WORKER_MEMORY_REQUEST) ?? "1Gi",
+      memoryLimit: optionalString(parsed.KUBERNETES_WORKER_MEMORY_LIMIT) ?? "4Gi",
+    },
+    workspaceVolumeSize:
+      optionalString(parsed.KUBERNETES_WORKER_WORKSPACE_VOLUME_SIZE) ?? "10Gi",
+    dataVolumeSize:
+      optionalString(parsed.KUBERNETES_WORKER_DATA_VOLUME_SIZE) ?? "10Gi",
+    workerStorageClass: optionalString(parsed.KUBERNETES_WORKER_STORAGE_CLASS),
+    healthcheckTimeoutMs: Number(
+      parsed.KUBERNETES_HEALTHCHECK_TIMEOUT_MS ?? "300000",
+    ),
+    pollIntervalMs: Number(parsed.KUBERNETES_POLL_INTERVAL_MS ?? "1000"),
+    workerRecordTtlSeconds: Number(
+      parsed.KUBERNETES_WORKER_RECORD_TTL_SECONDS ?? "3600",
+    ),
   },
 }

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -199,6 +199,22 @@ const EnvSchema = z.object({
   KUBERNETES_HEALTHCHECK_TIMEOUT_MS: z.string().optional(),
   KUBERNETES_POLL_INTERVAL_MS: z.string().optional(),
   KUBERNETES_WORKER_RECORD_TTL_SECONDS: z.string().optional(),
+  // Optional operator overrides for the worker pod spec.
+  KUBERNETES_WORKER_IMAGE_PULL_SECRETS: z.string().optional(),
+  KUBERNETES_WORKER_NODE_SELECTOR: z.string().optional(),
+  KUBERNETES_WORKER_TOLERATIONS: z.string().optional(),
+  KUBERNETES_WORKER_AFFINITY: z.string().optional(),
+  KUBERNETES_WORKER_TOPOLOGY_SPREAD_CONSTRAINTS: z.string().optional(),
+  KUBERNETES_WORKER_PRIORITY_CLASS_NAME: z.string().optional(),
+  KUBERNETES_WORKER_POD_ANNOTATIONS: z.string().optional(),
+  KUBERNETES_WORKER_POD_LABELS: z.string().optional(),
+  KUBERNETES_WORKER_POD_SECURITY_CONTEXT: z.string().optional(),
+  KUBERNETES_WORKER_CONTAINER_SECURITY_CONTEXT: z.string().optional(),
+  KUBERNETES_WORKER_EXTRA_VOLUMES: z.string().optional(),
+  KUBERNETES_WORKER_EXTRA_VOLUME_MOUNTS: z.string().optional(),
+  KUBERNETES_WORKER_EXTRA_ENV: z.string().optional(),
+  KUBERNETES_WORKER_DNS_POLICY: z.string().optional(),
+  KUBERNETES_WORKER_DNS_CONFIG: z.string().optional(),
   DEN_CKPT_INTERVAL_SECONDS: z.string().optional(),
   DEN_CKPT_KEEP: z.string().optional(),
   INFERENCE_PROXY_BASE_URL: z.string().optional(),
@@ -290,6 +306,43 @@ function automationTuning(value: string | undefined, fallback: number) {
 function optionalString(value: string | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed : undefined
+}
+
+function optionalJsonObject(value: string | undefined): Record<string, unknown> | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function optionalJsonArray(value: string | undefined): unknown[] | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    return Array.isArray(parsed) ? parsed : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function optionalStringList(value: string | undefined): string[] | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  const names = trimmed.split(",").map((s) => s.trim()).filter(Boolean)
+  return names.length ? names : undefined
 }
 
 function readOptionalSecretFile(envName: string, pathValue: string | undefined) {
@@ -980,5 +1033,36 @@ export const env = {
     workerRecordTtlSeconds: Number(
       parsed.KUBERNETES_WORKER_RECORD_TTL_SECONDS ?? "3600",
     ),
+    // Optional operator overrides for the worker pod spec. All default
+    // unset, leaving the manifest exactly as the provisioner builds it.
+    workerImagePullSecrets:
+      optionalStringList(parsed.KUBERNETES_WORKER_IMAGE_PULL_SECRETS),
+    workerNodeSelector:
+      optionalJsonObject(parsed.KUBERNETES_WORKER_NODE_SELECTOR),
+    workerTolerations:
+      optionalJsonArray(parsed.KUBERNETES_WORKER_TOLERATIONS),
+    workerAffinity:
+      optionalJsonObject(parsed.KUBERNETES_WORKER_AFFINITY),
+    workerTopologySpreadConstraints:
+      optionalJsonArray(parsed.KUBERNETES_WORKER_TOPOLOGY_SPREAD_CONSTRAINTS),
+    workerPriorityClassName:
+      optionalString(parsed.KUBERNETES_WORKER_PRIORITY_CLASS_NAME),
+    workerPodAnnotations:
+      optionalJsonObject(parsed.KUBERNETES_WORKER_POD_ANNOTATIONS),
+    workerPodLabels:
+      optionalJsonObject(parsed.KUBERNETES_WORKER_POD_LABELS),
+    workerPodSecurityContext:
+      optionalJsonObject(parsed.KUBERNETES_WORKER_POD_SECURITY_CONTEXT),
+    workerContainerSecurityContext:
+      optionalJsonObject(parsed.KUBERNETES_WORKER_CONTAINER_SECURITY_CONTEXT),
+    workerExtraVolumes:
+      optionalJsonArray(parsed.KUBERNETES_WORKER_EXTRA_VOLUMES),
+    workerExtraVolumeMounts:
+      optionalJsonArray(parsed.KUBERNETES_WORKER_EXTRA_VOLUME_MOUNTS),
+    workerExtraEnv:
+      optionalJsonArray(parsed.KUBERNETES_WORKER_EXTRA_ENV),
+    workerDnsPolicy: optionalString(parsed.KUBERNETES_WORKER_DNS_POLICY),
+    workerDnsConfig:
+      optionalJsonObject(parsed.KUBERNETES_WORKER_DNS_CONFIG),
   },
 }

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -104,6 +104,8 @@ const EnvSchema = z.object({
   CLOUD_IDLE_LOOP_SECONDS: z.string().optional(),
   CLOUD_IDLE_STOP_BATCH_SIZE: z.string().optional(),
   PROVISIONER_MODE: z.enum(["stub", "render", "daytona", "kubernetes"]).optional(),
+  // {workerId} receives the DNS-safe hyphenated worker name (e.g. wrk-abc...) for
+  // the kubernetes provisioner; the raw worker id's underscore is invalid in DNS.
   WORKER_URL_TEMPLATE: z.string().optional(),
   WORKER_ACTIVITY_BASE_URL: z.string().optional(),
   DEN_AUTOMATIONS_ENABLED: z.string().optional(),
@@ -957,7 +959,9 @@ export const env = {
       optionalString(parsed.KUBERNETES_WORKER_IMAGE_PULL_POLICY) ?? "IfNotPresent",
     workerPort: Number(parsed.KUBERNETES_WORKER_PORT ?? "8787"),
     workerApprovalMode:
-      optionalString(parsed.KUBERNETES_WORKER_APPROVAL_MODE) ?? "manual",
+      // Cloud workers run --approval auto: manual mode's gated writes time out
+      // with 403 because nothing is wired to answer approvals in a sandbox.
+      optionalString(parsed.KUBERNETES_WORKER_APPROVAL_MODE) ?? "auto",
     workerResources: {
       cpuRequest: optionalString(parsed.KUBERNETES_WORKER_CPU_REQUEST) ?? "500m",
       cpuLimit: optionalString(parsed.KUBERNETES_WORKER_CPU_LIMIT) ?? "2",

--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -252,15 +252,16 @@ const CLOUD_NOT_AVAILABLE_MESSAGE =
 
 /**
  * Whether the remote-session capabilities exist on this deployment at all.
- * When Den cannot host Cloud (self-hosted single-org mode or no Daytona
- * provisioner), the capabilities are hidden from search and execute reports
- * them as unknown. Organization entitlement is enforced at execution time by
- * the OpenWork Web access check, which returns a clear access-required error.
+ * When Den cannot host Cloud (self-hosted single-org mode or a provisioner
+ * other than Daytona/Kubernetes), the capabilities are hidden from search and
+ * execute reports them as unknown. Organization entitlement is enforced at
+ * execution time by the OpenWork Web access check, which returns a clear
+ * access-required error.
  */
 export function remoteSessionCapabilitiesEnabled(
   _organizationMetadata?: Record<string, unknown> | string | null | undefined,
 ): boolean {
-  if (env.provisionerMode !== "daytona" || !env.daytona.apiKey) return false
+  if (env.provisionerMode === "daytona" ? !env.daytona.apiKey : env.provisionerMode !== "kubernetes") return false
   return cloudHostingAvailable({ orgMode: env.orgMode })
 }
 

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -16,10 +16,14 @@ import {
   openWorkWebAccessRequiredPayload,
   type OpenWorkWebRuntimeAccessResolver,
 } from "../../openwork-web-runtime-access.js"
-import { currentDaytonaSandboxName, flushWorkerCheckpointOnDaytona, getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview, stopWorkerOnDaytona } from "../../workers/daytona.js"
+import { currentDaytonaSandboxName, flushWorkerCheckpointOnDaytona } from "../../workers/daytona.js"
+import { stopWorkerOnKubernetes } from "../../workers/kubernetes.js"
 import { CLOUD_INSTANCE_BACKEND, CLOUD_INSTANCE_NAME } from "../../workers/cloud-constants.js"
 import { recoverClaimedCloudWorker as defaultRecoverCloudWorker, wakeCloudWorker as defaultWakeCloudWorker } from "../../workers/cloud-lifecycle.js"
 import {
+  defaultGetSandboxRecord,
+  defaultInspectSandbox,
+  defaultRefreshSignedPreview,
   probeCloudRuntimeSignedPreview,
   resolveCloudRuntimeAccess,
   resolveCloudRuntimeState,
@@ -28,6 +32,7 @@ import {
   type CloudRuntimeState,
   type CloudRuntimeStore,
   type CloudRuntimeWorker,
+  type RefreshSignedPreview,
 } from "../../workers/worker-access.js"
 import { appLogger } from "../../observability/logger.js"
 import {
@@ -42,11 +47,11 @@ import { continueCloudProvisioning, token } from "../workers/shared.js"
 type CloudRouteOptions = {
   memberRoute?: MiddlewareHandler<{ Variables: OrgRouteVariables }>
   orgMode?: DenOrgMode
-  provisionerMode?: "stub" | "render" | "daytona"
+  provisionerMode?: "stub" | "render" | "daytona" | "kubernetes"
   daytonaApiKey?: string
   gatewayKey?: string
   continueProvisioning?: typeof continueCloudProvisioning
-  refreshSignedPreview?: typeof refreshDaytonaSignedPreview
+  refreshSignedPreview?: RefreshSignedPreview
   cloudWorkerStore?: CloudWorkerStore
   ensureCloudWorker?: EnsureCloudWorker
   getSandboxRecord?: GetSandboxRecord
@@ -349,8 +354,18 @@ const databaseCloudWorkerStore: CloudWorkerStore = {
 }
 
 function hasDaytonaProvisioner(options: CloudRouteOptions) {
-  const apiKey = options.daytonaApiKey !== undefined ? options.daytonaApiKey : env.daytona.apiKey
-  return (options.provisionerMode ?? env.provisionerMode) === "daytona" && Boolean(apiKey?.trim())
+  const mode = options.provisionerMode ?? env.provisionerMode
+  if (mode === "daytona") {
+    const apiKey = options.daytonaApiKey !== undefined ? options.daytonaApiKey : env.daytona.apiKey
+    return Boolean(apiKey?.trim())
+  }
+  if (mode === "kubernetes") {
+    return Boolean(env.kubernetes.workerImage?.trim())
+  }
+  return false
+}
+function cloudWorkerImage() {
+  return env.provisionerMode === "kubernetes" ? env.kubernetes.workerImage ?? null : env.daytona.snapshot
 }
 
 // Deployment-level availability only. The single-org and no-provisioner 404s
@@ -503,7 +518,7 @@ export function ensureMemberCloudWorker(input: { orgId: OrgId; createdByUserId: 
 }
 
 function workerNeedsUserRequestedUpdate(worker: CloudWorker) {
-  const snapshot = env.daytona.snapshot
+  const snapshot = cloudWorkerImage()
   return Boolean(snapshot && (worker.image_version ?? null) !== snapshot)
 }
 
@@ -536,7 +551,7 @@ function memberCloudInstanceResponse(worker: CloudWorker, instance: CloudRuntime
     url: instance.url,
     imageVersion: worker.image_version ?? null,
     ...(instanceName ? { instanceName } : {}),
-    latestVersion: env.daytona.snapshot ?? null,
+    latestVersion: cloudWorkerImage() ?? null,
     ...(failure ? { failure: publicCloudStartupFailure(failure) } : {}),
   }
 }
@@ -545,7 +560,7 @@ async function resolveCloudInstanceForMember(input: {
   payload: NonNullable<OrgRouteVariables["organizationContext"]>
   user: CloudRouteUser
   continueProvisioning: typeof continueCloudProvisioning
-  refreshSignedPreview: typeof refreshDaytonaSignedPreview
+  refreshSignedPreview: RefreshSignedPreview
   store: CloudWorkerStore
   ensureWorker: EnsureCloudWorker
   getSandboxRecord: GetSandboxRecord
@@ -630,7 +645,7 @@ async function resolveCloudInstanceForGateway(input: {
   payload: NonNullable<OrgRouteVariables["organizationContext"]>
   user: CloudRouteUser
   continueProvisioning: typeof continueCloudProvisioning
-  refreshSignedPreview: typeof refreshDaytonaSignedPreview
+  refreshSignedPreview: RefreshSignedPreview
   store: CloudWorkerStore
   ensureWorker: EnsureCloudWorker
   getSandboxRecord: GetSandboxRecord
@@ -716,17 +731,17 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
   const getOpenWorkWebAccess = options.getOpenWorkWebAccess ?? getOpenWorkWebRuntimeAccess
   const continueProvisioning: typeof continueCloudProvisioning = options.continueProvisioning
     ?? ((input, continueOptions = {}) => continueCloudProvisioning(input, { ...continueOptions, materializeProviders }))
-  const refreshSignedPreview = options.refreshSignedPreview ?? refreshDaytonaSignedPreview
+  const refreshSignedPreview = options.refreshSignedPreview ?? defaultRefreshSignedPreview()
   const store = options.cloudWorkerStore ?? databaseCloudWorkerStore
   const ensureWorker = options.ensureCloudWorker ?? ensureCloudWorker
-  const getSandboxRecord = options.getSandboxRecord ?? getDaytonaSandboxRecord
-  const inspectSandbox = options.inspectSandbox ?? inspectDaytonaSandbox
+  const getSandboxRecord = options.getSandboxRecord ?? defaultGetSandboxRecord()
+  const inspectSandbox = options.inspectSandbox ?? defaultInspectSandbox()
   const signedPreviewProbe = options.probeSignedPreview ?? probeCloudRuntimeSignedPreview
   const wakeCloudWorker = options.wakeCloudWorker ?? defaultWakeCloudWorker
   const recoverCloudWorker = options.recoverCloudWorker
     ?? (options.wakeCloudWorker ? options.wakeCloudWorker : defaultRecoverCloudWorker)
   const flushWorkerCheckpoint = options.flushWorkerCheckpoint ?? flushWorkerCheckpointOnDaytona
-  const stopCloudWorker = options.stopCloudWorker ?? stopWorkerOnDaytona
+  const stopCloudWorker = options.stopCloudWorker ?? stopWorkerOnKubernetes
   const now = options.now ?? Date.now
   const gatewayKey = options.gatewayKey !== undefined ? options.gatewayKey : env.gatewayKey
   const wakingWorkers = new Set<CloudWorker["id"]>()

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -151,7 +151,7 @@ export function persistedWorkerInstanceUrl(provisioned: Pick<ProvisionedWorker, 
 }
 
 export function workerSandboxBackend(input: Pick<z.infer<typeof createWorkerSchema>, "destination" | "sandboxBackend">) {
-  if (input.destination === "cloud" && env.provisionerMode === "daytona") return CLOUD_INSTANCE_BACKEND
+  if (input.destination === "cloud" && (env.provisionerMode === "daytona" || env.provisionerMode === "kubernetes")) return CLOUD_INSTANCE_BACKEND
   return input.sandboxBackend ?? null
 }
 

--- a/ee/apps/den-api/src/workers/cloud-failure.ts
+++ b/ee/apps/den-api/src/workers/cloud-failure.ts
@@ -70,7 +70,7 @@ export function classifyCloudStartupFailure(error: unknown): CloudStartupFailure
   if (message.includes("provisioning deadline") || message.includes("cloud wake") && message.includes("deadline")) {
     return "provisioning_timeout"
   }
-  if (message.includes("timed out waiting for daytona worker health")) return "runtime_health_timeout"
+  if (/timed out waiting for .* worker health/.test(message)) return "runtime_health_timeout"
   if (message.includes("openwork session exited") || message.includes("binary missing")) return "runtime_start_failed"
   if (message.includes("sandbox") && message.includes("not found")) return "sandbox_missing"
   if (message.includes("start failed") || message.includes("sandbox") && message.includes("state change")) {

--- a/ee/apps/den-api/src/workers/cloud-lifecycle.ts
+++ b/ee/apps/den-api/src/workers/cloud-lifecycle.ts
@@ -14,6 +14,12 @@ import {
   wakeWorkerOnDaytona,
   type StopWorkerOnDaytonaResult,
 } from "./daytona.js"
+import {
+  isKubernetesWorkerMissingError,
+  provisionWorkerOnKubernetes,
+  stopWorkerOnKubernetes,
+  wakeWorkerOnKubernetes,
+} from "./kubernetes.js"
 import { withProvisionDeadline } from "./provision-deadline.js"
 import { touchProvisioningWorker, withProvisioningHeartbeat } from "./provisioning-heartbeat.js"
 import {
@@ -27,9 +33,9 @@ type WorkerId = typeof WorkerTable.$inferSelect.id
 type WorkerStatus = typeof WorkerTable.$inferSelect.status
 type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status" | "last_active_at" | "updated_at"> & Partial<Pick<typeof WorkerTable.$inferSelect, "org_id">>
 type WorkerToken = typeof WorkerTokenTable.$inferSelect
-type WakeWorkerOnDaytona = typeof wakeWorkerOnDaytona
-type ProvisionWorkerOnDaytona = typeof provisionWorkerOnDaytona
-type StopWorkerOnDaytona = typeof stopWorkerOnDaytona
+type WakeCloudWorker = typeof wakeWorkerOnDaytona
+type ProvisionCloudWorker = typeof provisionWorkerOnDaytona
+type StopCloudWorker = typeof stopWorkerOnDaytona
 
 type CloudLifecycleStore = {
   getWorker: (workerId: WorkerId) => Promise<CloudWorker | null>
@@ -49,8 +55,8 @@ type CloudLifecycleStore = {
 
 type WakeCloudWorkerOptions = {
   store?: CloudLifecycleStore
-  wakeWorker?: WakeWorkerOnDaytona
-  provisionWorker?: ProvisionWorkerOnDaytona
+  wakeWorker?: WakeCloudWorker
+  provisionWorker?: ProvisionCloudWorker
   materializeProviders?: typeof materializeCloudWorkerProviders
   deadlineMs?: number
   heartbeatIntervalMs?: number
@@ -58,7 +64,7 @@ type WakeCloudWorkerOptions = {
 
 type StopIdleCloudWorkersOptions = {
   store?: CloudLifecycleStore
-  stopWorker?: StopWorkerOnDaytona
+  stopWorker?: StopCloudWorker
   provisionerMode?: typeof env.provisionerMode
   idleMs?: number
   idleBefore?: Date
@@ -77,6 +83,18 @@ let cloudIdleStopPromise: Promise<void> | null = null
 
 function tokenByScope(tokens: WorkerToken[], scope: typeof WorkerTokenTable.$inferSelect.scope) {
   return tokens.find((entry) => entry.scope === scope)?.token ?? null
+}
+
+function defaultWakeWorker(): WakeCloudWorker {
+  return env.provisionerMode === "kubernetes" ? wakeWorkerOnKubernetes : wakeWorkerOnDaytona
+}
+
+function defaultProvisionWorker(): ProvisionCloudWorker {
+  return env.provisionerMode === "kubernetes" ? provisionWorkerOnKubernetes : provisionWorkerOnDaytona
+}
+
+function defaultStopWorker(): StopCloudWorker {
+  return env.provisionerMode === "kubernetes" ? stopWorkerOnKubernetes : stopWorkerOnDaytona
 }
 
 const databaseCloudLifecycleStore: CloudLifecycleStore = {
@@ -200,8 +218,8 @@ async function safelyMarkWorkerFailed(store: CloudLifecycleStore, workerId: Work
 
 async function runClaimedCloudWorkerRecovery(workerId: WorkerId, options: WakeCloudWorkerOptions) {
   const store = options.store ?? databaseCloudLifecycleStore
-  const wakeWorker = options.wakeWorker ?? wakeWorkerOnDaytona
-  const provisionWorker = options.provisionWorker ?? provisionWorkerOnDaytona
+  const wakeWorker = options.wakeWorker ?? defaultWakeWorker()
+  const provisionWorker = options.provisionWorker ?? defaultProvisionWorker()
   const materializeProviders = options.materializeProviders ?? materializeCloudWorkerProviders
   const deadlineMs = options.deadlineMs ?? env.cloudProvisionDeadlineMs
 
@@ -252,7 +270,7 @@ async function runClaimedCloudWorkerRecovery(workerId: WorkerId, options: WakeCl
             try {
               return await wakeWorker(wakeInput)
             } catch (error) {
-              if (!isDaytonaSandboxMissingError(error)) {
+              if (!isDaytonaSandboxMissingError(error) && !isKubernetesWorkerMissingError(error)) {
                 throw error
               }
 
@@ -347,12 +365,13 @@ function stopResultAllowsStoppedStatus(result: StopWorkerOnDaytonaResult) {
 }
 
 export async function stopIdleCloudWorkers(options: StopIdleCloudWorkersOptions = {}) {
-  if ((options.provisionerMode ?? env.provisionerMode) !== "daytona") {
+  const mode = options.provisionerMode ?? env.provisionerMode
+  if (mode !== "daytona" && mode !== "kubernetes") {
     return { checked: 0, stopped: 0 }
   }
 
   const store = options.store ?? databaseCloudLifecycleStore
-  const stopWorker = options.stopWorker ?? stopWorkerOnDaytona
+  const stopWorker = options.stopWorker ?? defaultStopWorker()
   const idleBefore = options.idleBefore ?? new Date(Date.now() - (options.idleMs ?? env.cloudIdleStopMs))
   const workers = await store.listIdleWorkers({
     idleBefore,

--- a/ee/apps/den-api/src/workers/kubernetes-client.ts
+++ b/ee/apps/den-api/src/workers/kubernetes-client.ts
@@ -1,0 +1,211 @@
+import { readFileSync } from "node:fs"
+import { Agent, fetch as undiciFetch } from "undici"
+
+const inClusterTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+const inClusterCaPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+export class KubernetesApiError extends Error {
+  readonly status: number
+  readonly body: string
+
+  constructor(message: string, status: number, body: string) {
+    super(message)
+    this.name = "KubernetesApiError"
+    this.status = status
+    this.body = body
+  }
+}
+
+export class KubernetesNotFoundError extends KubernetesApiError {
+  constructor(resource: string, body: string) {
+    super(`Kubernetes ${resource} not found`, 404, body)
+    this.name = "KubernetesNotFoundError"
+  }
+}
+
+export function isKubernetesNotFoundError(error: unknown) {
+  return error instanceof KubernetesNotFoundError
+    || (error instanceof KubernetesApiError && error.status === 404)
+}
+
+export type KubernetesClientConfig = {
+  apiUrl?: string
+  apiToken?: string
+  apiCaFile?: string
+}
+
+type KubernetesObject = Record<string, unknown>
+
+function readTokenFile(path: string) {
+  return readFileSync(path, "utf8").trim()
+}
+
+function resolveBaseUrl(config: KubernetesClientConfig) {
+  const explicit = config.apiUrl?.trim()
+  if (explicit) {
+    return explicit.replace(/\/+$/, "")
+  }
+
+  const host = process.env.KUBERNETES_SERVICE_HOST
+  const port = process.env.KUBERNETES_SERVICE_PORT
+  if (!host || !port) {
+    throw new Error(
+      "KUBERNETES_API_URL is required when not running inside a Kubernetes cluster",
+    )
+  }
+
+  return `https://${host}:${port}`
+}
+
+export function createKubernetesClient(config: KubernetesClientConfig & { namespace: string }) {
+  const baseUrl = resolveBaseUrl(config)
+  const isInClusterCa = !config.apiCaFile && baseUrl.startsWith("https://")
+    && Boolean(process.env.KUBERNETES_SERVICE_HOST)
+
+  let cachedDispatcher: Agent | null = null
+
+  function dispatcher(): Agent | null {
+    if (!baseUrl.startsWith("https://")) {
+      return null
+    }
+
+    if (cachedDispatcher) {
+      return cachedDispatcher
+    }
+
+    const caPath = config.apiCaFile ?? (isInClusterCa ? inClusterCaPath : undefined)
+    const ca = caPath ? readFileSync(caPath, "utf8") : undefined
+    cachedDispatcher = new Agent({ connect: ca ? { ca } : {} })
+    return cachedDispatcher
+  }
+
+  // ServiceAccount tokens rotate; resolve per request instead of caching.
+  function authorizationHeader() {
+    if (config.apiToken?.trim()) {
+      return `Bearer ${config.apiToken.trim()}`
+    }
+
+    return `Bearer ${readTokenFile(inClusterTokenPath)}`
+  }
+
+  async function request(path: string, init: {
+    method?: string
+    body?: unknown
+    contentType?: string
+    accept?: string
+  } = {}): Promise<string> {
+    const headers: Record<string, string> = {
+      Authorization: authorizationHeader(),
+      Accept: init.accept ?? "application/json",
+    }
+    if (init.body !== undefined) {
+      headers["Content-Type"] = init.contentType ?? "application/json"
+    }
+
+    const response = await undiciFetch(`${baseUrl}${path}`, {
+      method: init.method ?? "GET",
+      headers,
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      signal: AbortSignal.timeout(30_000),
+      dispatcher: dispatcher() ?? undefined,
+    })
+
+    const text = await response.text()
+
+    if (response.status === 404) {
+      throw new KubernetesNotFoundError(path, text)
+    }
+
+    if (!response.ok) {
+      throw new KubernetesApiError(
+        `Kubernetes API ${init.method ?? "GET"} ${path} failed (${response.status}): ${text.slice(0, 400)}`,
+        response.status,
+        text,
+      )
+    }
+
+    return text
+  }
+
+  async function requestJson<T extends KubernetesObject>(path: string, init?: Parameters<typeof request>[1]): Promise<T> {
+    const text = await request(path, init)
+    return text ? JSON.parse(text) as T : {} as T
+  }
+
+  const namespace = config.namespace
+
+  return {
+    namespace,
+    async getDeployment(name: string) {
+      return requestJson<KubernetesObject>(`/apis/apps/v1/namespaces/${namespace}/deployments/${name}`)
+    },
+    async createDeployment(manifest: KubernetesObject) {
+      return requestJson<KubernetesObject>(`/apis/apps/v1/namespaces/${namespace}/deployments`, {
+        method: "POST",
+        body: manifest,
+      })
+    },
+    async patchDeployment(name: string, patch: KubernetesObject, contentType = "application/strategic-merge-patch+json") {
+      return requestJson<KubernetesObject>(`/apis/apps/v1/namespaces/${namespace}/deployments/${name}`, {
+        method: "PATCH",
+        body: patch,
+        contentType,
+      })
+    },
+    async deleteDeployment(name: string) {
+      await request(`/apis/apps/v1/namespaces/${namespace}/deployments/${name}`, { method: "DELETE" })
+    },
+    async getService(name: string) {
+      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/services/${name}`)
+    },
+    async createService(manifest: KubernetesObject) {
+      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/services`, {
+        method: "POST",
+        body: manifest,
+      })
+    },
+    async deleteService(name: string) {
+      await request(`/api/v1/namespaces/${namespace}/services/${name}`, { method: "DELETE" })
+    },
+    async createSecret(manifest: KubernetesObject) {
+      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/secrets`, {
+        method: "POST",
+        body: manifest,
+      })
+    },
+    async deleteSecret(name: string) {
+      await request(`/api/v1/namespaces/${namespace}/secrets/${name}`, { method: "DELETE" })
+    },
+    async createPvc(manifest: KubernetesObject) {
+      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/persistentvolumeclaims`, {
+        method: "POST",
+        body: manifest,
+      })
+    },
+    async getPvc(name: string) {
+      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/persistentvolumeclaims/${name}`)
+    },
+    async deletePvc(name: string) {
+      await request(`/api/v1/namespaces/${namespace}/persistentvolumeclaims/${name}`, { method: "DELETE" })
+    },
+    async listPods(labelSelector: string) {
+      const query = new URLSearchParams({ labelSelector })
+      return requestJson<{ items?: KubernetesObject[] }>(`/api/v1/namespaces/${namespace}/pods?${query.toString()}`)
+    },
+    async getPod(name: string) {
+      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/pods/${name}`)
+    },
+    async getPodLogs(name: string, options: { tailLines?: number } = {}) {
+      const query = new URLSearchParams()
+      if (options.tailLines !== undefined) {
+        query.set("tailLines", String(options.tailLines))
+      }
+      const suffix = query.size > 0 ? `?${query.toString()}` : ""
+      return request(`/api/v1/namespaces/${namespace}/pods/${name}/log${suffix}`, {
+        accept: "text/plain",
+      })
+    },
+  }
+}
+
+export type KubernetesClient = ReturnType<typeof createKubernetesClient>

--- a/ee/apps/den-api/src/workers/kubernetes-client.ts
+++ b/ee/apps/den-api/src/workers/kubernetes-client.ts
@@ -167,6 +167,9 @@ export function createKubernetesClient(config: KubernetesClientConfig & { namesp
     async deleteService(name: string) {
       await request(`/api/v1/namespaces/${namespace}/services/${name}`, { method: "DELETE" })
     },
+    async getSecret(name: string) {
+      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/secrets/${name}`)
+    },
     async createSecret(manifest: KubernetesObject) {
       return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/secrets`, {
         method: "POST",
@@ -191,9 +194,6 @@ export function createKubernetesClient(config: KubernetesClientConfig & { namesp
     async listPods(labelSelector: string) {
       const query = new URLSearchParams({ labelSelector })
       return requestJson<{ items?: KubernetesObject[] }>(`/api/v1/namespaces/${namespace}/pods?${query.toString()}`)
-    },
-    async getPod(name: string) {
-      return requestJson<KubernetesObject>(`/api/v1/namespaces/${namespace}/pods/${name}`)
     },
     async getPodLogs(name: string, options: { tailLines?: number } = {}) {
       const query = new URLSearchParams()

--- a/ee/apps/den-api/src/workers/kubernetes.ts
+++ b/ee/apps/den-api/src/workers/kubernetes.ts
@@ -202,6 +202,10 @@ function containerEnv(input: ProvisionInput) {
     { name: "DEN_ACTIVITY_HEARTBEAT_ENABLED", value: "1" },
     { name: "DEN_ACTIVITY_HEARTBEAT_URL", value: workerActivityHeartbeatUrl(input.workerId) },
     { name: "DEN_ACTIVITY_HEARTBEAT_TOKEN", ...secretKeyRef("DEN_ACTIVITY_HEARTBEAT_TOKEN") },
+    // opencode stores conversations/sessions in $XDG_DATA_HOME/opencode; point it
+    // at the /data PVC so they survive pod recreation (the container FS is
+    // ephemeral). The entrypoint creates the dir; the data PVC is RW at /data.
+    { name: "XDG_DATA_HOME", value: "/data/opencode-xdg/data" },
   ]
 }
 

--- a/ee/apps/den-api/src/workers/kubernetes.ts
+++ b/ee/apps/den-api/src/workers/kubernetes.ts
@@ -116,7 +116,10 @@ function workerServiceUrl(workerId: WorkerId) {
 function provisionedInstanceUrl(workerId: WorkerId) {
   const template = env.workerUrlTemplate?.trim()
   if (template) {
-    return template.replace("{workerId}", workerId)
+    // The template is a URL host, so the placeholder receives the DNS-safe
+    // hyphenated worker name rather than the raw worker id (its underscore is
+    // invalid in DNS labels).
+    return template.replace("{workerId}", kubernetesWorkerName(workerId))
   }
 
   return workerServiceUrl(workerId)
@@ -138,10 +141,6 @@ function workerRecord(workerId: WorkerId, nowMs: number): KubernetesWorkerRecord
     signed_preview_url: provisionedInstanceUrl(workerId),
     signed_preview_url_expires_at: new Date(nowMs + env.kubernetes.workerRecordTtlSeconds * 1000),
   }
-}
-
-function base64(value: string) {
-  return Buffer.from(value, "utf8").toString("base64")
 }
 
 function tokenSecretManifest(input: ProvisionInput) {
@@ -192,9 +191,8 @@ function containerEnv(input: ProvisionInput) {
     { name: "OPENWORK_DATA_DIR", value: "/data/openwork-server" },
     { name: "OPENWORK_SIDECAR_DIR", value: "/data/sidecars" },
     { name: "OPENWORK_PORT", value: String(env.kubernetes.workerPort) },
-    // The worker must answer on the pod IP for the ClusterIP service to route,
-    // so the entrypoint default loopback bind is explicitly overridden.
-    { name: "OPENWORK_CONNECT_HOST", value: "0.0.0.0" },
+    // The microsandbox entrypoint already starts openwork-server with
+    // `--host 0.0.0.0` (CLI beats env), so no bind override is needed here.
     { name: "OPENWORK_APPROVAL_MODE", value: env.kubernetes.workerApprovalMode },
     { name: "OPENWORK_CORS_ORIGINS", value: "*" },
     { name: "OPENWORK_TOKEN", ...secretKeyRef("OPENWORK_TOKEN") },
@@ -218,6 +216,12 @@ function deploymentManifest(input: ProvisionInput) {
     },
     spec: {
       replicas: 1,
+      // Recreate instead of RollingUpdate: the workspace/data PVCs are
+      // ReadWriteOnce, so a surge pod during a rolling image patch would
+      // MultiAttach-stall behind the terminating pod.
+      strategy: {
+        type: "Recreate",
+      },
       selector: {
         matchLabels: podLabels(input.workerId),
       },
@@ -338,7 +342,27 @@ async function ensureWorkspaceReady(client: KubernetesClient, workerId: WorkerId
   await client.getPvc(dataVolumeName(workerId))
 }
 
-async function diagnosticSnapshot(client: KubernetesClient, workerId: WorkerId) {
+// The worker entrypoint prints the client/host tokens at startup, so the log
+// tail embedded in health-timeout errors must never carry them.
+function redactPodLogs(logs: string, input: ProvisionInput) {
+  return logs
+    .split("\n")
+    .map((line) => {
+      let redacted = line
+      for (const token of [input.clientToken, input.hostToken, input.activityToken]) {
+        if (token) {
+          redacted = redacted.split(token).join("[REDACTED]")
+        }
+      }
+      if (redacted.toLowerCase().includes("token:")) {
+        redacted = "[REDACTED]"
+      }
+      return redacted
+    })
+    .join("\n")
+}
+
+async function diagnosticSnapshot(client: KubernetesClient, workerId: WorkerId, input: ProvisionInput) {
   try {
     const pods = await client.listPods(`openwork.den.worker-id=${workerId}`)
     const items = Array.isArray(pods.items) ? pods.items : []
@@ -359,7 +383,7 @@ async function diagnosticSnapshot(client: KubernetesClient, workerId: WorkerId) 
 
       const logs = await client.getPodLogs(name, { tailLines: podLogTailLines }).catch(() => null)
       if (logs?.trim()) {
-        lines.push(`logs:\n${logs.trim().slice(-4000)}`)
+        lines.push(`logs:\n${redactPodLogs(logs.trim(), input).slice(-4000)}`)
       }
     }
 
@@ -370,7 +394,7 @@ async function diagnosticSnapshot(client: KubernetesClient, workerId: WorkerId) 
   }
 }
 
-async function waitForHealth(url: string, timeoutMs: number, runtime: KubernetesProvisioningRuntime, workerId: WorkerId) {
+async function waitForHealth(url: string, timeoutMs: number, runtime: KubernetesProvisioningRuntime, workerId: WorkerId, input: ProvisionInput) {
   const fetchImpl = runtime.healthFetch ?? fetch
   const startedAt = Date.now()
 
@@ -394,7 +418,7 @@ async function waitForHealth(url: string, timeoutMs: number, runtime: Kubernetes
     }
   }
 
-  const diagnostics = await diagnosticSnapshot(runtime.client, workerId)
+  const diagnostics = await diagnosticSnapshot(runtime.client, workerId, input)
   throw new Error(
     [
       `Timed out waiting for Kubernetes worker health at ${url.replace(/\/$/, "")}/health`,
@@ -403,6 +427,12 @@ async function waitForHealth(url: string, timeoutMs: number, runtime: Kubernetes
       .filter(Boolean)
       .join("\n\n"),
   )
+}
+
+function deploymentContainerImage(deployment: Record<string, unknown>) {
+  const containers = (deployment.spec as { template?: { spec?: { containers?: Array<{ image?: string }> } } } | undefined)
+    ?.template?.spec?.containers
+  return containers?.[0]?.image ?? null
 }
 
 async function adoptExistingWorker(input: {
@@ -414,12 +444,52 @@ async function adoptExistingWorker(input: {
   await ensureWorkspaceReady(input.runtime.client, input.provisionInput.workerId)
 
   const replicas = deploymentReplicas(input.deployment)
-  if (replicas === null || replicas < 1) {
+  const runningImage = deploymentContainerImage(input.deployment)
+  if (runningImage && runningImage !== env.kubernetes.workerImage) {
+    // The deployment was adopted with an older image; reconcile it before
+    // reporting healthy so the DB imageVersion and the running pod agree.
+    await patchWorkerDeployment(input.runtime.client, input.provisionInput.workerId, {
+      spec: {
+        replicas: 1,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: "openwork-server",
+                image: env.kubernetes.workerImage,
+              },
+            ],
+          },
+        },
+      },
+    })
+  } else if (replicas === null || replicas < 1) {
     await patchWorkerDeployment(input.runtime.client, input.provisionInput.workerId, { spec: { replicas: 1 } })
   }
 
-  await waitForHealth(workerServiceUrl(input.provisionInput.workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, input.provisionInput.workerId)
+  await waitForHealth(workerServiceUrl(input.provisionInput.workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, input.provisionInput.workerId, input.provisionInput)
   return provisionedInstance(input.provisionInput.workerId)
+}
+
+// A 409 on a supporting-object create means a concurrent replica (or a
+// half-completed deprovision) already created it; verify the object exists
+// and continue instead of dead-ending the provision attempt.
+async function createOrAdoptObject(
+  client: KubernetesClient,
+  create: () => Promise<unknown>,
+  verify: () => Promise<unknown>,
+  label: string,
+  workerId: WorkerId,
+) {
+  try {
+    await create()
+  } catch (error) {
+    if (!(error instanceof KubernetesApiError && error.status === 409)) {
+      throw error
+    }
+    await verify()
+    logger.info("adopted existing Kubernetes worker object after create conflict", { object: label, worker_id: workerId })
+  }
 }
 
 async function provisionFreshWorker(input: {
@@ -429,13 +499,37 @@ async function provisionFreshWorker(input: {
   const { client } = input.runtime
   const workerId = input.provisionInput.workerId
 
-  await client.createPvc(pvcManifest(workspaceVolumeName(workerId), workerId, env.kubernetes.workspaceVolumeSize))
-  await client.createPvc(pvcManifest(dataVolumeName(workerId), workerId, env.kubernetes.dataVolumeSize))
-  await client.createSecret(tokenSecretManifest(input.provisionInput))
+  await createOrAdoptObject(
+    client,
+    () => client.createPvc(pvcManifest(workspaceVolumeName(workerId), workerId, env.kubernetes.workspaceVolumeSize)),
+    () => client.getPvc(workspaceVolumeName(workerId)),
+    "workspace-pvc",
+    workerId,
+  )
+  await createOrAdoptObject(
+    client,
+    () => client.createPvc(pvcManifest(dataVolumeName(workerId), workerId, env.kubernetes.dataVolumeSize)),
+    () => client.getPvc(dataVolumeName(workerId)),
+    "data-pvc",
+    workerId,
+  )
+  await createOrAdoptObject(
+    client,
+    () => client.createSecret(tokenSecretManifest(input.provisionInput)),
+    () => client.getSecret(tokenSecretName(workerId)),
+    "token-secret",
+    workerId,
+  )
   await client.createDeployment(deploymentManifest(input.provisionInput))
-  await client.createService(serviceManifest(input.provisionInput))
+  await createOrAdoptObject(
+    client,
+    () => client.createService(serviceManifest(input.provisionInput)),
+    () => client.getService(kubernetesWorkerName(workerId)),
+    "service",
+    workerId,
+  )
 
-  await waitForHealth(workerServiceUrl(workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, workerId)
+  await waitForHealth(workerServiceUrl(workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, workerId, input.provisionInput)
   return provisionedInstance(workerId)
 }
 
@@ -521,7 +615,7 @@ async function wakeExistingWorker(input: {
     await patchWorkerDeployment(input.runtime.client, input.provisionInput.workerId, { spec: { replicas: 1 } })
   }
 
-  await waitForHealth(workerServiceUrl(input.provisionInput.workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, input.provisionInput.workerId)
+  await waitForHealth(workerServiceUrl(input.provisionInput.workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, input.provisionInput.workerId, input.provisionInput)
   return provisionedInstance(input.provisionInput.workerId)
 }
 

--- a/ee/apps/den-api/src/workers/kubernetes.ts
+++ b/ee/apps/den-api/src/workers/kubernetes.ts
@@ -1,0 +1,650 @@
+import { WorkerTable } from "@openwork-ee/den-db/schema"
+import { db } from "../db.js"
+import { env } from "../env.js"
+import { appLogger } from "../observability/logger.js"
+import { eq } from "@openwork-ee/den-db/drizzle"
+import {
+  createKubernetesClient,
+  isKubernetesNotFoundError,
+  KubernetesApiError,
+  type KubernetesClient,
+} from "./kubernetes-client.js"
+
+type WorkerId = typeof WorkerTable.$inferSelect.id
+
+type ProvisionInput = {
+  workerId: WorkerId
+  name: string
+  hostToken: string
+  clientToken: string
+  activityToken: string
+}
+
+type ProvisionedInstance = {
+  provider: string
+  url: string
+  status: "provisioning" | "healthy"
+  region?: string
+  imageVersion?: string | null
+}
+
+export class KubernetesWorkerMissingError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "KubernetesWorkerMissingError"
+  }
+}
+
+export function isKubernetesWorkerMissingError(error: unknown) {
+  return error instanceof KubernetesWorkerMissingError
+    || (error instanceof Error && error.name === "KubernetesWorkerMissingError")
+}
+
+export type StopWorkerOnKubernetesResult =
+  | { status: "no_sandbox" }
+  | { status: "stopped" }
+
+export type KubernetesWorkerRecord = {
+  sandbox_id: string
+  signed_preview_url: string
+  signed_preview_url_expires_at: Date
+}
+
+export type KubernetesProvisioningRuntime = {
+  client: KubernetesClient
+  healthFetch?: typeof fetch
+  now?: () => number
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+const healthRequestTimeoutMs = 5_000
+const createConflictLookupMaxAttempts = 6
+const createConflictLookupBackoffMs = 2_000
+const podLogTailLines = 100
+const logger = appLogger.child({ component: "kubernetes_provisioner" })
+
+const podLabels = (workerId: WorkerId) => ({
+  "openwork.den.provider": "kubernetes",
+  "openwork.den.worker-id": workerId,
+})
+
+// TypeID worker ids look like wrk_<26 base32 chars>; swapping the separator
+// yields lowercase alphanumeric + hyphen, which is already DNS-1123 safe.
+export function kubernetesWorkerName(workerId: WorkerId) {
+  return workerId.replace(/_/g, "-")
+}
+
+function tokenSecretName(workerId: WorkerId) {
+  return `${kubernetesWorkerName(workerId)}-tokens`
+}
+
+function workspaceVolumeName(workerId: WorkerId) {
+  return `${kubernetesWorkerName(workerId)}-workspace`
+}
+
+function dataVolumeName(workerId: WorkerId) {
+  return `${kubernetesWorkerName(workerId)}-data`
+}
+
+function workerActivityHeartbeatUrl(workerId: WorkerId) {
+  const base = env.workerActivityBaseUrl.replace(/\/+$/, "")
+  return `${base}/v1/workers/${encodeURIComponent(workerId)}/activity-heartbeat`
+}
+
+function assertKubernetesConfig() {
+  if (!env.kubernetes.workerImage) {
+    throw new Error("KUBERNETES_WORKER_IMAGE is required for kubernetes provisioner")
+  }
+}
+
+function createRuntime(): KubernetesProvisioningRuntime {
+  return {
+    client: createKubernetesClient({
+      apiUrl: env.kubernetes.apiUrl,
+      apiToken: env.kubernetes.apiToken,
+      apiCaFile: env.kubernetes.apiCaFile,
+      namespace: env.kubernetes.workerNamespace,
+    }),
+  }
+}
+
+function workerServiceUrl(workerId: WorkerId) {
+  const port = env.kubernetes.workerPort
+  return `http://${kubernetesWorkerName(workerId)}.${env.kubernetes.workerNamespace}.svc.cluster.local:${port}`
+}
+
+function provisionedInstanceUrl(workerId: WorkerId) {
+  const template = env.workerUrlTemplate?.trim()
+  if (template) {
+    return template.replace("{workerId}", workerId)
+  }
+
+  return workerServiceUrl(workerId)
+}
+
+function provisionedInstance(workerId: WorkerId): ProvisionedInstance {
+  return {
+    provider: "kubernetes",
+    url: provisionedInstanceUrl(workerId),
+    status: "healthy",
+    region: env.kubernetes.workerNamespace,
+    imageVersion: env.kubernetes.workerImage ?? null,
+  }
+}
+
+function workerRecord(workerId: WorkerId, nowMs: number): KubernetesWorkerRecord {
+  return {
+    sandbox_id: kubernetesWorkerName(workerId),
+    signed_preview_url: provisionedInstanceUrl(workerId),
+    signed_preview_url_expires_at: new Date(nowMs + env.kubernetes.workerRecordTtlSeconds * 1000),
+  }
+}
+
+function base64(value: string) {
+  return Buffer.from(value, "utf8").toString("base64")
+}
+
+function tokenSecretManifest(input: ProvisionInput) {
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: {
+      name: tokenSecretName(input.workerId),
+      namespace: env.kubernetes.workerNamespace,
+      labels: podLabels(input.workerId),
+    },
+    type: "Opaque",
+    stringData: {
+      OPENWORK_TOKEN: input.clientToken,
+      OPENWORK_HOST_TOKEN: input.hostToken,
+      DEN_ACTIVITY_HEARTBEAT_TOKEN: input.activityToken,
+    },
+  }
+}
+
+function pvcManifest(name: string, workerId: WorkerId, size: string) {
+  return {
+    apiVersion: "v1",
+    kind: "PersistentVolumeClaim",
+    metadata: {
+      name,
+      namespace: env.kubernetes.workerNamespace,
+      labels: podLabels(workerId),
+    },
+    spec: {
+      accessModes: ["ReadWriteOnce"],
+      resources: {
+        requests: {
+          storage: size,
+        },
+      },
+      ...(env.kubernetes.workerStorageClass ? { storageClassName: env.kubernetes.workerStorageClass } : {}),
+    },
+  }
+}
+
+function containerEnv(input: ProvisionInput) {
+  const secretName = tokenSecretName(input.workerId)
+  const secretKeyRef = (key: string) => ({ valueFrom: { secretKeyRef: { name: secretName, key } } })
+
+  return [
+    { name: "OPENWORK_WORKSPACE", value: "/workspace" },
+    { name: "OPENWORK_DATA_DIR", value: "/data/openwork-server" },
+    { name: "OPENWORK_SIDECAR_DIR", value: "/data/sidecars" },
+    { name: "OPENWORK_PORT", value: String(env.kubernetes.workerPort) },
+    // The worker must answer on the pod IP for the ClusterIP service to route,
+    // so the entrypoint default loopback bind is explicitly overridden.
+    { name: "OPENWORK_CONNECT_HOST", value: "0.0.0.0" },
+    { name: "OPENWORK_APPROVAL_MODE", value: env.kubernetes.workerApprovalMode },
+    { name: "OPENWORK_CORS_ORIGINS", value: "*" },
+    { name: "OPENWORK_TOKEN", ...secretKeyRef("OPENWORK_TOKEN") },
+    { name: "OPENWORK_HOST_TOKEN", ...secretKeyRef("OPENWORK_HOST_TOKEN") },
+    { name: "DEN_WORKER_ID", value: input.workerId },
+    { name: "DEN_RUNTIME_PROVIDER", value: "kubernetes" },
+    { name: "DEN_ACTIVITY_HEARTBEAT_ENABLED", value: "1" },
+    { name: "DEN_ACTIVITY_HEARTBEAT_URL", value: workerActivityHeartbeatUrl(input.workerId) },
+    { name: "DEN_ACTIVITY_HEARTBEAT_TOKEN", ...secretKeyRef("DEN_ACTIVITY_HEARTBEAT_TOKEN") },
+  ]
+}
+
+function deploymentManifest(input: ProvisionInput) {
+  return {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: {
+      name: kubernetesWorkerName(input.workerId),
+      namespace: env.kubernetes.workerNamespace,
+      labels: podLabels(input.workerId),
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: podLabels(input.workerId),
+      },
+      template: {
+        metadata: {
+          labels: podLabels(input.workerId),
+        },
+        spec: {
+          automountServiceAccountToken: false,
+          containers: [
+            {
+              name: "openwork-server",
+              image: env.kubernetes.workerImage,
+              imagePullPolicy: env.kubernetes.workerImagePullPolicy,
+              ports: [
+                { containerPort: env.kubernetes.workerPort },
+              ],
+              env: containerEnv(input),
+              readinessProbe: {
+                httpGet: { path: "/health", port: env.kubernetes.workerPort },
+              },
+              livenessProbe: {
+                httpGet: { path: "/health", port: env.kubernetes.workerPort },
+              },
+              resources: {
+                requests: {
+                  cpu: env.kubernetes.workerResources.cpuRequest,
+                  memory: env.kubernetes.workerResources.memoryRequest,
+                },
+                limits: {
+                  cpu: env.kubernetes.workerResources.cpuLimit,
+                  memory: env.kubernetes.workerResources.memoryLimit,
+                },
+              },
+              volumeMounts: [
+                { name: "workspace", mountPath: "/workspace" },
+                { name: "data", mountPath: "/data" },
+              ],
+            },
+          ],
+          volumes: [
+            {
+              name: "workspace",
+              persistentVolumeClaim: { claimName: workspaceVolumeName(input.workerId) },
+            },
+            {
+              name: "data",
+              persistentVolumeClaim: { claimName: dataVolumeName(input.workerId) },
+            },
+          ],
+        },
+      },
+    },
+  }
+}
+
+function serviceManifest(input: ProvisionInput) {
+  return {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: {
+      name: kubernetesWorkerName(input.workerId),
+      namespace: env.kubernetes.workerNamespace,
+      labels: podLabels(input.workerId),
+    },
+    spec: {
+      type: "ClusterIP",
+      selector: podLabels(input.workerId),
+      ports: [
+        {
+          port: env.kubernetes.workerPort,
+          targetPort: env.kubernetes.workerPort,
+        },
+      ],
+    },
+  }
+}
+
+async function upsertTokenSecret(client: KubernetesClient, input: ProvisionInput) {
+  try {
+    await client.createSecret(tokenSecretManifest(input))
+    return
+  } catch (error) {
+    if (!(error instanceof KubernetesApiError && error.status === 409)) {
+      throw error
+    }
+  }
+
+  await client.deleteSecret(tokenSecretName(input.workerId)).catch((error) => {
+    logger.warn("failed to delete stale Kubernetes worker token secret", { worker_id: input.workerId, error })
+  })
+  await client.createSecret(tokenSecretManifest(input))
+}
+
+async function getWorkerDeployment(client: KubernetesClient, workerId: WorkerId) {
+  try {
+    return await client.getDeployment(kubernetesWorkerName(workerId))
+  } catch (error) {
+    if (isKubernetesNotFoundError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+function deploymentReplicas(deployment: Record<string, unknown>) {
+  const spec = deployment.spec as { replicas?: number } | undefined
+  return spec?.replicas ?? null
+}
+
+async function patchWorkerDeployment(client: KubernetesClient, workerId: WorkerId, patch: Record<string, unknown>) {
+  await client.patchDeployment(kubernetesWorkerName(workerId), patch)
+}
+
+async function ensureWorkspaceReady(client: KubernetesClient, workerId: WorkerId) {
+  await client.getPvc(workspaceVolumeName(workerId))
+  await client.getPvc(dataVolumeName(workerId))
+}
+
+async function diagnosticSnapshot(client: KubernetesClient, workerId: WorkerId) {
+  try {
+    const pods = await client.listPods(`openwork.den.worker-id=${workerId}`)
+    const items = Array.isArray(pods.items) ? pods.items : []
+    if (items.length === 0) {
+      return "no worker pods found"
+    }
+
+    const lines: string[] = []
+    for (const pod of items) {
+      const metadata = pod.metadata as { name?: string } | undefined
+      const status = pod.status as { phase?: string } | undefined
+      const name = metadata?.name ?? "unknown"
+      lines.push(`pod ${name} phase=${status?.phase ?? "unknown"}`)
+
+      if (lines.length > 1) {
+        continue
+      }
+
+      const logs = await client.getPodLogs(name, { tailLines: podLogTailLines }).catch(() => null)
+      if (logs?.trim()) {
+        lines.push(`logs:\n${logs.trim().slice(-4000)}`)
+      }
+    }
+
+    return lines.join("\n")
+  } catch (error) {
+    logger.warn("failed to collect Kubernetes worker diagnostics", { worker_id: workerId, error })
+    return null
+  }
+}
+
+async function waitForHealth(url: string, timeoutMs: number, runtime: KubernetesProvisioningRuntime, workerId: WorkerId) {
+  const fetchImpl = runtime.healthFetch ?? fetch
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const remainingMs = timeoutMs - (Date.now() - startedAt)
+      const response = await fetchImpl(`${url.replace(/\/$/, "")}/health`, {
+        method: "GET",
+        signal: AbortSignal.timeout(Math.max(1, Math.min(remainingMs, healthRequestTimeoutMs))),
+      })
+      if (response.ok) {
+        return
+      }
+    } catch {
+      // ignore transient startup failures
+    }
+
+    const remainingAfterProbeMs = timeoutMs - (Date.now() - startedAt)
+    if (remainingAfterProbeMs > 0) {
+      await sleep(Math.min(env.kubernetes.pollIntervalMs, remainingAfterProbeMs))
+    }
+  }
+
+  const diagnostics = await diagnosticSnapshot(runtime.client, workerId)
+  throw new Error(
+    [
+      `Timed out waiting for Kubernetes worker health at ${url.replace(/\/$/, "")}/health`,
+      diagnostics ?? "",
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+  )
+}
+
+async function adoptExistingWorker(input: {
+  provisionInput: ProvisionInput
+  runtime: KubernetesProvisioningRuntime
+  deployment: Record<string, unknown>
+}): Promise<ProvisionedInstance> {
+  await upsertTokenSecret(input.runtime.client, input.provisionInput)
+  await ensureWorkspaceReady(input.runtime.client, input.provisionInput.workerId)
+
+  const replicas = deploymentReplicas(input.deployment)
+  if (replicas === null || replicas < 1) {
+    await patchWorkerDeployment(input.runtime.client, input.provisionInput.workerId, { spec: { replicas: 1 } })
+  }
+
+  await waitForHealth(workerServiceUrl(input.provisionInput.workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, input.provisionInput.workerId)
+  return provisionedInstance(input.provisionInput.workerId)
+}
+
+async function provisionFreshWorker(input: {
+  provisionInput: ProvisionInput
+  runtime: KubernetesProvisioningRuntime
+}): Promise<ProvisionedInstance> {
+  const { client } = input.runtime
+  const workerId = input.provisionInput.workerId
+
+  await client.createPvc(pvcManifest(workspaceVolumeName(workerId), workerId, env.kubernetes.workspaceVolumeSize))
+  await client.createPvc(pvcManifest(dataVolumeName(workerId), workerId, env.kubernetes.dataVolumeSize))
+  await client.createSecret(tokenSecretManifest(input.provisionInput))
+  await client.createDeployment(deploymentManifest(input.provisionInput))
+  await client.createService(serviceManifest(input.provisionInput))
+
+  await waitForHealth(workerServiceUrl(workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, workerId)
+  return provisionedInstance(workerId)
+}
+
+export async function provisionWorkerOnKubernetesWithRuntime(
+  input: ProvisionInput,
+  runtime: KubernetesProvisioningRuntime,
+  options: { sleep?: (ms: number) => Promise<unknown> } = {},
+): Promise<ProvisionedInstance> {
+  const existing = await getWorkerDeployment(runtime.client, input.workerId)
+  if (existing) {
+    return adoptExistingWorker({ provisionInput: input, runtime, deployment: existing })
+  }
+
+  try {
+    return await provisionFreshWorker({ provisionInput: input, runtime })
+  } catch (error) {
+    if (!(error instanceof KubernetesApiError && error.status === 409)) {
+      throw error
+    }
+
+    // Another replica provisioned the same worker concurrently; adopt its
+    // objects instead of failing the request.
+    for (let attempt = 1; attempt <= createConflictLookupMaxAttempts; attempt += 1) {
+      const deployment = await getWorkerDeployment(runtime.client, input.workerId)
+      if (deployment) {
+        return adoptExistingWorker({ provisionInput: input, runtime, deployment })
+      }
+
+      if (attempt < createConflictLookupMaxAttempts) {
+        await (options.sleep ?? sleep)(createConflictLookupBackoffMs)
+      }
+    }
+
+    throw error
+  }
+}
+
+export async function provisionWorkerOnKubernetes(
+  input: ProvisionInput,
+): Promise<ProvisionedInstance> {
+  assertKubernetesConfig()
+
+  return provisionWorkerOnKubernetesWithRuntime(input, createRuntime())
+}
+
+async function getWorkerImageVersion(workerId: WorkerId) {
+  const rows = await db
+    .select({ image_version: WorkerTable.image_version })
+    .from(WorkerTable)
+    .where(eq(WorkerTable.id, workerId))
+    .limit(1)
+
+  return rows[0]?.image_version ?? null
+}
+
+async function wakeExistingWorker(input: {
+  provisionInput: ProvisionInput
+  runtime: KubernetesProvisioningRuntime
+  deployment: Record<string, unknown>
+  workerImageVersion: string | null
+}): Promise<ProvisionedInstance> {
+  const imageVersion = env.kubernetes.workerImage
+  if (imageVersion && input.workerImageVersion !== imageVersion) {
+    // Stale-image recycle: the PVCs survive the rollout, so the workspace and
+    // data persist across the image update the same way Daytona snapshot
+    // recycling preserves the shared volume.
+    await patchWorkerDeployment(input.runtime.client, input.provisionInput.workerId, {
+      spec: {
+        replicas: 1,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: "openwork-server",
+                image: imageVersion,
+              },
+            ],
+          },
+        },
+      },
+    })
+  } else if (deploymentReplicas(input.deployment) === null || deploymentReplicas(input.deployment)! < 1) {
+    await patchWorkerDeployment(input.runtime.client, input.provisionInput.workerId, { spec: { replicas: 1 } })
+  }
+
+  await waitForHealth(workerServiceUrl(input.provisionInput.workerId), env.kubernetes.healthcheckTimeoutMs, input.runtime, input.provisionInput.workerId)
+  return provisionedInstance(input.provisionInput.workerId)
+}
+
+export async function wakeWorkerOnKubernetesWithRuntime(
+  input: ProvisionInput,
+  runtime: KubernetesProvisioningRuntime,
+  workerImageVersion: string | null,
+): Promise<ProvisionedInstance> {
+  const deployment = await getWorkerDeployment(runtime.client, input.workerId)
+  if (!deployment) {
+    throw new KubernetesWorkerMissingError(`Kubernetes worker deployment missing for worker ${input.workerId}`)
+  }
+
+  return wakeExistingWorker({ provisionInput: input, runtime, deployment, workerImageVersion })
+}
+
+export async function wakeWorkerOnKubernetes(
+  input: ProvisionInput,
+): Promise<ProvisionedInstance> {
+  assertKubernetesConfig()
+
+  const runtime = createRuntime()
+  const workerImageVersion = await getWorkerImageVersion(input.workerId)
+  return wakeWorkerOnKubernetesWithRuntime(input, runtime, workerImageVersion)
+}
+
+export async function stopWorkerOnKubernetesWithRuntime(workerId: WorkerId, runtime: KubernetesProvisioningRuntime): Promise<StopWorkerOnKubernetesResult> {
+  const client = runtime.client
+  const deployment = await getWorkerDeployment(client, workerId)
+  if (!deployment) {
+    return { status: "no_sandbox" }
+  }
+
+  const replicas = deploymentReplicas(deployment)
+  if (replicas !== null && replicas < 1) {
+    return { status: "stopped" }
+  }
+
+  // Scale to zero instead of deleting: the PVCs and secret survive so the
+  // next wake reuses the workspace, mirroring a stopped Daytona sandbox.
+  await patchWorkerDeployment(client, workerId, { spec: { replicas: 0 } })
+
+  return { status: "stopped" }
+}
+
+export async function stopWorkerOnKubernetes(workerId: WorkerId): Promise<StopWorkerOnKubernetesResult> {
+  assertKubernetesConfig()
+
+  return stopWorkerOnKubernetesWithRuntime(workerId, createRuntime())
+}
+
+export async function deprovisionWorkerOnKubernetesWithRuntime(workerId: WorkerId, runtime: KubernetesProvisioningRuntime) {
+  const client = runtime.client
+  await client.deleteDeployment(kubernetesWorkerName(workerId)).catch((error) => {
+    if (!isKubernetesNotFoundError(error)) {
+      logger.warn("failed to delete Kubernetes worker deployment", { worker_id: workerId, error })
+    }
+  })
+  await client.deleteService(kubernetesWorkerName(workerId)).catch((error) => {
+    if (!isKubernetesNotFoundError(error)) {
+      logger.warn("failed to delete Kubernetes worker service", { worker_id: workerId, error })
+    }
+  })
+  await client.deleteSecret(tokenSecretName(workerId)).catch((error) => {
+    if (!isKubernetesNotFoundError(error)) {
+      logger.warn("failed to delete Kubernetes worker token secret", { worker_id: workerId, error })
+    }
+  })
+  await client.deletePvc(workspaceVolumeName(workerId)).catch((error) => {
+    if (!isKubernetesNotFoundError(error)) {
+      logger.warn("failed to delete Kubernetes worker workspace PVC", { worker_id: workerId, error })
+    }
+  })
+  await client.deletePvc(dataVolumeName(workerId)).catch((error) => {
+    if (!isKubernetesNotFoundError(error)) {
+      logger.warn("failed to delete Kubernetes worker data PVC", { worker_id: workerId, error })
+    }
+  })
+}
+
+export async function deprovisionWorkerOnKubernetes(workerId: WorkerId) {
+  assertKubernetesConfig()
+
+  return deprovisionWorkerOnKubernetesWithRuntime(workerId, createRuntime())
+}
+
+export async function inspectKubernetesWorkerWithRuntime(workerId: WorkerId, runtime: KubernetesProvisioningRuntime) {
+  const deployment = await getWorkerDeployment(runtime.client, workerId)
+  if (!deployment) {
+    return null
+  }
+
+  const replicas = deploymentReplicas(deployment)
+  return { state: replicas !== null && replicas < 1 ? "stopped" : "started" }
+}
+
+export async function inspectKubernetesWorker(workerId: WorkerId) {
+  assertKubernetesConfig()
+
+  return inspectKubernetesWorkerWithRuntime(workerId, createRuntime())
+}
+
+export async function getKubernetesWorkerRecordWithRuntime(workerId: WorkerId, runtime: KubernetesProvisioningRuntime): Promise<KubernetesWorkerRecord | null> {
+  const deployment = await getWorkerDeployment(runtime.client, workerId)
+  if (!deployment) {
+    return null
+  }
+
+  return workerRecord(workerId, (runtime.now ?? Date.now)())
+}
+
+export async function getKubernetesWorkerRecord(workerId: WorkerId): Promise<KubernetesWorkerRecord | null> {
+  assertKubernetesConfig()
+
+  return getKubernetesWorkerRecordWithRuntime(workerId, createRuntime())
+}
+
+export async function refreshKubernetesSignedPreviewWithRuntime(workerId: WorkerId, runtime: KubernetesProvisioningRuntime): Promise<KubernetesWorkerRecord | null> {
+  return getKubernetesWorkerRecordWithRuntime(workerId, runtime)
+}
+
+export async function refreshKubernetesSignedPreview(workerId: WorkerId): Promise<KubernetesWorkerRecord | null> {
+  assertKubernetesConfig()
+
+  return refreshKubernetesSignedPreviewWithRuntime(workerId, createRuntime())
+}

--- a/ee/apps/den-api/src/workers/kubernetes.ts
+++ b/ee/apps/den-api/src/workers/kubernetes.ts
@@ -209,6 +209,88 @@ function containerEnv(input: ProvisionInput) {
   ]
 }
 
+// Operator-provided pod overrides (scheduling, security, metadata, networking).
+// The provisioner's own selector labels, env, and volumes always win on a
+// name collision; operator extras that collide are dropped with a warning.
+const RESERVED_VOLUME_NAMES = ["workspace", "data"]
+
+function operatorPodTemplateLabels(workerId: WorkerId) {
+  const reserved = Object.keys(podLabels(workerId))
+  const operator = env.kubernetes.workerPodLabels
+  if (!operator) {
+    return podLabels(workerId)
+  }
+  // Operator labels come first so the provisioner's selector labels override any
+  // attempt to clobber openwork.den.worker-id / openwork.den.provider.
+  return { ...operator, ...podLabels(workerId), ...Object.fromEntries(reserved.map((k) => [k, (podLabels(workerId) as Record<string, string>)[k]])) }
+}
+
+function operatorPodAnnotations() {
+  return env.kubernetes.workerPodAnnotations ?? {}
+}
+
+function operatorImagePullSecrets() {
+  const names = env.kubernetes.workerImagePullSecrets
+  return names?.length ? names.map((name) => ({ name })) : undefined
+}
+
+function mergeExtraEnv(base: ReturnType<typeof containerEnv>, extras: unknown[] | undefined) {
+  if (!extras || !extras.length) {
+    return base
+  }
+  const reserved = new Set(base.map((e: { name: string }) => e.name))
+  const accepted: Record<string, unknown>[] = []
+  for (const entry of extras) {
+    if (entry && typeof entry === "object" && "name" in entry && typeof (entry as { name: unknown }).name === "string") {
+      if (reserved.has((entry as { name: string }).name)) {
+        logger.warn("dropping operator env override that collides with a provisioner env var", { env_var: (entry as { name: string }).name })
+        continue
+      }
+      reserved.add((entry as { name: string }).name)
+      accepted.push(entry as Record<string, unknown>)
+    }
+  }
+  return accepted.length ? [...base, ...accepted] : base
+}
+
+function mergeExtraVolumes(extras: unknown[] | undefined) {
+  if (!extras || !extras.length) {
+    return undefined
+  }
+  const reserved = new Set(RESERVED_VOLUME_NAMES)
+  const accepted: Record<string, unknown>[] = []
+  for (const vol of extras) {
+    if (vol && typeof vol === "object" && "name" in vol && typeof (vol as { name: unknown }).name === "string") {
+      if (reserved.has((vol as { name: string }).name)) {
+        logger.warn("dropping operator volume that collides with a provisioner volume", { volume: (vol as { name: string }).name })
+        continue
+      }
+      reserved.add((vol as { name: string }).name)
+      accepted.push(vol as Record<string, unknown>)
+    }
+  }
+  return accepted.length ? accepted : undefined
+}
+
+function mergeExtraVolumeMounts(extras: unknown[] | undefined) {
+  if (!extras || !extras.length) {
+    return undefined
+  }
+  const reserved = new Set(RESERVED_VOLUME_NAMES)
+  const accepted: Record<string, unknown>[] = []
+  for (const mount of extras) {
+    if (mount && typeof mount === "object" && "name" in mount && typeof (mount as { name: unknown }).name === "string") {
+      if (reserved.has((mount as { name: string }).name)) {
+        logger.warn("dropping operator volume mount that collides with a provisioner volume mount", { volume_mount: (mount as { name: string }).name })
+        continue
+      }
+      reserved.add((mount as { name: string }).name)
+      accepted.push(mount as Record<string, unknown>)
+    }
+  }
+  return accepted.length ? accepted : undefined
+}
+
 function deploymentManifest(input: ProvisionInput) {
   return {
     apiVersion: "apps/v1",
@@ -231,10 +313,20 @@ function deploymentManifest(input: ProvisionInput) {
       },
       template: {
         metadata: {
-          labels: podLabels(input.workerId),
+          labels: operatorPodTemplateLabels(input.workerId),
+          ...(Object.keys(operatorPodAnnotations()).length ? { annotations: operatorPodAnnotations() } : {}),
         },
         spec: {
           automountServiceAccountToken: false,
+          ...(operatorImagePullSecrets() ? { imagePullSecrets: operatorImagePullSecrets() } : {}),
+          ...(env.kubernetes.workerNodeSelector ? { nodeSelector: env.kubernetes.workerNodeSelector } : {}),
+          ...(env.kubernetes.workerTolerations ? { tolerations: env.kubernetes.workerTolerations } : {}),
+          ...(env.kubernetes.workerAffinity ? { affinity: env.kubernetes.workerAffinity } : {}),
+          ...(env.kubernetes.workerTopologySpreadConstraints ? { topologySpreadConstraints: env.kubernetes.workerTopologySpreadConstraints } : {}),
+          ...(env.kubernetes.workerPriorityClassName ? { priorityClassName: env.kubernetes.workerPriorityClassName } : {}),
+          ...(env.kubernetes.workerDnsPolicy ? { dnsPolicy: env.kubernetes.workerDnsPolicy } : {}),
+          ...(env.kubernetes.workerDnsConfig ? { dnsConfig: env.kubernetes.workerDnsConfig } : {}),
+          ...(env.kubernetes.workerPodSecurityContext ? { securityContext: env.kubernetes.workerPodSecurityContext } : {}),
           containers: [
             {
               name: "openwork-server",
@@ -243,7 +335,7 @@ function deploymentManifest(input: ProvisionInput) {
               ports: [
                 { containerPort: env.kubernetes.workerPort },
               ],
-              env: containerEnv(input),
+              env: mergeExtraEnv(containerEnv(input), env.kubernetes.workerExtraEnv),
               readinessProbe: {
                 httpGet: { path: "/health", port: env.kubernetes.workerPort },
               },
@@ -260,9 +352,11 @@ function deploymentManifest(input: ProvisionInput) {
                   memory: env.kubernetes.workerResources.memoryLimit,
                 },
               },
+              ...(env.kubernetes.workerContainerSecurityContext ? { securityContext: env.kubernetes.workerContainerSecurityContext } : {}),
               volumeMounts: [
                 { name: "workspace", mountPath: "/workspace" },
                 { name: "data", mountPath: "/data" },
+                ...(mergeExtraVolumeMounts(env.kubernetes.workerExtraVolumeMounts) ?? []),
               ],
             },
           ],
@@ -275,6 +369,7 @@ function deploymentManifest(input: ProvisionInput) {
               name: "data",
               persistentVolumeClaim: { claimName: dataVolumeName(input.workerId) },
             },
+            ...(mergeExtraVolumes(env.kubernetes.workerExtraVolumes) ?? []),
           ],
         },
       },

--- a/ee/apps/den-api/src/workers/provisioner.ts
+++ b/ee/apps/den-api/src/workers/provisioner.ts
@@ -6,6 +6,10 @@ import {
   provisionWorkerOnDaytona,
 } from "./daytona.js"
 import {
+  deprovisionWorkerOnKubernetes,
+  provisionWorkerOnKubernetes,
+} from "./kubernetes.js"
+import {
   customDomainForWorker,
   ensureVercelDnsRecord,
 } from "./vanity-domain.js"
@@ -360,6 +364,10 @@ export async function provisionWorker(
     return provisionWorkerOnDaytona(input)
   }
 
+  if (env.provisionerMode === "kubernetes") {
+    return provisionWorkerOnKubernetes(input)
+  }
+
   const template = env.workerUrlTemplate ?? "https://workers.local/{workerId}"
   const url = template.replace("{workerId}", input.workerId)
   return {
@@ -375,6 +383,11 @@ export async function deprovisionWorker(input: {
 }) {
   if (env.provisionerMode === "daytona") {
     await deprovisionWorkerOnDaytona(input.workerId)
+    return
+  }
+
+  if (env.provisionerMode === "kubernetes") {
+    await deprovisionWorkerOnKubernetes(input.workerId)
     return
   }
 

--- a/ee/apps/den-api/src/workers/worker-access.ts
+++ b/ee/apps/den-api/src/workers/worker-access.ts
@@ -10,6 +10,11 @@ import {
   inspectDaytonaSandbox,
   refreshDaytonaSignedPreview,
 } from "./daytona.js"
+import {
+  getKubernetesWorkerRecord,
+  inspectKubernetesWorker,
+  refreshKubernetesSignedPreview,
+} from "./kubernetes.js"
 import { recoverClaimedCloudWorker, wakeCloudWorker } from "./cloud-lifecycle.js"
 import { fetchWithConnectRetry, previewFetch } from "./preview-fetch.js"
 import {
@@ -191,6 +196,18 @@ function tokenByScope(tokens: CloudRuntimeToken[], scope: CloudRuntimeToken["sco
   return tokens.find((entry) => entry.scope === scope)?.token ?? null
 }
 
+function defaultGetSandboxRecord(): GetSandboxRecord {
+  return env.provisionerMode === "kubernetes" ? getKubernetesWorkerRecord : getDaytonaSandboxRecord
+}
+
+function defaultRefreshSignedPreview(): RefreshSignedPreview {
+  return env.provisionerMode === "kubernetes" ? refreshKubernetesSignedPreview : refreshDaytonaSignedPreview
+}
+
+function defaultInspectSandbox(): InspectSandbox {
+  return env.provisionerMode === "kubernetes" ? inspectKubernetesWorker : inspectDaytonaSandbox
+}
+
 function healthUrlForPreview(signedPreviewUrl: string) {
   return `${signedPreviewUrl.replace(/\/+$/, "")}/health`
 }
@@ -332,6 +349,11 @@ function isStoppedSandboxState(state: string | null) {
 }
 
 function workerNeedsSnapshotRecycle(worker: CloudRuntimeWorker) {
+  if (env.provisionerMode === "kubernetes") {
+    const image = env.kubernetes.workerImage
+    return Boolean(image && "image_version" in worker && worker.image_version !== image)
+  }
+
   const snapshot = env.daytona.snapshot
   return Boolean(snapshot && "image_version" in worker && worker.image_version !== snapshot)
 }
@@ -474,9 +496,9 @@ export async function resolveCloudRuntimeAccess(
 
   const store = options.store ?? databaseCloudRuntimeStore
   const state = await resolveCloudRuntimeState({ worker, organizationId: ownership.organizationId }, {
-    refreshSignedPreview: options.refreshSignedPreview ?? refreshDaytonaSignedPreview,
-    getSandboxRecord: options.getSandboxRecord ?? getDaytonaSandboxRecord,
-    inspectSandbox: options.inspectSandbox ?? inspectDaytonaSandbox,
+    refreshSignedPreview: options.refreshSignedPreview ?? defaultRefreshSignedPreview(),
+    getSandboxRecord: options.getSandboxRecord ?? defaultGetSandboxRecord(),
+    inspectSandbox: options.inspectSandbox ?? defaultInspectSandbox(),
     probeSignedPreview: options.probeSignedPreview ?? probeCloudRuntimeSignedPreview,
     startWake: options.startWake ?? startDefaultWake,
     startRecovery: options.startRecovery ?? startDefaultRecovery,

--- a/ee/apps/den-api/src/workers/worker-access.ts
+++ b/ee/apps/den-api/src/workers/worker-access.ts
@@ -49,7 +49,7 @@ type UserId = NonNullable<typeof WorkerTable.$inferSelect.created_by_user_id>
 type WorkerId = typeof WorkerTable.$inferSelect.id
 type GetSandboxRecord = (workerId: WorkerId) => Promise<CloudRuntimeSandboxRecord | null>
 type InspectSandbox = (workerId: WorkerId) => Promise<CloudRuntimeSandboxInspection>
-type RefreshSignedPreview = (workerId: WorkerId) => Promise<CloudRuntimeSandboxRecord | null>
+export type RefreshSignedPreview = (workerId: WorkerId) => Promise<CloudRuntimeSandboxRecord | null>
 type ProbeSignedPreview = (signedPreviewUrl: string) => Promise<boolean>
 type StartWake = (workerId: WorkerId) => void
 
@@ -196,15 +196,15 @@ function tokenByScope(tokens: CloudRuntimeToken[], scope: CloudRuntimeToken["sco
   return tokens.find((entry) => entry.scope === scope)?.token ?? null
 }
 
-function defaultGetSandboxRecord(): GetSandboxRecord {
+export function defaultGetSandboxRecord(): GetSandboxRecord {
   return env.provisionerMode === "kubernetes" ? getKubernetesWorkerRecord : getDaytonaSandboxRecord
 }
 
-function defaultRefreshSignedPreview(): RefreshSignedPreview {
+export function defaultRefreshSignedPreview(): RefreshSignedPreview {
   return env.provisionerMode === "kubernetes" ? refreshKubernetesSignedPreview : refreshDaytonaSignedPreview
 }
 
-function defaultInspectSandbox(): InspectSandbox {
+export function defaultInspectSandbox(): InspectSandbox {
   return env.provisionerMode === "kubernetes" ? inspectKubernetesWorker : inspectDaytonaSandbox
 }
 

--- a/ee/apps/den-api/test/kubernetes-provisioning.test.ts
+++ b/ee/apps/den-api/test/kubernetes-provisioning.test.ts
@@ -464,3 +464,104 @@ describe("Kubernetes health deadline", () => {
     expect(message).toContain("[REDACTED]")
   })
 })
+
+describe("Kubernetes worker pod overrides", () => {
+  // Reads the Deployment manifest the provisioner created from the fake client.
+  async function createdManifest() {
+    const input = provisionInput()
+    const fake = makeClient()
+    await kubernetes.provisionWorkerOnKubernetesWithRuntime(input, makeRuntime(fake.client))
+    const manifest = (await fake.client.getDeployment(kubernetes.kubernetesWorkerName(input.workerId))) as Record<string, unknown>
+    const spec = manifest.spec as { template: { spec: Record<string, unknown>; metadata: { labels?: Record<string, string>; annotations?: Record<string, unknown> } } }
+    const template = spec.template
+    return { input, template, podSpec: template.spec, podMeta: template.metadata }
+  }
+
+  test("injects nodeSelector, tolerations, affinity, and imagePullSecrets when configured", async () => {
+    env.kubernetes.workerNodeSelector = { "nodepool": "gpu" }
+    env.kubernetes.workerTolerations = [{ key: "gpu", operator: "Exists" }]
+    env.kubernetes.workerAffinity = { nodeAffinity: {} }
+    env.kubernetes.workerImagePullSecrets = ["regcred"]
+    const { podSpec } = await createdManifest()
+    expect(podSpec.nodeSelector).toEqual({ nodepool: "gpu" })
+    expect(podSpec.tolerations).toEqual([{ key: "gpu", operator: "Exists" }])
+    expect(podSpec.affinity).toEqual({ nodeAffinity: {} })
+    expect(podSpec.imagePullSecrets).toEqual([{ name: "regcred" }])
+    env.kubernetes.workerNodeSelector = undefined
+    env.kubernetes.workerTolerations = undefined
+    env.kubernetes.workerAffinity = undefined
+    env.kubernetes.workerImagePullSecrets = undefined
+  })
+
+  test("merges operator pod labels without clobbering the provisioner selector labels", async () => {
+    env.kubernetes.workerPodLabels = { "team": "platform", "openwork.den.worker-id": "evil" }
+    const { podMeta, input } = await createdManifest()
+    expect(podMeta.labels?.["team"]).toBe("platform")
+    // The provisioner selector label must win over the operator's attempt to clobber it.
+    expect(podMeta.labels?.["openwork.den.worker-id"]).toBe(input.workerId)
+    env.kubernetes.workerPodLabels = undefined
+  })
+
+  test("applies pod annotations, security contexts, priority class, and dns config", async () => {
+    env.kubernetes.workerPodAnnotations = { "corp.io/owner": "infra" }
+    env.kubernetes.workerPodSecurityContext = { runAsNonRoot: true }
+    env.kubernetes.workerContainerSecurityContext = { allowPrivilegeEscalation: false }
+    env.kubernetes.workerPriorityClassName = "worker-priority"
+    env.kubernetes.workerDnsPolicy = "ClusterFirst"
+    env.kubernetes.workerDnsConfig = { nameservers: ["1.1.1.1"] }
+    const { podSpec, podMeta } = await createdManifest()
+    expect(podMeta.annotations?.["corp.io/owner"]).toBe("infra")
+    expect(podSpec.securityContext).toEqual({ runAsNonRoot: true })
+    expect((podSpec.containers as Array<{ securityContext?: unknown }>)[0].securityContext).toEqual({ allowPrivilegeEscalation: false })
+    expect(podSpec.priorityClassName).toBe("worker-priority")
+    expect(podSpec.dnsPolicy).toBe("ClusterFirst")
+    expect(podSpec.dnsConfig).toEqual({ nameservers: ["1.1.1.1"] })
+    env.kubernetes.workerPodAnnotations = undefined
+    env.kubernetes.workerPodSecurityContext = undefined
+    env.kubernetes.workerContainerSecurityContext = undefined
+    env.kubernetes.workerPriorityClassName = undefined
+    env.kubernetes.workerDnsPolicy = undefined
+    env.kubernetes.workerDnsConfig = undefined
+  })
+
+  test("appends non-colliding extra volumes and mounts, drops colliding ones", async () => {
+    env.kubernetes.workerExtraVolumes = [{ name: "scratch", emptyDir: {} }, { name: "workspace", emptyDir: {} }]
+    env.kubernetes.workerExtraVolumeMounts = [{ name: "scratch", mountPath: "/scratch" }, { name: "data", mountPath: "/evil" }]
+    const { podSpec } = await createdManifest()
+    const volumes = podSpec.volumes as Array<{ name: string }>
+    const mounts = (podSpec.containers as Array<{ volumeMounts: Array<{ name: string }> }>)[0].volumeMounts
+    expect(volumes.some((v) => v.name === "scratch")).toBe(true)
+    expect(volumes.filter((v) => v.name === "workspace").length).toBe(1)
+    expect(mounts.some((m) => m.name === "scratch")).toBe(true)
+    expect(mounts.filter((m) => m.name === "data").length).toBe(1)
+    expect(mounts.some((m) => m.mountPath === "/evil")).toBe(false)
+    env.kubernetes.workerExtraVolumes = undefined
+    env.kubernetes.workerExtraVolumeMounts = undefined
+  })
+
+  test("appends non-colliding extra env and drops entries that override provisioner env", async () => {
+    env.kubernetes.workerExtraEnv = [{ name: "EXTRA_VAR", value: "yes" }, { name: "OPENWORK_TOKEN", value: "stolen" }]
+    const { podSpec } = await createdManifest()
+    const envArr = (podSpec.containers as Array<{ env: Array<{ name: string; value?: string }> }>)[0].env
+    expect(envArr.some((e) => e.name === "EXTRA_VAR" && e.value === "yes")).toBe(true)
+    expect(envArr.filter((e) => e.name === "OPENWORK_TOKEN").length).toBe(1)
+    expect(envArr.find((e) => e.name === "OPENWORK_TOKEN")?.value).toBeUndefined()
+    env.kubernetes.workerExtraEnv = undefined
+  })
+
+  test("produces the same manifest as today when no overrides are set", async () => {
+    const { podSpec, podMeta } = await createdManifest()
+    expect(podSpec.nodeSelector).toBeUndefined()
+    expect(podSpec.affinity).toBeUndefined()
+    expect(podSpec.tolerations).toBeUndefined()
+    expect(podSpec.imagePullSecrets).toBeUndefined()
+    expect(podSpec.securityContext).toBeUndefined()
+    expect(podSpec.priorityClassName).toBeUndefined()
+    expect(podSpec.dnsPolicy).toBeUndefined()
+    expect(podSpec.dnsConfig).toBeUndefined()
+    expect(podMeta.annotations).toBeUndefined()
+    expect((podSpec.containers as Array<{ securityContext?: unknown }>)[0].securityContext).toBeUndefined()
+    const volumes = podSpec.volumes as Array<{ name: string }>
+    expect(volumes.map((v) => v.name).sort()).toEqual(["data", "workspace"])
+  })
+})

--- a/ee/apps/den-api/test/kubernetes-provisioning.test.ts
+++ b/ee/apps/den-api/test/kubernetes-provisioning.test.ts
@@ -1,7 +1,7 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, describe, expect, test } from "bun:test"
 import type { KubernetesClient } from "../src/workers/kubernetes-client.js"
-import { KubernetesNotFoundError } from "../src/workers/kubernetes-client.js"
+import { KubernetesApiError, KubernetesNotFoundError } from "../src/workers/kubernetes-client.js"
 import { env } from "../src/env.js"
 
 type KubernetesModule = typeof import("../src/workers/kubernetes.js")
@@ -52,12 +52,36 @@ function makeClient(input: {
   deployment?: Record<string, unknown> | null
   podPhase?: string
   podLogs?: string
+  conflictOnCreate?: Array<"createPvc" | "createSecret" | "createService">
 } = {}) {
   const ops: RecordedOp[] = []
   let deployment = input.deployment ?? null
+  // A pre-existing deployment implies a pre-existing worker whose PVCs exist.
+  let pvc: Record<string, unknown> | null = input.deployment ? {} : null
+  let secret: Record<string, unknown> | null = null
+  let service: Record<string, unknown> | null = null
 
   const notFound = (name: string) => {
     throw new KubernetesNotFoundError(`deployments/${name}`, "")
+  }
+
+  // Simulates a concurrent replica winning the create: the object lands in the
+  // store and the create reports 409 once per listed occurrence.
+  const pendingConflicts = [...(input.conflictOnCreate ?? [])]
+  const conflictIfRequested = (op: "createPvc" | "createSecret" | "createService") => {
+    const index = pendingConflicts.indexOf(op)
+    if (index === -1) {
+      return
+    }
+    pendingConflicts.splice(index, 1)
+    if (op === "createPvc") {
+      pvc = pvc ?? {}
+    } else if (op === "createSecret") {
+      secret = secret ?? {}
+    } else {
+      service = service ?? {}
+    }
+    throw new KubernetesApiError(`Kubernetes API POST ${op} failed (409)`, 409, "already exists")
   }
 
   const client = {
@@ -80,36 +104,70 @@ function makeClient(input: {
     },
     async deleteDeployment(name: string) {
       ops.push({ op: "deleteDeployment", name })
+      if (!deployment) {
+        notFound(name)
+      }
       deployment = null
     },
     async getService(name: string) {
       ops.push({ op: "getService", name })
-      return {}
+      if (!service) {
+        notFound(name)
+      }
+      return service
     },
     async createService(manifest: Record<string, unknown>) {
       ops.push({ op: "createService" })
+      conflictIfRequested("createService")
+      service = manifest
       return manifest
     },
     async deleteService(name: string) {
       ops.push({ op: "deleteService", name })
+      if (!service) {
+        notFound(name)
+      }
+      service = null
+    },
+    async getSecret(name: string) {
+      ops.push({ op: "getSecret", name })
+      if (!secret) {
+        notFound(name)
+      }
+      return secret
     },
     async createSecret(manifest: Record<string, unknown>) {
       ops.push({ op: "createSecret" })
+      conflictIfRequested("createSecret")
+      secret = manifest
       return manifest
     },
     async deleteSecret(name: string) {
       ops.push({ op: "deleteSecret", name })
+      if (!secret) {
+        notFound(name)
+      }
+      secret = null
     },
     async createPvc(manifest: Record<string, unknown>) {
       ops.push({ op: "createPvc" })
+      conflictIfRequested("createPvc")
+      pvc = manifest
       return manifest
     },
     async getPvc(name: string) {
       ops.push({ op: "getPvc", name })
-      return {}
+      if (!pvc) {
+        notFound(name)
+      }
+      return pvc
     },
     async deletePvc(name: string) {
       ops.push({ op: "deletePvc", name })
+      if (!pvc) {
+        notFound(name)
+      }
+      pvc = null
     },
     async listPods(_labelSelector: string) {
       ops.push({ op: "listPods" })
@@ -121,10 +179,6 @@ function makeClient(input: {
           },
         ],
       }
-    },
-    async getPod(name: string) {
-      ops.push({ op: "getPod", name })
-      return {}
     },
     async getPodLogs(_name: string, _options?: { tailLines?: number }) {
       ops.push({ op: "getPodLogs" })
@@ -206,6 +260,73 @@ describe("Kubernetes worker provisioning", () => {
 
     const patch = fake.ops.find((entry) => entry.op === "patchDeployment")?.patch as { spec?: { replicas?: number } } | undefined
     expect(patch?.spec?.replicas).toBe(1)
+  })
+
+  test("tolerates 409 conflicts on supporting-object creates in the fresh path", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ conflictOnCreate: ["createPvc", "createPvc", "createSecret", "createService"] })
+    const provisioned = await kubernetes.provisionWorkerOnKubernetesWithRuntime(
+      input,
+      makeRuntime(fake.client),
+    )
+
+    expect(fake.ops.filter((entry) => entry.op === "getPvc").length).toBe(2)
+    expect(fake.ops.some((entry) => entry.op === "getSecret")).toBe(true)
+    expect(fake.ops.some((entry) => entry.op === "getService")).toBe(true)
+    expect(provisioned.status).toBe("healthy")
+  })
+
+  test("upserts the token secret by delete and recreate after a create conflict", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: { spec: { replicas: 1 } }, conflictOnCreate: ["createSecret"] })
+    const provisioned = await kubernetes.provisionWorkerOnKubernetesWithRuntime(
+      input,
+      makeRuntime(fake.client),
+    )
+
+    const secretOps = fake.ops.filter((entry) => entry.op === "createSecret" || entry.op === "deleteSecret").map((entry) => entry.op)
+    expect(secretOps).toEqual(["createSecret", "deleteSecret", "createSecret"])
+    expect(provisioned.status).toBe("healthy")
+  })
+
+  test("patches an adopted deployment running a stale image before reporting healthy", async () => {
+    const input = provisionInput()
+    const fake = makeClient({
+      deployment: {
+        spec: {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [{ name: "openwork-server", image: "registry.test/openwork-worker:stale" }],
+            },
+          },
+        },
+      },
+    })
+    const provisioned = await kubernetes.provisionWorkerOnKubernetesWithRuntime(
+      input,
+      makeRuntime(fake.client),
+    )
+
+    const patch = fake.ops.find((entry) => entry.op === "patchDeployment")?.patch as {
+      spec?: { template?: { spec?: { containers?: Array<{ image?: string }> } } }
+    } | undefined
+    expect(patch?.spec?.template?.spec?.containers?.[0]?.image).toBe("registry.test/openwork-worker:test")
+    expect(provisioned.imageVersion).toBe("registry.test/openwork-worker:test")
+  })
+
+  test("substitutes the DNS-safe worker name into WORKER_URL_TEMPLATE", async () => {
+    const input = provisionInput()
+    const original = env.workerUrlTemplate
+    env.workerUrlTemplate = "https://{workerId}.workers.example.test:8787"
+    try {
+      const fake = makeClient()
+      const provisioned = await kubernetes.provisionWorkerOnKubernetesWithRuntime(input, makeRuntime(fake.client))
+      expect(provisioned.url).toBe(`https://${kubernetes.kubernetesWorkerName(input.workerId)}.workers.example.test:8787`)
+      expect(provisioned.url).not.toContain("_")
+    } finally {
+      env.workerUrlTemplate = original
+    }
   })
 })
 
@@ -320,6 +441,26 @@ describe("Kubernetes health deadline", () => {
 
     expect(
       kubernetes.provisionWorkerOnKubernetesWithRuntime(input, runtime),
-    ).rejects.toThrow("Timed out waiting for Kubernetes worker health")
+    ).rejects.toThrow(/CrashLoopBackOff[\s\S]*worker crashed at boot/s)
+  })
+
+  test("redacts tokens printed by the worker entrypoint from health-timeout diagnostics", async () => {
+    const input = provisionInput()
+    const logs = [
+      "Starting OpenWork micro-sandbox",
+      `- client token: ${input.clientToken}`,
+      `- host token: ${input.hostToken}`,
+      "worker crashed at boot",
+    ].join("\n")
+    const fake = makeClient({ podPhase: "CrashLoopBackOff", podLogs: logs })
+    const runtime = makeRuntime(fake.client, failingFetch())
+
+    const error = await kubernetes.provisionWorkerOnKubernetesWithRuntime(input, runtime).catch((e) => e)
+    const message = error instanceof Error ? error.message : String(error)
+    expect(message).toContain("CrashLoopBackOff")
+    expect(message).toContain("worker crashed at boot")
+    expect(message).not.toContain(input.clientToken)
+    expect(message).not.toContain(input.hostToken)
+    expect(message).toContain("[REDACTED]")
   })
 })

--- a/ee/apps/den-api/test/kubernetes-provisioning.test.ts
+++ b/ee/apps/den-api/test/kubernetes-provisioning.test.ts
@@ -1,0 +1,325 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+import type { KubernetesClient } from "../src/workers/kubernetes-client.js"
+import { KubernetesNotFoundError } from "../src/workers/kubernetes-client.js"
+import { env } from "../src/env.js"
+
+type KubernetesModule = typeof import("../src/workers/kubernetes.js")
+type ProvisionInput = Parameters<KubernetesModule["provisionWorkerOnKubernetesWithRuntime"]>[0]
+type Runtime = Parameters<KubernetesModule["provisionWorkerOnKubernetesWithRuntime"]>[1]
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+// env.ts is parsed once per process and sibling test files import it first, so
+// the kubernetes tuning is applied to the parsed snapshot rather than relying
+// on process.env seeding.
+function seedKubernetesEnv() {
+  env.kubernetes.workerImage = "registry.test/openwork-worker:test"
+  env.kubernetes.workerNamespace = "openwork-workers"
+  // Small enough that a failing health endpoint trips the deadline quickly in
+  // the timeout test, large enough for immediate-200 probes everywhere else.
+  env.kubernetes.healthcheckTimeoutMs = 60
+  env.kubernetes.pollIntervalMs = 10
+}
+
+let kubernetes: KubernetesModule
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  kubernetes = await import("../src/workers/kubernetes.js")
+  seedKubernetesEnv()
+})
+
+function provisionInput(): ProvisionInput {
+  return {
+    workerId: createDenTypeId("worker"),
+    name: "Cloud",
+    hostToken: "host-token",
+    clientToken: "client-token",
+    activityToken: "activity-token",
+  }
+}
+
+type RecordedOp = { op: string; name?: string; patch?: unknown }
+
+function makeClient(input: {
+  deployment?: Record<string, unknown> | null
+  podPhase?: string
+  podLogs?: string
+} = {}) {
+  const ops: RecordedOp[] = []
+  let deployment = input.deployment ?? null
+
+  const notFound = (name: string) => {
+    throw new KubernetesNotFoundError(`deployments/${name}`, "")
+  }
+
+  const client = {
+    namespace: "openwork-workers",
+    async getDeployment(name: string) {
+      ops.push({ op: "getDeployment", name })
+      if (!deployment) {
+        notFound(name)
+      }
+      return deployment
+    },
+    async createDeployment(manifest: Record<string, unknown>) {
+      ops.push({ op: "createDeployment" })
+      deployment = manifest
+      return manifest
+    },
+    async patchDeployment(name: string, patch: Record<string, unknown>) {
+      ops.push({ op: "patchDeployment", name, patch })
+      return {}
+    },
+    async deleteDeployment(name: string) {
+      ops.push({ op: "deleteDeployment", name })
+      deployment = null
+    },
+    async getService(name: string) {
+      ops.push({ op: "getService", name })
+      return {}
+    },
+    async createService(manifest: Record<string, unknown>) {
+      ops.push({ op: "createService" })
+      return manifest
+    },
+    async deleteService(name: string) {
+      ops.push({ op: "deleteService", name })
+    },
+    async createSecret(manifest: Record<string, unknown>) {
+      ops.push({ op: "createSecret" })
+      return manifest
+    },
+    async deleteSecret(name: string) {
+      ops.push({ op: "deleteSecret", name })
+    },
+    async createPvc(manifest: Record<string, unknown>) {
+      ops.push({ op: "createPvc" })
+      return manifest
+    },
+    async getPvc(name: string) {
+      ops.push({ op: "getPvc", name })
+      return {}
+    },
+    async deletePvc(name: string) {
+      ops.push({ op: "deletePvc", name })
+    },
+    async listPods(_labelSelector: string) {
+      ops.push({ op: "listPods" })
+      return {
+        items: [
+          {
+            metadata: { name: "wrk-test-abc123" },
+            status: { phase: input.podPhase ?? "CrashLoopBackOff" },
+          },
+        ],
+      }
+    },
+    async getPod(name: string) {
+      ops.push({ op: "getPod", name })
+      return {}
+    },
+    async getPodLogs(_name: string, _options?: { tailLines?: number }) {
+      ops.push({ op: "getPodLogs" })
+      return input.podLogs ?? "worker booting"
+    },
+  }
+
+  return {
+    client: client as unknown as KubernetesClient,
+    ops,
+    setDeployment(value: Record<string, unknown> | null) {
+      deployment = value
+    },
+  }
+}
+
+function healthyFetch(): typeof fetch {
+  return (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch
+}
+
+function failingFetch(): typeof fetch {
+  return (async () => new Response("{}", { status: 503 })) as unknown as typeof fetch
+}
+
+function makeRuntime(client: KubernetesClient, healthFetch: typeof fetch = healthyFetch()): Runtime {
+  return { client, healthFetch }
+}
+
+describe("Kubernetes worker naming", () => {
+  test("maps typeid worker ids to DNS-1123-safe names", () => {
+    expect(kubernetes.kubernetesWorkerName("wrk_abcdefghjkmnpqrstuvwxyz3")).toBe("wrk-abcdefghjkmnpqrstuvwxyz3")
+  })
+})
+
+describe("Kubernetes worker provisioning", () => {
+  test("creates the PVC, secret, deployment, and service set for a fresh worker", async () => {
+    const input = provisionInput()
+    const fake = makeClient()
+    const provisioned = await kubernetes.provisionWorkerOnKubernetesWithRuntime(
+      input,
+      makeRuntime(fake.client),
+    )
+
+    const created = fake.ops.filter((entry) => entry.op === "createPvc").length
+    expect(created).toBe(2)
+    expect(fake.ops.some((entry) => entry.op === "createSecret")).toBe(true)
+    expect(fake.ops.some((entry) => entry.op === "createDeployment")).toBe(true)
+    expect(fake.ops.some((entry) => entry.op === "createService")).toBe(true)
+
+    expect(provisioned).toEqual({
+      provider: "kubernetes",
+      url: `http://${kubernetes.kubernetesWorkerName(input.workerId)}.openwork-workers.svc.cluster.local:8787`,
+      status: "healthy",
+      region: "openwork-workers",
+      imageVersion: "registry.test/openwork-worker:test",
+    })
+  })
+
+  test("adopts an existing deployment instead of recreating objects", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: { spec: { replicas: 1 } } })
+    const provisioned = await kubernetes.provisionWorkerOnKubernetesWithRuntime(
+      input,
+      makeRuntime(fake.client),
+    )
+
+    expect(fake.ops.some((entry) => entry.op === "createDeployment")).toBe(false)
+    expect(fake.ops.some((entry) => entry.op === "createService")).toBe(false)
+    expect(fake.ops.some((entry) => entry.op === "createPvc")).toBe(false)
+    // Adoption refreshes tokens so a restarted worker keeps working access.
+    expect(fake.ops.some((entry) => entry.op === "createSecret")).toBe(true)
+    expect(provisioned.status).toBe("healthy")
+  })
+
+  test("scales an adopted scaled-down deployment back up", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: { spec: { replicas: 0 } } })
+    await kubernetes.provisionWorkerOnKubernetesWithRuntime(input, makeRuntime(fake.client))
+
+    const patch = fake.ops.find((entry) => entry.op === "patchDeployment")?.patch as { spec?: { replicas?: number } } | undefined
+    expect(patch?.spec?.replicas).toBe(1)
+  })
+})
+
+describe("Kubernetes worker wake", () => {
+  test("patches a stale image onto the deployment before waking", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: { spec: { replicas: 0 } } })
+    const provisioned = await kubernetes.wakeWorkerOnKubernetesWithRuntime(
+      input,
+      makeRuntime(fake.client),
+      "registry.test/openwork-worker:old",
+    )
+
+    const patch = fake.ops.find((entry) => entry.op === "patchDeployment")?.patch as {
+      spec?: { replicas?: number; template?: { spec?: { containers?: Array<{ image?: string }> } } }
+    } | undefined
+    expect(patch?.spec?.replicas).toBe(1)
+    expect(patch?.spec?.template?.spec?.containers?.[0]?.image).toBe("registry.test/openwork-worker:test")
+    expect(provisioned.imageVersion).toBe("registry.test/openwork-worker:test")
+  })
+
+  test("throws a missing-worker error when the deployment is gone", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: null })
+    expect(
+      kubernetes.wakeWorkerOnKubernetesWithRuntime(input, makeRuntime(fake.client), null),
+    ).rejects.toHaveProperty("name", "KubernetesWorkerMissingError")
+  })
+})
+
+describe("Kubernetes worker stop and deprovision", () => {
+  test("scales a running worker to zero without deleting its objects", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: { spec: { replicas: 1 } } })
+    const result = await kubernetes.stopWorkerOnKubernetesWithRuntime(input.workerId, makeRuntime(fake.client))
+
+    expect(result).toEqual({ status: "stopped" })
+    expect(fake.ops.some((entry) => entry.op === "deleteDeployment")).toBe(false)
+    const patch = fake.ops.find((entry) => entry.op === "patchDeployment")?.patch as { spec?: { replicas?: number } } | undefined
+    expect(patch?.spec?.replicas).toBe(0)
+  })
+
+  test("reports an already-stopped worker without patching", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: { spec: { replicas: 0 } } })
+    const result = await kubernetes.stopWorkerOnKubernetesWithRuntime(input.workerId, makeRuntime(fake.client))
+
+    expect(result).toEqual({ status: "stopped" })
+    expect(fake.ops.some((entry) => entry.op === "patchDeployment")).toBe(false)
+  })
+
+  test("reports no_sandbox when the deployment is missing", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: null })
+    const result = await kubernetes.stopWorkerOnKubernetesWithRuntime(input.workerId, makeRuntime(fake.client))
+
+    expect(result).toEqual({ status: "no_sandbox" })
+  })
+
+  test("deletes every worker object and tolerates missing ones", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: null })
+    await kubernetes.deprovisionWorkerOnKubernetesWithRuntime(input.workerId, makeRuntime(fake.client))
+
+    const deleted = fake.ops.filter((entry) => entry.op.startsWith("delete")).map((entry) => entry.op)
+    expect(deleted).toEqual([
+      "deleteDeployment",
+      "deleteService",
+      "deleteSecret",
+      "deletePvc",
+      "deletePvc",
+    ])
+  })
+})
+
+describe("Kubernetes worker records and inspection", () => {
+  test("returns a preview record with the configured TTL for a live deployment", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: { spec: { replicas: 1 } } })
+    const record = await kubernetes.getKubernetesWorkerRecordWithRuntime(input.workerId, makeRuntime(fake.client))
+
+    expect(record?.sandbox_id).toBe(kubernetes.kubernetesWorkerName(input.workerId))
+    expect(record?.signed_preview_url).toContain("svc.cluster.local")
+    expect(record!.signed_preview_url_expires_at.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  test("returns no record when the deployment is missing", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ deployment: null })
+    const record = await kubernetes.getKubernetesWorkerRecordWithRuntime(input.workerId, makeRuntime(fake.client))
+
+    expect(record).toBeNull()
+  })
+
+  test("inspects replica state as stopped or started", async () => {
+    const input = provisionInput()
+    const stopped = makeClient({ deployment: { spec: { replicas: 0 } } })
+    expect(await kubernetes.inspectKubernetesWorkerWithRuntime(input.workerId, makeRuntime(stopped.client)))
+      .toEqual({ state: "stopped" })
+
+    const started = makeClient({ deployment: { spec: { replicas: 1 } } })
+    expect(await kubernetes.inspectKubernetesWorkerWithRuntime(input.workerId, makeRuntime(started.client)))
+      .toEqual({ state: "started" })
+  })
+})
+
+describe("Kubernetes health deadline", () => {
+  test("includes pod phase and log tail in the health timeout error", async () => {
+    const input = provisionInput()
+    const fake = makeClient({ podPhase: "CrashLoopBackOff", podLogs: "worker crashed at boot" })
+    const runtime = makeRuntime(fake.client, failingFetch())
+
+    expect(
+      kubernetes.provisionWorkerOnKubernetesWithRuntime(input, runtime),
+    ).rejects.toThrow("Timed out waiting for Kubernetes worker health")
+  })
+})

--- a/evals/packages/labs/src/index.ts
+++ b/evals/packages/labs/src/index.ts
@@ -4,6 +4,7 @@ export * from "./idp.ts";
 export * from "./mock-google.ts";
 export * from "./mock-github.ts";
 export * from "./mock-cloud-runtime.ts";
+export * from "./mock-kubernetes-apiserver.ts";
 export * from "./mock-mcp.ts";
 export * from "./not-implemented.ts";
 export * from "./release-feed.ts";

--- a/evals/packages/labs/src/mock-kubernetes-apiserver.ts
+++ b/evals/packages/labs/src/mock-kubernetes-apiserver.ts
@@ -72,7 +72,7 @@ export async function startMockKubernetesApiserver() {
   const pvcs = new Map<string, Record<string, unknown>>();
   const patches: Array<{ kind: MockKubernetesObjectKind; name: string; patch: Record<string, unknown>; at: number }> = [];
   const deletes: Array<{ kind: MockKubernetesObjectKind; name: string; at: number }> = [];
-  const requests: Array<{ method: string; path: string; at: number }> = [];
+  const requests: Array<{ method: string; path: string; at: number; contentType?: string }> = [];
   const unexpected: string[] = [];
   let healthy = false;
   let url = "";
@@ -107,7 +107,13 @@ export async function startMockKubernetesApiserver() {
   async function handle(request: IncomingMessage, response: ServerResponse) {
     const method = request.method ?? "GET";
     const path = new URL(request.url ?? "/", "http://localhost").pathname;
-    requests.push({ method, path, at: Date.now() });
+    const rawContentType = request.headers["content-type"];
+    const contentType = method === "PATCH"
+      ? typeof rawContentType === "string"
+        ? rawContentType
+        : ""
+      : undefined;
+    requests.push({ method, path, at: Date.now(), ...(contentType !== undefined ? { contentType } : {}) });
 
     // Worker-pod health probes arrive here through the eval fetch shim (the
     // in-cluster service DNS name is rewritten to the witness base URL).
@@ -138,6 +144,9 @@ export async function startMockKubernetesApiserver() {
         return existing ? json(response, 200, existing) : json(response, 404, { message: "not found", reason: "NotFound", code: 404 });
       }
       if (method === "PATCH" && existing) {
+        if (contentType !== "application/strategic-merge-patch+json") {
+          return json(response, 415, { message: `PATCH requires Content-Type application/strategic-merge-patch+json, got: ${contentType || "<none>"}`, reason: "UnsupportedMediaType", code: 415 });
+        }
         const patch = await body(request);
         const merged = strategicMerge(existing, patch);
         deployments.set(name, merged);

--- a/evals/packages/labs/src/mock-kubernetes-apiserver.ts
+++ b/evals/packages/labs/src/mock-kubernetes-apiserver.ts
@@ -1,0 +1,292 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected a JSON object");
+  return value;
+}
+
+async function body(request: IncomingMessage): Promise<Record<string, unknown>> {
+  let raw = "";
+  for await (const chunk of request) raw += String(chunk);
+  return raw ? record(JSON.parse(raw)) : {};
+}
+
+function json(response: ServerResponse, status: number, value: unknown) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+
+function metadataOf(manifest: Record<string, unknown>) {
+  return record(manifest.metadata ?? {});
+}
+
+function nameOf(manifest: Record<string, unknown>) {
+  return String(metadataOf(manifest).name ?? "");
+}
+
+function labelsOf(manifest: Record<string, unknown>) {
+  const labels = metadataOf(manifest).labels;
+  return isRecord(labels) ? labels : {};
+}
+
+/**
+ * Kubernetes strategic-merge-patch, reduced to what the worker provisioner
+ * sends: plain object deep merge, with `containers` lists merged per container
+ * name instead of replaced.
+ */
+function strategicMerge(target: Record<string, unknown>, patch: Record<string, unknown>): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...target };
+  for (const [key, value] of Object.entries(patch)) {
+    const current = merged[key];
+    if (key === "containers" && Array.isArray(current) && Array.isArray(value)) {
+      const byName = new Map(current.map((container) => [String(record(container).name ?? ""), container as Record<string, unknown>]));
+      for (const entry of value) {
+        const container = record(entry);
+        const name = String(container.name ?? "");
+        const existing = byName.get(name);
+        byName.set(name, existing ? strategicMerge(existing, container) : container);
+      }
+      merged[key] = [...byName.values()];
+      continue;
+    }
+    if (isRecord(current) && isRecord(value)) {
+      merged[key] = strategicMerge(current, value);
+      continue;
+    }
+    merged[key] = value;
+  }
+  return merged;
+}
+
+export type MockKubernetesObjectKind = "deployments" | "services" | "secrets" | "persistentvolumeclaims";
+
+/** HTTP witness faking the Kubernetes API surface the worker provisioner uses. */
+export async function startMockKubernetesApiserver() {
+  const deployments = new Map<string, Record<string, unknown>>();
+  const services = new Map<string, Record<string, unknown>>();
+  const secrets = new Map<string, Record<string, unknown>>();
+  const pvcs = new Map<string, Record<string, unknown>>();
+  const patches: Array<{ kind: MockKubernetesObjectKind; name: string; patch: Record<string, unknown>; at: number }> = [];
+  const deletes: Array<{ kind: MockKubernetesObjectKind; name: string; at: number }> = [];
+  const requests: Array<{ method: string; path: string; at: number }> = [];
+  const unexpected: string[] = [];
+  let healthy = false;
+  let url = "";
+
+  const stores: Record<MockKubernetesObjectKind, Map<string, Record<string, unknown>>> = {
+    deployments,
+    services,
+    secrets,
+    persistentvolumeclaims: pvcs,
+  };
+
+  function workerDeploymentManifests(workerId: string) {
+    return [...deployments.values()].filter((manifest) => labelsOf(manifest)["openwork.den.worker-id"] === workerId);
+  }
+
+  function deploymentPodItems() {
+    return [...deployments.values()].map((manifest, index) => {
+      const replicas = record(record(manifest.spec ?? {}).template ?? {});
+      const pod = {
+        metadata: {
+          name: `${nameOf(manifest)}-pod-${index + 1}`,
+          namespace: metadataOf(manifest).namespace ?? "",
+          labels: labelsOf(manifest),
+        },
+        status: { phase: healthy ? "Running" : "Pending" },
+        spec: replicas,
+      };
+      return pod;
+    });
+  }
+
+  async function handle(request: IncomingMessage, response: ServerResponse) {
+    const method = request.method ?? "GET";
+    const path = new URL(request.url ?? "/", "http://localhost").pathname;
+    requests.push({ method, path, at: Date.now() });
+
+    // Worker-pod health probes arrive here through the eval fetch shim (the
+    // in-cluster service DNS name is rewritten to the witness base URL).
+    if (path === "/health") {
+      return json(response, healthy ? 200 : 503, { ready: healthy });
+    }
+
+    const deploymentCollection = path.match(/^\/apis\/apps\/v1\/namespaces\/[^/]+\/deployments$/);
+    const deploymentItem = path.match(/^\/apis\/apps\/v1\/namespaces\/[^/]+\/deployments\/([^/]+)$/);
+    const coreCollection = path.match(/^\/api\/v1\/namespaces\/[^/]+\/(services|secrets|persistentvolumeclaims)$/);
+    const coreItem = path.match(/^\/api\/v1\/namespaces\/[^/]+\/(services|secrets|persistentvolumeclaims)\/([^/]+)$/);
+    const pods = path.match(/^\/api\/v1\/namespaces\/[^/]+\/pods$/);
+    const podLogs = path.match(/^\/api\/v1\/namespaces\/[^/]+\/pods\/([^/]+)\/log$/);
+
+    if (method === "POST" && deploymentCollection) {
+      const manifest = await body(request);
+      const name = nameOf(manifest);
+      if (deployments.has(name)) {
+        return json(response, 409, { message: `deployments.apps "${name}" already exists`, reason: "AlreadyExists", code: 409 });
+      }
+      deployments.set(name, manifest);
+      return json(response, 201, manifest);
+    }
+    if (deploymentItem) {
+      const name = decodeURIComponent(deploymentItem[1] ?? "");
+      const existing = deployments.get(name);
+      if (method === "GET") {
+        return existing ? json(response, 200, existing) : json(response, 404, { message: "not found", reason: "NotFound", code: 404 });
+      }
+      if (method === "PATCH" && existing) {
+        const patch = await body(request);
+        const merged = strategicMerge(existing, patch);
+        deployments.set(name, merged);
+        patches.push({ kind: "deployments", name, patch, at: Date.now() });
+        return json(response, 200, merged);
+      }
+      if (method === "DELETE" && existing) {
+        deployments.delete(name);
+        deletes.push({ kind: "deployments", name, at: Date.now() });
+        return json(response, 200, existing);
+      }
+      if (!existing && method !== "GET") {
+        return json(response, 404, { message: "not found", reason: "NotFound", code: 404 });
+      }
+    }
+    if (method === "POST" && coreCollection) {
+      const kind = coreCollection[1] as MockKubernetesObjectKind;
+      const manifest = await body(request);
+      const name = nameOf(manifest);
+      const store = stores[kind];
+      if (store.has(name)) {
+        return json(response, 409, { message: `${kind} "${name}" already exists`, reason: "AlreadyExists", code: 409 });
+      }
+      store.set(name, manifest);
+      return json(response, 201, manifest);
+    }
+    if (coreItem) {
+      const kind = coreItem[1] as MockKubernetesObjectKind;
+      const name = decodeURIComponent(coreItem[2] ?? "");
+      const store = stores[kind];
+      const existing = store.get(name);
+      if (method === "GET") {
+        return existing ? json(response, 200, existing) : json(response, 404, { message: "not found", reason: "NotFound", code: 404 });
+      }
+      if (method === "DELETE" && existing) {
+        store.delete(name);
+        deletes.push({ kind, name, at: Date.now() });
+        return json(response, 200, existing);
+      }
+      if (!existing && method !== "GET") {
+        return json(response, 404, { message: "not found", reason: "NotFound", code: 404 });
+      }
+    }
+    if (method === "GET" && pods) {
+      const incoming = new URL(request.url ?? "/", "http://localhost");
+      const selector = incoming.searchParams.get("labelSelector") ?? "";
+      const [key, value] = selector.split("=");
+      const items = deploymentPodItems().filter((pod) => key && record(pod.metadata).labels && record(record(pod.metadata).labels)[key] === value);
+      return json(response, 200, { items });
+    }
+    if (method === "GET" && podLogs) {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("openwork-server starting\n");
+      return;
+    }
+
+    unexpected.push(`${method} ${path}`);
+    json(response, 404, { message: `Unimplemented Kubernetes witness route: ${method} ${path}` });
+  }
+
+  const server = createServer((request, response) => {
+    void handle(request, response).catch((error: unknown) => {
+      unexpected.push(error instanceof Error ? error.message : String(error));
+      json(response, 500, { message: "Kubernetes witness failed" });
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Kubernetes witness has no listening address");
+  url = `http://127.0.0.1:${address.port}`;
+
+  function allOf(kind: MockKubernetesObjectKind) {
+    return [...stores[kind].values()];
+  }
+
+  function deploymentReplicas(deploymentName: string) {
+    const manifest = deployments.get(deploymentName);
+    if (!manifest) return null;
+    const replicas = record(record(manifest).spec ?? {}).replicas;
+    return typeof replicas === "number" ? replicas : null;
+  }
+
+  function deploymentContainers(deploymentName: string) {
+    const manifest = deployments.get(deploymentName);
+    if (!manifest) return null;
+    const containers = record(record(record(record(manifest).spec ?? {}).template ?? {}).spec ?? {}).containers;
+    return Array.isArray(containers) ? containers as Array<Record<string, unknown>> : null;
+  }
+
+  return {
+    url,
+    requests,
+    unexpected,
+    patches,
+    deletes,
+    allOf,
+    names: (kind: MockKubernetesObjectKind) => [...stores[kind].keys()],
+    count: (kind: MockKubernetesObjectKind) => stores[kind].size,
+    deploymentNames: () => [...deployments.keys()],
+    deploymentForWorker: (workerId: string) => workerDeploymentManifests(workerId)[0] ?? null,
+    secretStringData: (name: string) => {
+      const secret = secrets.get(name);
+      const stringData = secret ? record(secret).stringData : undefined;
+      return isRecord(stringData) ? stringData : null;
+    },
+    containerEnv: (deploymentName: string) => deploymentContainers(deploymentName)?.[0]?.env as Array<Record<string, unknown>> | undefined ?? null,
+    deploymentImage: (deploymentName: string) => deploymentContainers(deploymentName)?.[0]?.image as string | undefined ?? null,
+    replicasOf: deploymentReplicas,
+    ready() {
+      healthy = true;
+    },
+    setHealthy(value: boolean) {
+      healthy = value;
+    },
+    async [Symbol.asyncDispose]() {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  };
+}
+
+export type MockKubernetesApiserver = Awaited<ReturnType<typeof startMockKubernetesApiserver>>;
+
+/**
+ * Node preload script (--require) for eval journeys: den-api probes worker
+ * pods at their in-cluster service DNS name, which cannot resolve outside a
+ * cluster. When KUBERNETES_HEALTH_WITNESS_URL is set, fetches to any
+ * *.svc.cluster.local host are rewritten to the witness so the REAL
+ * provisioner health polling runs against the mock control plane.
+ */
+export const KUBERNETES_HEALTH_SHIM_SCRIPT = String.raw`try {
+  const witness = process.env.KUBERNETES_HEALTH_WITNESS_URL;
+  if (witness) {
+    const original = globalThis.fetch;
+    globalThis.fetch = function patchedFetch(input, init) {
+      try {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url) {
+          const parsed = new URL(url);
+          if (parsed.hostname.endsWith(".svc.cluster.local")) {
+            const rewritten = new URL(parsed.pathname + parsed.search, witness);
+            return original(rewritten, init);
+          }
+        }
+      } catch {
+      }
+      return original(input, init);
+    };
+  }
+} catch {
+}
+`;

--- a/evals/packages/labs/test/mock-kubernetes-apiserver.test.ts
+++ b/evals/packages/labs/test/mock-kubernetes-apiserver.test.ts
@@ -70,6 +70,26 @@ test("witness applies strategic merge patches and records them", async () => {
   assert.equal(witness.containerEnv(WORKER_ID.replace(/_/g, "-"))?.length, 1);
 });
 
+test("witness rejects non strategic-merge PATCH content types with 415", async () => {
+  await using witness = await startMockKubernetesApiserver();
+  await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments`, {
+    method: "POST", body: JSON.stringify(deploymentManifest()),
+  });
+  const wrongType = await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments/${WORKER_ID.replace(/_/g, "-")}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ spec: { replicas: 0 } }),
+  });
+  assert.equal(wrongType.status, 415);
+  assert.equal((await wrongType.json()).reason, "UnsupportedMediaType");
+  // The rejected patch must not have been applied.
+  assert.equal(witness.replicasOf(WORKER_ID.replace(/_/g, "-")), 1);
+  assert.equal(witness.patches.length, 0);
+  // The rejected request is still recorded, with its content type.
+  const patchRequest = witness.requests.find((request) => request.method === "PATCH");
+  assert.equal(patchRequest?.contentType, "application/json");
+});
+
 test("witness lists pods by label selector and serves health readiness", async () => {
   await using witness = await startMockKubernetesApiserver();
   await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments`, {

--- a/evals/packages/labs/test/mock-kubernetes-apiserver.test.ts
+++ b/evals/packages/labs/test/mock-kubernetes-apiserver.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { startMockKubernetesApiserver } from "../src/mock-kubernetes-apiserver.ts";
+
+const WORKER_ID = "wrk_abcdefghijklmnopqrstuvwxyz";
+
+function workerLabels() {
+  return {
+    "openwork.den.provider": "kubernetes",
+    "openwork.den.worker-id": WORKER_ID,
+  };
+}
+
+function deploymentManifest() {
+  return {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: { name: WORKER_ID.replace(/_/g, "-"), namespace: "openwork-workers", labels: workerLabels() },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: workerLabels() },
+      template: {
+        metadata: { labels: workerLabels() },
+        spec: {
+          containers: [{ name: "openwork-server", image: "registry.example/worker:test", env: [{ name: "A", value: "b" }] }],
+        },
+      },
+    },
+  };
+}
+
+test("witness stores manifests, returns 409 on duplicate create, and 404 on missing get", async () => {
+  await using witness = await startMockKubernetesApiserver();
+  const create = await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments`, {
+    method: "POST", body: JSON.stringify(deploymentManifest()),
+  });
+  assert.equal(create.status, 201);
+  const duplicate = await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments`, {
+    method: "POST", body: JSON.stringify(deploymentManifest()),
+  });
+  assert.equal(duplicate.status, 409);
+  const get = await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments/${WORKER_ID.replace(/_/g, "-")}`);
+  assert.equal(get.status, 200);
+  const missing = await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments/wrk_missing`);
+  assert.equal(missing.status, 404);
+  assert.deepEqual(witness.deploymentNames(), [WORKER_ID.replace(/_/g, "-")]);
+});
+
+test("witness applies strategic merge patches and records them", async () => {
+  await using witness = await startMockKubernetesApiserver();
+  await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments`, {
+    method: "POST", body: JSON.stringify(deploymentManifest()),
+  });
+  const patch = await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments/${WORKER_ID.replace(/_/g, "-")}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/strategic-merge-patch+json" },
+    body: JSON.stringify({ spec: { replicas: 0 } }),
+  });
+  assert.equal(patch.status, 200);
+  assert.equal(witness.replicasOf(WORKER_ID.replace(/_/g, "-")), 0);
+  assert.equal(witness.patches.length, 1);
+  // Container-level patches merge by container name instead of replacing.
+  await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments/${WORKER_ID.replace(/_/g, "-")}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/strategic-merge-patch+json" },
+    body: JSON.stringify({ spec: { template: { spec: { containers: [{ name: "openwork-server", image: "registry.example/worker:new" }] } } } }),
+  });
+  assert.equal(witness.deploymentImage(WORKER_ID.replace(/_/g, "-")), "registry.example/worker:new");
+  assert.equal(witness.containerEnv(WORKER_ID.replace(/_/g, "-"))?.length, 1);
+});
+
+test("witness lists pods by label selector and serves health readiness", async () => {
+  await using witness = await startMockKubernetesApiserver();
+  await fetch(`${witness.url}/apis/apps/v1/namespaces/openwork-workers/deployments`, {
+    method: "POST", body: JSON.stringify(deploymentManifest()),
+  });
+  witness.setHealthy(false);
+  const health = await fetch(`${witness.url}/health`);
+  assert.equal(health.status, 503);
+  witness.ready();
+  assert.equal((await fetch(`${witness.url}/health`)).status, 200);
+  const pods = await fetch(`${witness.url}/api/v1/namespaces/openwork-workers/pods?labelSelector=${encodeURIComponent(`openwork.den.worker-id=${WORKER_ID}`)}`);
+  assert.equal(pods.status, 200);
+  const payload = await pods.json() as { items: Array<{ metadata: { labels: Record<string, string> } }> };
+  assert.equal(payload.items.length, 1);
+  assert.equal(payload.items[0]?.metadata.labels["openwork.den.worker-id"], WORKER_ID);
+});
+
+test("witness records deletes and flags unexpected routes", async () => {
+  await using witness = await startMockKubernetesApiserver();
+  await fetch(`${witness.url}/api/v1/namespaces/openwork-workers/secrets`, {
+    method: "POST",
+    body: JSON.stringify({ metadata: { name: "wrk-tokens", namespace: "openwork-workers" }, stringData: { OPENWORK_TOKEN: "t" } }),
+  });
+  const del = await fetch(`${witness.url}/api/v1/namespaces/openwork-workers/secrets/wrk-tokens`, { method: "DELETE" });
+  assert.equal(del.status, 200);
+  const missing = await fetch(`${witness.url}/api/v1/namespaces/openwork-workers/secrets/wrk-tokens`, { method: "DELETE" });
+  assert.equal(missing.status, 404);
+  assert.deepEqual(witness.names("secrets"), []);
+  assert.equal(witness.deletes.length, 1);
+  assert.equal(witness.deletes[0]?.kind, "secrets");
+  await fetch(`${witness.url}/definitely/not/a/route`);
+  assert.equal(witness.unexpected.length, 1);
+});

--- a/evals/specs/kubernetes-worker-provisioning.test.ts
+++ b/evals/specs/kubernetes-worker-provisioning.test.ts
@@ -1,0 +1,264 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import { queryDenDatabase } from "@openwork/env";
+import { KUBERNETES_HEALTH_SHIM_SCRIPT, startMockKubernetesApiserver } from "@openwork/labs";
+import { eventually, localMysqlIsRunning, localRedisIsRunning, needs, server, test } from "@openwork/testkit";
+
+const available = await localMysqlIsRunning() && await localRedisIsRunning();
+
+const WORKER_IMAGE = "registry.example/openwork-microsandbox:journey";
+const STALE_WORKER_IMAGE = "registry.example/openwork-microsandbox:stale";
+const WORKER_URL_TEMPLATE = "https://{workerId}.workers.example.com";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected a JSON object");
+  return value;
+}
+
+function expectString(value: unknown, label: string): string {
+  if (typeof value !== "string") throw new Error(`${label} missing`);
+  return value;
+}
+
+function dnsSafeWorkerName(workerId: string) {
+  return workerId.replace(/_/g, "-");
+}
+
+test("kubernetes provisioner drives real worker provisioning, idle stop, wake, and deprovision", { timeout: 300_000 }, async ({ place, evidence, skip }) => {
+  needs({ placement: "local" });
+  if (!available) skip("needs: local MySQL and Redis");
+  await using witness = await startMockKubernetesApiserver();
+
+  // den-api probes worker pods at their in-cluster service DNS name, which
+  // cannot resolve outside a cluster. The preload shim rewrites those fetches
+  // to the witness so the REAL provisioner health polling runs unchanged.
+  const shimDir = await mkdtemp(join(tmpdir(), "kubernetes-health-shim-"));
+  const shimPath = join(shimDir, "kubernetes-health-shim.cjs");
+  await writeFile(shimPath, KUBERNETES_HEALTH_SHIM_SCRIPT);
+
+  try {
+    await using den = await server({
+      place,
+      web: false,
+      env: {
+        PROVISIONER_MODE: "kubernetes",
+        KUBERNETES_API_URL: witness.url,
+        KUBERNETES_API_TOKEN: "witness-not-a-real-token",
+        KUBERNETES_WORKER_IMAGE: WORKER_IMAGE,
+        KUBERNETES_WORKER_NAMESPACE: "openwork-workers",
+        KUBERNETES_HEALTHCHECK_TIMEOUT_MS: "20000",
+        KUBERNETES_POLL_INTERVAL_MS: "100",
+        WORKER_URL_TEMPLATE,
+        WORKER_PROVISIONING_RECONCILE_INTERVAL_MS: "0",
+        CLOUD_IDLE_STOP_MINUTES: "1",
+        CLOUD_IDLE_LOOP_SECONDS: "1",
+        NODE_OPTIONS: `--require ${shimPath}`,
+        KUBERNETES_HEALTH_WITNESS_URL: witness.url,
+      },
+    });
+    if (!den.database) throw new Error("This isolated HTTP journey requires its own database");
+    const databaseUrl = den.database.url;
+
+    const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
+    const organizations = record(orgs.body).orgs;
+    if (!Array.isArray(organizations) || organizations.length !== 1) throw new Error("Expected one isolated organization");
+    const orgId = expectString(record(organizations[0]).id, "Organization id");
+    // Seed the paid entitlement so the cloud-destination gate opens; all access
+    // checks and provisioning still run the real API and database.
+    await queryDenDatabase(databaseUrl,
+      "INSERT INTO org_subscriptions (id, organization_id, type, status, stripe_customer_id, stripe_subscription_id, stripe_price_id, quantity) VALUES (?, ?, 'web', 'active', ?, ?, ?, 1)",
+      ["osub_000000000000000000000000k8", orgId, "cus_kubernetes_witness", "sub_kubernetes_witness", "price_kubernetes_witness"],
+    );
+
+    const workers = async () => {
+      return queryDenDatabase(databaseUrl, "SELECT id, status, image_version FROM worker WHERE org_id = ?", [orgId]);
+    };
+
+    async function workerInstanceUrl(workerId: string) {
+      const rows = await queryDenDatabase(databaseUrl, "SELECT url, status FROM worker_instance WHERE worker_id = ? ORDER BY created_at DESC LIMIT 1", [workerId]);
+      return rows[0] ?? null;
+    }
+
+    const create = await denFetch(den.admin, "/v1/workers", {
+      method: "POST",
+      headers: { authorization: `Bearer ${den.admin.token}`, "content-type": "application/json" },
+      body: JSON.stringify({ name: "Kubernetes witness worker", destination: "cloud" }),
+    });
+    expect(create.response.status, create.text).toBe(202);
+    const workerId = expectString(record(record(create.body).worker).id, "Worker id");
+    const workerName = dnsSafeWorkerName(workerId);
+    evidence.recordAssertionEvidence("Cloud worker creation is accepted asynchronously", "POST /v1/workers returned 202 with a provisioning worker row; provisioning continues in the background.", true);
+
+    await eventually(() => witness.count("deployments") + witness.count("services") + witness.count("secrets") + witness.count("persistentvolumeclaims"), {
+      within: 20_000,
+      label: "provisioner creates the worker object set",
+      until: (total) => total === 5,
+    });
+    expect(witness.count("deployments")).toBe(1);
+    expect(witness.count("services")).toBe(1);
+    expect(witness.count("persistentvolumeclaims")).toBe(2);
+    expect(witness.count("secrets")).toBe(1);
+    expect(witness.deploymentNames()).toEqual([workerName]);
+    const tokenSecret = witness.secretStringData(`${workerName}-tokens`);
+    expect(tokenSecret).toMatchObject({ OPENWORK_TOKEN: expect.any(String), OPENWORK_HOST_TOKEN: expect.any(String), DEN_ACTIVITY_HEARTBEAT_TOKEN: expect.any(String) });
+    const deployment = witness.deploymentForWorker(workerId);
+    if (!deployment) throw new Error("Witness has no deployment for the worker");
+    expect(record(deployment.metadata ?? {}).labels).toMatchObject({ "openwork.den.worker-id": workerId });
+    const env = witness.containerEnv(workerName) ?? [];
+    const tokenEnv = env.filter((entry) => entry.name === "OPENWORK_TOKEN" || entry.name === "OPENWORK_HOST_TOKEN" || entry.name === "DEN_ACTIVITY_HEARTBEAT_TOKEN");
+    expect(tokenEnv.length).toBe(3);
+    for (const entry of tokenEnv) {
+      // Tokens must be referenced from the Secret, never inlined as values.
+      expect(entry.value).toBeUndefined();
+      expect(JSON.stringify(entry)).toContain("secretKeyRef");
+    }
+    evidence.recordAssertionEvidence("Provisioning creates exactly one object set with Secret-backed tokens", "The real provisioner created 1 Deployment, 1 Service, 2 PVCs, and 1 Secret; worker tokens live in Secret stringData and are mounted via secretKeyRef; labels carry the worker id.", true);
+
+    witness.ready();
+    await eventually(async () => (await workers()).map((entry) => record(entry).status), {
+      within: 60_000,
+      label: "worker becomes healthy after witness health",
+      until: (statuses) => statuses.length === 1 && statuses[0] === "healthy",
+    });
+    const instance = await workerInstanceUrl(workerId);
+    expect(record(instance).status).toBe("healthy");
+    expect(record(instance).url).toBe(WORKER_URL_TEMPLATE.replace("{workerId}", workerName));
+    expect(record((await workers())[0]).image_version).toBe(WORKER_IMAGE);
+    evidence.recordAssertionEvidence("Healthy worker records the template-substituted instance URL", "After the worker pod reported healthy, the worker row became healthy and its instance URL substituted the DNS-safe worker name into WORKER_URL_TEMPLATE.", true);
+
+    // Idle stop scales the deployment to zero but keeps stateful objects.
+    await queryDenDatabase(databaseUrl,
+      "UPDATE worker SET last_active_at = DATE_SUB(NOW(3), INTERVAL 1 HOUR), last_heartbeat_at = DATE_SUB(NOW(3), INTERVAL 1 HOUR), updated_at = DATE_SUB(NOW(3), INTERVAL 1 HOUR) WHERE id = ?",
+      [workerId],
+    );
+    await eventually(() => witness.replicasOf(workerName), {
+      within: 30_000,
+      label: "idle stop scales the worker deployment to zero",
+      until: (replicas) => replicas === 0,
+    });
+    await eventually(async () => (await workers()).map((entry) => record(entry).status), {
+      within: 20_000,
+      label: "worker row reports stopped",
+      until: (statuses) => statuses.length === 1 && statuses[0] === "stopped",
+    });
+    expect(witness.count("persistentvolumeclaims")).toBe(2);
+    expect(witness.count("secrets")).toBe(1);
+    evidence.recordAssertionEvidence("Idle stop scales to zero without erasing worker state", "The idle loop patched the deployment to 0 replicas, the worker row became stopped, and the PVCs and token secret survived for the next wake.", true);
+
+    // Refresh activity so the idle loop cannot race the wake below: the aged
+    // timestamps only exist to trigger the idle stop above.
+    await queryDenDatabase(databaseUrl,
+      "UPDATE worker SET last_active_at = NOW(3), last_heartbeat_at = NOW(3), updated_at = NOW(3) WHERE id = ?",
+      [workerId],
+    );
+
+    // Wake through the tokens path: replicas return to one and health passes.
+    const wake = await denFetch(den.admin, `/v1/workers/${workerId}/tokens`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${den.admin.token}`, "content-type": "application/json" },
+      body: JSON.stringify({ includeExpiringOpenworkUrl: true }),
+    });
+    expect(wake.response.status, wake.text).toBe(200);
+    await eventually(() => witness.replicasOf(workerName), {
+      within: 30_000,
+      label: "wake scales the worker deployment back up",
+      until: (replicas) => replicas === 1,
+    });
+    await eventually(async () => (await workers()).map((entry) => record(entry).status), {
+      within: 60_000,
+      label: "woken worker becomes healthy again",
+      until: (statuses) => statuses.length === 1 && statuses[0] === "healthy",
+    });
+    expect(witness.patches.some((entry) => entry.kind === "deployments" && entry.name === workerName && record(entry.patch.spec ?? {}).replicas === 1)).toBe(true);
+    evidence.recordAssertionEvidence("Access tokens wake a stopped worker in place", "Requesting worker tokens with the expiring URL patched the stopped deployment back to 1 replica and the worker became healthy without recreating its objects.", true);
+
+    // Stale-image recycle: a stopped worker on an old image is patched to the
+    // configured image before it scales up.
+    await queryDenDatabase(databaseUrl,
+      "UPDATE worker SET status = 'stopped', image_version = ?, last_active_at = NOW(3), last_heartbeat_at = NOW(3), updated_at = NOW(3) WHERE id = ?",
+      [STALE_WORKER_IMAGE, workerId],
+    );
+    const wakeStale = await denFetch(den.admin, `/v1/workers/${workerId}/tokens`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${den.admin.token}`, "content-type": "application/json" },
+      body: JSON.stringify({ includeExpiringOpenworkUrl: true }),
+    });
+    expect(wakeStale.response.status, wakeStale.text).toBe(200);
+    await eventually(() => witness.deploymentImage(workerName), {
+      within: 30_000,
+      label: "stale-image wake patches the container image",
+      until: (image) => image === WORKER_IMAGE,
+    });
+    await eventually(async () => (await workers()).map((entry) => record(entry).status), {
+      within: 60_000,
+      label: "stale-image woken worker becomes healthy",
+      until: (statuses) => statuses.length === 1 && statuses[0] === "healthy",
+    });
+    expect(record((await workers())[0]).image_version).toBe(WORKER_IMAGE);
+    evidence.recordAssertionEvidence("Stale-image wake updates the image before scale-up", "A stopped worker whose recorded image_version was old was patched to the configured worker image during wake, keeping the database and the running pod in agreement.", true);
+
+    // Deprovision deletes every object the provisioner created.
+    const del = await denFetch(den.admin, `/v1/workers/${workerId}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${den.admin.token}` },
+    });
+    expect(del.response.status, del.text).toBe(204);
+    await eventually(() => witness.count("deployments") + witness.count("services") + witness.count("secrets") + witness.count("persistentvolumeclaims"), {
+      within: 30_000,
+      label: "deprovision deletes the whole object set",
+      until: (total) => total === 0,
+    });
+    const deletedKinds = witness.deletes.map((entry) => entry.kind).sort();
+    expect(deletedKinds).toEqual(["deployments", "persistentvolumeclaims", "persistentvolumeclaims", "secrets", "services"]);
+    evidence.recordAssertionEvidence("Worker deletion erases its Kubernetes objects", "DELETE /v1/workers removed the Deployment, Service, token Secret, and both PVCs, matching the documented data-erasure contract.", true);
+
+    expect(witness.unexpected).toEqual([]);
+  } finally {
+    await rm(shimDir, { recursive: true, force: true });
+  }
+});
+
+test("stub mode never calls the Kubernetes API", { timeout: 300_000 }, async ({ place, evidence, skip }) => {
+  needs({ placement: "local" });
+  if (!available) skip("needs: local MySQL and Redis");
+  await using witness = await startMockKubernetesApiserver();
+  await using den = await server({
+    place,
+    web: false,
+    env: {
+      PROVISIONER_MODE: "stub",
+      KUBERNETES_API_URL: witness.url,
+      KUBERNETES_API_TOKEN: "witness-not-a-real-token",
+      KUBERNETES_WORKER_IMAGE: WORKER_IMAGE,
+      WORKER_PROVISIONING_RECONCILE_INTERVAL_MS: "0",
+    },
+  });
+  if (!den.database) throw new Error("This isolated HTTP journey requires its own database");
+  const databaseUrl = den.database.url;
+  const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
+  const organizations = record(orgs.body).orgs;
+  if (!Array.isArray(organizations) || organizations.length !== 1) throw new Error("Expected one isolated organization");
+  const orgId = expectString(record(organizations[0]).id, "Organization id");
+  await queryDenDatabase(databaseUrl,
+    "INSERT INTO org_subscriptions (id, organization_id, type, status, stripe_customer_id, stripe_subscription_id, stripe_price_id, quantity) VALUES (?, ?, 'web', 'active', ?, ?, ?, 1)",
+    ["osub_000000000000000000000000st", orgId, "cus_stub_witness", "sub_stub_witness", "price_stub_witness"],
+  );
+  const create = await denFetch(den.admin, "/v1/workers", {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}`, "content-type": "application/json" },
+    body: JSON.stringify({ name: "Stub worker", destination: "cloud" }),
+  });
+  expect(create.response.status, create.text).toBe(202);
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  expect(witness.requests).toEqual([]);
+  expect(witness.unexpected).toEqual([]);
+  evidence.recordAssertionEvidence("Stub mode leaves the Kubernetes API untouched", "A cloud worker created under PROVISIONER_MODE=stub produced zero requests against the Kubernetes witness.", true);
+});

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -984,3 +984,70 @@ Readiness probes use dependency-aware endpoints:
 ## Worker Provisioning Recovery
 
 `den-api` periodically reconciles cloud workers that remain in `provisioning` beyond `config.provisioner.reconcileStaleMs`. This lets a replacement pod resume provisioning after a crash. Keep `denApi.replicaCount: 1` unless your worker provider operations are idempotent or you add external leader election.
+
+## Kubernetes Worker Provisioner
+
+Set `config.provisioner.mode: kubernetes` to have `den-api` provision each cloud worker directly in your cluster as a Deployment + Service + token Secret + two PVCs (`/workspace`, `/data`). Per-user workers idle-stop to zero replicas, wake in place, and deprovision with full data erasure. This is the self-hosted alternative to the hosted Daytona and Render providers.
+
+### Values
+
+| Value | Default | Description |
+| --- | --- | --- |
+| `config.provisioner.mode` | `stub` | Set to `kubernetes` to enable the provisioner. |
+| `config.kubernetes.workerImage` | (den-api default, required) | Worker image, e.g. built from `packaging/docker/Dockerfile.microsandbox`. Provisioning fails fast when unset. |
+| `config.kubernetes.workerNamespace` | `openwork-workers` | Namespace where worker objects are created. Also rendered as `KUBERNETES_WORKER_NAMESPACE` so RBAC and API calls agree. |
+| `config.kubernetes.apiUrl` | in-cluster detection | Kubernetes API URL. Leave empty in-cluster; set only for out-of-cluster testing. |
+| `config.kubernetes.apiCaFile` | in-cluster CA | CA bundle for `apiUrl`. |
+| `config.kubernetes.workerImagePullPolicy` | `IfNotPresent` | Worker container pull policy. |
+| `config.kubernetes.workerPort` | `8787` | `openwork-server` port inside the worker pod. |
+| `config.kubernetes.workerApprovalMode` | `auto` | Worker approval mode; `manual` blocks unattended cloud runs. |
+| `config.kubernetes.workerCpuRequest` / `workerCpuLimit` | `500m` / `2` | Worker CPU requests/limits. |
+| `config.kubernetes.workerMemoryRequest` / `workerMemoryLimit` | `1Gi` / `4Gi` | Worker memory requests/limits. |
+| `config.kubernetes.workerWorkspaceVolumeSize` / `workerDataVolumeSize` | `10Gi` / `10Gi` | PVC sizes for `/workspace` and `/data`. |
+| `config.kubernetes.workerStorageClass` | cluster default | StorageClass for the worker PVCs. |
+| `config.kubernetes.healthcheckTimeoutMs` | `300000` | How long provisioning waits for the worker `/health` endpoint. |
+| `config.kubernetes.pollIntervalMs` | `1000` | Health poll interval while provisioning. |
+| `config.kubernetes.workerRecordTtlSeconds` | `3600` | TTL for the worker record served to clients. |
+| `secret.kubernetesApiToken` | `""` | `KUBERNETES_API_TOKEN`. Leave empty in-cluster (the ServiceAccount token is used). |
+| `workers.kubernetes.createNamespace` | `true` | Create the worker namespace from the chart. |
+| `workers.kubernetes.serviceAccount.create` | `true` | Create a dedicated ServiceAccount for `den-api`. |
+| `workers.kubernetes.serviceAccount.name` | `<release>-den-api` | Explicit ServiceAccount name when `create: false`. |
+| `workers.kubernetes.rbac.create` | `true` | Render the namespaced Role and RoleBinding. |
+| `config.provisioner.workerUrlTemplate` | `""` | Optional public worker URL template (see below). |
+
+### Worker image
+
+Build and push the microsandbox worker image once per release, then reference it:
+
+```bash
+./scripts/build-microsandbox-openwork-image.sh
+docker tag <built-image> registry.example.com/openwork-microsandbox:<version>
+docker push registry.example.com/openwork-microsandbox:<version>
+```
+
+```yaml
+config:
+  provisioner:
+    mode: kubernetes
+  kubernetes:
+    workerImage: registry.example.com/openwork-microsandbox:<version>
+```
+
+The chart deploys only the control plane; the worker image must be present in a registry reachable by the cluster (or pre-loaded on single-node clusters such as k3s with `k3s ctr images import`).
+
+### RBAC scope
+
+When `workers.kubernetes.rbac.create: true` the chart renders, in the worker namespace only:
+
+- a Role granting get/list/create/update/patch/delete on `apps/deployments`, get/list/create/delete on core `services`, `secrets`, and `persistentvolumeclaims`, get/list on `pods`, and get on `pods/log`
+- a RoleBinding binding that Role to the `den-api` ServiceAccount
+
+Nothing cluster-scoped is rendered, and worker pods run with `automountServiceAccountToken: false`.
+
+### URLs and ingress
+
+`den-api` reaches workers at `http://<worker>.<workerNamespace>.svc.cluster.local:<workerPort>`. Set `config.provisioner.workerUrlTemplate` (for example `https://{workerId}.workers.example.com`) only when workers must be reachable by hostname outside the cluster: the `{workerId}` placeholder receives the DNS-safe, hyphenated worker NAME (`wrk_abc...` becomes `wrk-abc...`), and you are responsible for routing that host to the worker Service. Worker pods must be able to reach `den-api` in-cluster for activity heartbeats; set `config.internal.apiBaseUrl` explicitly if your Service/URL layout is non-standard (`WORKER_ACTIVITY_BASE_URL` follows the internal API URL).
+
+### Public ingress
+
+The worker Services are ClusterIP-internal by default. If you expose workers publicly through `workerUrlTemplate`, front them with your own ingress, TLS, and authentication — the chart does not render worker ingresses. Keep `WORKER_URL_TEMPLATE` unset for fully private clusters.

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -1039,7 +1039,7 @@ The chart deploys only the control plane; the worker image must be present in a 
 
 When `workers.kubernetes.rbac.create: true` the chart renders, in the worker namespace only:
 
-- a Role granting get/list/create/update/patch/delete on `apps/deployments`, get/list/create/delete on core `services`, `secrets`, and `persistentvolumeclaims`, get/list on `pods`, and get on `pods/log`
+- a Role granting get/create/patch/delete on `apps/deployments`, get/create/delete on core `services`, `secrets`, and `persistentvolumeclaims`, get/list on `pods` (get covers the `pods/log` subresource reads used for health-timeout diagnostics), and get on `pods/log`
 - a RoleBinding binding that Role to the `den-api` ServiceAccount
 
 Nothing cluster-scoped is rendered, and worker pods run with `automountServiceAccountToken: false`.

--- a/packaging/helm/openwork-ee/templates/_helpers.tpl
+++ b/packaging/helm/openwork-ee/templates/_helpers.tpl
@@ -87,6 +87,24 @@ app.kubernetes.io/component: {{ .component }}
 {{- default (printf "http://%s:%v" (include "openwork-ee.inferenceServiceName" .) .Values.inference.service.port) .Values.config.internal.inferenceProxyBaseUrl -}}
 {{- end -}}
 
+{{- define "openwork-ee.kubernetesWorkerNamespace" -}}
+{{- default "openwork-workers" .Values.config.kubernetes.workerNamespace -}}
+{{- end -}}
+
+{{- define "openwork-ee.denApiServiceAccountName" -}}
+{{- default (printf "%s-den-api" (include "openwork-ee.fullname" .)) .Values.workers.kubernetes.serviceAccount.name -}}
+{{- end -}}
+
+{{- define "openwork-ee.kubernetesWorkersValidate" -}}
+{{- if eq .Values.config.provisioner.mode "kubernetes" -}}
+{{- if not .Values.workers.kubernetes.serviceAccount.create -}}
+{{- if not .Values.workers.kubernetes.serviceAccount.name -}}
+{{- fail "workers.kubernetes.serviceAccount.name is required when workers.kubernetes.serviceAccount.create=false and config.provisioner.mode=kubernetes" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "openwork-ee.customCa.mountPath" -}}
 /etc/openwork/custom-ca
 {{- end -}}

--- a/packaging/helm/openwork-ee/templates/_helpers.tpl
+++ b/packaging/helm/openwork-ee/templates/_helpers.tpl
@@ -102,6 +102,9 @@ app.kubernetes.io/component: {{ .component }}
 {{- fail "workers.kubernetes.serviceAccount.name is required when workers.kubernetes.serviceAccount.create=false and config.provisioner.mode=kubernetes" -}}
 {{- end -}}
 {{- end -}}
+{{- if not .Values.config.kubernetes.workerImage -}}
+{{- fail "config.kubernetes.workerImage is required when config.provisioner.mode=kubernetes" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -174,6 +174,61 @@ data:
   {{ with .Values.config.daytona.healthcheckTimeoutMs }}
   DAYTONA_HEALTHCHECK_TIMEOUT_MS: {{ . | quote }}
   {{ end }}
+  {{- if eq .Values.config.provisioner.mode "kubernetes" }}
+  # Kubernetes worker provisioner. KUBERNETES_API_TOKEN lives in the release
+  # secret; everything else is plain config. The worker namespace is emitted
+  # explicitly (with the same default as den-api) so the rendered RBAC in
+  # kubernetes-workers.yaml and the API calls always agree.
+  KUBERNETES_WORKER_NAMESPACE: {{ default "openwork-workers" .Values.config.kubernetes.workerNamespace | quote }}
+  {{ with .Values.config.kubernetes.apiUrl }}
+  KUBERNETES_API_URL: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.apiCaFile }}
+  KUBERNETES_API_CA_FILE: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerImage }}
+  KUBERNETES_WORKER_IMAGE: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerImagePullPolicy }}
+  KUBERNETES_WORKER_IMAGE_PULL_POLICY: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerPort }}
+  KUBERNETES_WORKER_PORT: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerApprovalMode }}
+  KUBERNETES_WORKER_APPROVAL_MODE: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerCpuRequest }}
+  KUBERNETES_WORKER_CPU_REQUEST: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerCpuLimit }}
+  KUBERNETES_WORKER_CPU_LIMIT: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerMemoryRequest }}
+  KUBERNETES_WORKER_MEMORY_REQUEST: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerMemoryLimit }}
+  KUBERNETES_WORKER_MEMORY_LIMIT: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerWorkspaceVolumeSize }}
+  KUBERNETES_WORKER_WORKSPACE_VOLUME_SIZE: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerDataVolumeSize }}
+  KUBERNETES_WORKER_DATA_VOLUME_SIZE: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerStorageClass }}
+  KUBERNETES_WORKER_STORAGE_CLASS: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.healthcheckTimeoutMs }}
+  KUBERNETES_HEALTHCHECK_TIMEOUT_MS: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.pollIntervalMs }}
+  KUBERNETES_POLL_INTERVAL_MS: {{ . | quote }}
+  {{ end }}
+  {{ with .Values.config.kubernetes.workerRecordTtlSeconds }}
+  KUBERNETES_WORKER_RECORD_TTL_SECONDS: {{ . | quote }}
+  {{ end }}
+  {{- end }}
   {{ with .Values.config.inference.openRouterWorkspaceId }}
   OPENROUTER_WORKSPACE_ID: {{ . | quote }}
   {{ end }}

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -227,8 +227,56 @@ data:
   {{ end }}
   {{ with .Values.config.kubernetes.workerRecordTtlSeconds }}
   KUBERNETES_WORKER_RECORD_TTL_SECONDS: {{ . | quote }}
-  {{ end }}
   {{- end }}
+  # Optional operator overrides for the worker pod spec (scheduling, security,
+  # metadata, networking). Emitted only when set; unset values keep the
+  # provisioner's default pod shape.
+  {{- with .Values.config.kubernetes.workerImagePullSecrets }}
+  KUBERNETES_WORKER_IMAGE_PULL_SECRETS: {{ join "," . | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerNodeSelector }}
+  KUBERNETES_WORKER_NODE_SELECTOR: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerTolerations }}
+  KUBERNETES_WORKER_TOLERATIONS: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerAffinity }}
+  KUBERNETES_WORKER_AFFINITY: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerTopologySpreadConstraints }}
+  KUBERNETES_WORKER_TOPOLOGY_SPREAD_CONSTRAINTS: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerPriorityClassName }}
+  KUBERNETES_WORKER_PRIORITY_CLASS_NAME: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerPodAnnotations }}
+  KUBERNETES_WORKER_POD_ANNOTATIONS: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerPodLabels }}
+  KUBERNETES_WORKER_POD_LABELS: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerPodSecurityContext }}
+  KUBERNETES_WORKER_POD_SECURITY_CONTEXT: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerContainerSecurityContext }}
+  KUBERNETES_WORKER_CONTAINER_SECURITY_CONTEXT: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerExtraVolumes }}
+  KUBERNETES_WORKER_EXTRA_VOLUMES: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerExtraVolumeMounts }}
+  KUBERNETES_WORKER_EXTRA_VOLUME_MOUNTS: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerExtraEnv }}
+  KUBERNETES_WORKER_EXTRA_ENV: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerDnsPolicy }}
+  KUBERNETES_WORKER_DNS_POLICY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.kubernetes.workerDnsConfig }}
+  KUBERNETES_WORKER_DNS_CONFIG: {{ . | toJson | quote }}
+  {{- end }}
+{{- end }}
   {{ with .Values.config.inference.openRouterWorkspaceId }}
   OPENROUTER_WORKSPACE_ID: {{ . | quote }}
   {{ end }}

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -50,6 +50,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if eq .Values.config.provisioner.mode "kubernetes" }}
+      serviceAccountName: {{ include "openwork-ee.denApiServiceAccountName" . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/packaging/helm/openwork-ee/templates/kubernetes-workers.yaml
+++ b/packaging/helm/openwork-ee/templates/kubernetes-workers.yaml
@@ -35,10 +35,10 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "list", "create", "update", "patch", "delete"]
+    verbs: ["get", "create", "patch", "delete"]
   - apiGroups: [""]
     resources: ["services", "secrets", "persistentvolumeclaims"]
-    verbs: ["get", "list", "create", "delete"]
+    verbs: ["get", "create", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]

--- a/packaging/helm/openwork-ee/templates/kubernetes-workers.yaml
+++ b/packaging/helm/openwork-ee/templates/kubernetes-workers.yaml
@@ -1,0 +1,65 @@
+{{- include "openwork-ee.kubernetesWorkersValidate" . }}
+{{- if eq .Values.config.provisioner.mode "kubernetes" }}
+{{- $workerNamespace := include "openwork-ee.kubernetesWorkerNamespace" . }}
+{{- $serviceAccountName := include "openwork-ee.denApiServiceAccountName" . }}
+{{- if .Values.workers.kubernetes.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $serviceAccountName }}
+  labels:
+    {{- include "openwork-ee.labels" . | nindent 4 }}
+    app.kubernetes.io/component: den-api
+---
+{{- end }}
+{{- if and .Values.workers.kubernetes.createNamespace (ne $workerNamespace .Release.Namespace) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $workerNamespace }}
+  labels:
+    {{- include "openwork-ee.labels" . | nindent 4 }}
+---
+{{- end }}
+{{- if .Values.workers.kubernetes.rbac.create }}
+# Namespaced only, on purpose: den-api manages worker Deployments, Services,
+# Secrets, and PVCs inside the worker namespace, and reads pods and their logs
+# for provisioning diagnostics. Nothing here grants cluster-scoped access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "openwork-ee.fullname" . }}-worker-manager
+  namespace: {{ $workerNamespace }}
+  labels:
+    {{- include "openwork-ee.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "secrets", "persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "openwork-ee.fullname" . }}-worker-manager
+  namespace: {{ $workerNamespace }}
+  labels:
+    {{- include "openwork-ee.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "openwork-ee.fullname" . }}-worker-manager
+{{- end }}
+{{- end }}

--- a/packaging/helm/openwork-ee/templates/secret.yaml
+++ b/packaging/helm/openwork-ee/templates/secret.yaml
@@ -12,6 +12,7 @@ stringData:
   {{ .Values.secret.keys.betterAuthSecret }}: {{ .Values.secret.values.betterAuthSecret | quote }}
   {{ .Values.secret.keys.denDbEncryptionKey }}: {{ .Values.secret.values.denDbEncryptionKey | quote }}
   {{ .Values.secret.keys.daytonaApiKey }}: {{ .Values.secret.values.daytonaApiKey | quote }}
+  {{ .Values.secret.keys.kubernetesApiToken }}: {{ .Values.secret.values.kubernetesApiToken | quote }}
   {{ .Values.secret.keys.polarAccessToken }}: {{ .Values.secret.values.polarAccessToken | quote }}
   {{ .Values.secret.keys.openRouterManagementApiKey }}: {{ .Values.secret.values.openRouterManagementApiKey | quote }}
   {{ .Values.secret.keys.inferenceAdminToken }}: {{ .Values.secret.values.inferenceAdminToken | quote }}

--- a/packaging/helm/openwork-ee/tests/kubernetes-workers.sh
+++ b/packaging/helm/openwork-ee/tests/kubernetes-workers.sh
@@ -122,6 +122,7 @@ config:
     mode: kubernetes
   kubernetes:
     workerNamespace: "my-workers"
+    workerImage: "registry.example/openwork-microsandbox:test"
 workers:
   kubernetes:
     createNamespace: false
@@ -145,5 +146,14 @@ if helm template openwork-ee "$chart_dir" \
   exit 1
 fi
 grep -q "serviceAccount.name is required" "$tmp_dir/invalid.err"
+
+# Kubernetes mode without a worker image fails at render time.
+if helm template openwork-ee "$chart_dir" \
+    --set config.provisioner.mode=kubernetes \
+    > "$tmp_dir/invalid-image.yaml" 2> "$tmp_dir/invalid-image.err"; then
+  printf 'Expected chart render to fail when config.kubernetes.workerImage is empty\n' >&2
+  exit 1
+fi
+grep -q "config.kubernetes.workerImage is required" "$tmp_dir/invalid-image.err"
 
 printf 'kubernetes-workers chart checks passed\n'

--- a/packaging/helm/openwork-ee/tests/kubernetes-workers.sh
+++ b/packaging/helm/openwork-ee/tests/kubernetes-workers.sh
@@ -84,6 +84,10 @@ config:
     healthcheckTimeoutMs: "300000"
     pollIntervalMs: "1000"
     workerRecordTtlSeconds: "3600"
+    workerImagePullSecrets:
+      - regcred
+    workerNodeSelector:
+      nodepool: gpu
 EOF
 kubernetes_rendered="$tmp_dir/kubernetes.yaml"
 helm template openwork-ee "$chart_dir" -f "$kubernetes_values" > "$kubernetes_rendered"
@@ -109,6 +113,8 @@ assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_STORAGE_CLASS: \"ceph
 assert_contains "$kubernetes_configmap" "KUBERNETES_HEALTHCHECK_TIMEOUT_MS: \"300000\""
 assert_contains "$kubernetes_configmap" "KUBERNETES_POLL_INTERVAL_MS: \"1000\""
 assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_RECORD_TTL_SECONDS: \"3600\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_IMAGE_PULL_SECRETS: \"regcred\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_NODE_SELECTOR:"
 assert_contains "$kubernetes_rendered" "KUBERNETES_API_TOKEN"
 assert_contains "$kubernetes_rendered" "serviceAccountName:"
 assert_not_document "$kubernetes_rendered" "ClusterRole"

--- a/packaging/helm/openwork-ee/tests/kubernetes-workers.sh
+++ b/packaging/helm/openwork-ee/tests/kubernetes-workers.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart NOT to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+# Document-kind assertions match "kind: <Kind>" as a standalone YAML document
+# line, so nested fields like roleRef.kind: Role or subjects[].kind:
+# ServiceAccount do not produce false positives.
+assert_document() {
+  local file="$1"
+  local kind="$2"
+  if ! grep -E -q "^kind: ${kind}$" "$file"; then
+    printf 'Expected rendered chart to contain a %s document\n' "$kind" >&2
+    return 1
+  fi
+}
+
+assert_not_document() {
+  local file="$1"
+  local kind="$2"
+  if grep -E -q "^kind: ${kind}$" "$file"; then
+    printf 'Expected rendered chart NOT to contain a %s document\n' "$kind" >&2
+    return 1
+  fi
+}
+
+# Default (stub) render: no kubernetes RBAC objects, no KUBERNETES_ env vars
+# in the config map (the release secret may carry an empty KUBERNETES_API_TOKEN
+# key, mirroring the unconditional DAYTONA_API_KEY convention).
+default_rendered="$tmp_dir/default.yaml"
+helm template openwork-ee "$chart_dir" > "$default_rendered"
+assert_not_document "$default_rendered" "Role"
+assert_not_document "$default_rendered" "RoleBinding"
+assert_not_document "$default_rendered" "ServiceAccount"
+assert_not_document "$default_rendered" "Namespace"
+default_configmap="$tmp_dir/default-configmap.yaml"
+helm template openwork-ee "$chart_dir" --show-only templates/configmap.yaml > "$default_configmap"
+assert_not_contains "$default_configmap" "KUBERNETES_"
+
+# Kubernetes mode: ServiceAccount + namespaced Role/RoleBinding + worker
+# namespace + the full KUBERNETES_ config surface, and never anything
+# cluster-scoped.
+kubernetes_values="$tmp_dir/kubernetes-values.yaml"
+cat > "$kubernetes_values" <<'EOF'
+config:
+  provisioner:
+    mode: kubernetes
+    workerUrlTemplate: "https://{workerId}.workers.example.com"
+  kubernetes:
+    apiUrl: "https://kubernetes.default.svc"
+    apiCaFile: "/etc/openwork/ca.crt"
+    workerNamespace: ""
+    workerImage: "registry.example/openwork-microsandbox:test"
+    workerImagePullPolicy: "Always"
+    workerPort: "8787"
+    workerApprovalMode: "auto"
+    workerCpuRequest: "500m"
+    workerCpuLimit: "2"
+    workerMemoryRequest: "1Gi"
+    workerMemoryLimit: "4Gi"
+    workerWorkspaceVolumeSize: "10Gi"
+    workerDataVolumeSize: "5Gi"
+    workerStorageClass: "ceph-block"
+    healthcheckTimeoutMs: "300000"
+    pollIntervalMs: "1000"
+    workerRecordTtlSeconds: "3600"
+EOF
+kubernetes_rendered="$tmp_dir/kubernetes.yaml"
+helm template openwork-ee "$chart_dir" -f "$kubernetes_values" > "$kubernetes_rendered"
+kubernetes_configmap="$tmp_dir/kubernetes-configmap.yaml"
+helm template openwork-ee "$chart_dir" -f "$kubernetes_values" --show-only templates/configmap.yaml > "$kubernetes_configmap"
+assert_document "$kubernetes_rendered" "ServiceAccount"
+assert_document "$kubernetes_rendered" "Role"
+assert_document "$kubernetes_rendered" "RoleBinding"
+assert_document "$kubernetes_rendered" "Namespace"
+assert_contains "$kubernetes_rendered" "name: openwork-workers"
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_NAMESPACE: \"openwork-workers\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_API_URL: \"https://kubernetes.default.svc\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_API_CA_FILE: \"/etc/openwork/ca.crt\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_IMAGE: \"registry.example/openwork-microsandbox:test\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_IMAGE_PULL_POLICY: \"Always\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_PORT: \"8787\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_APPROVAL_MODE: \"auto\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_CPU_REQUEST: \"500m\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_MEMORY_LIMIT: \"4Gi\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_WORKSPACE_VOLUME_SIZE: \"10Gi\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_DATA_VOLUME_SIZE: \"5Gi\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_STORAGE_CLASS: \"ceph-block\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_HEALTHCHECK_TIMEOUT_MS: \"300000\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_POLL_INTERVAL_MS: \"1000\""
+assert_contains "$kubernetes_configmap" "KUBERNETES_WORKER_RECORD_TTL_SECONDS: \"3600\""
+assert_contains "$kubernetes_rendered" "KUBERNETES_API_TOKEN"
+assert_contains "$kubernetes_rendered" "serviceAccountName:"
+assert_not_document "$kubernetes_rendered" "ClusterRole"
+assert_not_document "$kubernetes_rendered" "ClusterRoleBinding"
+
+# Custom namespace and pre-created service account are honored.
+custom_values="$tmp_dir/custom-values.yaml"
+cat > "$custom_values" <<'EOF'
+config:
+  provisioner:
+    mode: kubernetes
+  kubernetes:
+    workerNamespace: "my-workers"
+workers:
+  kubernetes:
+    createNamespace: false
+    serviceAccount:
+      create: false
+      name: "precreated-den-api"
+EOF
+custom_rendered="$tmp_dir/custom.yaml"
+helm template openwork-ee "$chart_dir" -f "$custom_values" > "$custom_rendered"
+assert_contains "$custom_rendered" "KUBERNETES_WORKER_NAMESPACE: \"my-workers\""
+assert_contains "$custom_rendered" "serviceAccountName: precreated-den-api"
+assert_not_document "$custom_rendered" "Namespace"
+assert_not_document "$custom_rendered" "ServiceAccount"
+
+# Missing service account name with create=false fails loudly.
+if helm template openwork-ee "$chart_dir" \
+    --set config.provisioner.mode=kubernetes \
+    --set workers.kubernetes.serviceAccount.create=false \
+    > "$tmp_dir/invalid.yaml" 2> "$tmp_dir/invalid.err"; then
+  printf 'Expected chart render to fail when serviceAccount.create=false and no name is set\n' >&2
+  exit 1
+fi
+grep -q "serviceAccount.name is required" "$tmp_dir/invalid.err"
+
+printf 'kubernetes-workers chart checks passed\n'

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -120,6 +120,24 @@ config:
     healthcheckTimeoutMs: ""
     pollIntervalMs: ""
     workerRecordTtlSeconds: ""
+    # Worker pod scheduling, security, metadata, and networking overrides
+    # (all optional). When unset the provisioner builds its default pod shape.
+    # JSON-shaped values are parsed by den-api; imagePullSecrets is a string list.
+    workerImagePullSecrets: []
+    workerNodeSelector: {}
+    workerTolerations: []
+    workerAffinity: {}
+    workerTopologySpreadConstraints: []
+    workerPriorityClassName: ""
+    workerPodAnnotations: {}
+    workerPodLabels: {}
+    workerPodSecurityContext: {}
+    workerContainerSecurityContext: {}
+    workerExtraVolumes: []
+    workerExtraVolumeMounts: []
+    workerExtraEnv: []
+    workerDnsPolicy: ""
+    workerDnsConfig: {}
   polar:
     featureGateEnabled: "false"
     apiBase: ""

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -98,6 +98,28 @@ config:
     createTimeoutSeconds: ""
     deleteTimeoutSeconds: ""
     healthcheckTimeoutMs: ""
+  # Kubernetes worker provisioner (config.provisioner.mode: kubernetes).
+  # Empty keys fall back to the den-api defaults documented in
+  # docs/kubernetes-workers.md. KUBERNETES_API_TOKEN belongs in the release
+  # secret (secret.kubernetesApiToken), never in this config map.
+  kubernetes:
+    apiUrl: ""
+    apiCaFile: ""
+    workerNamespace: ""
+    workerImage: ""
+    workerImagePullPolicy: ""
+    workerPort: ""
+    workerApprovalMode: ""
+    workerCpuRequest: ""
+    workerCpuLimit: ""
+    workerMemoryRequest: ""
+    workerMemoryLimit: ""
+    workerWorkspaceVolumeSize: ""
+    workerDataVolumeSize: ""
+    workerStorageClass: ""
+    healthcheckTimeoutMs: ""
+    pollIntervalMs: ""
+    workerRecordTtlSeconds: ""
   polar:
     featureGateEnabled: "false"
     apiBase: ""
@@ -165,6 +187,7 @@ secret:
     betterAuthSecret: BETTER_AUTH_SECRET
     denDbEncryptionKey: DEN_DB_ENCRYPTION_KEY
     daytonaApiKey: DAYTONA_API_KEY
+    kubernetesApiToken: KUBERNETES_API_TOKEN
     polarAccessToken: POLAR_ACCESS_TOKEN
     openRouterManagementApiKey: OPENROUTER_MANAGEMENT_API_KEY
     inferenceAdminToken: INFERENCE_ADMIN_TOKEN
@@ -186,6 +209,7 @@ secret:
     betterAuthSecret: CHANGE_ME_32_CHARS_MINIMUM_BETTER_AUTH
     denDbEncryptionKey: CHANGE_ME_32_CHARS_MINIMUM_DB_ENCRYPTION
     daytonaApiKey: ""
+    kubernetesApiToken: ""
     polarAccessToken: ""
     openRouterManagementApiKey: ""
     inferenceAdminToken: ""
@@ -201,6 +225,22 @@ secret:
     githubConnectorAppWebhookSecret: ""
     connectLinkPrivateKey: ""
     initialAdminBootstrapCode: ""
+
+# Kubernetes worker-provisioner RBAC. Only used when
+# config.provisioner.mode is "kubernetes". The chart creates a dedicated
+# ServiceAccount for den-api and a namespaced Role in the worker namespace;
+# nothing cluster-scoped is ever rendered.
+workers:
+  kubernetes:
+    # Create the worker namespace (config.kubernetes.workerNamespace,
+    # default "openwork-workers") from the chart.
+    createNamespace: true
+    serviceAccount:
+      create: true
+      # Leave empty to use <release>-den-api.
+      name: ""
+    rbac:
+      create: true
 
 installerArtifacts:
   enabled: false


### PR DESCRIPTION
## Why

When you self-host Den on Kubernetes, the existing provisioners don't fit. `daytona` and `render` are external SaaS — they spin up workers somewhere else, which defeats the point of running on scalable infra you already own. This adds `PROVISIONER_MODE=kubernetes` so Den provisions each worker as a native in-cluster workload: a `Deployment`, a `ClusterIP` Service, a token `Secret`, and two `PVC`s, all in a worker namespace den-api manages with a namespaced `Role` (no `ClusterRole`). Workers scale up and down inside the same cluster Den runs in, talking to whatever in-cluster inference backend you already have — no external account, no egress to a third-party sandbox provider.

## What it does

Per worker, den-api creates and owns five objects named from the worker id (`wrk-<suffix>`, DNS-safe):

- **Provision** — create the two PVCs (workspace + data), token secret, Deployment, and Service; poll `/health` through the Service DNS name until the pod is ready.
- **Wake** — scale `replicas` back to 1 and, if the worker was created on an older image, patch the image (PVCs survive the recycle, so workspace and data persist across upgrades).
- **Stop** — scale to 0. The objects stay; the PVCs keep their data.
- **Deprovision** — delete all five objects, tolerating already-gone ones.
- **Inspect / preview / health-timeout** — replica state, a TTL'd preview record, and health-timeout diagnostics that redact the tokens the worker entrypoint prints at startup.

It mirrors the existing `daytona.ts` provider surface so dispatch, idle-stop, preview, and the health classifier all treat it as a first-class provider. No new runtime dependencies — `kubernetes-client.ts` is a ~210-line REST client on `undici`, which is already a direct dependency.

One behavior fix came out of live testing: opencode stores its session database under `$XDG_DATA_HOME/opencode`, which the worker image defaults to the ephemeral container filesystem. The provisioner now points `XDG_DATA_HOME` at the data PVC so conversations survive pod restarts (without it, every pod recreation wiped the chat history).

## Files

- `ee/apps/den-api/src/env.ts` — `kubernetes` enum value + the `KUBERNETES_*` config surface (api url/token/ca, worker namespace, image, port, storage class, resources, TTL, approval mode, pull policy).
- `ee/apps/den-api/src/workers/kubernetes-client.ts` — minimal namespaced K8s REST client (get/create/patch/delete/list, bearer token + optional CA, in-cluster ServiceAccount defaults).
- `ee/apps/den-api/src/workers/kubernetes.ts` — the provider (748 lines), structured to match `daytona.ts`.
- Dispatch wiring in `provisioner.ts`, `cloud-lifecycle.ts` (idle stop now covers kubernetes), `worker-access.ts`, `routes/workers/shared.ts`, and `cloud-failure.ts` (health-timeout classification).
- Gate fixes so `kubernetes` passes `remote-session-capabilities.ts` and `cloud-agent-executor.ts`.
- `packaging/helm/openwork-ee/` — chart support: worker ServiceAccount, optional worker Namespace, namespaced Role/RoleBinding, den-api SA wiring, configmap + values, and a render-time chart test.
- `evals/` — a mock Kubernetes apiserver witness and a journey spec covering the full provision / wake / stop / deprovision cycle (plus stub-mode inertia — kubernetes mode never touches the API).
- `docs/kubernetes-workers.md` — operator docs.

## Testing

**Unit / eval / chart — all green**

- `kubernetes-provisioning.test.ts` — 19 tests: name mapping, fresh create, 409 adopt, token upsert, stale-image reconcile, stop, deprovision, preview, inspect, and token redaction in health-timeout errors.
- `mock-kubernetes-apiserver.test.ts` and the `kubernetes-worker-provisioning` journey spec.
- `tests/kubernetes-workers.sh` — renders the chart in default, kubernetes, custom-namespace, and invalid configs; asserts no `ClusterRole` / `ClusterRoleBinding` is ever produced and that the chart fails fast on a missing worker image or service-account name.
- `tsc` clean; full den-api suite passes.

**Live cluster test (k3s, `openwork-dev` / `openwork-workers-dev`)**

I deployed the fork chart against a real k3s cluster and ran the full path:

- `POST /v1/workers` returned 202; den-api created the Deployment, Service, Secret, and both PVCs; the worker pod reached `/health` over the Service DNS name; the DB row went `healthy`.
- `DELETE /v1/workers` returned 204; all five objects were deleted.
- RBAC checked verb-for-verb against the client calls — no permission errors.
- I pointed a custom Den LLM provider at an in-cluster Bifrost gateway fronting vLLM, materialized it into a running worker, and ran a real prompt through the worker's opencode → Bifrost → vLLM (`qwen3.8-27b`) → response. Den is not in the inference path; the worker reaches the in-cluster model backend directly.
- Killed the worker pod to confirm crash recovery: the Deployment controller recreated it in ~13s, same PVCs reattached, same Service + IngressRoute, no dangling. A conversation created through the worker survived the pod deletion once `XDG_DATA_HOME` landed on the PVC.

## Notes

- The `routes/cloud/index.ts` cloud-browser-instance path stays daytona-only here (deferred to a follow-up). The worker lifecycle, idle stop, preview, and capability gates all accept `kubernetes`.
- Commits are DCO-signed; this is an `ee/` contribution on an individual CLA basis.
