### PR TITLE
chore(warden): add evidence-led review and local preflight

### DIFF
--- a/.opencode/agents/orchestrator.md
+++ b/.opencode/agents/orchestrator.md
@@ -35,4 +35,4 @@ Then: `write-a-spec` → `run-tests` → `diagnose-a-red-run` when red → `publ
 
 ## Verification
 
-Read the full diff yourself and rerun the executor's narrowest check. Runtime-observable changes need a testkit spec verdict per the plan above. Docs, types-only, and inert `.opencode/` config skip runtime proof — say so explicitly.
+Read the full diff yourself and rerun the executor's narrowest check. Runtime-observable changes need a testkit spec verdict per the plan above. Docs, types-only, and inert `.opencode/` config skip runtime proof — say so explicitly. After journey checks, one owner follows `.warden/README.md` for the full final local Warden review; scoped runs are diagnostic only.

--- a/.warden/README.md
+++ b/.warden/README.md
@@ -1,0 +1,49 @@
+# Local Warden preflight
+
+Prerequisites: Node 20 or newer and approved Pi/OpenAI credentials. The repository pins
+the native CLI through `pnpm warden:check`; do not substitute a global install.
+
+## Final review
+
+Run journey checks first. Then assign one owner and record both refs:
+
+```sh
+git rev-parse HEAD
+git rev-parse origin/dev
+pnpm warden:check
+git rev-parse HEAD
+git rev-parse origin/dev
+```
+
+The bare config mode reviews committed branch changes against the configured
+`dev` base. It is the final policy check; explicit `--git` or file mode does not
+have the same fail policy. The working tree should be clean because unstaged
+and untracked files are not reviewed. Do not commit unless the user authorized
+it.
+
+Only completed expected applicable skills, verified scope, and no blockers
+means reviewed with no blockers. Exit 0 with no files or no matching triggers
+is `Not reviewed` or `Not applicable`, with scope explicit, never clear.
+Missing credentials, CLI/model errors, cancellation, or partial skill coverage
+is `Incomplete`. Record the expected and actually reviewed skills, both
+before/after refs, exact command, exit code, scope, and run reference. Keep
+private analysis logs private; do not attach them to a public PR.
+
+For quick iteration on authorized but uncommitted work, use:
+
+```sh
+pnpm warden:check --staged
+pnpm warden:check --skill <name>
+```
+
+These are diagnostics only: `--staged` sees the index only, and `--skill`
+provides partial coverage. Do not use `--fix`. After the last edit, rebase, base
+update, policy change, or model change, rerun bare `pnpm warden:check` with all
+applicable skills. Do not run it in every parallel subagent.
+
+Finish with each native finding ID, classification, evidence, `Clear when`, and
+disposition, plus the run metadata above. Reuse native IDs and deduplicate an
+already-reported root cause; never invent durable advisory IDs. A suggested
+reproduction is not an executed test. Local clearance never authorizes GitHub
+approval, must not be cached across changes, and must not be pushed across
+branches or worktrees as approval evidence.

--- a/.warden/skills/confidentiality-review/SKILL.md
+++ b/.warden/skills/confidentiality-review/SKILL.md
@@ -5,6 +5,11 @@ allowed-tools: Read Grep Glob
 ---
 
 Flag any added line that identifies a customer, prospect, partner, or outside
-person (by name, link, quote, or deal detail); ignore vendors named as
-technology, the team itself, fictional fixtures, and removed lines; cite file
-and line only, never the text.
+person; ignore vendors named as technology, the team itself, fictional
+fixtures, and removed lines. Never quote, paraphrase, or otherwise reproduce
+identity content. Group related locations under one root-cause finding and give
+only file/line locations; state generically how the changed line makes a public
+artifact identify an outside party, the smallest generic remediation, the safe
+internal location for the content, and `Clear when:` with an observable
+condition. Check contrary evidence before reporting. If the identity is already
+public, escalate it; never imply deletion reverses the existing disclosure.

--- a/.warden/skills/desktop-den-sync-review/SKILL.md
+++ b/.warden/skills/desktop-den-sync-review/SKILL.md
@@ -28,7 +28,8 @@ Contract surfaces:
 Severity is the gating contract. Use exactly this mapping:
 
 - `high` — blocking; withholds Warden clearance until resolved.
-- `medium` — advisory; posted as a comment but never blocks clearance.
+- `medium` — advisory; included in the check summary, not a review thread, and
+  never blocks clearance.
 - Never report `low` findings from this skill.
 
 Report a HIGH (blocking) finding only in these two cases:
@@ -75,12 +76,16 @@ Do NOT report:
 
 For each finding, report:
 
-- The exact file and changed lines that introduce the drift.
-- Which published-vs-deployed pair breaks: what the published desktop calls
-  or expects, and what den now serves (or vice versa).
+- One finding per root cause, grouping all related file/line locations and
+  identifying the changed lines that cause the drift.
+- The exact compatibility pair: what client code calls or expects and what den
+  serves (or vice versa). For a removed client usage, cite its before-change
+  reference. Check and address contrary evidence; do not invent deployment,
+  publication, or adoption state.
 - Severity per the mapping above.
 - The concrete rollout fix: what ships first, what waits, and what change in
   this diff should be split out.
+- `Clear when:` followed by the observable compatibility condition.
 
 If the diff introduces no desktop<->den drift, report nothing. Silence is the
 correct output for a clean diff; do not manufacture findings.

--- a/.warden/skills/diff-security-review/SKILL.md
+++ b/.warden/skills/diff-security-review/SKILL.md
@@ -42,12 +42,15 @@ are not exempt when such a path exists.
 
 For each finding, report:
 
-- The exact file and changed lines that introduce the issue.
-- The attack path: who controls the input and what they gain.
+- One finding per root cause, grouping all related locations and identifying
+  the exact changed lines that cause it.
+- The reachable attack path: who controls the input, the concrete failure,
+  and what they gain. Check and address contrary evidence before reporting.
 - Severity: `critical` (RCE, auth bypass, real secret leak), `high`
   (injection, XSS, SSRF, traversal), `medium` (info disclosure, weak crypto),
   `low` (defense-in-depth regression introduced by this diff).
-- A concrete fix in the changed code.
+- The smallest concrete fix in the changed code.
+- `Clear when:` followed by the observable condition that resolves the finding.
 
 If the diff introduces no new security issues, report nothing. Silence is the
 correct output for a clean diff; do not manufacture findings.

--- a/.warden/skills/spec-provenance-review/SKILL.md
+++ b/.warden/skills/spec-provenance-review/SKILL.md
@@ -47,7 +47,9 @@ Do not report:
 - Test-only shortcuts, mocks, or fixtures that do not invalidate the claim.
 - Pre-existing gaps, title wording alone, or anything outside the scoped paths.
 
-Never report `high` or `low`. Each finding must quote the claimed behavior,
-identify the changed line that bypasses it, explain the concrete failure that
-would still pass, and suggest the smallest fix. If that evidence is missing,
-report nothing.
+Every finding is `medium` advisory; never report `high` or `low`, and never
+turn helper-style policy into a finding. Use one finding per root cause, group
+related locations, quote the claimed behavior, identify changed-code causality,
+explain the reachable concrete failure that would still pass, address contrary
+evidence, suggest the smallest fix, and state `Clear when:` with an observable
+condition. If that evidence is missing, report nothing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,25 @@ escalate any leak instead of rewriting history.
 - `Passed` requires an observable assertion for every claim; skips are never passed.
 - Docs/comments, types-only, and inert agent config may skip runtime proof — say so.
 - Skill chain: `write-a-spec` → `run-tests` → `diagnose-a-red-run` when red → `publish-evidence`.
+- After journey checks, one owner runs the final local Warden review; see
+  `.warden/README.md`. Record `git HEAD` and `origin/dev` before and after it,
+  use bare `pnpm warden:check` against the clean committed branch, and report
+  expected versus actually reviewed skills. Unstaged and untracked files are
+  not reviewed. Do not require a commit unless the user authorized one; for
+  uncommitted work, `--staged` is diagnostic only and its limits must be stated.
+- Only completed expected applicable skills, verified scope, and no blockers
+  means reviewed with no blockers. Exit 0 with no files or no matching triggers
+  is `Not reviewed` or `Not applicable`, with scope explicit, never clear.
+  Missing credentials, errors, cancellation, or partial coverage are
+  `Incomplete`. After the last edit, rebase,
+  base update, policy change, or model change, rerun the full final review with
+  all applicable skills. `--skill <name>` and `--staged` are scoped diagnostics,
+  not final clearance. Do not use `--fix` or run Warden in every parallel
+  subagent.
+- Finish with finding IDs, classification, evidence, `Clear when`, disposition,
+  exact command/exit code/scope/run reference, and the recorded refs. A local
+  result never authorizes GitHub approval. A suggested repro is not an executed
+  test.
 
 ## Pull requests
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:session-switch": "pnpm --filter @openwork/app test:session-switch",
     "test:fs-engine": "pnpm --filter @openwork/app test:fs-engine",
     "test:eval-runner": "pnpm --dir evals run test",
+    "warden:check": "pnpm dlx @sentry/warden@0.43.0 --runtime pi --config-path warden.toml --log",
     "check:outbound-access": "node scripts/check-outbound-access.mjs",
     "test:e2e": "pnpm --filter @openwork/app test:e2e",
     "test:admin-scale": "pnpm --filter @openwork-ee/den-api test:admin-scale",

--- a/warden.toml
+++ b/warden.toml
@@ -7,6 +7,7 @@ version = 1
 # Clearance itself is granted by .github/workflows/warden-clearance.yml.
 
 [defaults]
+defaultBranch = "dev"
 reportOn = "low"
 ignorePaths = [
   "**/node_modules/**",
@@ -32,9 +33,11 @@ type = "pull_request"
 # Omitting draft matches both draft and ready PRs.
 actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
-# Lets developers run `warden` locally on uncommitted changes before pushing.
+# Local bare mode reviews committed branch changes; `--staged` is diagnostic.
 [[skills.triggers]]
 type = "local"
+failOn = "info"
+minConfidence = "low"
 
 # Public repo: customer/prospect/partner identities must never land in the
 # tree (see AGENTS.md, Confidentiality).
@@ -47,6 +50,8 @@ actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
 [[skills.triggers]]
 type = "local"
+failOn = "info"
+minConfidence = "low"
 
 [[skills]]
 name = "spec-provenance-review"
@@ -59,6 +64,7 @@ actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
 [[skills.triggers]]
 type = "local"
+failOn = "off"
 
 [[skills]]
 name = "desktop-den-sync-review"
@@ -76,3 +82,5 @@ actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
 [[skills.triggers]]
 type = "local"
+failOn = "high"
+minConfidence = "low"


### PR DESCRIPTION
## Summary
- require changed-code causality, reachable failures, contrary-evidence checks, smallest fixes, and explicit `Clear when` conditions in Warden findings
- add a pinned native Warden 0.43.0 local preflight for committed branch scope, with `--staged` and `--skill` documented as targeted diagnostics only
- document one-owner completion, scope verification, native finding-ID reuse, confidentiality-safe reporting, and explicit incomplete/not-applicable outcomes

## Verification
- `git diff --check` — passed
- Python 3.12 TOML/package policy assertions — passed
- `pnpm warden:check --version` — passed (`warden 0.43.0`)
- `pnpm warden:check --help` — passed
- `pnpm warden:check` on committed `823f6eeb8fd10c72447f41f92a3bc20d22e0680a` against `origin/dev` `9a8aeba852a91426e3142222d140f46c4a28ded8` — **Incomplete** (exit 1). Two of four local triggers matched the committed scope: confidentiality review completed with no findings; security review could not run because existing OpenAI model credentials were unavailable. Provenance and desktop/Den sync were not applicable to the changed paths. Refs were unchanged before/after; the failed call was not retried.
- Follow-up credential check: the Infisical CLI is installed, but `infisical user get` failed with existing authentication. No secret lookup, login, fallback credential search, or unchanged-model Warden retry was attempted; the review remains **Incomplete**.

This change is prompt, inert agent configuration, and documentation, so product runtime journey proof is exempt; no new journey or source-reading spec is needed. The incomplete model review is why this PR remains draft. Existing GitHub policy guards still require independent human review and are not bypassed by local results. Reload OpenCode for the updated agent instructions to apply to future sessions.