### PR TITLE
fix(app): reclaim thread title space around the plus button

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -2301,9 +2301,9 @@ function SessionMenuItem({
   const rowButtonClass = cn(
     // Soft pill @ 11px radius from Paper; overlay tint adapts to theme
     // (light: --ow-light-hover ≈ black/5, dark: #FFFFFF17 ≈ white/9).
-    // The end padding tracks SessionHoverQuickActions: reserve their width
-    // whenever they show, including the layouts that show them without hover.
-    "relative h-8 rounded-md transition-[padding,background-color] duration-75 pe-7 group-hover/menu-sub-item:pe-18 group-has-data-popup-open/menu-sub-item:pe-18 max-lg:pe-18 pointer-coarse:pe-18 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-[13px] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
+    // Reserve quick-action space only while visible. The side-chat control
+    // occupies its own flex slot, so idle titles need only the normal end inset.
+    "relative h-8 rounded-md transition-[padding,background-color] duration-75 pe-2.5 group-hover/menu-sub-item:pe-18 group-has-data-popup-open/menu-sub-item:pe-18 max-lg:pe-18 pointer-coarse:pe-18 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-[13px] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
   );
   const rowButtonStyle = {
     paddingInlineStart: sidebarRowPaddingInlineStart(0),

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -107,6 +107,37 @@ test("side chats keep questions, replies, and saved splits attached to their own
     });
   };
   const before = await ids();
+  await step("only the conversation showing the plus gives up title space", async () => {
+    for (const selected of [world.switchSession.sessionId, primary]) {
+      await reopen(selected);
+      await user.hover("composer");
+      for (const sessionId of [primary, world.switchSession.sessionId]) {
+        const selector = `[data-sidebar-session-id="${sessionId}"]`;
+        const layout = await probe.eventually(() => probe.dom(
+          `${selector}, ${selector} [data-session-tab-id], ${selector} [data-session-title-slot], ${selector} [data-session-side-chat]`,
+        ), {
+          within: 10_000,
+          label: "idle row restores its title space after selection and hover settle",
+          until: ({ elements }) => elements.length === (sessionId === selected ? 4 : 3)
+            && elements[1]!.rect.right - elements[2]!.rect.right <= 11,
+        });
+        const [row, main, title, side] = layout.elements;
+        if (!row || !main || !title) throw new Error("Missing conversation row geometry");
+        expect(title.rect.width).toBeGreaterThan(0);
+        expect(main.rect.right - title.rect.right, "no invisible action gutter").toBeCloseTo(10, 0);
+        if (sessionId === selected) {
+          if (!side) throw new Error("The selected conversation must offer a side chat");
+          expect(side.rect.width).toBeGreaterThan(0);
+          expect(main.rect.right).toBeCloseTo(side.rect.left, 0);
+          expect(side.rect.right).toBeCloseTo(row.rect.right, 0);
+        } else {
+          expect(side).toBeUndefined();
+          expect(main.rect.right, "other conversations use the plus space").toBeCloseTo(row.rect.right, 0);
+        }
+      }
+    }
+    expect(await ids(), "switching rows must not create a side chat").toEqual(before);
+  });
   await step("only a genuinely empty main conversation offers starters", async () => {
     await probe.eventually(() => world.continuity.surfaceState("primary"), {
       within: 15_000, label: "loaded empty primary offers starters",


### PR DESCRIPTION
## Summary

- Restore 18px of unused title space by reducing the idle thread-row end inset from 28px to the normal 10px.
- Keep the plus/side-chat control in its existing conditional flex slot: only the row displaying it gives up that space.
- Preserve spacing for visible hover, popup, narrow-screen, and touch quick actions.
- Extend the existing split-chat journey to check both selection directions, title space, control adjacency, and no accidental side-chat creation.

## Why

The plus already renders only for the selected conversation or a saved side chat. An additional idle gutter still shortened every thread title unnecessarily. Removing that gutter lets other threads use the available width without changing split behavior, keyboard shortcuts, or action hit targets.

## Verification — Incomplete

- **Passed, focused feedback before the conflict-free rebase:** `pnpm --filter @openwork/app exec bun test --isolate ./tests/session-title-marquee.test.tsx` — exit 0; 9 passed, 0 failed. This checks title remeasurement behavior, not the rendered row layout.
- **Passed:** `git diff --check`.
- **Deferred:** `pnpm evals:e2e new-split-session`. The added geometry assertions have not been executed. Exact-head real-app evidence is missing; this PR does not claim a verified runtime layout or merge readiness.
- No broader suite or cross-platform checks were run.

### Manual verification

1. Open a workspace with at least two threads in a desktop-width sidebar.
2. Select one thread and move the pointer out of the sidebar. Confirm that only its row shows the plus and that other rows use the available width, leaving only the normal end inset.
3. Select the other thread. Confirm the previous row regains the space and no side chat is created merely by switching.
4. Hover a thread and confirm its quick actions remain clear of the title.
