### PR TITLE
fix(browser): keep panel geometry in sync with resize and zoom

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -242,7 +242,7 @@ declare global {
         use?: (id: string) => Promise<RecoveryActionResult>;
       };
       browser?: {
-        show?: (bounds: { x: number; y: number; width: number; height: number }, sessionId?: string | null) => Promise<void>;
+        show?: (bounds: { x: number; y: number; width: number; height: number }, sessionId?: string | null) => Promise<boolean | void>;
         hide?: () => Promise<void>;
         openUrl?: (
           url: string,
@@ -254,7 +254,7 @@ declare global {
         back?: () => Promise<void>;
         forward?: () => Promise<void>;
         reload?: () => Promise<void>;
-        setBounds?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
+        setBounds?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<boolean | void>;
         getState?: () => Promise<BrowserStatePayload | null>;
         createTab?: (url?: string, sessionId?: string | null) => Promise<{ tabId: string }>;
         closeTab?: (tabId: string) => Promise<string | null>;

--- a/apps/app/src/react-app/domains/session/panel/browser-bounds-sync.test.ts
+++ b/apps/app/src/react-app/domains/session/panel/browser-bounds-sync.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { setImmediate } from "node:timers/promises";
+import { createBrowserBoundsSync, type BrowserBounds } from "./browser-bounds-sync";
+
+const BOUNDS = { x: 800, y: 40, width: 400, height: 900 };
+
+function deferred() {
+  let resolve!: (value: boolean) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<boolean>((accept, fail) => { resolve = accept; reject = fail; });
+  return { promise, resolve, reject };
+}
+
+function fixture() {
+  const shows: { bounds: BrowserBounds; sessionId: string }[] = [];
+  const updates: BrowserBounds[] = [];
+  const errors: unknown[] = [];
+  const controls = { show: async () => true, setBounds: async () => true };
+  let hides = 0;
+  const sync = createBrowserBoundsSync({
+    show(bounds, sessionId) {
+      shows.push({ bounds, sessionId });
+      return controls.show();
+    },
+    setBounds(bounds) {
+      updates.push(bounds);
+      return controls.setBounds();
+    },
+    async hide() { hides++; },
+  }, "A", (error) => { errors.push(error); });
+  return { sync, shows, updates, errors, controls, get hides() { return hides; } };
+}
+
+test("shared RAF/RO writer deduplicates idle frames but sends post-RAF layout changes immediately", async () => {
+  const { sync, shows, updates } = fixture();
+  sync.sync(BOUNDS, 2, false);
+  await setImmediate();
+  for (let frame = 0; frame < 100; frame++) sync.sync({ ...BOUNDS }, 2, false);
+  assert.deepEqual(shows, [{ bounds: BOUNDS, sessionId: "A" }]);
+  assert.deepEqual(updates, []);
+
+  // RO can settle panel constraints after RAF. It uses this same writer,
+  // which must send now, not defer the new rectangle to another frame.
+  const resized = { ...BOUNDS, x: 700, width: 500 };
+  sync.sync(resized, 2, false);
+  assert.deepEqual(updates, [resized]);
+  sync.sync({ ...resized }, 2, false);
+  assert.equal(updates.length, 1);
+  await setImmediate();
+
+  sync.sync(resized, 2.5, false);
+  assert.deepEqual(updates, [resized, resized]);
+  await setImmediate();
+  sync.invalidate();
+  sync.sync(resized, 2.5, false);
+  assert.deepEqual(updates, [resized, resized, resized]); // DPR never scales CSS bounds.
+});
+
+test("a rejected show stays a failed intent until geometry changes or explicit invalidation", async () => {
+  const { sync, shows, updates, controls, errors } = fixture();
+  const pending = deferred();
+  controls.show = () => pending.promise;
+  sync.sync(BOUNDS, 1, false);
+  for (let frame = 0; frame < 10; frame++) sync.sync(BOUNDS, 1, false);
+  assert.equal(shows.length, 1);
+  assert.deepEqual(updates, []);
+  pending.resolve(false);
+  await setImmediate();
+  for (let frame = 0; frame < 10; frame++) {
+    sync.sync(BOUNDS, 1, false);
+    await setImmediate();
+  }
+  assert.equal(shows.length, 1);
+  assert.deepEqual(errors, []);
+  controls.show = async () => true;
+  sync.invalidate();
+  sync.sync(BOUNDS, 1, false);
+  assert.equal(shows.length, 2);
+  await setImmediate();
+  sync.sync(BOUNDS, 1, false);
+  assert.deepEqual(updates, []);
+});
+
+test("permanent show errors report once per intent instead of retrying and toasting every frame", async () => {
+  const { sync, shows, updates, controls, errors } = fixture();
+  const error = new Error("Browser unavailable");
+  controls.show = async () => { throw error; };
+  for (let frame = 0; frame < 10; frame++) {
+    sync.sync(BOUNDS, 1, false);
+    await setImmediate();
+  }
+  assert.equal(shows.length, 1);
+  assert.deepEqual(errors, [error]);
+  assert.deepEqual(updates, []);
+
+  const resized = { ...BOUNDS, width: 450 };
+  controls.show = async () => true;
+  sync.sync(resized, 1, false);
+  assert.equal(shows.length, 2);
+  await setImmediate();
+  sync.sync(resized, 1, false);
+  assert.deepEqual(updates, []);
+});
+
+test("hide supersedes pending show without concurrent shows, stale toasts, or a poisoned cache", async () => {
+  const f = fixture();
+  const pending = deferred();
+  f.controls.show = () => pending.promise;
+  f.sync.sync(BOUNDS, 1, false);
+  f.sync.invalidate();
+  f.sync.sync(BOUNDS, 1, true);
+  f.sync.sync(BOUNDS, 1, true);
+  assert.equal(f.hides, 1);
+  f.sync.sync(BOUNDS, 1, false);
+  assert.equal(f.shows.length, 1, "the old show remains the only in-flight show");
+  pending.reject(new Error("Superseded"));
+  await setImmediate();
+  assert.deepEqual(f.errors, []);
+  f.controls.show = async () => true;
+  f.sync.sync(BOUNDS, 1, false);
+  assert.equal(f.shows.length, 2);
+  await setImmediate();
+  f.sync.sync(BOUNDS, 1, true);
+  f.sync.sync(BOUNDS, 1, false);
+  assert.equal(f.shows.length, 3, "hide clears same-geometry dedup");
+});
+
+test("invalidation during a pending show is not lost, and disposal ignores late show failure", async () => {
+  const f = fixture();
+  const pending = deferred();
+  f.controls.show = () => pending.promise;
+  f.sync.sync(BOUNDS, 1, false);
+  f.sync.invalidate();
+  f.sync.sync(BOUNDS, 1, false);
+  assert.equal(f.shows.length, 1);
+  pending.resolve(false);
+  await setImmediate();
+  const next = deferred();
+  f.controls.show = () => next.promise;
+  f.sync.sync(BOUNDS, 1, false);
+  assert.equal(f.shows.length, 2);
+  f.sync.dispose();
+  next.reject(new Error("Disposed"));
+  await setImmediate();
+  f.sync.invalidate();
+  f.sync.sync(BOUNDS, 2, false);
+  assert.equal(f.shows.length, 2);
+  assert.equal(f.hides, 1);
+  assert.deepEqual(f.errors, []);
+});
+
+test("failed bounds sends clear local dedup but superseded failures cannot clear newer geometry", async () => {
+  const { sync, updates, controls } = fixture();
+  sync.sync(BOUNDS, 1, false);
+  await setImmediate();
+  const first = { ...BOUNDS, width: 450 };
+  const latest = { ...BOUNDS, width: 500 };
+  const pending = deferred();
+  controls.setBounds = () => pending.promise;
+  sync.sync(first, 1, false);
+  controls.setBounds = async () => true;
+  sync.sync(latest, 1, false);
+  await setImmediate();
+  pending.reject(new Error("Old bounds failed"));
+  await setImmediate();
+  sync.sync(latest, 1, false);
+  assert.deepEqual(updates, [first, latest]);
+
+  for (const fail of [async () => false, async () => { throw new Error("Bounds failed"); }]) {
+    controls.setBounds = fail;
+    sync.invalidate();
+    sync.sync(latest, 1, false);
+    await setImmediate();
+    const count = updates.length;
+    controls.setBounds = async () => true;
+    sync.sync(latest, 1, false);
+    assert.equal(updates.length, count + 1);
+    await setImmediate();
+  }
+});

--- a/apps/app/src/react-app/domains/session/panel/browser-bounds-sync.ts
+++ b/apps/app/src/react-app/domains/session/panel/browser-bounds-sync.ts
@@ -1,0 +1,85 @@
+export type BrowserBounds = { x: number; y: number; width: number; height: number };
+
+type BrowserBoundsBridge = {
+  show?: (bounds: BrowserBounds, sessionId: string) => Promise<boolean | void>;
+  setBounds?: (bounds: BrowserBounds) => Promise<boolean | void>;
+  hide?: () => Promise<void>;
+};
+
+type Geometry = { bounds: BrowserBounds; pixelRatio: number };
+
+export function createBrowserBoundsSync(
+  browser: BrowserBoundsBridge,
+  sessionId: string,
+  onError: (error: unknown) => void,
+) {
+  let disposed = false;
+  let shown = false;
+  let visibleIntent = false;
+  let showInFlight = false;
+  let lastGeometry: Geometry | null = null;
+  let failedShow: Geometry | null = null;
+
+  function sameGeometry(geometry: Geometry | null, bounds: BrowserBounds, pixelRatio: number) {
+    return geometry !== null && geometry.pixelRatio === pixelRatio
+      && geometry.bounds.x === bounds.x && geometry.bounds.y === bounds.y
+      && geometry.bounds.width === bounds.width && geometry.bounds.height === bounds.height;
+  }
+
+  async function send(geometry: Geometry, show: boolean) {
+    if (show) showInFlight = true;
+    try {
+      const accepted = await (show
+        ? browser.show?.(geometry.bounds, sessionId)
+        : browser.setBounds?.(geometry.bounds));
+      if (disposed || lastGeometry !== geometry) return;
+      if (accepted === false) {
+        lastGeometry = null;
+        if (show) failedShow = geometry;
+      } else if (show) {
+        shown = true;
+        failedShow = null;
+      }
+    } catch (error) {
+      if (disposed || lastGeometry !== geometry) return;
+      lastGeometry = null;
+      if (show) {
+        failedShow = geometry;
+        onError(error);
+      }
+    } finally {
+      if (show) showInFlight = false;
+    }
+  }
+
+  return {
+    sync(bounds: BrowserBounds, pixelRatio: number, occluded: boolean) {
+      if (disposed) return;
+      if (bounds.width < 1 || bounds.height < 1 || occluded) {
+        if (visibleIntent) void browser.hide?.();
+        visibleIntent = false;
+        shown = false;
+        lastGeometry = null;
+        failedShow = null;
+        return;
+      }
+      // DPR is only a zoom-change hint for fast local dedup, never a scale factor.
+      // Preload still stamps the actual webFrame zoom alongside the CSS bounds.
+      if (showInFlight || sameGeometry(lastGeometry, bounds, pixelRatio)
+        || (!shown && sameGeometry(failedShow, bounds, pixelRatio))) return;
+      const geometry = { bounds, pixelRatio };
+      lastGeometry = geometry;
+      visibleIntent = true;
+      void send(geometry, !shown);
+    },
+    invalidate() {
+      lastGeometry = null;
+      failedShow = null;
+    },
+    dispose() {
+      disposed = true;
+      lastGeometry = null;
+      void browser.hide?.();
+    },
+  };
+}

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -43,9 +43,9 @@ import {
   getElectronBrowser,
   getNativeMenuPoint,
   hasNativeBrowserOccluder,
-  sameBounds,
 } from "./utils";
 import { LoginSyncCard } from "../../browser-logins/login-sync-card";
+import { createBrowserBoundsSync } from "./browser-bounds-sync";
 
 type SidePanelProps = {
   sessionId: string;
@@ -180,9 +180,6 @@ function BrowserPanelContent({
   const urlFocusedRef = React.useRef(false);
   const contentRef = React.useRef<HTMLDivElement>(null);
   const urlInputRef = React.useRef<HTMLInputElement>(null);
-  const shownRef = React.useRef(false);
-  const boundsFrameRef = React.useRef<number | null>(null);
-  const lastBoundsRef = React.useRef<{ x: number; y: number; width: number; height: number } | null>(null);
 
   React.useEffect(() => {
     if (!urlFocusedRef.current) {
@@ -232,37 +229,24 @@ function BrowserPanelContent({
   React.useLayoutEffect(() => {
     const browser = getElectronBrowser();
     const content = contentRef.current;
-    if (!browser || !content || !isAvailable) {
-      return;
-    }
-
-    const bounds = computeBounds(content);
-    if (bounds.width < 1 || bounds.height < 1) {
-      return;
-    }
-
-    browser.setBounds?.(bounds);
-    lastBoundsRef.current = bounds;
-  });
-
-  React.useLayoutEffect(() => {
-    const browser = getElectronBrowser();
-    const content = contentRef.current;
 
     if (!browser || !content || !isAvailable) {
       browser?.hide?.();
-      shownRef.current = false;
-      lastBoundsRef.current = null;
-
-      if (boundsFrameRef.current != null) {
-        window.cancelAnimationFrame(boundsFrameRef.current);
-        boundsFrameRef.current = null;
-      }
-
       return;
     }
 
     let disposed = false;
+    let ready = false;
+    let boundsFrame: number | null = null;
+    const boundsSync = createBrowserBoundsSync(browser, sessionId, (error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    });
+
+    const scheduleBounds = () => {
+      if (!disposed && ready && boundsFrame === null) {
+        boundsFrame = window.requestAnimationFrame(watchBounds);
+      }
+    };
 
     const resetNativeView = async () => {
       await browser.hide?.();
@@ -271,69 +255,46 @@ function BrowserPanelContent({
         return;
       }
 
-      shownRef.current = false;
-      lastBoundsRef.current = null;
-      boundsFrameRef.current = window.requestAnimationFrame(watchBounds);
+      ready = true;
+      scheduleBounds();
     };
 
     const syncBounds = () => {
-      const bounds = computeBounds(content);
+      if (!ready || disposed) return;
+      boundsSync.sync(computeBounds(content), window.devicePixelRatio, hasNativeBrowserOccluder());
+    };
 
-      if (bounds.width < 1 || bounds.height < 1 || hasNativeBrowserOccluder()) {
-        if (shownRef.current) {
-          browser.hide?.();
-          shownRef.current = false;
-          lastBoundsRef.current = null;
-        }
-
-        return;
-      }
-
-      if (!shownRef.current) {
-        // Naming the conversation lets the native browser put that
-        // conversation's tabs on screen and keep every other conversation's
-        // tabs silently in the background.
-        void browser.show?.(bounds, sessionId).catch((error: unknown) => {
-          toast.error(error instanceof Error ? error.message : String(error));
-        });
-        shownRef.current = true;
-        lastBoundsRef.current = bounds;
-        return;
-      }
-
-      if (!sameBounds(lastBoundsRef.current, bounds)) {
-        browser.setBounds?.(bounds);
-        lastBoundsRef.current = bounds;
-      }
+    const invalidateBounds = () => {
+      boundsSync.invalidate();
+      scheduleBounds();
     };
 
     const watchBounds = () => {
+      boundsFrame = null;
       syncBounds();
-      boundsFrameRef.current = window.requestAnimationFrame(watchBounds);
+      // Position-only layout changes and dialog occlusion also need tracking.
+      scheduleBounds();
     };
 
     void resetNativeView();
 
+    // Panel constraints can settle in ResizeObserver after this frame's RAF.
     const observer = new ResizeObserver(syncBounds);
-
     observer.observe(content);
-    window.addEventListener("resize", syncBounds);
-    window.addEventListener("scroll", syncBounds, true);
+    window.addEventListener("resize", invalidateBounds);
+    window.addEventListener("openwork:browser:bounds-invalidated", invalidateBounds);
 
     return () => {
       disposed = true;
       observer.disconnect();
-      window.removeEventListener("resize", syncBounds);
-      window.removeEventListener("scroll", syncBounds, true);
+      window.removeEventListener("resize", invalidateBounds);
+      window.removeEventListener("openwork:browser:bounds-invalidated", invalidateBounds);
 
-      if (boundsFrameRef.current != null) {
-        window.cancelAnimationFrame(boundsFrameRef.current);
-        boundsFrameRef.current = null;
+      if (boundsFrame !== null) {
+        window.cancelAnimationFrame(boundsFrame);
       }
 
-      browser.hide?.();
-      shownRef.current = false;
-      lastBoundsRef.current = null;
+      boundsSync.dispose();
     };
   }, [isAvailable, sessionId]);
 

--- a/apps/app/src/react-app/domains/session/panel/utils.ts
+++ b/apps/app/src/react-app/domains/session/panel/utils.ts
@@ -8,10 +8,8 @@ export function getElectronBrowser() {
   return window.__OPENWORK_ELECTRON__?.browser ?? null;
 }
 
-// Bounds and points are sent in renderer CSS pixels. The Electron main process
-// converts them to window device-independent pixels using the authoritative
-// webContents zoom factor at apply time, so the renderer never needs to track
-// (and can never disagree with) the real zoom state.
+// Bounds and menu points use CSS pixels. Preload stamps the browser bounds with
+// measurement zoom; native menus handle their own coordinate conversion.
 export function getNativeMenuPoint(
   el: HTMLElement | null,
   point?: { clientX: number; clientY: number },
@@ -41,19 +39,6 @@ export function computeBounds(el: HTMLElement) {
     width: rect.width,
     height: rect.height,
   };
-}
-
-export function sameBounds(
-  left: { x: number; y: number; width: number; height: number } | null,
-  right: { x: number; y: number; width: number; height: number },
-) {
-  return Boolean(
-    left &&
-      left.x === right.x &&
-      left.y === right.y &&
-      left.width === right.width &&
-      left.height === right.height,
-  );
 }
 
 export function hasNativeBrowserOccluder() {

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -104,8 +104,8 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
   const registry = createBrowserTabRegistry();
   let browserViewVisible = false;
   let backgroundWindow = null;
-  // Last browser panel bounds reported by the renderer, in renderer CSS pixels.
-  // Converted to window device-independent pixels at every setBounds call.
+  // Last accepted geometry in window DIPs. Reattaching must not scale an old
+  // CSS rectangle with a newer zoom while the renderer is still catching up.
   let lastBrowserBounds = null;
   let browserTabCounter = 0;
   // Active proxy for the built-in browser session: { rules, username, password }.
@@ -923,30 +923,32 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     return next;
   }
 
-  // The renderer reports bounds in CSS pixels, which Electron scales by the main
-  // window's zoom factor. Read the factor from the webContents at apply time so
-  // the conversion is always correct, no matter how the zoom was changed
-  // (shortcuts, native menu, or Chromium's persisted per-origin zoom).
   function mainWindowZoomFactor() {
     try {
       const factor = window()?.webContents.getZoomFactor();
-      return typeof factor === "number" && factor > 0 ? factor : 1;
+      return Number.isFinite(factor) && factor > 0 ? factor : 1;
     } catch {
       return 1;
     }
   }
 
-  function scaleRendererBounds(bounds) {
-    const zoom = mainWindowZoomFactor();
+  function acceptBrowserBounds(bounds) {
+    if (!bounds || ![bounds.x, bounds.y, bounds.width, bounds.height].every(Number.isFinite)
+      || bounds.width <= 0 || bounds.height <= 0) return false;
+    const currentZoom = mainWindowZoomFactor();
+    // Unstamped callers retain the existing CSS-pixel IPC contract.
+    const zoom = bounds.zoomFactor === undefined ? currentZoom : bounds.zoomFactor;
+    if (!Number.isFinite(zoom) || zoom <= 0 || Math.abs(zoom - currentZoom) > 1e-6) return false;
     // Round edges (not width/height) so the far edge has no sub-pixel seam.
     const x = Math.round(bounds.x * zoom);
     const y = Math.round(bounds.y * zoom);
-    return {
+    lastBrowserBounds = {
       x,
       y,
       width: Math.round((bounds.x + bounds.width) * zoom) - x,
       height: Math.round((bounds.y + bounds.height) * zoom) - y,
     };
+    return true;
   }
 
   // Automation clients (docs shots, screenshot skills, Playwright) attach to a
@@ -999,7 +1001,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     tab.view.setVisible(!approvals.has(tab.tabId));
     detachIdleBrowserViews(tab.view);
     // Size before attaching so a restored view never flashes at stale bounds.
-    tab.view.setBounds(scaleRendererBounds(lastBrowserBounds));
+    tab.view.setBounds(lastBrowserBounds);
     if (!mainWindow.contentView.children.includes(tab.view)) {
       mainWindow.contentView.addChildView(tab.view);
     }
@@ -1204,8 +1206,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
    * @param {string | null} [opts.sessionId] - the conversation whose panel is showing
    */
   function attachBrowserView(bounds, { preloadDefault = false, ensureTab = false, sessionId } = {}) {
-    if (!window()) return;
-    lastBrowserBounds = bounds;
+    if (!window() || !acceptBrowserBounds(bounds)) return false;
     browserViewVisible = true;
     if (sessionId !== undefined) {
       const previous = registry.visibleSessionId();
@@ -1219,15 +1220,13 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     }
     const view = getActiveBrowserView();
     attachActiveBrowserView();
-    if (bounds.width > 0 && bounds.height > 0) {
-      view?.setBounds(scaleRendererBounds(bounds));
-    }
     resetViewportEmulation(view);
     const url = view?.webContents.getURL();
     if (preloadDefault && (!url || url === "about:blank")) {
       runDetachedTask("load browser default page", () => view?.webContents.loadURL(BROWSER_DEFAULT_URL));
     }
     sendBrowserState();
+    return true;
   }
 
   function hideBrowserView() {
@@ -1294,11 +1293,12 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
       getActiveWebContents()?.reload();
     });
     ipcMain.handle("openwork:browser:bounds", (_event, bounds) => {
-      lastBrowserBounds = bounds;
+      if (!acceptBrowserBounds(bounds)) return false;
       const view = getActiveBrowserView();
-      if (view && browserViewVisible && bounds.width > 0 && bounds.height > 0) {
-        view.setBounds(scaleRendererBounds(bounds));
+      if (view && browserViewVisible) {
+        view.setBounds(lastBrowserBounds);
       }
+      return true;
     });
     ipcMain.handle("openwork:browser:state", () => ({
       ...browserStatePayload(),

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -16,7 +16,11 @@ export const controls = {
 export const exposed = {};
 export const contextBridge = { exposeInMainWorld(name, value) { exposed[name] = value; } };
 export const webUtils = {};
-export const webFrame = { zoomFactor: 1, getZoomFactor() { return this.zoomFactor; } };
+export const webFrame = {
+  zoomFactor: 1,
+  getZoomFactor() { return this.zoomFactor; },
+  setZoomFactor(factor) { this.zoomFactor = factor; },
+};
 export const preloadCalls = [];
 export const ipcRenderer = new EventEmitter();
 ipcRenderer.invoke = (channel, ...args) => { preloadCalls.push({ channel, args }); return controls.invoke(channel, ...args); };
@@ -250,16 +254,16 @@ const flush = () => new Promise((resolve) => setImmediate(resolve));
 
 let preloadTestId = 0;
 async function loadPreload(t) {
-  const previousWindow = globalThis.window;
-  globalThis.window = new EventTarget();
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  Object.defineProperty(globalThis, "window", { value: new EventTarget(), configurable: true, writable: true });
   t.after(() => {
     if (previousWindow === undefined) delete globalThis.window;
-    else globalThis.window = previousWindow;
+    else Object.defineProperty(globalThis, "window", previousWindow);
     ipcRenderer.removeAllListeners();
   });
   ipcRenderer.removeAllListeners();
   controls.invoke = async () => true;
-  webFrame.zoomFactor = 1;
+  webFrame.setZoomFactor(1);
   preloadCalls.length = 0;
   await import(`./preload.mjs?geometry-test=${++preloadTestId}`);
   // Existing bootstrap reads are outside the geometry path under test.
@@ -322,10 +326,10 @@ test("geometry updates scale fractional edges at changing zoom without replacing
   const foreground = onScreen();
   const background = views().find(view => view !== foreground);
   const backgroundBounds = background.getBounds();
-  for (const [zoomFactor, expected] of [
-    [1, { x: 10, y: 21, width: 101, height: 81 }],
-    [1.25, { x: 13, y: 27, width: 126, height: 101 }],
-    [0.8, { x: 8, y: 17, width: 81, height: 65 }],
+  for (const { zoomFactor, expected } of [
+    { zoomFactor: 1, expected: { x: 10, y: 21, width: 101, height: 81 } },
+    { zoomFactor: 1.25, expected: { x: 13, y: 27, width: 126, height: 101 } },
+    { zoomFactor: 0.8, expected: { x: 8, y: 17, width: 81, height: 65 } },
   ]) {
     mainContents.zoomFactor = zoomFactor;
     assert.equal(invoke("openwork:browser:bounds", { ...bounds, zoomFactor }), true);
@@ -394,7 +398,7 @@ test("preload deduplicates geometry including zoom, invalidates after applied zo
   assert.equal(preloadCalls.length, 1, "show and same-geometry frames share a dedup cache");
   assert.deepEqual(preloadCalls[0].args, [{ ...PANEL_BOUNDS, zoomFactor: 1 }, "A"]);
   mainContents.zoomFactor = 1.25;
-  webFrame.zoomFactor = 1.25;
+  webFrame.setZoomFactor(1.25);
   await browser.setBounds(PANEL_BOUNDS);
   assert.equal(preloadCalls.length, 2, "equal CSS bounds at a different zoom must still be sent");
   assert.deepEqual(onScreen().getBounds(), { x: 1000, y: 50, width: 500, height: 1125 });
@@ -430,7 +434,7 @@ test("preload retries rejected zoom snapshots but a late rejection cannot invali
   controls.invoke = async () => { await pending.promise; return false; };
   const stale = browser.setBounds({ ...PANEL_BOUNDS, width: 300 });
   controls.invoke = async () => true;
-  webFrame.zoomFactor = 1.25;
+  webFrame.setZoomFactor(1.25);
   await browser.setBounds(PANEL_BOUNDS);
   pending.finish();
   assert.equal(await stale, false);

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -11,7 +11,17 @@ export const effects = [];
 export const controls = {
   ready: true,
   confirm: async () => 0, beforeLoad: async () => {}, beforeCommand: async () => {}, beforeDiscovery: async () => {},
+  invoke: async () => true,
 };
+export const exposed = {};
+export const contextBridge = { exposeInMainWorld(name, value) { exposed[name] = value; } };
+export const webUtils = {};
+export const webFrame = { zoomFactor: 1, getZoomFactor() { return this.zoomFactor; } };
+export const preloadCalls = [];
+export const ipcRenderer = new EventEmitter();
+ipcRenderer.invoke = (channel, ...args) => { preloadCalls.push({ channel, args }); return controls.invoke(channel, ...args); };
+ipcRenderer.send = (channel, ...args) => { preloadCalls.push({ channel, args }); };
+ipcRenderer.sendSync = () => null;
 export const app = { on() {} };
 export const clipboard = { writeText(url) { effects.push({ type: "copy", url }); } };
 export const dialog = { async showMessageBox(_window, options) { effects.push({ type: "dialog" }); return { response: await controls.confirm(options) }; } };
@@ -144,7 +154,7 @@ export function load(url, context, next) {
 register(`data:text/javascript,${encodeURIComponent(hooks)}`);
 const { createBrowserPanel } = await import("./browser-panel.mjs");
 // @ts-expect-error The registered test-only Electron stub exports its witnesses.
-const { createdViews, effects, controls, browserSession, navigation, requestHooks } = await import("electron");
+const { createdViews, effects, controls, browserSession, navigation, requestHooks, exposed, webFrame, preloadCalls, ipcRenderer } = await import("electron");
 
 const PANEL_BOUNDS = { x: 800, y: 40, width: 400, height: 900 };
 const LINK = { url: "https://example.com/a%2Fb?x=one%20two&x=%2F#section", point: { x: 20, y: 30 }, sessionId: "A" };
@@ -179,8 +189,8 @@ function createPanel(checkPolicy = async (_request) => {}, remoteDebugPort = 0) 
     webContents: Object.assign(new EventEmitter(), {
       mainFrame: {},
       getURL: () => "http://localhost/index.html",
-      /** @returns {number} */
-      getZoomFactor: () => 1,
+      zoomFactor: 1,
+      getZoomFactor() { return this.zoomFactor; },
       destroyed: false,
       isDestroyed() { return this.destroyed; },
       send(channel, payload) { sent.push({ channel, payload }); },
@@ -238,6 +248,25 @@ function createPanel(checkPolicy = async (_request) => {}, remoteDebugPort = 0) 
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
 
+let preloadTestId = 0;
+async function loadPreload(t) {
+  const previousWindow = globalThis.window;
+  globalThis.window = new EventTarget();
+  t.after(() => {
+    if (previousWindow === undefined) delete globalThis.window;
+    else globalThis.window = previousWindow;
+    ipcRenderer.removeAllListeners();
+  });
+  ipcRenderer.removeAllListeners();
+  controls.invoke = async () => true;
+  webFrame.zoomFactor = 1;
+  preloadCalls.length = 0;
+  await import(`./preload.mjs?geometry-test=${++preloadTestId}`);
+  // Existing bootstrap reads are outside the geometry path under test.
+  t.mock.method(ipcRenderer, "sendSync", () => { throw new Error("Geometry must not use synchronous IPC"); });
+  return exposed.__OPENWORK_ELECTRON__.browser;
+}
+
 test("browser manager construction before app readiness defers session hooks until the first tab", async (t) => {
   controls.ready = false;
   t.after(() => { controls.ready = true; });
@@ -281,6 +310,134 @@ test("showing the panel sizes the active tab and resets viewport emulation left 
   assert.deepEqual(view.getBounds(), PANEL_BOUNDS);
   assert.deepEqual(commands(view), RESET_SEQUENCE);
   assert.equal(view.webContents.debugger.isAttached(), false, "the temporary debugger session is released");
+});
+
+test("geometry updates scale fractional edges at changing zoom without replacing or resizing background tabs", async () => {
+  const { invoke, mainContents, onScreen, views } = createPanel();
+  const bounds = { x: 10.4, y: 21.2, width: 100.8, height: 80.8 };
+  invoke("openwork:browser:createTab", "about:blank", "A");
+  invoke("openwork:browser:createTab", "about:blank", "B");
+  await flush();
+  invoke("openwork:browser:show", { ...bounds, zoomFactor: 1 }, "A");
+  const foreground = onScreen();
+  const background = views().find(view => view !== foreground);
+  const backgroundBounds = background.getBounds();
+  for (const [zoomFactor, expected] of [
+    [1, { x: 10, y: 21, width: 101, height: 81 }],
+    [1.25, { x: 13, y: 27, width: 126, height: 101 }],
+    [0.8, { x: 8, y: 17, width: 81, height: 65 }],
+  ]) {
+    mainContents.zoomFactor = zoomFactor;
+    assert.equal(invoke("openwork:browser:bounds", { ...bounds, zoomFactor }), true);
+    assert.equal(onScreen(), foreground);
+    assert.deepEqual(foreground.getBounds(), expected);
+    assert.deepEqual(background.getBounds(), backgroundBounds);
+  }
+  assert.equal(views().length, 2, "geometry never allocates a new page");
+});
+
+test("stale zoom snapshots cannot move a view, replace cached bounds, change ownership, or reopen a hidden panel", async () => {
+  const { invoke, mainContents, onScreen } = createPanel();
+  const a = invoke("openwork:browser:createTab", "about:blank", "A");
+  invoke("openwork:browser:createTab", "about:blank", "B");
+  const stale = { ...PANEL_BOUNDS, zoomFactor: 1 };
+  assert.equal(invoke("openwork:browser:show", stale, "A"), true);
+  const view = onScreen();
+  mainContents.zoomFactor = 1.25;
+  assert.equal(invoke("openwork:browser:show", stale, "B"), false);
+  assert.equal(invoke("openwork:browser:bounds", stale), false);
+  assert.equal(invoke("openwork:browser:state").visibleSessionId, "A");
+  assert.equal(onScreen(), view);
+  assert.deepEqual(view.getBounds(), PANEL_BOUNDS);
+
+  const latest = { x: 640, y: 48, width: 320, height: 600, zoomFactor: 1.25 };
+  assert.equal(invoke("openwork:browser:bounds", latest), true);
+  const nativeBounds = { x: 800, y: 60, width: 400, height: 750 };
+  assert.deepEqual(view.getBounds(), nativeBounds);
+  assert.equal(invoke("openwork:browser:bounds", stale), false);
+  mainContents.zoomFactor = 0.8;
+  await invoke("openwork:browser:selectTab", a.tabId);
+  assert.deepEqual(view.getBounds(), nativeBounds, "reattachment never rescales cached CSS with a new zoom");
+
+  invoke("openwork:browser:hide");
+  assert.equal(invoke("openwork:browser:show", latest, "B"), false);
+  assert.equal(onScreen(), null);
+  assert.equal(invoke("openwork:browser:state").visibleSessionId, "A");
+  assert.equal(invoke("openwork:browser:show", { ...latest, zoomFactor: 0.8 }, "B"), true);
+  assert.notEqual(onScreen(), view);
+  assert.equal(invoke("openwork:browser:state").visibleSessionId, "B");
+});
+
+test("unstamped geometry keeps the legacy CSS contract and malformed snapshots leave placement intact", () => {
+  const { invoke, mainContents, onScreen } = createPanel();
+  mainContents.zoomFactor = 1.25;
+  invoke("openwork:browser:createTab", "about:blank");
+  assert.equal(invoke("openwork:browser:show", PANEL_BOUNDS), true);
+  assert.deepEqual(onScreen().getBounds(), { x: 1000, y: 50, width: 500, height: 1125 });
+  const latest = { x: 80, y: 40, width: 240, height: 400 };
+  assert.equal(invoke("openwork:browser:bounds", latest), true);
+  const expected = { x: 100, y: 50, width: 300, height: 500 };
+  for (const invalid of [null, { ...latest, x: NaN }, { ...latest, width: 0 },
+    { ...latest, zoomFactor: Infinity }, { ...latest, zoomFactor: 0 }, { ...latest, zoomFactor: null }]) {
+    assert.equal(invoke("openwork:browser:bounds", invalid), false);
+    assert.deepEqual(onScreen().getBounds(), expected);
+  }
+});
+
+test("preload deduplicates geometry including zoom, invalidates after applied zoom, and preserves show/hide intent", async (t) => {
+  const { invoke, mainContents, onScreen } = createPanel();
+  invoke("openwork:browser:createTab", "about:blank", "A");
+  const browser = await loadPreload(t);
+  controls.invoke = async (channel, ...args) => invoke(channel, ...args);
+  assert.equal(await browser.show(PANEL_BOUNDS, "A"), true);
+  await browser.setBounds({ ...PANEL_BOUNDS });
+  assert.equal(preloadCalls.length, 1, "show and same-geometry frames share a dedup cache");
+  assert.deepEqual(preloadCalls[0].args, [{ ...PANEL_BOUNDS, zoomFactor: 1 }, "A"]);
+  mainContents.zoomFactor = 1.25;
+  webFrame.zoomFactor = 1.25;
+  await browser.setBounds(PANEL_BOUNDS);
+  assert.equal(preloadCalls.length, 2, "equal CSS bounds at a different zoom must still be sent");
+  assert.deepEqual(onScreen().getBounds(), { x: 1000, y: 50, width: 500, height: 1125 });
+  const resized = { ...PANEL_BOUNDS, x: 700, width: 500 };
+  await browser.setBounds(resized);
+  await browser.setBounds(resized);
+  assert.equal(preloadCalls.length, 3);
+  assert.deepEqual(onScreen().getBounds(), { x: 875, y: 50, width: 625, height: 1125 });
+  let invalidations = 0;
+  window.addEventListener("openwork:browser:bounds-invalidated", () => { invalidations++; });
+  ipcRenderer.emit("openwork:browser:bounds-invalidated", {});
+  assert.equal(invalidations, 1, "the renderer is explicitly asked to remeasure");
+  await browser.setBounds(resized);
+  assert.equal(preloadCalls.length, 4, "invalidation forces even identical geometry to be resent");
+  await browser.hide();
+  assert.equal(onScreen(), null);
+  await browser.show(resized, "A");
+  await browser.show(resized, "A");
+  assert.equal(preloadCalls.length, 7, "show intent is never deduplicated");
+  assert.ok(onScreen());
+});
+
+test("preload retries rejected zoom snapshots but a late rejection cannot invalidate newer geometry", async (t) => {
+  const browser = await loadPreload(t);
+  controls.invoke = async () => false;
+  assert.equal(await browser.show(PANEL_BOUNDS, "A"), false, "the renderer can retry a rejected show");
+  assert.equal(await browser.setBounds(PANEL_BOUNDS), false);
+  controls.invoke = async () => true;
+  assert.equal(await browser.setBounds(PANEL_BOUNDS), true);
+  assert.equal(preloadCalls.length, 3, "rejected geometry cannot poison deduplication");
+
+  const pending = gate();
+  controls.invoke = async () => { await pending.promise; return false; };
+  const stale = browser.setBounds({ ...PANEL_BOUNDS, width: 300 });
+  controls.invoke = async () => true;
+  webFrame.zoomFactor = 1.25;
+  await browser.setBounds(PANEL_BOUNDS);
+  pending.finish();
+  assert.equal(await stale, false);
+  await browser.setBounds(PANEL_BOUNDS);
+  assert.equal(preloadCalls.length, 5, "late rejection leaves the newer accepted snapshot cached");
+  assert.equal(preloadCalls[3].args[0].zoomFactor, 1, "zoom is captured before awaiting IPC");
+  assert.equal(preloadCalls[4].args[0].zoomFactor, 1.25);
 });
 
 test("selecting a tab from the tab strip resets that tab only", async () => {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2383,6 +2383,7 @@ const desktopCommandHandlers = {
         return false;
       }
       window.webContents.setZoomFactor(factor);
+      window.webContents.send("openwork:browser:bounds-invalidated");
       return true;
   },
   "__setNativeTheme": async (event, ...args) => {

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, webUtils } from "electron";
+import { contextBridge, ipcRenderer, webFrame, webUtils } from "electron";
 
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
@@ -6,6 +6,27 @@ const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
 const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
 const AUTOMATION_RUNNER_CREDENTIAL_REJECTED_EVENT = "openwork:automation-runner:credential-rejected";
+const BROWSER_BOUNDS_INVALIDATED_EVENT = "openwork:browser:bounds-invalidated";
+
+let lastBrowserGeometry = null;
+
+async function sendBrowserGeometry(channel, bounds, ...args) {
+  // Capture zoom in the same renderer turn as the CSS measurement, not after IPC.
+  const geometry = { ...bounds, zoomFactor: webFrame.getZoomFactor() };
+  if (channel === "openwork:browser:bounds" && lastBrowserGeometry
+    && ["x", "y", "width", "height", "zoomFactor"].every((key) => geometry[key] === lastBrowserGeometry[key])) {
+    return true;
+  }
+  lastBrowserGeometry = geometry;
+  try {
+    const accepted = await ipcRenderer.invoke(channel, geometry, ...args);
+    if (accepted === false && lastBrowserGeometry === geometry) lastBrowserGeometry = null;
+    return accepted;
+  } catch (error) {
+    if (lastBrowserGeometry === geometry) lastBrowserGeometry = null;
+    throw error;
+  }
+}
 
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
@@ -195,15 +216,18 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     },
   },
   browser: {
-    show(bounds, sessionId) { return ipcRenderer.invoke("openwork:browser:show", bounds, sessionId); },
-    hide() { return ipcRenderer.invoke("openwork:browser:hide"); },
+    show(bounds, sessionId) { return sendBrowserGeometry("openwork:browser:show", bounds, sessionId); },
+    hide() {
+      lastBrowserGeometry = null;
+      return ipcRenderer.invoke("openwork:browser:hide");
+    },
     openUrl(url, provider, options) { return ipcRenderer.invoke("openwork:browser:openUrl", url, provider, options); },
     setVisibleSession(sessionId) { return ipcRenderer.invoke("openwork:browser:setVisibleSession", sessionId); },
     navigate(url) { return ipcRenderer.invoke("openwork:browser:navigate", url); },
     back() { return ipcRenderer.invoke("openwork:browser:back"); },
     forward() { return ipcRenderer.invoke("openwork:browser:forward"); },
     reload() { return ipcRenderer.invoke("openwork:browser:reload"); },
-    setBounds(bounds) { return ipcRenderer.invoke("openwork:browser:bounds", bounds); },
+    setBounds(bounds) { return sendBrowserGeometry("openwork:browser:bounds", bounds); },
     getState() { return ipcRenderer.invoke("openwork:browser:state"); },
     createTab(url, sessionId) { return ipcRenderer.invoke("openwork:browser:createTab", url, sessionId); },
     closeTab(tabId) { return ipcRenderer.invoke("openwork:browser:closeTab", tabId); },
@@ -223,7 +247,10 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     getProxy() { return ipcRenderer.invoke("openwork:browser:getProxy"); },
     setControlEnabled(enabled) { return ipcRenderer.invoke("openwork:browser:setControlEnabled", enabled); },
     showTabContextMenu(tabId, point) { return ipcRenderer.invoke("openwork:browser:tabContextMenu", tabId, point); },
-    destroy() { return ipcRenderer.invoke("openwork:browser:destroy"); },
+    destroy() {
+      lastBrowserGeometry = null;
+      return ipcRenderer.invoke("openwork:browser:destroy");
+    },
     onStateChange(callback) {
       const handler = (_event, state) => callback(state);
       ipcRenderer.on("openwork:browser:state", handler);
@@ -322,6 +349,11 @@ ipcRenderer.on(NATIVE_MENU_CHECK_UPDATES_EVENT, () => {
 ipcRenderer.on(NATIVE_MENU_ZOOM_EVENT, (_event, action) => {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent(NATIVE_MENU_ZOOM_EVENT, { detail: action }));
+});
+
+ipcRenderer.on(BROWSER_BOUNDS_INVALIDATED_EVENT, () => {
+  lastBrowserGeometry = null;
+  window.dispatchEvent(new Event(BROWSER_BOUNDS_INVALIDATED_EVENT));
 });
 
 if (!applyShellDocumentMarkers() && typeof document !== "undefined") {

--- a/evals/packages/behaviors/src/browser-task.ts
+++ b/evals/packages/behaviors/src/browser-task.ts
@@ -107,14 +107,17 @@ export async function readBrowserState(app: Surface): Promise<BrowserState> {
   };
 }
 
-export async function readBrowserTabMetrics(app: Surface, targetId: string): Promise<{ width: number; height: number; hasFocus: boolean }> {
+export async function readBrowserTabMetrics(app: Surface, targetId: string): Promise<{ width: number; height: number; hasFocus: boolean; url: string; title: string; timeOrigin: number }> {
   const target = (await listTargets(app.handle.cdpUrl)).find((candidate) => candidate.id === targetId);
   if (!target) throw new Error("The exact browser tab target is no longer available.");
   const client = await connect(debuggerUrlFor(app.handle.cdpUrl, target));
   try {
-    const value = await evaluate(client, () => ({ width: innerWidth, height: innerHeight, hasFocus: document.hasFocus() }));
-    if (!record(value) || typeof value.width !== "number" || typeof value.height !== "number" || typeof value.hasFocus !== "boolean") throw new Error("Invalid browser metrics.");
-    return { width: value.width, height: value.height, hasFocus: value.hasFocus };
+    const value = await evaluate(client, () => ({ width: innerWidth, height: innerHeight, hasFocus: document.hasFocus(),
+      url: location.href, title: document.title, timeOrigin: performance.timeOrigin }));
+    if (!record(value) || typeof value.width !== "number" || typeof value.height !== "number" || typeof value.hasFocus !== "boolean"
+      || typeof value.url !== "string" || typeof value.title !== "string" || typeof value.timeOrigin !== "number") throw new Error("Invalid browser metrics.");
+    return { width: value.width, height: value.height, hasFocus: value.hasFocus,
+      url: value.url, title: value.title, timeOrigin: value.timeOrigin };
   } finally { client.close(); }
 }
 

--- a/evals/packages/cdp/src/input.ts
+++ b/evals/packages/cdp/src/input.ts
@@ -1,7 +1,7 @@
 import { callFunctionOnSurface, evaluateOnSurface } from "./surface.ts";
 import type { Surface } from "./surface.ts";
 
-export type TargetRole = "button" | "link" | "textbox" | "checkbox" | "menuitem" | "tab" | "option";
+export type TargetRole = "button" | "link" | "textbox" | "checkbox" | "menuitem" | "tab" | "option" | "separator";
 export type TargetMatcher = string | RegExp;
 
 export type Target = string | {
@@ -216,7 +216,7 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
       ? '[contenteditable="true"][data-lexical-editor="true"]'
       : target.text && !target.role && !target.label && !target.placeholder && !target.testId
         ? 'body *'
-        : 'button, a[href], input, textarea, select, [role="combobox"], [role="listbox"], [contenteditable="true"], [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="menuitem"], [role="tab"], [role="option"], [data-testid]';
+        : 'button, a[href], input, textarea, select, [role="combobox"], [role="listbox"], [contenteditable="true"], [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="menuitem"], [role="tab"], [role="option"], [role="separator"], [data-testid]';
     const candidates = [...document.querySelectorAll<HTMLElement>(selector)].filter((element: Element) => {
       if (target.role && implicitRole(element) !== target.role) return false;
       if (target.placeholder !== undefined && (element.getAttribute("placeholder") ?? element.getAttribute("aria-placeholder")) !== target.placeholder) return false;

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -883,6 +883,19 @@ export class ProbeChannel implements Probe {
     return new ProbeChannel(this.#runtime, surface);
   }
 
+  zoom(): Promise<number> {
+    const surface = requireSurface(this.#surface);
+    return this.#runtime.call("probe", "zoom", "zoom(Page.getLayoutMetrics)", surface, async () => {
+      const metrics = await surface.client.send("Page.getLayoutMetrics");
+      if (!isRecord(metrics) || !isRecord(metrics.cssVisualViewport)
+        || typeof metrics.cssVisualViewport.zoom !== "number"
+        || !Number.isFinite(metrics.cssVisualViewport.zoom) || metrics.cssVisualViewport.zoom <= 0) {
+        throw new Error("Chromium did not report its applied page zoom.");
+      }
+      return metrics.cssVisualViewport.zoom;
+    });
+  }
+
   dom(selector: string) {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("probe", "dom", `dom(${JSON.stringify(redacted(selector))})`, surface, () => readDom(surface, selector));

--- a/evals/packages/testkit/src/spec/types.ts
+++ b/evals/packages/testkit/src/spec/types.ts
@@ -63,6 +63,8 @@ export interface Agent {
 }
 
 export interface Probe {
+  /** Applied CSS-to-DIP page zoom from Chromium, not the stored zoom preference. */
+  zoom(): Promise<number>;
   browserState(): Promise<import("@openwork/behaviors").BrowserState>;
   browserTabMetrics(targetId: string): ReturnType<typeof import("@openwork/behaviors").readBrowserTabMetrics>;
   browserFixtureState(origin: string): Promise<import("@openwork/env").BrowserFixtureState>;

--- a/evals/specs/browser-panel-viewport-recovery.e2e.test.ts
+++ b/evals/specs/browser-panel-viewport-recovery.e2e.test.ts
@@ -100,10 +100,13 @@ geometryTest("the native browser follows app zoom and keyboard panel resizing wi
     // Keep the observation bounded even if eventually finishes a probe after its deadline.
     expect(performance.now() - started).toBeLessThanOrEqual(budgetMs);
     await user.on(page).see(field, { value: draft, timeoutMs: budgetMs });
-    // Reading the page's input must leave keyboard resizing focused on the separator.
+    return sample;
+  };
+
+  const focusSeparator = async () => {
+    await user.click({ role: "separator" });
     expect((await probe.dom('[data-slot="resizable-handle"][role="separator"]')).elements.map(element => element.focused))
       .toEqual([true]);
-    return sample;
   };
 
   // The single separator resizes the side panel through trusted keyboard events.
@@ -115,17 +118,22 @@ geometryTest("the native browser follows app zoom and keyboard panel resizing wi
     // assertions, not a claim about every frame or native OS window dragging.
     await user.press("Control+=");
     await user.press("Control+=");
-    const enlarged = await aligned(1.2);
+    await aligned(1.2);
+    // Zoom can cross the responsive breakpoint that hides the resize handle.
+    // Check alignment there too, then return to the resizable desktop layout.
+    await user.press("Control+-");
+    const enlarged = await aligned(1.1);
+    await focusSeparator();
     await user.press("ArrowLeft");
     await user.press("ArrowLeft");
-    const wider = await aligned(1.2);
+    const wider = await aligned(1.1);
     expect(wider.rect.width).toBeGreaterThan(enlarged.rect.width + 10);
     expect(wider.rect.left).toBeLessThan(enlarged.rect.left - 10);
 
     await user.press("Control+-");
     await user.press("Control+-");
-    await user.press("Control+-");
     const reduced = await aligned(0.9);
+    await focusSeparator();
     await user.press("ArrowRight");
     await user.press("ArrowRight");
     const narrower = await aligned(0.9);

--- a/evals/specs/browser-panel-viewport-recovery.e2e.test.ts
+++ b/evals/specs/browser-panel-viewport-recovery.e2e.test.ts
@@ -1,9 +1,10 @@
 import { expect } from "vitest";
 import type { Target } from "@openwork/testkit";
 import { spec } from "@openwork/testkit";
-import { browserViewportWorld, CAPTURE_VIEWPORT } from "../worlds/browser-panel.ts";
+import { browserGeometryWorld, browserViewportWorld, CAPTURE_VIEWPORT, INPUT_PROBE_PAGE } from "../worlds/browser-panel.ts";
 
 const test = spec.world(browserViewportWorld);
+const geometryTest = spec.world(browserGeometryWorld);
 
 // Screenshot and docs-shots clients emulate a capture viewport on the visible
 // built-in browser tab over CDP. Chromium keeps that emulated size after the
@@ -33,4 +34,112 @@ test("a visible built-in browser tab left with an automation viewport snaps back
     expect(recovered).toMatchObject(panelViewport);
     evidence.recordAssertionEvidence("Selecting the tab restores the panel viewport", "Clicking the visible tab restored both viewport dimensions to their original panel values.", true);
   });
+});
+
+geometryTest("the native browser follows app zoom and keyboard panel resizing without replacing its page or losing input", async ({ world, user, probe, step }) => {
+  const { tab, page, session } = world;
+  const field: Target = { role: "textbox" };
+  const draft = "Keep this browser input through layout changes";
+  const budgetMs = 5_000;
+  await user.see({ role: "button", label: "Reload page" });
+  await probe.eventually(() => probe.browserState(), {
+    within: budgetMs,
+    until: state => state.activeTabId === tab.tabId && state.nativeViews.some(view =>
+      view.tabId === tab.tabId && view.attached && view.aboveApp && view.visible),
+    label: "the seeded browser tab is visible in its panel before typing",
+  });
+  await user.on(page).see({ role: "button", label: "hit" });
+  await user.on(page).type(field, draft);
+  const original = await probe.browserTabMetrics(tab.targetId);
+  expect(original).toMatchObject({ url: INPUT_PROBE_PAGE, title: "input-probe" });
+  const identity = { url: original.url, title: original.title, timeOrigin: original.timeOrigin };
+
+  // This is the actual contentRef div, not the surrounding toolbar/panel shell.
+  const container = '[data-slot="resizable-panel"]:has(button[aria-label="Reload page"]) .relative.min-h-0.flex-1.overflow-hidden > .h-full.overflow-hidden';
+  // This bound includes CDP round trips; it is not a renderer latency measurement.
+  const aligned = async (expectedZoom: number) => {
+    const started = performance.now();
+    let consecutive = 0;
+    const sample = await probe.eventually(async () => {
+      try {
+        const zoom = await probe.zoom();
+        expect(zoom).toBeCloseTo(expectedZoom, 5);
+        const dom = await probe.dom(container);
+        expect(dom.elements).toHaveLength(1);
+        const rect = dom.elements[0].rect;
+        expect(rect.width).toBeGreaterThan(0);
+        expect(rect.height).toBeGreaterThan(0);
+        const state = await probe.browserState();
+        expect(state.activeTabId).toBe(tab.tabId);
+        expect(state.visibleSessionId).toBe(session.sessionId);
+        expect(state.tabs.map(item => ({ id: item.id, ownerSessionId: item.ownerSessionId })))
+          .toEqual([{ id: tab.tabId, ownerSessionId: session.sessionId }]);
+        expect(state.nativeViews).toHaveLength(1);
+        const view = state.nativeViews[0];
+        expect(view).toMatchObject({ tabId: tab.tabId, attached: true, aboveApp: true, visible: true });
+        const expected = {
+          x: Math.round(rect.left * zoom), y: Math.round(rect.top * zoom),
+          width: Math.round(rect.right * zoom) - Math.round(rect.left * zoom),
+          height: Math.round(rect.bottom * zoom) - Math.round(rect.top * zoom),
+        };
+        // One DIP accommodates independent fractional-edge rounding, not stale layout.
+        const edges: Array<keyof typeof expected> = ["x", "y", "width", "height"];
+        for (const key of edges) {
+          expect(Math.abs(view.bounds[key] - expected[key]), `${key}: native vs current container at zoom ${zoom}`).toBeLessThanOrEqual(1);
+        }
+        const metrics = await probe.browserTabMetrics(tab.targetId);
+        expect(metrics).toMatchObject({ ...identity, width: view.bounds.width, height: view.bounds.height });
+        expect(await probe.zoom()).toBe(zoom);
+        consecutive += 1;
+        return { rect, zoom };
+      } catch (error) {
+        consecutive = 0;
+        throw error;
+      }
+    }, { within: budgetMs, intervalMs: 50, until: () => consecutive >= 3, label: "three aligned native/container/viewport samples within five seconds" });
+    // Keep the observation bounded even if eventually finishes a probe after its deadline.
+    expect(performance.now() - started).toBeLessThanOrEqual(budgetMs);
+    await user.on(page).see(field, { value: draft, timeoutMs: budgetMs });
+    // Reading the page's input must leave keyboard resizing focused on the separator.
+    expect((await probe.dom('[data-slot="resizable-handle"][role="separator"]')).elements.map(element => element.focused))
+      .toEqual([true]);
+    return sample;
+  };
+
+  // The single separator resizes the side panel through trusted keyboard events.
+  await user.click({ role: "separator" });
+  await user.press("Control+0");
+  await aligned(1);
+  await step("Zoom and keyboard panel resizing reach aligned samples within five seconds and retain the exact document and draft", async () => {
+    // No settling waits between keys in a burst. These are sampled convergence
+    // assertions, not a claim about every frame or native OS window dragging.
+    await user.press("Control+=");
+    await user.press("Control+=");
+    const enlarged = await aligned(1.2);
+    await user.press("ArrowLeft");
+    await user.press("ArrowLeft");
+    const wider = await aligned(1.2);
+    expect(wider.rect.width).toBeGreaterThan(enlarged.rect.width + 10);
+    expect(wider.rect.left).toBeLessThan(enlarged.rect.left - 10);
+
+    await user.press("Control+-");
+    await user.press("Control+-");
+    await user.press("Control+-");
+    const reduced = await aligned(0.9);
+    await user.press("ArrowRight");
+    await user.press("ArrowRight");
+    const narrower = await aligned(0.9);
+    expect(narrower.rect.width).toBeLessThan(reduced.rect.width - 10);
+    expect(narrower.rect.left).toBeGreaterThan(reduced.rect.left + 10);
+    await user.press("Control+=");
+    await user.press("ArrowLeft");
+    await user.press("Control+=");
+    await user.press("ArrowRight");
+    await aligned(1.1);
+    await user.press("Control+0");
+    await aligned(1);
+  });
+  await user.on(page).type(field, " and still editable");
+  await user.on(page).see(field, { value: `${draft} and still editable`, timeoutMs: budgetMs });
+  expect(await probe.browserTabMetrics(tab.targetId)).toMatchObject(identity);
 });

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -641,6 +641,16 @@ export async function builtinBrowserWorld(seed: Seed, options: { workspacePath?:
   return { app, workspace, session, origin: info.baseUrl.replace(/\/+$/, "") };
 }
 
+/** Real native tab and deterministic document, with no viewport emulation. */
+export async function browserGeometryWorld(seed: Seed) {
+  const world = await createBuiltinBrowserWorld(seed);
+  const tab = await world.openTab("geometry", world.session.sessionId);
+  await world.loadInputProbe(tab);
+  const page = await attachBuiltinTab(world.app, tab.targetId);
+  return { app: world.app, session: world.session, tab, page,
+    async [Symbol.asyncDispose]() { await page.stop(); } };
+}
+
 /** Leave the emulation fault behind before the body; recovery is a real user act. */
 export async function browserViewportWorld(seed: Seed) {
   const base = await builtinBrowserWorld(seed);


### PR DESCRIPTION
## Summary

Keep the built-in browser aligned with its panel as layout and app zoom change, without replacing its native page or losing input.

- Use one bounds writer for ResizeObserver and animation-frame updates. Keep immediate post-layout resizing and position/occlusion tracking, but deduplicate unchanged geometry before crossing the desktop bridge.
- Capture the renderer's zoom with each bounds measurement, reject outdated zoom snapshots, and cache accepted native bounds rather than rescaling an old CSS rectangle on tab attachment.
- Explicitly invalidate geometry when desktop zoom changes. Handle rejected or superseded show requests without leaving a blank panel or retrying/toasting on every idle frame.
- Extend the existing viewport-recovery journey with zoom, responsive-breakpoint, keyboard panel-resize, document-identity, and retained-input assertions.

The native browser, tab ownership, consent controls, and current native context menus remain unchanged. This does not replace WebContentsView with an iframe or claim atomic DOM/native painting.

## Verification

**Verdict: Passed for the covered journey** at `6df8ff5a0ba677db61b09a5b33c51c38514c15b2`, based on `dev@be5ab613c0e5286a644060abee27cad303110466`.

| Check | Result |
| --- | --- |
| `env -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_EVAL_DEN_WEB_URL OPENWORK_EVAL_REF=6df8ff5a0ba677db61b09a5b33c51c38514c15b2 pnpm evals:e2e browser-panel-viewport-recovery` | Exit 0; 2 passed, 0 failed, 0 skipped. Cold-boot resources on the exact head. `placement: daytona (daytona CLI authenticated)` |
| `node --test apps/desktop/electron/browser-panel.test.mjs` | 59 passed, 0 failed, 0 skipped after reconciling current native-menu changes |
| `bun test ./apps/app/src/react-app/domains/session/panel/browser-bounds-sync.test.ts` | 6 passed, 0 failed |
| `pnpm --filter @openwork/app typecheck` | Passed |
| `pnpm evals:check-browser` | Passed; 770 callbacks checked on the initial candidate |
| Focused TypeScript compilation of the changed journey and its imports | Passed |
| `git diff --check` | Passed |

The initial E2E attempt failed a test assumption: zooming the default window to 120% intentionally hides the resize handle below the responsive breakpoint. The revised test checks alignment at that breakpoint and restores the visible handle before keyboard resizing. Both tests pass on the final head; the earlier run is not reused as proof.

Additional check not passed: `pnpm --dir evals typecheck:spec-layer` reported nine ES2023-lib `Promise.withResolvers` diagnostics in `chat.ts`, `first-run.ts`, and `session-shell.ts`. Those files and the compiler configuration are not changed here; no clean-control claim is made.

## CI correction

Fixed the Electron typecheck errors in browser test fixtures: restore the fake window via its property descriptor, use the public webFrame zoom setter, and use named test-table fields. Production browser behavior is unchanged.

`pnpm --filter @openwork/desktop typecheck:electron` and all 59 browser tests pass. [Build and core checks](https://github.com/different-ai/openwork/actions/runs/34390049693), including the required gate and packaged desktop smoke, passed on this head. The two cold-boot browser journey tests were rerun and their evidence refreshed.

## Scope and remaining proof

The E2E checks three consecutive aligned native/container/viewport samples within a bounded five-second observation window, including CDP round trips. It asserts that the exact document and typed draft survive and the input remains editable. This is correctness/convergence evidence, not a renderer latency benchmark.

Deferred: native OS window-drag timing, macOS-specific shortcut execution, and every-frame compositor alignment. No full-suite or cross-platform claim.

## Manual check

Open a built-in browser page, enter text into a form, and alternate app zoom in/out/reset with side-panel resizing and window resizing. The browser should return to the correct panel rectangle without reloading the page or losing the form input. Check dialog occlusion and hiding/reopening the panel as well.
