### PR TITLE
perf(session): reuse cached history during hydration

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -5,16 +5,6 @@ import { mergeSnapshotAndLiveMessages } from "../sync/message-merge";
 import { applyRevertCursor } from "../sync/transcript-reconcile";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
 
-const snapshotMessageCache = new WeakMap<OpenworkSessionSnapshot, UIMessage[]>();
-
-function getSnapshotMessages(snapshot: OpenworkSessionSnapshot) {
-  const cached = snapshotMessageCache.get(snapshot);
-  if (cached) return cached;
-  const messages = snapshotToUIMessages(snapshot);
-  snapshotMessageCache.set(snapshot, messages);
-  return messages;
-}
-
 export function resolveRenderedSessionSnapshot(input: {
   sessionId: string;
   currentSnapshot: OpenworkSessionSnapshot | null | undefined;
@@ -40,7 +30,7 @@ export function deriveRenderedSessionMessages(input: {
   const liveMessages = input.transcriptState ?? [];
 
   const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
-    ? getSnapshotMessages(input.snapshot)
+    ? snapshotToUIMessages(input.snapshot)
     : [];
 
   // Render the server snapshot as the history floor and layer live stream

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1767,15 +1767,18 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
 export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionSnapshot) {
   const queryClient = getReactQueryClient();
   const key = transcriptKey(workspaceId, snapshot.session.id);
-  const incoming = snapshotToUIMessages(snapshot);
+  const projected = snapshotToUIMessages(snapshot);
+  let incoming = projected;
   // Commit against the old text before merging a cumulative snapshot, never
   // append those same queued bytes to the snapshot afterwards.
   for (const entry of syncs.values()) {
     if (entry.input.workspaceId !== workspaceId) continue;
     flushSessionDeltas(entry, workspaceId, snapshot.session.id);
     if (entry.pendingDeltas.size === 0) continue;
-    for (const message of incoming) {
-      for (const part of message.parts) {
+    for (let messageIndex = 0; messageIndex < incoming.length; messageIndex += 1) {
+      let message = incoming[messageIndex];
+      for (let partIndex = 0; partIndex < message.parts.length; partIndex += 1) {
+        const part = message.parts[partIndex];
         if (part.type !== "text" && part.type !== "reasoning") continue;
         const partId = getPartMetadataId(part);
         if (!partId) continue;
@@ -1784,7 +1787,13 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
         if (!pending || pending.messageId !== message.id) continue;
         // Early deltas and the declaration are cumulative views, as with
         // message.part.updated. Unrepresented parts remain pending.
-        if (pending.text.length > part.text.length) part.text = pending.text;
+        if (pending.text.length > part.text.length) {
+          const parts = message.parts.slice();
+          parts[partIndex] = { ...part, text: pending.text };
+          message = { ...message, parts };
+          if (incoming === projected) incoming = incoming.slice();
+          incoming[messageIndex] = message;
+        }
         entry.pendingDeltas.delete(pendingKey);
       }
     }

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -141,8 +141,19 @@ export function attachmentNoteToUIParts(part: TextPart): UIMessage["parts"] {
   });
 }
 
+type SnapshotMessages = OpenworkSessionSnapshot["messages"];
+const snapshotMessagesCache = new WeakMap<SnapshotMessages, UIMessage[]>();
+const snapshotMessageCache = new WeakMap<SnapshotMessages[number], UIMessage[]>();
+
+// Query snapshots are immutable. Share the projection between rendering and
+// hydration; a refreshed tail can also reuse unchanged historical messages.
+// Callers must copy before applying live updates to these cached messages.
 export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessage[] {
-  return snapshot.messages.flatMap((message) => {
+  const cached = snapshotMessagesCache.get(snapshot.messages);
+  if (cached) return cached;
+  const messages = snapshot.messages.flatMap((message) => {
+    const cachedMessage = snapshotMessageCache.get(message);
+    if (cachedMessage) return cachedMessage;
     const created = message.info.time?.created;
     const time = message.info.time;
     const completed = time && "completed" in time ? time.completed : undefined;
@@ -198,9 +209,14 @@ export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessa
     // error still gets its own message. An empty assistant carcass for the
     // errored turn is dropped so the error reads as that turn's outcome.
     const error = message.info.role === "assistant" && "error" in message.info ? message.info.error : undefined;
-    if (!error) return [uiMessage];
-
-    const errorMessage = createSessionErrorUIMessage(message.info.id, presentOpencodeSessionError(error), { created });
-    return uiMessage.parts.length > 0 ? [uiMessage, errorMessage] : [errorMessage];
+    let result: UIMessage[] = [uiMessage];
+    if (error) {
+      const errorMessage = createSessionErrorUIMessage(message.info.id, presentOpencodeSessionError(error), { created });
+      result = uiMessage.parts.length > 0 ? [uiMessage, errorMessage] : [errorMessage];
+    }
+    snapshotMessageCache.set(message, result);
+    return result;
   });
+  snapshotMessagesCache.set(snapshot.messages, messages);
+  return messages;
 }

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -11,6 +11,8 @@ import { useSessionInteractions, type UseSessionInteractionsInput } from "../src
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+import { snapshotToUIMessages } from "../src/react-app/domains/session/sync/usechat-adapter";
 import {
   __applySessionSyncEventForTest,
   __createWorkspaceSessionSyncForTest,
@@ -695,6 +697,53 @@ describe("session transcript sync", () => {
     expect(transcript?.map((message) => message.id)).toEqual(["msg-user", "msg-assistant"]);
   });
 
+  test("rendering and hydration reuse unchanged history across cached revisits and tail refreshes", () => {
+    const snapshot = snapshotWithMessages(Array.from({ length: 140 }, (_, index) => ({
+      id: `history-${index}`, role: "assistant", text: `answer-${index}`,
+    })));
+    let projectionReads = 0;
+    for (const message of snapshot.messages) {
+      for (const part of message.parts) {
+        if (part.type !== "text") continue;
+        const text = part.text;
+        Object.defineProperty(part, "text", { get() { projectionReads += 1; return text; } });
+      }
+    }
+    const queryClient = getReactQueryClient();
+    const key = transcriptKey("workspace-a", "session-a");
+    const render = (current: OpenworkSessionSnapshot) => deriveRenderedSessionMessages({
+      snapshot: current, transcriptState: queryClient.getQueryData<UIMessage[]>(key),
+    });
+    render(snapshot);
+    seedSessionState("workspace-a", snapshot);
+    const first = render(snapshot);
+    projectionReads = 0;
+    for (let index = 0; index < 20; index += 1) {
+      // A status/title envelope update still contains the exact same history.
+      const revisited = { ...snapshot, session: { ...snapshot.session, title: `title-${index}` } };
+      seedSessionState("workspace-a", revisited);
+      const rendered = render(revisited);
+      expect(rendered.every((message, at) => message === first[at])).toBe(true);
+    }
+    console.info(`cached hydration: history=140, revisits=20, projectionReads=${projectionReads}`);
+    expect(projectionReads).toBe(0);
+
+    const fresh = snapshotWithMessages([{ id: "history-139", role: "assistant", text: "fresh answer" }]);
+    const changed = fresh.messages[0]!;
+    const refreshed = {
+      ...snapshot,
+      messages: [...snapshot.messages.slice(0, -1), {
+        ...changed, info: { ...changed.info, time: { created: 140 } },
+      }],
+    };
+    seedSessionState("workspace-a", refreshed);
+    const rendered = render(refreshed);
+    expect(projectionReads).toBe(0);
+    expect(rendered.slice(0, -1).every((message, at) => message === first[at])).toBe(true);
+    expect(rendered.at(-1)?.parts[0]).toMatchObject({ text: "fresh answer" });
+    expect(snapshotToUIMessages(snapshot).at(-1)?.parts[0]).toMatchObject({ text: "answer-139" });
+  });
+
   test("todo hydration rejects old reads and cached reapplication but accepts newer snapshots", () => {
     const input = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
     const cleanup = __createWorkspaceSessionSyncForTest(input);
@@ -766,10 +815,21 @@ describe("session transcript sync", () => {
         delta("answer", declared ? " world" : "hello world");
         delta("unknown", "retained");
         const snapshot = snapshotWithMessages([
+          { id: "history", role: "user", text: "unchanged history" },
           { id: "answer", role: "assistant", text: declared ? "hello world" : "hello" },
         ]);
+        const projected = snapshotToUIMessages(snapshot);
+        for (const message of projected) {
+          for (const part of message.parts) Object.freeze(part);
+          Object.freeze(message.parts);
+          Object.freeze(message);
+        }
+        Object.freeze(projected);
         seedSessionState("workspace-a", snapshot);
-        expect(snapshot.messages[0]?.parts[0]).toMatchObject({ text: declared ? "hello world" : "hello" });
+        expect(projected[1]?.parts[0]).toMatchObject({ text: declared ? "hello world" : "hello" });
+        expect(snapshotToUIMessages(snapshot)).toBe(projected);
+        expect(queryClient.getQueryData<UIMessage[]>(key)?.find((message) => message.id === "history")).toEqual(projected[0]);
+        expect(snapshot.messages[1]?.parts[0]).toMatchObject({ text: declared ? "hello world" : "hello" });
         for (const run of scheduled.splice(0)) run();
         expect(queryClient.getQueryData<UIMessage[]>(key)?.find((m) => m.id === "answer")?.parts[0])
           .toMatchObject({ text: "hello world" });


### PR DESCRIPTION
## Summary

Avoid rebuilding unchanged thread history when cached snapshots are reapplied. Rendering previously cached its own UI projection, while hydration reconstructed every message separately. Snapshot-envelope updates also discarded rendering's projection cache, repeating conversion and reconciliation work.

This is a performance follow-up to #4676, not a rollback of the hydration freshness fixes.

## Changes

- Share weak-keyed snapshot-array and source-message projections between rendering and hydration, including unchanged history when only the tail refreshes.
- Copy affected message parts before applying early streaming deltas so the shared projection remains immutable.
- Extend existing regression tests for cached revisits, changed-tail freshness, and frozen projections while retaining tool-result, todo, and cross-thread delta protection.

Cache lifetimes, revert behavior, and freshness rules remain unchanged.

## Focused measurement

After warm-up, 20 reapplications of a 140-message cached history performed **5,600 source-text projection reads before the change and zero after**. The fixture also checks that changed tail content arrives and historical message references remain stable.

This is a deterministic operation count, not a measured frame-time or thread-switch latency improvement.

## Verification

**Verdict: Incomplete — focused checks passed; runtime journey proof is not yet available.**

Checked commit: `f1be459ffd161c1774c725b31ae006b88f7659a4`, based on `9b5a5913cf22f20f2200f8c536c6abd81ef5667c`.

| Check | Result |
| --- | --- |
| `pnpm --filter @openwork/app exec bun test --isolate ./tests/session-render-state.test.ts ./tests/session-sync-permissions.test.ts` | Exit 0; 61 passed, 0 failed, 5,883 assertions |
| `pnpm --filter @openwork/app typecheck` | Exit 0 |
| `git diff --check origin/dev...HEAD` | Exit 0 |

The focused regression reproduced redundant history conversion before repair. No full app journey, live frame-time profile, or end-to-end evidence publication was run in this pass. Unit results do not establish runtime proof or that every reported hesitation is resolved.

### Remaining runtime verification

Run the existing thread-switch continuity journey on this exact head:

```sh
OPENWORK_EVAL_REF=f1be459ffd161c1774c725b31ae006b88f7659a4 pnpm evals:e2e new-split-session
```

Verify warm and cold history, held refetches, split-session isolation, and ongoing streaming. Measure long-thread switching separately before making an app-level latency claim.
