### PR TITLE
feat(composer): click a draft image attachment to view it full-size

### DIFF
--- a/apps/app/src/components/chat/image-attachment-badge.tsx
+++ b/apps/app/src/components/chat/image-attachment-badge.tsx
@@ -1,11 +1,7 @@
 import * as React from "react"
 import { X } from "lucide-react"
 
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { ImageLightbox } from "@/components/chat/image-lightbox"
 import { cn } from "@/lib/utils"
 
 type ImageAttachmentBadgeProps = {
@@ -54,16 +50,7 @@ export function ImageAttachmentBadge({
           <X className="size-3" />
         </button>
       ) : null}
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[95vh] w-auto max-w-[95vw] overflow-hidden border-none bg-transparent p-0 shadow-none ring-0 lg:w-max lg:max-w-[95vw]">
-          <DialogTitle className="sr-only">{alt}</DialogTitle>
-          <img
-            src={src}
-            alt={alt}
-            className="max-h-[92vh] w-auto max-w-full rounded-xl object-contain"
-          />
-        </DialogContent>
-      </Dialog>
+      <ImageLightbox src={src} alt={alt} open={open} onOpenChange={setOpen} />
     </div>
   )
 }

--- a/apps/app/src/components/chat/image-lightbox.tsx
+++ b/apps/app/src/components/chat/image-lightbox.tsx
@@ -1,0 +1,23 @@
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+
+type ImageLightboxProps = {
+  src: string
+  alt: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/** Full-size image viewer shared by sent, queued, and draft image attachments. */
+export function ImageLightbox({ src, alt, open, onOpenChange }: ImageLightboxProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-image-lightbox=""
+        className="max-h-[95vh] w-auto max-w-[95vw] overflow-hidden border-none bg-transparent p-0 shadow-none ring-0 lg:w-max lg:max-w-[95vw]"
+      >
+        <DialogTitle className="sr-only">{alt}</DialogTitle>
+        <img src={src} alt={alt} className="max-h-[92vh] w-auto max-w-full rounded-xl object-contain" />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -16,6 +16,7 @@ import {
   type ComposerSettingsSection,
 } from "@/react-app/domains/settings/library";
 import { ModelSelect } from "@/components/model-select";
+import { ImageLightbox } from "@/components/chat/image-lightbox";
 import { LexicalPromptEditor, syncAttachmentChipStatus, type ComposerAttachmentToken, type LexicalPromptEditorHandle } from "./editor";
 import { listRunningAppsForMention } from "./app-mentions";
 import { COMPUTER_MENTIONS } from "./computer-mentions";
@@ -744,6 +745,10 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
     props.onExpandPastedText(target.id);
   }, [props.onExpandPastedText, props.pastedText]);
 
+  // Draft image chip clicked: show it full-size so it can be inspected before sending.
+  const [expandedAttachmentId, setExpandedAttachmentId] = useState<string | null>(null);
+  const expandedAttachment = props.attachments.find((attachment) => attachment.id === expandedAttachmentId);
+
   const activeMenu = slashOpen ? "slash" : mentionOpen ? "mention" : null;
   const activeItems = activeMenu === "slash" ? slashFiltered : activeMenu === "mention" ? mentionFiltered : [];
   const toolCommandItems = commands.filter(isLibraryCommand);
@@ -1332,6 +1337,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
               onChange={props.onDraftChange}
               onSubmit={handleEditorSubmit}
               onExpandPastedText={handleExpandPastedText}
+              onExpandAttachment={setExpandedAttachmentId}
               onRemoveAttachment={props.onRemoveAttachment}
               onPasteText={props.onPasteText}
               onPaste={(event) => {
@@ -1869,6 +1875,17 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
 
       </div>
     </div>
+    {/* Sibling of the composer root so Escape closes the lightbox without arming stop. */}
+    {expandedAttachment?.previewUrl ? (
+      <ImageLightbox
+        src={expandedAttachment.previewUrl}
+        alt={expandedAttachment.name}
+        open
+        onOpenChange={(open) => {
+          if (!open) setExpandedAttachmentId(null);
+        }}
+      />
+    ) : null}
     </DevProfiler>
   );
 });

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -58,6 +58,7 @@ type EditorProps = {
   onChange: (value: string) => void;
   onSubmit: (options: { queue: boolean }) => void | Promise<void>;
   onExpandPastedText?: (label: string) => void;
+  onExpandAttachment?: (id: string) => void;
   onRemoveAttachment?: (id: string) => void;
   onPaste?: React.ClipboardEventHandler<HTMLDivElement>;
   onPasteText?: (text: string) => void;
@@ -462,12 +463,19 @@ function createAttachmentChipDom(attachment: ComposerAttachmentToken) {
   dom.dataset.attachmentStatus = "ready";
 
   if (attachment.kind === "image" && attachment.previewUrl) {
+    // Clicking the thumbnail opens the full-size lightbox (see AttachmentChipPlugin).
+    const expand = document.createElement("button");
+    expand.type = "button";
+    expand.className = "h-10 w-10 cursor-zoom-in overflow-hidden rounded-xl border border-border/70 transition-opacity hover:opacity-90";
+    expand.setAttribute("aria-label", `Expand ${attachment.name}`);
+    expand.dataset.attachmentExpandId = attachment.id;
     const img = document.createElement("img");
     img.src = attachment.previewUrl;
     img.alt = attachment.name;
     img.decoding = "async";
-    img.className = "h-10 w-10 rounded-xl border border-border/70 object-cover";
-    dom.append(img);
+    img.className = "h-full w-full object-cover";
+    expand.append(img);
+    dom.append(expand);
   } else {
     const chip = document.createElement("span");
     chip.className = "inline-flex h-10 max-w-[140px] items-center gap-1.5 rounded-xl border border-border/70 bg-muted/40 px-2";
@@ -530,6 +538,11 @@ function updateAttachmentChipDom(dom: HTMLElement, attachment: ComposerAttachmen
   if (remove instanceof HTMLButtonElement) {
     remove.dataset.attachmentRemoveId = attachment.id;
     remove.setAttribute("aria-label", `Remove ${attachment.name}`);
+  }
+  const expand = dom.querySelector("button[data-attachment-expand-id]");
+  if (expand instanceof HTMLButtonElement) {
+    expand.dataset.attachmentExpandId = attachment.id;
+    expand.setAttribute("aria-label", `Expand ${attachment.name}`);
   }
   const img = dom.querySelector("img");
   if (img instanceof HTMLImageElement && attachment.previewUrl) {
@@ -1171,35 +1184,39 @@ function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEd
   return null;
 }
 
-function attachmentRemoveButton(target: EventTarget | null) {
+function attachmentChipButton(target: EventTarget | null) {
   if (!(target instanceof Element)) return null;
-  const button = target.closest("button[data-attachment-remove-id]");
+  const button = target.closest("button[data-attachment-remove-id], button[data-attachment-expand-id]");
   return button instanceof HTMLButtonElement ? button : null;
 }
 
-function AttachmentRemovePlugin(props: { onRemoveAttachment?: (id: string) => void }) {
+function AttachmentChipPlugin(props: { onRemoveAttachment?: (id: string) => void; onExpandAttachment?: (id: string) => void }) {
   const [editor] = useLexicalComposerContext();
   const onRemoveAttachmentRef = useRef(props.onRemoveAttachment);
+  const onExpandAttachmentRef = useRef(props.onExpandAttachment);
 
   useEffect(() => {
     onRemoveAttachmentRef.current = props.onRemoveAttachment;
-  }, [props.onRemoveAttachment]);
+    onExpandAttachmentRef.current = props.onExpandAttachment;
+  }, [props.onExpandAttachment, props.onRemoveAttachment]);
 
   useEffect(() => {
     const handleMouseDown = (event: MouseEvent) => {
-      if (!attachmentRemoveButton(event.target)) return;
+      if (!attachmentChipButton(event.target)) return;
       event.preventDefault();
       event.stopPropagation();
     };
 
     const handleClick = (event: MouseEvent) => {
-      const button = attachmentRemoveButton(event.target);
+      const button = attachmentChipButton(event.target);
       if (!button) return;
-      const id = button.dataset.attachmentRemoveId;
-      if (!id) return;
+      const removeId = button.dataset.attachmentRemoveId;
+      const expandId = button.dataset.attachmentExpandId;
+      if (!removeId && !expandId) return;
       event.preventDefault();
       event.stopPropagation();
-      onRemoveAttachmentRef.current?.(id);
+      if (removeId) onRemoveAttachmentRef.current?.(removeId);
+      if (expandId) onExpandAttachmentRef.current?.(expandId);
     };
 
     return editor.registerRootListener((rootElement, previousRootElement) => {
@@ -1291,7 +1308,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         <SubmitPlugin onSubmit={props.onSubmit} disabled={props.submitDisabled} />
         <PasteChipPlugin onPasteText={props.onPasteText} />
         <PastedTextExpandPlugin pastedText={props.pastedText} onExpandPastedText={props.onExpandPastedText} />
-        <AttachmentRemovePlugin onRemoveAttachment={props.onRemoveAttachment} />
+        <AttachmentChipPlugin onRemoveAttachment={props.onRemoveAttachment} onExpandAttachment={props.onExpandAttachment} />
         <MentionChipNavigationPlugin />
         <ImperativeHandlePlugin editorRef={ref} />
       </div>

--- a/evals/specs/attachment-upload-loading-state.e2e.test.ts
+++ b/evals/specs/attachment-upload-loading-state.e2e.test.ts
@@ -67,6 +67,34 @@ test(`sending an image in ${entryPoint} immediately moves it into the thread whi
   expect(attached.chipStatus).toBe("ready");
   await user.screenshot();
 
+  await step("clicking the draft image thumbnail opens it full-size and Escape returns to the draft", async () => {
+    const thumbnail = (await probe.dom("[data-attachment-id] img")).elements[0];
+    if (!thumbnail) throw new Error("draft image thumbnail missing");
+    await user.click({ role: "button", label: `Expand ${attachmentName}` });
+    const lightbox = await probe.eventually(() => probe.dom("[data-image-lightbox] img"), {
+      within: 10_000,
+      label: "draft image lightbox",
+      until: (dom) => dom.elements.length === 1,
+    });
+    const preview = lightbox.elements[0];
+    if (!preview) throw new Error("lightbox image missing");
+    expect(preview.rect.width).toBeGreaterThan(thumbnail.rect.width * 4);
+    expect(await probe.eval(() => {
+      const chip = document.querySelector<HTMLImageElement>("[data-attachment-id] img");
+      const large = document.querySelector<HTMLImageElement>("[data-image-lightbox] img");
+      return Boolean(chip && large && chip.src === large.src);
+    })).toBe(true);
+    await user.screenshot();
+    await user.press("Escape");
+    await probe.eventually(() => probe.dom("[data-image-lightbox]"), {
+      within: 10_000,
+      label: "draft image lightbox closed",
+      until: (dom) => dom.elements.length === 0,
+    });
+    expect((await probe.dom("[data-attachment-id]")).elements).toHaveLength(1);
+    await user.see("composer", { text: /Describe the attached image\./ });
+  });
+
   await step("paste a video alongside the image", async () => {
     expect(await seed.evalIn(world.app, () => {
       const editor = document.querySelector<HTMLElement>('[contenteditable="true"]');

--- a/evals/specs/attachment-upload-loading-state.e2e.test.ts
+++ b/evals/specs/attachment-upload-loading-state.e2e.test.ts
@@ -22,7 +22,7 @@ test(`sending an image in ${entryPoint} immediately moves it into the thread whi
     expect(world.writeElapsedMs).toBeGreaterThanOrEqual(world.approvalTimeoutMs - 100);
   });
 
-  if (entryPoint === "new task") await user.click({ role: "button", label: /^New task$/ });
+  if (entryPoint === "new task") await user.click({ role: "button", label: "New session" });
   await user.type("composer", "Describe the attached image.");
   // TODO(primitive): attach an in-memory file through the composer's file chooser.
   const attached = await seed.evalIn(world.app, browserScript(async (attachmentName: string) => {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1,7 +1,9 @@
 import { browserScript, reattachSurface } from "@openwork/cdp";
 import { spawn } from "node:child_process";
+import { mkdtempSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { evalIn, assertNoLiveSecret, liveOpenAiEnabled, liveOpenAiModel, liveProviderId, provisionLiveOpenAi } from "@openwork/behaviors";
 import { resolveEvalEngine, SkipError, type Seed } from "@openwork/env";
@@ -528,8 +530,12 @@ async function startManualApprovalServer(approvalTimeoutMs: number) {
     console.log("SPEC_SERVER_PORT:" + server.port);
     setInterval(() => {}, 60000);
   `;
+  // Isolate runtime state: without this the spawned server reads the host's
+  // ~/.config/openwork/runtime.sqlite, and a persisted managed policy there
+  // turns every write into an instant 403 policy_unavailable.
   const child = spawn("bun", ["--conditions=development", "-e", script], {
     cwd: join(repoRoot, "apps", "server"),
+    env: { ...process.env, OPENWORK_RUNTIME_DB: join(mkdtempSync(join(tmpdir(), "openwork-attachment-spec-runtime-")), "runtime.sqlite") },
     stdio: ["ignore", "pipe", "pipe"],
   });
   const port = await new Promise<number>((resolvePort, reject) => {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -638,7 +638,10 @@ export async function attachmentUpload(seed: Seed) {
           window.fetch = async (input, init) => {
             const url = input instanceof Request ? input.url : String(input);
             const method = init?.method ?? (input instanceof Request ? input.method : "GET");
-            if (method === "POST" && /\/inbox\?/.test(url) && url.includes("chat-attachments")) {
+            // The client posts multipart to /workspace/<id>/inbox with the target
+            // path as a form field, not a query parameter.
+            const formPath = init?.body instanceof FormData ? String(init.body.get("path") ?? "") : "";
+            if (method === "POST" && /\/inbox(\?|$)/.test(url) && `${url} ${formPath}`.includes("chat-attachments")) {
               fault.attempts++;
               await gate;
             }


### PR DESCRIPTION
## Summary

Image attachments added to the prompt only ever rendered as 40px thumbnails, with no way to inspect them before sending (sent and queued images already had a lightbox).

- The image chip in the prompt editor is now an **Expand** button that opens the same full-size lightbox used for sent/queued images; Escape (or the close button) returns to the draft with nothing changed.
- Extract the shared dialog into `ImageLightbox` so the badge and the composer use one viewer (the lightbox mounts as a sibling of the composer root so Escape cannot arm stop-agent).

## Journey spec

`evals/specs/attachment-upload-loading-state.e2e.test.ts` (extended, both entry points):
- new step: click the draft thumbnail → lightbox image is >4× the chip width and shares its `src` → Escape → lightbox gone, chip and draft intact.
- This spec landed in #4652 with its e2e run explicitly deferred and had never run green; making it runnable required two world fixes and one spec fix, all pre-existing on `dev` (confirmed with a clean `origin/dev` control that failed identically):
  - the standalone approval server read the host's `~/.config/openwork/runtime.sqlite`, so a persisted managed policy turned every write into an instant `403 policy_unavailable` → runtime DB is now isolated per run;
  - the upload gate matched `/inbox?…chat-attachments` in the URL, but the client posts to `/workspace/<id>/inbox` with `path` as a form field → gate now inspects the actual request;
  - the sidebar control was renamed "New task" → "New session" in #4491.

## Verification — Passed

Lane: **Daytona** (`placement: daytona (--daytona)`, `OPENWORK_EVAL_REF=feat/attachment-image-lightbox`, checkout resolved `97a00a4686fd` = PR head).

- `OPENWORK_EVAL_REF=feat/attachment-image-lightbox infisical run --silent -- pnpm evals:e2e attachment-upload-loading-state --daytona` — exit 0; **2 passed, 0 failed, 0 skipped**. Evidence for both journeys at this head is in the comments below (sticky + companion).
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `pnpm evals:typecheck` reports the same 363 pre-existing errors with and without this branch; none in touched files.
- `apps/app/tests/composer-focus-continuity.test.tsx` fails identically on a clean `origin/dev` worktree ("Platform context is missing", since #4650); not caused here.

## Known pre-existing flake (not addressed here)

The **new task** variant of this spec fails roughly every other run after `user.reload()` with `Session snapshot owner changed before the local read completed.` and an empty thread. Bisected on Daytona at this head: it fails and passes both with and without the new lightbox step (and on `origin/dev`), so it is independent of this change. The snapshot owner includes the draft scope, which flips when the cloud session hydrates after reload, and the loopback snapshot query has `retry: false` with an owner-less key — worth its own PR.

Note: `evals/specs/streamed-markdown-answer.e2e.test.ts:32` still targets the old "New task" label; left untouched here.