### PR TITLE
perf(runtime): bound workspace background work and retained output

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -157,7 +157,8 @@ type TextStream = {
   messageID: string;
   partID: string;
   ordinal: number;
-  text: string;
+  // Missing after completion: retain identity, not another copy of the transcript.
+  text?: string;
   start: number;
 };
 
@@ -171,13 +172,24 @@ type ToolStream = {
   input: Record<string, unknown>;
   metadata: Record<string, unknown>;
   start?: number;
+  inputEnded?: boolean;
 };
+
+type V2EventPosition = { sequence?: number; created?: number };
+
+// /api/event is live-only, not a replay log. Defensively guard recent retired
+// sessions; arbitrary replay beyond this window requires authoritative history.
+// Active executions keep their own watermark and are never capacity-evicted.
+const V2_TERMINAL_SESSION_LIMIT = 256;
 
 export type V2EventTranslationState = {
   streams: Map<string, TextStream>;
-  tools: Map<string, ToolStream>;
+  // Null marks a completed call until its execution ends; late events are no-ops.
+  tools: Map<string, ToolStream | null>;
   latestStreamKeyBySession: Map<string, string>;
   nextOrdinalByMessage: Map<string, number>;
+  executionBySession: Map<string, V2EventPosition & { terminal?: boolean; retired?: V2EventPosition }>;
+  terminalBySession: Map<string, V2EventPosition>;
   unknownTypes: Set<string>;
 };
 
@@ -691,7 +703,7 @@ function readToolCallID(value: Record<string, unknown>): string {
 }
 
 function toolStreamKey(sessionID: string, callID: string): string {
-  return `${sessionID}:${callID}`;
+  return JSON.stringify([sessionID, callID]);
 }
 
 function resolveToolStream(
@@ -792,12 +804,66 @@ function failedToolPart(
   };
 }
 
+function trackV2Execution(
+  state: V2EventTranslationState,
+  value: Record<string, unknown>,
+  properties: Record<string, unknown>,
+): void {
+  const sessionID = readSessionID(properties);
+  const current = state.executionBySession.get(sessionID) ?? { retired: state.terminalBySession.get(sessionID) };
+  const sequence = readNumber(value.durable, "seq");
+  const created = readNumber(properties, "timestamp") ?? readNumber(value, "created");
+  if (sequence !== undefined) current.sequence = Math.max(current.sequence ?? sequence, sequence);
+  if (created !== undefined) current.created = Math.max(current.created ?? created, created);
+  current.terminal = false;
+  state.executionBySession.set(sessionID, current);
+}
+
+function isRetiredV2Event(
+  state: V2EventTranslationState,
+  value: Record<string, unknown>,
+  properties: Record<string, unknown>,
+): boolean {
+  const sessionID = readSessionID(properties);
+  const retired = state.executionBySession.get(sessionID)?.retired ?? state.terminalBySession.get(sessionID);
+  const sequence = readNumber(value.durable, "seq");
+  if (sequence !== undefined && retired?.sequence !== undefined) return sequence <= retired.sequence;
+  const created = readNumber(properties, "timestamp") ?? readNumber(value, "created");
+  // Equal wall-clock timestamps do not order a legacy successor against a terminal.
+  return created !== undefined && retired?.created !== undefined && created < retired.created;
+}
+
+function clearV2SessionTranslation(state: V2EventTranslationState, sessionID: string, deleted = false): void {
+  if (!deleted) {
+    if (!state.executionBySession.get(sessionID)?.terminal) return;
+    // /api/event is volatile, not a durable-log drain marker. A session terminal
+    // must not discard input/identity needed by a late final part update.
+    for (const stream of state.streams.values()) {
+      if (stream.sessionID === sessionID && stream.text !== undefined) return;
+    }
+    for (const stream of state.tools.values()) {
+      if (stream?.sessionID === sessionID) return;
+    }
+  }
+  // Every translation key is a JSON tuple with the session first. Keep counters
+  // and completion markers through retries/tool steps, but not across executions.
+  const prefix = `${JSON.stringify([sessionID]).slice(0, -1)},`;
+  for (const map of [state.streams, state.tools, state.latestStreamKeyBySession, state.nextOrdinalByMessage]) {
+    for (const key of map.keys()) {
+      if (key.startsWith(prefix)) map.delete(key);
+    }
+  }
+  state.executionBySession.delete(sessionID);
+}
+
 export function createV2EventTranslationState(): V2EventTranslationState {
   return {
     streams: new Map(),
     tools: new Map(),
     latestStreamKeyBySession: new Map(),
     nextOrdinalByMessage: new Map(),
+    executionBySession: new Map(),
+    terminalBySession: new Map(),
     unknownTypes: new Set(),
   };
 }
@@ -841,6 +907,38 @@ export function translateV2Event(
 
   if (type.startsWith("session.execution.")) {
     if (!sessionID) return null;
+    if (type === "session.execution.started") {
+      if (isRetiredV2Event(state, value, properties)) return null;
+      trackV2Execution(state, value, properties);
+    }
+    if (type === "session.execution.succeeded" || type === "session.execution.failed" || type === "session.execution.interrupted") {
+      const current = state.executionBySession.get(sessionID);
+      const sequence = readNumber(value.durable, "seq");
+      const created = readNumber(properties, "timestamp") ?? readNumber(value, "created");
+      // A replayed terminal from a predecessor must not discard its successor's
+      // active buffers. Prefer native ordering; timestamps cover legacy envelopes.
+      const stale = sequence !== undefined && current?.sequence !== undefined
+        ? sequence <= current.sequence
+        : created !== undefined && current?.created !== undefined && created < current.created;
+      if (!stale && !isRetiredV2Event(state, value, properties)) {
+        const retired = { sequence, created };
+        if (sequence !== undefined || created !== undefined) {
+          state.terminalBySession.delete(sessionID);
+          state.terminalBySession.set(sessionID, retired);
+          if (state.terminalBySession.size > V2_TERMINAL_SESSION_LIMIT) {
+            const oldest = state.terminalBySession.keys().next().value;
+            if (oldest !== undefined) state.terminalBySession.delete(oldest);
+          }
+        }
+        // Active successors retain their predecessor's watermark even if its
+        // idle-cache entry is evicted. No active buffers are capacity-evicted.
+        state.executionBySession.set(sessionID, {
+          ...current, terminal: true,
+          retired: sequence !== undefined || created !== undefined ? retired : current?.retired,
+        });
+        clearV2SessionTranslation(state, sessionID);
+      }
+    }
     return [{ type, properties: {
       ...properties, sequence: readNumber(value.durable, "seq"),
       ...(type === "session.execution.failed" ? {
@@ -853,6 +951,8 @@ export function translateV2Event(
     const attempt = readNumber(properties, "attempt");
     const next = readNumber(properties, "at");
     if (!sessionID || attempt === undefined || next === undefined) return null;
+    if (isRetiredV2Event(state, value, properties)) return null;
+    trackV2Execution(state, value, properties);
     return [{ type: "session.status", properties: {
       sessionID,
       sequence: readNumber(value.durable, "seq"),
@@ -861,6 +961,8 @@ export function translateV2Event(
   }
 
   if (type === "session.step.started") {
+    if (isRetiredV2Event(state, value, properties)) return null;
+    if (sessionID) trackV2Execution(state, value, properties);
     return sessionID ? [{ type: "session.execution.progress", properties: {
       sessionID, sequence: readNumber(value.durable, "seq"),
     } }] : null;
@@ -870,6 +972,7 @@ export function translateV2Event(
   if (type === `session.${kind}.started` || type === `session.next.${kind}.started`) {
     const messageID = readMessageID(properties);
     if (!sessionID || !messageID) return null;
+    if (isRetiredV2Event(state, value, properties)) return null;
     const key = streamKey(properties, sessionID, messageID, kind);
     const counterKey = JSON.stringify([sessionID, messageID, kind]);
     const candidate = state.streams.get(key);
@@ -886,6 +989,8 @@ export function translateV2Event(
       text: "",
       start: toolEventTimestamp(value, properties),
     };
+    if (stream.text === undefined) return null;
+    trackV2Execution(state, value, properties);
     state.streams.set(key, stream);
     state.latestStreamKeyBySession.set(JSON.stringify([sessionID, kind]), key);
     if (!existing) {
@@ -917,7 +1022,7 @@ export function translateV2Event(
   if (type === `session.${kind}.delta` || type === `session.next.${kind}.delta`) {
     const stream = resolveTextStream(properties, state, kind);
     const delta = readString(properties, "delta");
-    if (!stream || delta === undefined) return null;
+    if (!stream || stream.text === undefined || delta === undefined) return null;
     stream.text += delta;
     return [{
       type: "message.part.delta",
@@ -933,7 +1038,7 @@ export function translateV2Event(
 
   if (type === `session.${kind}.ended` || type === `session.next.${kind}.ended`) {
     const stream = resolveTextStream(properties, state, kind);
-    if (!stream) return null;
+    if (!stream || stream.text === undefined) return null;
     const fullText = readString(properties, "text");
     if (fullText !== undefined) stream.text = fullText;
     const part: TextPart | ReasoningPart = {
@@ -946,6 +1051,8 @@ export function translateV2Event(
         time: { start: stream.start, end: toolEventTimestamp(value, properties) },
       } : { type: kind }),
     };
+    delete stream.text;
+    clearV2SessionTranslation(state, stream.sessionID);
     return [{ type: "message.part.updated", properties: { part } }];
   }
 
@@ -954,8 +1061,10 @@ export function translateV2Event(
     const callID = readToolCallID(properties);
     const sourceTool = readString(properties, "name") ?? readString(properties, "tool");
     if (!sessionID || !messageID || !callID || !sourceTool) return null;
+    if (isRetiredV2Event(state, value, properties)) return null;
     const key = toolStreamKey(sessionID, callID);
     const existing = state.tools.get(key);
+    if (existing === null || existing?.inputEnded || existing?.start !== undefined) return null;
     const stream = existing ?? {
       sessionID,
       messageID,
@@ -966,6 +1075,7 @@ export function translateV2Event(
       input: {},
       metadata: {},
     };
+    trackV2Execution(state, value, properties);
     state.tools.set(key, stream);
     return [
       {
@@ -986,7 +1096,7 @@ export function translateV2Event(
   if (type === "session.tool.input.delta" || type === "session.next.tool.input.delta") {
     const stream = resolveToolStream(properties, state);
     const delta = readString(properties, "delta");
-    if (!stream || delta === undefined) return null;
+    if (!stream || stream.inputEnded || stream.start !== undefined || delta === undefined) return null;
     stream.raw += delta;
     stream.input = parseToolInput(stream.raw, stream.tool);
     return [{ type: "message.part.updated", properties: { part: pendingToolPart(stream) } }];
@@ -995,17 +1105,21 @@ export function translateV2Event(
   if (type === "session.tool.input.ended" || type === "session.next.tool.input.ended") {
     const stream = resolveToolStream(properties, state);
     const text = readString(properties, "text");
-    if (!stream || text === undefined) return null;
+    if (!stream || stream.inputEnded || stream.start !== undefined || text === undefined) return null;
     stream.raw = text;
     stream.input = parseToolInput(text, stream.tool);
-    return [{ type: "message.part.updated", properties: { part: pendingToolPart(stream) } }];
+    const part = pendingToolPart(stream);
+    stream.inputEnded = true;
+    stream.raw = "";
+    return [{ type: "message.part.updated", properties: { part } }];
   }
 
   if (type === "session.tool.called" || type === "session.next.tool.called") {
     const stream = resolveToolStream(properties, state);
     if (!stream) return null;
     stream.input = parseToolInput(properties.input, stream.tool);
-    stream.start = toolEventTimestamp(value, properties);
+    stream.raw = "";
+    stream.start ??= toolEventTimestamp(value, properties);
     return [{
       type: "message.part.updated",
       properties: { part: runningToolPart(stream, stream.start) },
@@ -1018,6 +1132,7 @@ export function translateV2Event(
     stream.metadata = readRecord(properties, "metadata") ?? readRecord(properties, "structured") ?? stream.metadata;
     const start = stream.start ?? toolEventTimestamp(value, properties);
     stream.start = start;
+    stream.raw = "";
     return [{
       type: "message.part.updated",
       properties: { part: runningToolPart(stream, start) },
@@ -1029,6 +1144,8 @@ export function translateV2Event(
     if (!stream) return null;
     stream.metadata = readRecord(properties, "metadata") ?? readRecord(properties, "structured") ?? stream.metadata;
     const part = completedToolPart(stream, properties, toolEventTimestamp(value, properties));
+    state.tools.set(toolStreamKey(stream.sessionID, stream.callID), null);
+    clearV2SessionTranslation(state, stream.sessionID);
     return [{ type: "message.part.updated", properties: { part } }];
   }
 
@@ -1037,6 +1154,8 @@ export function translateV2Event(
     if (!stream) return null;
     stream.metadata = readRecord(properties, "metadata") ?? stream.metadata;
     const part = failedToolPart(stream, properties, toolEventTimestamp(value, properties));
+    state.tools.set(toolStreamKey(stream.sessionID, stream.callID), null);
+    clearV2SessionTranslation(state, stream.sessionID);
     return [{ type: "message.part.updated", properties: { part } }];
   }
 
@@ -1095,6 +1214,8 @@ export function translateV2Event(
     const info = mapV2Session(properties, readString(readRecord(value, "location") ?? {}, "directory"));
     const deletedSessionID = sessionID || info?.id || "";
     if (!deletedSessionID) return null;
+    clearV2SessionTranslation(state, deletedSessionID, true);
+    state.terminalBySession.delete(deletedSessionID);
     return [{
       type: "session.deleted",
       properties: { sessionID: deletedSessionID, ...(info ? { info } : {}) },
@@ -1130,6 +1251,8 @@ function translateV2Events(
     if (stopped) return;
     stopped = true;
     signal?.removeEventListener("abort", stop);
+    for (const collection of Object.values(state)) collection.clear();
+    discoveredForks.clear();
     for (const lookup of lookups.values()) lookup.abort();
     lookups.clear();
     discoveries.length = 0;

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -85,12 +85,12 @@ type SyncEntry = {
   dispose: () => void;
   disposeTimer: ReturnType<typeof setTimeout> | null;
   trackedSessionRefs: Map<string, number>;
-  retainedSessionTimers: Map<string, ReturnType<typeof setTimeout>>;
+  retainedSessionTimers: Map<string, { timer: ReturnType<typeof setTimeout>; releaseAt: number }>;
   sessionCreatedListeners: ListenerRegistry<NonNullable<SyncOptions["onSessionCreated"]>>;
   sessionUpdatedListeners: ListenerRegistry<NonNullable<SyncOptions["onSessionUpdated"]>>;
   sessionDeletedListeners: ListenerRegistry<NonNullable<SyncOptions["onSessionDeleted"]>>;
   sessionStatusListeners: ListenerRegistry<NonNullable<SyncOptions["onSessionStatus"]>>;
-  pendingDeltas: Map<string, { messageId: string; reasoning: boolean; text: string }>;
+  pendingDeltas: Map<string, { sessionId: string; messageId: string; reasoning: boolean; text: string }>;
   // Coalesce rapid-fire delta events from the SSE stream into one visible
   // cache commit per animation frame. Background transcripts use a slower
   // lane because they have no renderer waiting on token-sized updates.
@@ -102,7 +102,8 @@ type SyncEntry = {
   statusReconcileAbort: AbortController | null;
   runActiveObservedAt: Map<string, number>;
   assistantMessageCompletedAt: Map<string, number>;
-  nativeSequenceBySession: Map<string, number>;
+  nativeSequenceBySession: Map<string, { sequence: number; revision: number }>;
+  nativeSequenceRevision: number;
   nativeTerminalSessions: Set<string>;
   permissionReconciles: Map<string, AbortController>;
   titleRecovery: SessionTitleRecovery | null;
@@ -482,10 +483,32 @@ function partHasVisibleAssistantOutput(part: Part) {
 }
 
 function clearTrackedSession(input: SyncOptions, entry: SyncEntry, sessionId: string) {
-  entry.trackedSessionRefs.delete(sessionId);
-  const retainedTimer = entry.retainedSessionTimers.get(sessionId);
-  if (retainedTimer) clearTimeout(retainedTimer);
+  if ((entry.trackedSessionRefs.get(sessionId) ?? 0) > 0) return;
+  const queryClient = getReactQueryClient();
+  const record = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId]?.[sessionId];
+  // Leaving Settings or switching workspaces must not turn retention into a
+  // run timeout, or discard an interaction that is still awaiting a reply.
+  if (
+    entry.liveSessionIds.has(sessionId)
+    || record?.runActive
+    || record?.compacting
+    || record?.waitingPermissionIds.length
+    || record?.waitingQuestionIds.length
+    || queryClient.getQueryData<PendingPermission[]>(permissionKey(input.workspaceId, sessionId))?.length
+    || queryClient.getQueryData<PendingQuestion[]>(questionKey(input.workspaceId, sessionId))?.length
+    || entry.permissionReconciles.has(sessionId)
+  ) {
+    retainSession(input, entry, sessionId);
+    return;
+  }
+  const retained = entry.retainedSessionTimers.get(sessionId);
+  if (retained) clearTimeout(retained.timer);
   entry.retainedSessionTimers.delete(sessionId);
+  entry.runActiveObservedAt.delete(sessionId);
+  entry.assistantMessageCompletedAt.delete(sessionId);
+  for (const [key, pending] of entry.pendingDeltas) {
+    if (pending.sessionId === sessionId) entry.pendingDeltas.delete(key);
+  }
   entry.deltaFlushBuffer = entry.deltaFlushBuffer.filter(
     (item) => item.sessionId !== sessionId,
   );
@@ -494,8 +517,10 @@ function clearTrackedSession(input: SyncOptions, entry: SyncEntry, sessionId: st
     entry.deltaFlushLane = null;
     entry.cancelDeltaFlush = null;
   }
-  const queryClient = getReactQueryClient();
+  // Keep sequence and settlement watermarks: delayed events/reads must not
+  // resurrect a terminal run or a replied interaction after cache release.
   queryClient.removeQueries({ queryKey: permissionKey(input.workspaceId, sessionId), exact: true });
+  queryClient.removeQueries({ queryKey: questionKey(input.workspaceId, sessionId), exact: true });
   // Status entries are exempt from TanStack GC (see query-client.ts), so the
   // tracked-session lifecycle owns their cleanup.
   queryClient.removeQueries({ queryKey: statusKey(input.workspaceId, sessionId), exact: true });
@@ -507,10 +532,16 @@ function clearTrackedSession(input: SyncOptions, entry: SyncEntry, sessionId: st
 
 function retainSession(input: SyncOptions, entry: SyncEntry, sessionId: string, ttlMs = retainedSessionTtlMs) {
   const existing = entry.retainedSessionTimers.get(sessionId);
-  if (existing) clearTimeout(existing);
-  entry.retainedSessionTimers.set(sessionId, setTimeout(() => {
-    clearTrackedSession(input, entry, sessionId);
-  }, ttlMs));
+  const releaseAt = Date.now() + ttlMs;
+  if (existing && existing.releaseAt <= releaseAt) return;
+  if (existing) clearTimeout(existing.timer);
+  entry.retainedSessionTimers.set(sessionId, {
+    releaseAt,
+    timer: setTimeout(() => {
+      entry.retainedSessionTimers.delete(sessionId);
+      clearTrackedSession(input, entry, sessionId);
+    }, ttlMs),
+  });
 }
 
 function disposeWorkspaceSync(key: string, entry: SyncEntry) {
@@ -519,7 +550,7 @@ function disposeWorkspaceSync(key: string, entry: SyncEntry) {
     clearTimeout(entry.disposeTimer);
     entry.disposeTimer = null;
   }
-  for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
+  for (const { timer } of entry.retainedSessionTimers.values()) clearTimeout(timer);
   entry.retainedSessionTimers.clear();
   entry.cancelDeltaFlush?.();
   entry.deltaFlushLane = null;
@@ -856,8 +887,8 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const sessionId = sessionIdFromProperties(props);
     const sequence = props && typeof props === "object" && "sequence" in props ? props.sequence : undefined;
     if (sessionId && typeof sequence === "number") {
-      if (sequence <= (entry.nativeSequenceBySession.get(sessionId) ?? -1)) return;
-      entry.nativeSequenceBySession.set(sessionId, sequence);
+      if (sequence <= (entry.nativeSequenceBySession.get(sessionId)?.sequence ?? -1)) return;
+      entry.nativeSequenceBySession.set(sessionId, { sequence, revision: ++entry.nativeSequenceRevision });
     }
   }
 
@@ -927,14 +958,33 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.deleted") {
     const props = (event.properties ?? {}) as { sessionID?: string; info?: { id?: string } };
     const sessionId = props.sessionID ?? props.info?.id ?? "";
-    if (sessionId) void closeSessionBrowserTabs(sessionId);
-    if (sessionId) entry.titleRecovery?.resolve(sessionId);
-    if (sessionId) useSessionActivityStore.getState().removeSession(workspaceId, sessionId);
-    if (sessionId) useWorkbenchStore.getState().closeTab({ workspaceId, sessionId });
-    if (sessionId) stopTrackingLiveSession(entry, sessionId);
-    if (sessionId) {
-      for (const listener of entry.sessionDeletedListeners.keys()) listener(sessionId);
+    if (!sessionId) return;
+    entry.permissionReconciles.get(sessionId)?.abort();
+    entry.permissionReconciles.delete(sessionId);
+    // Deletion settles known interactions, but their watermarks must outlive
+    // the pending caches so delayed snapshots/events cannot revive them.
+    const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+    for (const requestId of new Set([
+      ...(record?.waitingPermissionIds ?? []),
+      ...(queryClient.getQueryData<PendingPermission[]>(permissionKey(workspaceId, sessionId)) ?? []).map((request) => request.id),
+    ])) {
+      settlePermissionState(workspaceId, sessionId, requestId);
     }
+    for (const requestId of new Set([
+      ...(record?.waitingQuestionIds ?? []),
+      ...(queryClient.getQueryData<PendingQuestion[]>(questionKey(workspaceId, sessionId)) ?? []).map((request) => request.id),
+    ])) {
+      settleQuestionState(workspaceId, sessionId, requestId);
+    }
+    queryClient.removeQueries({ queryKey: permissionKey(workspaceId, sessionId), exact: true });
+    queryClient.removeQueries({ queryKey: questionKey(workspaceId, sessionId), exact: true });
+    void closeSessionBrowserTabs(sessionId);
+    entry.titleRecovery?.resolve(sessionId);
+    useSessionActivityStore.getState().removeSession(workspaceId, sessionId);
+    useWorkbenchStore.getState().closeTab({ workspaceId, sessionId });
+    stopTrackingLiveSession(entry, sessionId);
+    for (const listener of entry.sessionDeletedListeners.keys()) listener(sessionId);
+    clearTrackedSession(input, entry, sessionId);
     return;
   }
 
@@ -1326,6 +1376,7 @@ function commitDeltas(entry: SyncEntry, workspaceId: string, items: PendingDelta
           // projecting them into the wrong Markdown surface.
           const pendingKey = JSON.stringify([sessionId, item.messageId, item.partId]);
           const existing = entry.pendingDeltas.get(pendingKey) ?? {
+            sessionId,
             messageId: item.messageId,
             reasoning: item.reasoning,
             text: "",
@@ -1502,6 +1553,7 @@ async function reconcileSessionPermissions(entry: SyncEntry, sessionId: string) 
 
 // Snapshot-only busy observations need the same validation as stream edges.
 function trackLiveSession(entry: SyncEntry, sessionId: string, status: SessionStatus, source: SessionStatusSource) {
+  if (entry.refs <= 0 && !isTrackedSession(entry, sessionId)) retainSession(entry.input, entry, sessionId);
   if (!entry.liveSessionIds.has(sessionId)) {
     entry.liveSessionIds.add(sessionId);
     entry.runActiveObservedAt.set(sessionId, perfNow());
@@ -1518,7 +1570,9 @@ async function reconcileSessionRunStatuses(
 ) {
   const startedAt = Date.now();
   const key = syncKey(input);
-  const sequences = new Map(entry.nativeSequenceBySession);
+  // Capture one revision instead of copying every historical sequence on each
+  // poll. A same-clock native edge still invalidates this read for its session.
+  const sequenceRevision = entry.nativeSequenceRevision;
   if (source === "connect-reconcile") {
     const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId] ?? {};
     for (const sessionId of new Set([...Object.keys(records), ...entry.trackedSessionRefs.keys()])) {
@@ -1547,19 +1601,24 @@ async function reconcileSessionRunStatuses(
   // than waiting out the outage's backoff. Healthy streams ignore the nudge.
   if (recovered) entry.notifyStreamGenerationChanged?.();
 
-  // Level-triggered convergence on every SSE (re)connect: sessions the fetch
-  // reports live are seeded busy (heals a subscriber that missed the busy
-  // edge), and known records the fetch no longer reports are seeded idle
-  // (heals a missed idle edge). Both flow through the same path a
-  // session.status event uses so the status cache and listeners converge too.
+  // Reconnect converges all known records. Steady-state polls only revisit
+  // live/unsettled sessions, not the workspace's entire idle history. Include
+  // newly reported live sessions to heal missed busy edges, and owned pending
+  // runs whose optimistic activity write arrived without a stream edge.
   const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId] ?? {};
-  const sessionIds = new Set([
-    ...Object.keys(statuses),
-    ...Object.keys(records),
-    ...entry.liveSessionIds,
-  ]);
+  const sessionIds = new Set(entry.liveSessionIds);
+  for (const [sessionId, status] of Object.entries(statuses)) {
+    if (source === "connect-reconcile" || isLiveStatus(status)) sessionIds.add(sessionId);
+  }
+  const knownSessionIds = source === "connect-reconcile"
+    ? Object.keys(records)
+    : [...entry.trackedSessionRefs.keys(), ...entry.retainedSessionTimers.keys()];
+  for (const sessionId of knownSessionIds) {
+    const record = records[sessionId];
+    if (source === "connect-reconcile" || record?.runActive || record?.compacting) sessionIds.add(sessionId);
+  }
   for (const sessionId of sessionIds) {
-    if (sequences.get(sessionId) !== entry.nativeSequenceBySession.get(sessionId)) continue;
+    if ((entry.nativeSequenceBySession.get(sessionId)?.revision ?? 0) > sequenceRevision) continue;
     applySessionRunStatus(entry, input.workspaceId, sessionId, statuses[sessionId] ?? idleStatus, {
       snapshotStartedAt: startedAt,
       source,
@@ -1698,6 +1757,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     runActiveObservedAt: new Map(),
     assistantMessageCompletedAt: new Map(),
     nativeSequenceBySession: new Map(),
+    nativeSequenceRevision: 0,
     nativeTerminalSessions: new Set(),
     permissionReconciles: new Map(),
     titleRecovery: null,
@@ -1755,6 +1815,10 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   releaseListener(existing.sessionStatusListeners, input.onSessionStatus);
   existing.refs = Math.max(0, existing.refs - 1);
   if (existing.refs > 0) return;
+  // A status fetch can discover work that no transcript owner ever mounted.
+  for (const sessionId of existing.liveSessionIds) {
+    if (!isTrackedSession(existing, sessionId)) retainSession(input, existing, sessionId);
+  }
   if (existing.retainedSessionTimers.size > 0 || existing.disposeTimer) return;
   existing.disposeTimer = setTimeout(() => {
     existing.disposeTimer = null;
@@ -1896,7 +1960,7 @@ export function trackWorkspaceSessionSync(input: SyncOptions, sessionId: string 
 
   const retainedTimer = entry.retainedSessionTimers.get(normalizedSessionId);
   if (retainedTimer) {
-    clearTimeout(retainedTimer);
+    clearTimeout(retainedTimer.timer);
     entry.retainedSessionTimers.delete(normalizedSessionId);
   }
 
@@ -1954,6 +2018,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     runActiveObservedAt: new Map(),
     assistantMessageCompletedAt: new Map(),
     nativeSequenceBySession: new Map(),
+    nativeSequenceRevision: 0,
     nativeTerminalSessions: new Set(),
     permissionReconciles: new Map(),
     titleRecovery: null,
@@ -1961,7 +2026,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
   return () => {
     const entry = syncs.get(key);
     if (entry) {
-      for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
+      for (const { timer } of entry.retainedSessionTimers.values()) clearTimeout(timer);
       if (entry.statusReconcileTimer) clearTimeout(entry.statusReconcileTimer);
       entry.statusReconcileAbort?.abort();
       for (const controller of entry.permissionReconciles.values()) controller.abort();

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -429,6 +429,10 @@ describe("OpenCode v2 event translation", () => {
       },
       { type: "session.execution.succeeded", properties: { sessionID: "s", sequence: undefined } },
     ]);
+    expect(state.streams.size).toBe(0);
+    expect(state.latestStreamKeyBySession.size).toBe(0);
+    expect(state.nextOrdinalByMessage.size).toBe(0);
+    expect(state.executionBySession.size).toBe(0);
   });
 
   test("translates the captured v2 shell lifecycle using the bash presentation", () => {
@@ -598,6 +602,13 @@ describe("OpenCode v2 event translation", () => {
           type: `session.next.${kind}.ended`, created: 20,
           data: { sessionID: identity.sessionID, [`${kind}ID`]: `shared_${ordinal}` },
         }, state)).toMatchObject([{ properties: { part: { id, text: "legacy" } } }]);
+        expect(translateV2Event(started, state)).toBeNull();
+        expect(translateV2Event({
+          type: `session.next.${kind}.ended`, data: { sessionID: identity.sessionID },
+        }, state)).toBeNull();
+        expect(translateV2Event({
+          type: `session.next.${kind}.delta`, data: { sessionID: identity.sessionID, delta: "LATE" },
+        }, state)).toBeNull();
         expect(translateV2Event({
           type: `session.next.${kind}.delta`,
           data: { ...identity, assistantMessageID: "msg_other", [`${kind}ID`]: `shared_${ordinal}`, delta: "WRONG" },
@@ -608,6 +619,250 @@ describe("OpenCode v2 event translation", () => {
         }, state)).toBeNull();
       }
     }
+  });
+
+  test("releases completed payloads across thousands of parts and turns without disturbing active streams", () => {
+    const state = createV2EventTranslationState();
+    const other = { sessionID: "s:other", assistantMessageID: "m" };
+    const input = { command: "keep this active input" };
+    for (const kind of ["text", "reasoning"]) {
+      translateV2Event({ type: `session.${kind}.started`, data: { ...other, ordinal: 0 } }, state);
+      translateV2Event({ type: `session.${kind}.delta`, data: { ...other, ordinal: 0, delta: "still " } }, state);
+    }
+    translateV2Event({ type: "session.tool.input.started", data: { ...other, id: "call", name: "shell" } }, state);
+    translateV2Event({ type: "session.tool.called", created: 5, data: { ...other, id: "call", input } }, state);
+    const activeStreams = [...state.streams.values()];
+    const activeTool = state.tools.get(JSON.stringify([other.sessionID, "call"]));
+    const payload = "completed payload ".repeat(4_096);
+
+    for (let turn = 0; turn < 500; turn += 1) {
+      const identity = { sessionID: "s", assistantMessageID: `m_${turn}` };
+      translateV2Event({ type: "session.execution.started", data: identity }, state);
+      for (let step = 0; step < 3; step += 1) {
+        // Each kind keeps its own implicit ordinal through tool steps and retries.
+        for (const kind of ["reasoning", "text"]) {
+          const data = { ...identity, [`${kind}ID`]: `${turn}_${step}` };
+          const id = `${identity.assistantMessageID}:${kind === "reasoning" ? "reasoning:" : ""}${step}`;
+          const text = `${turn}:${step}:${kind}:${payload}`;
+          const started = { type: `session.next.${kind}.started`, created: 10, data };
+          expect(translateV2Event(started, state)?.[1]).toMatchObject({ properties: { part: { id, text: "" } } });
+          translateV2Event({ type: `session.next.${kind}.delta`, data: { ...data, delta: text } }, state);
+          const ended = { type: `session.next.${kind}.ended`, created: 20, data };
+          const completed = translateV2Event(ended, state);
+          expect(completed).toMatchObject([{ properties: { part: { id, text } } }]);
+          expect([...state.streams.values()].filter((stream) => stream.sessionID === "s").every((stream) => stream.text === undefined)).toBe(true);
+          expect(translateV2Event(ended, state)).toBeNull();
+          expect(translateV2Event(started, state)).toBeNull();
+          expect(translateV2Event({ type: `session.next.${kind}.delta`, data: { ...data, delta: "LATE" } }, state)).toBeNull();
+          expect(completed).toMatchObject([{ properties: { part: { id, text } } }]);
+        }
+
+        const data = { ...identity, id: `call_${step}` };
+        const toolInput = { command: `${turn}:${step}:${payload}` };
+        const raw = JSON.stringify(toolInput);
+        const started = { type: "session.tool.input.started", data: { ...data, name: "shell" } };
+        translateV2Event(started, state);
+        translateV2Event({ type: "session.tool.input.delta", data: { ...data, delta: raw } }, state);
+        const pending = translateV2Event({ type: "session.tool.input.ended", data: { ...data, text: raw } }, state);
+        expect(pending).toMatchObject([{ properties: { part: { state: { input: toolInput, raw } } } }]);
+        expect(state.tools.get(JSON.stringify(["s", data.id]))).toMatchObject({ raw: "", input: toolInput });
+        translateV2Event({ type: "session.tool.called", created: 30, data: { ...data, input: toolInput } }, state);
+        translateV2Event({ type: "session.tool.progress", data: { ...data, metadata: { detail: payload } } }, state);
+        const terminal = {
+          type: step === 1 ? "session.tool.failed" : "session.tool.success", created: 40,
+          data: { ...data, content: [{ type: "text", text: payload }], error: { message: "tool failed" } },
+        };
+        const completed = translateV2Event(terminal, state);
+        const expected = [{ properties: { part: { id: data.id, tool: "bash", state: {
+          input: toolInput, metadata: { detail: payload }, time: { start: 30, end: 40 },
+          ...(step === 1 ? { status: "error", error: "tool failed" } : { status: "completed", output: payload }),
+        } } } }];
+        expect(completed).toMatchObject(expected);
+        expect(state.tools.get(JSON.stringify(["s", data.id]))).toBeNull();
+        expect(translateV2Event(terminal, state)).toBeNull();
+        expect(translateV2Event(started, state)).toBeNull();
+        expect(translateV2Event({ type: "session.tool.progress", data: { ...data, metadata: { detail: "LATE" } } }, state)).toBeNull();
+        expect(completed).toMatchObject(expected);
+        translateV2Event({ type: "session.retry.scheduled", data: { ...identity, attempt: 2, at: 100, error: "retry" } }, state);
+        translateV2Event({ type: "session.step.started", data: identity }, state);
+      }
+      // Only small identity markers survive within the execution, never its output.
+      expect(state.streams.size).toBe(8);
+      expect(state.tools.size).toBe(4);
+      expect(state.nextOrdinalByMessage.get(JSON.stringify(["s", identity.assistantMessageID, "text"]))).toBe(3);
+      expect(state.nextOrdinalByMessage.get(JSON.stringify(["s", identity.assistantMessageID, "reasoning"]))).toBe(3);
+      translateV2Event({ type: "session.execution.succeeded", data: identity }, state);
+      expect([...state.streams.values()]).toEqual(activeStreams);
+      expect([...state.tools.values()]).toEqual([activeTool]);
+      expect(state.latestStreamKeyBySession.size).toBe(2);
+      expect(state.nextOrdinalByMessage.size).toBe(2);
+      expect([...state.executionBySession.keys()]).toEqual([other.sessionID]);
+    }
+
+    for (const kind of ["text", "reasoning"]) {
+      const data = { ...other, ordinal: 0 };
+      translateV2Event({ type: `session.${kind}.delta`, data: { ...data, delta: "active" } }, state);
+      expect(translateV2Event({ type: `session.${kind}.ended`, data }, state))
+        .toMatchObject([{ properties: { part: { text: "still active", sessionID: other.sessionID } } }]);
+    }
+    expect(translateV2Event({ type: "session.tool.success", created: 50, data: { ...other, id: "call", result: "kept" } }, state))
+      .toMatchObject([{ properties: { part: { state: { input, output: "kept", time: { start: 5, end: 50 } } } } }]);
+    translateV2Event({ type: "session.execution.succeeded", data: other }, state);
+    for (const map of [state.streams, state.tools, state.latestStreamKeyBySession, state.nextOrdinalByMessage, state.executionBySession]) {
+      expect(map.size).toBe(0);
+    }
+  });
+
+  test.each(["succeeded", "failed", "interrupted", "deleted"])("cleans up settled %s execution state and ignores late terminals for a successor", (terminal) => {
+    const state = createV2EventTranslationState();
+    const identity = { sessionID: "s", assistantMessageID: "m", ordinal: 0 };
+    const started = { type: "session.execution.started", created: 10, durable: { seq: 1 }, data: { sessionID: "s" } };
+    const ended = terminal === "deleted"
+      ? { type: "session.deleted", created: 20, durable: { seq: 2 }, data: { info: { id: "s" } } }
+      : { type: `session.execution.${terminal}`, created: 20, durable: { seq: 2 }, data: { sessionID: "s", reason: "shutdown" } };
+    translateV2Event(started, state);
+    translateV2Event({ type: "session.text.started", created: 11, data: identity }, state);
+    translateV2Event({ type: "session.text.delta", data: { ...identity, delta: "unfinished" } }, state);
+    translateV2Event({ type: "session.tool.input.started", data: { ...identity, id: "call", name: "shell" } }, state);
+    if (terminal !== "deleted") {
+      translateV2Event({ type: "session.text.ended", data: identity }, state);
+      translateV2Event({ type: "session.tool.failed", data: { ...identity, id: "call", error: "settled" } }, state);
+    }
+    translateV2Event(ended, state);
+    translateV2Event(ended, state);
+    for (const map of [state.streams, state.tools, state.latestStreamKeyBySession, state.nextOrdinalByMessage, state.executionBySession]) {
+      expect(map.size).toBe(0);
+    }
+    expect(translateV2Event({ type: "session.text.ended", data: { ...identity, text: "late" } }, state)).toBeNull();
+    expect(translateV2Event({ type: "session.tool.failed", data: { ...identity, id: "call", error: "late" } }, state)).toBeNull();
+    if (terminal === "deleted") return;
+
+    for (const sequenced of [true, false]) {
+      const data = { ...identity, assistantMessageID: `successor_${sequenced}` };
+      const created = sequenced ? 30 : 50;
+      translateV2Event({ ...started, created, durable: sequenced ? { seq: 3 } : undefined }, state);
+      translateV2Event({ type: "session.text.started", created: created + 1, data }, state);
+      translateV2Event({ type: "session.text.delta", data: { ...data, delta: "new " } }, state);
+      translateV2Event({ ...ended, durable: sequenced ? ended.durable : undefined }, state);
+      translateV2Event({ type: "session.text.delta", data: { ...data, delta: "execution" } }, state);
+      expect(translateV2Event({ type: "session.text.ended", created: created + 9, data }, state))
+        .toMatchObject([{ properties: { part: { id: `${data.assistantMessageID}:0`, text: "new execution" } } }]);
+      translateV2Event({ ...ended, created: created + 10, durable: sequenced ? { seq: 4 } : undefined }, state);
+      expect(state.streams.size).toBe(0);
+      expect(state.executionBySession.size).toBe(0);
+    }
+  });
+
+  test.each(["sequence", "created", "timestamp"])("rejects post-terminal replay using %s without touching a successor or another active stream", (ordering) => {
+    const state = createV2EventTranslationState();
+    const event = (type: string, data: Record<string, unknown>, sequence: number) => ({
+      type,
+      // Native sequence is authoritative even when every event shares a clock tick.
+      ...(ordering === "timestamp" ? {} : { created: ordering === "sequence" ? 10 : sequence * 10 }),
+      ...(ordering === "sequence" ? { durable: { aggregateID: data.sessionID, seq: sequence, version: 1 } } : {}),
+      data: { ...data, ...(ordering === "timestamp" ? { timestamp: sequence * 10 } : {}) },
+    });
+    const other = { sessionID: "other", assistantMessageID: "m_other", ordinal: 0 };
+    translateV2Event(event("session.text.started", other, 1), state);
+    translateV2Event({ type: "session.text.delta", data: { ...other, delta: "other " } }, state);
+    const identity = { sessionID: "s", assistantMessageID: "m", ordinal: 0 };
+    const started = event("session.text.started", identity, 1);
+    translateV2Event(started, state);
+    const ended = event("session.text.ended", { ...identity, text: "final answer" }, 2);
+    const final = translateV2Event(ended, state);
+    expect(final).toMatchObject([{ properties: { part: { id: "m:0", text: "final answer" } } }]);
+    const toolStarted = event("session.tool.input.started", { ...identity, id: "call", name: "shell" }, 3);
+    translateV2Event(toolStarted, state);
+    translateV2Event(event("session.tool.called", { ...identity, id: "call", input: { command: "result" } }, 4), state);
+    const toolEnded = event("session.tool.success", { ...identity, id: "call", result: "final tool output" }, 5);
+    expect(translateV2Event(toolEnded, state)).toMatchObject([{ properties: { part: { state: {
+      status: "completed", input: { command: "result" }, output: "final tool output",
+    } } } }]);
+    const terminal = event("session.execution.succeeded", { sessionID: "s" }, 6);
+    translateV2Event(terminal, state);
+    expect(state.streams.size).toBe(1);
+    expect(state.tools.size).toBe(0);
+    expect(state.executionBySession.has("s")).toBe(false);
+    for (const replay of [started, ended, toolStarted, toolEnded]) expect(translateV2Event(replay, state)).toBeNull();
+
+    const successor = { sessionID: "s", assistantMessageID: "m_next", ordinal: 0 };
+    translateV2Event(event("session.execution.started", { sessionID: "s" }, 7), state);
+    expect(translateV2Event(event("session.text.started", successor, 8), state)?.[1])
+      .toMatchObject({ properties: { part: { id: "m_next:0", text: "" } } });
+    translateV2Event({ type: "session.text.delta", data: { ...successor, delta: "new " } }, state);
+
+    // Only the idle replay window is bounded. Evicting it must not unprotect
+    // the still-active successor or cause unbounded terminal-history growth.
+    for (let index = 0; index < 1_000; index += 1) {
+      translateV2Event(event("session.execution.succeeded", { sessionID: `retired_${index}` }, 1), state);
+      expect(state.terminalBySession.size).toBeLessThanOrEqual(256);
+    }
+    expect(state.terminalBySession.has("s")).toBe(false);
+    expect(state.executionBySession.size).toBe(2);
+    for (const replay of [started, ended, toolStarted, toolEnded, event("session.execution.started", { sessionID: "s" }, 0)]) {
+      expect(translateV2Event(replay, state)).toBeNull();
+    }
+    translateV2Event(terminal, state);
+    translateV2Event({ type: "session.text.delta", data: { ...successor, delta: "answer" } }, state);
+    expect(translateV2Event(event("session.text.ended", successor, 9), state))
+      .toMatchObject([{ properties: { part: { id: "m_next:0", text: "new answer" } } }]);
+    translateV2Event(event("session.execution.succeeded", { sessionID: "s" }, 10), state);
+    translateV2Event({ type: "session.text.delta", data: { ...other, delta: "answer" } }, state);
+    expect(translateV2Event(event("session.text.ended", other, 2), state))
+      .toMatchObject([{ properties: { part: { id: "m_other:0", text: "other answer" } } }]);
+    expect(final).toMatchObject([{ properties: { part: { id: "m:0", text: "final answer" } } }]);
+    translateV2Event(event("session.execution.succeeded", { sessionID: "other" }, 3), state);
+    expect(state.streams.size).toBe(0);
+    expect(state.executionBySession.size).toBe(0);
+  });
+
+  test.each(["succeeded", "failed", "interrupted"])("keeps unresolved parts through execution.%s until late final content arrives", (terminal) => {
+    const state = createV2EventTranslationState();
+    const data = { sessionID: "s", assistantMessageID: "m", ordinal: 0 };
+    const other = { sessionID: "other", assistantMessageID: "m_other", ordinal: 0 };
+    translateV2Event({ type: "session.text.started", created: 10, data: other }, state);
+    translateV2Event({ type: "session.text.delta", data: { ...other, delta: "unrelated" } }, state);
+    for (const kind of ["text", "reasoning"]) {
+      translateV2Event({ type: `session.${kind}.started`, created: 10, durable: { seq: 1 }, data }, state);
+      translateV2Event({ type: `session.${kind}.delta`, data: { ...data, delta: "partial " } }, state);
+    }
+    const tool = { ...data, id: "call", name: "shell" };
+    const input = { command: "kept input" };
+    translateV2Event({ type: "session.tool.input.started", created: 20, durable: { seq: 2 }, data: tool }, state);
+    translateV2Event({ type: "session.tool.input.ended", created: 21, data: { ...tool, text: JSON.stringify(input) } }, state);
+    const ended = { type: `session.execution.${terminal}`, created: 100, durable: { seq: 10 }, data: { sessionID: "s" } };
+    translateV2Event(ended, state);
+    translateV2Event(ended, state);
+    expect(state.streams.size).toBe(3);
+    expect(state.tools.size).toBe(1);
+    expect(state.executionBySession.get("s")?.terminal).toBe(true);
+
+    // Neither old timestamps nor a retired execution may suppress final content
+    // for an already-known part. Text.Ended's full value also repairs a late delta.
+    for (const kind of ["text", "reasoning"]) {
+      translateV2Event({ type: `session.${kind}.delta`, created: 30, data: { ...data, delta: "tail" } }, state);
+      const completed = translateV2Event({ type: `session.${kind}.ended`, created: 40, durable: { seq: 3 },
+        data: { ...data, ...(kind === "text" ? { text: "authoritative final answer" } : {}) } }, state);
+      expect(completed).toMatchObject([{ properties: { part: {
+        type: kind, text: kind === "text" ? "authoritative final answer" : "partial tail",
+      } } }]);
+      expect(translateV2Event({ type: `session.${kind}.delta`, created: 30, data: { ...data, delta: "late duplicate" } }, state)).toBeNull();
+    }
+    expect(translateV2Event({ type: "session.tool.called", created: 50, durable: { seq: 4 }, data: { ...tool, input } }, state))
+      .toMatchObject([{ properties: { part: { state: { status: "running", input } } } }]);
+    translateV2Event({ type: "session.tool.progress", created: 60, data: { ...tool, metadata: { detail: "kept metadata" } } }, state);
+    const completed = translateV2Event({ type: terminal === "failed" ? "session.tool.failed" : "session.tool.success",
+      created: 70, durable: { seq: 5 }, data: { ...tool, result: "final output", error: "final error" } }, state);
+    expect(completed).toMatchObject([{ properties: { part: { state: {
+      input, metadata: { detail: "kept metadata" }, time: { start: 50, end: 70 },
+      ...(terminal === "failed" ? { status: "error", error: "final error" } : { status: "completed", output: "final output" }),
+    } } } }]);
+    expect(state.tools.size).toBe(0);
+    expect([...state.streams.values()]).toMatchObject([{ sessionID: "other", text: "unrelated" }]);
+    expect(state.nextOrdinalByMessage.size).toBe(1);
+    expect(state.latestStreamKeyBySession.size).toBe(1);
+    expect(state.executionBySession.has("s")).toBe(false);
+    expect(translateV2Event({ type: "session.tool.input.started", created: 20, durable: { seq: 2 }, data: tool }, state)).toBeNull();
   });
 
   test("preserves execution failure for sequenced terminal handling", () => {
@@ -814,7 +1069,7 @@ describe("OpenCode v2 client compatibility", () => {
         translateV2Event({ type: `session.${kind}.delta`, data: { ...data, delta: "partial" } }, state);
         const ended = { type: `session.${kind}.ended`, created: end, data: { ...data, text } };
         expect(translateV2Event(ended, state)).toEqual([{ type: "message.part.updated", properties: { part: parts?.[index] } }]);
-        expect(translateV2Event(ended, state)).toEqual([{ type: "message.part.updated", properties: { part: parts?.[index] } }]);
+        expect(translateV2Event(ended, state)).toBeNull();
       }
     } finally {
       globalThis.fetch = originalFetch;
@@ -854,10 +1109,10 @@ describe("OpenCode v2 client compatibility", () => {
             { id: `${tool.id}:file:1`, sessionID: "ses_files", messageID: "msg_files", type: "file", url: content[3]?.uri, mime: "image/png" },
           ],
         } });
-        // Repeated completion retains IDs, including identical URIs on distinct calls.
+        // Repeated completion is a no-op, not an empty-input overwrite of the final part.
         expect(translateV2Event({
           type: "session.tool.success", created: 30, data: { ...identity, content },
-        }, state)).toEqual(completed);
+        }, state)).toBeNull();
       }
     } finally {
       globalThis.fetch = originalFetch;
@@ -891,21 +1146,23 @@ describe("OpenCode v2 client compatibility", () => {
           tool: expectedTool, state: { input: expectedInput, ...(index > 0 ? { metadata: expectedMetadata } : {}) },
         });
       }
-      const state = createV2EventTranslationState();
       const identity = { sessionID: "ses_parent", assistantMessageID: "msg_parent", id: "call_child" };
-      translateV2Event({ type: "session.tool.input.started", created: 10, data: { ...identity, name } }, state);
-      for (const type of ["session.tool.input.delta", "session.tool.input.ended"]) {
-        expect(translateV2Event({ type, data: { ...identity, delta: JSON.stringify(input), text: JSON.stringify(input) } }, state))
-          .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[0]?.parts[0] } }]);
+      for (const terminal of ["success", "failed"]) {
+        const state = createV2EventTranslationState();
+        translateV2Event({ type: "session.tool.input.started", created: 10, data: { ...identity, name } }, state);
+        for (const type of ["session.tool.input.delta", "session.tool.input.ended"]) {
+          expect(translateV2Event({ type, data: { ...identity, delta: JSON.stringify(input), text: JSON.stringify(input) } }, state))
+            .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[0]?.parts[0] } }]);
+        }
+        expect(translateV2Event({ type: "session.tool.called", created: 20, data: { ...identity, input, executed: false } }, state))
+          .toMatchObject([{ properties: { part: { tool: expectedTool, state: { input: expectedInput, status: "running" } } } }]);
+        expect(translateV2Event({ type: "session.tool.progress", created: 25, data: { ...identity, metadata } }, state))
+          .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[1]?.parts[0] } }]);
+        expect(translateV2Event({ type: `session.tool.${terminal}`, created: 30, data: { ...identity, metadata, content, error, executed: false } }, state))
+          .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[terminal === "success" ? 2 : 3]?.parts[0] } }]);
+        expect(translateV2Event({ type: `session.tool.${terminal === "success" ? "failed" : "success"}`, created: 31,
+          data: { ...identity, metadata, content, error, executed: false } }, state)).toBeNull();
       }
-      expect(translateV2Event({ type: "session.tool.called", created: 20, data: { ...identity, input, executed: false } }, state))
-        .toMatchObject([{ properties: { part: { tool: expectedTool, state: { input: expectedInput, status: "running" } } } }]);
-      expect(translateV2Event({ type: "session.tool.progress", created: 25, data: { ...identity, metadata } }, state))
-        .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[1]?.parts[0] } }]);
-      expect(translateV2Event({ type: "session.tool.success", created: 30, data: { ...identity, metadata, content, executed: false } }, state))
-        .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[2]?.parts[0] } }]);
-      expect(translateV2Event({ type: "session.tool.failed", created: 30, data: { ...identity, metadata, error, executed: false } }, state))
-        .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[3]?.parts[0] } }]);
       expect(result.data?.[3]?.parts[0]).toMatchObject({ state: { error: "child failed" } });
       expect(input).not.toHaveProperty("subagent_type");
       expect(metadata).not.toHaveProperty("sessionId");
@@ -1171,6 +1428,43 @@ describe("OpenCode v2 client compatibility", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test("a reconnected subscription rebuilds the same completed parts without retaining old payloads or tombstones", async () => {
+    const originalFetch = globalThis.fetch;
+    const identity = { sessionID: "s", assistantMessageID: "m", ordinal: 0 };
+    const events = [
+      { type: "session.execution.started", data: { sessionID: "s" } },
+      { type: "session.text.started", created: 10, data: identity },
+      { type: "session.text.delta", data: { ...identity, delta: "hello " } },
+      { type: "session.text.delta", data: { ...identity, delta: "world" } },
+      { type: "session.text.ended", data: identity },
+      { type: "session.execution.succeeded", created: 20, data: { sessionID: "s" } },
+      { type: "session.text.started", created: 10, data: identity },
+      { type: "session.text.ended", data: identity },
+      ...capturedV2ToolEvents,
+    ];
+    globalThis.fetch = async () => new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", undefined, {});
+      // Duplicate wire frames after completion must not replace the final answer.
+      const first = await client.event.subscribe();
+      const received = [];
+      for await (const event of first.stream) received.push(event);
+      expect(received).toContainEqual({ type: "message.part.updated", properties: { part: {
+        id: "m:0", messageID: "m", sessionID: "s", type: "text", text: "hello world",
+      } } });
+      expect(received.filter((event) => event.type === "message.updated")).toHaveLength(2);
+      expect(received.at(-1)).toMatchObject({ properties: { part: { id: "call_captured_shell", state: {
+        status: "completed", input: { command: "printf 'TOOL_RESULT_OK\\n'", timeout: 30_000 },
+        output: "TOOL_RESULT_OK\n\nCommand exited with code 0.",
+      } } } });
+      // A new subscription has a fresh replay window and may rebuild the parts.
+      const reconnected = await client.event.subscribe();
+      const replayed = [];
+      for await (const event of reconnected.stream) replayed.push(event);
+      expect(replayed).toEqual(received);
+    } finally { globalThis.fetch = originalFetch; }
   });
 
   test("discovers external forks from authoritative sessions once, without fetching foreign events or the source", async () => {

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, jest, setSystemTime, spyOn, test } from "bun:test";
-import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
+import type { PermissionV2Request, SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { markTaskRunStart, takeTaskRunStart } from "../src/app/lib/analytics";
@@ -10,18 +10,25 @@ import {
   __applySessionSyncEventForTest,
   __createWorkspaceSessionSyncForTest,
   __disposeWorkspaceSessionSyncForTest,
+  __hasWorkspaceSessionSyncForTest,
   __resetWorkspaceSyncReconcileHealthForTest,
   __revalidateWorkspaceSyncsForTest,
+  __setWorkspaceSessionSyncPermissionFetcherForTest,
   __setWorkspaceSessionSyncStatusFetcherForTest,
   __setWorkspaceSessionSyncSubscriptionFactoryForTest,
   ensureWorkspaceSessionSync,
   getWorkspaceSessionSyncStreamPhase,
   markSessionSnapshotFetchStart,
+  permissionKey,
+  questionKey,
   reconcileFailureDegradedThreshold,
   revalidateWorkspaceSessionSync,
+  seedPermissionState,
+  seedQuestionState,
   seedSessionState,
   snapshotKey,
   statusKey,
+  todoKey,
   trackWorkspaceSessionSync,
   transcriptKey,
   useWorkspaceSyncStreamStore,
@@ -72,9 +79,9 @@ function createSyncInput(): SyncInput {
   return input;
 }
 
-function createTestSync() {
+function createTestSync(onSessionStatus?: (update: { sessionId: string; status: SessionStatus }) => void) {
   const input = createSyncInput();
-  const cleanup = __createWorkspaceSessionSyncForTest(input);
+  const cleanup = __createWorkspaceSessionSyncForTest({ ...input, onSessionStatus });
   const releaseSession = trackWorkspaceSessionSync(input, sessionId);
   return { input, cleanup, releaseSession };
 }
@@ -178,6 +185,7 @@ afterEach(() => {
   subscriptions.length = 0;
   __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
   __setWorkspaceSessionSyncStatusFetcherForTest(null);
+  __setWorkspaceSessionSyncPermissionFetcherForTest(null);
   useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
   useWorkspaceSyncStreamStore.setState({ phasesByKey: {} });
   __resetWorkspaceSyncReconcileHealthForTest();
@@ -481,6 +489,25 @@ describe("session run status ordering", () => {
 });
 
 describe("session run status reconnect reconciliation", () => {
+  test("reconnect still converges untracked history and discovers background work", async () => {
+    jest.useFakeTimers();
+    const statusUpdates = jest.fn();
+    const { input } = createTestSync(statusUpdates);
+    const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, "missed-terminal", { type: "busy" });
+    store.setRunStatus(workspaceId, "historical-idle", { type: "idle" });
+    store.setRunStatus("other-workspace", "untouched", { type: "busy" });
+    const otherRecords = useSessionActivityStore.getState().recordsByWorkspaceId["other-workspace"];
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ "missed-busy": { type: "busy" } }));
+
+    await revalidateWorkspaceSessionSync(input);
+
+    expect(statusUpdates.mock.calls.map(([update]) => update.sessionId).sort()).toEqual(["historical-idle", "missed-busy", "missed-terminal"]);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, "missed-terminal")).toBe("idle");
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, "missed-busy")).toBe("thinking");
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId["other-workspace"]).toBe(otherRecords);
+  });
+
   test("seeds a missed busy edge into the status cache on connect", async () => {
     __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ [sessionId]: { type: "busy" } }));
@@ -594,6 +621,254 @@ describe("session run status reconnect reconciliation", () => {
 });
 
 describe("active session status reconciliation", () => {
+  test("polls active work without rewriting a large idle history, including missed busy and terminal edges", async () => {
+    jest.useFakeTimers();
+    const statusUpdates = jest.fn();
+    const { input } = createTestSync(statusUpdates);
+    const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, "historical-template", { type: "idle" });
+    const template = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]!["historical-template"]!;
+    const historicalIds = Array.from({ length: 2_000 }, (_, index) => `historical-${index}`);
+    useSessionActivityStore.setState({
+      recordsByWorkspaceId: { [workspaceId]: Object.fromEntries(historicalIds.map((id) => [id, { ...template }])) },
+      statusesByWorkspaceId: { [workspaceId]: Object.fromEntries(historicalIds.map((id) => [id, "idle"])) },
+    });
+    store.setError(workspaceId, "historical-error", "Keep this error visible");
+    const history = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]!;
+    applyStatus(input, { type: "busy" });
+    let statuses: Record<string, SessionStatus> = { [sessionId]: { type: "busy" }, "missed-busy": { type: "busy" } };
+    // Some engines also return idle entries. They are not active poll work.
+    for (const id of historicalIds) statuses[id] = { type: "idle" };
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => statuses);
+    statusUpdates.mockClear();
+
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    expect(statusUpdates.mock.calls.map(([update]) => update.sessionId).sort()).toEqual(["missed-busy", sessionId].sort());
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, "missed-busy")).toBe("thinking");
+
+    statusUpdates.mockClear();
+    statuses = { [sessionId]: { type: "busy" } };
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    expect(statusUpdates).toHaveBeenCalledTimes(2);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, "missed-busy")).toBe("idle");
+    statusUpdates.mockClear();
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    expect(statusUpdates).toHaveBeenCalledTimes(1);
+    const after = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]!;
+    for (const id of Object.keys(history)) expect(after[id]).toBe(history[id]);
+    expect(store.getSessionError(workspaceId, "historical-error")).toBe("Keep this error visible");
+  });
+
+  test("settles an owned optimistic run that never received a busy stream edge", async () => {
+    jest.useFakeTimers();
+    const { input } = createTestSync();
+    applyStatus(input, { type: "busy" });
+    trackWorkspaceSessionSync(input, "optimistic-run");
+    useSessionActivityStore.getState().setRunStatus(workspaceId, "optimistic-run", { type: "busy" });
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ [sessionId]: { type: "busy" } }));
+
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, "optimistic-run")).toBe("idle");
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, "optimistic-run"))).toEqual({ type: "idle" });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+  });
+
+  test("repeated idle observations cannot postpone release while another task stays active", async () => {
+    jest.useFakeTimers();
+    const { input, releaseSession } = createTestSync();
+    const queryClient = getReactQueryClient();
+    applyStatus(input, { type: "busy" });
+    applyCompletedToolAndFinalAnswer(input);
+    const transcript = queryClient.getQueryData(transcriptKey(workspaceId, sessionId));
+    queryClient.setQueryData(permissionKey(workspaceId, sessionId), []);
+    queryClient.setQueryData(questionKey(workspaceId, sessionId), []);
+    queryClient.setQueryData([...questionKey(workspaceId, sessionId), "settled"], ["answered"]);
+    queryClient.setQueryData(todoKey(workspaceId, sessionId), []);
+    releaseSession();
+    applyStatus(input, { type: "idle" });
+    trackWorkspaceSessionSync(input, "background-live");
+    __applySessionSyncEventForTest(input, {
+      type: "session.status",
+      properties: { sessionID: "background-live", status: { type: "busy" } },
+    });
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ "background-live": { type: "busy" } }));
+
+    for (let tick = 0; tick < 39; tick += 1) {
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+      applyStatus(input, { type: "idle" });
+    }
+    expect(queryClient.getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    for (const key of [statusKey, permissionKey, questionKey, todoKey]) {
+      expect(queryClient.getQueryData(key(workspaceId, sessionId))).toBeUndefined();
+    }
+    expect(queryClient.getQueryData(transcriptKey(workspaceId, sessionId))).toBe(transcript);
+    expect(queryClient.getQueryData([...questionKey(workspaceId, sessionId), "settled"])).toEqual(["answered"]);
+    expect(queryClient.getQueryData(statusKey(workspaceId, "background-live"))).toEqual({ type: "busy" });
+  });
+
+  test("retains a background live run beyond the normal TTL after the workspace owner leaves", async () => {
+    jest.useFakeTimers();
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ [sessionId]: { type: "busy" } }));
+    const input = createSyncInput();
+    const releaseWorkspace = ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await flushMicrotasks();
+    releaseSession();
+    releaseWorkspace();
+
+    jest.advanceTimersByTime(10 * 60_000 + 1);
+    await flushMicrotasks();
+    expect(__hasWorkspaceSessionSyncForTest(input)).toBe(true);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+    applyCompletedToolAndFinalAnswer(input);
+    expect(getReactQueryClient().getQueryData(transcriptKey(workspaceId, sessionId))).toMatchObject([
+      { id: "assistant-tool" }, { id: "assistant-final" },
+    ]);
+
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+    await revalidateWorkspaceSessionSync(input);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
+    jest.advanceTimersByTime(10_000);
+    await flushMicrotasks();
+    expect(__hasWorkspaceSessionSyncForTest(input)).toBe(false);
+  });
+
+  test.each(["before", "after"])("retains work discovered %s the last workspace owner leaves", async (when) => {
+    jest.useFakeTimers();
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ [sessionId]: { type: "busy" } }));
+    const input = createSyncInput();
+    const releaseWorkspace = ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await flushMicrotasks();
+    releaseSession();
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({ "unmounted-live": { type: "busy" } }));
+    if (when === "after") releaseWorkspace();
+    await revalidateWorkspaceSessionSync(input);
+    if (when === "before") releaseWorkspace();
+
+    jest.advanceTimersByTime(10_000);
+    await flushMicrotasks();
+
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toBeUndefined();
+    expect(__hasWorkspaceSessionSyncForTest(input)).toBe(true);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.["unmounted-live"]?.runActive).toBe(true);
+  });
+
+  test.each(["permission", "question"] as const)("retains a pending %s at the idle release deadline", (kind) => {
+    jest.useFakeTimers();
+    const { input, releaseSession } = createTestSync();
+    releaseSession();
+    applyStatus(input, { type: "idle" });
+    useSessionActivityStore.getState().setWaitingRequest(workspaceId, sessionId, kind, "pending-request", true);
+    jest.advanceTimersByTime(10_000);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("waiting");
+  });
+
+  test("deletion releases a waiting session and rejects its late permission read without clearing another session", async () => {
+    jest.useFakeTimers();
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+    const input = { ...createSyncInput(), baseUrl: "https://run-status.example/opencode2" };
+    syncInputs.push(input);
+    const releaseWorkspace = ensureWorkspaceSessionSync(input);
+    const releaseDeleted = trackWorkspaceSessionSync(input, sessionId);
+    const otherSessionId = "still-waiting";
+    const releaseOther = trackWorkspaceSessionSync(input, otherSessionId);
+    await flushMicrotasks();
+    const permission = (sessionID: string): PermissionV2Request => ({
+      id: `permission-${sessionID}`, sessionID, action: "file.read", resources: ["/tmp/requested-file"],
+    });
+    for (const id of [sessionId, otherSessionId]) {
+      seedPermissionState(workspaceId, id, [permission(id)]);
+      seedQuestionState(workspaceId, id, [{
+        id: `question-${id}`, sessionID: id,
+        questions: [{ header: "Choice", question: "Continue?", options: [{ label: "Yes", description: "Proceed" }] }],
+      }]);
+    }
+    const queryClient = getReactQueryClient();
+    const otherPermissions = queryClient.getQueryData(permissionKey(workspaceId, otherSessionId));
+    const otherQuestions = queryClient.getQueryData(questionKey(workspaceId, otherSessionId));
+    const pending = Promise.withResolvers<PermissionV2Request[]>();
+    let permissionSignal: AbortSignal | undefined;
+    __setWorkspaceSessionSyncPermissionFetcherForTest((_url, _token, id, signal) => {
+      if (id !== sessionId) return Promise.resolve([permission(id)]);
+      permissionSignal = signal;
+      return pending.promise;
+    });
+    __applySessionSyncEventForTest(input, {
+      type: "session.execution.started", properties: { sessionID: sessionId, sequence: 1 },
+    });
+    releaseDeleted();
+    releaseOther();
+    releaseWorkspace();
+    __applySessionSyncEventForTest(input, {
+      type: "session.execution.succeeded", properties: { sessionID: sessionId, sequence: 2 },
+    });
+    expect(permissionSignal?.aborted).toBe(false);
+    __applySessionSyncEventForTest(input, { type: "session.deleted", properties: { sessionID: sessionId } });
+
+    expect(permissionSignal?.aborted).toBe(true);
+    for (const key of [permissionKey, questionKey, statusKey]) {
+      expect(queryClient.getQueryData(key(workspaceId, sessionId))).toBeUndefined();
+    }
+    expect(queryClient.getQueryData([...permissionKey(workspaceId, sessionId), "settled"])).toContain(`permission-${sessionId}`);
+    expect(queryClient.getQueryData([...questionKey(workspaceId, sessionId), "settled"])).toContain(`question-${sessionId}`);
+    expect(queryClient.getQueryData(permissionKey(workspaceId, otherSessionId))).toBe(otherPermissions);
+    expect(queryClient.getQueryData(questionKey(workspaceId, otherSessionId))).toBe(otherQuestions);
+
+    // This request was never in the cache: only the aborted-controller check
+    // can reject it while the other session still keeps this sync alive.
+    pending.resolve([{ ...permission(sessionId), id: "late-unseen-permission" }]);
+    await flushMicrotasks();
+    __applySessionSyncEventForTest(input, {
+      type: "session.execution.started", properties: { sessionID: sessionId, sequence: 1 },
+    });
+    __applySessionSyncEventForTest(input, {
+      type: "permission.v2.asked", properties: permission(sessionId),
+    });
+    expect(queryClient.getQueryData(permissionKey(workspaceId, sessionId))).toBeUndefined();
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]).toBeUndefined();
+    jest.advanceTimersByTime(10 * 60_000 + 1);
+    await flushMicrotasks();
+    expect(__hasWorkspaceSessionSyncForTest(input)).toBe(true);
+    expect(queryClient.getQueryData(permissionKey(workspaceId, otherSessionId))).toEqual(otherPermissions);
+    expect(queryClient.getQueryData(questionKey(workspaceId, otherSessionId))).toEqual(otherQuestions);
+
+    __applySessionSyncEventForTest(input, { type: "session.deleted", properties: { sessionID: otherSessionId } });
+    expect(__hasWorkspaceSessionSyncForTest(input)).toBe(false);
+  });
+
+  test("keeps the normal ten-minute retention and cancels idle release when a new owner returns", () => {
+    jest.useFakeTimers();
+    const { input, releaseSession } = createTestSync();
+    applyStatus(input, { type: "idle" });
+    releaseSession();
+    jest.advanceTimersByTime(10 * 60_000 - 1);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+    jest.advanceTimersByTime(1);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toBeUndefined();
+
+    const releaseAgain = trackWorkspaceSessionSync(input, sessionId);
+    releaseAgain();
+    applyStatus(input, { type: "idle" });
+    jest.advanceTimersByTime(9_000);
+    trackWorkspaceSessionSync(input, sessionId);
+    jest.advanceTimersByTime(10_000);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+  });
+
   test("converges a missed terminal edge to idle without losing the completed tool or final answer", async () => {
     jest.useFakeTimers();
     setSystemTime(100);

--- a/apps/server/src/engine-output.ts
+++ b/apps/server/src/engine-output.ts
@@ -1,0 +1,45 @@
+// Limits are UTF-16 code units, not bytes. Diagnostics must not grow with uptime.
+export const ENGINE_OUTPUT_MAX_CHARS = 64 * 1024;
+export const ENGINE_STARTUP_LINE_MAX_CHARS = 8 * 1024;
+
+export function appendEngineOutputTail(tail: string, text: string): string {
+  if (text.length >= ENGINE_OUTPUT_MAX_CHARS) return text.slice(-ENGINE_OUTPUT_MAX_CHARS);
+  return tail.slice(-(ENGINE_OUTPUT_MAX_CHARS - text.length)) + text;
+}
+
+// Wait for a newline: even the port in an announcement can span chunks.
+export function createEngineStartupLineReader(onLine: (line: string) => void) {
+  let listener: typeof onLine | undefined = onLine;
+  let pending = "";
+  let oversized = false;
+  return {
+    write(text: string) {
+      let start = 0;
+      while (listener && start < text.length) {
+        const newline = text.indexOf("\n", start);
+        const end = newline === -1 ? text.length : newline;
+        if (!oversized) {
+          if (pending.length + end - start > ENGINE_STARTUP_LINE_MAX_CHARS) {
+            // Discard the whole line, not a suffix that could resemble readiness.
+            pending = "";
+            oversized = true;
+          } else {
+            pending += text.slice(start, end);
+          }
+        }
+        if (newline === -1) return;
+        const line = pending;
+        const emit = !oversized;
+        pending = "";
+        oversized = false;
+        if (emit) listener(line);
+        start = newline + 1;
+      }
+    },
+    stop() {
+      listener = undefined;
+      pending = "";
+      oversized = false;
+    },
+  };
+}

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -493,7 +493,8 @@ export function createEngineV2Preview(options: { config: ServerConfig; env?: Pic
     const managed = await createManagedOpencodeV2Server({
       bin: resolved.bin,
       rootDir,
-      env: { OPENCODE_MODELS_URL: opencodeModelsUrl, OPENWORK_SERVER_URL: `http://127.0.0.1:${config.port}`, OPENWORK_POLICY_TOKEN: managedDesktopPolicy(config).evaluationToken },
+      env: { OPENCODE_MODELS_URL: opencodeModelsUrl },
+      checkPolicy: (action, input) => managedDesktopPolicy(config).assert(action, input),
       permissions: async () => executionRules((await readGlobalRuntimeOpencodeConfig(config)).managedPolicy?.execution),
     });
     sidecar = managed;

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -6,6 +6,7 @@ import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { appendEngineOutputTail, createEngineStartupLineReader } from "./engine-output.js";
 
 export { installOpencodeV2Binary } from "./opencode-v2-binary.js";
 
@@ -124,11 +125,24 @@ export async function createManagedOpencodeV2Server(
   let stdout = "";
   let stderr = "";
   let spawnError: Error | undefined;
+  let announced: string | undefined;
+  const lines = createEngineStartupLineReader((line) => {
+    announced = line.match(/server listening on (http:\/\/[^\s]+)/)?.[1];
+    if (announced) lines.stop();
+  });
+  // A close event, unlike exit, includes the final bytes from both pipes.
+  let closed = false;
+  child.once("close", () => {
+    closed = true;
+    lines.stop();
+  });
   child.stdout.on("data", (chunk) => {
-    stdout += String(chunk);
+    const text = String(chunk);
+    stdout = appendEngineOutputTail(stdout, text);
+    lines.write(text);
   });
   child.stderr.on("data", (chunk) => {
-    stderr += String(chunk);
+    stderr = appendEngineOutputTail(stderr, String(chunk));
   });
   child.on("error", (error) => {
     spawnError = error;
@@ -224,6 +238,7 @@ export async function createManagedOpencodeV2Server(
   }
 
   async function close(): Promise<void> {
+    lines.stop();
     if (child.exitCode !== null || child.signalCode !== null) return;
     const exit = new Promise<void>((resolve) => child.once("exit", () => resolve()));
     child.kill("SIGTERM");
@@ -271,23 +286,28 @@ export async function createManagedOpencodeV2Server(
   while (Date.now() < deadline) {
     if (spawnError !== undefined) {
       await close();
-      throw new Error(`Failed to start OpenCode v2 server: ${spawnError.message}`);
+      throw new Error(`Failed to start OpenCode v2 server: ${spawnError.message}\nstdout:\n${stdout.slice(-4_000)}\nstderr:\n${stderr.slice(-4_000)}`);
     }
-    if (child.exitCode !== null || child.signalCode !== null) throw diagnostics(child.exitCode, stdout, stderr);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      if (closed) throw diagnostics(child.exitCode, stdout, stderr);
+      await sleep(250);
+      continue;
+    }
     // Only the child can write its stdout pipe. Do not send the generated
     // credential to a probed port before that child confirms it has bound.
-    if (!url) {
-      const announced = stdout.match(/server listening on (http:\/\/[^\s]+)/)?.[1];
-      if (announced) {
+    if (!url && announced) {
+      try {
         const endpoint = new URL(announced);
         if (endpoint.hostname !== hostname || !endpoint.port || endpoint.port === "0"
           || endpoint.username || endpoint.password || endpoint.pathname !== "/"
           || endpoint.search || endpoint.hash
           || (port !== 0 && Number(endpoint.port) !== port)) {
-          await close();
           throw new Error("OpenCode v2 announced an unexpected listener");
         }
         url = endpoint.origin;
+      } catch (error) {
+        await close();
+        throw error;
       }
     }
     try {
@@ -299,6 +319,8 @@ export async function createManagedOpencodeV2Server(
     await sleep(250);
   }
 
+  const exited = child.exitCode !== null || child.signalCode !== null;
   await close();
+  if (exited) throw diagnostics(child.exitCode, stdout, stderr);
   throw new Error(`Timed out waiting ${bootTimeoutMs}ms for OpenCode v2 health\nstdout:\n${stdout.slice(-4_000)}\nstderr:\n${stderr.slice(-4_000)}`);
 }

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -1,11 +1,13 @@
 import { managedPolicyPluginPath } from "./managed-policy-plugin.js";
 import type { EnginePermissionRule } from "./managed-policy-rules.js";
+import { serveManagedPolicyIpc, type ManagedPolicyCheck } from "./managed-policy-ipc.js";
 // Parallel v2 lane prototype: provider injection is a watched-config write. This module
 // deliberately has no reload/dispose call, unlike managed-opencode.ts and server.ts reloadOpencodeEngine.
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { appendEngineOutputTail, createEngineStartupLineReader } from "./engine-output.js";
 
 export { installOpencodeV2Binary } from "./opencode-v2-binary.js";
@@ -37,6 +39,7 @@ export interface ManagedOpencodeV2ServerOptions {
   env?: Record<string, string>;
   bootTimeoutMs?: number;
   permissions?: () => Promise<EnginePermissionRule[]>;
+  checkPolicy?: ManagedPolicyCheck;
 }
 
 export interface OpencodeV2Health {
@@ -82,6 +85,7 @@ export async function createManagedOpencodeV2Server(
   const port = options.port ?? 0;
   const bootTimeoutMs = options.bootTimeoutMs ?? 60_000;
   const configDir = join(options.rootDir, "config");
+  const policyPluginDir = join(options.rootDir, "managed-policy");
   const password = randomBytes(24).toString("base64url");
   const username = "opencode";
   let url = "";
@@ -91,7 +95,6 @@ export async function createManagedOpencodeV2Server(
   // cloud, database, or control-plane credentials. Unknown keys stay private.
   const inherited: Record<string, string> = {};
   for (const key of [
-    "OPENWORK_SERVER_URL", "OPENWORK_POLICY_TOKEN",
     "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "TMP", "TEMP",
     "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TERM", "CI",
     "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_RUNTIME_DIR",
@@ -109,6 +112,15 @@ export async function createManagedOpencodeV2Server(
   await chmod(options.rootDir, 0o700);
   await mkdir(configDir, { recursive: true, mode: 0o700 });
   await chmod(configDir, 0o700);
+  if (options.checkPolicy) {
+    // The pinned v2 loader accepts configured plugin directories, not files.
+    // Keep its entrypoint inside that directory for the loader's path check.
+    await mkdir(policyPluginDir, { recursive: true, mode: 0o700 });
+    await chmod(policyPluginDir, 0o700);
+    await writeFile(join(policyPluginDir, "server.js"),
+      `export { default } from ${JSON.stringify(pathToFileURL(managedPolicyPluginPath(true)).href)};\n`,
+      { mode: 0o600 });
+  }
   // Load enforcement on the first boot, before any session can run.
   await writeProviders();
   const child = spawn(options.bin, ["serve", "--hostname", hostname, "--port", String(port)], {
@@ -119,8 +131,10 @@ export async function createManagedOpencodeV2Server(
       OPENCODE_CONFIG_DIR: configDir,
       ...(opencodeModelsUrl === undefined ? {} : { OPENCODE_MODELS_URL: opencodeModelsUrl }),
     },
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "pipe", options.checkPolicy ? "ipc" : "ignore"],
+    serialization: "json",
   });
+  if (options.checkPolicy) serveManagedPolicyIpc(child, options.checkPolicy);
 
   let stdout = "";
   let stderr = "";
@@ -136,12 +150,14 @@ export async function createManagedOpencodeV2Server(
     closed = true;
     lines.stop();
   });
-  child.stdout.on("data", (chunk) => {
+  // The extra IPC entry selects spawn's nullable-stream overload, but both
+  // diagnostic streams are explicitly piped above.
+  child.stdout!.on("data", (chunk) => {
     const text = String(chunk);
     stdout = appendEngineOutputTail(stdout, text);
     lines.write(text);
   });
-  child.stderr.on("data", (chunk) => {
+  child.stderr!.on("data", (chunk) => {
     stderr = appendEngineOutputTail(stderr, String(chunk));
   });
   child.on("error", (error) => {
@@ -232,13 +248,14 @@ export async function createManagedOpencodeV2Server(
       $schema: "https://opencode.ai/config.json",
       providers: providerConfig,
       ...(options.permissions ? { permissions: await options.permissions() } : {}),
-      ...(options.env?.OPENWORK_SERVER_URL ? { plugins: [managedPolicyPluginPath(true)] } : {}),
+      ...(options.checkPolicy ? { plugins: [policyPluginDir] } : {}),
     }, null, 2)}\n`, { mode: 0o600 });
     await rename(temporary, target);
   }
 
   async function close(): Promise<void> {
     lines.stop();
+    if (child.connected) child.disconnect();
     if (child.exitCode !== null || child.signalCode !== null) return;
     const exit = new Promise<void>((resolve) => child.once("exit", () => resolve()));
     child.kill("SIGTERM");

--- a/apps/server/src/managed-opencode.test.ts
+++ b/apps/server/src/managed-opencode.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { createManagedOpencodeServer } from "./managed-opencode.js";
 import { createManagedOpencodeV2Server } from "./managed-opencode-v2.js";
+import { appendEngineOutputTail, createEngineStartupLineReader, ENGINE_OUTPUT_MAX_CHARS, ENGINE_STARTUP_LINE_MAX_CHARS } from "./engine-output.js";
+import { loopbackFetch } from "./server-fetch.js";
 
 const roots: string[] = [];
 
@@ -26,6 +28,95 @@ async function writeExecutable(root: string, name: string, lines: string[]): Pro
 }
 
 describe("managed OpenCode startup", () => {
+  test("bounds diagnostic tails and partial lines, and stops parsing once ready", () => {
+    let tail = "old diagnostics\n";
+    for (let index = 0; index < 256; index++) {
+      tail = appendEngineOutputTail(tail, "x".repeat(4096));
+      expect(tail.length).toBeLessThanOrEqual(ENGINE_OUTPUT_MAX_CHARS);
+    }
+    tail = appendEngineOutputTail(tail, "y".repeat(ENGINE_OUTPUT_MAX_CHARS * 4) + "failure tail");
+    expect(tail).toHaveLength(ENGINE_OUTPUT_MAX_CHARS);
+    expect(tail.endsWith("failure tail")).toBe(true);
+    expect(tail).not.toContain("old diagnostics");
+
+    const seen: string[] = [];
+    const lines = createEngineStartupLineReader((line) => { seen.push(line); lines.stop(); });
+    lines.write("x".repeat(ENGINE_STARTUP_LINE_MAX_CHARS));
+    lines.write("opencode server listening on http://wrong:1\n");
+    expect(seen).toEqual([]);
+    lines.write("open");
+    lines.write("code server listening on http://127.0.0.1:12");
+    expect(seen).toEqual([]);
+    lines.write("345\r");
+    expect(seen).toEqual([]);
+    lines.write("\nopencode server listening on http://wrong:2\n");
+    lines.write("opencode server listening without a URL\n".repeat(1000));
+    expect(seen).toEqual(["opencode server listening on http://127.0.0.1:12345\r"]);
+  });
+
+  for (const engine of ["v1", "v2"]) {
+    test(`${engine} recognizes fragmented stdout readiness amid stderr and keeps draining after ready`, async () => {
+      const root = await createRoot();
+      const bin = await writeExecutable(root, "noisy-startup.mjs", [
+        "const write = (stream, text) => new Promise((resolve) => stream.write(text, resolve));",
+        "const server = Bun.serve({ hostname: '127.0.0.1', port: Number(process.argv[process.argv.indexOf('--port') + 1]), async fetch(request) {",
+        "  if (new URL(request.url).pathname === '/noise') {",
+        "    for (let i = 0; i < 32; i++) { await write(process.stdout, 'x'.repeat(65536)); await write(process.stderr, 'y'.repeat(65536)); }",
+        "    await write(process.stdout, '\\nopencode server listening on http://127.0.0.1:1\\nopencode server listening without a URL\\n');",
+        "  }",
+        "  return Response.json({ healthy: true, version: 'test', pid: process.pid });",
+        "} });",
+        "process.on('SIGTERM', () => { server.stop(true); process.exit(0); });",
+        "await write(process.stdout, 'old stdout\\n' + 'x'.repeat(1048576) + '\\nopen');",
+        "await write(process.stderr, 'old stderr\\n' + 'y'.repeat(1048576) + '\\nserver listening on http://127.0.0.1:1\\n');",
+        "await write(process.stdout, 'code server listening on http://127.0.0.1:');",
+        "await write(process.stderr, 'interleaved diagnostic\\n');",
+        "await write(process.stdout, `${server.port}\\r\\n`);",
+      ]);
+      const managed = engine === "v1"
+        ? await createManagedOpencodeServer({ bin, cwd: root, timeoutMs: 5000 })
+        : await createManagedOpencodeV2Server({ bin, rootDir: root, bootTimeoutMs: 5000 });
+      try {
+        const url = managed.url;
+        const response = await loopbackFetch(`${url}/noise`, { signal: AbortSignal.timeout(5000) });
+        expect(await response.json()).toEqual({ healthy: true, version: "test", pid: "pid" in managed ? managed.pid : managed.childPid });
+        expect(managed.url).toBe(url);
+        expect((await loopbackFetch(url, { signal: AbortSignal.timeout(5000) })).ok).toBe(true);
+        if ("stdout" in managed) {
+          expect(managed.stdout.length).toBeLessThanOrEqual(ENGINE_OUTPUT_MAX_CHARS);
+          expect(managed.stderr.length).toBeLessThanOrEqual(ENGINE_OUTPUT_MAX_CHARS);
+          expect(managed.stdout).not.toContain("old stdout");
+          expect(managed.stderr).not.toContain("old stderr");
+        }
+      } finally {
+        await managed.close();
+      }
+    });
+
+    test(`${engine} retains bounded final diagnostics when startup fails after large output`, async () => {
+      const root = await createRoot();
+      const bin = await writeExecutable(root, "noisy-failure.mjs", [
+        "const write = (stream, text) => new Promise((resolve) => stream.write(text, resolve));",
+        "await write(process.stdout, 'old stdout\\n' + 'x'.repeat(1048576) + '\\nfinal stdout diagnostic\\n');",
+        "await write(process.stderr, 'old stderr\\n' + 'y'.repeat(1048576) + '\\nfatal configuration tail\\n');",
+        "process.exit(1);",
+      ]);
+      let thrown: unknown;
+      try {
+        if (engine === "v1") await createManagedOpencodeServer({ bin, cwd: root });
+        else await createManagedOpencodeV2Server({ bin, rootDir: root });
+      } catch (error) { thrown = error; }
+      expect(thrown).toBeInstanceOf(Error);
+      if (!(thrown instanceof Error)) throw new Error("Expected noisy startup to fail");
+      expect(thrown.message).toContain("exited with code 1");
+      expect(thrown.message).toContain("final stdout diagnostic");
+      expect(thrown.message).toContain("fatal configuration tail");
+      expect(thrown.message).not.toContain("old stdout");
+      expect(thrown.message).not.toContain("old stderr");
+      expect(thrown.message.length).toBeLessThan(ENGINE_OUTPUT_MAX_CHARS * 2 + 200);
+    });
+  }
+
   test("gives the next engine a policy-only credential without inheriting the client credential", async () => {
     const root = await createRoot();
     const bin = await writeExecutable(root, "policy-env.mjs", [
@@ -78,7 +169,12 @@ describe("managed OpenCode startup", () => {
     const diagnosticPath = join(root, "delayed-eaddrinuse.mjs");
     await writeFile(diagnosticPath, [
       "const port = process.argv[2];",
-      "setTimeout(() => console.error(`listen EADDRINUSE: address already in use 127.0.0.1:${port}`), 50);",
+      "setTimeout(async () => {",
+      "  const write = (text) => new Promise((resolve) => process.stderr.write(text, resolve));",
+      "  await write('listen EADDR');",
+      "  await write(`INUSE: address already in use 127.0.0.1:${port}\\n`);",
+      "  await write('x'.repeat(1048576) + '\\nfinal retry diagnostic\\n');",
+      "}, 50);",
     ].join("\n"));
     const bin = await writeExecutable(root, "retry-eaddrinuse.mjs", [
       "import { spawn } from 'node:child_process';",

--- a/apps/server/src/managed-opencode.test.ts
+++ b/apps/server/src/managed-opencode.test.ts
@@ -117,11 +117,29 @@ describe("managed OpenCode startup", () => {
     });
   }
 
-  test("gives the next engine a policy-only credential without inheriting the client credential", async () => {
+  test("checks next-engine policy over private IPC without giving shell children a credential or channel", async () => {
     const root = await createRoot();
+    const clientPath = new URL("./opencode-plugins/managed-policy-next.ts", import.meta.url).href;
+    const shellPath = join(root, "shell-child.mjs");
+    await writeFile(shellPath, "console.log(JSON.stringify({ policy: process.env.OPENWORK_POLICY_TOKEN ?? null, client: process.env.OPENWORK_SERVER_TOKEN ?? null, ipc: typeof process.send === 'function' }));");
+    const checked: Array<{ action: string; input: Record<string, unknown> }> = [];
+    const checking = Promise.withResolvers<void>();
+    const unblock = Promise.withResolvers<void>();
     const bin = await writeExecutable(root, "policy-env.mjs", [
-      "const server = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch(request) {",
-      "  if (new URL(request.url).pathname === '/env') return Response.json({ policy: process.env.OPENWORK_POLICY_TOKEN, client: process.env.OPENWORK_SERVER_TOKEN ?? null });",
+      `import plugin from ${JSON.stringify(clientPath)};`,
+      "import { execFileSync } from 'node:child_process';",
+      "const hooks = {};",
+      "await plugin.setup(Object.fromEntries(['tool', 'shell', 'session'].map(kind => [kind, { hook: async (name, callback) => { hooks[kind] = callback; } }])));",
+      "const server = Bun.serve({ hostname: '127.0.0.1', port: 0, async fetch(request) {",
+      "  const path = new URL(request.url).pathname;",
+      "  if (path === '/env') return Response.json({ policy: process.env.OPENWORK_POLICY_TOKEN ?? null, client: process.env.OPENWORK_SERVER_TOKEN ?? null });",
+      `  if (path === '/shell-env') return Response.json(JSON.parse(execFileSync(process.execPath, [${JSON.stringify(shellPath)}], { encoding: 'utf8' })));`,
+      "  if (path === '/disconnect') { process.disconnect(); return Response.json({ ok: true }); }",
+      "  if (path === '/check') {",
+      "    const { kind, event } = await request.json();",
+      "    try { await hooks[kind](event); return Response.json({ allowed: true }); }",
+      "    catch (error) { return Response.json({ allowed: false, message: error.message }); }",
+      "  }",
       "  return Response.json({ healthy: true, version: 'test', pid: process.pid });",
       "} });",
       "console.log(`opencode server listening on http://127.0.0.1:${server.port}`);",
@@ -130,10 +148,33 @@ describe("managed OpenCode startup", () => {
     const managed = await createManagedOpencodeV2Server({
       bin, rootDir: root,
       env: { OPENWORK_SERVER_TOKEN: "must-stay-private", OPENWORK_POLICY_TOKEN: "policy-only-test-token" },
+      checkPolicy: async (action, input) => {
+        checked.push({ action, input });
+        if (input.command === "blocked") throw new Error("Command blocked by team policy.");
+        if (input.command === "waiting") { checking.resolve(); await unblock.promise; }
+      },
     });
     try {
-      expect(await managed.fetchJson("/env")).toEqual({ status: 200, json: { policy: "policy-only-test-token", client: null } });
-    } finally { await managed.close(); }
+      expect(await managed.fetchJson("/env")).toEqual({ status: 200, json: { policy: null, client: null } });
+      expect(await managed.fetchJson("/shell-env")).toEqual({ status: 200, json: { policy: null, client: null, ipc: false } });
+      const check = (kind: string, event: Record<string, unknown>) => managed.fetchJson("/check", { method: "POST", body: { kind, event }, timeoutMs: 2000 });
+      expect(await check("shell", { command: "allowed" })).toEqual({ status: 200, json: { allowed: true } });
+      expect(await check("shell", { command: "blocked" })).toEqual({ status: 200, json: { allowed: false, message: "Command blocked by team policy." } });
+      expect(await check("tool", { tool: "read", input: {} })).toEqual({ status: 200, json: { allowed: true } });
+      expect(await check("session", { model: { providerID: "fixture", id: "model" } })).toEqual({ status: 200, json: { allowed: true } });
+      expect(checked).toEqual([
+        { action: "shell", input: { command: "allowed" } },
+        { action: "shell", input: { command: "blocked" } },
+        { action: "sync", input: {} },
+        { action: "model", input: { providerID: "fixture", id: "model" } },
+      ]);
+      const waiting = check("shell", { command: "waiting" });
+      await checking.promise;
+      await managed.fetchJson("/disconnect");
+      expect(await waiting).toEqual({ status: 200, json: { allowed: false, message: "OpenWork policy service is unavailable." } });
+      expect(await check("shell", { command: "allowed" })).toEqual({ status: 200, json: { allowed: false, message: "OpenWork policy service is unavailable." } });
+      expect(checked).toHaveLength(5);
+    } finally { unblock.resolve(); await managed.close(); }
   });
 
   test("spawns the engine with npm audit disabled so first-run installs never wait on the advisories endpoint", async () => {

--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import net from "node:net";
 import { randomUUID } from "node:crypto";
+import { appendEngineOutputTail, createEngineStartupLineReader } from "./engine-output.js";
 
 export type ManagedChildProcess = {
   exitCode: number | null;
@@ -131,17 +132,19 @@ type ManagedOpencodeServerOptions = {
 
 class ManagedOpencodeExitError extends Error {
   readonly exitCode: number | null;
+  readonly addressInUse: boolean;
 
-  constructor(exitCode: number | null, output: string) {
-    super(`OpenCode server exited with code ${exitCode}${output.trim() ? `\n${output}` : ""}`);
+  constructor(exitCode: number | null, output: string, addressInUse: boolean) {
+    super(`OpenCode server exited with code ${exitCode}${addressInUse ? " (EADDRINUSE)" : ""}${output.trim() ? `\n${output}` : ""}`);
     this.exitCode = exitCode;
+    this.addressInUse = addressInUse;
   }
 }
 
 function isRetryableAddressInUseExit(error: unknown): boolean {
   return error instanceof ManagedOpencodeExitError &&
     error.exitCode === 1 &&
-    /\bEADDRINUSE\b/.test(error.message);
+    error.addressInUse;
 }
 
 async function startManagedOpencodeServer(
@@ -192,32 +195,62 @@ async function startManagedOpencodeServer(
   let url: string;
   try {
     url = await new Promise<string>((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error(`Timeout waiting for OpenCode server after ${options.timeoutMs ?? 15000}ms`)), options.timeoutMs ?? 15000);
-      let output = "";
-      const done = (value: string) => {
+      let settled = false;
+      let stdout = "";
+      let stderr = "";
+      let addressInUse = false;
+      const output = () => `stdout:\n${stdout}\nstderr:\n${stderr}`;
+      const collect = (tail: string, text: string) => {
+        // Remember the retry signal even if later diagnostics evict it. Keep
+        // stream boundaries separate, including a token split across chunks.
+        // Do not invent a word boundary where the overlap was cut.
+        addressInUse ||= /\bEADDRINUSE\b[\s\S]/.test((tail.length > 16 ? "_" : "") + tail.slice(-16) + text);
+        return appendEngineOutputTail(tail, text);
+      };
+      const finish = () => {
+        settled = true;
         clearTimeout(timeout);
+        lines.stop();
+        stdout = "";
+        stderr = "";
+        child.removeListener("close", onClose);
+      };
+      const done = (value: string) => {
+        if (settled) return;
+        finish();
         resolve(value);
       };
       const fail = (error: Error) => {
-        clearTimeout(timeout);
+        if (settled) return;
+        finish();
         reject(error);
       };
+      const lines = createEngineStartupLineReader((line) => {
+        if (!line.startsWith("opencode server listening")) return;
+        const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+        if (!match?.[1]) return fail(new Error(`Failed to parse OpenCode server URL from: ${line}\n${output()}`));
+        done(match[1]);
+      });
+      const timeout = setTimeout(() => fail(new Error(`Timeout waiting for OpenCode server after ${options.timeoutMs ?? 15000}ms\n${output()}`)), options.timeoutMs ?? 15000);
+      const onClose = (code: number | null) => {
+        if (!settled) fail(new ManagedOpencodeExitError(code, output(),
+          addressInUse || /\bEADDRINUSE$/.test(stdout) || /\bEADDRINUSE$/.test(stderr)));
+      };
       child.stdout?.on("data", (chunk) => {
-        output += chunk.toString();
-        for (const line of output.split("\n")) {
-          if (!line.startsWith("opencode server listening")) continue;
-          const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
-          if (!match?.[1]) return fail(new Error(`Failed to parse OpenCode server URL from: ${line}`));
-          done(match[1]);
-        }
+        // Keep draining both pipes after startup, without decoding or parsing.
+        if (settled) return;
+        const text = chunk.toString();
+        stdout = collect(stdout, text);
+        lines.write(text);
       });
       child.stderr?.on("data", (chunk) => {
-        output += chunk.toString();
+        if (settled) return;
+        stderr = collect(stderr, chunk.toString());
       });
-      child.once("error", fail);
+      child.on("error", fail);
       // ChildProcess can emit "exit" before its stdio pipes have drained. Wait
       // for "close" so retry classification includes every diagnostic line.
-      child.once("close", (code) => fail(new ManagedOpencodeExitError(code, output)));
+      child.once("close", onClose);
     });
   } catch (error) {
     await processLifecycle.close();

--- a/apps/server/src/managed-policy-ipc.ts
+++ b/apps/server/src/managed-policy-ipc.ts
@@ -1,0 +1,85 @@
+import type { ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { managedPolicyActionSchema, type ManagedPolicyAction } from "./managed-policy-rules.js";
+
+const channel = "openwork.managed-policy";
+const unavailable = "OpenWork policy service is unavailable.";
+const maxPending = 256;
+const requestSchema = z.object({
+  channel: z.literal(channel),
+  id: z.string().uuid(),
+  action: managedPolicyActionSchema,
+  input: z.record(z.string(), z.unknown()),
+});
+const responseSchema = z.object({
+  channel: z.literal(channel),
+  id: z.string().uuid(),
+  error: z.string().nullable(),
+});
+export type ManagedPolicyCheck = (action: ManagedPolicyAction, input: Record<string, unknown>) => Promise<void>;
+
+// Node's IPC descriptor belongs only to the spawned engine. It is not a
+// listening socket, credential, or stdio stream inherited by shell children.
+export function serveManagedPolicyIpc(child: ChildProcess, check: ManagedPolicyCheck): void {
+  const pending = new Set<string>();
+  const receive = async (message: unknown) => {
+    const parsed = requestSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { id, action, input } = parsed.data;
+    if (pending.has(id)) return;
+    let error: string | null = null;
+    if (pending.size >= maxPending) error = unavailable;
+    else {
+      pending.add(id);
+      try { await check(action, input); }
+      catch (cause) { error = cause instanceof Error ? cause.message : unavailable; }
+      finally { pending.delete(id); }
+    }
+    if (child.connected) {
+      // Disconnect can race an in-flight evaluation; never raise an unhandled
+      // channel error or resume work in a replacement engine.
+      try { child.send({ channel, id, error }, () => {}); } catch { /* closed */ }
+    }
+  };
+  child.on("message", receive);
+  child.once("disconnect", () => child.off("message", receive));
+}
+
+export function createManagedPolicyIpcClient(): ManagedPolicyCheck {
+  const pending = new Map<string, (error: Error | null) => void>();
+  const receive = (message: unknown) => {
+    const parsed = responseSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { id, error } = parsed.data;
+    pending.get(id)?.(error === null ? null : new Error(error));
+  };
+  const disconnect = () => {
+    process.off("message", receive);
+    for (const finish of pending.values()) finish(new Error(unavailable));
+  };
+  if (process.send) {
+    process.on("message", receive);
+    process.once("disconnect", disconnect);
+  }
+  return (action, input) => new Promise<void>((resolve, reject) => {
+    if (!process.send || !process.connected || pending.size >= maxPending) {
+      reject(new Error(unavailable));
+      return;
+    }
+    const id = randomUUID();
+    const finish = (error: Error | null) => {
+      if (!pending.delete(id)) return;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    };
+    const timer = setTimeout(() => finish(new Error(unavailable)), 15_000);
+    pending.set(id, finish);
+    try {
+      process.send({ channel, id, action, input }, (error: Error | null) => {
+        if (error) finish(new Error(unavailable));
+      });
+    } catch { finish(new Error(unavailable)); }
+  });
+}

--- a/apps/server/src/opencode-plugins/managed-policy-client.ts
+++ b/apps/server/src/opencode-plugins/managed-policy-client.ts
@@ -5,7 +5,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function record(value: unknown): Record<string, unknown> { return isRecord(value) ? value : {}; }
-export async function checkManagedTool(tool: string, raw: unknown): Promise<void> {
+export async function checkManagedTool(tool: string, raw: unknown, evaluate = check): Promise<void> {
   const input = record(raw);
   let action: ManagedPolicyAction | undefined;
   if (tool === "bash" || tool === "shell") action = "shell";
@@ -13,12 +13,12 @@ export async function checkManagedTool(tool: string, raw: unknown): Promise<void
   else if (tool === "webfetch" || tool === "websearch") action = tool;
   else if (tool === "browser_navigate" || tool === "browser_open") action = "browser";
   else if (tool === "openwork_execute") {
-    if (input.id === "browser.open_url") return check("browser", record(input.args));
+    if (input.id === "browser.open_url") return evaluate("browser", record(input.args));
     if (typeof input.id === "string" && /^(?:plugin|skill|mcp)\.(?:install|add|update|remove)/.test(input.id)) action = "extensions";
   }
   // Even read-only tools synchronize policy, so unknown identities cannot keep
   // running with a previous member's loaded configuration.
-  await check(action ?? "sync", input);
+  await evaluate(action ?? "sync", input);
 }
 export async function check(action: ManagedPolicyAction, input: Record<string, unknown>): Promise<void> {
   const base = process.env.OPENWORK_SERVER_URL;

--- a/apps/server/src/opencode-plugins/managed-policy-next.ts
+++ b/apps/server/src/opencode-plugins/managed-policy-next.ts
@@ -1,4 +1,6 @@
-import { check, checkManagedTool } from "./managed-policy-client.js";
+import { checkManagedTool } from "./managed-policy-client.js";
+import { createManagedPolicyIpcClient } from "../managed-policy-ipc.js";
+const check = createManagedPolicyIpcClient();
 // Plugin.define is the identity function in the pinned SDK. The structural
 // contract avoids loading either engine's SDK into the other engine.
 export default {
@@ -8,7 +10,7 @@ export default {
     shell: { hook(name: "create.before", callback: (event: { command: string }) => Promise<void>): Promise<unknown> };
     session: { hook(name: "http.request", callback: (event: { model: { providerID: string; id: string } }) => Promise<void>): Promise<unknown> };
   }) {
-    await ctx.tool.hook("execute.before", (event) => checkManagedTool(event.tool, event.input));
+    await ctx.tool.hook("execute.before", (event) => checkManagedTool(event.tool, event.input, check));
     await ctx.shell.hook("create.before", (event) => check("shell", { command: event.command }));
     await ctx.session.hook("http.request", (event) => check("model", event.model));
   },

--- a/evals/specs/opencode-v2-provider-hot-inject.test.ts
+++ b/evals/specs/opencode-v2-provider-hot-inject.test.ts
@@ -182,7 +182,7 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
     console.info(`[opencode-v2-spec] cold catalog readiness: ${catalogReadinessMs}ms`);
     evidence.recordAssertionEvidence(
       "C1 positive baseline and negative provider absence",
-      `The cold-cache v2 engine listed models after ${catalogReadinessMs}ms while containing neither witness A nor witness B before injection.`,
+      `The freshly booted v2 engine listed models after ${catalogReadinessMs}ms while containing neither witness A nor witness B before injection. The package cache is shared; this is not cold-cache installation proof.`,
       true,
     );
 

--- a/evals/specs/opencode-v2-provider-hot-inject.test.ts
+++ b/evals/specs/opencode-v2-provider-hot-inject.test.ts
@@ -52,6 +52,8 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
   const binary = await resolveOpencodeV2Bin();
   const nonce = `WITNESS-OK-${randomBytes(12).toString("hex")}`;
   const requests: WitnessRequest[] = [];
+  const policyChecks: Array<{ action: string; input: Record<string, unknown> }> = [];
+  let blockProviderB = true;
   let impersonatorRequests = 0;
   const witness = createServer(async (request, response) => {
     if (request.url === "/api/health") {
@@ -131,9 +133,16 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
         OPENCODE_CONFIG: baseConfig, OPENCODE_MODELS_URL: opencodeModelsUrl,
         OPENWORK_ENCRYPTION_KEY: "fixture-server-only", OPENWORK_TOKEN: "fixture-server-only",
         OPENWORK_HOST_TOKEN: "fixture-server-only", OPENWORK_SERVER_TOKEN: "fixture-server-only",
+        OPENWORK_POLICY_TOKEN: "fixture-server-only",
         OPENAI_API_KEY: "fixture-server-only", ANTHROPIC_API_KEY: "fixture-server-only",
         AWS_SECRET_ACCESS_KEY: "fixture-server-only", GITHUB_TOKEN: "fixture-server-only",
         DATABASE_URL: "fixture-server-only", CUSTOM_SERVICE_SECRET: "fixture-server-only",
+      },
+      checkPolicy: async (action, input) => {
+        policyChecks.push({ action, input });
+        if (blockProviderB && action === "model" && input.providerID === "openwork-witness-b") {
+          throw new Error("Witness B is blocked by team policy.");
+        }
       },
     });
     const initialHealth = await server.health();
@@ -151,7 +160,7 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
       expect(names).toContain("PATH");
       evidence.recordAssertionEvidence(
         "server credentials do not cross the sidecar process boundary",
-        "The live Linux sidecar retained PATH but contained none of the ten synthetic control-plane, provider, cloud, database, or arbitrary service credentials supplied through spawn options. Unknown environment keys were not inherited.",
+        "The live Linux sidecar retained PATH but contained none of the synthetic policy, control-plane, provider, cloud, database, or arbitrary service credentials supplied through spawn options. Unknown environment keys were not inherited.",
         true,
       );
     }
@@ -222,6 +231,28 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
     const idA = sessionId(sessionA.json);
     expect(idA).toBeTypeOf("string");
     if (idA === undefined) throw new Error("Provider A session response did not contain data.id");
+    const shellProbe = join(directory, "policy-boundary.cjs");
+    await writeFile(shellProbe, `console.log(JSON.stringify({ policy: Object.hasOwn(process.env, "OPENWORK_POLICY_TOKEN"), client: Object.hasOwn(process.env, "OPENWORK_SERVER_TOKEN"), ipc: typeof process.send === "function" }));\n`);
+    const command = `node "${shellProbe}"`;
+    const shell = await server.fetchJson(`/api/session/${idA}/shell`, {
+      method: "POST", directory, body: { command }, timeoutMs: 15_000,
+    });
+    expect(shell.status).toBe(204);
+    const shellMessages = await server.fetchJson(`/api/session/${idA}/message`, { directory });
+    const shellMessage: unknown = isRecord(shellMessages.json) && Array.isArray(shellMessages.json.data)
+      ? shellMessages.json.data.find((message: unknown) => isRecord(message) && message.type === "shell" && message.command === command)
+      : undefined;
+    expect(shellMessage).toMatchObject({ status: "exited", exit: 0 });
+    if (!isRecord(shellMessage) || !isRecord(shellMessage.output) || typeof shellMessage.output.output !== "string") {
+      throw new Error("The policy boundary shell probe did not return output");
+    }
+    expect(JSON.parse(shellMessage.output.output.trim())).toEqual({ policy: false, client: false, ipc: false });
+    expect(policyChecks).toContainEqual({ action: "shell", input: { command } });
+    evidence.recordAssertionEvidence(
+      "shell execution cannot inherit the host policy credential or IPC channel",
+      "The real v2 shell completed a presence-only probe: neither policy nor client credentials nor a process IPC capability were inherited, while its shell policy hook reached the host.",
+      true,
+    );
     const promptA = await server.fetchJson(`/api/session/${idA}/prompt`, {
       method: "POST",
       directory,
@@ -234,6 +265,7 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
     );
     expect(requests.some((entry) => entry.auth === "Bearer witness-key-a" && entry.model === "witness-model-a")).toBe(true);
     expect(requests.some((entry) => entry.model === "witness-model-b")).toBe(false);
+    expect(policyChecks).toContainEqual({ action: "model", input: expect.objectContaining({ providerID: "openwork-witness-a", id: "witness-model-a" }) });
     evidence.recordAssertionEvidence(
       "C3 positive provider A execution and negative wrong-credential routing",
       "The A session received the witness nonce, and the witness observed model A paired with only the expected Bearer key A assertion.",
@@ -282,6 +314,29 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
       body: { text: "reply with anything" },
     });
     expect(promptB.status).toBe(200);
+    await eventually(async () => {
+      const result = await server?.fetchJson(`/api/session/${idB}`, { directory });
+      return isRecord(result?.json) && isRecord(result.json.data) ? result.json.data.outcome : undefined;
+    }, { within: 15_000, intervalMs: 100, label: "blocked model execution to fail", until: (outcome) => outcome === "failed" });
+    await eventually(async () => {
+      const result = await server?.fetchJson("/api/session/active", { directory });
+      return isRecord(result?.json) && isRecord(result.json.data) && result.json.data[idB] === undefined;
+    }, { within: 15_000, intervalMs: 100, label: "blocked model execution to settle", until: (idle) => idle });
+    expect(policyChecks.some((entry) => entry.action === "model" && entry.input.providerID === "openwork-witness-b")).toBe(true);
+    expect(requests.some((entry) => entry.model === "witness-model-b")).toBe(false);
+    evidence.recordAssertionEvidence(
+      "policy checks stay in the host without a policy credential in the engine",
+      "The v2 model hook reached the host over private IPC: A was permitted, B reached a failed idle outcome after the host denied it, and the provider witness received no B request.",
+      true,
+    );
+    // Removing the restriction uses the same host callback and same engine.
+    blockProviderB = false;
+    const allowedPromptB = await server.fetchJson(`/api/session/${idB}/prompt`, {
+      method: "POST",
+      directory,
+      body: { text: "reply with anything" },
+    });
+    expect(allowedPromptB.status).toBe(200);
     await eventually(
       async () => JSON.stringify((await server?.fetchJson(`/api/session/${idB}/message`, { directory }))?.json),
       { within: 60_000, intervalMs: 250, label: "provider B witness response", until: (text) => text.includes(nonce) },


### PR DESCRIPTION
## Summary

Keep long-lived workspaces responsive without interrupting background tasks or changing the conversation UI.

- Reconcile active/unsettled sessions instead of rewriting idle history on every status poll. Preserve full reconnect convergence and native event ordering without copying the entire historical sequence map per poll.
- Make idle retention deadlines non-postponable. Preserve live work and pending approvals; release deleted sessions without allowing stale permission reads to renew their retention.
- Release completed v2 text/reasoning and tool-input payloads. Preserve unresolved final parts across terminal events and bound recent terminal replay markers to 256 idle sessions.
- Bound engine diagnostics to 65,536 UTF-16 code units per stream. Parse startup announcements incrementally, stop v1 startup parsing after readiness, and preserve fragmented announcements and address-in-use retry diagnostics.

### Review correction: keep v2 policy credentials in the host

- Remove the policy token and server URL from the v2 engine environment. The host evaluates typed policy requests over the engine's private process IPC channel instead of passing a bearer credential to a shell-capable process.
- Preserve tool, shell, model, and identity-sync checks. Bound pending requests and deadlines; disconnect rejects pending and subsequent checks rather than allowing work.
- Register the policy plugin as a directory with a local entrypoint, as required by the pinned v2 loader. An individual configured file was silently ignored.
- Keep the legacy engine's policy transport unchanged; this is a scoped v2 correction, not a claim of general OS sandboxing.

## Verification — Incomplete overall

Current head: `130c0aeae0a4d7bbb5221d3682673797517a30b1`.
Base/merge-base: `89c48dac202d336f9a47bf54271f2da98eb71add` (`dev`).
All three branch commits have verified signatures. The rebase preserved both implementation patches unchanged.

### Passed: exact-head v2 boundary journey

```sh
OPENWORK_EVAL_ENGINE=v2 pnpm --dir evals run test:pr specs/opencode-v2-provider-hot-inject.test.ts
```

**1 passed, 0 failed, 0 skipped**, exit 0. Published test evidence on this PR records **9 passed expectations, 0 failed, 0 pending**, matching the current head and engine v2.

The test launches the pinned real v2 executable locally on macOS with a fresh process, database, and config plus a deterministic provider witness. It uses the existing package cache; this is not cold-cache installation or cross-platform proof. The app-less PR runner has no E2E placement banner.

Observable assertions include:

- A real v2 shell reports only presence booleans: no policy token, client token, or inherited process IPC capability. Its shell-policy hook still reaches the host.
- Model A is allowed. Model B reaches a failed, settled outcome when denied by the host, and the provider witness receives no B request. Removing the restriction permits B without replacing the engine.
- Provider hot injection, per-provider credential routing, restrictive config-file permissions, child listener verification, and stable engine PID remain intact.

The root `pnpm evals:pr` wrapper initially stopped during automatic dependency reconciliation (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`). The command above is its exact underlying PR script, not a different test lane.

### Passed: focused supporting checks

On implementation head `a29a8e386567248623b0ed71b805abacb65c7bce` (the subsequent commit changes evidence wording only):

```sh
bun --conditions=development test apps/server/src/managed-opencode.test.ts
apps/server/node_modules/.bin/tsc -p apps/server/tsconfig.json --noEmit
```

- **9 passed, 0 failed**, exit 0. Includes allowed/denied policy hooks, read-only identity synchronization, shell inheritance, and both in-flight and subsequent checks failing closed after disconnect.
- Server typecheck: exit 0.
- `git diff origin/dev...HEAD --check`: passed on the current head.

Historical app checks on the original publication head `c32067281799b5c8272b85fabf3ba2a914377445`:

```sh
# From apps/app
bun test --isolate ./tests/session-sync-run-status.test.ts ./tests/session-sync-permissions.test.ts ./tests/session-sync-lifecycle.test.ts ./tests/opencode-v2-adapter.test.ts
```

**162 passed, 0 failed**, exit 0. These are supporting historical results, not exact-head full-app proof.

### Missing / deferred

- Full-PR runtime proof remains **Incomplete**: no exact-head real-app workspace/performance journey or CPU/RSS/latency soak comparison. No measured speedup is claimed.
- The newly required final local policy preflight remains unrun (**Incomplete**); no local clearance or merge readiness is claimed.
- Linux and Windows process-boundary execution were not run locally. The Linux-only `/proc` environment assertion is not covered by this macOS run.
- No failed or skipped tests in the final selected run. Broader coverage was not run, rather than reported as a passing skip.

## Limits and scope

- Active record updates still copy the workspace activity dictionary; reconnect still traverses known records. Neither is claimed to be constant-time.
- Unresolved v2 parts remain until completion, deletion, or subscription cleanup. Recent terminal markers are bounded, not a total memory budget or arbitrary-history deduplication guarantee. Exact pinned-engine event ordering for the retention changes still needs runtime validation.
- Startup announcements must be newline-terminated and no longer than 8,192 UTF-16 code units. Oversized lines are discarded through their newline.
- Transcript virtualization, scroll persistence, permission enumeration, and MCP admission optimization are outside this patch.
- No dependency or durable conversation-data migration.
