### PR TITLE
fix(session): show pending feedback while stopping a response

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -130,6 +130,7 @@ export default {
   "composer.escape_to_stop": "Hit Escape again to stop the agent",
   "composer.skill_source": "Skill",
   "composer.stop": "Stop",
+  "composer.stopping": "Stopping…",
   "composer.tools_label": "Agents, commands, skills, plugins, and connections",
   "composer.upload_to_shared_folder": "Upload to shared folder",
   "composer.uploaded_multiple_files": "Uploaded {count} files to the shared folder and inserted links.",

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -56,6 +56,7 @@ type ComposerProps = {
   onQueue: () => void | Promise<void>;
   onStop: () => void | Promise<void>;
   busy: boolean;
+  stopping?: boolean;
   steering: boolean;
   submissionPreparing: boolean;
   queuedCount: number;
@@ -1032,6 +1033,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
     const anyMenuOpen = agentMenuOpen || toolMenuOpen || Boolean(activeMenu);
     if (event.key === "Escape" && props.busy && !anyMenuOpen) {
       event.preventDefault();
+      if (props.stopping) return;
       if (escapeArmed) {
         disarmEscape();
         void props.onStop();
@@ -1793,7 +1795,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                   Cmd/Ctrl+Enter still steers).
               */}
               <div data-composer-actions className="col-start-2 row-start-2 ml-auto flex shrink-0 items-center gap-1.5">
-                {props.busy && escapeArmed ? (
+                {props.busy && !props.stopping && escapeArmed ? (
                   <span className="self-center pr-1 text-[12px] font-medium text-gray-10 hidden @min-[720px]/composer:inline">
                     {t("composer.escape_to_stop")}
                   </span>
@@ -1809,31 +1811,41 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                   }
                   disabled={
                     props.disabled
+                    || props.stopping
                     || (!props.busy && (!canSend || props.submissionPreparing))
                   }
                   aria-label={
-                    props.busy
-                      ? t("composer.stop")
-                      : props.submissionPreparing
-                        ? "Preparing connected service tools…"
-                        : t("composer.run_task")
+                    props.stopping
+                      ? t("composer.stopping")
+                      : props.busy
+                        ? t("composer.stop")
+                        : props.submissionPreparing
+                          ? "Preparing connected service tools…"
+                          : t("composer.run_task")
                   }
+                  aria-busy={props.stopping || undefined}
                   className={`inline-flex h-9 max-h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors ${
-                    props.busy
-                      ? "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
-                      : !canSend || props.disabled || props.submissionPreparing
-                        ? "bg-gray-4 text-gray-10"
-                        : "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
+                    props.stopping
+                      ? "cursor-wait bg-[var(--dls-accent)] text-[var(--dls-accent-fg)]"
+                      : props.busy
+                        ? "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
+                        : !canSend || props.disabled || props.submissionPreparing
+                          ? "bg-gray-4 text-gray-10"
+                          : "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
                   }`}
                   title={
-                    props.busy
-                      ? t("composer.stop")
-                      : props.submissionPreparing
-                        ? "Preparing connected service tools…"
-                        : t("composer.run_task")
+                    props.stopping
+                      ? t("composer.stopping")
+                      : props.busy
+                        ? t("composer.stop")
+                        : props.submissionPreparing
+                          ? "Preparing connected service tools…"
+                          : t("composer.run_task")
                   }
                 >
-                  {props.busy ? (
+                  {props.stopping ? (
+                    <LoaderCircle size={15} className="animate-spin" />
+                  ) : props.busy ? (
                     <Square size={12} fill="currentColor" />
                   ) : props.submissionPreparing ? (
                     <LoaderCircle size={15} className="animate-spin" />
@@ -1841,11 +1853,13 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                     <ArrowUp size={15} />
                   )}
                   <span className="sr-only">
-                    {props.busy
-                      ? t("composer.stop")
-                      : props.submissionPreparing
-                        ? "Preparing connected service tools…"
-                        : t("composer.run_task")}
+                    {props.stopping
+                      ? t("composer.stopping")
+                      : props.busy
+                        ? t("composer.stop")
+                        : props.submissionPreparing
+                          ? "Preparing connected service tools…"
+                          : t("composer.run_task")}
                   </span>
                 </button>
               </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { UIMessage } from "ai";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 import { Check, CirclePause, Minimize2 } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
@@ -1226,6 +1226,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [pendingSendSessions, setPendingSendSessions] = useState<string[]>([]);
   const pendingSendsRef = useRef(new Map<symbol, string>());
   const sending = pendingSendSessions.includes(sessionOwner);
+  const pendingStopsRef = useRef(new Set<string>());
+  const [pendingStopSessions, setPendingStopSessions] = useState<string[]>([]);
+  const stopping = pendingStopSessions.includes(sessionOwner);
+  const queryClient = useQueryClient();
   const cloudQueueBlockedRef = useRef(false);
   const evalSnapshotFailureRef = useRef(false);
   // Shared with promote-to-send so a manual send-now cannot race the idle drain.
@@ -2265,34 +2269,42 @@ export function SessionSurface(props: SessionSurfaceProps) {
   ]);
 
   const handleAbort = useCallback(async () => {
+    if (pendingStopsRef.current.has(sessionOwner)) return;
     const phase = getQueuedDrainState(props.sessionId).phase;
     if (!chatStreaming && phase.kind !== "sending" && phase.kind !== "admission_unknown") return;
-    setError(null);
-    // Stop means stop: drop queued follow-ups before aborting, otherwise the
-    // queue-drain effect below re-prompts the agent the moment the abort
-    // lands and the session reports idle (#2014).
-    getComposerQueuedDrafts(useComposerStateStore.getState(), props.sessionId)
-      .forEach((item) => item.draft.attachments.forEach(revokeAttachmentPreview));
-    clearQueuedDrafts(props.sessionId);
-    dispatchQueuedDrain(props.sessionId, { type: "queue_cleared" });
-    // The prompt was sent through a directory-scoped client (session-route
-    // passes the workspace root), so the abort must target the same scope —
-    // without it the server resolves the default project, finds no live run,
-    // and answers `200: false` while the stream keeps going (#2014).
+    pendingStopsRef.current.add(sessionOwner);
+    setPendingStopSessions([...pendingStopsRef.current]);
     try {
+      setError(null);
+      // Stop means stop: drop queued follow-ups before aborting, otherwise the
+      // queue-drain effect below re-prompts the agent the moment the abort
+      // lands and the session reports idle (#2014).
+      getComposerQueuedDrafts(useComposerStateStore.getState(), props.sessionId)
+        .forEach((item) => item.draft.attachments.forEach(revokeAttachmentPreview));
+      clearQueuedDrafts(props.sessionId);
+      dispatchQueuedDrain(props.sessionId, { type: "queue_cleared" });
+      // The prompt was sent through a directory-scoped client (session-route
+      // passes the workspace root), so the abort must target the same scope —
+      // without it the server resolves the default project, finds no live run,
+      // and answers `200: false` while the stream keeps going (#2014).
       await interruptSessionTurn(props.opencodeBaseUrl, opencodeClient, props.sessionId,
         props.workspaceRoot.trim() || undefined, {
           admissionUnknown: phase.kind === "admission_unknown",
           onStopped: () => dispatchQueuedDrain(props.sessionId, { type: "stop_confirmed" }),
         });
+      captureAnalyticsEvent("task_run_stopped", {});
+      // The surface survives navigation; refresh the stopped conversation, not
+      // whichever query the observer is showing when cancellation finishes.
+      await queryClient.refetchQueries({ queryKey: snapshotQueryKey, exact: true });
+      return true;
     } catch (error) {
       setError({ message: error instanceof Error ? error.message : t("session.stop_failed") });
       return false;
+    } finally {
+      pendingStopsRef.current.delete(sessionOwner);
+      setPendingStopSessions([...pendingStopsRef.current]);
     }
-    captureAnalyticsEvent("task_run_stopped", {});
-    await snapshotQuery.refetch();
-    return true;
-  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.opencodeBaseUrl, props.sessionId, props.workspaceRoot, snapshotQuery.refetch, setError]);
+  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.opencodeBaseUrl, props.sessionId, props.workspaceRoot, queryClient, sessionOwner, snapshotQueryKey, setError]);
 
   const checkUnknownAdmission = useCallback(async (notify = false) => {
     const phase = getQueuedDrainState(props.sessionId).phase;
@@ -2597,10 +2609,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
     label: "Stop the current run",
     description: "Stop the current streaming session run.",
     sideEffect: "mutation",
-    disabled: !chatStreaming && queuedDrainState.phase.kind !== "sending" && queuedDrainState.phase.kind !== "admission_unknown",
+    disabled: stopping || (!chatStreaming && queuedDrainState.phase.kind !== "sending" && queuedDrainState.phase.kind !== "admission_unknown"),
     targetRef: composerShellRef,
     execute: handleAbort,
-  }), [chatStreaming, handleAbort, queuedDrainState.phase.kind]);
+  }), [chatStreaming, handleAbort, queuedDrainState.phase.kind, stopping]);
   useControlAction(props.isControlTarget ? composerStopControlAction : null);
 
   const listSkills = useCallback(async (): Promise<SkillCard[]> => {
@@ -3280,6 +3292,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onQueue={handleQueue}
         onStop={async () => { await handleAbort(); }}
         busy={chatStreaming}
+        stopping={stopping}
         steering={steering}
         submissionPreparing={preparingCloudTools || sending || autoSending}
         queuedCount={queuedItems.length}

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -18,11 +18,11 @@ import type {
 const workspaceId = "workspace-focus-continuity";
 const sessionId = "session-focus-continuity";
 
-function createSnapshot(status: SessionStatus, updated: number): OpenworkSessionSnapshot {
+function createSnapshot(status: SessionStatus, updated: number, id = sessionId): OpenworkSessionSnapshot {
   return {
     session: {
-      id: sessionId,
-      slug: sessionId,
+      id,
+      slug: id,
       projectID: "project-focus-continuity",
       directory: "/tmp/project-focus-continuity",
       title: "Focus continuity",
@@ -31,10 +31,10 @@ function createSnapshot(status: SessionStatus, updated: number): OpenworkSession
     },
     messages: [{
       info: {
-        id: "existing-user-message", sessionID: sessionId, role: "user", time: { created: 1 },
+        id: "existing-user-message", sessionID: id, role: "user", time: { created: 1 },
         agent: "build", model: { providerID: "test", modelID: "test-model" },
       },
-      parts: [{ id: "existing-user-part", sessionID: sessionId, messageID: "existing-user-message", type: "text", text: "Keep this session mounted." }],
+      parts: [{ id: "existing-user-part", sessionID: id, messageID: "existing-user-message", type: "text", text: "Keep this session mounted." }],
     }],
     todos: [],
     status,
@@ -75,7 +75,7 @@ async function waitFor(predicate: () => boolean, label: string) {
   throw new Error(`Timed out waiting for ${label}`);
 }
 
-test("composer focus and optimistic sends preserve drafts through snapshots and first-message handoff", async () => {
+test("composer focus, pending stops, and optimistic sends preserve drafts through snapshots and first-message handoff", async () => {
   const require = createRequire(import.meta.url);
   // Bun's isolated test loader cycles Lexical's ESM entries; use their real CJS entries before the app imports the editor.
   for (const moduleId of [
@@ -142,10 +142,19 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
   Object.defineProperty(window, "fetch", { configurable: true, value: fetchStub });
   window.localStorage.setItem("openwork.shell-config", JSON.stringify({ starterCards: false }));
   let fetchedSnapshot = createSnapshot({ type: "busy" }, 1);
+  const otherSessionId = `${sessionId}-other`;
+  const otherSnapshot = createSnapshot({ type: "busy" }, 1, otherSessionId);
+  const interruptionModule = await import("../src/app/lib/opencode-interruption");
+  let interruption = Promise.withResolvers<void>();
+  const interrupt = mock((..._args: Parameters<typeof interruptionModule.interruptSessionTurn>) => interruption.promise);
+  mock.module("@/app/lib/opencode-interruption", () => ({
+    ...interruptionModule,
+    interruptSessionTurn: interrupt,
+  }));
   mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
   mock.module("@/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
   mock.module("@/app/lib/opencode-session-native", () => ({
-    composeNativeSessionSnapshot: async () => fetchedSnapshot,
+    composeNativeSessionSnapshot: async (_target: unknown, id: string) => id === otherSessionId ? otherSnapshot : fetchedSnapshot,
   }));
   const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
   const { snapshotKey, transcriptKey } = await import("../src/react-app/domains/session/sync/session-sync");
@@ -168,7 +177,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
   let prepareSubmission: ((text?: string) => void) | undefined;
   const revokePreview = spyOn(URL, "revokeObjectURL");
 
-  const renderSurface = (opencodeBaseUrl = "http://127.0.0.1:1/opencode") => root.render(
+  const renderSurface = (opencodeBaseUrl = "http://127.0.0.1:1/opencode", activeSessionId = sessionId) => root.render(
         <QueryClientProvider client={queryClient}>
           <LocalProvider>
             <ShellConfigProvider>
@@ -176,7 +185,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
                 client={client}
                 workspaceId={workspaceId}
                 workspaceRoot="/tmp/project-focus-continuity"
-                sessionId={sessionId}
+                sessionId={activeSessionId}
                 draftScope="local"
                 isControlTarget={false}
                 opencodeBaseUrl={opencodeBaseUrl}
@@ -216,6 +225,7 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
           </LocalProvider>
         </QueryClientProvider>,
       );
+  const renderSession = (activeSessionId = sessionId) => renderSurface(undefined, activeSessionId);
   try {
     await act(async () => renderSurface());
     await waitFor(
@@ -233,6 +243,118 @@ test("composer focus and optimistic sends preserve drafts through snapshots and 
     if (!editor) throw new Error("Expected the Lexical editor");
     editor.focus();
     expect(document.activeElement).toBe(editor);
+
+    // Hold both async boundaries: idle alone must not release Stop's feedback.
+    let snapshotRefresh = Promise.withResolvers<void>();
+    const refetch = spyOn(queryClient, "refetchQueries").mockImplementation(() => snapshotRefresh.promise);
+    const stop = () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Stop"]');
+      if (!button || button.disabled) throw new Error("Expected an enabled Stop button");
+      button.click();
+      button.click();
+    };
+    const expectStopping = () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Stopping…"]');
+      expect(button?.disabled).toBe(true);
+      expect(button?.getAttribute("aria-busy")).toBe("true");
+      expect(button?.querySelector("svg.lucide-loader-circle.animate-spin")).not.toBeNull();
+      expect(container.querySelector('button[aria-label="Run task"]')).toBeNull();
+      expect(container.querySelector('[data-lexical-editor="true"]')?.getAttribute("contenteditable")).toBe("true");
+    };
+    const escape = () => editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    await act(async () => stop());
+    expect(interrupt).toHaveBeenCalledTimes(1);
+    expect(interrupt.mock.calls[0]).toEqual([
+      "http://127.0.0.1:1/opencode", expect.anything(), sessionId, "/tmp/project-focus-continuity",
+      { admissionUnknown: false, onStopped: expect.any(Function) },
+    ]);
+    expectStopping();
+    await act(async () => { escape(); });
+    await act(async () => { escape(); });
+    expect(interrupt).toHaveBeenCalledTimes(1);
+    expect(refetch).not.toHaveBeenCalled();
+    await act(async () => {
+      fetchedSnapshot = createSnapshot({ type: "idle" }, 2);
+      queryClient.setQueryData(snapshotKey(workspaceId, sessionId), fetchedSnapshot);
+    });
+    await waitFor(() => container.textContent?.includes("status: idle") === true, "idle while Stop is pending");
+    expectStopping();
+    await act(async () => interruption.resolve());
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refetch).toHaveBeenLastCalledWith({ queryKey: snapshotKey(workspaceId, sessionId), exact: true });
+    expectStopping();
+    expect(container.querySelector('[data-lexical-editor="true"]')).toBe(editor);
+    expect(editor.textContent).toBe(draft);
+    await act(async () => snapshotRefresh.resolve());
+    expect(container.querySelector('button[aria-label="Stopping…"]')).toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Run task"]')?.disabled).toBe(false);
+    expect(container.querySelector('button[aria-busy="true"]')).toBeNull();
+
+    await act(async () => {
+      fetchedSnapshot = createSnapshot({ type: "busy" }, 3);
+      queryClient.setQueryData(snapshotKey(workspaceId, sessionId), fetchedSnapshot);
+    });
+    await waitFor(() => container.querySelector('button[aria-label="Stop"]') !== null, "Stop on the next busy turn");
+    interruption = Promise.withResolvers<void>();
+    await act(async () => stop());
+    expect(interrupt).toHaveBeenCalledTimes(2);
+    await act(async () => { escape(); });
+    await act(async () => interruption.reject(new Error("Stop unavailable")));
+    expect(container.textContent).toContain("Stop unavailable");
+    expect(container.textContent).not.toContain("Hit Escape again to stop the agent");
+    expect(container.querySelector('button[aria-label="Stopping…"]')).toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Stop"]')?.disabled).toBe(false);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    interruption = Promise.withResolvers<void>();
+    await act(async () => { escape(); });
+    expect(interrupt).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Hit Escape again to stop the agent");
+    await act(async () => { escape(); });
+    expect(interrupt).toHaveBeenCalledTimes(3);
+    expect(container.textContent).not.toContain("Stop unavailable");
+    expectStopping();
+
+    // Re-render without a key so pending owners share the same mounted surface.
+    const originalInterruption = interruption;
+    snapshotRefresh = Promise.withResolvers<void>();
+    await act(async () => {
+      queryClient.setQueryData(snapshotKey(workspaceId, otherSessionId), otherSnapshot);
+      renderSession(otherSessionId);
+    });
+    // Seed after first-render hydration, just as for the original session.
+    await act(async () => useComposerStateStore.getState().setDraft(otherSessionId, "Other session draft"));
+    await waitFor(
+      () => container.querySelector('[data-lexical-editor="true"]')?.textContent === "Other session draft",
+      "the other session draft to reach Lexical",
+    );
+    expect(container.querySelector('button[aria-label="Stopping…"]')).toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Stop"]')?.disabled).toBe(false);
+    interruption = Promise.withResolvers<void>();
+    await act(async () => stop());
+    expect(interrupt).toHaveBeenCalledTimes(4);
+    expect(interrupt.mock.calls[3]?.[2]).toBe(otherSessionId);
+    expectStopping();
+    await act(async () => originalInterruption.resolve());
+    expect(refetch).toHaveBeenCalledTimes(2);
+    expect(refetch).toHaveBeenLastCalledWith({ queryKey: snapshotKey(workspaceId, sessionId), exact: true });
+    expectStopping();
+    await act(async () => renderSession());
+    expectStopping();
+    await act(async () => snapshotRefresh.resolve());
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Stop"]')?.disabled).toBe(false);
+    await act(async () => renderSession(otherSessionId));
+    expectStopping();
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Other session draft");
+    await act(async () => interruption.reject(new Error("Other session Stop unavailable")));
+    expect(container.textContent).toContain("Other session Stop unavailable");
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Stop"]')?.disabled).toBe(false);
+    await act(async () => renderSession());
+    expect(container.textContent).not.toContain("Other session Stop unavailable");
+    expect(container.querySelector('[data-lexical-editor="true"]')).toBe(editor);
+    expect(editor.textContent).toBe(draft);
+    expect(refetch).toHaveBeenCalledTimes(2);
+    refetch.mockRestore();
+    editor.focus();
 
     await act(async () => {
       fetchedSnapshot = createSnapshot({ type: "idle" }, 2);


### PR DESCRIPTION
## Summary
- Immediately replace Stop with a disabled spinner and a “Stopping…” label while interruption and transcript refresh settle.
- Ignore repeated clicks and Escape-to-stop while pending; release the control after failure so stopping remains retryable.
- Keep pending feedback scoped to its conversation across retained navigation and refresh the original conversation after cancellation. Typing and the underlying interruption algorithm remain unchanged.

## Verification
**Verdict: Incomplete** — focused mounted-component coverage passes, but exact-head runtime journey evidence has not been run or published.

- Passed on `d43f44b3a`: `pnpm --filter @openwork/app exec bun test --isolate ./tests/composer-focus-continuity.test.tsx` — exit 0; 1 passed, 0 failed, 0 skipped; 245 assertions.
- Passed: `git diff origin/dev...HEAD --check`.
- The mounted regression holds mocked interruption and snapshot-refresh boundaries. It checks immediate pending feedback, duplicate Stop suppression, idle-before-refresh behavior, failure/retry, editable drafts, and isolation across retained session navigation.
- Deferred: extend the existing `parent-child-permission-approval` journey with deterministic pending-feedback coverage, then run `pnpm evals:e2e parent-child-permission-approval` and publish exact-head evidence. Component success is not runtime proof.

## Manual verification
1. Start a response and click Stop while it is running.
2. Confirm the control immediately becomes a disabled spinner labeled “Stopping…” and cannot trigger duplicate Stop requests.
3. Confirm typing remains available and the spinner persists until cancellation and transcript refresh finish.
4. Switch conversations during the pending Stop and verify the other conversation retains its own control state.
5. Simulate interruption failure and verify Stop becomes retryable.

Rebased onto current `dev` before publication. No merge or release is included.