### PR TITLE
fix(chat): show sent attachments immediately and preserve reading position

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -45,6 +45,14 @@ type PromptPart = {
   text?: unknown;
 };
 
+/** The exact native prompt body, also used to correlate text-only user acknowledgements. */
+export function v2PromptText(parts: readonly PromptPart[]): string {
+  return parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => typeof part.text === "string" ? part.text : "")
+    .join("");
+}
+
 type PromptParameters = SessionParameters & {
   model?: { providerID: string; modelID: string };
   parts?: PromptPart[];
@@ -1594,10 +1602,7 @@ export function createClientV2(
           { value: parameters.system }, options?.signal);
         if (!instructions.response.ok) return failedResult(instructions);
       }
-      const text = (parameters.parts ?? [])
-        .filter((part) => part.type === "text" && typeof part.text === "string")
-        .map((part) => typeof part.text === "string" ? part.text : "")
-        .join("");
+      const text = v2PromptText(parameters.parts ?? []);
       const promptResult = await request(
         "POST",
         `/api/session/${encodeURIComponent(parameters.sessionID)}/prompt`,

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -25,6 +25,7 @@ import {
 import { LinkActionMenu } from "./link-action-menu";
 import { useMermaidEnhancer } from "./mermaid";
 import { useSelectionStableValue } from "./selection-stability";
+import { enhanceNearViewport } from "./near-viewport";
 
 export { renderHighlightedMarkdownHtml, renderMarkdownHtml } from "./markdown-primitive";
 
@@ -191,27 +192,6 @@ function MarkdownBlockInner({
     };
   }, []);
 
-  useEffect(() => {
-    if (streaming || !hasFencedCodeBlock(text)) {
-      setHighlightedHtml(null);
-      return;
-    }
-
-    let cancelled = false;
-    void renderHighlightedMarkdownHtml(text).then((html) => {
-      if (!cancelled && html.trim()) {
-        setHighlightedHtml({ text, html });
-      }
-    }).catch(() => {
-      if (!cancelled) {
-        setHighlightedHtml(null);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [streaming, text]);
-
   const candidate = useMemo<RenderedMarkdown>(() => {
     if (!streaming && highlightedHtml?.text === text) return { kind: "document", html: highlightedHtml.html };
     if (streamedBlocks) return { kind: "blocks", blocks: streamedBlocks };
@@ -228,6 +208,30 @@ function MarkdownBlockInner({
   const isEmpty = rendered.kind === "document"
     ? !rendered.html
     : rendered.blocks.every((block) => !block.__html);
+
+  useEffect(() => {
+    if (streaming || !hasFencedCodeBlock(text)) {
+      setHighlightedHtml(null);
+      return;
+    }
+    // Selection stability commits the settled document on a later render. Wait
+    // for that keyed root, not the streaming root that is about to be removed.
+    const root = rootRef.current;
+    if (!root || isEmpty || rendered.kind !== "document") return;
+    let cancelled = false;
+    const stopObserving = enhanceNearViewport([root], () => {
+      void renderHighlightedMarkdownHtml(text).then((html) => {
+        if (!cancelled && html.trim()) setHighlightedHtml({ text, html });
+      }).catch(() => {
+        if (!cancelled) setHighlightedHtml(null);
+      });
+    });
+    return () => {
+      cancelled = true;
+      stopObserving();
+    };
+  }, [isEmpty, rendered.kind, streaming, text]);
+
   useMermaidEnhancer(rootRef, rendered, !streaming);
 
   useEffect(() => {

--- a/apps/app/src/components/markdown/mermaid.ts
+++ b/apps/app/src/components/markdown/mermaid.ts
@@ -1,6 +1,7 @@
 import DOMPurify from "dompurify";
 import { useEffect, useSyncExternalStore, type RefObject } from "react";
 import type { MermaidConfig } from "mermaid";
+import { enhanceNearViewport } from "./near-viewport";
 
 import {
   getResolvedThemeMode,
@@ -408,10 +409,13 @@ export function useMermaidEnhancer(
     };
 
     root.addEventListener("click", handleClick);
-    for (const diagram of diagrams) void enhanceMermaidElement(diagram, theme, controller.signal);
+    const stopObserving = enhanceNearViewport(diagrams, (diagram) => {
+      void enhanceMermaidElement(diagram, theme, controller.signal);
+    });
 
     return () => {
       controller.abort();
+      stopObserving();
       root.removeEventListener("click", handleClick);
     };
   }, [content, enabled, rootRef, theme]);

--- a/apps/app/src/components/markdown/near-viewport.ts
+++ b/apps/app/src/components/markdown/near-viewport.ts
@@ -1,0 +1,23 @@
+/** Keep readable markup in the document; only defer its optional enhancements. */
+export function enhanceNearViewport(elements: HTMLElement[], enhance: (element: HTMLElement) => void) {
+  const pending = new Set(elements);
+  if (!pending.size) return () => {};
+  if (typeof IntersectionObserver === "undefined") {
+    elements.forEach(enhance);
+    return () => {};
+  }
+
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting || !(entry.target instanceof HTMLElement) || !pending.delete(entry.target)) continue;
+      observer.unobserve(entry.target);
+      enhance(entry.target);
+    }
+    if (!pending.size) observer.disconnect();
+  }, { rootMargin: "320px 0px" });
+  for (const element of pending) observer.observe(element);
+  return () => {
+    pending.clear();
+    observer.disconnect();
+  };
+}

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -9,6 +9,7 @@ import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelOption, Mod
 import { t } from "@/i18n";
 import type { ComposerSettingsSection } from "@/react-app/domains/settings/library";
 import { ReactSessionComposer } from "@/react-app/domains/session/surface/composer/composer";
+import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge";
 import { WorkspaceRunModeMenu } from "@/react-app/domains/session/surface/composer/workspace-run-mode-menu";
 import {
   snapshotComposerSessionState,
@@ -126,8 +127,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const [pastedText, setPastedText] = useState<PastedTextChip[]>([]);
   const submittingRef = useRef(false);
   const draftRevisionRef = useRef(0);
-  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
-  const [preparingAttachments, setPreparingAttachments] = useState(false);
+  const [pendingSubmission, setPendingSubmission] = useState<ComposerSessionState | null>(null);
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [failedSubmission, setFailedSubmission] = useState<ComposerSessionState | null>(null);
   const draftRef = useRef(props.draft);
@@ -167,8 +167,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       setAttachments([]);
       setMentions({});
       setPastedText([]);
-      setPendingPrompt(null);
-      setPreparingAttachments(false);
+      setPendingSubmission(null);
       setSubmissionError(null);
       setFailedSubmission(null);
     }
@@ -189,6 +188,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const updateAttachments = (next: ComposerAttachment[]) => {
     const holder = continuationHolderRef.current;
     if (holder.frozen) return;
+    draftRevisionRef.current += 1;
     holder.state = { ...holder.state, attachments: next };
     setAttachments(next);
   };
@@ -196,6 +196,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const updateMentions = (next: Record<string, ComposerMentionKind>) => {
     const holder = continuationHolderRef.current;
     if (holder.frozen) return;
+    draftRevisionRef.current += 1;
     holder.state = { ...holder.state, mentions: next };
     setMentions(next);
   };
@@ -203,6 +204,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const updatePasteParts = (next: PastedTextChip[]) => {
     const holder = continuationHolderRef.current;
     if (holder.frozen) return;
+    draftRevisionRef.current += 1;
     holder.state = { ...holder.state, pasteParts: next };
     setPastedText(next);
   };
@@ -370,19 +372,15 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     const revision = draftRevisionRef.current;
     const submitted = snapshotComposerSessionState({ ...submissionHolder.state, draft: originalDraft });
     const resolved = resolvePastedTextPlaceholders(originalDraft, submitted.pasteParts);
-    if (!submitted.attachments.length) setPendingPrompt(resolved.replace(/\[attachment [^\]]+\]/g, ""));
-    setPreparingAttachments(submitted.attachments.length > 0);
+    setPendingSubmission(submitted);
     setSubmissionError(null);
-    // Attachment drafts stay visible through session creation and are handed
-    // to the session composer, which clears them only after preparation.
-    if (!submitted.attachments.length) {
-      props.onDraftChange("");
-      draftRef.current = "";
-      submissionHolder.state = emptyNewTaskComposerState();
-      setAttachments([]);
-      setMentions({});
-      setPastedText([]);
-    }
+    // Transfer the files and preview URLs to the pending turn before clearing input.
+    props.onDraftChange("");
+    draftRef.current = "";
+    submissionHolder.state = emptyNewTaskComposerState();
+    setAttachments([]);
+    setMentions({});
+    setPastedText([]);
     try {
       await props.onRunTask(resolved, submitted.attachments, {
         submitted,
@@ -390,16 +388,13 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       });
     } catch (error) {
       if (continuationHolderRef.current !== submissionHolder || submissionHolder.frozen) return;
-      if (!submitted.attachments.length) {
-        if (draftRevisionRef.current === revision && !draftRef.current) {
-          restoreComposer(submitted);
-        } else {
-          setFailedSubmission(submitted);
-        }
+      if (draftRevisionRef.current === revision && !draftRef.current) {
+        restoreComposer(submitted);
+      } else {
+        setFailedSubmission(submitted);
       }
       setSubmissionError(error instanceof Error ? error.message : "Could not create the conversation. Try again.");
-      setPendingPrompt(null);
-      setPreparingAttachments(false);
+      setPendingSubmission(null);
       submittingRef.current = false;
     }
   };
@@ -412,9 +407,15 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
 
   return (
     <>
-    {pendingPrompt !== null ? <div className="mb-4 whitespace-pre-wrap rounded-xl bg-muted px-4 py-3 text-sm" data-message-role="user">
-      {pendingPrompt}
+    {pendingSubmission ? <div className="mb-4 whitespace-pre-wrap rounded-xl bg-muted px-4 py-3 text-sm" data-message-role="user">
+      {resolvePastedTextPlaceholders(pendingSubmission.draft, pendingSubmission.pasteParts).replace(/\[attachment [^\]]+\]/g, "")}
+      {pendingSubmission.attachments.map((attachment) => <span key={attachment.id} className="mx-1 inline-flex align-middle">
+        {attachment.kind === "image" && attachment.previewUrl
+          ? <ImageAttachmentBadge src={attachment.previewUrl} alt={attachment.name} />
+          : attachment.name}
+      </span>)}
     </div> : null}
+    {pendingSubmission?.attachments.length ? <div role="status" className="mb-2 text-xs text-muted-foreground">Creating conversation...</div> : null}
     {submissionError ? <div role="alert" className="mb-2 text-sm text-red-11">{submissionError}</div> : null}
     {failedSubmission ? <button type="button" disabled={Boolean(props.draft || attachments.length)} className="mb-2 text-sm disabled:opacity-50" onClick={() => {
       restoreComposer(failedSubmission);
@@ -431,7 +432,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onStop={noop}
       busy={false}
       steering={false}
-      submissionPreparing={props.busy || pendingPrompt !== null || preparingAttachments || failedSubmission !== null}
+      submissionPreparing={props.busy || pendingSubmission !== null || failedSubmission !== null}
       queuedCount={0}
       disabled={Boolean(context?.modelUnavailable)}
       modelUnavailable={context?.modelUnavailable}
@@ -447,7 +448,6 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onModelPickerOpenChange={context?.onModelPickerOpenChange ?? noop}
       onModelChange={context?.onModelChange ?? noop}
       attachments={attachments}
-      attachmentsUploading={preparingAttachments}
       onAttachFiles={handleAttachFiles}
       onRemoveAttachment={handleRemoveAttachment}
       attachmentsEnabled

--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -36,7 +36,13 @@ export function snapshotComposerSessionState(state: ComposerSessionState): Compo
 
 export type ComposerStateStore = {
   failedDrafts: Record<string, ComposerSessionState[]>;
-  pendingMessages: Record<string, { draft: ComposerDraft & { messageId: string }; previousMessageIds: string[] }[]>;
+  pendingMessages: Record<string, {
+    draft: ComposerDraft & { messageId: string };
+    previousMessageIds: string[];
+    serverMessageId?: string;
+    preparedText?: string;
+    settled: boolean;
+  }[]>;
   pendingFocusSessionId: string | null;
   sessions: Record<string, ComposerSessionState>;
   queuedDrafts: Record<string, QueuedComposerItem[]>;

--- a/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
@@ -1,38 +1,21 @@
-import { useCallback, useEffect, useRef, type RefObject, type UIEventHandler } from "react";
+import { useCallback, useLayoutEffect, useRef, type RefObject, type UIEventHandler } from "react";
 
-import { getSessionScrollState, useSessionScrollStore, type SessionScrollState } from "./scroll-store";
-
-function readScrollState(sessionId: string | null): SessionScrollState {
-  return getSessionScrollState(useSessionScrollStore.getState().sessions, sessionId);
-}
-
-function isStickyBottom(sessionId: string | null) {
-  return readScrollState(sessionId).mode === "stickyBottom";
-}
+import { flushSessionScrollState, getSessionScrollState, useSessionScrollStore, type SessionScrollAnchor } from "./scroll-store";
 
 const EXACT_BOTTOM_GAP_PX = 1;
-// Widened from 250ms so a single wheel or trackpad flick isn't missed between
-// two rapid programmatic scroll-to-bottom frames during streaming.
 const SCROLL_GESTURE_WINDOW_MS = 600;
-// Threshold (px) that counts as a meaningful "scroll upward" gesture. Anything
-// smaller is treated as anchoring jitter and ignored so we don't trip out of
-// sticky bottom mode for pixel-level content growth.
-const MANUAL_BROWSE_UPWARD_THRESHOLD_PX = 16;
 
 type SessionScrollControllerOptions = {
   selectedSessionId: string | null;
   submittedMessageId: string | null;
+  historyReady: boolean;
   renderedMessages: unknown;
   containerRef: RefObject<HTMLDivElement | null>;
   contentRef: RefObject<HTMLDivElement | null>;
 };
 
-function scrollBottomGap(container: HTMLElement) {
-  return container.scrollHeight - (container.scrollTop + container.clientHeight);
-}
-
 function isExactlyAtBottom(container: HTMLElement) {
-  return scrollBottomGap(container) <= EXACT_BOTTOM_GAP_PX;
+  return container.scrollHeight - (container.scrollTop + container.clientHeight) <= EXACT_BOTTOM_GAP_PX;
 }
 
 function messageIdForElement(element: HTMLElement) {
@@ -40,345 +23,324 @@ function messageIdForElement(element: HTMLElement) {
   return id && id.length > 0 ? id : null;
 }
 
-function latestMessageElement(container: HTMLElement) {
-  const messageEls = container.querySelectorAll("[data-message-id]");
-  for (let index = messageEls.length - 1; index >= 0; index -= 1) {
-    const element = messageEls.item(index);
-    if (element instanceof HTMLElement) return element;
-  }
-  return null;
-}
-
 function messageElementById(container: HTMLElement, messageId: string) {
-  const messageEls = container.querySelectorAll("[data-message-id]");
-  for (const element of messageEls) {
-    if (!(element instanceof HTMLElement)) continue;
+  for (const element of container.querySelectorAll<HTMLElement>("[data-message-id]")) {
     if (messageIdForElement(element) === messageId) return element;
   }
   return null;
 }
 
-function latestMessageTopClippedId(container: HTMLElement) {
-  const latestMessage = latestMessageElement(container);
-  if (!latestMessage) return null;
+function readingAnchor(container: HTMLElement): SessionScrollAnchor | undefined {
+  const viewport = container.getBoundingClientRect();
+  for (const element of container.querySelectorAll<HTMLElement>("[data-message-id]")) {
+    const rect = element.getBoundingClientRect();
+    const messageId = messageIdForElement(element);
+    if (messageId && rect.height > 0 && rect.bottom > viewport.top && rect.top < viewport.bottom) {
+      return { messageId, offset: rect.top - viewport.top };
+    }
+  }
+  return undefined;
+}
 
-  const messageId = messageIdForElement(latestMessage);
-  if (!messageId) return null;
+function latestMessageTopClippedId(container: HTMLElement) {
+  const messages = container.querySelectorAll<HTMLElement>("[data-message-id]");
+  const latestMessage = messages.item(messages.length - 1);
+  if (!latestMessage) return null;
 
   const containerRect = container.getBoundingClientRect();
   const latestRect = latestMessage.getBoundingClientRect();
   const lastMessageDoesNotFit = latestRect.height > containerRect.height + 1;
   const startVisible = latestRect.top >= containerRect.top - 1 && latestRect.top <= containerRect.bottom + 1;
-
-  return lastMessageDoesNotFit && !startVisible ? messageId : null;
+  return lastMessageDoesNotFit && !startVisible ? messageIdForElement(latestMessage) : null;
 }
 
-export function useSessionScrollController(
-  options: SessionScrollControllerOptions,
-) {
-  const selectedSessionId = options.selectedSessionId;
-  const setStickyBottom = useSessionScrollStore((state) => state.setStickyBottom);
-  const setManualScroll = useSessionScrollStore((state) => state.setManualScroll);
-  const setTopClippedMessageId = useSessionScrollStore((state) => state.setTopClippedMessageId);
+type ScrollController = {
+  sessionId: string | null;
+  update: (historyReady: boolean, submittedMessageId: string | null) => void;
+  handleScroll: UIEventHandler<HTMLDivElement>;
+  markScrollGesture: (target?: EventTarget | null) => void;
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+  jumpToStartOfMessage: (behavior?: ScrollBehavior) => void;
+};
 
-  const lastKnownScrollTopRef = useRef(0);
-  const programmaticScrollRef = useRef(false);
-  const positioningRafRef = useRef<number | undefined>(undefined);
-  const programmaticScrollResetRafARef = useRef<number | undefined>(undefined);
-  const programmaticScrollResetRafBRef = useRef<number | undefined>(undefined);
-  const observedContentHeightRef = useRef(0);
-  const lastGestureAtRef = useRef(0);
-  const previousSessionIdRef = useRef<string | null>(null);
-  const revealedMessageIdRef = useRef<string | null>(null);
+export function useSessionScrollController(options: SessionScrollControllerOptions) {
+  const { selectedSessionId, containerRef, contentRef } = options;
+  const controllerRef = useRef<ScrollController | null>(null);
+  // Consumed (including cancelled) submissions survive session effect recreation.
+  const submittedMessagesRef = useRef(new Set<string>());
 
-  const hasScrollGesture = useCallback(
-    () => Date.now() - lastGestureAtRef.current < SCROLL_GESTURE_WINDOW_MS,
-    [],
-  );
+  // Every observer, frame and DOM reference belongs to this committed session.
+  // Cleanup never saves from the DOM: React may already have replaced its history.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
 
-  const updateOverflowAnchor = useCallback(() => {
-    const container = options.containerRef.current;
-    if (!container) return;
-    container.style.overflowAnchor = isStickyBottom(selectedSessionId) ? "none" : "auto";
-  }, [options.containerRef, selectedSessionId]);
-
-  const markScrollGesture = useCallback(
-    (target?: EventTarget | null) => {
-      const container = options.containerRef.current;
-      if (!container) return;
-
-      const el = target instanceof Element ? target : undefined;
-      const nested = el?.closest("[data-scrollable]");
-      if (nested && nested !== container) return;
-
-      lastGestureAtRef.current = Date.now();
-    },
-    [options.containerRef],
-  );
-
-  const clearProgrammaticScrollReset = useCallback(() => {
-    if (programmaticScrollResetRafARef.current !== undefined) {
-      window.cancelAnimationFrame(programmaticScrollResetRafARef.current);
-      programmaticScrollResetRafARef.current = undefined;
-    }
-    if (programmaticScrollResetRafBRef.current !== undefined) {
-      window.cancelAnimationFrame(programmaticScrollResetRafBRef.current);
-      programmaticScrollResetRafBRef.current = undefined;
-    }
-  }, []);
-
-  const clearPendingPosition = useCallback(() => {
-    if (positioningRafRef.current === undefined) return;
-    window.cancelAnimationFrame(positioningRafRef.current);
-    positioningRafRef.current = undefined;
-  }, []);
-
-  const releaseProgrammaticScrollSoon = useCallback(() => {
-    clearProgrammaticScrollReset();
-    programmaticScrollResetRafARef.current = window.requestAnimationFrame(() => {
-      programmaticScrollResetRafARef.current = undefined;
-      programmaticScrollResetRafBRef.current = window.requestAnimationFrame(() => {
-        programmaticScrollResetRafBRef.current = undefined;
-        programmaticScrollRef.current = false;
+    const store = useSessionScrollStore.getState();
+    const readState = () => getSessionScrollState(useSessionScrollStore.getState().sessions, selectedSessionId);
+    let active = true;
+    let historyReady = false;
+    let pendingRestore = true;
+    let pendingSubmittedMessageId: string | null = null;
+    let cancelledWhileLoading = false;
+    let smoothJump = false;
+    let activePointerId: number | null = null;
+    let pointerScrolled = false;
+    let gestureBeforePointer = -Infinity;
+    let lastGestureAt = -Infinity;
+    let lastKnownScrollTop = container.scrollTop;
+    const frames = new Set<number>();
+    const hasScrollGesture = () => activePointerId !== null || Date.now() - lastGestureAt < SCROLL_GESTURE_WINDOW_MS;
+    const scheduleFrame = (callback: () => void) => {
+      const id = window.requestAnimationFrame(() => {
+        if (!frames.delete(id) || !active) return;
+        callback();
       });
-    });
-  }, [clearProgrammaticScrollReset]);
-
-  const refreshTopClippedMessage = useCallback(() => {
-    const container = options.containerRef.current;
-    const nextId = container ? latestMessageTopClippedId(container) : null;
-    setTopClippedMessageId(selectedSessionId, nextId);
-    return nextId;
-  }, [options.containerRef, selectedSessionId, setTopClippedMessageId]);
-
-  const scrollToBottom = useCallback(
-    (behavior: ScrollBehavior = "auto") => {
-      const container = options.containerRef.current;
-      if (!container) return;
-
-      setStickyBottom(selectedSessionId, null);
-      programmaticScrollRef.current = true;
-      clearPendingPosition();
-
-      if (behavior === "smooth") {
-        container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
-        releaseProgrammaticScrollSoon();
+      frames.add(id);
+    };
+    const cancelFrames = () => {
+      for (const id of frames) window.cancelAnimationFrame(id);
+      frames.clear();
+    };
+    const refreshTopClippedMessage = () => {
+      if (active && historyReady) store.setTopClippedMessageId(selectedSessionId, latestMessageTopClippedId(container));
+    };
+    const scrollToBottom = (behavior: ScrollBehavior = "auto") => {
+      if (!active) return;
+      cancelFrames();
+      pendingRestore = false;
+      pendingSubmittedMessageId = null;
+      cancelledWhileLoading = false;
+      lastGestureAt = -Infinity;
+      store.setStickyBottom(selectedSessionId, null);
+      smoothJump = behavior === "smooth";
+      container.scrollTo({ top: container.scrollHeight, behavior });
+      lastKnownScrollTop = container.scrollTop;
+      if (behavior === "auto") scheduleFrame(() => {
+        container.scrollTop = container.scrollHeight;
+        lastKnownScrollTop = container.scrollTop;
+        refreshTopClippedMessage();
+      });
+    };
+    const anchorTop = (anchor: SessionScrollAnchor) => {
+      const message = messageElementById(container, anchor.messageId);
+      return message ? container.scrollTop + message.getBoundingClientRect().top
+        - container.getBoundingClientRect().top - anchor.offset : null;
+    };
+    const reconcile = () => {
+      if (!active || container.clientHeight === 0) return;
+      if (activePointerId !== null) {
+        refreshTopClippedMessage();
         return;
       }
-
-      container.scrollTop = container.scrollHeight;
-      lastKnownScrollTopRef.current = container.scrollTop;
-      positioningRafRef.current = window.requestAnimationFrame(() => {
-        positioningRafRef.current = undefined;
-        const next = options.containerRef.current;
-        if (!next) {
-          programmaticScrollRef.current = false;
+      if (pendingSubmittedMessageId) {
+        const top = anchorTop({ messageId: pendingSubmittedMessageId, offset: 0 });
+        if (top === null) return;
+        // Sending is explicit navigation, even while history loads. Align an
+        // oversized prompt's start; a short prompt clamps to the bottom.
+        pendingSubmittedMessageId = null;
+        pendingRestore = false;
+        cancelledWhileLoading = false;
+        cancelFrames();
+        if (smoothJump) container.scrollTo({ top: container.scrollTop, behavior: "instant" });
+        smoothJump = false;
+        lastGestureAt = -Infinity;
+        container.scrollTop = top;
+        lastKnownScrollTop = container.scrollTop;
+        const clipped = latestMessageTopClippedId(container);
+        if (isExactlyAtBottom(container)) store.setStickyBottom(selectedSessionId, clipped);
+        else store.setManualScroll(selectedSessionId, container.scrollTop, clipped, readingAnchor(container));
+        return;
+      }
+      if (!historyReady) return;
+      const saved = readState();
+      if (pendingRestore) {
+        pendingRestore = false;
+        if (saved.mode === "manual") {
+          // A bounded snapshot may not contain the old message. Fall back once,
+          // without persisting a clamped position or silently becoming sticky.
+          const top = saved.anchor ? anchorTop(saved.anchor) : null;
+          container.scrollTop = top ?? saved.scrollTop;
+          lastKnownScrollTop = container.scrollTop;
+        } else {
+          scrollToBottom();
+        }
+      } else if (!cancelledWhileLoading) {
+        if (saved.mode === "stickyBottom") {
+          if (!hasScrollGesture() && !isExactlyAtBottom(container)) scrollToBottom();
+        }
+      }
+      refreshTopClippedMessage();
+    };
+    const markScrollGesture = (target?: EventTarget | null) => {
+      if (!active) return;
+      const nested = target instanceof Element ? target.closest("[data-scrollable]") : null;
+      if (nested && nested !== container) return;
+      // Pointer presses may just be clicks. Defer cancelling restoration until
+      // they actually scroll; release without scrolling resumes pending follow.
+      if (activePointerId === null) {
+        cancelledWhileLoading ||= pendingRestore;
+        pendingRestore = false;
+        pendingSubmittedMessageId = null;
+      }
+      cancelFrames();
+      // Stop an in-flight smooth jump too, before the wheel/key moves the view.
+      if (smoothJump) container.scrollTo({ top: container.scrollTop, behavior: "instant" });
+      smoothJump = false;
+      lastGestureAt = Date.now();
+    };
+    const handleScroll: UIEventHandler<HTMLDivElement> = () => {
+      if (!active) return;
+      // Layout clamping and our own anchoring also dispatch scroll events. Only
+      // actual input may replace the saved reading position or change its mode.
+      if (hasScrollGesture() && container.scrollTop !== lastKnownScrollTop) {
+        // Trackpad momentum can outlast the original wheel/touch event.
+        lastGestureAt = Date.now();
+        if (activePointerId !== null) pointerScrolled = true;
+        pendingRestore = false;
+        pendingSubmittedMessageId = null;
+        if (!historyReady) {
+          cancelledWhileLoading = true;
+          lastKnownScrollTop = container.scrollTop;
           return;
         }
-        next.scrollTop = next.scrollHeight;
-        lastKnownScrollTopRef.current = next.scrollTop;
-        refreshTopClippedMessage();
-        releaseProgrammaticScrollSoon();
-      });
-    },
-    [clearPendingPosition, options.containerRef, refreshTopClippedMessage, releaseProgrammaticScrollSoon, selectedSessionId, setStickyBottom],
-  );
-
-  const saveScrollPosition = useCallback(
-    (container: HTMLDivElement) => {
-      const nextTopClippedMessageId = latestMessageTopClippedId(container);
-      if (isExactlyAtBottom(container)) {
-        setStickyBottom(selectedSessionId, nextTopClippedMessageId);
-      } else {
-        setManualScroll(selectedSessionId, container.scrollTop, nextTopClippedMessageId);
-      }
-      return nextTopClippedMessageId;
-    },
-    [selectedSessionId, setManualScroll, setStickyBottom],
-  );
-
-  const handleScroll = useCallback<UIEventHandler<HTMLDivElement>>(
-    (event) => {
-      const container = event.currentTarget;
-      const currentTop = container.scrollTop;
-      const previousTop = lastKnownScrollTopRef.current;
-      const delta = currentTop - previousTop;
-      const scrolledUp = delta <= -MANUAL_BROWSE_UPWARD_THRESHOLD_PX;
-      const userGestured = hasScrollGesture();
-
-      // If the user scrolls up meaningfully while a programmatic scroll is
-      // in flight, abandon the programmatic state and switch to manual browse
-      // immediately. Without this the ResizeObserver's auto-scroll during
-      // streaming keeps re-anchoring us to the bottom and the user can never
-      // actually get away from the tail of the transcript.
-      if (programmaticScrollRef.current && (userGestured || scrolledUp)) {
-        programmaticScrollRef.current = false;
-        clearPendingPosition();
-        clearProgrammaticScrollReset();
-        saveScrollPosition(container);
-        lastKnownScrollTopRef.current = currentTop;
-        return;
-      }
-
-      if (programmaticScrollRef.current) {
-        lastKnownScrollTopRef.current = currentTop;
-        refreshTopClippedMessage();
-        return;
-      }
-
-      if (!userGestured && !scrolledUp) {
+        cancelledWhileLoading = false;
+        const clipped = latestMessageTopClippedId(container);
         if (isExactlyAtBottom(container)) {
-          setStickyBottom(selectedSessionId, latestMessageTopClippedId(container));
+          store.setStickyBottom(selectedSessionId, clipped);
         } else {
-          refreshTopClippedMessage();
+          store.setManualScroll(selectedSessionId, container.scrollTop, clipped, readingAnchor(container));
         }
-        lastKnownScrollTopRef.current = currentTop;
-        return;
+      } else {
+        const saved = readState();
+        // Native anchoring can move scrollTop when a diagram/image expands
+        // inside the reading message. Remember that adjustment for the next
+        // visit, but never persist the initial restore's clamp or missing anchor.
+        if (!pendingRestore && historyReady && container.scrollTop !== lastKnownScrollTop
+          && saved.mode === "manual" && saved.anchor && messageElementById(container, saved.anchor.messageId)) {
+          store.setManualScroll(selectedSessionId, container.scrollTop, latestMessageTopClippedId(container), readingAnchor(container));
+        }
+        refreshTopClippedMessage();
       }
-
-      saveScrollPosition(container);
-      lastKnownScrollTopRef.current = currentTop;
-    },
-    [clearPendingPosition, clearProgrammaticScrollReset, hasScrollGesture, refreshTopClippedMessage, saveScrollPosition, selectedSessionId, setStickyBottom],
-  );
-
-  const jumpToLatest = useCallback(
-    (behavior: ScrollBehavior = "smooth") => {
-      scrollToBottom(behavior);
-    },
-    [scrollToBottom],
-  );
-
-  const jumpToStartOfMessage = useCallback(
-    (behavior: ScrollBehavior = "smooth") => {
-      const messageId = readScrollState(selectedSessionId).topClippedMessageId;
-      const container = options.containerRef.current;
-      if (!messageId || !container) return;
-
-      const target = messageElementById(container, messageId);
-      if (!target) return;
-
-      setManualScroll(selectedSessionId, container.scrollTop, messageId);
-      target.scrollIntoView({ behavior, block: "start" });
-    },
-    [options.containerRef, selectedSessionId, setManualScroll],
-  );
-
-  useEffect(() => {
-    updateOverflowAnchor();
-    return useSessionScrollStore.subscribe(updateOverflowAnchor);
-  }, [updateOverflowAnchor]);
-
-  useEffect(() => {
-    const content = options.contentRef.current;
-    if (!content) return;
-
-    observedContentHeightRef.current = content.offsetHeight;
-    const observer = new ResizeObserver(() => {
-      const nextContent = options.contentRef.current;
-      if (!nextContent) return;
-
-      const nextHeight = nextContent.offsetHeight;
-      const previousContentHeight = observedContentHeightRef.current;
-      const grew = nextHeight > previousContentHeight + 1;
-      observedContentHeightRef.current = nextHeight;
-
-      // Only re-anchor to the bottom when we're already in sticky bottom mode
-      // AND the user isn't actively scrolling. If they've touched the wheel,
-      // touchpad, or scrollbar in the last SCROLL_GESTURE_WINDOW_MS, treat
-      // that as intent to break out of autoscroll and leave their position
-      // alone until the next handleScroll tick reclassifies the mode.
-      if (grew && isStickyBottom(selectedSessionId) && !hasScrollGesture()) {
-        scrollToBottom("auto");
-        return;
-      }
-
-      refreshTopClippedMessage();
-    });
-
-    observer.observe(content);
-    return () => observer.disconnect();
-  }, [hasScrollGesture, options.contentRef, refreshTopClippedMessage, scrollToBottom, selectedSessionId]);
-
-  useEffect(() => {
-    if (selectedSessionId === previousSessionIdRef.current) return;
-    previousSessionIdRef.current = selectedSessionId;
-    clearPendingPosition();
-    if (!selectedSessionId) return;
-
-    observedContentHeightRef.current = 0;
-    lastKnownScrollTopRef.current = 0;
-    queueMicrotask(() => {
-      const container = options.containerRef.current;
-      if (!container) return;
-
-      const savedState = getSessionScrollState(useSessionScrollStore.getState().sessions, selectedSessionId);
-      if (savedState.mode === "manual") {
-        programmaticScrollRef.current = true;
-        container.scrollTop = Math.min(savedState.scrollTop, Math.max(0, container.scrollHeight - container.clientHeight));
-        lastKnownScrollTopRef.current = container.scrollTop;
-        positioningRafRef.current = window.requestAnimationFrame(() => {
-          positioningRafRef.current = undefined;
-          const next = options.containerRef.current;
-          if (!next) {
-            programmaticScrollRef.current = false;
-            return;
-          }
-          next.scrollTop = Math.min(savedState.scrollTop, Math.max(0, next.scrollHeight - next.clientHeight));
-          lastKnownScrollTopRef.current = next.scrollTop;
-          saveScrollPosition(next);
-          releaseProgrammaticScrollSoon();
-        });
-        return;
-      }
-
-      scrollToBottom("auto");
-    });
-  }, [clearPendingPosition, options.containerRef, releaseProgrammaticScrollSoon, saveScrollPosition, scrollToBottom, selectedSessionId]);
-
-  useEffect(() => {
-    void options.renderedMessages;
-    queueMicrotask(refreshTopClippedMessage);
-  }, [options.renderedMessages, refreshTopClippedMessage]);
-
-  useEffect(() => {
-    const messageId = options.submittedMessageId;
-    if (!messageId || messageId === revealedMessageIdRef.current) return;
-    let cancelled = false;
-    // Wait for the submitted row and any session restoration to commit. Sending
-    // is explicit navigation; passive output must still respect manual browsing.
-    queueMicrotask(() => {
-      if (cancelled) return;
-      const container = options.containerRef.current;
-      const target = container && messageElementById(container, messageId);
-      if (!container || !target) return;
-      revealedMessageIdRef.current = messageId;
-      clearPendingPosition();
-      lastGestureAtRef.current = 0;
-      programmaticScrollRef.current = true;
-      const containerRect = container.getBoundingClientRect();
-      const targetRect = target.getBoundingClientRect();
-      // Align the start of an oversized prompt; short prompts clamp to the tail.
-      container.scrollTop += targetRect.top - containerRect.top;
-      lastKnownScrollTopRef.current = container.scrollTop;
-      saveScrollPosition(container);
-      releaseProgrammaticScrollSoon();
-    });
-    return () => { cancelled = true; };
-  }, [clearPendingPosition, options.submittedMessageId, options.renderedMessages, options.containerRef, selectedSessionId, saveScrollPosition, releaseProgrammaticScrollSoon]);
-
-  useEffect(() => {
-    return () => {
-      clearPendingPosition();
-      clearProgrammaticScrollReset();
+      lastKnownScrollTop = container.scrollTop;
     };
-  }, [clearPendingPosition, clearProgrammaticScrollReset]);
+    const jumpToStartOfMessage = (behavior: ScrollBehavior = "smooth") => {
+      if (!active) return;
+      const messageId = readState().topClippedMessageId;
+      if (!messageId) return;
+      const anchor = { messageId, offset: 0 };
+      const top = anchorTop(anchor);
+      if (top === null) return;
+      cancelFrames();
+      pendingRestore = false;
+      pendingSubmittedMessageId = null;
+      cancelledWhileLoading = false;
+      lastGestureAt = -Infinity;
+      store.setManualScroll(selectedSessionId, top, messageId, anchor);
+      smoothJump = behavior === "smooth";
+      container.scrollTo({ top, behavior });
+      lastKnownScrollTop = container.scrollTop;
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.target instanceof Element && event.target.closest("input, textarea, select, [contenteditable=true]")) return;
+      if (["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key)) markScrollGesture(event.target);
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!event.isPrimary || event.button !== 0 || activePointerId !== null) return;
+      const nested = event.target instanceof Element ? event.target.closest("[data-scrollable], input, textarea, select, [contenteditable=true]") : null;
+      if (nested && nested !== container) return;
+      activePointerId = event.pointerId;
+      pointerScrolled = false;
+      gestureBeforePointer = lastGestureAt;
+      cancelFrames();
+      if (smoothJump) container.scrollTo({ top: container.scrollTop, behavior: "instant" });
+      smoothJump = false;
+    };
+    const handlePointerUp = (event: PointerEvent) => {
+      if (event.pointerId !== activePointerId) return;
+      activePointerId = null;
+      lastGestureAt = pointerScrolled ? Date.now() : gestureBeforePointer;
+      if (!pointerScrolled) reconcile();
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "hidden") flushSessionScrollState();
+    };
 
-  return {
-    handleScroll,
-    markScrollGesture,
-    scrollToBottom,
-    jumpToLatest,
-    jumpToStartOfMessage,
-  };
+    // The browser owns manual reflow, including changes inside a long message.
+    // Message-root offsets are only used when restoring a session.
+    const previousOverflowAnchor = container.style.overflowAnchor;
+    const updateOverflowAnchor = () => {
+      const next = readState().mode === "manual" ? "auto" : "none";
+      if (container.style.overflowAnchor !== next) container.style.overflowAnchor = next;
+    };
+    updateOverflowAnchor();
+    const unsubscribeScrollState = useSessionScrollStore.subscribe(updateOverflowAnchor);
+    const observer = new ResizeObserver(reconcile);
+    observer.observe(content);
+    observer.observe(container);
+    container.addEventListener("keydown", handleKeyDown);
+    container.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+    window.addEventListener("pagehide", flushSessionScrollState);
+    document.addEventListener("visibilitychange", handleVisibility);
+    controllerRef.current = {
+      sessionId: selectedSessionId,
+      update: (ready, messageId) => {
+        historyReady = ready;
+        if (!messageId) pendingSubmittedMessageId = null;
+        else {
+          const key = JSON.stringify([selectedSessionId, messageId]);
+          if (!submittedMessagesRef.current.has(key)) {
+            submittedMessagesRef.current.add(key);
+            pendingSubmittedMessageId = messageId;
+            cancelFrames();
+          }
+        }
+        reconcile();
+      },
+      handleScroll,
+      markScrollGesture,
+      scrollToBottom,
+      jumpToStartOfMessage,
+    };
+
+    return () => {
+      active = false;
+      cancelFrames();
+      if (smoothJump) container.scrollTo({ top: container.scrollTop, behavior: "instant" });
+      observer.disconnect();
+      unsubscribeScrollState();
+      container.removeEventListener("keydown", handleKeyDown);
+      container.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      window.removeEventListener("pagehide", flushSessionScrollState);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      container.style.overflowAnchor = previousOverflowAnchor;
+      controllerRef.current = null;
+      flushSessionScrollState();
+    };
+  }, [selectedSessionId, containerRef, contentRef]);
+
+  useLayoutEffect(() => {
+    controllerRef.current?.update(options.historyReady, options.submittedMessageId);
+  }, [selectedSessionId, containerRef, contentRef, options.historyReady, options.submittedMessageId, options.renderedMessages]);
+
+  const handleScroll = useCallback<UIEventHandler<HTMLDivElement>>((event) => {
+    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.handleScroll(event);
+  }, [selectedSessionId]);
+  const markScrollGesture = useCallback((target?: EventTarget | null) => {
+    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.markScrollGesture(target);
+  }, [selectedSessionId]);
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
+    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.scrollToBottom(behavior);
+  }, [selectedSessionId]);
+  const jumpToLatest = useCallback((behavior: ScrollBehavior = "smooth") => scrollToBottom(behavior), [scrollToBottom]);
+  const jumpToStartOfMessage = useCallback((behavior: ScrollBehavior = "smooth") => {
+    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.jumpToStartOfMessage(behavior);
+  }, [selectedSessionId]);
+
+  return { handleScroll, markScrollGesture, scrollToBottom, jumpToLatest, jumpToStartOfMessage };
 }

--- a/apps/app/src/react-app/domains/session/surface/scroll-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-store.ts
@@ -1,6 +1,9 @@
 import { create } from "zustand";
 
 const SESSION_SCROLL_STORAGE_KEY = "openwork:session-scroll:v1";
+const PERSIST_DELAY_MS = 250;
+
+export type SessionScrollAnchor = { messageId: string; offset: number };
 
 type StickyBottomSessionScrollState = {
   mode: "stickyBottom";
@@ -10,6 +13,7 @@ type StickyBottomSessionScrollState = {
 type ManualSessionScrollState = {
   mode: "manual";
   scrollTop: number;
+  anchor?: SessionScrollAnchor;
   topClippedMessageId: string | null;
 };
 
@@ -45,6 +49,10 @@ function normalizeSessionScrollState(value: unknown): SessionScrollState | null 
   return {
     mode: "manual",
     scrollTop: Math.max(0, Math.round(value.scrollTop)),
+    ...(isRecord(value.anchor) && typeof value.anchor.messageId === "string" && value.anchor.messageId.trim()
+      && typeof value.anchor.offset === "number" && Number.isFinite(value.anchor.offset)
+      ? { anchor: { messageId: value.anchor.messageId, offset: value.anchor.offset } }
+      : {}),
     topClippedMessageId,
   };
 }
@@ -74,7 +82,13 @@ function persistSessionScrollState(sessions: SessionScrollStateById): void {
   if (globalThis.window === undefined) return;
 
   try {
-    window.localStorage.setItem(SESSION_SCROLL_STORAGE_KEY, JSON.stringify(sessions));
+    // Clipped-message controls are presentation state, not a reading position.
+    const positions = Object.fromEntries(Object.entries(sessions).map(([id, state]) => [id,
+      state.mode === "manual"
+        ? { mode: state.mode, scrollTop: state.scrollTop, anchor: state.anchor }
+        : { mode: state.mode },
+    ]));
+    window.localStorage.setItem(SESSION_SCROLL_STORAGE_KEY, JSON.stringify(positions));
   } catch {
     return;
   }
@@ -125,6 +139,7 @@ function setSessionManualScroll(
   sessionId: string | null | undefined,
   scrollTop: number,
   topClippedMessageId: string | null,
+  anchor?: SessionScrollAnchor,
 ): SessionScrollStateById {
   if (!sessionId) return sessions;
 
@@ -133,6 +148,8 @@ function setSessionManualScroll(
   if (
     current.mode === "manual" &&
     current.scrollTop === nextScrollTop &&
+    current.anchor?.messageId === anchor?.messageId &&
+    current.anchor?.offset === anchor?.offset &&
     current.topClippedMessageId === topClippedMessageId
   ) {
     return sessions;
@@ -140,7 +157,7 @@ function setSessionManualScroll(
 
   return {
     ...sessions,
-    [sessionId]: { mode: "manual", scrollTop: nextScrollTop, topClippedMessageId },
+    [sessionId]: { mode: "manual", scrollTop: nextScrollTop, topClippedMessageId, anchor },
   };
 }
 
@@ -163,7 +180,7 @@ function setSessionTopClippedMessageId(
 type SessionScrollStore = {
   sessions: SessionScrollStateById;
   setStickyBottom: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
-  setManualScroll: (sessionId: string | null | undefined, scrollTop: number, topClippedMessageId: string | null) => void;
+  setManualScroll: (sessionId: string | null | undefined, scrollTop: number, topClippedMessageId: string | null, anchor?: SessionScrollAnchor) => void;
   setTopClippedMessageId: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
 };
 
@@ -171,10 +188,12 @@ export const useSessionScrollStore = create<SessionScrollStore>((set) => ({
   sessions: readPersistedSessionScrollState(),
   setStickyBottom: (sessionId, topClippedMessageId) => set((state) => {
     const sessions = setSessionStickyBottom(state.sessions, sessionId, topClippedMessageId);
+    schedulePersistence(getSessionScrollState(state.sessions, sessionId), getSessionScrollState(sessions, sessionId));
     return sessions === state.sessions ? state : { sessions };
   }),
-  setManualScroll: (sessionId, scrollTop, topClippedMessageId) => set((state) => {
-    const sessions = setSessionManualScroll(state.sessions, sessionId, scrollTop, topClippedMessageId);
+  setManualScroll: (sessionId, scrollTop, topClippedMessageId, anchor) => set((state) => {
+    const sessions = setSessionManualScroll(state.sessions, sessionId, scrollTop, topClippedMessageId, anchor);
+    schedulePersistence(getSessionScrollState(state.sessions, sessionId), getSessionScrollState(sessions, sessionId));
     return sessions === state.sessions ? state : { sessions };
   }),
   setTopClippedMessageId: (sessionId, topClippedMessageId) => set((state) => {
@@ -183,4 +202,21 @@ export const useSessionScrollStore = create<SessionScrollStore>((set) => ({
   }),
 }));
 
-useSessionScrollStore.subscribe((state) => persistSessionScrollState(state.sessions));
+let persistTimer: ReturnType<typeof setTimeout> | undefined;
+
+export function flushSessionScrollState() {
+  if (persistTimer === undefined) return;
+  clearTimeout(persistTimer);
+  persistTimer = undefined;
+  persistSessionScrollState(useSessionScrollStore.getState().sessions);
+}
+
+function schedulePersistence(before: SessionScrollState, next: SessionScrollState) {
+  const changed = before.mode !== next.mode || (next.mode === "manual" && before.mode === "manual" && (
+    next.scrollTop !== before.scrollTop || next.anchor?.messageId !== before.anchor?.messageId
+    || next.anchor?.offset !== before.anchor?.offset
+  ));
+  if (!changed) return;
+  clearTimeout(persistTimer);
+  persistTimer = setTimeout(flushSessionScrollState, PERSIST_DELAY_MS);
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -9,7 +9,7 @@ import { toast } from "@/components/ui/sonner";
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
 import { interruptSessionTurn, sessionNeedsStop, submitAfterInterruption, subscribeSessionInterruption } from "@/app/lib/opencode-interruption";
 import { createClient, createPromptMessageID, hasAcceptedPromptMessage, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
-import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
+import { createClientV2, isOpencodeV2BaseUrl, v2PromptText } from "@/app/lib/opencode-v2-adapter";
 import * as opencodeSessionNative from "@/app/lib/opencode-session-native";
 import type { NativeSessionSnapshotTarget } from "@/app/lib/opencode-session-native";
 import { isDesktopRuntime } from "@/app/lib/runtime-env";
@@ -119,6 +119,7 @@ import {
   getComposerRevertMessageId,
   getComposerSessionDraftScope,
   persistableComposerDraftText,
+  snapshotComposerSessionState,
   type ComposerSessionState,
   useComposerStateStore,
 } from "./composer-state-store";
@@ -601,7 +602,7 @@ export type SessionSurfaceProps = {
   onRefreshOrganizationModels?: () => void | Promise<void>;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef, variant?: string | null) => void;
-  onSendDraft: (draft: ComposerDraft, sessionId: string, onPrepared?: () => void) => Promise<CloudMcpSubmissionResult>;
+  onSendDraft: (draft: ComposerDraft, sessionId: string, onPrepared?: (text?: string) => void) => Promise<CloudMcpSubmissionResult>;
   cloudMcpSubmissionState: CloudMcpSubmissionGateState;
   onOpenConnect: () => void;
   onDraftChange: (draft: ComposerDraft) => void;
@@ -952,6 +953,46 @@ function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }
   URL.revokeObjectURL(attachment.previewUrl);
 }
 
+function revokeUnownedAttachmentPreviews(attachments: ComposerAttachment[]) {
+  const state = useComposerStateStore.getState();
+  const retained = [
+    ...Object.values(state.sessions),
+    ...Object.values(state.failedDrafts).flat(),
+    ...Object.values(state.queuedDrafts).flat().map((item) => item.draft),
+    ...Object.values(state.pendingMessages).flat().map((item) => item.draft),
+  ].flatMap((item) => item.attachments);
+  for (const attachment of attachments) {
+    if (!retained.some((item) => item.previewUrl === attachment.previewUrl)) revokeAttachmentPreview(attachment);
+  }
+}
+
+function pendingMessageParts(text: string, attachments: ComposerAttachment[], serverParts: UIMessage["parts"] = []) {
+  const parts = [...serverParts];
+  if (text && !parts.some((part) => part.type === "text" && part.text)) parts.unshift({ type: "text", text });
+  const matched = new Set<number>();
+  let attachmentsReady = true;
+  for (const attachment of attachments) {
+    const filename = resolveAttachmentFileMetadata(attachment.file).filename;
+    // Compression can change an image's extension, but never its submitted bytes here.
+    const compressedFilename = attachment.kind === "image"
+      ? resolveAttachmentFileMetadata({ name: `${attachment.file.name.replace(/\.[^.]+$/, "") || "image"}.jpg`, type: "image/jpeg" }).filename
+      : filename;
+    const index = serverParts.findIndex((part, index) => !matched.has(index) && part.type === "file"
+      && (part.filename === filename || part.filename === compressedFilename));
+    if (index >= 0) matched.add(index);
+    const part = serverParts[index];
+    const usable = part?.type === "file" && (attachment.kind === "image"
+      ? part.mediaType.startsWith("image/") && /^(data:image\/|https?:\/\/)/.test(part.url)
+      : /^(data:|file:\/\/|https?:\/\/)/.test(part.url));
+    if (usable) continue;
+    attachmentsReady = false;
+    const preview = { type: "file", filename: attachment.name, mediaType: attachment.mimeType, url: attachment.previewUrl ?? "" } satisfies UIMessage["parts"][number];
+    if (part) parts[parts.indexOf(part)] = preview;
+    else parts.push(preview);
+  }
+  return { parts, attachmentsReady };
+}
+
 function draftWithEditedText(draft: ComposerDraft, text: string): ComposerDraft {
   return {
     ...draft,
@@ -997,8 +1038,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
   const draft = useComposerStateStore((state) => getComposerDraft(state, props.sessionId));
   const attachments = useComposerStateStore((state) => getComposerAttachments(state, props.sessionId));
-  // True while a send with attachments is in flight (compression + inbox
-  // upload + prompt POST); drives the uploading overlay on composer chips.
+  // Preparation belongs to the submitted message, not the next composer draft.
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
   const mentions = useComposerStateStore((state) => getComposerMentions(state, props.sessionId));
   const pasteParts = useComposerStateStore((state) => getComposerPasteParts(state, props.sessionId));
@@ -1440,38 +1480,55 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const failedDraft = useComposerStateStore((state) => state.failedDrafts[sessionOwner]?.[0]);
   const autoSendPayload = getComposerAutoSendPayload(props.sessionId, sessionOwner);
   const autoSending = (Boolean(autoSendPayload)
-    || (hasComposerAutoSend(props.sessionId) && attachments.length === 0))
+    || hasComposerAutoSend(props.sessionId))
     && !sessionModelUnavailable;
-  const unmatchedPendingMessages = useMemo(() => {
+  const pendingReconciliation = useMemo(() => {
     const matchedIds = new Set<string>();
-    const remaining = (pendingMessages ?? []).filter(({ draft: pending, previousMessageIds }) => {
+    const messages = [...baseRenderedMessages];
+    const remaining = (pendingMessages ?? []).flatMap((item) => {
+      const { draft: pending, previousMessageIds } = item;
+      const text = pending.resolvedText ?? pending.text;
+      // Native v2 assigns its own ID and may never expose files in the transcript.
+      // Upload paths and filename changes must come from the prepared request, not a guess.
+      const acknowledgementText = item.preparedText ?? (pending.attachments.length ? undefined : text);
       const match = baseRenderedMessages.find((message) => message.role === "user"
         && !matchedIds.has(message.id)
-        && (message.id === pending.messageId || (isOpencodeV2BaseUrl(props.opencodeBaseUrl) && !previousMessageIds.includes(message.id)
-          && message.parts.some((part) => part.type === "text" && part.text === (pending.resolvedText ?? pending.text)))));
-      if (!match) return true;
+        && (message.id === (item.serverMessageId ?? pending.messageId) || (!item.serverMessageId && isOpencodeV2BaseUrl(props.opencodeBaseUrl) && !previousMessageIds.includes(message.id)
+          && Boolean(acknowledgementText?.trim()) && v2PromptText(message.parts) === acknowledgementText)));
+      const { parts, attachmentsReady } = pendingMessageParts(text, pending.attachments, match?.parts);
+      if (!match) {
+        messages.push({ id: pending.messageId, role: "user", parts });
+        return [item];
+      }
       matchedIds.add(match.id);
-      return false;
+      messages[messages.indexOf(match)] = { ...match, parts };
+      const textReady = !text.trim()
+        || match.parts.some((part) => part.type === "text" && part.text.trim());
+      if (attachmentsReady && textReady && item.settled) return [];
+      return [item.serverMessageId === match.id ? item : { ...item, serverMessageId: match.id }];
     });
     // A server turn can acknowledge only one pending send, even when two
     // consecutive prompts have identical text and v2 assigns its own IDs.
-    return matchedIds.size ? remaining.map((item) => ({
-      ...item,
-      previousMessageIds: [...item.previousMessageIds, ...matchedIds],
-    })) : remaining;
+    return { messages, remaining: remaining.map((item) => {
+      const claimed = [...matchedIds].filter((id) => id !== item.serverMessageId && !item.previousMessageIds.includes(id));
+      return claimed.length ? { ...item, previousMessageIds: [...item.previousMessageIds, ...claimed] } : item;
+    }) };
   }, [baseRenderedMessages, pendingMessages, props.opencodeBaseUrl]);
+  const remainingPendingMessages = pendingReconciliation.remaining;
   useEffect(() => {
-    if (!pendingMessages || pendingMessages.length === unmatchedPendingMessages.length) return;
+    if (!pendingMessages || (pendingMessages.length === remainingPendingMessages.length
+      && pendingMessages.every((item, index) => item === remainingPendingMessages[index]))) return;
+    // Another pane or a completed send may have updated the same owner since render.
+    if (useComposerStateStore.getState().pendingMessages[sessionOwner] !== pendingMessages) return;
     useComposerStateStore.setState((state) => ({
-      pendingMessages: { ...state.pendingMessages, [sessionOwner]: unmatchedPendingMessages },
+      pendingMessages: { ...state.pendingMessages, [sessionOwner]: remainingPendingMessages },
     }));
-  }, [pendingMessages, sessionOwner, unmatchedPendingMessages]);
+    revokeUnownedAttachmentPreviews(pendingMessages
+      .filter((item) => !remainingPendingMessages.some((remaining) => remaining.draft === item.draft))
+      .flatMap((item) => item.draft.attachments));
+  }, [pendingMessages, sessionOwner, remainingPendingMessages]);
   const renderedMessages = useMemo(() => {
-    const pending: UIMessage[] = unmatchedPendingMessages.map(({ draft: item }) => ({
-      id: item.messageId,
-      role: "user",
-      parts: [{ type: "text", text: item.resolvedText ?? item.text }],
-    }));
+    const pending: UIMessage[] = [];
     if (autoSending) {
       const pendingComposer = autoSendPayload?.composer;
       const pendingText = pendingComposer?.draft ?? draft;
@@ -1479,11 +1536,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
       if (pendingText.trim() || (pendingComposer?.attachments.length ?? attachments.length)) pending.push({
         id: `${props.sessionId}:first-send`,
         role: "user",
-        parts: [{ type: "text", text: resolvePastedTextPlaceholders(pendingText, pendingPasteParts).replace(/\[attachment [^\]]+\]/g, "") }],
+        parts: pendingMessageParts(resolvePastedTextPlaceholders(pendingText, pendingPasteParts).replace(/\[attachment [^\]]+\]/g, ""), pendingComposer?.attachments ?? attachments).parts,
       });
     }
-    return [...baseRenderedMessages, ...pending, ...evalMarkdownMessages];
-  }, [attachments.length, autoSendPayload, autoSending, baseRenderedMessages, draft, evalMarkdownMessages, pasteParts, props.sessionId, unmatchedPendingMessages]);
+    return [...pendingReconciliation.messages, ...pending, ...evalMarkdownMessages];
+  }, [attachments, autoSendPayload, autoSending, draft, evalMarkdownMessages, pasteParts, pendingReconciliation.messages, props.sessionId]);
   const renderedMessagesRef = useRef(renderedMessages);
   useEffect(() => {
     renderedMessagesRef.current = renderedMessages;
@@ -1965,7 +2022,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Core sender shared by initial send and steered follow-ups. OpenCode
   // accepts follow-up user turns mid-run (steering) — the running loop picks
   // up the new message — so this is safe to call while the agent is busy.
-  const sendDraft = useCallback(async (nextDraft: ComposerDraft, itemId: string, onPrepared?: () => void): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
+  const sendDraft = useCallback(async (nextDraft: ComposerDraft, itemId: string, onPrepared?: (text?: string) => void): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
     const messageId = nextDraft.messageId ?? createPromptMessageID();
     const generation = getQueuedSendGeneration(props.sessionId);
     const submissionId = Symbol();
@@ -2020,48 +2077,49 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // share the same immediate path.
   const handleSend = useCallback(async (sourceComposer?: ComposerSessionState) => {
     if ([...pendingSendsRef.current.values()].includes(sessionOwner)) return;
-    const originalDraft = sourceComposer?.draft ?? draft;
-    const sourceAttachments = sourceComposer?.attachments ?? attachments;
+    const composerCheckpoint = useComposerStateStore.getState().sessions[props.sessionId];
+    const submittedComposer = sourceComposer ?? composerCheckpoint;
+    const originalDraft = submittedComposer?.draft ?? draft;
+    const sourceAttachments = submittedComposer?.attachments ?? attachments;
     const text = originalDraft.trim();
     if (!text && sourceAttachments.length === 0) return;
+    const savedComposer = snapshotComposerSessionState(submittedComposer ?? {
+      draft: originalDraft, attachments: sourceAttachments, mentions, pasteParts, revertMessageId: null,
+    });
+    const sentAttachments = savedComposer.attachments;
     const nextDraft = {
-      ...buildDraft(text, sourceAttachments, sourceComposer),
+      ...buildDraft(text, sentAttachments, savedComposer),
       messageId: createPromptMessageID(),
     };
     // Immediate sends and queued sends share the same slot across all panes.
     dispatchQueuedDrain(props.sessionId, { type: "user_retry" });
     if (!claimQueuedSend(props.sessionId, nextDraft.messageId, true)) return;
-    const sentAttachments = sourceAttachments;
-    const composerCheckpoint = useComposerStateStore.getState().sessions[props.sessionId];
-    const savedComposer = sourceComposer ?? composerCheckpoint;
-    let clearedComposer: typeof savedComposer;
-    let composerCleared = false;
-    let pendingRegistered = false;
-    const registerPending = () => {
-      if (pendingRegistered) return;
-      pendingRegistered = true;
-      setSubmittedMessage({ owner: sessionOwner, id: nextDraft.messageId });
-      useComposerStateStore.setState((state) => ({
-        pendingMessages: {
-          ...state.pendingMessages,
-          [sessionOwner]: [...(state.pendingMessages[sessionOwner] ?? []), {
-            draft: nextDraft,
-            previousMessageIds: baseRenderedMessages.map((message) => message.id),
-          }],
-        },
-      }));
-    };
-    const markPrepared = () => {
-      // Do not erase edits made while attachments were being prepared.
-      if (!sourceComposer
-        && useComposerStateStore.getState().sessions[props.sessionId] === composerCheckpoint
-        && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
-        clearComposer();
-        clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
-        composerCleared = true;
-      }
-      registerPending();
+    for (const attachment of sentAttachments) {
+      if (attachment.kind === "image" && !attachment.previewUrl) attachment.previewUrl = URL.createObjectURL(attachment.file);
+    }
+    setSubmittedMessage({ owner: sessionOwner, id: nextDraft.messageId });
+    useComposerStateStore.setState((state) => ({
+      pendingMessages: {
+        ...state.pendingMessages,
+        [sessionOwner]: [...(state.pendingMessages[sessionOwner] ?? []), {
+          draft: nextDraft,
+          previousMessageIds: baseRenderedMessages.map((message) => message.id),
+          settled: false,
+        }],
+      },
+    }));
+    // A hero handoff owns the submitted snapshot, never a newer continuation.
+    if ((!sourceComposer || sourceComposer === composerCheckpoint)
+      && useComposerStateStore.getState().sessions[props.sessionId] === composerCheckpoint
+      && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) clearComposer();
+    const clearedComposer = useComposerStateStore.getState().sessions[props.sessionId];
+    const markPrepared = (preparedText?: string) => {
       setAttachmentsUploading(false);
+      if (preparedText === undefined) return;
+      useComposerStateStore.setState((state) => ({ pendingMessages: {
+        ...state.pendingMessages,
+        [sessionOwner]: (state.pendingMessages[sessionOwner] ?? []).map((item) => item.draft === nextDraft ? { ...item, preparedText } : item),
+      } }));
     };
     const removePending = () => useComposerStateStore.setState((state) => ({
       pendingMessages: {
@@ -2072,51 +2130,40 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const restore = () => {
       removePending();
       const state = useComposerStateStore.getState();
-      if (!composerCleared) {
-        if (!sourceComposer || !savedComposer) return;
-        if (state.sessions[props.sessionId] === composerCheckpoint
-          && !composerSessionHasContent(composerCheckpoint)
-          && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
-          useComposerStateStore.setState({ sessions: { ...state.sessions, [props.sessionId]: savedComposer } });
-          props.onDraftChange(nextDraft);
-        } else {
-          useComposerStateStore.setState({ failedDrafts: {
-            ...state.failedDrafts,
-            [sessionOwner]: [...(state.failedDrafts[sessionOwner] ?? []), savedComposer],
-          } });
-        }
-        return;
-      }
       // Identity, not text equality: typing and then deleting is still a newer edit.
-      if (savedComposer && state.sessions[props.sessionId] === clearedComposer
+      if (!composerSessionHasContent(clearedComposer) && state.sessions[props.sessionId] === clearedComposer
         && getComposerSessionDraftScope(props.sessionId) === persistedDraftKey) {
         useComposerStateStore.setState({ sessions: { ...state.sessions, [props.sessionId]: savedComposer } });
         props.onDraftChange(nextDraft);
-      } else if (savedComposer) {
+      } else {
         useComposerStateStore.setState({ failedDrafts: {
           ...state.failedDrafts,
           [sessionOwner]: [...(state.failedDrafts[sessionOwner] ?? []), savedComposer],
         } });
       }
     };
-    if (sourceComposer && sentAttachments.length) registerPending();
     if (sentAttachments.length) setAttachmentsUploading(true);
-    else markPrepared();
     try {
-      const result = await sendDraft(nextDraft, nextDraft.messageId, sentAttachments.length ? markPrepared : undefined);
+      const result = await sendDraft(nextDraft, nextDraft.messageId, markPrepared);
       if (result.outcome === "blocked" || result.outcome === "cancelled") {
         restore();
         return;
       }
-      if (result.outcome !== "unknown" && (nextDraft.command || nextDraft.mode === "shell")) removePending();
-      const retained = useComposerStateStore.getState().sessions[props.sessionId]?.attachments ?? [];
-      sentAttachments.filter((attachment) => !retained.some((item) => item.id === attachment.id)).forEach(revokeAttachmentPreview);
+      if (result.outcome !== "unknown" && (nextDraft.command || nextDraft.mode === "shell")) {
+        removePending();
+        revokeUnownedAttachmentPreviews(sentAttachments);
+      } else {
+        useComposerStateStore.setState((state) => ({ pendingMessages: {
+          ...state.pendingMessages,
+          [sessionOwner]: (state.pendingMessages[sessionOwner] ?? []).map((item) => item.draft === nextDraft ? { ...item, settled: true } : item),
+        } }));
+      }
     } catch {
       restore();
     } finally {
       setAttachmentsUploading(false);
     }
-  }, [attachments, baseRenderedMessages, buildDraft, clearComposer, draft, persistedDraftKey, props.onDraftChange, props.sessionId, sendDraft, sessionOwner]);
+  }, [attachments, baseRenderedMessages, buildDraft, clearComposer, draft, mentions, pasteParts, persistedDraftKey, props.onDraftChange, props.sessionId, sendDraft, sessionOwner]);
 
   // One-step run from the empty-state hero: the route keeps the continuation
   // in this session's composer and marks the submitted snapshot for auto-send.
@@ -2681,6 +2728,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const sessionScroll = useSessionScrollController({
     selectedSessionId: props.sessionId,
     submittedMessageId: submittedMessage?.owner === sessionOwner ? submittedMessage.id : null,
+    historyReady: snapshot !== null,
     renderedMessages,
     containerRef: scrollRef,
     contentRef,
@@ -2928,10 +2976,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
     execute: () => {
       const container = scrollRef.current;
       if (!container) return { ok: false, error: "Session transcript is not mounted" };
+      sessionScroll.markScrollGesture(container);
       container.scrollTo({ top: 0, behavior: "smooth" });
       return { ok: true, position: "top" };
     },
-  }), []);
+  }), [sessionScroll.markScrollGesture]);
   useControlAction(props.isControlTarget ? sessionScrollTopControlAction : null);
 
   const sessionScrollBottomControlAction = useMemo<OpenworkControlAction>(() => ({
@@ -3218,11 +3267,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
             }}>Restore unsent message</button>
           </div>
         ) : null}
-        {unmatchedPendingMessages.flatMap(({ draft: pending }) => pending.attachments.map((attachment) => (
-          <div key={attachment.id} className="mx-3 mb-2 text-xs text-muted-foreground" data-attachment-status={sending ? "uploading" : "ready"}>
-            {attachment.name}{sending ? " · Uploading…" : ""}
-          </div>
-        )))}
+        {attachmentsUploading ? <div role="status" className="mx-3 mb-2 text-xs text-muted-foreground" data-attachment-status="uploading">
+          Preparing attachments...
+        </div> : null}
         <ReactSessionComposer
           runModeControl={<WorkspaceRunModeMenu client={props.client} workspaceId={props.workspaceId} busy={chatStreaming || preparingCloudTools || Boolean(props.activePermission || props.activeQuestion)} />}
           draft={autoSendPayload ? draft : autoSending ? "" : draft}
@@ -3249,8 +3296,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onModelPickerOpenChange={handleModelPickerOpenChange}
         onModelChange={handleModelChange}
         sessionId={props.sessionId}
-        attachments={attachments}
-        attachmentsUploading={attachmentsUploading}
+        attachments={autoSending && !autoSendPayload ? [] : attachments}
         onAttachFiles={handleAttachFiles}
         onRemoveAttachment={handleRemoveAttachment}
         attachmentsEnabled={props.attachmentsEnabled}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -18,7 +18,7 @@ import { buildDiagnosticsBundleJson } from "@/app/lib/diagnostics-bundle";
 import { downloadTextAsFile } from "@/app/lib/download";
 import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
 import { createClient, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
-import { createClientV2, isOpencodeV2BaseUrl, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
+import { createClientV2, isOpencodeV2BaseUrl, v2PromptText, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession, unrevertSession } from "@/app/lib/opencode-session";
 import { getNativeSessionMessages } from "@/app/lib/opencode-session-native";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -1339,7 +1339,7 @@ export function SessionRoute() {
           openSettings: handleOpenSettings,
         });
       },
-      onSendDraft: async (draft: ComposerDraft, sessionId: string, onPrepared?: () => void): Promise<CloudMcpSubmissionResult> => {
+      onSendDraft: async (draft: ComposerDraft, sessionId: string, onPrepared?: (text?: string) => void): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || selectedSessionId;
         if (!targetSessionId) return { outcome: "cancelled", reason: "context_changed" };
         const generation = getQueuedSendGeneration(targetSessionId);
@@ -1439,7 +1439,7 @@ export function SessionRoute() {
                   runtimeKey: environmentRuntimeKey,
                 });
                 assertCurrent();
-                onPrepared?.();
+                onPrepared?.(v2PromptText(parts));
                 const result = await opencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
                   messageID: draft.messageId,
@@ -1697,7 +1697,7 @@ export function SessionRoute() {
       isSandboxWorkspace: isSandboxWorkspace(workspace),
       environmentRuntimeKey: workspace.workspaceType === "remote" ? null : environmentRuntimeKey,
       onApplyEnvironmentChanges: undefined,
-      onSendDraft: async (draft: ComposerDraft, sessionId: string, onPrepared?: () => void): Promise<CloudMcpSubmissionResult> => {
+      onSendDraft: async (draft: ComposerDraft, sessionId: string, onPrepared?: (text?: string) => void): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || session.sessionId;
         const generation = getQueuedSendGeneration(targetSessionId);
         const assertCurrent = () => assertQueuedSendCurrent(targetSessionId, generation);
@@ -1771,7 +1771,7 @@ export function SessionRoute() {
                   runtimeKey: workspace.workspaceType === "remote" ? null : environmentRuntimeKey,
                 });
                 assertCurrent();
-                onPrepared?.();
+                onPrepared?.(v2PromptText(parts));
                 const result = await workspaceOpencodeClient.session.promptAsync({
                   sessionID: targetSessionId,
                   messageID: draft.messageId,

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { expect, mock, test } from "bun:test";
+import { expect, mock, spyOn, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { createRequire } from "node:module";
@@ -118,8 +118,18 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
   Object.defineProperty(document, "compatMode", { configurable: true, value: "CSS1Compat" });
   let acceptedMessageId: string | null = null;
   const acceptanceRequests: Request[] = [];
+  const nativePromptTexts: string[] = [];
+  const nativeMessages: { id: string; role: "user"; text: string }[] = [];
   const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = new Request(input, init);
+    const path = new URL(request.url).pathname;
+    if (path === `/opencode2/api/session/${sessionId}/prompt`) {
+      const body: unknown = await request.json();
+      if (!body || typeof body !== "object" || !("text" in body) || typeof body.text !== "string") throw new Error("Expected a native text prompt");
+      nativePromptTexts.push(body.text);
+      return new Response(null, { status: 204 });
+    }
+    if (path === `/opencode2/api/session/${sessionId}/message`) return Response.json({ data: nativeMessages });
     if (new URL(request.url).pathname.includes(`/session/${sessionId}/message/`)) {
       acceptanceRequests.push(request);
       return acceptedMessageId
@@ -155,11 +165,10 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
   const draft = "Keep this draft while the task finishes";
   let submission = Promise.withResolvers<CloudMcpSubmissionResult>();
   const sentDrafts: ComposerDraft[] = [];
-  let prepareSubmission: (() => void) | undefined;
+  let prepareSubmission: ((text?: string) => void) | undefined;
+  const revokePreview = spyOn(URL, "revokeObjectURL");
 
-  try {
-    await act(async () => {
-      root.render(
+  const renderSurface = (opencodeBaseUrl = "http://127.0.0.1:1/opencode") => root.render(
         <QueryClientProvider client={queryClient}>
           <LocalProvider>
             <ShellConfigProvider>
@@ -170,7 +179,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
                 sessionId={sessionId}
                 draftScope="local"
                 isControlTarget={false}
-                opencodeBaseUrl="http://127.0.0.1:1/opencode"
+                opencodeBaseUrl={opencodeBaseUrl}
                 openworkToken="test-token"
                 developerMode
                 modelLabel="Test model"
@@ -207,7 +216,8 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
           </LocalProvider>
         </QueryClientProvider>,
       );
-    });
+  try {
+    await act(async () => renderSurface());
     await waitFor(
       () => container.querySelector('[contenteditable="true"][data-lexical-editor="true"]') !== null,
       "the Lexical editor",
@@ -241,16 +251,20 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
       button.click();
     };
     const attachment: ComposerAttachment = { id: "image-ready", name: "photo.png", mimeType: "image/png", size: 3, kind: "image",
-      file: new File(["png"], "photo.png", { type: "image/png" }) };
+      file: new File(["png"], "photo.png", { type: "image/png" }), previewUrl: URL.createObjectURL(new Blob(["png"], { type: "image/png" })) };
     await act(async () => {
       useComposerStateStore.getState().setAttachments(sessionId, [attachment]);
-      useComposerStateStore.getState().setDraft(sessionId, `${draft}[attachment image-ready]`);
+      useComposerStateStore.getState().setDraft(sessionId, "[attachment image-ready]");
     });
     await act(async () => send());
     expect(sentDrafts).toHaveLength(1);
-    expect(editor.textContent).toContain(draft);
+    expect(editor.textContent).toBe("");
+    expect(useComposerStateStore.getState().sessions[sessionId]).toBeUndefined();
+    expect(container.querySelector("[data-attachment-id]")).toBeNull();
+    expect(container.querySelector('[data-message-role="user"] img[alt="photo.png"]')?.getAttribute("src")).toBe(attachment.previewUrl);
     expect(container.querySelector('[data-attachment-status="uploading"]')).not.toBeNull();
-    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
+    expect(revokePreview).not.toHaveBeenCalledWith(attachment.previewUrl);
     await act(async () => {
       editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
       editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true, bubbles: true }));
@@ -258,9 +272,11 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(sentDrafts).toHaveLength(1);
     expect(useComposerStateStore.getState().queuedDrafts[sessionId]).toBeUndefined();
     await act(async () => submission.reject(new Error("Image preparation failed")));
-    expect(editor.textContent).toContain(draft);
+    expect(useComposerStateStore.getState().sessions[sessionId]?.draft).toBe("[attachment image-ready]");
     expect(useComposerStateStore.getState().sessions[sessionId]?.attachments).toEqual([attachment]);
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
     expect(Object.values(useComposerStateStore.getState().failedDrafts).flat()).toHaveLength(0);
+    expect(revokePreview).not.toHaveBeenCalledWith(attachment.previewUrl);
 
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
     await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Dismiss error"]')?.click());
@@ -270,7 +286,52 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     expect(editor.textContent).toBe("");
     expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
     await act(async () => submission.resolve({ outcome: "cancelled", reason: "context_changed" }));
-    expect(editor.textContent).toContain(draft);
+    expect(useComposerStateStore.getState().sessions[sessionId]?.draft).toBe("[attachment image-ready]");
+    expect(useComposerStateStore.getState().sessions[sessionId]?.attachments).toEqual([attachment]);
+
+    // A message-created or text-only acknowledgement must not take the preview away.
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => send());
+    const imageMessageId = sentDrafts[2]?.messageId;
+    if (!imageMessageId) throw new Error("Expected an image-only message identity");
+    await act(async () => {
+      prepareSubmission?.();
+      submission.resolve({ outcome: "accepted" });
+      queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{ id: imageMessageId, role: "user", parts: [] }]);
+    });
+    const imageRows = () => container.querySelectorAll(`[data-message-id="${imageMessageId}"]`);
+    await waitFor(() => Object.values(useComposerStateStore.getState().pendingMessages).flat()
+      .some((item) => item.serverMessageId === imageMessageId), "the message-created acknowledgement to reconcile");
+    expect(imageRows()).toHaveLength(1);
+    expect(imageRows()[0]?.querySelector('img[alt="photo.png"]')?.getAttribute("src")).toBe(attachment.previewUrl);
+    expect(revokePreview).not.toHaveBeenCalledWith(attachment.previewUrl);
+    await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{
+      id: imageMessageId, role: "user", parts: [{ type: "text", text: "Image acknowledged" }],
+    }]));
+    await waitFor(() => imageRows()[0]?.textContent?.includes("Image acknowledged") === true, "the text-only acknowledgement to render");
+    expect(imageRows()).toHaveLength(1);
+    expect(imageRows()[0]?.querySelector('img[alt="photo.png"]')?.getAttribute("src")).toBe(attachment.previewUrl);
+    expect(revokePreview).not.toHaveBeenCalledWith(attachment.previewUrl);
+    await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{
+      id: imageMessageId, role: "user", parts: [
+        { type: "text", text: "Image path acknowledged" },
+        { type: "file", filename: "photo.png", mediaType: "image/png", url: "file:///tmp/photo.png" },
+      ],
+    }]));
+    await waitFor(() => imageRows()[0]?.textContent?.includes("Image path acknowledged") === true, "the unusable image path acknowledgement to render");
+    expect(imageRows()[0]?.querySelectorAll("img")).toHaveLength(1);
+    expect(imageRows()[0]?.querySelector("img")?.getAttribute("src")).toBe(attachment.previewUrl);
+    expect(revokePreview).not.toHaveBeenCalledWith(attachment.previewUrl);
+    const serverImageUrl = "data:image/jpeg;base64,cG5n";
+    await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{
+      id: imageMessageId, role: "user", parts: [{ type: "file", filename: "photo.jpg", mediaType: "image/jpeg", url: serverImageUrl }],
+    }]));
+    await waitFor(() => imageRows()[0]?.querySelector("img")?.getAttribute("src") === serverImageUrl, "the server image to replace the local preview");
+    expect(imageRows()).toHaveLength(1);
+    expect(imageRows()[0]?.querySelector("img")?.getAttribute("src")).toBe(serverImageUrl);
+    expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
+    expect(revokePreview).toHaveBeenCalledWith(attachment.previewUrl);
+    expect(sentDrafts).toHaveLength(3);
     await act(async () => {
       useComposerStateStore.getState().setAttachments(sessionId, []);
       useComposerStateStore.getState().setDraft(sessionId, draft);
@@ -385,6 +446,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
       size: scopedFile.size,
       kind: "image",
       file: scopedFile,
+      previewUrl: URL.createObjectURL(scopedFile),
     };
     const submittedComposer = {
       draft: "First [pasted text handoff][attachment scoped-image]",
@@ -393,9 +455,12 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
       pasteParts: [{ id: "submitted-paste", label: "handoff", text: "submitted body", lines: 1 }],
       revertMessageId: null,
     };
+    const continuationFile = new File(["newer image"], "continuation.png", { type: "image/png" });
+    const continuationAttachment: ComposerAttachment = { ...scopedAttachment, id: "continuation-image", name: continuationFile.name,
+      file: continuationFile, previewUrl: URL.createObjectURL(continuationFile) };
     const continuationComposer = {
-      draft: "Continuation B",
-      attachments: [],
+      draft: "Continuation B[attachment continuation-image]",
+      attachments: [continuationAttachment],
       mentions: {},
       pasteParts: [{ id: "continuation-paste", label: "handoff", text: "wrong continuation metadata", lines: 1 }],
       revertMessageId: null,
@@ -416,37 +481,172 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     });
     await waitFor(() => sentDrafts.length === 5, "scoped first-message auto-send");
     expect(sentDrafts[4]?.resolvedText).toBe("First submitted body");
-    expect(editor.textContent).toBe("Continuation B");
+    expect(editor.textContent).toContain("Continuation B");
     expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationComposer);
     const scopedPendingRows = () => [...container.querySelectorAll('[data-message-role="user"]')]
-      .filter((row) => row.textContent === "First submitted body");
+      .filter((row) => row.textContent?.includes("First submitted body"));
     expect(scopedPendingRows()).toHaveLength(1);
+    expect(scopedPendingRows()[0]?.querySelector('img[alt="scoped.png"]')?.getAttribute("src")).toBe(scopedAttachment.previewUrl);
+    expect(editor.querySelector('[data-attachment-status="uploading"]')).toBeNull();
     expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
-    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Continuation B before preparation"));
-    expect(editor.textContent).toBe("Continuation B before preparation");
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Continuation B before preparation[attachment continuation-image]"));
+    expect(editor.textContent).toContain("Continuation B before preparation");
     const continuationBeforePreparation = useComposerStateStore.getState().sessions[sessionId];
     expect(prepareSubmission).toBeFunction();
     await act(async () => prepareSubmission?.());
     expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationBeforePreparation);
     expect(scopedPendingRows()).toHaveLength(1);
     expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(1);
-    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Continuation B after preparation"));
-    expect(editor.textContent).toBe("Continuation B after preparation");
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Continuation B after preparation[attachment continuation-image]"));
+    expect(editor.textContent).toContain("Continuation B after preparation");
     const continuationAfterPreparation = useComposerStateStore.getState().sessions[sessionId];
     await act(async () => submission.reject(new Error("Scoped submission unavailable")));
-    expect(editor.textContent).toBe("Continuation B after preparation");
+    expect(editor.textContent).toContain("Continuation B after preparation");
     expect(useComposerStateStore.getState().sessions[sessionId]).toBe(continuationAfterPreparation);
+    expect(continuationAfterPreparation?.attachments).toEqual([continuationAttachment]);
+    expect(revokePreview).not.toHaveBeenCalledWith(scopedAttachment.previewUrl);
+    expect(revokePreview).not.toHaveBeenCalledWith(continuationAttachment.previewUrl);
     expect(Object.values(useComposerStateStore.getState().failedDrafts).flat().map((item) => item.draft)).toEqual([
       "First [pasted text handoff][attachment scoped-image]",
     ]);
     expect(Object.values(useComposerStateStore.getState().failedDrafts).flat()[0]?.attachments[0]?.file).toBe(scopedFile);
-    await act(async () => useComposerStateStore.getState().setDraft(sessionId, ""));
+    await act(async () => {
+      useComposerStateStore.getState().setDraft(sessionId, "");
+      useComposerStateStore.getState().setAttachments(sessionId, []);
+    });
     await act(async () => {
       const restore = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent === "Restore unsent message");
       expect(restore?.disabled).toBe(false);
       restore?.click();
     });
     expect(useComposerStateStore.getState().sessions[sessionId]?.attachments[0]?.file).toBe(scopedFile);
+
+    // The unchanged hero now hands off an empty continuation, not its submitted chips.
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => {
+      markComposerAutoSend(sessionId, {
+        scopeKey: composerAutoSendScopeKey({ draftScope: "local", opencodeBaseUrl: "http://127.0.0.1:1/opencode", workspaceId, sessionId }),
+        composer: submittedComposer,
+      });
+      useComposerStateStore.getState().clearSession(sessionId);
+    });
+    await waitFor(() => sentDrafts.length === 6, "unchanged hero attachment handoff");
+    expect(editor.textContent).toBe("");
+    expect(container.querySelector("[data-attachment-id]")).toBeNull();
+    expect(scopedPendingRows()).toHaveLength(1);
+    await act(async () => prepareSubmission?.());
+    expect(useComposerStateStore.getState().sessions[sessionId]).toBeUndefined();
+    await act(async () => submission.reject(new Error("Unchanged hero submission failed")));
+    expect(useComposerStateStore.getState().sessions[sessionId]?.attachments[0]?.file).toBe(scopedFile);
+    expect(useComposerStateStore.getState().sessions[sessionId]?.draft).toBe(submittedComposer.draft);
+    expect(Object.values(useComposerStateStore.getState().failedDrafts).flat()).toHaveLength(0);
+    expect(revokePreview).not.toHaveBeenCalledWith(scopedAttachment.previewUrl);
+
+    // Native v2 returns admission without an ID and normalizes user turns to text only.
+    const { createClientV2, v2PromptText } = await import("../src/app/lib/opencode-v2-adapter");
+    const { draftToParts } = await import("../src/react-app/domains/session/sync/draft-parts");
+    const { snapshotToUIMessages } = await import("../src/react-app/domains/session/sync/usechat-adapter");
+    const nativeBaseUrl = "http://127.0.0.1:1/opencode2";
+    const nativeClient = createClientV2(nativeBaseUrl, "/tmp/project-focus-continuity", {});
+    const nativeOwner = composerAutoSendScopeKey({ draftScope: "local", opencodeBaseUrl: nativeBaseUrl, workspaceId, sessionId });
+    const nativePending = () => useComposerStateStore.getState().pendingMessages[nativeOwner] ?? [];
+    const nativeRow = (id: string) => container.querySelector(`[data-message-id="${id}"]`);
+    const refreshNativeTranscript = async () => {
+      const result = await nativeClient.session.messages({ sessionID: sessionId });
+      if (result.error || !result.data) throw new Error("Expected native transcript data");
+      expect(result.data.every((message) => message.parts.every((part) => part.type === "text"))).toBe(true);
+      const nativeSnapshot: OpenworkSessionSnapshot = {
+        ...createSnapshot({ type: "idle" }, 10),
+        messages: result.data.map(({ info, parts }) => ({
+          info: { id: info.id, sessionID: info.sessionID, role: "user", time: info.time,
+            agent: "build", model: { providerID: "test", modelID: "test-model" } },
+          parts,
+        })),
+      };
+      await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), snapshotToUIMessages(nativeSnapshot)));
+    };
+    nativeMessages.push({ id: "native-historical", role: "user", text: "Historical attachment" });
+    await refreshNativeTranscript();
+    await act(async () => {
+      useComposerStateStore.getState().clearSession(sessionId);
+      renderSurface(nativeBaseUrl);
+    });
+    await waitFor(() => nativeRow("native-historical") !== null, "the native history before attachment sends");
+    const nativeAttachments = ["first", "second"].map((id): ComposerAttachment => {
+      const file = new File([id], "native:photo?.png", { type: "image/jpeg" });
+      return { id, name: file.name, mimeType: file.type, size: file.size, kind: "image", file, previewUrl: URL.createObjectURL(file) };
+    });
+    const uploadedPaths: string[] = [];
+    const nativeDrafts: ComposerDraft[] = [];
+    for (const attachment of nativeAttachments) {
+      submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+      await act(async () => {
+        useComposerStateStore.getState().setAttachments(sessionId, [attachment]);
+        useComposerStateStore.getState().setDraft(sessionId, `[attachment ${attachment.id}]`);
+      });
+      await act(async () => send());
+      const submitted = sentDrafts.at(-1);
+      if (!submitted?.messageId) throw new Error("Expected a native image submission");
+      nativeDrafts.push(submitted);
+      expect(nativeRow(submitted.messageId)?.querySelector("img")?.getAttribute("src")).toBe(attachment.previewUrl);
+      expect(editor.textContent).toBe("");
+      const parts = await draftToParts(submitted, "/tmp/project-focus-continuity", sessionId, {
+        workspaceId,
+        client: { uploadInbox: async (_workspace, file, options) => {
+          if (!options?.path) throw new Error("Expected a scoped attachment upload path");
+          uploadedPaths.push(options.path);
+          return { ok: true, path: options.path, bytes: file.size };
+        } },
+      });
+      expect(parts.some((part) => part.type === "file" && part.filename === "native_photo_.jpg")).toBe(true);
+      await act(async () => prepareSubmission?.(v2PromptText(parts)));
+      const admitted = await nativeClient.session.promptAsync({
+        sessionID: sessionId, messageID: submitted.messageId, parts,
+        model: { providerID: "test", modelID: "test-model" },
+      });
+      expect(admitted.response.status).toBe(204);
+      await act(async () => submission.resolve({ outcome: "accepted" }));
+    }
+    expect(uploadedPaths).toHaveLength(2);
+    expect(nativePromptTexts).toHaveLength(2);
+    expect(nativePromptTexts[0]).not.toBe(nativePromptTexts[1]);
+    expect(nativePending()).toHaveLength(2);
+    expect(nativePending().map((item) => item.preparedText)).toEqual(nativePromptTexts);
+    const firstText = nativePromptTexts[0];
+    const secondText = nativePromptTexts[1];
+    if (!firstText || !secondText) throw new Error("Expected exact native prompt bodies");
+    // Neither an already-known ID nor similar text may take ownership of a preview.
+    nativeMessages[0] = { id: "native-historical", role: "user", text: firstText };
+    nativeMessages.push({ id: "native-unrelated", role: "user", text: `${firstText}\nA different turn` });
+    await refreshNativeTranscript();
+    await waitFor(() => nativeRow("native-unrelated") !== null, "the unrelated native turn");
+    expect(nativePending().every((item) => !item.serverMessageId)).toBe(true);
+    expect(nativeRow("native-historical")?.querySelector("img")).toBeNull();
+    expect(nativeRow("native-unrelated")?.querySelector("img")).toBeNull();
+
+    // Observe the sibling first: equal filenames must not make the first upload claim it.
+    nativeMessages.push({ id: "native-second", role: "user", text: secondText });
+    await refreshNativeTranscript();
+    await waitFor(() => nativePending()[1]?.serverMessageId === "native-second", "the second upload's exact text-only acknowledgement");
+    expect(nativePending()[0]?.serverMessageId).toBeUndefined();
+    expect(nativeRow("native-second")?.querySelector("img")?.getAttribute("src")).toBe(nativeAttachments[1]?.previewUrl);
+    nativeMessages.push({ id: "native-first", role: "user", text: firstText });
+    await refreshNativeTranscript();
+    await waitFor(() => nativePending()[0]?.serverMessageId === "native-first", "the first upload's exact text-only acknowledgement");
+    expect(nativeRow("native-first")?.querySelector("img")?.getAttribute("src")).toBe(nativeAttachments[0]?.previewUrl);
+    expect(container.querySelectorAll('[data-message-role="user"] img')).toHaveLength(2);
+    for (const submitted of nativeDrafts) expect(nativeRow(submitted.messageId ?? "")).toBeNull();
+    for (const attachment of nativeAttachments) expect(revokePreview).not.toHaveBeenCalledWith(attachment.previewUrl);
+    expect(nativePending()).toHaveLength(2);
+    const firstNativeMessage = nativeMessages.find((message) => message.id === "native-first");
+    if (!firstNativeMessage) throw new Error("Expected the acknowledged native image turn");
+    firstNativeMessage.text = "Native user text normalized";
+    await refreshNativeTranscript();
+    await waitFor(() => nativeRow("native-first")?.textContent?.includes("Native user text normalized") === true, "the pinned native acknowledgement after its text changes");
+    expect(nativeRow("native-first")?.querySelector("img")?.getAttribute("src")).toBe(nativeAttachments[0]?.previewUrl);
+    expect(container.querySelectorAll('[data-message-role="user"] img')).toHaveLength(2);
+    expect(nativePending().map((item) => item.serverMessageId)).toEqual(["native-first", "native-second"]);
+    expect(sentDrafts).toHaveLength(8);
 
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
     let creation = Promise.withResolvers<void>();
@@ -491,12 +691,35 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     });
     await act(async () => send());
     expect(creations).toBe(2);
-    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toContain("First hero message");
-    expect(container.querySelector('[data-message-role="user"]')).toBeNull();
-    expect(container.querySelector('[data-attachment-status="uploading"]')).not.toBeNull();
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("");
+    expect(container.querySelector('[data-message-role="user"]')?.textContent).toContain("First hero message");
+    expect(container.querySelector('[data-message-role="user"] img[alt="photo.png"]')).not.toBeNull();
+    expect(container.querySelector("[data-attachment-id]")).toBeNull();
+    expect(capturedHandoff?.getContinuation()).toEqual({ draft: "", attachments: [], mentions: {}, pasteParts: [], revertMessageId: null });
+    expect(capturedHandoff?.submitted.attachments[0]?.file).toBe(attachment.file);
     await act(async () => creation.reject(new Error("Image session creation failed")));
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toContain("First hero message");
     expect(container.querySelector('[data-attachment-id]')).not.toBeNull();
+
+    creation = Promise.withResolvers<void>();
+    await act(async () => send());
+    const attachmentHandoff = capturedHandoff;
+    if (!attachmentHandoff) throw new Error("Expected the attachment handoff");
+    const heroPreview = attachmentHandoff.submitted.attachments[0]?.previewUrl;
+    await act(async () => {
+      const input = container.querySelector<HTMLInputElement>('input[type="file"][multiple]');
+      if (!input) throw new Error("Expected the continuation attachment input");
+      Object.defineProperty(input, "files", { configurable: true, value: [continuationFile] });
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    const heroContinuation = attachmentHandoff.getContinuation();
+    expect(heroContinuation.attachments[0]?.file).toBe(continuationFile);
+    await act(async () => creation.reject(new Error("Hero upload unavailable")));
+    expect(attachmentHandoff.getContinuation()).toEqual(heroContinuation);
+    expect(container.querySelector('[data-attachment-id]')?.getAttribute("title")).toBe("continuation.png");
+    expect(revokePreview).not.toHaveBeenCalledWith(heroPreview);
+    expect(container.textContent).toContain("Clear the current draft to restore the unsent message");
+    expect(creations).toBe(3);
 
     await act(async () => updateDraftOwner("owner-b"));
     await waitFor(
@@ -506,7 +729,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     creation = Promise.withResolvers<void>();
     await act(async () => updateHeroDraft("Owner B submission"));
     await act(async () => send());
-    expect(creations).toBe(3);
+    expect(creations).toBe(4);
     const ownerBHandoff = capturedHandoff;
     if (!ownerBHandoff) throw new Error("Expected the owner B handoff");
     await act(async () => updateHeroDraft("Owner B continuation"));

--- a/apps/app/tests/live-step-scroll.test.ts
+++ b/apps/app/tests/live-step-scroll.test.ts
@@ -38,7 +38,7 @@ describe("submitted message reveal", () => {
   let container: HTMLDivElement;
   let contentHeight: number;
   let resize: () => void;
-  let render: (sessionId: string, submittedMessageId: string | null, rows: Row[]) => Promise<void>;
+  let render: (sessionId: string, submittedMessageId: string | null, rows: Row[], historyReady?: boolean) => Promise<void>;
   let flushFrames: () => Promise<void>;
   let originalResizeObserver: typeof ResizeObserver;
 
@@ -81,10 +81,11 @@ describe("submitted message reveal", () => {
     const containerRef = createRef<HTMLDivElement>();
     const contentRef = createRef<HTMLDivElement>();
     let scrollTop = 0;
-    function Harness(props: { sessionId: string; submittedMessageId: string | null; rows: Row[] }) {
+    function Harness(props: { sessionId: string; submittedMessageId: string | null; rows: Row[]; historyReady: boolean }) {
       const controller = useSessionScrollController({
         selectedSessionId: props.sessionId,
         submittedMessageId: props.submittedMessageId,
+        historyReady: props.historyReady,
         renderedMessages: props.rows,
         containerRef,
         contentRef,
@@ -103,6 +104,7 @@ describe("submitted message reveal", () => {
               get: () => scrollTop,
               set: (value: number) => { scrollTop = Math.max(0, Math.min(value, contentHeight - 500)); },
             },
+            scrollTo: { configurable: true, value: (options: ScrollToOptions) => { node.scrollTop = options.top ?? scrollTop; } },
           });
           node.getBoundingClientRect = () => new DOMRect(0, 100, 800, 500);
         },
@@ -122,8 +124,8 @@ describe("submitted message reveal", () => {
       }, row.id))));
     }
     root = createRoot(document.createElement("div"));
-    render = async (sessionId, submittedMessageId, rows) => {
-      await act(async () => { root.render(createElement(Harness, { sessionId, submittedMessageId, rows })); });
+    render = async (sessionId, submittedMessageId, rows, historyReady = true) => {
+      await act(async () => { root.render(createElement(Harness, { sessionId, submittedMessageId, rows, historyReady })); });
     };
   });
 
@@ -189,6 +191,10 @@ describe("submitted message reveal", () => {
     expect(container.scrollTop).toBe(400);
     expect(useSessionScrollStore.getState().sessions["session-a"]).toMatchObject({ mode: "manual", scrollTop: 200 });
     expect(useSessionScrollStore.getState().sessions["session-b"]).toMatchObject({ mode: "manual", scrollTop: 400 });
+    await render("session-a", "submitted-a", [...history, { id: "submitted-a", top: 2000, height: 100 }]);
+    await flushFrames();
+    expect(container.scrollTop).toBe(200);
+    expect(useSessionScrollStore.getState().sessions["session-b"]).toMatchObject({ mode: "manual", scrollTop: 400 });
   });
 
   test("reveals the start rather than the tail of an oversized submitted prompt", async () => {
@@ -203,7 +209,7 @@ describe("submitted message reveal", () => {
     expect(container.querySelector('[data-message-id="submitted"]')?.getBoundingClientRect().top)
       .toBe(container.getBoundingClientRect().top);
     expect(useSessionScrollStore.getState().sessions["session-a"])
-      .toEqual({ mode: "manual", scrollTop: 2000, topClippedMessageId: null });
+      .toEqual({ mode: "manual", scrollTop: 2000, topClippedMessageId: null, anchor: { messageId: "submitted", offset: 0 } });
     contentHeight = 2900;
     await render("session-a", "submitted", [...rows]);
     await act(async () => resize());
@@ -214,13 +220,64 @@ describe("submitted message reveal", () => {
   test("session restoration does not overwrite a newly revealed prompt on the next frame", async () => {
     useSessionScrollStore.getState().setManualScroll("session-a", 200, null);
     await render("session-a", null, history);
-    // Send before restoration's second (animation-frame) pass has executed.
+    // Send before queued positioning callbacks have drained.
     contentHeight = 2800;
     await render("session-a", "submitted", [...history, { id: "submitted", top: 2000, height: 800 }]);
     expect(container.scrollTop).toBe(2000);
     await flushFrames();
     expect(container.scrollTop).toBe(2000);
     expect(useSessionScrollStore.getState().sessions["session-a"])
-      .toEqual({ mode: "manual", scrollTop: 2000, topClippedMessageId: null });
+      .toEqual({ mode: "manual", scrollTop: 2000, topClippedMessageId: null, anchor: { messageId: "submitted", offset: 0 } });
+  });
+
+  test("newer user scrolling cancels a reveal while its row is missing", async () => {
+    await render("session-a", null, history);
+    await flushFrames();
+    await browse(200);
+    await render("session-a", "submitted", history);
+    await browse(350);
+    contentHeight = 2100;
+    const rows = [...history, { id: "submitted", top: 2000, height: 100 }];
+    await render("session-a", "submitted", rows);
+    await act(async () => resize());
+    await flushFrames();
+    expect(container.scrollTop).toBe(350);
+    expect(useSessionScrollStore.getState().sessions["session-a"]).toMatchObject({ mode: "manual", scrollTop: 350 });
+    await render("session-b", null, history);
+    await flushFrames();
+    await render("session-a", "submitted", rows);
+    await flushFrames();
+    expect(container.scrollTop).toBe(350);
+  });
+
+  test("revealed submissions stay consumed after visiting and sending in another session", async () => {
+    contentHeight = 2100;
+    const rows = [...history, { id: "submitted", top: 2000, height: 100 }];
+    for (const sessionId of ["session-a", "session-b"]) {
+      await render(sessionId, "submitted", rows);
+      expect(container.scrollTop).toBe(1600);
+      await browse(sessionId === "session-a" ? 300 : 400);
+    }
+    await render("session-a", "submitted", rows);
+    await flushFrames();
+    expect(container.scrollTop).toBe(300);
+    await render("session-b", "submitted", rows);
+    await flushFrames();
+    expect(container.scrollTop).toBe(400);
+  });
+
+  test("an optimistic submitted row reveals before history readiness and is not reset by the snapshot", async () => {
+    useSessionScrollStore.getState().setManualScroll("session-a", 200, null);
+    await render("session-a", null, history, false);
+    contentHeight = 2800;
+    const rows = [...history, { id: "submitted", top: 2000, height: 800 }];
+    await render("session-a", "submitted", rows, false);
+    expect(container.scrollTop).toBe(2000);
+    await render("session-a", "submitted", rows, true);
+    await act(async () => resize());
+    await flushFrames();
+    expect(container.scrollTop).toBe(2000);
+    expect(useSessionScrollStore.getState().sessions["session-a"])
+      .toEqual({ mode: "manual", scrollTop: 2000, topClippedMessageId: null, anchor: { messageId: "submitted", offset: 0 } });
   });
 });

--- a/apps/app/tests/markdown-code-block.test.ts
+++ b/apps/app/tests/markdown-code-block.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { renderHighlightedMarkdownHtml, renderMarkdownHtml } from "../src/components/markdown/markdown";
+import { MarkdownBlock, renderHighlightedMarkdownHtml, renderMarkdownHtml } from "../src/components/markdown/markdown";
 import {
   codeWrapClassStates,
   renderHighlightedMarkdownHtml as renderPrimitiveHighlightedMarkdownHtml,
   renderMarkdownHtml as renderPrimitiveMarkdownHtml,
 } from "../src/components/markdown/markdown-primitive";
 import { textHighlightParts } from "../src/components/markdown/text-highlights";
+import { enhanceNearViewport } from "../src/components/markdown/near-viewport";
 
 const CODE = "const value = 1;\nconsole.log(value);";
 const MARKDOWN = `\`\`\`ts\n${CODE}\n\`\`\``;
@@ -146,4 +147,100 @@ describe("markdown text highlighting", () => {
       { text: " again", highlighted: false },
     ]);
   });
+});
+
+test("optional formatting waits for the reading viewport, runs once, and cancels on navigation", async () => {
+  const { GlobalRegistrator } = await import("@happy-dom/global-registrator");
+  const ownedDom = typeof window === "undefined";
+  if (ownedDom) GlobalRegistrator.register();
+  const originalObserver = globalThis.IntersectionObserver;
+  const observers: TestObserver[] = [];
+  class TestObserver implements IntersectionObserver {
+    readonly root = null;
+    readonly rootMargin = "320px 0px";
+    readonly thresholds = [0];
+    readonly scrollMargin = "0px";
+    pending = new Set<Element>();
+    constructor(readonly callback: IntersectionObserverCallback, options: IntersectionObserverInit) {
+      expect(options.rootMargin).toBe(this.rootMargin);
+      observers.push(this);
+    }
+    observe(element: Element) { this.pending.add(element); }
+    unobserve(element: Element) { this.pending.delete(element); }
+    disconnect() { this.pending.clear(); }
+    takeRecords() { return []; }
+    notify(target: Element, isIntersecting: boolean) {
+      const rect = target.getBoundingClientRect();
+      this.callback([{ target, isIntersecting, time: 0, rootBounds: null,
+        boundingClientRect: rect, intersectionRect: rect, intersectionRatio: Number(isIntersecting) }], this);
+    }
+  }
+  Reflect.set(globalThis, "IntersectionObserver", TestObserver);
+  try {
+    const recent = document.createElement("div");
+    const older = document.createElement("div");
+    recent.innerHTML = renderMarkdownHtml(MARKDOWN);
+    older.innerHTML = renderMarkdownHtml(MARKDOWN);
+    const enhanced: HTMLElement[] = [];
+    const stop = enhanceNearViewport([recent, older], (element) => enhanced.push(element));
+    expect(recent.textContent).toContain(CODE);
+    expect(older.textContent).toContain(CODE);
+    expect(enhanced).toEqual([]);
+    const observer = observers[0];
+    observer.notify(older, false);
+    observer.notify(recent, true);
+    observer.notify(recent, true);
+    expect(enhanced).toEqual([recent]);
+    expect(observer.pending.has(older)).toBe(true);
+    observer.notify(older, true);
+    expect(enhanced).toEqual([recent, older]);
+    expect(observer.pending.size).toBe(0);
+    stop();
+
+    const cancel = enhanceNearViewport([older], (element) => enhanced.push(element));
+    cancel();
+    observers[1].notify(older, true);
+    expect(enhanced).toHaveLength(2);
+
+    Reflect.set(globalThis, "IntersectionObserver", undefined);
+    enhanceNearViewport([recent], (element) => enhanced.push(element));
+    expect(enhanced).toEqual([recent, older, recent]);
+
+    // Streaming and settled documents use different keyed DOM roots. The
+    // observer must follow the committed root, including an initially empty one.
+    Reflect.set(globalThis, "IntersectionObserver", TestObserver);
+    const { act, createElement } = await import("react");
+    const { createRoot } = await import("react-dom/client");
+    const previousActEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    try {
+      for (const initial of [{ text: MARKDOWN, streaming: true }, { text: "", streaming: false }]) {
+        await act(async () => root.render(createElement(MarkdownBlock, initial)));
+        const previousRoot = host.firstElementChild;
+        await act(async () => root.render(createElement(MarkdownBlock, { text: MARKDOWN, streaming: false })));
+        const settledRoot = host.firstElementChild;
+        if (!(settledRoot instanceof HTMLElement)) throw new Error("Missing settled markdown root");
+        expect(settledRoot).not.toBe(previousRoot);
+        const observer = observers.at(-1);
+        if (!observer) throw new Error("Missing settled-document observer");
+        expect(observer.pending.has(settledRoot)).toBe(true);
+        await act(async () => observer.notify(settledRoot, true));
+        for (let attempt = 0; attempt < 100 && !settledRoot.querySelector("pre.shiki"); attempt++) {
+          await act(async () => { await new Promise((resolve) => setTimeout(resolve, 5)); });
+        }
+        expect(settledRoot.querySelector("pre.shiki")).not.toBeNull();
+        await act(async () => root.render(null));
+      }
+    } finally {
+      await act(async () => root.unmount());
+      host.remove();
+      Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousActEnvironment);
+    }
+  } finally {
+    Reflect.set(globalThis, "IntersectionObserver", originalObserver);
+    if (ownedDom) await GlobalRegistrator.unregister();
+  }
 });

--- a/apps/app/tests/session-scroll.test.tsx
+++ b/apps/app/tests/session-scroll.test.tsx
@@ -1,0 +1,460 @@
+/** @jsxImportSource react */
+import { afterAll, afterEach, beforeEach, describe, expect, jest, mock, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, useCallback, useRef } from "react";
+import { createRoot } from "react-dom/client";
+import { useSessionScrollController } from "../src/react-app/domains/session/surface/scroll-controller";
+import { flushSessionScrollState, getSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
+
+const ownedDom = typeof window === "undefined";
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+const originalResizeObserver = globalThis.ResizeObserver;
+const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+const storageKey = "openwork:session-scroll:v1";
+const frames = new Map<number, FrameRequestCallback>();
+const observers: (() => void)[] = [];
+const cleanups: (() => Promise<void>)[] = [];
+let frameId = 0;
+let now = 1_000;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  spyOn(Date, "now").mockImplementation(() => now);
+  spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    frames.set(++frameId, callback);
+    return frameId;
+  });
+  spyOn(window, "cancelAnimationFrame").mockImplementation((id) => { frames.delete(id); });
+  Reflect.set(globalThis, "ResizeObserver", class {
+    constructor(callback: ResizeObserverCallback) { observers.push(() => callback([], this)); }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+  useSessionScrollStore.setState({ sessions: {} });
+  flushSessionScrollState();
+  localStorage.clear();
+});
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+  flushSessionScrollState();
+  frames.clear();
+  observers.length = 0;
+  now = 1_000;
+  Reflect.set(globalThis, "ResizeObserver", originalResizeObserver);
+  mock.restore();
+  jest.useRealTimers();
+});
+
+afterAll(async () => {
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+  if (ownedDom) await GlobalRegistrator.unregister();
+});
+
+function state(id = "a") {
+  return getSessionScrollState(useSessionScrollStore.getState().sessions, id);
+}
+
+function runFrames() {
+  const pending = [...frames.values()];
+  frames.clear();
+  for (const callback of pending) callback(now);
+}
+
+function observeStorageWrites() {
+  const storage = window.localStorage;
+  const setItem = storage.setItem;
+  const writes = mock(setItem);
+  // Happy DOM caches bound methods; defineProperty bypasses that binding while
+  // the forwarding mock still exercises real storage and serialized values.
+  Object.defineProperty(storage, "setItem", { configurable: true, writable: true, value: writes });
+  cleanups.push(async () => {
+    Object.defineProperty(storage, "setItem", { configurable: true, writable: true, value: setItem });
+  });
+  return writes;
+}
+
+function fixture() {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const layout = {
+    height: 1_000,
+    viewportHeight: 200,
+    messages: [
+      { id: "first", top: 0, height: 300 },
+      { id: "reading", top: 300, height: 300 },
+      { id: "latest", top: 600, height: 400 },
+    ],
+  };
+  let scrollTop = 0;
+  const scrollWrites: number[] = [];
+  let controls: ReturnType<typeof useSessionScrollController> | undefined;
+  let unmounted = false;
+  function Harness({ sessionId, ready }: { sessionId: string; ready: boolean }) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
+    const setContainer = useCallback((node: HTMLDivElement | null) => {
+      containerRef.current = node;
+      if (!node) return;
+      Object.defineProperties(node, {
+        scrollHeight: { configurable: true, get: () => layout.height },
+        clientHeight: { configurable: true, get: () => layout.viewportHeight },
+        scrollTop: { configurable: true, get: () => scrollTop, set: (top: number) => {
+          scrollWrites.push(top);
+          scrollTop = Math.max(0, Math.min(top, layout.height - layout.viewportHeight));
+        } },
+        scrollTo: { configurable: true, value: (options: ScrollToOptions) => { node.scrollTop = options.top ?? scrollTop; } },
+        getBoundingClientRect: { configurable: true, value: () => new DOMRect(0, 40, 500, layout.viewportHeight) },
+      });
+    }, []);
+    const scroll = useSessionScrollController({
+      selectedSessionId: sessionId, submittedMessageId: null, historyReady: ready, renderedMessages: [...layout.messages], containerRef, contentRef,
+    });
+    controls = scroll;
+    return <div ref={setContainer} onScroll={scroll.handleScroll} onWheel={(event) => scroll.markScrollGesture(event.target)}
+      onPointerDown={(event) => { if (event.target === event.currentTarget) scroll.markScrollGesture(event.target); }}>
+      <div ref={contentRef}>
+        {layout.messages.map((message) => <div key={message.id} data-message-id={message.id} ref={(node) => {
+          if (node) node.getBoundingClientRect = () => new DOMRect(0, 40 + message.top - scrollTop, 500, message.height);
+        }}>{message.id}</div>)}
+        <div data-scrollable>Nested scroll area</div>
+      </div>
+    </div>;
+  }
+  const unmount = async () => {
+    if (unmounted) return;
+    unmounted = true;
+    await act(async () => root.unmount());
+    host.remove();
+  };
+  cleanups.push(unmount);
+  return {
+    layout,
+    scrollWrites,
+    unmount,
+    async render(sessionId = "a", ready = true) { await act(async () => root.render(<Harness sessionId={sessionId} ready={ready} />)); },
+    get container() {
+      const container = host.firstElementChild;
+      if (!(container instanceof HTMLDivElement)) throw new Error("Missing scroll viewport");
+      return container;
+    },
+    get controls() {
+      if (!controls) throw new Error("Missing scroll controller");
+      return controls;
+    },
+    scroll(top: number) {
+      this.container.scrollTop = top;
+      this.container.dispatchEvent(new Event("scroll"));
+    },
+    wheel(top: number) {
+      this.container.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: top - scrollTop }));
+      this.scroll(top);
+    },
+    resize() { for (const callback of observers) callback(); },
+  };
+}
+
+describe("session reading position", () => {
+  test("remembers native reflow adjustments without applying a competing scroll", async () => {
+    useSessionScrollStore.getState().setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
+    const view = fixture();
+    await view.render();
+    expect(view.container.style.overflowAnchor).toBe("auto");
+    // Simulate the browser preserving a paragraph as content above it expands
+    // inside the same message; the controller only records the native result.
+    view.layout.messages[1].height += 80;
+    view.layout.messages[2].top += 80;
+    view.layout.height += 80;
+    view.scroll(405);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 405, anchor: { messageId: "reading", offset: -105 } });
+    view.resize();
+    runFrames();
+    expect(view.container.scrollTop).toBe(405);
+  });
+
+  test("waits for authoritative history, ignores empty/live-tail clamping, and restores message-relative position on return", async () => {
+    useSessionScrollStore.getState().setManualScroll("a", 900, "latest", { messageId: "reading", offset: -25 });
+    const saved = state();
+    const view = fixture();
+    view.layout.height = 200;
+    view.layout.messages = [];
+    await view.render("a", false);
+    view.scroll(0);
+    runFrames();
+    view.resize();
+    expect(state()).toEqual(saved);
+
+    view.layout.messages = [{ id: "latest", top: 0, height: 100 }];
+    await view.render("a", false);
+    view.scroll(0);
+    expect(state()).toEqual(saved);
+    view.layout.height = 1_000;
+    view.layout.messages = [{ id: "reading", top: 300, height: 300 }, { id: "latest", top: 600, height: 400 }];
+    await view.render();
+    expect(view.container.scrollTop).toBe(325);
+    expect(state()).toEqual(saved);
+    await view.render("b");
+    view.layout.messages[0].top += 180;
+    view.layout.messages[1].top += 180;
+    view.layout.height += 180;
+    await view.render("a");
+    runFrames();
+    view.scroll(view.container.scrollTop);
+    expect(view.container.scrollTop).toBe(505);
+    expect(state()).toEqual(saved);
+  });
+
+  test("leaves manual reflow to native anchoring without competing scroll writes", async () => {
+    useSessionScrollStore.getState().setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
+    const view = fixture();
+    await view.render();
+    expect(view.container.style.overflowAnchor).toBe("auto");
+    // Model a browser-owned adjustment inside the same message. This verifies
+    // controller ownership, not the browser's layout or paragraph anchoring.
+    view.layout.messages[1].height += 180;
+    view.layout.messages[2].top += 180;
+    view.layout.height += 180;
+    view.scroll(505);
+    view.scrollWrites.length = 0;
+    view.resize();
+    await view.render();
+    runFrames();
+    expect(view.scrollWrites).toEqual([]);
+    expect(view.container.scrollTop).toBe(505);
+    expect(view.container.style.overflowAnchor).toBe("auto");
+    view.controls.jumpToLatest("auto");
+    runFrames();
+    expect(view.container.style.overflowAnchor).toBe("none");
+    view.controls.jumpToStartOfMessage("auto");
+    expect(view.container.style.overflowAnchor).toBe("auto");
+    const detached = view.container;
+    await view.unmount();
+    expect(detached.style.overflowAnchor).toBe("");
+    useSessionScrollStore.getState().setStickyBottom("a", null);
+    expect(detached.style.overflowAnchor).toBe("");
+  });
+
+  test("ignores cancelled frames and observers on rapid switches and unmount", async () => {
+    useSessionScrollStore.getState().setManualScroll("b", 325, null, { messageId: "reading", offset: -25 });
+    const view = fixture();
+    await view.render();
+    const staleFrames = [...frames.values()];
+    const oldObserver = observers[0];
+    const oldControls = view.controls;
+    await view.render("b");
+    const saved = state("b");
+    for (const callback of staleFrames) callback(now);
+    oldObserver();
+    oldControls.jumpToLatest();
+    expect(view.container.scrollTop).toBe(325);
+    expect(state("b")).toEqual(saved);
+    await view.render("a", false);
+    await view.render("b");
+    runFrames();
+    expect(view.container.scrollTop).toBe(325);
+    const detached = view.container;
+    const lastFrames = [...frames.values()];
+    await view.unmount();
+    for (const callback of lastFrames) callback(now);
+    view.resize();
+    expect(detached.scrollTop).toBe(325);
+    expect(state("b")).toEqual(saved);
+  });
+
+  test("real input cancels delayed restoration and keeps recording continued momentum", async () => {
+    useSessionScrollStore.getState().setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
+    const view = fixture();
+    await view.render("a", false);
+    view.wheel(80);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 325 });
+    now += 1_000;
+    await view.render();
+    runFrames();
+    view.resize();
+    expect(view.container.scrollTop).toBe(80);
+    view.container.dispatchEvent(new KeyboardEvent("keydown", { key: "PageDown", bubbles: true }));
+    view.scroll(400);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 400, anchor: { messageId: "reading", offset: -100 } });
+    now += 500;
+    view.scroll(420);
+    now += 500;
+    view.scroll(440);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 440, anchor: { messageId: "reading", offset: -140 } });
+    view.container.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, isPrimary: true, pointerId: 1 }));
+    now += 1_000;
+    view.scroll(500);
+    view.resize();
+    expect(view.container.scrollTop).toBe(500);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 500 });
+    window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 }));
+  });
+
+  test.each(["pointerup", "pointercancel"])("selection-drag scrolling owns the viewport until %s", async (endEvent) => {
+    const view = fixture();
+    await view.render();
+    const staleFrames = [...frames.values()];
+    const message = view.container.querySelector('[data-message-id="latest"]');
+    if (!message) throw new Error("Missing selection target");
+    message.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, isPrimary: true, pointerId: 1 }));
+    now += 1_000;
+    view.layout.height += 100;
+    view.resize();
+    for (const callback of staleFrames) callback(now);
+    expect(view.container.scrollTop).toBe(800);
+    // Selection extending beyond the viewport generates scroll without a wheel
+    // or key event, including while the pointer is outside the transcript.
+    view.scroll(350);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 350 });
+    expect(view.container.style.overflowAnchor).toBe("auto");
+    window.dispatchEvent(new PointerEvent(endEvent, { pointerId: 2 }));
+    now += 1_000;
+    view.scroll(375);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 375 });
+    window.dispatchEvent(new PointerEvent(endEvent, { pointerId: 1 }));
+    now += 1_000;
+    // Once released, a native layout adjustment can update the manual anchor,
+    // but reaching the bottom without fresh input must not enable follow.
+    view.scroll(view.layout.height - view.layout.viewportHeight);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 900 });
+    view.scrollWrites.length = 0;
+    view.resize();
+    expect(view.scrollWrites).toEqual([]);
+  });
+
+  test.each(["pointerup", "pointercancel"])("non-scrolling clicks resume pending restoration and sticky follow after %s", async (endEvent) => {
+    const view = fixture();
+    await view.render("a", false);
+    // The surface also marks direct viewport presses. They must not leave a
+    // permanent loading cancellation when the press never actually scrolls.
+    view.container.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, isPrimary: true, pointerId: 1 }));
+    now += 1_000;
+    await view.render();
+    expect(view.container.scrollTop).toBe(0);
+    window.dispatchEvent(new PointerEvent(endEvent, { pointerId: 1 }));
+    runFrames();
+    expect(view.container.scrollTop).toBe(800);
+    expect(state().mode).toBe("stickyBottom");
+    expect(view.container.style.overflowAnchor).toBe("none");
+    const message = view.container.querySelector('[data-message-id="latest"]');
+    if (!message) throw new Error("Missing click target");
+    message.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, isPrimary: true, pointerId: 2 }));
+    view.layout.height += 100;
+    view.resize();
+    expect(view.container.scrollTop).toBe(800);
+    window.dispatchEvent(new PointerEvent(endEvent, { pointerId: 2 }));
+    runFrames();
+    expect(view.container.scrollTop).toBe(900);
+  });
+
+  test("uses legacy pixels or a missing anchor once without persisting clamps or locking manual mode", async () => {
+    for (const anchor of [undefined, { messageId: "evicted", offset: -25 }]) {
+      useSessionScrollStore.getState().setManualScroll("a", 900, null, anchor);
+      const view = fixture();
+      await view.render();
+      view.scroll(view.container.scrollTop);
+      expect(view.container.scrollTop).toBe(800);
+      expect(state()).toMatchObject({ mode: "manual", scrollTop: 900 });
+      view.layout.height = 1_200;
+      await view.render();
+      runFrames();
+      expect(view.container.scrollTop).toBe(800);
+      expect(state()).toMatchObject({ mode: "manual", scrollTop: 900 });
+      view.wheel(150);
+      expect(state()).toMatchObject({ mode: "manual", scrollTop: 150 });
+      await view.unmount();
+    }
+  });
+
+  test("keeps sticky streaming and jump controls, but never steals a wheel gesture", async () => {
+    const view = fixture();
+    await view.render();
+    runFrames();
+    expect(view.container.scrollTop).toBe(800);
+    expect(state()).toMatchObject({ mode: "stickyBottom", topClippedMessageId: "latest" });
+    view.layout.height += 100;
+    view.resize();
+    const stickyFrames = [...frames.values()];
+    view.wheel(350);
+    for (const callback of stickyFrames) callback(now);
+    expect(view.container.scrollTop).toBe(350);
+    expect(state()).toMatchObject({ mode: "manual", anchor: { messageId: "reading", offset: -50 } });
+    now += 1_000;
+    view.layout.height += 100;
+    view.resize();
+    expect(view.container.scrollTop).toBe(350);
+    view.controls.jumpToLatest("auto");
+    runFrames();
+    expect(view.container.scrollTop).toBe(1_000);
+    expect(state().mode).toBe("stickyBottom");
+    view.controls.jumpToStartOfMessage("auto");
+    expect(view.container.scrollTop).toBe(600);
+    expect(state()).toMatchObject({ mode: "manual", anchor: { messageId: "latest", offset: 0 } });
+  });
+
+  test("nested scrolling does not cancel restoration or change the session's position", async () => {
+    useSessionScrollStore.getState().setManualScroll("a", 325, null);
+    const view = fixture();
+    await view.render("a", false);
+    const nested = view.container.querySelector("[data-scrollable]");
+    if (!nested) throw new Error("Missing nested scroll area");
+    nested.dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+    nested.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, isPrimary: true, pointerId: 1 }));
+    const message = view.container.querySelector('[data-message-id="reading"]');
+    if (!message) throw new Error("Missing pointer target");
+    message.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, isPrimary: false, pointerId: 2 }));
+    message.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 2, isPrimary: true, pointerId: 3 }));
+    await view.render();
+    expect(view.container.scrollTop).toBe(325);
+    expect(state()).toMatchObject({ mode: "manual", scrollTop: 325 });
+  });
+});
+
+describe("scroll persistence", () => {
+  test("coalesces hot scroll writes, keeps memory immediate and does not persist clipped-message controls", () => {
+    const writes = observeStorageWrites();
+    const store = useSessionScrollStore.getState();
+    for (let top = 0; top < 100; top++) store.setManualScroll("a", top, null, { messageId: "reading", offset: -top });
+    expect(state()).toMatchObject({ scrollTop: 99, anchor: { offset: -99 } });
+    expect(writes).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(249);
+    expect(writes).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(writes).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorage.getItem(storageKey)!)).toEqual({
+      a: { mode: "manual", scrollTop: 99, anchor: { messageId: "reading", offset: -99 } },
+    });
+    store.setTopClippedMessageId("a", "latest");
+    jest.advanceTimersByTime(500);
+    expect(state().topClippedMessageId).toBe("latest");
+    expect(writes).toHaveBeenCalledTimes(1);
+  });
+
+  test("flushes current memory on session switch, visibility loss, pagehide and unmount", async () => {
+    const view = fixture();
+    await view.render();
+    const writes = observeStorageWrites();
+    view.wheel(325);
+    await view.render("b");
+    expect(writes).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorage.getItem(storageKey)!)).toMatchObject({ a: { mode: "manual", scrollTop: 325 } });
+    view.wheel(200);
+    window.dispatchEvent(new Event("pagehide"));
+    expect(writes).toHaveBeenCalledTimes(2);
+    view.wheel(250);
+    const visibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState");
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+    document.dispatchEvent(new Event("visibilitychange"));
+    if (visibilityState) Object.defineProperty(document, "visibilityState", visibilityState);
+    else Reflect.deleteProperty(document, "visibilityState");
+    expect(writes).toHaveBeenCalledTimes(3);
+    view.wheel(300);
+    await view.unmount();
+    expect(writes).toHaveBeenCalledTimes(4);
+    jest.advanceTimersByTime(1_000);
+    expect(writes).toHaveBeenCalledTimes(4);
+    expect(JSON.parse(localStorage.getItem(storageKey)!)).toMatchObject({ b: { mode: "manual", scrollTop: 300 } });
+  });
+});

--- a/evals/specs/attachment-upload-loading-state.e2e.test.ts
+++ b/evals/specs/attachment-upload-loading-state.e2e.test.ts
@@ -14,7 +14,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 for (const entryPoint of ["existing chat", "new task"]) {
-test(`attaching an image in ${entryPoint} retains the draft until the upload is ready`, async ({ world, user, seed, probe, step }) => {
+test(`sending an image in ${entryPoint} immediately moves it into the thread while upload is pending`, async ({ world, user, seed, probe, step }) => {
   await step("manual approval exempts only chat-attachment inbox uploads", async () => {
     expect(world.uploadStatus).toBe(200);
     expect(world.uploadElapsedMs).toBeLessThan(world.approvalTimeoutMs);
@@ -94,25 +94,34 @@ test(`attaching an image in ${entryPoint} retains the draft until the upload is 
   await user.click("Run task");
 
   // TODO(primitive): await a transient attachment-status witness.
-  expect(await probe.eventually(() => probe.eval(() => (globalThis.__attachmentUploadingSeen === true && window.__openworkSubmissionFault?.attempts === 1)), {
+  expect(await probe.eventually(() => probe.eval(() => {
+    const rows = document.querySelectorAll('[data-message-role="user"]');
+    const image = rows[0]?.querySelector<HTMLImageElement>("img");
+    return globalThis.__attachmentUploadingSeen === true && window.__openworkSubmissionFault?.attempts === 1
+      && rows.length === 1 && Boolean(image?.complete && image.naturalWidth > 0)
+      && !document.querySelector("[data-attachment-id]")
+      && document.querySelector('[contenteditable="true"]')?.textContent === "";
+  }), {
     within: 30_000,
     intervalMs: 50,
-    label: "attachment uploading state observed",
+    label: "one decoded thread preview and cleared composer while upload is held",
     until: (value) => value === true,
   })).toBe(true);
-  await step("the draft is not sent while its image is preparing", async () => {
-    await user.see("composer", { text: /Describe the attached image\./ });
-    expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(0);
-    await user.click("composer");
+  await step("Send moves the attachments immediately and preserves the next draft", async () => {
+    await user.see("composer", { text: "" });
+    expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(1);
+    expect((await probe.dom('[data-message-role="user"] img')).elements).toHaveLength(1);
+    await user.see({ text: "pasted-recording.mp4" });
+    await user.type("composer", "Continue after upload.");
     await user.press("Enter");
     await user.press("Meta+Enter");
-    await user.see("composer", { text: /Describe the attached image\./ });
-    expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(0);
+    await user.see("composer", { text: "Continue after upload." });
+    expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(1);
     await user.notSee({ text: /1 queued/ });
   });
   await world.releaseUploads();
   await user.see({ text: "attachment upload loading proof" });
-  await user.see("composer", { text: "" });
+  await user.see("composer", { text: "Continue after upload." });
   expect((await probe.dom('[data-message-role="user"]')).elements).toHaveLength(1);
   await user.notSee({ text: /1 queued/ });
   expect((await probe.hash()).includes("/session/ses_")).toBe(true);

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -214,6 +214,16 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
       return { ...geometry, stable };
     }, { within: 5_000, label: "keyboard browsing settles above the latest turn", until: (value) => value.stable });
   };
+  const scrollStorageKey = "openwork:session-scroll:v1";
+  const savedScroll = (sessionId: string): Promise<unknown> => probe.storage(scrollStorageKey, (value): unknown =>
+    value && typeof value === "object" ? Reflect.get(value, sessionId) ?? null : null);
+  const readingGeometry = async (messageId: string) => {
+    const { elements } = await probe.dom(`${viewportSelector}, ${surface} [data-message-id="${messageId}"]`);
+    const [viewport, message] = elements;
+    if (elements.length !== 2 || !viewport || !message) return null;
+    return { text: message.text, offset: message.rect.top - viewport.rect.top,
+      visible: message.rect.bottom > viewport.rect.top && message.rect.top < viewport.rect.bottom };
+  };
 
   await step("the live cache retains history older than the native 140-message snapshot", async () => {
     expect(await orderedHistory()).toEqual(world.history);
@@ -298,19 +308,50 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     expect(await transcript.finish()).toMatchObject({ seen: [true, true, true, true, true], violations: [], stopped: false });
   });
 
-  await step("switching conversations preserves the full cached history and keeps targets scoped", async () => {
+  const readingPosition = await step("choose a reading message inside the retained history tail", async () => {
+    await user.press(place.kind === "local" && process.platform === "darwin" ? "Meta+f" : "Control+f");
+    await user.type({ placeholder: "Find in conversation" }, world.history[129]!, { replace: true });
+    await user.see({ text: world.history[129]! });
+    await user.click({ role: "button", label: "Close find" });
+    return probe.eventually(async () => {
+      const saved: unknown = await savedScroll(world.session.sessionId);
+      if (!saved || typeof saved !== "object" || !("mode" in saved) || saved.mode !== "manual"
+        || !("anchor" in saved) || !saved.anchor || typeof saved.anchor !== "object"
+        || !("messageId" in saved.anchor) || typeof saved.anchor.messageId !== "string"
+        || !("offset" in saved.anchor) || typeof saved.anchor.offset !== "number") return null;
+      const geometry = await readingGeometry(saved.anchor.messageId);
+      if (!geometry?.visible || !world.history.slice(100).some(text => geometry.text.includes(text))
+        || Math.abs(geometry.offset - saved.anchor.offset) > 2) return null;
+      return { messageId: saved.anchor.messageId, text: geometry.text, offset: geometry.offset };
+    }, { within: 10_000, label: "persisted visible reading anchor", until: value => value !== null });
+  });
+  if (!readingPosition) throw new Error("No retained reading position was captured");
+  const neighborScroll = await savedScroll(world.neighbor.sessionId);
+  const expectReadingPosition = async () => {
+    const geometry = await probe.eventually(() => readingGeometry(readingPosition.messageId), {
+      within: 60_000, label: "same reading message and viewport offset",
+      until: value => Boolean(value?.visible && Math.abs(value.offset - readingPosition.offset) <= 2),
+    });
+    expect(geometry?.text).toBe(readingPosition.text);
+    expect(geometry?.visible).toBe(true);
+    expect(Math.abs(geometry!.offset - readingPosition.offset)).toBeLessThanOrEqual(2);
+    expect(await savedScroll(world.neighbor.sessionId)).toEqual(neighborScroll);
+  };
+
+  await step("switching conversations preserves the reading position, full cached history and scoped targets", async () => {
     await agent.run("session.open", { sessionId: world.neighbor.sessionId });
     await user.see("composer", { editable: true });
     await user.notSee({ text: world.opening });
     // Return before the inactive transcript's 15-second GC window. The slower
     // palette isolation checks below deliberately belong to the cold path.
     await agent.run("session.open", { sessionId: world.session.sessionId });
-    await user.see({ text: world.closing });
+    await expectReadingPosition();
     expect(await orderedHistory()).toEqual(world.history);
     await expectTargets([...oldTargets, world.latestTool]);
     await agent.run("session.open", { sessionId: world.neighbor.sessionId });
     await user.see("composer", { editable: true });
     await expectTargets([...oldTargets, world.latestTool], false);
+    expect(await savedScroll(world.neighbor.sessionId)).toEqual(neighborScroll);
   });
 
   await step("cold reload keeps the bounded history tail ordered and old and new tool links usable", async () => {
@@ -322,7 +363,7 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     expect(retainedHistory.length).toBeLessThan(world.history.length);
     await agent.run("session.open", { sessionId: world.session.sessionId });
     await user.reload();
-    await user.see({ text: world.closing }, { timeoutMs: 60_000 });
+    await expectReadingPosition();
     expect(await orderedHistory()).toEqual(retainedHistory);
     expect(occurrences((await readTranscriptMessages(probe, "user")).join("\n"), world.prompt)).toBe(1);
     expect(occurrences((await readTranscriptMessages(probe, "assistant")).join("\n"), world.closing)).toBe(1);


### PR DESCRIPTION
## Summary

Make conversation feedback immediate without discarding readable history or fighting the person's scroll position.

- Move submitted attachments out of the composer and into one optimistic user message immediately, including image-only sends and new-task handoffs. Preparation continues separately; newer typing and attachments survive failure/cancellation.
- Keep local previews through message-created/text-only acknowledgements. Correlate native v2 acknowledgements using the exact prepared prompt text, pin the accepted message identity, and reclaim previews only once usable server attachments replace them.
- Restore saved message anchors only after history is available; never save a temporary empty/clamped position. Cancel stale session callbacks, preserve native anchoring while reading, respect wheel/keyboard/selection dragging, and debounce persistent scroll writes.
- Keep Markdown text and code readable immediately. Start optional syntax highlighting and diagram rendering near the viewport instead of enhancing every historical message on mount. Re-arm highlighting when a streaming answer becomes a settled document.

Rebased onto `dev` at `52a028817ec185df72c28d08bc87db90ba7c71a4`. This preserves #4681's cached-history reuse and #4683's one-shot reveal of newly submitted messages, including oversized prompts.

## Scope

No new virtualizer, smaller history limit, eager history prefetch, upload parallelism, or changes to task execution/admission. Server history pagination, snapshot/status decoupling, and split-pane stream scheduling are deferred rather than bundled into this change.

The v2 adapter still omits user file parts. Its acknowledged message retains the local preview while the app is open; this PR does not claim attachment persistence across a reload on that engine. Pending previews without a complete server replacement remain retained for recovery.

## Verification — Incomplete

Candidate: `f32d3f71d9819e45d811ca012d6399455cba9ea2`.

**Passed:** 44 focused tests, 0 failures in the final selected invocations, plus app typecheck and whitespace validation.

From `apps/app`, run these as separate invocations:

```sh
bun test --isolate ./tests/session-scroll.test.tsx
# 14 passed, 0 failed
bun test --isolate ./tests/live-step-scroll.test.ts
# 10 passed, 0 failed
bun test --isolate ./tests/composer-focus-continuity.test.tsx
# 1 passed, 0 failed; 170 assertions
bun test --isolate ./tests/markdown-code-block.test.ts ./tests/markdown-mermaid.test.ts
# 19 passed, 0 failed
```

From the repository root:

```sh
pnpm --filter @openwork/app typecheck
git diff --check origin/dev...HEAD
```

**Earlier failed check:** combining the DOM component and Markdown tests in one Bun 1.3.4 invocation reported four Markdown wrapper/sanitizer assertions. That runtime does not advertise `--isolate`; the final invocations keep the DOM fixtures in separate processes. The Markdown-only command passed both here and in a clean base control. The combined failure is not classified as a pre-existing product defect.

**Deferred / missing proof:** the existing `streamed-markdown-answer` and `attachment-upload-loading-state` journeys were extended, but their real-app, exact-head runs and published test evidence have not been produced in this pass. No cloud test resources were provisioned. Focused component tests are not browser-layout or runtime proof; this is not a merge-readiness claim.

Remaining verification commands, with the pushed candidate selected for remote resources:

```sh
OPENWORK_EVAL_REF=f32d3f71d9819e45d811ca012d6399455cba9ea2 pnpm evals:e2e streamed-markdown-answer
OPENWORK_EVAL_REF=f32d3f71d9819e45d811ca012d6399455cba9ea2 pnpm evals:e2e attachment-upload-loading-state
```

## Manual acceptance

1. Scroll into a long conversation, switch away and return, then reload: the retained reading message should stay at the same viewport offset.
2. While output streams, scroll or drag-select older text: it must not pull the view back down. Sending a new message should still reveal that specific row.
3. Send an image with upload held or slow: one preview appears in the thread, the composer clears, and typing a new draft is not erased when preparation finishes or fails.
4. Scroll toward older code and diagrams: readable source remains available, and optional formatting appears as it approaches the viewport.
