### PR TITLE
fix(session): reveal newly submitted messages

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
@@ -21,6 +21,7 @@ const MANUAL_BROWSE_UPWARD_THRESHOLD_PX = 16;
 
 type SessionScrollControllerOptions = {
   selectedSessionId: string | null;
+  submittedMessageId: string | null;
   renderedMessages: unknown;
   containerRef: RefObject<HTMLDivElement | null>;
   contentRef: RefObject<HTMLDivElement | null>;
@@ -82,11 +83,13 @@ export function useSessionScrollController(
 
   const lastKnownScrollTopRef = useRef(0);
   const programmaticScrollRef = useRef(false);
+  const positioningRafRef = useRef<number | undefined>(undefined);
   const programmaticScrollResetRafARef = useRef<number | undefined>(undefined);
   const programmaticScrollResetRafBRef = useRef<number | undefined>(undefined);
   const observedContentHeightRef = useRef(0);
   const lastGestureAtRef = useRef(0);
   const previousSessionIdRef = useRef<string | null>(null);
+  const revealedMessageIdRef = useRef<string | null>(null);
 
   const hasScrollGesture = useCallback(
     () => Date.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS,
@@ -124,6 +127,12 @@ export function useSessionScrollController(
     }
   }, []);
 
+  const clearPendingPosition = useCallback(() => {
+    if (positioningRafRef.current === undefined) return;
+    window.cancelAnimationFrame(positioningRafRef.current);
+    positioningRafRef.current = undefined;
+  }, []);
+
   const releaseProgrammaticScrollSoon = useCallback(() => {
     clearProgrammaticScrollReset();
     programmaticScrollResetRafARef.current = window.requestAnimationFrame(() => {
@@ -149,6 +158,7 @@ export function useSessionScrollController(
 
       setStickyBottom(selectedSessionId, null);
       programmaticScrollRef.current = true;
+      clearPendingPosition();
 
       if (behavior === "smooth") {
         container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
@@ -158,7 +168,8 @@ export function useSessionScrollController(
 
       container.scrollTop = container.scrollHeight;
       lastKnownScrollTopRef.current = container.scrollTop;
-      window.requestAnimationFrame(() => {
+      positioningRafRef.current = window.requestAnimationFrame(() => {
+        positioningRafRef.current = undefined;
         const next = options.containerRef.current;
         if (!next) {
           programmaticScrollRef.current = false;
@@ -170,7 +181,7 @@ export function useSessionScrollController(
         releaseProgrammaticScrollSoon();
       });
     },
-    [options.containerRef, refreshTopClippedMessage, releaseProgrammaticScrollSoon, selectedSessionId, setStickyBottom],
+    [clearPendingPosition, options.containerRef, refreshTopClippedMessage, releaseProgrammaticScrollSoon, selectedSessionId, setStickyBottom],
   );
 
   const saveScrollPosition = useCallback(
@@ -202,6 +213,7 @@ export function useSessionScrollController(
       // actually get away from the tail of the transcript.
       if (programmaticScrollRef.current && (userGestured || scrolledUp)) {
         programmaticScrollRef.current = false;
+        clearPendingPosition();
         clearProgrammaticScrollReset();
         saveScrollPosition(container);
         lastKnownScrollTopRef.current = currentTop;
@@ -227,7 +239,7 @@ export function useSessionScrollController(
       saveScrollPosition(container);
       lastKnownScrollTopRef.current = currentTop;
     },
-    [clearProgrammaticScrollReset, hasScrollGesture, refreshTopClippedMessage, saveScrollPosition, selectedSessionId, setStickyBottom],
+    [clearPendingPosition, clearProgrammaticScrollReset, hasScrollGesture, refreshTopClippedMessage, saveScrollPosition, selectedSessionId, setStickyBottom],
   );
 
   const jumpToLatest = useCallback(
@@ -291,6 +303,7 @@ export function useSessionScrollController(
   useEffect(() => {
     if (selectedSessionId === previousSessionIdRef.current) return;
     previousSessionIdRef.current = selectedSessionId;
+    clearPendingPosition();
     if (!selectedSessionId) return;
 
     observedContentHeightRef.current = 0;
@@ -304,7 +317,8 @@ export function useSessionScrollController(
         programmaticScrollRef.current = true;
         container.scrollTop = Math.min(savedState.scrollTop, Math.max(0, container.scrollHeight - container.clientHeight));
         lastKnownScrollTopRef.current = container.scrollTop;
-        window.requestAnimationFrame(() => {
+        positioningRafRef.current = window.requestAnimationFrame(() => {
+          positioningRafRef.current = undefined;
           const next = options.containerRef.current;
           if (!next) {
             programmaticScrollRef.current = false;
@@ -320,7 +334,7 @@ export function useSessionScrollController(
 
       scrollToBottom("auto");
     });
-  }, [options.containerRef, releaseProgrammaticScrollSoon, saveScrollPosition, scrollToBottom, selectedSessionId]);
+  }, [clearPendingPosition, options.containerRef, releaseProgrammaticScrollSoon, saveScrollPosition, scrollToBottom, selectedSessionId]);
 
   useEffect(() => {
     void options.renderedMessages;
@@ -328,10 +342,37 @@ export function useSessionScrollController(
   }, [options.renderedMessages, refreshTopClippedMessage]);
 
   useEffect(() => {
+    const messageId = options.submittedMessageId;
+    if (!messageId || messageId === revealedMessageIdRef.current) return;
+    let cancelled = false;
+    // Wait for the submitted row and any session restoration to commit. Sending
+    // is explicit navigation; passive output must still respect manual browsing.
+    queueMicrotask(() => {
+      if (cancelled) return;
+      const container = options.containerRef.current;
+      const target = container && messageElementById(container, messageId);
+      if (!container || !target) return;
+      revealedMessageIdRef.current = messageId;
+      clearPendingPosition();
+      lastGestureAtRef.current = 0;
+      programmaticScrollRef.current = true;
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      // Align the start of an oversized prompt; short prompts clamp to the tail.
+      container.scrollTop += targetRect.top - containerRect.top;
+      lastKnownScrollTopRef.current = container.scrollTop;
+      saveScrollPosition(container);
+      releaseProgrammaticScrollSoon();
+    });
+    return () => { cancelled = true; };
+  }, [clearPendingPosition, options.submittedMessageId, options.renderedMessages, options.containerRef, selectedSessionId, saveScrollPosition, releaseProgrammaticScrollSoon]);
+
+  useEffect(() => {
     return () => {
+      clearPendingPosition();
       clearProgrammaticScrollReset();
     };
-  }, [clearProgrammaticScrollReset]);
+  }, [clearPendingPosition, clearProgrammaticScrollReset]);
 
   return {
     handleScroll,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1436,6 +1436,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     [snapshot, transcriptState],
   );
   const pendingMessages = useComposerStateStore((state) => state.pendingMessages[sessionOwner]);
+  const [submittedMessage, setSubmittedMessage] = useState<{ owner: string; id: string } | null>(null);
   const failedDraft = useComposerStateStore((state) => state.failedDrafts[sessionOwner]?.[0]);
   const autoSendPayload = getComposerAutoSendPayload(props.sessionId, sessionOwner);
   const autoSending = (Boolean(autoSendPayload)
@@ -2039,6 +2040,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const registerPending = () => {
       if (pendingRegistered) return;
       pendingRegistered = true;
+      setSubmittedMessage({ owner: sessionOwner, id: nextDraft.messageId });
       useComposerStateStore.setState((state) => ({
         pendingMessages: {
           ...state.pendingMessages,
@@ -2678,6 +2680,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const sessionScroll = useSessionScrollController({
     selectedSessionId: props.sessionId,
+    submittedMessageId: submittedMessage?.owner === sessionOwner ? submittedMessage.id : null,
     renderedMessages,
     containerRef: scrollRef,
     contentRef,

--- a/apps/app/tests/live-step-scroll.test.ts
+++ b/apps/app/tests/live-step-scroll.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createElement, createRef } from "react";
+import { createRoot } from "react-dom/client";
 
 import {
   isLiveStepAtBottom,
@@ -6,6 +9,8 @@ import {
   pinnedAfterWheel,
   shouldFollowLiveStepGrowth,
 } from "../src/components/chat/live-step-scroll";
+import { useSessionScrollController } from "../src/react-app/domains/session/surface/scroll-controller";
+import { useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
 
 describe("live step scroll", () => {
   test("follows streaming growth only while the user is pinned to the tail", () => {
@@ -23,5 +28,199 @@ describe("live step scroll", () => {
   test("treats a small tail gap as still at the bottom", () => {
     expect(isLiveStepAtBottom({ scrollHeight: 800, scrollTop: 284, clientHeight: 520 })).toBe(true);
     expect(isLiveStepAtBottom({ scrollHeight: 800, scrollTop: 100, clientHeight: 520 })).toBe(false);
+  });
+});
+
+describe("submitted message reveal", () => {
+  type Row = { id: string; top: number; height: number };
+  const history: Row[] = [{ id: "history", top: 0, height: 2000 }];
+  let root: ReturnType<typeof createRoot>;
+  let container: HTMLDivElement;
+  let contentHeight: number;
+  let resize: () => void;
+  let render: (sessionId: string, submittedMessageId: string | null, rows: Row[]) => Promise<void>;
+  let flushFrames: () => Promise<void>;
+  let originalResizeObserver: typeof ResizeObserver;
+
+  beforeEach(() => {
+    GlobalRegistrator.register({ url: "http://localhost/" });
+    Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+    useSessionScrollStore.setState({ sessions: {} });
+    contentHeight = 2000;
+    resize = () => {};
+    originalResizeObserver = globalThis.ResizeObserver;
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: class implements ResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+          resize = () => callback([], this);
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() { resize = () => {}; }
+      },
+    });
+    const frames = new Map<number, FrameRequestCallback>();
+    let frameId = 0;
+    spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.set(++frameId, callback);
+      return frameId;
+    });
+    spyOn(window, "cancelAnimationFrame").mockImplementation((id) => { frames.delete(id); });
+    flushFrames = async () => {
+      await act(async () => {
+        for (let frame = 0; frame < 5 && frames.size; frame += 1) {
+          const pending = [...frames.values()];
+          frames.clear();
+          for (const callback of pending) callback(frame * 16);
+        }
+      });
+      expect(frames.size).toBe(0);
+    };
+
+    const containerRef = createRef<HTMLDivElement>();
+    const contentRef = createRef<HTMLDivElement>();
+    let scrollTop = 0;
+    function Harness(props: { sessionId: string; submittedMessageId: string | null; rows: Row[] }) {
+      const controller = useSessionScrollController({
+        selectedSessionId: props.sessionId,
+        submittedMessageId: props.submittedMessageId,
+        renderedMessages: props.rows,
+        containerRef,
+        contentRef,
+      });
+      return createElement("div", {
+        ref: (node: HTMLDivElement | null) => {
+          containerRef.current = node;
+          if (!node) return;
+          container = node;
+          // happy-dom has no layout or native scroll clamping.
+          Object.defineProperties(node, {
+            clientHeight: { configurable: true, get: () => 500 },
+            scrollHeight: { configurable: true, get: () => contentHeight },
+            scrollTop: {
+              configurable: true,
+              get: () => scrollTop,
+              set: (value: number) => { scrollTop = Math.max(0, Math.min(value, contentHeight - 500)); },
+            },
+          });
+          node.getBoundingClientRect = () => new DOMRect(0, 100, 800, 500);
+        },
+        onScroll: controller.handleScroll,
+        onWheel: (event) => controller.markScrollGesture(event.target),
+      }, createElement("div", {
+        ref: (node: HTMLDivElement | null) => {
+          contentRef.current = node;
+          if (node) Object.defineProperty(node, "offsetHeight", { configurable: true, get: () => contentHeight });
+        },
+      }, props.rows.map((row) => createElement("div", {
+        key: row.id,
+        "data-message-id": row.id,
+        ref: (node: HTMLDivElement | null) => {
+          if (node) node.getBoundingClientRect = () => new DOMRect(0, 100 + row.top - scrollTop, 800, row.height);
+        },
+      }, row.id))));
+    }
+    root = createRoot(document.createElement("div"));
+    render = async (sessionId, submittedMessageId, rows) => {
+      await act(async () => { root.render(createElement(Harness, { sessionId, submittedMessageId, rows })); });
+    };
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    mock.restore();
+    useSessionScrollStore.setState({ sessions: {} });
+    Object.defineProperty(globalThis, "ResizeObserver", { configurable: true, value: originalResizeObserver });
+    await GlobalRegistrator.unregister();
+  });
+
+  async function browse(top: number) {
+    await act(async () => {
+      container.dispatchEvent(new WheelEvent("wheel", { deltaY: -120, bubbles: true }));
+      container.scrollTop = top;
+      container.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  test("waits for the submitted row, overrides a recent browse gesture, and does not repeat on passive updates", async () => {
+    await render("session-a", null, history);
+    await flushFrames();
+    await browse(200);
+    expect(useSessionScrollStore.getState().sessions["session-a"]).toMatchObject({ mode: "manual", scrollTop: 200 });
+
+    await render("session-a", "submitted", history);
+    expect(container.scrollTop).toBe(200);
+    contentHeight = 2100;
+    const rows = [...history, { id: "submitted", top: 2000, height: 100 }];
+    await render("session-a", "submitted", rows);
+    expect(container.scrollTop).toBe(1600);
+    expect(useSessionScrollStore.getState().sessions["session-a"]).toMatchObject({ mode: "stickyBottom" });
+
+    // Growth immediately after sending follows the tail despite the prior gesture.
+    contentHeight = 2200;
+    await act(async () => resize());
+    await flushFrames();
+    expect(container.scrollTop).toBe(1700);
+    await browse(300);
+    contentHeight = 2300;
+    await render("session-a", "submitted", [...rows, { id: "assistant", top: 2100, height: 200 }]);
+    await act(async () => resize());
+    await flushFrames();
+    expect(container.scrollTop).toBe(300);
+    expect(useSessionScrollStore.getState().sessions["session-a"]).toMatchObject({ mode: "manual", scrollTop: 300 });
+  });
+
+  test("a pending reveal does not move the other session after navigation", async () => {
+    useSessionScrollStore.getState().setManualScroll("session-b", 400, null);
+    await render("session-a", null, history);
+    await flushFrames();
+    await browse(200);
+    await render("session-a", "submitted-a", history);
+
+    // SessionSurface clears the submitted ID when its owner is not selected.
+    await render("session-b", null, history);
+    await flushFrames();
+    expect(container.scrollTop).toBe(400);
+    contentHeight = 2100;
+    await render("session-b", null, [...history, { id: "message-b", top: 2000, height: 100 }]);
+    await act(async () => resize());
+    await flushFrames();
+    expect(container.scrollTop).toBe(400);
+    expect(useSessionScrollStore.getState().sessions["session-a"]).toMatchObject({ mode: "manual", scrollTop: 200 });
+    expect(useSessionScrollStore.getState().sessions["session-b"]).toMatchObject({ mode: "manual", scrollTop: 400 });
+  });
+
+  test("reveals the start rather than the tail of an oversized submitted prompt", async () => {
+    await render("session-a", null, history);
+    await flushFrames();
+    await browse(200);
+    contentHeight = 2800;
+    const rows = [...history, { id: "submitted", top: 2000, height: 800 }];
+    await render("session-a", "submitted", rows);
+    await flushFrames();
+    expect(container.scrollTop).toBe(2000);
+    expect(container.querySelector('[data-message-id="submitted"]')?.getBoundingClientRect().top)
+      .toBe(container.getBoundingClientRect().top);
+    expect(useSessionScrollStore.getState().sessions["session-a"])
+      .toEqual({ mode: "manual", scrollTop: 2000, topClippedMessageId: null });
+    contentHeight = 2900;
+    await render("session-a", "submitted", [...rows]);
+    await act(async () => resize());
+    await flushFrames();
+    expect(container.scrollTop).toBe(2000);
+  });
+
+  test("session restoration does not overwrite a newly revealed prompt on the next frame", async () => {
+    useSessionScrollStore.getState().setManualScroll("session-a", 200, null);
+    await render("session-a", null, history);
+    // Send before restoration's second (animation-frame) pass has executed.
+    contentHeight = 2800;
+    await render("session-a", "submitted", [...history, { id: "submitted", top: 2000, height: 800 }]);
+    expect(container.scrollTop).toBe(2000);
+    await flushFrames();
+    expect(container.scrollTop).toBe(2000);
+    expect(useSessionScrollStore.getState().sessions["session-a"])
+      .toEqual({ mode: "manual", scrollTop: 2000, topClippedMessageId: null });
   });
 });

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -178,6 +178,42 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     await user.notSee(rootSearch);
   };
   const oldTargets = [world.toolNames[0]!, world.toolNames.at(-1)!];
+  const surface = `[data-session-surface-id="${world.session.sessionId}"]`;
+  const viewportSelector = `${surface} > div > .overflow-y-auto`;
+  const userRowsSelector = `${viewportSelector} [data-message-role="user"]`;
+  const transcriptGeometry = async () => {
+    const [viewport, composer, rows, texts] = await Promise.all([
+      probe.dom(viewportSelector),
+      probe.dom(`${surface} > div:has([data-lexical-editor="true"])`),
+      probe.dom(userRowsSelector),
+      probe.dom(`${userRowsSelector} span.whitespace-pre-wrap`),
+    ]);
+    expect(viewport.elements).toHaveLength(1);
+    expect(composer.elements).toHaveLength(1);
+    expect(rows.elements.length).toBeGreaterThan(0);
+    expect(texts.elements).toHaveLength(rows.elements.length);
+    return {
+      viewport: viewport.elements[0]!.rect,
+      composer: composer.elements[0]!.rect,
+      rows: rows.elements.map((row, index) => ({ rect: row.rect, text: texts.elements[index]!.text })),
+    };
+  };
+  const browseHistory = async () => {
+    await user.click({ text: world.history[74]! });
+    const initialTop = (await probe.dom(userRowsSelector)).elements[74]!.rect.top;
+    await user.press("PageUp");
+    let previousTop = Number.NaN;
+    return probe.eventually(async () => {
+      const geometry = await transcriptGeometry();
+      const top = geometry.rows[74]!.rect.top;
+      const stable = Math.abs(top - previousTop) <= 1;
+      previousTop = top;
+      expect(top).toBeGreaterThan(initialTop + 16);
+      expect(geometry.rows.at(-1)!.rect.top).toBeGreaterThanOrEqual(geometry.viewport.bottom);
+      expect(geometry.rows.some(({ rect }) => rect.top >= geometry.viewport.top && rect.bottom <= geometry.viewport.bottom)).toBe(true);
+      return { ...geometry, stable };
+    }, { within: 5_000, label: "keyboard browsing settles above the latest turn", until: (value) => value.stable });
+  };
 
   await step("the live cache retains history older than the native 140-message snapshot", async () => {
     expect(await orderedHistory()).toEqual(world.history);
@@ -196,7 +232,24 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     { role: "assistant", text: world.opening },
   ]);
   await user.type("composer", world.prompt);
-  await user.click("Run task");
+  await step("sending from older history reveals the exact latest user row above the composer without Jump to latest", async () => {
+    await browseHistory();
+    await user.click("Run task");
+    // user.see() scrolls its target into view and would mask this regression.
+    await probe.eventually(async () => {
+      const { viewport, composer, rows } = await transcriptGeometry();
+      const latest = rows.at(-1)!;
+      expect(latest.text).toBe(world.prompt);
+      expect(rows.filter(({ text }) => text === world.prompt)).toHaveLength(1);
+      expect(latest.rect.width).toBeGreaterThan(0);
+      expect(latest.rect.height).toBeGreaterThan(0);
+      expect(latest.rect.left).toBeGreaterThanOrEqual(viewport.left);
+      expect(latest.rect.right).toBeLessThanOrEqual(viewport.right);
+      expect(latest.rect.top).toBeGreaterThanOrEqual(viewport.top);
+      expect(latest.rect.bottom).toBeLessThanOrEqual(Math.min(viewport.bottom, composer.top));
+      return true;
+    }, { within: 5_000, label: "submitted user row inside the transcript viewport" });
+  });
 
   await step("new tool output becomes accessible without losing old targets while text grows", async () => {
     await user.see({ text: world.opening }, { timeoutMs: 90_000 });
@@ -207,6 +260,27 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     await user.see({ text: world.middle }, { timeoutMs: 90_000 });
     await user.notSee({ text: world.closing });
     expect(await orderedHistory()).toEqual(world.history);
+  });
+
+  await step("passive streamed output does not jump away from the history being read", async () => {
+    const before = await browseHistory();
+    const anchor = before.rows.find(({ rect }) => rect.top >= before.viewport.top && rect.bottom <= before.viewport.bottom)!;
+    expect(await probe.has(world.closing)).toBe(false);
+    let maxMovement = 0;
+    const after = await probe.eventually(async () => {
+      const complete = await probe.has(world.closing);
+      const geometry = await transcriptGeometry();
+      const retained = geometry.rows.find(({ text }) => text === anchor.text)!;
+      maxMovement = Math.max(maxMovement, Math.abs(retained.rect.top - anchor.rect.top));
+      return { ...geometry, complete };
+    }, {
+      within: 120_000, label: "new output arrives while browsing history", until: (value) => value.complete,
+    });
+    const retained = after.rows.find(({ text }) => text === anchor.text)!;
+    expect(maxMovement).toBeLessThanOrEqual(2);
+    expect(retained.rect.top).toBeGreaterThanOrEqual(after.viewport.top);
+    expect(retained.rect.bottom).toBeLessThanOrEqual(after.viewport.bottom);
+    expect(after.rows.at(-1)!.rect.top).toBeGreaterThanOrEqual(after.viewport.bottom);
   });
 
   await step("settled history and the advancing answer never disappear or duplicate", async () => {


### PR DESCRIPTION
## Summary

Submitting from older history in a long conversation can leave the new user message below the viewport. Submission previously depended on passive bottom-follow behavior, which correctly stops after manual browsing.

- Reveal the exact locally submitted row once it mounts, including after a recent scroll gesture. Reveal the start of an oversized prompt instead of only its tail.
- Cancel pending scroll-position frames so a previous restoration cannot undo the reveal. Keep the request scoped to its conversation and leave subsequent manual browsing undisturbed.
- Extend the existing tool-rich history journey with viewport visibility and passive-scroll preservation assertions. Add focused hook regressions for delayed mounting, gestures, session isolation, oversized prompts, and restoration timing.

Queued-send handoff and metadata-only acknowledgement visibility are separate follow-ups, not changed here.

## Verification — Incomplete

Head: `4905dd674`.

Passed:
- `pnpm --filter @openwork/app exec bun test --isolate ./tests/live-step-scroll.test.ts` — exit 0; 7 passed, 0 failed, 36 assertions. These are focused unit/hook checks, not runtime journey proof.
- `git diff --check` — exit 0.

Blocked:
- `OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e streamed-markdown-answer` — exit 1 before any tests ran: `Command "vitest" not found`.
- Printed placement: `placement: daytona (daytona CLI authenticated)`.
- Journey passed/failed/skipped counts are unavailable because the runner did not start. No runtime evidence was produced or published.

Next proof step: install the standalone eval dependencies with `pnpm --dir evals install`, then run the command above on this exact pushed head with `OPENWORK_EVAL_REF` pinned to the full head SHA and publish its evidence. No local-lane substitution or broad test suite was used.

## Reproduction

1. Open a long conversation with tool output and scroll into older history.
2. Submit a short follow-up while idle, or explicitly steer an active turn.
3. Confirm the submitted text is visible above the composer without using Jump to latest.
4. Scroll back into history while the response advances; confirm passive output does not pull the viewport back down.
