### PR TITLE
fix(den): complete native connection sign-in without reload

### DIFF
--- a/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
@@ -32,7 +32,7 @@ export type NativeProviderConnectionEntry = {
   /** Native providers are implemented by Den itself and never have a standard MCP catalog to expose. */
   exposeDirectly: false
   connected: boolean
-  connectedAt: null
+  connectedAt: string | null
   connectedForMe: boolean
   needsReconnect: boolean
   missingFeatures: string[]
@@ -75,6 +75,7 @@ export function buildNativeProviderEntry(
   state: {
     clientConfigured: boolean
     connectedForMe: boolean
+    connectedAt?: Date
     externalAccountId?: string | null
     grantedScopes?: string[] | null
     reconnect?: NativeProviderReconnectState
@@ -95,7 +96,7 @@ export function buildNativeProviderEntry(
     exposeDirectly: false,
     nativeProviderKey: provider.providerId,
     connected: true,
-    connectedAt: null,
+    connectedAt: state.connectedForMe && state.connectedAt ? state.connectedAt.toISOString() : null,
     connectedForMe: state.connectedForMe,
     needsReconnect: state.reconnect?.needsReconnect ?? false,
     missingFeatures: state.reconnect?.missingFeatures ?? [],
@@ -132,6 +133,7 @@ export async function listNativeProviderUsableEntries(input: {
     const entry = buildNativeProviderEntry(provider, {
       clientConfigured: true,
       connectedForMe: Boolean(account?.accessToken),
+      connectedAt: account?.connectedAt,
       credentialProviderId: connection.id,
       name: connection.name,
       ...(account?.externalAccountId ? { externalAccountId: account.externalAccountId } : {}),
@@ -160,6 +162,7 @@ export async function listNativeProviderUsableEntries(input: {
     const entry = buildNativeProviderEntry(provider, {
       clientConfigured: true,
       connectedForMe: Boolean(account?.accessToken),
+      connectedAt: account?.connectedAt,
       ...(account?.externalAccountId ? { externalAccountId: account.externalAccountId } : {}),
       ...(account?.scopes ? { grantedScopes: account.scopes } : {}),
       ...(provider.tenantIdExtraKey

--- a/ee/apps/den-api/src/capability-sources/oauth-credentials.ts
+++ b/ee/apps/den-api/src/capability-sources/oauth-credentials.ts
@@ -220,7 +220,14 @@ async function updateExistingConnectedAccountForActiveMember(
 
     await tx
       .update(ConnectedAccountTable)
-      .set(connectedAccountChanges(input))
+      .set({
+        ...connectedAccountChanges(input),
+        // Only a completed authorization advances the member's connection marker.
+        // Keep it distinct even if two completions share a millisecond.
+        ...(input.expectedPendingCodeVerifier !== undefined
+          ? { connectedAt: new Date(Math.max(Date.now(), existing.connectedAt.getTime() + 1)) }
+          : {}),
+      })
       .where(eq(ConnectedAccountTable.id, existing.id))
 
     const saved = await tx

--- a/evals/specs/mcp-oauth-response-issuer.test.ts
+++ b/evals/specs/mcp-oauth-response-issuer.test.ts
@@ -2,8 +2,9 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect } from "vitest";
-import { denFetch } from "@openwork/behaviors";
+import { createNativeConnector, denFetch, readUsableConnection } from "@openwork/behaviors";
 import { queryDenDatabase } from "@openwork/env";
+import { startMockGoogle } from "@openwork/labs";
 import { eventually, mcpMock, needs, server, test } from "@openwork/testkit";
 import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
 
@@ -213,6 +214,94 @@ for (const issuerSupport of [true, false, undefined]) {
     }
   });
 }
+
+test("Den native OAuth callbacks publish member completion timestamps", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun"], placement: "local" });
+  const email = "native-oauth-completion@example.test";
+  // This fixture issues email-bearing ID tokens for both providers, so the
+  // Microsoft callback resolves identity without fetching Graph userinfo.
+  await using provider = await startMockGoogle({ accounts: [email], port: 0 });
+  await using den = await server({
+    place, web: false,
+    org: { name: `Native OAuth Completion ${Date.now()}`, members: { teammate: {}, observer: {} } },
+    env: {
+      DEN_MICROSOFT_OAUTH_AUTHORIZE_URL: `${provider.authorizeUrl}?tenantId={tenantId}`,
+      DEN_MICROSOFT_OAUTH_TOKEN_URL: `${provider.tokenUrl}?tenantId={tenantId}`,
+      DEN_GOOGLE_OAUTH_AUTHORIZE_URL: provider.authorizeUrl,
+      DEN_GOOGLE_OAUTH_TOKEN_URL: provider.tokenUrl,
+      DEN_GOOGLE_OAUTH_USERINFO_URL: provider.userinfoUrl,
+      DEN_GOOGLE_API_BASE_URL: provider.apiUrl,
+    },
+  });
+  const member = den.members.teammate;
+  const headers = { authorization: `Bearer ${member.token}` };
+  for (const providerKey of ["microsoft-365", "google-workspace"]) {
+    const connection = await createNativeConnector(den.admin, {
+      providerKey, name: `${providerKey} completion`,
+      clientId: "mock-native-client", clientSecret: "mock-native-secret", features: [],
+    });
+    if (providerKey === "microsoft-365") {
+      const configured = await denFetch(den.admin, `/v1/oauth-providers/${connection.id}/client`, {
+        method: "POST", headers: { authorization: `Bearer ${den.admin.token}` },
+        body: JSON.stringify({ tenantId: "12345678-1234-1234-1234-123456789abc" }),
+      });
+      expect(configured.response.status, configured.text).toBe(200);
+    }
+    const disconnected = { ...connection, connectedForMe: false, connectedAt: null };
+    expect(await readUsableConnection(den.members.observer, connection.id)).toEqual(disconnected);
+    let connectedAt: string | null = null;
+    for (const phase of ["first connect", "reconnect"]) {
+      const before = { ...connection, connectedForMe: connectedAt !== null, connectedAt };
+      expect(await readUsableConnection(member, connection.id)).toEqual(before);
+      const started = await denFetch(member, `/v1/mcp-connections/${connection.id}/connect/start`, { headers });
+      expect(started.response.status, started.text).toBe(200);
+      expect(started.body).toMatchObject({ status: "needs_auth" });
+      if (!isRecord(started.body) || typeof started.body.authorizeUrl !== "string") throw new Error("Native authorization URL missing");
+      const authorize = new URL(started.body.authorizeUrl);
+      expect(`${authorize.origin}${authorize.pathname}`).toBe(provider.authorizeUrl);
+      if (providerKey === "microsoft-365") expect(authorize.searchParams.get("tenantId")).toBe("12345678-1234-1234-1234-123456789abc");
+      expect(authorize.searchParams.get("redirect_uri")).toBe(`${den.ref.apiUrl}/v1/oauth-providers/${providerKey}/connect/callback`);
+      expect(await readUsableConnection(member, connection.id)).toEqual(before);
+      expect(await readUsableConnection(den.members.observer, connection.id)).toEqual(disconnected);
+      evidence.recordAssertionEvidence(`${providerKey} ${phase} waits for callback completion`, "Starting pending authorization preserved the exact member connection state and timestamp; another member remained disconnected with a null timestamp.", true);
+
+      const redirect = await fetch(authorize, { redirect: "manual", signal: AbortSignal.timeout(15_000) });
+      let callback: URL | undefined;
+      if (providerKey === "google-workspace") {
+        expect(redirect.status).toBe(200);
+        await provider.chooseAccount(email, { timeoutMs: 30_000 });
+      } else {
+        expect(redirect.status).toBe(302);
+        const location = redirect.headers.get("location");
+        if (!location) throw new Error("Native callback redirect missing");
+        callback = new URL(location);
+        expect(`${callback.origin}${callback.pathname}`).toBe(authorize.searchParams.get("redirect_uri"));
+        const completed = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+        expect(completed.status, await completed.text()).toBe(200);
+      }
+      const connected = await readUsableConnection(member, connection.id);
+      expect(connected).toEqual({ ...connection, connectedForMe: true, connectedAt: expect.any(String) });
+      if (!connected?.connectedAt) throw new Error("Native completion timestamp missing");
+      expect(Date.parse(connected.connectedAt)).not.toBeNaN();
+      expect(connected.connectedAt).not.toBe(connectedAt);
+      connectedAt = connected.connectedAt;
+      const status = await denFetch(member, `/v1/oauth-providers/${connection.id}/status`, { headers });
+      expect(status.response.status, status.text).toBe(200);
+      expect(status.body).toMatchObject({ providerId: connection.id, connected: true, externalAccountId: email });
+      expect(await readUsableConnection(member, connection.id)).toEqual(connected);
+      expect(await readUsableConnection(den.members.observer, connection.id)).toEqual(disconnected);
+      evidence.recordAssertionEvidence(`${providerKey} ${phase} publishes a stable member completion timestamp`, "The exact native connection row became connected with a valid non-null timestamp different from its previous value. Repeated reads preserved it and the expected account identity; another member remained disconnected with a null timestamp.", true);
+
+      if (callback) {
+        const replay = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+        expect(replay.status).toBe(400);
+        expect(await readUsableConnection(member, connection.id)).toEqual(connected);
+        expect(await readUsableConnection(den.members.observer, connection.id)).toEqual(disconnected);
+        evidence.recordAssertionEvidence(`Microsoft 365 ${phase} rejects callback replay without changing completion`, "Replaying the successful callback returned HTTP 400 and left the member completion timestamp and the other member's disconnected state unchanged.", true);
+      }
+    }
+  }
+});
 
 // Rows isolated in July kept their admin-registered client, so the provider
 // still receives that client's shared redirect while Den signed a per-connection


### PR DESCRIPTION
## Problem

Native Microsoft 365 and Google Workspace authorization can succeed while desktop continues showing Connecting until a reload. Desktop's completion polling requires a changed, nonempty `connectedAt`, but native usable-connection entries always returned `null`.

## Change

- Advance the member account's completion timestamp atomically with successful OAuth callback persistence, retaining the existing member/account/PKCE checks. Ensure successive completions remain distinct at millisecond precision.
- Return the saved timestamp for connected native entries, including both connector-row and legacy provider IDs. Disconnected entries still return `null`.
- Leave pending authorization, token-refresh timestamp behavior, desktop freshness checks, callback URLs, and permissions unchanged. No schema migration.
- Extend the existing OAuth journey with synthetic Microsoft 365 and Google first-connect/reconnect coverage, pending-state preservation, member isolation, and Microsoft callback replay rejection.

## Verification

**Verdict: Incomplete.** The server completion contract passes on the exact commit below. The actual desktop spinner-clearing journey has not been run, so this does not claim complete desktop end-to-end verification or deployed behavior.

Head: `63a3217ae02042acd4e3efa44b67a02c1a8be4a1`  
Base: `9b5a5913cf22f20f2200f8c536c6abd81ef5667c`

```sh
env -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_EVAL_DEN_WEB_URL OPENWORK_EVAL_DAYTONA=0 corepack pnpm evals:pr specs/mcp-oauth-response-issuer.test.ts -t '^Den native OAuth callbacks publish member completion timestamps$'
```

- Direct Vitest PR lane; cold local Den, isolated test database, synthetic OAuth provider; no real Microsoft or Google account.
- Exit 0: **1 passed, 0 failed, 8 other tests excluded by the title filter** (Vitest reports those as skipped), 26.00 seconds. The selected journey recorded 10 passing assertion-evidence entries.
- Verified for both providers: first connect and reconnect return a valid, changed timestamp; pending authorization preserves prior state; repeated reads preserve completion; another member remains disconnected with a null timestamp. Microsoft callback replay returns 400 without changing either member's state.
- `git diff --check` passed.
- Deferred: desktop UI journey, dedicated token-refresh/legacy-ID runtime assertions, and broader suites. Required CI remains unchanged.

### Remaining desktop check

Using an isolated desktop pointed at the patched Den with a synthetic native OAuth provider, connect from the connection UI, complete consent, and verify Connecting clears without reloading. Repeat Reconnect while preserving another member's disconnected state.

No merge or deployment is included.
