### PR TITLE
Add working Gmail, Calendar, Drive, Sheets, and Microsoft 365 actions

### DIFF
--- a/apps/app/src/app/lib/deep-link-bridge.ts
+++ b/apps/app/src/app/lib/deep-link-bridge.ts
@@ -44,3 +44,16 @@ export function drainPendingDeepLinks(target: Window): string[] {
   }
   return [...pending];
 }
+
+/**
+ * Remove and return only the pending links a consumer owns, leaving the rest
+ * queued for the consumers that parse them.
+ */
+export function takePendingDeepLinks(target: Window, owns: (url: string) => boolean): string[] {
+  const pending = target.__OPENWORK__?.deepLinks ?? [];
+  const taken = pending.filter(owns);
+  if (target.__OPENWORK__ && taken.length > 0) {
+    target.__OPENWORK__.deepLinks = pending.filter((url) => !owns(url));
+  }
+  return taken;
+}

--- a/apps/app/src/app/lib/openwork-links.ts
+++ b/apps/app/src/app/lib/openwork-links.ts
@@ -20,6 +20,18 @@ export type ConnectDeepLink = {
   key: string;
 };
 
+/** `openwork://chat?prompt=…&connector=…` — open a new chat with a seeded composer. */
+export type ChatDeepLink = {
+  prompt: string;
+  /** Connector the prompt is about (rendered as a chip ahead of the prompt). */
+  connector: string | null;
+  /** Dedupe key so a replayed queue never seeds the same chat twice. */
+  key: string;
+};
+
+const CHAT_DEEP_LINK_PROMPT_MAX_LENGTH = 4000;
+const CHAT_DEEP_LINK_CONNECTOR_MAX_LENGTH = 80;
+
 function isSupportedDeepLinkProtocol(protocol: string): boolean {
   const normalized = protocol.toLowerCase();
   return normalized === "openwork:"
@@ -177,6 +189,45 @@ export function parseConnectDeepLink(rawUrl: string): ConnectDeepLink | null {
   }
 
   return { rawUrl, key: signed ? `signed:${token}` : `exchange:${apiBaseUrl}:${code}` };
+}
+
+export function parseChatDeepLink(rawUrl: string): ChatDeepLink | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  // Chat seeding is a desktop handoff from Den; ordinary web URLs never
+  // pre-fill the composer.
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== "openwork:" && protocol !== "openwork-dev:") {
+    return null;
+  }
+
+  const routeHost = url.hostname.toLowerCase();
+  const routePath = url.pathname.replace(/^\/+/, "").toLowerCase();
+  const routeSegments = routePath.split("/").filter(Boolean);
+  const routeTail = routeSegments[routeSegments.length - 1] ?? "";
+  if (routeHost !== "chat" && routePath !== "chat" && routeTail !== "chat") {
+    return null;
+  }
+
+  const prompt = (url.searchParams.get("prompt") ?? "").trim().slice(0, CHAT_DEEP_LINK_PROMPT_MAX_LENGTH);
+  const connector = (url.searchParams.get("connector") ?? "")
+    .trim()
+    .replace(/[\[\]\n\r]/g, "")
+    .slice(0, CHAT_DEEP_LINK_CONNECTOR_MAX_LENGTH);
+  if (!prompt && !connector) {
+    return null;
+  }
+
+  return {
+    prompt,
+    connector: connector || null,
+    key: `chat:${connector}:${prompt}`,
+  };
 }
 
 function normalizeDebugDeepLinkInput(rawValue: string): string {

--- a/apps/app/src/react-app/domains/session/chat/pending-chat-seed.ts
+++ b/apps/app/src/react-app/domains/session/chat/pending-chat-seed.ts
@@ -1,0 +1,21 @@
+/**
+ * One-shot handoff between a deep link and the new-task composer. The link
+ * consumer stores the draft and navigates; the hero picks it up on mount (or
+ * immediately, if it is already showing) and puts the caret after it.
+ */
+export const pendingChatSeedEvent = "openwork:pending-chat-seed";
+
+let pendingDraft: string | null = null;
+
+export function setPendingChatSeed(draft: string): void {
+  pendingDraft = draft;
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(pendingChatSeedEvent));
+  }
+}
+
+export function consumePendingChatSeed(): string | null {
+  const draft = pendingDraft;
+  pendingDraft = null;
+  return draft;
+}

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -20,6 +20,7 @@ import {
   type NewTaskComposerContext,
   type NewTaskComposerHandoff,
 } from "./new-task-composer";
+import { consumePendingChatSeed, pendingChatSeedEvent } from "./pending-chat-seed";
 
 type HeroSuggestion = {
   title: string;
@@ -85,6 +86,20 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     const handlePromoChanged = () => setModelsPromoHidden(isOpenWorkModelsPromoHidden());
     window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
     return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
+
+  // A chat deep link (Den's connector "Chat" action) seeds the composer with
+  // the connector chip and its starter prompt; the person reviews and sends.
+  useEffect(() => {
+    const seed = () => {
+      const draft = consumePendingChatSeed();
+      if (draft === null) return;
+      setPrompt(draft);
+      window.dispatchEvent(new Event("openwork:focusPrompt"));
+    };
+    seed();
+    window.addEventListener(pendingChatSeedEvent, seed);
+    return () => window.removeEventListener(pendingChatSeedEvent, seed);
   }, []);
 
   // Quiet inline lead to OpenWork Models: replaces the old startup dialog

--- a/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
+++ b/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
@@ -6,6 +6,7 @@ import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge";
 import { t } from "@/i18n";
 import type { ComposerAttachment, ComposerDraft, ComposerPart } from "@/app/types";
 import { parseConnectSkillToken } from "@/react-app/domains/session/surface/composer/connect-skill-token";
+import { parseConnectorToken } from "@/react-app/domains/session/surface/composer/connector-token";
 import type { QueuedComposerItem } from "@/react-app/domains/session/surface/composer-state-store";
 
 export type QueuedMessagesPanelProps = {
@@ -17,7 +18,7 @@ export type QueuedMessagesPanelProps = {
   sending?: boolean;
 };
 
-const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\])/;
+const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\])/;
 
 function isImageAttachment(attachment: ComposerAttachment) {
   return attachment.kind === "image" || attachment.mimeType.startsWith("image/");
@@ -85,6 +86,20 @@ function QueuedDraftContent(props: { draft: ComposerDraft }) {
           title={`Skill: ${connectSkill?.name ?? skillName}`}
         >
           {`/${skillName}`}
+        </span>,
+      );
+      continue;
+    }
+
+    const connectorName = parseConnectorToken(segment);
+    if (connectorName) {
+      nodes.push(
+        <span
+          key={key}
+          className="mx-0.5 inline-flex items-center rounded-full border border-blue-6/35 bg-blue-3/20 px-2.5 py-1 text-xs font-medium text-blue-11 align-middle"
+          title={`Connector: ${connectorName}`}
+        >
+          {connectorName}
         </span>,
       );
       continue;

--- a/apps/app/src/react-app/domains/session/surface/composer/connector-token.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/connector-token.ts
@@ -1,0 +1,34 @@
+/**
+ * A `[connector …]` composer draft token names the connection (GitHub, Gmail,
+ * Notion, …) a prompt is about. The composer renders it as a chip ahead of
+ * the text; the send path expands it into a short steering sentence so the
+ * model reaches for that connector's tools. Den's connector catalog seeds it
+ * through the `openwork://chat` deep link.
+ */
+function sanitizeConnectorName(name: string) {
+  return name.replace(/[\[\]\n\r]/g, "").trim();
+}
+
+export function encodeConnectorToken(name: string) {
+  return `[connector ${sanitizeConnectorName(name)}]`;
+}
+
+/** The connector name carried by one `[connector …]` segment, or null. */
+export function parseConnectorToken(segment: string): string | null {
+  const match = segment.match(/^\[connector (.+)\]$/);
+  const name = match?.[1]?.trim();
+  return name ? name : null;
+}
+
+/** Expand a connector token into the model-facing steering text (same precedent as the skill load instruction). */
+export function connectorPrompt(name: string) {
+  return `This request is about the "${name}" connector; do not assume it is connected or that its tools are available. Answer planning and general questions without requiring a connection. For work needing live data or actions, discover capabilities normally with search_capabilities, omitting intent connect. Offer setup only if the requested operation needs an unavailable connection or the user explicitly asks to connect or set up the service; use intent connect only for an explicit setup request. Follow returned connection guidance and let the user authorize any connection themselves. This connector selection does not authorize sign-in, scope changes, or external writes; perform writes only when explicitly requested.`;
+}
+
+/** Draft text for a seeded chat: the connector chip, then the prompt. */
+export function seededConnectorDraft(input: { connector: string | null; prompt: string }) {
+  const prompt = input.prompt.trim();
+  if (!input.connector) return prompt;
+  const token = encodeConnectorToken(input.connector);
+  return prompt ? `${token} ${prompt}` : `${token} `;
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -36,6 +36,7 @@ import {
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
 import { parseConnectSkillToken } from "./connect-skill-token";
+import { encodeConnectorToken, parseConnectorToken } from "./connector-token";
 import { shouldCollapsePastedText, splitPastedText } from "./pasted-text";
 import { insertPastedText } from "./pasted-text-insertion";
 
@@ -320,6 +321,86 @@ class ComposerSkillNode extends TextNode {
 
 function $createComposerSkillNode(skillName: string, skillToken?: string) {
   return $applyNodeReplacement(new ComposerSkillNode(skillName, skillToken));
+}
+
+type SerializedComposerConnectorNode = Spread<
+  {
+    connectorName: string;
+    type: "composer-connector";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+/** `[connector GitHub]` — the connection a seeded prompt is about, shown as a chip. */
+class ComposerConnectorNode extends TextNode {
+  __connectorName: string;
+
+  static override getType() {
+    return "composer-connector";
+  }
+
+  static override clone(node: ComposerConnectorNode) {
+    return new ComposerConnectorNode(node.__connectorName, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerConnectorNode) {
+    return $createComposerConnectorNode(serializedNode.connectorName);
+  }
+
+  constructor(connectorName = "", key?: NodeKey) {
+    super(encodeConnectorToken(connectorName), key);
+    this.__connectorName = connectorName;
+  }
+
+  override exportJSON(): SerializedComposerConnectorNode {
+    return {
+      ...super.exportJSON(),
+      connectorName: this.__connectorName,
+      type: "composer-connector",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig) {
+    const dom = document.createElement("span");
+    dom.className = "inline-flex items-center rounded-full border border-blue-6/35 bg-blue-3/20 px-2.5 py-1 text-xs font-medium text-blue-11";
+    dom.textContent = this.__connectorName;
+    dom.contentEditable = "false";
+    dom.setAttribute("spellcheck", "false");
+    dom.dataset.composerConnector = this.__connectorName;
+    dom.title = `Connector: ${this.__connectorName}`;
+    return dom;
+  }
+
+  override updateDOM(prevNode: ComposerConnectorNode, dom: HTMLElement) {
+    if (prevNode.__connectorName !== this.__connectorName) {
+      dom.textContent = this.__connectorName;
+      dom.dataset.composerConnector = this.__connectorName;
+      dom.title = `Connector: ${this.__connectorName}`;
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+function $createComposerConnectorNode(connectorName: string) {
+  return $applyNodeReplacement(new ComposerConnectorNode(connectorName));
 }
 
 function pastedTextChipLabel(lines: number) {
@@ -671,6 +752,7 @@ type ComposerInlineTokenNode =
   | ComposerMentionNode
   | ComposerSlashCommandNode
   | ComposerSkillNode
+  | ComposerConnectorNode
   | ComposerPastedTextNode
   | ComposerAttachmentNode;
 
@@ -678,6 +760,7 @@ function isComposerInlineTokenNode(node: unknown): node is ComposerInlineTokenNo
   return node instanceof ComposerMentionNode
     || node instanceof ComposerSlashCommandNode
     || node instanceof ComposerSkillNode
+    || node instanceof ComposerConnectorNode
     || node instanceof ComposerPastedTextNode
     || node instanceof ComposerAttachmentNode;
 }
@@ -747,11 +830,16 @@ function setPrompt(
     value = slashMatch[2] ?? "";
   }
 
-  const segments = value.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+  const segments = value.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\]|@[^\s@]+)/);
   const pastedTextByLabel = new Map((pastedText ?? []).map((item) => [item.label, item]));
   const attachmentsById = new Map((attachments ?? []).map((item) => [item.id, item]));
   for (const segment of segments) {
     if (!segment) continue;
+    const connectorName = parseConnectorToken(segment);
+    if (connectorName) {
+      paragraph.append($createComposerConnectorNode(connectorName));
+      continue;
+    }
     const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
     if (attachmentMatch?.[1]) {
       const target = attachmentsById.get(attachmentMatch[1]);
@@ -1249,7 +1337,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         throw error;
       },
       editable: true,
-      nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode, ComposerAttachmentNode],
+      nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerConnectorNode, ComposerPastedTextNode, ComposerAttachmentNode],
       editorState: () => {
         setPrompt(props.value, props.mentions, props.pastedText, props.attachments);
       },

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -60,6 +60,7 @@ import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMe
 import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
 import { parseConnectSkillToken } from "./composer/connect-skill-token";
+import { connectorPrompt, parseConnectorToken } from "./composer/connector-token";
 import { createPastedTextChip, resolvePastedTextPlaceholders } from "./composer/pasted-text";
 import {
   canAdmitNextQueuedItem,
@@ -1955,8 +1956,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
   ): ComposerDraft => {
     const sourceMentions = sourceComposer?.mentions ?? mentions;
     const sourcePasteParts = sourceComposer?.pasteParts ?? pasteParts;
-    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment, index, segments) => {
+    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\]|@[^\s@]+)/).flatMap((segment, index, segments) => {
       if (!segment) return [] as ComposerDraft["parts"];
+      const connectorName = parseConnectorToken(segment);
+      if (connectorName) {
+        return [{ type: "text", text: connectorPrompt(connectorName) } satisfies ComposerDraft["parts"][number]];
+      }
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch) {
         // Attachment chips are visual tokens only; bytes travel via draft.attachments.
@@ -1998,6 +2003,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return token ? `/${token.slug}` : match;
     });
     resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
+    resolved = resolved.replace(/\[connector [^\]]+\]/g, (match) => {
+      const name = parseConnectorToken(match);
+      return name ? connectorPrompt(name) : match;
+    });
     for (const value of Object.keys(sourceMentions)) {
       resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
     }

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -17,6 +17,7 @@ import {
 } from "./prompt-file-parts";
 import { mentionPromptParts } from "./mention-parts";
 import { parseConnectSkillToken } from "../surface/composer/connect-skill-token";
+import { connectorPrompt, parseConnectorToken } from "../surface/composer/connector-token";
 import { decodeComposerMentionValue } from "../surface/composer/mention-encoding";
 
 // All workspace-scoped server URLs/clients/tokens come from
@@ -75,9 +76,14 @@ export async function draftToParts(
         .filter((part): part is Extract<ComposerPart, { type: "paste" }> => part.type === "paste")
         .map((part) => [part.label, part.text] as const),
     );
-    const segments = draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+    const segments = draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\]|@[^\s@]+)/);
     for (const [index, segment] of segments.entries()) {
       if (!segment) continue;
+      const connectorName = parseConnectorToken(segment);
+      if (connectorName) {
+        parts.push({ type: "text", text: connectorPrompt(connectorName) });
+        continue;
+      }
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch?.[1]) {
         const filePart = attachmentFileById.get(attachmentMatch[1]);

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -28,6 +28,7 @@ import { ForcedSigninPage } from "../domains/cloud/forced-signin-page";
 import { EnterpriseActivationGate } from "../domains/cloud/enterprise-activation-gate";
 import { OpenWorkWebAccessGate } from "../domains/cloud/openwork-web-access-gate";
 import { OrgOnboardingPage } from "../domains/cloud/org-onboarding-page";
+import { ChatDeepLinkListener } from "./chat-deep-link-listener";
 import { NewProvidersListener } from "./new-providers-listener";
 import { useDesktopFontZoomBehavior } from "./font-zoom";
 import { LoadingOverlay } from "./loading-overlay";
@@ -406,6 +407,7 @@ export function AppRoot() {
         <AppMenuProvider>
         <OpenworkControlProvider>
           <OpenworkRouteControlActions />
+          <ChatDeepLinkListener />
           <OpenworkContextPublisher />
           <DenAuthControlActions />
           <BrandThemeControlActions />

--- a/apps/app/src/react-app/shell/chat-deep-link-listener.tsx
+++ b/apps/app/src/react-app/shell/chat-deep-link-listener.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource react */
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router";
+
+import {
+  deepLinkBridgeEvent,
+  takePendingDeepLinks,
+  type DeepLinkBridgeDetail,
+} from "../../app/lib/deep-link-bridge";
+import { parseChatDeepLink } from "../../app/lib/openwork-links";
+import { isDesktopRuntime } from "../../app/utils";
+import { setPendingChatSeed } from "../domains/session/chat/pending-chat-seed";
+import { seededConnectorDraft } from "../domains/session/surface/composer/connector-token";
+import { readActiveWorkspaceId } from "./session-memory";
+import { workspaceSessionRoute } from "./workspace-routes";
+
+const isChatDeepLink = (url: string) => parseChatDeepLink(url) !== null;
+
+/**
+ * `openwork://chat?connector=…&prompt=…` from Den's connector catalog: land on
+ * the active workspace's new-task state with the connector chip and starter
+ * prompt already in the composer. Nothing is sent until the person presses
+ * send. Sibling of the connect and den-auth deep-link consumers; it only
+ * takes chat links out of the shared queue, and the same link may be opened
+ * again later to seed another chat.
+ */
+export function ChatDeepLinkListener() {
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !isDesktopRuntime()) return;
+
+    const handleUrls = (urls: readonly string[]) => {
+      const link = urls.map(parseChatDeepLink).findLast((parsed) => parsed !== null) ?? null;
+      if (!link) return;
+      setPendingChatSeed(seededConnectorDraft(link));
+      const workspaceId = readActiveWorkspaceId();
+      navigateRef.current(workspaceId ? workspaceSessionRoute(workspaceId) : "/session");
+    };
+
+    handleUrls(takePendingDeepLinks(window, isChatDeepLink));
+    const handleDeepLink = (event: Event) => {
+      const detail = (event as CustomEvent<DeepLinkBridgeDetail>).detail;
+      handleUrls(Array.isArray(detail?.urls) ? detail.urls : []);
+      // The bridge queues the same links it announces; clear ours so a later
+      // effect run does not replay them.
+      takePendingDeepLinks(window, isChatDeepLink);
+    };
+    window.addEventListener(deepLinkBridgeEvent, handleDeepLink);
+    return () => window.removeEventListener(deepLinkBridgeEvent, handleDeepLink);
+  }, []);
+
+  return null;
+}

--- a/apps/app/tests/chat-link-parse.test.ts
+++ b/apps/app/tests/chat-link-parse.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { parseChatDeepLink } from "../src/app/lib/openwork-links";
+
+const PROMPT = "Explain this repo's authentication using code and docs: components, request flow, and how credentials and tokens are handled";
+
+describe("parseChatDeepLink", () => {
+  test("parses connector and prompt from production and dev desktop links", () => {
+    const params = new URLSearchParams({ connector: "GitHub", prompt: PROMPT });
+    const parsed = parseChatDeepLink(`openwork://chat?${params}`);
+    expect(parsed).toEqual({ prompt: PROMPT, connector: "GitHub", key: `chat:GitHub:${PROMPT}` });
+    expect(parseChatDeepLink(`openwork-dev://chat?${params}`)?.connector).toBe("GitHub");
+    expect(parseChatDeepLink(`openwork:///chat?${params}`)?.prompt).toBe(PROMPT);
+  });
+
+  test("accepts a prompt without a connector and a connector without a prompt", () => {
+    expect(parseChatDeepLink("openwork://chat?prompt=Summarize%20my%20week")).toEqual({
+      prompt: "Summarize my week",
+      connector: null,
+      key: "chat::Summarize my week",
+    });
+    expect(parseChatDeepLink("openwork://chat?connector=Notion")?.connector).toBe("Notion");
+  });
+
+  test("strips token delimiters from the connector so it cannot break out of its chip", () => {
+    expect(parseChatDeepLink("openwork://chat?connector=%5BGit%5DHub%0A&prompt=x")?.connector).toBe("GitHub");
+  });
+
+  test("does not activate from web URLs, unrelated routes, or empty links", () => {
+    expect(parseChatDeepLink(`https://app.openworklabs.com/chat?prompt=${encodeURIComponent(PROMPT)}`)).toBeNull();
+    expect(parseChatDeepLink("openwork://connect?token=abc")).toBeNull();
+    expect(parseChatDeepLink("openwork://chat")).toBeNull();
+    expect(parseChatDeepLink("openwork://chat?prompt=%20%20")).toBeNull();
+    expect(parseChatDeepLink("not a url")).toBeNull();
+  });
+});

--- a/apps/app/tests/connector-chat-round-trip.test.ts
+++ b/apps/app/tests/connector-chat-round-trip.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { takePendingDeepLinks } from "../src/app/lib/deep-link-bridge";
+import { parseChatDeepLink } from "../src/app/lib/openwork-links";
+import { connectorPrompt, parseConnectorToken, seededConnectorDraft } from "../src/react-app/domains/session/surface/composer/connector-token";
+import {
+  connectorChatDeepLink,
+  connectorChatPrompt,
+  POPULAR_CONNECTORS,
+} from "../../../ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog";
+
+/**
+ * Den's connector "Chat" action and the desktop composer agree on one link
+ * shape. This pins both ends: every popular connector's link round-trips into
+ * a draft that leads with the connector chip and ends with its Explain prompt.
+ */
+describe("connector Chat deep link round trip", () => {
+  test("every popular connector's Chat link seeds the connector chip plus its Explain prompt", () => {
+    expect(POPULAR_CONNECTORS.length).toBeGreaterThan(0);
+    for (const connector of POPULAR_CONNECTORS) {
+      const href = connectorChatDeepLink({ connector: connector.displayName, prompt: connectorChatPrompt(connector.displayName) });
+      const link = parseChatDeepLink(href);
+      expect(link, href).not.toBeNull();
+      expect(link?.connector).toBe(connector.displayName);
+      expect(link?.prompt).toBe(connector.chatPrompt);
+      expect(connector.chatPrompt.startsWith("Explain")).toBe(true);
+
+      const draft = seededConnectorDraft({ connector: link?.connector ?? null, prompt: link?.prompt ?? "" });
+      const [chip, ...rest] = draft.split("] ");
+      expect(parseConnectorToken(`${chip}]`)).toBe(connector.displayName);
+      expect(rest.join("] ")).toBe(connector.chatPrompt);
+    }
+  });
+
+  test("the GitHub chip supports planning without assuming account access", () => {
+    const github = parseChatDeepLink(connectorChatDeepLink({ connector: "GitHub", prompt: connectorChatPrompt("GitHub") }));
+    const instruction = connectorPrompt(github?.connector ?? "");
+    expect(instruction).toContain('"GitHub"');
+    expect(instruction).toContain("do not assume it is connected");
+    expect(instruction).toContain("Answer planning and general questions without requiring a connection");
+    expect(github?.prompt).toBe(connectorChatPrompt("GitHub"));
+  });
+
+  test("only openwork://chat links seed a chat, and taking them leaves connect and den-auth links queued", () => {
+    expect(parseChatDeepLink("https://app.openworklabs.com/chat?prompt=hello")).toBeNull();
+    expect(parseChatDeepLink("openwork://connect?token=abc")).toBeNull();
+    expect(parseChatDeepLink("openwork://den-auth?grant=abc")).toBeNull();
+    expect(parseChatDeepLink("openwork://chat")).toBeNull();
+
+    const queue = {
+      deepLinks: ["openwork://connect?token=abc", "openwork://chat?connector=Notion&prompt=Explain", "openwork://den-auth?grant=xyz"],
+    };
+    const bridgeWindow = { __OPENWORK__: queue } as unknown as Window;
+    expect(takePendingDeepLinks(bridgeWindow, (url: string) => parseChatDeepLink(url) !== null))
+      .toEqual(["openwork://chat?connector=Notion&prompt=Explain"]);
+    expect(queue.deepLinks).toEqual(["openwork://connect?token=abc", "openwork://den-auth?grant=xyz"]);
+  });
+});

--- a/apps/app/tests/connector-token.test.ts
+++ b/apps/app/tests/connector-token.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  connectorPrompt,
+  encodeConnectorToken,
+  parseConnectorToken,
+  seededConnectorDraft,
+} from "../src/react-app/domains/session/surface/composer/connector-token";
+import { takePendingDeepLinks } from "../src/app/lib/deep-link-bridge";
+
+describe("connector composer token", () => {
+  test("round-trips a connector name through the draft token", () => {
+    expect(encodeConnectorToken("GitHub")).toBe("[connector GitHub]");
+    expect(parseConnectorToken("[connector GitHub]")).toBe("GitHub");
+    expect(parseConnectorToken("[connector Google Calendar]")).toBe("Google Calendar");
+    expect(parseConnectorToken("[skill GitHub]")).toBeNull();
+    expect(parseConnectorToken("plain text")).toBeNull();
+  });
+
+  test("keeps bracket characters out of the token so the chip boundary survives", () => {
+    expect(encodeConnectorToken("Git[Hub]\n")).toBe("[connector GitHub]");
+  });
+
+  test("seeds the chip ahead of the prompt and leaves a bare prompt untouched", () => {
+    expect(seededConnectorDraft({ connector: "GitHub", prompt: " Explain this repo " })).toBe("[connector GitHub] Explain this repo");
+    expect(seededConnectorDraft({ connector: "GitHub", prompt: "" })).toBe("[connector GitHub] ");
+    expect(seededConnectorDraft({ connector: null, prompt: "Explain this repo" })).toBe("Explain this repo");
+  });
+
+  test("steers discovery without assuming connection or authorizing setup and writes", () => {
+    const prompt = connectorPrompt("GitHub");
+    expect(prompt).toContain('This request is about the "GitHub" connector');
+    expect(prompt).toContain("do not assume it is connected or that its tools are available");
+    expect(prompt).toContain("Answer planning and general questions without requiring a connection");
+    expect(prompt).toContain("discover capabilities normally with search_capabilities, omitting intent connect");
+    expect(prompt).toContain("Offer setup only if the requested operation needs an unavailable connection or the user explicitly asks");
+    expect(prompt).toContain("use intent connect only for an explicit setup request");
+    expect(prompt).toContain("let the user authorize any connection themselves");
+    expect(prompt).toContain("does not authorize sign-in, scope changes, or external writes");
+    expect(prompt).toContain("perform writes only when explicitly requested");
+  });
+});
+
+describe("takePendingDeepLinks", () => {
+  test("removes only the links a consumer owns and leaves the rest queued", () => {
+    const target = { __OPENWORK__: { deepLinks: ["openwork://chat?prompt=hi", "openwork://connect?token=abc"] } } as unknown as Window;
+    expect(takePendingDeepLinks(target, (url) => url.startsWith("openwork://chat"))).toEqual(["openwork://chat?prompt=hi"]);
+    expect(target.__OPENWORK__?.deepLinks).toEqual(["openwork://connect?token=abc"]);
+    expect(takePendingDeepLinks(target, (url) => url.startsWith("openwork://chat"))).toEqual([]);
+  });
+});

--- a/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
@@ -6,7 +6,7 @@ function normalizedRemoteMcpUrl(value: string) {
   try {
     const url = new URL(value)
     const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname
-    return `${url.host.toLowerCase()}${pathname}`
+    return `${url.origin}${pathname}`
   } catch {
     return null
   }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
@@ -44,8 +44,29 @@ export function requiredPluginMcpAuthType(input: {
   declaredAuthType: "oauth" | null
   url: string
 }): PluginMcpAuthType | null {
+  if (input.declaredAuthType) return input.declaredAuthType
   const preset = matchExternalMcpPresetForUrl(input.url)
-  return preset?.authType ?? input.declaredAuthType
+  if (preset?.supportedAuthTypes && preset.supportedAuthTypes.length > 1) return null
+  return preset?.authType ?? null
+}
+
+// Stored connections predate preset setup allowlists; only a required auth type
+// can disqualify them. New configuration must also pass the preset allowlist.
+export function existingPluginMcpAuthTypeCompatible(input: {
+  authType: PluginMcpAuthType
+  requiredAuthType: PluginMcpAuthType | null
+}): boolean {
+  return input.requiredAuthType === null || input.authType === input.requiredAuthType
+}
+
+export function pluginMcpAuthTypeCompatible(input: {
+  authType: PluginMcpAuthType
+  requiredAuthType: PluginMcpAuthType | null
+  url: string
+}): boolean {
+  if (!existingPluginMcpAuthTypeCompatible(input)) return false
+  const preset = matchExternalMcpPresetForUrl(input.url)
+  return !preset || (preset.supportedAuthTypes ?? [preset.authType]).includes(input.authType)
 }
 
 export function pluginMcpRequiresPreRegisteredOAuthClient(url: string): boolean {
@@ -54,8 +75,15 @@ export function pluginMcpRequiresPreRegisteredOAuthClient(url: string): boolean 
 
 export function resolveGithubPluginMcpImportAuthType(input: {
   declaredAuthType: "oauth" | null
-  requestedAuthType: "none" | "oauth"
+  existingAuthType?: PluginMcpAuthType
+  requestedAuthType: PluginMcpAuthType
   url: string
 }): PluginMcpAuthType {
-  return requiredPluginMcpAuthType(input) ?? input.requestedAuthType
+  if (input.declaredAuthType) return input.declaredAuthType
+  const preset = matchExternalMcpPresetForUrl(input.url)
+  if (input.existingAuthType && preset?.supportedAuthTypes && existingPluginMcpAuthTypeCompatible({
+    authType: input.existingAuthType,
+    requiredAuthType: requiredPluginMcpAuthType(input),
+  })) return input.existingAuthType
+  return preset?.authType ?? input.requestedAuthType
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -21,7 +21,7 @@ import {
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
 import { env } from "../env.js"
-import { declaredPluginMcpAuthType, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
+import { declaredPluginMcpAuthType, existingPluginMcpAuthTypeCompatible, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
 import { isExternalMcpSharedCallbackRedirectUri } from "./external-mcp-oauth-contract.js"
 import {
   createExternalMcpIdentityBinding,
@@ -348,7 +348,10 @@ async function sourcedUsableExternalMcpConnections(input: {
     const requiredAuthType = entry
       ? requiredPluginMcpAuthType({ declaredAuthType: declaredPluginMcpAuthType(entry.config), url: declaredUrl })
       : null
-    if (!input.includeAuthMismatches && requiredAuthType && row.connection.authType !== requiredAuthType) return []
+    if (!input.includeAuthMismatches && !existingPluginMcpAuthTypeCompatible({
+      authType: row.connection.authType,
+      requiredAuthType,
+    })) return []
     return normalizeExternalMcpIdentityUrl(row.connection.url) === normalizeExternalMcpIdentityUrl(declaredUrl)
       ? [row.connection]
       : []

--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -12,7 +12,9 @@ export type ExternalMcpPreset = {
   displayName: string
   description: string
   url: string
+  // Setup default, not an exclusive requirement when supportedAuthTypes lists alternatives.
   authType: "oauth" | "apikey" | "none"
+  supportedAuthTypes?: readonly ("oauth" | "apikey" | "none")[]
   requiresOAuthClient?: boolean
   authorizationServerIssuer?: string
   defaultOAuthScopes?: readonly string[]
@@ -24,6 +26,7 @@ export const externalMcpPresetResponseSchema = z.object({
   description: z.string(),
   url: z.string(),
   authType: z.enum(["oauth", "apikey", "none"]),
+  supportedAuthTypes: z.array(z.enum(["oauth", "apikey", "none"])).optional(),
   requiresOAuthClient: z.boolean().optional(),
   authorizationServerIssuer: z.string().url().optional(),
   defaultOAuthScopes: z.array(z.string()).optional(),
@@ -34,6 +37,15 @@ export const externalMcpPresetListResponseSchema = z.object({
 }).meta({ ref: "ExternalMcpPresetListResponse" })
 
 export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
+  {
+    presetId: "github",
+    displayName: "GitHub",
+    description: "PRs, issues, code, and CI. Use a registered GitHub OAuth app for individual accounts, or a personal access token for a shared connection. Automatic app registration is not supported.",
+    url: "https://api.githubcopilot.com/mcp/",
+    authType: "oauth",
+    supportedAuthTypes: ["oauth", "apikey"],
+    requiresOAuthClient: true,
+  },
   {
     presetId: "notion",
     displayName: "Notion",
@@ -79,7 +91,7 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
   {
     presetId: "slack",
     displayName: "Slack",
-    description: "Channels, DMs, and search. Slack has no automatic app registration — paste your Slack app's OAuth client once; each person then connects their own account.",
+    description: "Channels, DMs, and search. Requires an eligible internal or Slack Marketplace-published app; not every Slack app can use MCP. An admin configures its OAuth client once, then each person connects their own account. Automatic app registration is not supported.",
     url: "https://mcp.slack.com/mcp",
     authType: "oauth",
     requiresOAuthClient: true,
@@ -101,7 +113,7 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
   {
     presetId: "exa",
     displayName: "Exa",
-    description: "AI web search, code search, and research for your agents. Paste your org's Exa API key from dashboard.exa.ai.",
+    description: "Web search, code context, and research. This connection uses your org's Exa API key from dashboard.exa.ai; provider usage limits and billing apply.",
     url: "https://mcp.exa.ai/mcp",
     authType: "apikey",
   },
@@ -115,7 +127,7 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
   {
     presetId: "context7",
     displayName: "Context7",
-    description: "Search product docs with richer context.",
+    description: "Up-to-date library documentation and code examples. Connect without an API key using Context7's rate-limited anonymous access.",
     url: "https://mcp.context7.com/mcp",
     authType: "none",
   },

--- a/ee/apps/den-api/src/capability-sources/microsoft-graph.ts
+++ b/ee/apps/den-api/src/capability-sources/microsoft-graph.ts
@@ -24,6 +24,10 @@ export type Microsoft365MailMessageSummary = {
 }
 
 export type Microsoft365MailMessage = Microsoft365MailMessageSummary & {
+  isDraft: boolean
+  isRead: boolean
+  categories: string[]
+  parentFolderId: string
   cc: Microsoft365EmailAddress[]
   body: string
   bodyContentType: string
@@ -89,6 +93,7 @@ type MicrosoftGraphClientOptions = {
   maxDownloadBytes?: number
   maxJsonResponseBytes?: number
   maxContentCharacters?: number
+  signal?: AbortSignal
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -186,6 +191,10 @@ function extractMailMessage(value: unknown): Microsoft365MailMessage {
     body: content.text,
     bodyContentType: readString(body, "contentType"),
     bodyTruncated: content.truncated,
+    isDraft: readBoolean(message, "isDraft"),
+    isRead: readBoolean(message, "isRead"),
+    categories: readArray(message, "categories").filter((value): value is string => typeof value === "string"),
+    parentFolderId: readString(message, "parentFolderId"),
   }
 }
 
@@ -359,6 +368,13 @@ export class MicrosoftGraphRequestError extends Error {
   }
 }
 
+export class MicrosoftGraphMutationOutcomeUnknownError extends MicrosoftGraphRequestError {
+  constructor(operation: string) {
+    super(operation, 502, "The mutation outcome is unknown. Verify the current state before trying again; do not automatically retry.")
+    this.name = "MicrosoftGraphMutationOutcomeUnknownError"
+  }
+}
+
 export class MicrosoftGraphClient {
   private readonly accessToken: string
   private readonly baseUrl: string
@@ -367,6 +383,7 @@ export class MicrosoftGraphClient {
   private readonly maxDownloadBytes: number
   private readonly maxJsonResponseBytes: number
   private readonly maxContentCharacters: number
+  private readonly signal?: AbortSignal
 
   constructor(options: MicrosoftGraphClientOptions) {
     this.accessToken = options.accessToken
@@ -376,6 +393,7 @@ export class MicrosoftGraphClient {
     this.maxDownloadBytes = options.maxDownloadBytes ?? DEFAULT_MAX_DOWNLOAD_BYTES
     this.maxJsonResponseBytes = options.maxJsonResponseBytes ?? DEFAULT_MAX_JSON_RESPONSE_BYTES
     this.maxContentCharacters = options.maxContentCharacters ?? DEFAULT_MAX_CONTENT_CHARACTERS
+    this.signal = options.signal
   }
 
   private url(path: string): URL {
@@ -388,7 +406,11 @@ export class MicrosoftGraphClient {
     const response = await this.fetchImpl(url, {
       ...init,
       headers,
-      signal: init?.signal ?? AbortSignal.timeout(this.timeoutMs),
+      signal: AbortSignal.any([
+        AbortSignal.timeout(this.timeoutMs),
+        ...(this.signal ? [this.signal] : []),
+        ...(init?.signal ? [init.signal] : []),
+      ]),
     })
     if (!response.ok) {
       const responseBody = await readBytesWithByteLimit(response, this.maxJsonResponseBytes)
@@ -412,6 +434,41 @@ export class MicrosoftGraphClient {
     }
   }
 
+  private async requestMutation(
+    operation: string,
+    path: string,
+    method: "POST" | "PATCH" | "DELETE",
+    expectedStatus: 200 | 201 | 202 | 204,
+    body?: unknown,
+  ): Promise<unknown> {
+    // A lost response may follow a successful write. Never replay a mutation,
+    // including redirects, and require Graph's operation-specific receipt.
+    try {
+      const response = await this.request(operation, this.url(path), {
+        method,
+        redirect: "error",
+        headers: body === undefined ? undefined : { "content-type": "application/json" },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      })
+      if (response.status !== expectedStatus) {
+        await response.body?.cancel()
+        throw new MicrosoftGraphMutationOutcomeUnknownError(operation)
+      }
+      if (expectedStatus === 202 || expectedStatus === 204) {
+        await response.body?.cancel()
+        return null
+      }
+      const responseBody = await readBytesWithByteLimit(response, this.maxJsonResponseBytes)
+      if (responseBody.limitExceeded) throw new MicrosoftGraphMutationOutcomeUnknownError(operation)
+      const value: unknown = JSON.parse(new TextDecoder().decode(responseBody.bytes))
+      if (!isRecord(value) || !readString(value, "id")) throw new MicrosoftGraphMutationOutcomeUnknownError(operation)
+      return value
+    } catch (error) {
+      if (error instanceof MicrosoftGraphRequestError && error.status >= 400 && error.status < 500) throw error
+      throw new MicrosoftGraphMutationOutcomeUnknownError(operation)
+    }
+  }
+
   async listMailMessages(input: { search?: string; maxResults: number }): Promise<Microsoft365MailMessageSummary[]> {
     const url = this.url("me/messages")
     url.searchParams.set("$top", String(input.maxResults))
@@ -427,7 +484,7 @@ export class MicrosoftGraphClient {
 
   async getMailMessage(messageId: string): Promise<Microsoft365MailMessage> {
     const url = this.url(`me/messages/${encodeURIComponent(messageId)}`)
-    url.searchParams.set("$select", "id,conversationId,subject,receivedDateTime,bodyPreview,body,from,toRecipients,ccRecipients,webLink,hasAttachments")
+    url.searchParams.set("$select", "id,conversationId,subject,receivedDateTime,bodyPreview,body,from,toRecipients,ccRecipients,webLink,hasAttachments,isDraft,isRead,categories,parentFolderId")
     const headers = { Prefer: 'outlook.body-content-type="text"' }
     const message = extractMicrosoftMailMessage(await this.requestJson("Microsoft 365 mail read", url, { headers }))
     const body = truncateText(message.body, this.maxContentCharacters)
@@ -464,6 +521,60 @@ export class MicrosoftGraphClient {
     url.searchParams.set("$orderby", "start/dateTime")
     url.searchParams.set("$select", "id,subject,bodyPreview,start,end,isAllDay,location,organizer,attendees,webLink,onlineMeeting,onlineMeetingUrl")
     return extractMicrosoftCalendarEvents(await this.requestJson("Microsoft 365 calendar list", url))
+  }
+
+  async sendMailDraft(messageId: string): Promise<{ draftId: string; status: "accepted" }> {
+    await this.requestMutation("Microsoft 365 mail draft send", `me/messages/${encodeURIComponent(messageId)}/send`, "POST", 202)
+    return { draftId: messageId, status: "accepted" }
+  }
+
+  async createMailReplyDraft(messageId: string, comment: string): Promise<Microsoft365MailMessage> {
+    const draft = extractMicrosoftMailMessage(await this.requestMutation(
+      "Microsoft 365 mail reply draft create", `me/messages/${encodeURIComponent(messageId)}/createReply`, "POST", 201, { comment },
+    ))
+    if (!draft.isDraft) throw new MicrosoftGraphMutationOutcomeUnknownError("Microsoft 365 mail reply draft create")
+    return draft
+  }
+
+  async updateMailMessage(messageId: string, input: { isRead?: boolean; categories?: string[] }): Promise<Microsoft365MailMessage> {
+    return extractMicrosoftMailMessage(await this.requestMutation(
+      "Microsoft 365 mail message update", `me/messages/${encodeURIComponent(messageId)}`, "PATCH", 200,
+      { isRead: input.isRead, categories: input.categories },
+    ))
+  }
+
+  async moveMailMessage(messageId: string, destinationId: "archive" | "deleteditems" | "inbox"): Promise<Microsoft365MailMessage> {
+    return extractMicrosoftMailMessage(await this.requestMutation(
+      "Microsoft 365 mail message move", `me/messages/${encodeURIComponent(messageId)}/move`, "POST", 201, { destinationId },
+    ))
+  }
+
+  async updateCalendarEvent(eventId: string, input: {
+    subject?: string
+    body?: string
+    start?: string
+    end?: string
+    location?: string
+  }): Promise<Microsoft365CalendarEvent> {
+    return extractMicrosoftCalendarEvent(await this.requestMutation(
+      "Microsoft 365 calendar event update", `me/events/${encodeURIComponent(eventId)}`, "PATCH", 200, {
+        subject: input.subject,
+        body: input.body === undefined ? undefined : { contentType: "Text", content: input.body },
+        start: input.start === undefined ? undefined : { dateTime: input.start, timeZone: "UTC" },
+        end: input.end === undefined ? undefined : { dateTime: input.end, timeZone: "UTC" },
+        location: input.location === undefined ? undefined : { displayName: input.location },
+      },
+    ))
+  }
+
+  async cancelCalendarEvent(eventId: string, comment?: string): Promise<{ eventId: string; status: "accepted" }> {
+    await this.requestMutation("Microsoft 365 calendar event cancel", `me/events/${encodeURIComponent(eventId)}/cancel`, "POST", 202, { comment })
+    return { eventId, status: "accepted" }
+  }
+
+  async deleteCalendarEvent(eventId: string): Promise<{ eventId: string; status: "deleted" }> {
+    await this.requestMutation("Microsoft 365 calendar event delete", `me/events/${encodeURIComponent(eventId)}`, "DELETE", 204)
+    return { eventId, status: "deleted" }
   }
 
   async createCalendarEvent(input: {
@@ -565,6 +676,22 @@ export class MicrosoftGraphClient {
       headers: { "content-type": "text/plain; charset=utf-8" },
       body: input.content,
     }))
+  }
+
+  async updateDriveItem(itemId: string, input: { name?: string; parentId?: string }): Promise<Microsoft365DriveItem> {
+    return extractMicrosoftDriveItem(await this.requestMutation(
+      "Microsoft 365 OneDrive item rename or move", `me/drive/items/${encodeURIComponent(itemId)}`, "PATCH", 200, {
+        name: input.name,
+        parentReference: input.parentId === undefined ? undefined : { id: input.parentId },
+      },
+    ))
+  }
+
+  async createDriveFolder(input: { parentId: string; name: string }): Promise<Microsoft365DriveItem> {
+    return extractMicrosoftDriveItem(await this.requestMutation(
+      "Microsoft 365 OneDrive folder create", `me/drive/items/${encodeURIComponent(input.parentId)}/children`, "POST", 201,
+      { name: input.name, folder: {}, "@microsoft.graph.conflictBehavior": "fail" },
+    ))
   }
 
   async listTeamsChats(maxResults: number): Promise<Microsoft365TeamsChat[]> {

--- a/ee/apps/den-api/src/capability-sources/provider-registry.ts
+++ b/ee/apps/den-api/src/capability-sources/provider-registry.ts
@@ -51,7 +51,12 @@ export const NATIVE_OAUTH_PROVIDERS: Record<string, NativeOAuthProviderConfig> =
       calendarRead: ["https://www.googleapis.com/auth/calendar.readonly"],
       calendarWrite: ["https://www.googleapis.com/auth/calendar.events"],
       gmailDraft: ["https://www.googleapis.com/auth/gmail.compose"],
+      gmailSend: ["https://www.googleapis.com/auth/gmail.compose"],
       gmailRead: ["https://www.googleapis.com/auth/gmail.readonly"],
+      gmailManage: ["https://www.googleapis.com/auth/gmail.modify"],
+      gmailLabels: ["https://www.googleapis.com/auth/gmail.labels"],
+      sheetsRead: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+      sheetsWrite: ["https://www.googleapis.com/auth/spreadsheets"],
       driveFile: ["https://www.googleapis.com/auth/drive.file"],
       driveRead: ["https://www.googleapis.com/auth/drive.readonly"],
       driveFull: ["https://www.googleapis.com/auth/drive"],
@@ -60,6 +65,11 @@ export const NATIVE_OAUTH_PROVIDERS: Record<string, NativeOAuthProviderConfig> =
         "https://www.googleapis.com/auth/chat.messages.readonly",
         "https://www.googleapis.com/auth/chat.messages.create",
       ],
+    },
+    scopeImplications: {
+      "https://www.googleapis.com/auth/gmail.modify": ["https://www.googleapis.com/auth/gmail.readonly", "https://www.googleapis.com/auth/gmail.compose", "https://www.googleapis.com/auth/gmail.labels"],
+      "https://www.googleapis.com/auth/spreadsheets": ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+      "https://www.googleapis.com/auth/drive": ["https://www.googleapis.com/auth/drive.readonly", "https://www.googleapis.com/auth/drive.file", "https://www.googleapis.com/auth/spreadsheets", "https://www.googleapis.com/auth/spreadsheets.readonly"],
     },
     usesPkce: true,
     extraAuthorizeParams: {
@@ -79,6 +89,8 @@ export const NATIVE_OAUTH_PROVIDERS: Record<string, NativeOAuthProviderConfig> =
     optionalFeatures: {
       mailRead: ["Mail.Read"],
       mailDraft: ["Mail.ReadWrite"],
+      mailSend: ["Mail.Send"],
+      mailManage: ["Mail.ReadWrite"],
       calendarRead: ["Calendars.Read"],
       calendarWrite: ["Calendars.ReadWrite"],
       filesRead: ["Files.Read"],

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -1006,6 +1006,7 @@ function matchingConnectionForRequirement(input: {
 
 async function statusForRequirement(input: {
   allConnections: ExternalMcpConnectionRow[]
+  mode: "readiness" | "execution"
   member: McpMemberIdentity
   requirement: MarketplacePluginMcpRequirement
   usableConnections: ExternalMcpConnectionRow[]
@@ -1027,8 +1028,10 @@ async function statusForRequirement(input: {
     ...(connection && usable ? { connectionId: connection.id, connectionName: connection.name, credentialMode: connection.credentialMode } : {}),
   }
 
+  // Discovery preserves legacy credential readiness; execution still requires the mandatory client.
   if (!connection || !usable || (
-    connection.authType === "oauth"
+    input.mode === "execution"
+    && connection.authType === "oauth"
     && pluginMcpRequiresPreRegisteredOAuthClient(connection.url)
     && !await getOrgOAuthClient(connection.organizationId, connection.id)
   )) {
@@ -1153,6 +1156,7 @@ async function marketplacePluginMcpRequirements(input: {
 }
 
 async function marketplacePluginMcpRequirementStatuses(input: {
+  mode: "readiness" | "execution"
   member: McpMemberIdentity
   organizationId: OrganizationId
   pluginIds: PluginId[]
@@ -1171,6 +1175,7 @@ async function marketplacePluginMcpRequirementStatuses(input: {
   for (const requirement of requirements) {
     const status = await statusForRequirement({
       allConnections,
+      mode: input.mode,
       member: input.member,
       requirement,
       usableConnections,
@@ -1443,6 +1448,7 @@ export async function searchMarketplaceCapabilities(input: {
     rows: await listActiveCapabilityRows(organizationId),
   })
   const requirementStatusesByPluginId = await marketplacePluginMcpRequirementStatuses({
+    mode: "readiness",
     organizationId,
     member: input.member,
     pluginIds: unique(rows.map((row) => row.plugin.id)),
@@ -1656,6 +1662,7 @@ export async function executeMarketplaceCapability(input: {
 
   if (marketplaceConfigObjectExecutionMode(row.configObject.objectType) === "instructional") {
     const requirementStatuses = await marketplacePluginMcpRequirementStatuses({
+      mode: "execution",
       organizationId,
       member: input.member,
       pluginIds: [row.plugin.id],

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -20,9 +20,10 @@ import {
 import {
   declaredPluginMcpAuthType,
   requiredPluginMcpAuthType,
+  existingPluginMcpAuthTypeCompatible,
+  pluginMcpRequiresPreRegisteredOAuthClient,
   type PluginMcpAuthType,
 } from "../capability-sources/external-mcp-auth-policy.js"
-import { EXTERNAL_MCP_PRESETS } from "../capability-sources/external-mcp-presets.js"
 import { getConnectedAccount, getOrgOAuthClient } from "../capability-sources/oauth-credentials.js"
 import { db } from "../db.js"
 import { resolvePluginArchGrantRole } from "../routes/org/plugin-system/access.js"
@@ -1010,7 +1011,10 @@ async function statusForRequirement(input: {
   usableConnections: ExternalMcpConnectionRow[]
 }): Promise<MarketplaceMcpRequirementStatus> {
   const connection = matchingConnectionForRequirement(input)
-  const authTypeMismatch = Boolean(connection && input.requirement.requiredAuthType && connection.authType !== input.requirement.requiredAuthType)
+  const authTypeMismatch = Boolean(connection && !existingPluginMcpAuthTypeCompatible({
+    authType: connection.authType,
+    requiredAuthType: input.requirement.requiredAuthType,
+  }))
   const usable = connection && !authTypeMismatch
     ? connectionIsUsable({ connectionId: connection.id, usableConnections: input.usableConnections })
     : false
@@ -1023,7 +1027,11 @@ async function statusForRequirement(input: {
     ...(connection && usable ? { connectionId: connection.id, connectionName: connection.name, credentialMode: connection.credentialMode } : {}),
   }
 
-  if (!connection || !usable) {
+  if (!connection || !usable || (
+    connection.authType === "oauth"
+    && pluginMcpRequiresPreRegisteredOAuthClient(connection.url)
+    && !await getOrgOAuthClient(connection.organizationId, connection.id)
+  )) {
     const state = "needs_admin_setup"
     return {
       ...base,
@@ -1209,9 +1217,11 @@ async function resolveMcpReadinessConnections(input: {
       connectedCache.set(matched.id, connectedForMe)
     }
     let oauthClientConfigured: boolean | undefined
-    const preset = EXTERNAL_MCP_PRESETS.find((candidate) => comparablePluginMcpRequirementUrl(candidate.url) === comparablePluginMcpRequirementUrl(matched.url))
-    const authTypeMismatch = Boolean(dependency.requiredAuthType && matched.authType !== dependency.requiredAuthType)
-    const oauthClientRequired = dependency.requiredAuthType === "oauth" && preset?.requiresOAuthClient === true
+    const authTypeMismatch = !existingPluginMcpAuthTypeCompatible({
+      authType: matched.authType,
+      requiredAuthType: dependency.requiredAuthType,
+    })
+    const oauthClientRequired = matched.authType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(matched.url)
     if (dependency.requiredAuthType === "oauth" || matched.authType === "oauth") {
       oauthClientConfigured = oauthClientConfiguredCache.get(matched.id)
       if (oauthClientConfigured === undefined) {

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -24,6 +24,7 @@ import {
   pluginMcpRequiresPreRegisteredOAuthClient,
   type PluginMcpAuthType,
 } from "../capability-sources/external-mcp-auth-policy.js"
+import { EXTERNAL_MCP_PRESETS } from "../capability-sources/external-mcp-presets.js"
 import { getConnectedAccount, getOrgOAuthClient } from "../capability-sources/oauth-credentials.js"
 import { db } from "../db.js"
 import { resolvePluginArchGrantRole } from "../routes/org/plugin-system/access.js"
@@ -1226,7 +1227,10 @@ async function resolveMcpReadinessConnections(input: {
       authType: matched.authType,
       requiredAuthType: dependency.requiredAuthType,
     })
-    const oauthClientRequired = dependency.requiredAuthType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(matched.url)
+    // Keep the published desktop readiness URL comparison, including query parameters.
+    // Execution and new setup use the stricter preset policy independently.
+    const preset = EXTERNAL_MCP_PRESETS.find((candidate) => comparablePluginMcpRequirementUrl(candidate.url) === comparablePluginMcpRequirementUrl(matched.url))
+    const oauthClientRequired = dependency.requiredAuthType === "oauth" && preset?.requiresOAuthClient === true
     if (dependency.requiredAuthType === "oauth" || matched.authType === "oauth") {
       oauthClientConfigured = oauthClientConfiguredCache.get(matched.id)
       if (oauthClientConfigured === undefined) {

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -1221,7 +1221,7 @@ async function resolveMcpReadinessConnections(input: {
       authType: matched.authType,
       requiredAuthType: dependency.requiredAuthType,
     })
-    const oauthClientRequired = matched.authType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(matched.url)
+    const oauthClientRequired = dependency.requiredAuthType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(matched.url)
     if (dependency.requiredAuthType === "oauth" || matched.authType === "oauth") {
       oauthClientConfigured = oauthClientConfiguredCache.get(matched.id)
       if (oauthClientConfigured === undefined) {

--- a/ee/apps/den-api/src/routes/org/gmail-management.ts
+++ b/ee/apps/den-api/src/routes/org/gmail-management.ts
@@ -1,0 +1,247 @@
+import { Hono, type Context } from "hono"
+import { bodyLimit } from "hono/body-limit"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { env } from "../../env.js"
+import { jsonValidator, orgMemberRoute, paramValidator, queryValidator } from "../../middleware/index.js"
+import { invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { GOOGLE_ACTION_MAX_BODY_BYTES, readGoogleActionJson, requestGoogleAction, type GoogleWorkspaceActionDependencies } from "./google-workspace-actions.js"
+import type { OrgRouteVariables } from "./shared.js"
+
+const MODIFY = "https://www.googleapis.com/auth/gmail.modify"
+const COMPOSE = "https://www.googleapis.com/auth/gmail.compose"
+const READ = "https://www.googleapis.com/auth/gmail.readonly"
+const LABELS = "https://www.googleapis.com/auth/gmail.labels"
+const DRAFT_WRITE = [MODIFY, COMPOSE]
+const DRAFT_READ = [MODIFY, COMPOSE, READ]
+const LABEL_WRITE = [MODIFY, LABELS]
+const LABEL_READ = [MODIFY, LABELS, READ, "https://www.googleapis.com/auth/gmail.metadata"]
+
+const idSchema = z.string().min(1).max(512).refine((id) => id.trim() === id && id !== "." && id !== "..", "Expected a Gmail resource ID.")
+const draftParams = z.object({ draftId: idSchema.describe("Existing Gmail draft ID, not its message ID.") }).strict()
+const messageParams = z.object({ messageId: idSchema }).strict()
+const labelParams = z.object({ labelId: idSchema }).strict()
+const confirmation = z.object({
+  confirm: z.literal(true).describe("True only when the user explicitly requested this action on this resource. Discovering or selecting a capability is not authorization."),
+}).strict()
+const messageSchema = z.looseObject({ id: z.string().trim().min(1), threadId: z.string().trim().min(1) })
+const draftSchema = z.looseObject({ id: z.string().trim().min(1), message: messageSchema })
+// Draft lists document id + threadId; minimal/metadata reads promise only message ID and labels.
+const draftReadSchema = draftSchema.extend({ message: messageSchema.partial({ threadId: true }) })
+const labelSchema = z.looseObject({ id: z.string().trim().min(1), name: z.string().min(1), type: z.enum(["user", "system"]) })
+const draftListSchema = z.looseObject({
+  drafts: z.array(draftSchema).max(100).optional(),
+  nextPageToken: z.string().optional(),
+  resultSizeEstimate: z.number().int().nonnegative().optional(),
+})
+const labelListSchema = z.looseObject({ labels: z.array(labelSchema).optional() })
+const labelBody = z.object({
+  name: z.string().trim().min(1).max(225).describe("User label name."),
+  messageListVisibility: z.enum(["show", "hide"]).optional(),
+  labelListVisibility: z.enum(["labelShow", "labelShowIfUnread", "labelHide"]).optional(),
+}).strict()
+const modifyBody = z.object({
+  addLabelIds: z.array(idSchema).max(100).default([]).describe("Add INBOX to unarchive, UNREAD to mark unread, STARRED to star, or user label IDs. Use the dedicated trash action for TRASH."),
+  removeLabelIds: z.array(idSchema).max(100).default([]).describe("Remove INBOX to archive, UNREAD to mark read, STARRED to unstar, or user label IDs. Use the dedicated untrash action for TRASH."),
+}).strict().superRefine((body, ctx) => {
+  if (body.addLabelIds.length + body.removeLabelIds.length === 0) {
+    ctx.addIssue({ code: "custom", message: "Specify at least one label change." })
+  }
+  for (const key of ["addLabelIds", "removeLabelIds"] as const) {
+    if (new Set(body[key]).size !== body[key].length || body[key].some((id) => ["TRASH", "DRAFT", "DRAFTS", "SENT"].includes(id))) {
+      ctx.addIssue({ code: "custom", path: [key], message: "Use unique, modifiable label IDs; TRASH requires the dedicated trash/untrash action." })
+    }
+  }
+  if (body.addLabelIds.some((id) => body.removeLabelIds.includes(id))) {
+    ctx.addIssue({ code: "custom", message: "Cannot add and remove the same label." })
+  }
+})
+
+function route(operationId: string, summary: string, description: string, schema: z.ZodType) {
+  return describeRoute({
+    operationId, tags: ["Capability Sources"], summary,
+    description: `${description} Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.`,
+    responses: {
+      200: jsonResponse("Google's validated response.", schema),
+      400: jsonResponse("Invalid input.", invalidRequestSchema),
+      401: jsonResponse("Sign-in required.", unauthorizedSchema),
+      409: jsonResponse("Missing permission or protected system label.", z.object({ error: z.string(), message: z.string() })),
+      413: jsonResponse("Request exceeds 6 MiB.", z.object({ error: z.literal("invalid_request"), message: z.string() })),
+      502: jsonResponse("Google rejected or did not confirm the operation.", z.object({ error: z.string(), message: z.string() })),
+    },
+  })
+}
+
+function gmailUrl(path: string) {
+  return new URL(`${(env.googleApiBaseUrl ?? "https://gmail.googleapis.com").replace(/\/+$/, "")}/gmail/v1/users/me/${path}`)
+}
+
+async function readGoogleJson<S extends z.ZodType>(c: Context<{ Variables: OrgRouteVariables }>, response: Response, schema: S, write: boolean) {
+  const parsed = schema.safeParse(await readGoogleActionJson(response))
+  if (!parsed.success) {
+    return { ok: false, reply: c.json({
+      error: "google_api_error",
+      message: write
+        ? "Google did not return a valid confirmation. The operation may have completed; check Gmail before retrying."
+        : "Google returned an invalid response.",
+    }, 502) } as const
+  }
+  return { ok: true, data: parsed.data } as const
+}
+
+export function registerGmailManagementRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>, dependencies: GoogleWorkspaceActionDependencies) {
+  const gmail = new Hono<{ Variables: OrgRouteVariables }>()
+  const boundedBody = bodyLimit({ maxSize: GOOGLE_ACTION_MAX_BODY_BYTES, onError: (c) => c.json({ error: "invalid_request", message: "Request exceeds 6 MiB." }, 413) })
+  async function execute(c: Context<{ Variables: OrgRouteVariables }>, scopes: readonly string[], url: URL, schema: z.ZodType, init: RequestInit = {}, requiredFeatures?: readonly string[]) {
+    const result = await requestGoogleAction(c, dependencies, scopes, url, init, requiredFeatures)
+    if (!result.ok) return result.reply
+    const parsed = await readGoogleJson(c, result.response, schema, Boolean(init.method && init.method !== "GET"))
+    if (!parsed.ok) return parsed.reply
+    return c.json(parsed.data)
+  }
+
+  async function userLabel(c: Context<{ Variables: OrgRouteVariables }>, labelId: string) {
+    const result = await requestGoogleAction(c, dependencies, LABEL_WRITE, gmailUrl(`labels/${encodeURIComponent(labelId)}`))
+    if (!result.ok) return result
+    const parsed = await readGoogleJson(c, result.response, labelSchema, false)
+    if (!parsed.ok) return parsed
+    if (parsed.data.id !== labelId || parsed.data.type !== "user") {
+      return { ok: false, reply: c.json({ error: "protected_label", message: "Only the specified user-created label may be modified or deleted; system labels are protected." }, 409) } as const
+    }
+    return { ok: true } as const
+  }
+
+  async function remove(c: Context<{ Variables: OrgRouteVariables }>, scopes: readonly string[], url: URL) {
+    const result = await requestGoogleAction(c, dependencies, scopes, url, { method: "DELETE" })
+    if (!result.ok) return result.reply
+    // Gmail delete methods return no resource: accept 204 or the documented empty JSON object.
+    if (result.response.status !== 204) {
+      const parsed = await readGoogleJson(c, result.response, z.object({}).strict(), true)
+      if (!parsed.ok) return parsed.reply
+    }
+    return c.json({ ok: true })
+  }
+
+  gmail.post(
+    "/v1/capabilities/google-workspace/gmail-draft/:draftId/send",
+    route("sendGmailDraft", "Send an existing Gmail draft", "Sends the existing draft unchanged, including To/Cc/Bcc, reply threading and attachments. Create or inspect the draft first. Requires gmail.compose or gmail.modify (gmail.send alone does not authorize drafts.send). A successful response contains the actual sent message id and threadId, not the old draft message ID.", messageSchema),
+    orgMemberRoute(), boundedBody, paramValidator(draftParams), jsonValidator(confirmation),
+    async (c) => execute(c, DRAFT_WRITE, gmailUrl("drafts/send"), messageSchema, {
+      method: "POST", body: JSON.stringify({ id: c.req.valid("param").draftId }),
+    }, ["gmailSend", "gmailManage"]),
+  )
+
+  gmail.get(
+    "/v1/capabilities/google-workspace/gmail-drafts",
+    route("listGmailDrafts", "List or search Gmail drafts", "Returns one page of drafts and the actual nextPageToken, if any. Pass it as pageToken for the next page. Requires gmail.readonly, gmail.compose or gmail.modify.", draftListSchema),
+    orgMemberRoute(), boundedBody,
+    queryValidator(z.object({
+      q: z.string().trim().min(1).max(1000).optional(),
+      maxResults: z.coerce.number().int().min(1).max(100).default(25),
+      pageToken: z.string().min(1).max(2048).optional(),
+      includeSpamTrash: z.enum(["true", "false"]).optional(),
+    }).strict()),
+    async (c) => {
+      const url = gmailUrl("drafts")
+      for (const [key, value] of Object.entries(c.req.valid("query"))) {
+        if (value !== undefined) url.searchParams.set(key, String(value))
+      }
+      return execute(c, DRAFT_READ, url, draftListSchema)
+    },
+  )
+
+  gmail.get(
+    "/v1/capabilities/google-workspace/gmail-draft/:draftId",
+    route("getGmailDraft", "Read a Gmail draft", "Returns Google's draft and message content, capped at 6 MiB. Use format=raw for the base64url RFC 2822 message including MIME attachments. Requires gmail.readonly, gmail.compose or gmail.modify.", draftReadSchema),
+    orgMemberRoute(), boundedBody, paramValidator(draftParams),
+    queryValidator(z.object({ format: z.enum(["minimal", "full", "raw", "metadata"]).default("full") }).strict()),
+    async (c) => {
+      const url = gmailUrl(`drafts/${encodeURIComponent(c.req.valid("param").draftId)}`)
+      url.searchParams.set("format", c.req.valid("query").format)
+      return execute(c, DRAFT_READ, url, c.req.valid("query").format === "minimal" || c.req.valid("query").format === "metadata" ? draftReadSchema : draftSchema)
+    },
+  )
+
+  gmail.put(
+    "/v1/capabilities/google-workspace/gmail-draft/:draftId",
+    route("updateGmailDraft", "Replace a Gmail draft's full content", "Replaces the draft message, not a partial text edit. Supply the complete base64url RFC 2822 MIME message, preserving intended recipients, reply headers, threadId and attachments. Read the existing draft first; omitted content is lost. Does not send. Requires gmail.compose or gmail.modify.", draftSchema),
+    orgMemberRoute(), boundedBody, paramValidator(draftParams),
+    jsonValidator(confirmation.extend({ message: z.object({
+      raw: z.string().min(1).max(5_000_000).regex(/^[A-Za-z0-9_-]+={0,2}$/).describe("Complete base64url RFC 2822 MIME message, not just body text."),
+      threadId: idSchema.optional().describe("Preserve the existing conversation's threadId for a reply, with matching subject and References/In-Reply-To headers in raw."),
+    }).strict() }).strict()),
+    async (c) => execute(c, DRAFT_WRITE, gmailUrl(`drafts/${encodeURIComponent(c.req.valid("param").draftId)}`), draftSchema, {
+      method: "PUT", body: JSON.stringify({ message: c.req.valid("json").message }),
+    }),
+  )
+
+  gmail.delete(
+    "/v1/capabilities/google-workspace/gmail-draft/:draftId",
+    route("deleteGmailDraft", "Permanently delete a Gmail draft", "Permanently discards the specified draft; this is not a move to trash. Requires gmail.compose or gmail.modify and explicit user confirmation.", z.object({ ok: z.literal(true) })),
+    orgMemberRoute(), boundedBody, paramValidator(draftParams), jsonValidator(confirmation),
+    async (c) => remove(c, DRAFT_WRITE, gmailUrl(`drafts/${encodeURIComponent(c.req.valid("param").draftId)}`)),
+  )
+
+  gmail.post(
+    "/v1/capabilities/google-workspace/gmail-message/:messageId/modify",
+    route("updateGmailMessageLabels", "Archive, unarchive, mark read or unread, star or change Gmail message labels", "Changes labels on one message. Archive removes INBOX; unarchive adds INBOX; mark read removes UNREAD; mark unread adds UNREAD; star adds STARRED; unstar removes STARRED. Supports user label IDs from gmail-labels. Requires gmail.modify, not gmail.labels or gmail.compose.", messageSchema),
+    orgMemberRoute(), boundedBody, paramValidator(messageParams), jsonValidator(modifyBody),
+    async (c) => execute(c, [MODIFY], gmailUrl(`messages/${encodeURIComponent(c.req.valid("param").messageId)}/modify`), messageSchema, {
+      method: "POST", body: JSON.stringify(c.req.valid("json")),
+    }),
+  )
+
+  gmail.post(
+    "/v1/capabilities/google-workspace/gmail-message/:messageId/trash",
+    route("trashGmailMessage", "Move a Gmail message to trash", "Moves one message to Gmail trash, not permanent deletion. Requires gmail.modify and explicit user confirmation.", messageSchema),
+    orgMemberRoute(), boundedBody, paramValidator(messageParams), jsonValidator(confirmation),
+    async (c) => execute(c, [MODIFY], gmailUrl(`messages/${encodeURIComponent(c.req.valid("param").messageId)}/trash`), messageSchema, { method: "POST" }),
+  )
+
+  gmail.post(
+    "/v1/capabilities/google-workspace/gmail-message/:messageId/untrash",
+    route("untrashGmailMessage", "Restore a Gmail message from trash", "Removes one message from trash. Requires gmail.modify. To put it in the inbox, also add INBOX using the modify capability.", messageSchema),
+    orgMemberRoute(), boundedBody, paramValidator(messageParams),
+    async (c) => execute(c, [MODIFY], gmailUrl(`messages/${encodeURIComponent(c.req.valid("param").messageId)}/untrash`), messageSchema, { method: "POST" }),
+  )
+
+  gmail.get(
+    "/v1/capabilities/google-workspace/gmail-labels",
+    route("listGmailLabels", "List Gmail labels", "Returns user and system labels with IDs and types; only user labels can be edited or deleted. Requires gmail.labels, gmail.readonly, gmail.metadata or gmail.modify.", labelListSchema),
+    orgMemberRoute(), boundedBody,
+    async (c) => execute(c, LABEL_READ, gmailUrl("labels"), labelListSchema),
+  )
+
+  gmail.post(
+    "/v1/capabilities/google-workspace/gmail-labels",
+    route("createGmailLabel", "Create a Gmail user label", "Creates a custom user label with its name and optional visibility settings. Requires gmail.labels or gmail.modify.", labelSchema),
+    orgMemberRoute(), boundedBody, jsonValidator(labelBody),
+    async (c) => execute(c, LABEL_WRITE, gmailUrl("labels"), labelSchema, { method: "POST", body: JSON.stringify(c.req.valid("json")) }),
+  )
+
+  gmail.patch(
+    "/v1/capabilities/google-workspace/gmail-label/:labelId",
+    route("updateGmailLabel", "Update a Gmail user label", "Renames or changes visibility of a user label. Reads its type first and refuses system labels. Requires gmail.labels or gmail.modify.", labelSchema),
+    orgMemberRoute(), boundedBody, paramValidator(labelParams),
+    jsonValidator(labelBody.partial().refine((body) => Object.keys(body).length > 0, "Specify at least one label field.")),
+    async (c) => {
+      const { labelId } = c.req.valid("param")
+      const allowed = await userLabel(c, labelId)
+      if (!allowed.ok) return allowed.reply
+      return execute(c, LABEL_WRITE, gmailUrl(`labels/${encodeURIComponent(labelId)}`), labelSchema, { method: "PATCH", body: JSON.stringify(c.req.valid("json")) })
+    },
+  )
+
+  gmail.delete(
+    "/v1/capabilities/google-workspace/gmail-label/:labelId",
+    route("deleteGmailLabel", "Permanently delete a Gmail user label", "Permanently removes the user label and its assignment from every message and thread, without deleting the messages. Reads its type first and refuses system labels. Requires gmail.labels or gmail.modify and explicit user confirmation.", z.object({ ok: z.literal(true) })),
+    orgMemberRoute(), boundedBody, paramValidator(labelParams), jsonValidator(confirmation),
+    async (c) => {
+      const { labelId } = c.req.valid("param")
+      const allowed = await userLabel(c, labelId)
+      if (!allowed.ok) return allowed.reply
+      return remove(c, LABEL_WRITE, gmailUrl(`labels/${encodeURIComponent(labelId)}`))
+    },
+  )
+  app.route("/", gmail)
+}

--- a/ee/apps/den-api/src/routes/org/google-productivity-management.ts
+++ b/ee/apps/den-api/src/routes/org/google-productivity-management.ts
@@ -1,0 +1,347 @@
+import { Hono, type Context } from "hono"
+import { bodyLimit } from "hono/body-limit"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { env } from "../../env.js"
+import { orgMemberRoute } from "../../middleware/route-access.js"
+import { jsonValidator, paramValidator, queryValidator } from "../../middleware/validation.js"
+import { invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { readGoogleActionJson, requestGoogleAction, type GoogleWorkspaceActionDependencies } from "./google-workspace-actions.js"
+import type { OrgRouteVariables } from "./shared.js"
+
+const scope = "https://www.googleapis.com/auth/"
+const calendarWriteScopes = ["calendar", "calendar.events", "calendar.events.owned", "calendar.app.created"].map((name) => scope + name)
+const calendarReadScopes = [...calendarWriteScopes, scope + "calendar.readonly", scope + "calendar.events.readonly", scope + "calendar.events.owned.readonly", scope + "calendar.events.public.readonly"]
+const driveWriteScopes = [scope + "drive.file", scope + "drive"]
+const driveReadScopes = [...driveWriteScopes, scope + "drive.readonly", scope + "drive.metadata.readonly", scope + "drive.metadata"]
+const sheetsWriteScopes = [...driveWriteScopes, scope + "spreadsheets"]
+const sheetsReadScopes = [...sheetsWriteScopes, scope + "spreadsheets.readonly", scope + "drive.readonly"]
+const base = "/v1/capabilities/google-workspace"
+const idSchema = z.string().min(1).max(512).regex(/^[A-Za-z0-9_-]+$/)
+const eventParams = z.object({ eventId: idSchema })
+const spreadsheetParams = z.object({ spreadsheetId: idSchema })
+const fileParams = z.object({ fileId: idSchema })
+const calendarQuery = z.object({ calendarId: z.string().min(1).max(512).regex(/^[^\s\x00-\x1f]+$/).default("primary") }).strict()
+const sendUpdatesSchema = z.enum(["none", "all", "externalOnly"]).default("none")
+  .describe("Notification policy. all/externalOnly requires confirmNotifications=true after explicit user approval. Google may still send some service emails with none.")
+const timeZoneSchema = z.string().min(1).max(128).refine((value) => {
+  try { new Intl.DateTimeFormat("en", { timeZone: value }); return true } catch { return false }
+}, "Use a valid IANA time zone.")
+const eventTimeSchema = z.union([
+  z.object({ dateTime: z.string().datetime({ offset: true }), timeZone: timeZoneSchema.optional() }).strict(),
+  z.object({ date: z.string().date() }).strict(),
+])
+const eventPatchSchema = z.object({
+  summary: z.string().trim().min(1).max(1_000).optional(),
+  description: z.string().max(20_000).optional(),
+  location: z.string().max(1_000).optional(),
+  start: eventTimeSchema.optional().describe("Rescheduling requires both start and end, of the same type. All-day end dates are exclusive."),
+  end: eventTimeSchema.optional(),
+  attendees: z.array(z.object({ email: z.string().email().max(320), optional: z.boolean().optional() }).strict()).max(100).optional()
+    .describe("Replaces the entire attendee list; [] removes all attendees. Read the event first to preserve existing guests."),
+  sendUpdates: sendUpdatesSchema,
+  confirmNotifications: z.boolean().optional(),
+}).strict().superRefine((input, ctx) => {
+  const { sendUpdates, confirmNotifications, ...patch } = input
+  if (!Object.values(patch).some((value) => value !== undefined)) ctx.addIssue({ code: "custom", message: "Provide at least one event field to update." })
+  if (sendUpdates !== "none" && confirmNotifications !== true) ctx.addIssue({ code: "custom", path: ["confirmNotifications"], message: "Explicit user approval to notify guests is required." })
+  if (input.start || input.end) {
+    const { start, end } = input
+    if (!start || !end || ("date" in start) !== ("date" in end)) {
+      ctx.addIssue({ code: "custom", path: ["end"], message: "Provide both start and end as dateTime values or both as all-day dates." })
+    } else {
+      const startMs = Date.parse("date" in start ? start.date : start.dateTime)
+      const endMs = Date.parse("date" in end ? end.date : end.dateTime)
+      if (endMs <= startMs) ctx.addIssue({ code: "custom", path: ["end"], message: "End must be later than start; all-day end dates are exclusive." })
+    }
+  }
+})
+const cancelQuery = calendarQuery.extend({
+  sendUpdates: sendUpdatesSchema,
+  confirmCancellation: z.literal("true").describe("Required explicit user confirmation to delete/cancel this event. A recurring master ID cancels the whole series; use an instance ID for one occurrence."),
+  confirmNotifications: z.enum(["true", "false"]).optional(),
+}).superRefine((input, ctx) => {
+  if (input.sendUpdates !== "none" && input.confirmNotifications !== "true") ctx.addIssue({ code: "custom", path: ["confirmNotifications"], message: "Explicit user approval to notify guests is required." })
+})
+const eventResponseTimeSchema = z.union([
+  z.object({ dateTime: z.string().datetime({ offset: true }), timeZone: z.string().optional() }),
+  z.object({ date: z.string().date(), timeZone: z.string().optional() }),
+])
+const eventSchema = z.object({
+  id: idSchema,
+  status: z.enum(["confirmed", "tentative", "cancelled"]),
+  summary: z.string().optional(), description: z.string().optional(), location: z.string().optional(),
+  start: eventResponseTimeSchema.optional(), end: eventResponseTimeSchema.optional(),
+  htmlLink: z.string().optional(), etag: z.string().optional(),
+  recurringEventId: z.string().optional(),
+  attendeesOmitted: z.boolean().optional(),
+  attendees: z.array(z.object({ email: z.string().optional(), displayName: z.string().optional(), responseStatus: z.string().optional(), optional: z.boolean().optional() })).max(100).optional(),
+})
+const eventReceiptSchema = z.object({ ok: z.literal(true), calendarId: z.string(), event: eventSchema, sendUpdates: sendUpdatesSchema.optional() })
+const cancelReceiptSchema = z.object({ ok: z.literal(true), calendarId: z.string(), eventId: z.string(), cancelled: z.literal(true), sendUpdates: sendUpdatesSchema })
+
+// Restrict to finite A1 rectangles, never whole columns/rows, named ranges, or arbitrary queries.
+function rangeDimensions(value: string) {
+  const match = /^(?:(?:'([^'\r\n]|'')+'|[A-Za-z_][A-Za-z0-9_ ]*)!)?\$?([A-Za-z]{1,3})\$?([1-9][0-9]{0,6})(?::\$?([A-Za-z]{1,3})\$?([1-9][0-9]{0,6}))?$/.exec(value)
+  if (!match) return null
+  const column = (letters: string) => [...letters.toUpperCase()].reduce((n, letter) => n * 26 + letter.charCodeAt(0) - 64, 0)
+  const firstColumn = column(match[2])
+  const lastColumn = match[4] ? column(match[4]) : firstColumn
+  const firstRow = Number(match[3])
+  const lastRow = match[5] ? Number(match[5]) : firstRow
+  const rows = lastRow - firstRow + 1
+  const columns = lastColumn - firstColumn + 1
+  if (lastColumn > 18_278 || lastRow > 1_000_000 || rows < 1 || rows > 500 || columns < 1 || columns > 100 || rows * columns > 5_000) return null
+  return { rows, columns }
+}
+const rangeSchema = z.string().min(1).max(256).refine((value) => rangeDimensions(value) !== null,
+  "Use a bounded A1 cell/rectangle (optionally sheet-qualified), at most 500 rows, 100 columns, and 5,000 cells; no named ranges or whole rows/columns.")
+const cellSchema = z.union([z.string().max(50_000), z.number().finite(), z.boolean()])
+const valuesSchema = z.array(z.array(cellSchema).min(1).max(100)).min(1).max(500)
+  .refine((rows) => rows.reduce((count, row) => count + row.length, 0) <= 5_000, "At most 5,000 cells per request.")
+const valuesReadQuery = z.object({ range: rangeSchema, valueRenderOption: z.enum(["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"]).default("FORMATTED_VALUE") }).strict()
+const valuesWriteSchema = z.object({
+  range: rangeSchema,
+  values: valuesSchema.describe("Rows of literal strings, numbers, and booleans. Empty strings clear cells; missing trailing cells stay unchanged."),
+  valueInputOption: z.enum(["RAW", "USER_ENTERED"]).default("RAW")
+    .describe("RAW stores strings literally, including =formulas. USER_ENTERED parses formulas/dates and can execute formulas or fetch external data; requires explicit approval via confirmUserEntered."),
+  confirmUserEntered: z.boolean().optional(),
+}).strict().superRefine((input, ctx) => {
+  if (input.valueInputOption === "USER_ENTERED" && input.confirmUserEntered !== true) ctx.addIssue({ code: "custom", path: ["confirmUserEntered"], message: "Explicit user approval of Google parsing/formula execution is required." })
+  const bounds = rangeDimensions(input.range)
+  if (bounds && (input.values.length > bounds.rows || input.values.some((row) => row.length > bounds.columns))) ctx.addIssue({ code: "custom", path: ["values"], message: "Values must fit inside the supplied bounded range." })
+})
+const sheetPropertiesSchema = z.object({
+  sheetId: z.number().int(), title: z.string(), index: z.number().int().optional(),
+  gridProperties: z.object({ rowCount: z.number().int().optional(), columnCount: z.number().int().optional() }).optional(),
+})
+const spreadsheetSchema = z.object({
+  spreadsheetId: idSchema, spreadsheetUrl: z.string().url(),
+  properties: z.object({ title: z.string(), locale: z.string().optional(), timeZone: z.string().optional() }),
+  sheets: z.array(z.object({ properties: sheetPropertiesSchema })).max(200),
+})
+const spreadsheetReceiptSchema = z.object({ ok: z.literal(true), spreadsheet: spreadsheetSchema })
+const createSpreadsheetSchema = z.object({
+  title: z.string().trim().min(1).max(255),
+  sheetTitle: z.string().trim().min(1).max(100).regex(/^[^:\\/?*\[\]]+$/).default("Sheet1"),
+  rowCount: z.number().int().min(1).max(10_000).default(1_000),
+  columnCount: z.number().int().min(1).max(100).default(26),
+}).strict()
+const readValuesSchema = z.object({ range: z.string().min(1), majorDimension: z.literal("ROWS").default("ROWS"), values: z.array(z.array(cellSchema).max(100)).max(500).optional() })
+const readValuesReceiptSchema = z.object({ ok: z.literal(true), spreadsheetId: z.string(), range: z.string(), majorDimension: z.literal("ROWS"), values: z.array(z.array(cellSchema)), valueRenderOption: valuesReadQuery.shape.valueRenderOption })
+const updateValuesSchema = z.object({ spreadsheetId: idSchema, updatedRange: z.string().min(1), updatedRows: z.number().int().nonnegative().max(500), updatedColumns: z.number().int().nonnegative().max(100), updatedCells: z.number().int().nonnegative().max(5_000) })
+const writeValuesReceiptSchema = z.object({ ok: z.literal(true), spreadsheetId: z.string(), updatedRange: z.string(), updatedRows: z.number(), updatedColumns: z.number(), updatedCells: z.number(), valueInputOption: valuesWriteSchema.shape.valueInputOption })
+const appendValuesSchema = z.object({ spreadsheetId: idSchema, tableRange: z.string().default(""), updates: updateValuesSchema })
+const appendValuesReceiptSchema = writeValuesReceiptSchema.extend({ tableRange: z.string() })
+const spreadsheetFields = "spreadsheetId,spreadsheetUrl,properties(title,locale,timeZone),sheets(properties(sheetId,title,index,gridProperties(rowCount,columnCount)))"
+
+const folderSchema = z.object({ name: z.string().trim().min(1).max(255), parentId: idSchema.optional() }).strict()
+const filePatchSchema = z.object({
+  name: z.string().trim().min(1).max(255).optional(),
+  addParentId: idSchema.optional().describe("Move destination folder ID. Also supply removeParentId from current file metadata; folder changes use Google addParents/removeParents query parameters."),
+  removeParentId: idSchema.optional(),
+  trashed: z.boolean().optional().describe("true moves to trash; false restores. Never permanently deletes."),
+  confirmTrash: z.boolean().optional().describe("Required explicit user approval when trashed=true; trashing a folder affects its children."),
+}).strict().superRefine((input, ctx) => {
+  if (input.name === undefined && input.trashed === undefined && input.addParentId === undefined) ctx.addIssue({ code: "custom", message: "Provide a name, move, or trash/restore change." })
+  if (Boolean(input.addParentId) !== Boolean(input.removeParentId) || (input.addParentId && input.addParentId === input.removeParentId)) ctx.addIssue({ code: "custom", path: ["addParentId"], message: "A move requires different destination and previous parent IDs." })
+  if (input.trashed === true && input.confirmTrash !== true) ctx.addIssue({ code: "custom", path: ["confirmTrash"], message: "Explicit user approval to trash the file/folder is required." })
+})
+const fileSchema = z.object({ id: idSchema, name: z.string(), mimeType: z.string(), trashed: z.boolean(), parents: z.array(z.string()).optional(), webViewLink: z.string().optional() })
+const fileReceiptSchema = z.object({ ok: z.literal(true), file: fileSchema })
+const folderMimeType = "application/vnd.google-apps.folder"
+const fileFields = "id,name,mimeType,trashed,parents,webViewLink"
+const upstreamErrorSchema = z.object({ error: z.literal("google_api_error"), message: z.string() })
+
+function routeDescription(operationId: string, summary: string, response: z.ZodType) {
+  return describeRoute({ operationId, tags: ["Capability Sources"], summary, description: "Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.", responses: {
+    200: jsonResponse("Google-confirmed result.", response),
+    400: jsonResponse("Invalid bounded request or missing confirmation.", invalidRequestSchema),
+    401: jsonResponse("Sign in first.", unauthorizedSchema),
+    409: jsonResponse("Connect with the required provider permission.", z.object({ error: z.literal("needs_connection"), message: z.string() })),
+    413: jsonResponse("Request exceeds 1 MiB.", z.object({ error: z.literal("invalid_request"), message: z.string() })),
+    502: jsonResponse("Google did not confirm the operation; do not blindly retry mutations.", upstreamErrorSchema),
+  } })
+}
+function boundedBody() {
+  return bodyLimit({ maxSize: 1024 * 1024, onError: (c) => c.json({ error: "invalid_request", message: "Request exceeds 1 MiB." }, 413) })
+}
+function unconfirmed(c: Context, mutation: boolean) {
+  return c.json({ error: "google_api_error", message: mutation
+    ? "Google did not return a valid confirmation. The operation may have completed; check the service before retrying."
+    : "Google did not return the requested data in a valid response." }, 502)
+}
+async function confirmedBody<S extends z.ZodType>(response: Response, schema: S): Promise<z.output<S> | null> {
+  if (response.status !== 200 && response.status !== 201) return null
+  try {
+    const body = await readGoogleActionJson(response)
+    const result = schema.safeParse(body)
+    return result.success ? result.data : null
+  } catch { return null }
+}
+function calendarUrl(calendarId: string, eventId: string) {
+  return new URL(`${googleBase("https://www.googleapis.com")}/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`)
+}
+function googleBase(fallback: string) { return (env.googleApiBaseUrl ?? fallback).replace(/\/+$/, "") }
+function confirmsEventTime(requested: z.infer<typeof eventTimeSchema> | undefined, actual: z.infer<typeof eventTimeSchema> | undefined) {
+  if (!requested) return true
+  if (!actual) return false
+  return "date" in requested
+    ? "date" in actual && requested.date === actual.date
+    : "dateTime" in actual && Date.parse(requested.dateTime) === Date.parse(actual.dateTime)
+}
+
+export function registerGoogleProductivityManagementRoutes<T extends { Variables: OrgRouteVariables }>(routeApp: Hono<T>, deps: GoogleWorkspaceActionDependencies) {
+  const app = new Hono<{ Variables: OrgRouteVariables }>()
+  app.get(`${base}/calendar-events/:eventId`, routeDescription("getGoogleCalendarEvent", "Read an individual Google Calendar event on a selected calendar", eventReceiptSchema), orgMemberRoute(), paramValidator(eventParams), queryValidator(calendarQuery), async (c) => {
+    const { eventId } = c.req.valid("param")
+    const { calendarId } = c.req.valid("query")
+    const url = calendarUrl(calendarId, eventId)
+    url.searchParams.set("maxAttendees", "100")
+    const result = await requestGoogleAction(c, deps, calendarReadScopes, url)
+    if (!result.ok) return result.reply
+    const event = await confirmedBody(result.response, eventSchema)
+    if (!event || event.id !== eventId) return unconfirmed(c, false)
+    return c.json({ ok: true, calendarId, event })
+  })
+
+  app.patch(`${base}/calendar-events/:eventId`, routeDescription("updateGoogleCalendarEvent", "Update or reschedule a Google Calendar event; explicitly approve guest notifications", eventReceiptSchema), orgMemberRoute(), boundedBody(), paramValidator(eventParams), queryValidator(calendarQuery), jsonValidator(eventPatchSchema), async (c) => {
+    const { eventId } = c.req.valid("param")
+    const { calendarId } = c.req.valid("query")
+    const { sendUpdates, confirmNotifications: _confirmation, ...patch } = c.req.valid("json")
+    const url = calendarUrl(calendarId, eventId)
+    url.searchParams.set("sendUpdates", sendUpdates)
+    url.searchParams.set("maxAttendees", "100")
+    const result = await requestGoogleAction(c, deps, calendarWriteScopes, url, { method: "PATCH", body: JSON.stringify(patch) })
+    if (!result.ok) return result.reply
+    const event = await confirmedBody(result.response, eventSchema)
+    if (!event || event.id !== eventId || event.status === "cancelled"
+      || (patch.summary !== undefined && event.summary !== patch.summary)
+      || (patch.description !== undefined && (event.description ?? "") !== patch.description)
+      || (patch.location !== undefined && (event.location ?? "") !== patch.location)
+      || !confirmsEventTime(patch.start, event.start) || !confirmsEventTime(patch.end, event.end)
+      || (patch.attendees && (event.attendeesOmitted || patch.attendees.length !== (event.attendees?.length ?? 0)
+        || patch.attendees.some((guest) => !event.attendees?.some((actual) => actual.email?.toLowerCase() === guest.email.toLowerCase()
+          && (guest.optional === undefined || Boolean(actual.optional) === guest.optional)))))) return unconfirmed(c, true)
+    return c.json({ ok: true, calendarId, event, sendUpdates })
+  })
+
+  app.delete(`${base}/calendar-events/:eventId`, routeDescription("deleteGoogleCalendarEvent", "Delete/cancel a Google Calendar event after explicit confirmation", cancelReceiptSchema), orgMemberRoute(), paramValidator(eventParams), queryValidator(cancelQuery), async (c) => {
+    const { eventId } = c.req.valid("param")
+    const { calendarId, sendUpdates } = c.req.valid("query")
+    const url = calendarUrl(calendarId, eventId)
+    url.searchParams.set("sendUpdates", sendUpdates)
+    const result = await requestGoogleAction(c, deps, calendarWriteScopes, url, { method: "DELETE" })
+    if (!result.ok) return result.reply
+    // Calendar events.delete returns 204 with no resource body, unlike the other mutations.
+    if (result.response.status !== 204) return unconfirmed(c, true)
+    return c.json({ ok: true, calendarId, eventId, cancelled: true, sendUpdates })
+  })
+
+  app.get(`${base}/spreadsheets/:spreadsheetId`, routeDescription("getGoogleSpreadsheet", "Read Google Sheets spreadsheet metadata and sheet names without grid data", spreadsheetReceiptSchema), orgMemberRoute(), paramValidator(spreadsheetParams), queryValidator(z.object({}).strict()), async (c) => {
+    const { spreadsheetId } = c.req.valid("param")
+    const url = new URL(`${googleBase("https://sheets.googleapis.com")}/v4/spreadsheets/${spreadsheetId}`)
+    url.searchParams.set("fields", spreadsheetFields)
+    url.searchParams.set("includeGridData", "false")
+    const result = await requestGoogleAction(c, deps, sheetsReadScopes, url)
+    if (!result.ok) return result.reply
+    const spreadsheet = await confirmedBody(result.response, spreadsheetSchema)
+    if (!spreadsheet || spreadsheet.spreadsheetId !== spreadsheetId) return unconfirmed(c, false)
+    return c.json({ ok: true, spreadsheet })
+  })
+
+  app.post(`${base}/spreadsheets`, routeDescription("createGoogleSpreadsheet", "Create a real Google Sheets spreadsheet with one bounded initial sheet", spreadsheetReceiptSchema), orgMemberRoute(), boundedBody(), queryValidator(z.object({}).strict()), jsonValidator(createSpreadsheetSchema), async (c) => {
+    const { title, sheetTitle, rowCount, columnCount } = c.req.valid("json")
+    const url = new URL(`${googleBase("https://sheets.googleapis.com")}/v4/spreadsheets`)
+    url.searchParams.set("fields", spreadsheetFields)
+    const result = await requestGoogleAction(c, deps, sheetsWriteScopes, url, { method: "POST", body: JSON.stringify({ properties: { title }, sheets: [{ properties: { title: sheetTitle, gridProperties: { rowCount, columnCount } } }] }) })
+    if (!result.ok) return result.reply
+    const spreadsheet = await confirmedBody(result.response, spreadsheetSchema)
+    if (!spreadsheet) return unconfirmed(c, true)
+    return c.json({ ok: true, spreadsheet })
+  })
+
+  app.get(`${base}/spreadsheets/:spreadsheetId/values`, routeDescription("getGoogleSheetsValues", "Read a bounded rectangle of Google Sheets cells", readValuesReceiptSchema), orgMemberRoute(), paramValidator(spreadsheetParams), queryValidator(valuesReadQuery), async (c) => {
+    const { spreadsheetId } = c.req.valid("param")
+    const { range, valueRenderOption } = c.req.valid("query")
+    const url = new URL(`${googleBase("https://sheets.googleapis.com")}/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(range)}`)
+    url.searchParams.set("majorDimension", "ROWS")
+    url.searchParams.set("valueRenderOption", valueRenderOption)
+    const result = await requestGoogleAction(c, deps, sheetsReadScopes, url)
+    if (!result.ok) return result.reply
+    const data = await confirmedBody(result.response, readValuesSchema)
+    const bounds = rangeDimensions(range)
+    if (!data || !bounds || (data.values && (data.values.length > bounds.rows || data.values.some((row) => row.length > bounds.columns)))) return unconfirmed(c, false)
+    return c.json({ ok: true, spreadsheetId, range: data.range, majorDimension: data.majorDimension, values: data.values ?? [], valueRenderOption })
+  })
+
+  app.put(`${base}/spreadsheets/:spreadsheetId/values`, routeDescription("updateGoogleSheetsValues", "Write Google Sheets cells, RAW by default; USER_ENTERED requires explicit approval", writeValuesReceiptSchema), orgMemberRoute(), boundedBody(), paramValidator(spreadsheetParams), queryValidator(z.object({}).strict()), jsonValidator(valuesWriteSchema), async (c) => {
+    const { spreadsheetId } = c.req.valid("param")
+    const { range, values, valueInputOption } = c.req.valid("json")
+    const url = new URL(`${googleBase("https://sheets.googleapis.com")}/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(range)}`)
+    url.searchParams.set("valueInputOption", valueInputOption)
+    const result = await requestGoogleAction(c, deps, sheetsWriteScopes, url, { method: "PUT", body: JSON.stringify({ range, majorDimension: "ROWS", values }) })
+    if (!result.ok) return result.reply
+    const data = await confirmedBody(result.response, updateValuesSchema)
+    if (!data || data.spreadsheetId !== spreadsheetId || data.updatedCells !== values.reduce((count, row) => count + row.length, 0)
+      || data.updatedRows !== values.length || data.updatedColumns !== Math.max(...values.map((row) => row.length))) return unconfirmed(c, true)
+    return c.json({ ok: true, ...data, valueInputOption })
+  })
+
+  app.post(`${base}/spreadsheets/:spreadsheetId/values/append`, routeDescription("appendGoogleSheetsValues", "Append rows after a Google Sheets table found in a bounded range; inserts rows, RAW by default", appendValuesReceiptSchema), orgMemberRoute(), boundedBody(), paramValidator(spreadsheetParams), queryValidator(z.object({}).strict()), jsonValidator(valuesWriteSchema), async (c) => {
+    const { spreadsheetId } = c.req.valid("param")
+    const { range, values, valueInputOption } = c.req.valid("json")
+    const url = new URL(`${googleBase("https://sheets.googleapis.com")}/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(range)}:append`)
+    url.searchParams.set("valueInputOption", valueInputOption)
+    url.searchParams.set("insertDataOption", "INSERT_ROWS")
+    const result = await requestGoogleAction(c, deps, sheetsWriteScopes, url, { method: "POST", body: JSON.stringify({ range, majorDimension: "ROWS", values }) })
+    if (!result.ok) return result.reply
+    const data = await confirmedBody(result.response, appendValuesSchema)
+    if (!data || data.spreadsheetId !== spreadsheetId || data.updates.spreadsheetId !== spreadsheetId
+      || data.updates.updatedCells !== values.reduce((count, row) => count + row.length, 0)
+      || data.updates.updatedRows !== values.length || data.updates.updatedColumns !== Math.max(...values.map((row) => row.length))) return unconfirmed(c, true)
+    return c.json({ ok: true, ...data.updates, tableRange: data.tableRange, valueInputOption })
+  })
+
+  app.post(`${base}/drive-folders`, routeDescription("createGoogleDriveFolder", "Create a Google Drive folder, optionally in a selected parent", fileReceiptSchema), orgMemberRoute(), boundedBody(), queryValidator(z.object({}).strict()), jsonValidator(folderSchema), async (c) => {
+    const { name, parentId } = c.req.valid("json")
+    const url = new URL(`${googleBase("https://www.googleapis.com")}/drive/v3/files`)
+    url.searchParams.set("fields", fileFields)
+    url.searchParams.set("supportsAllDrives", "true")
+    const result = await requestGoogleAction(c, deps, driveWriteScopes, url, { method: "POST", body: JSON.stringify({ name, mimeType: folderMimeType, ...(parentId ? { parents: [parentId] } : {}) }) })
+    if (!result.ok) return result.reply
+    const file = await confirmedBody(result.response, fileSchema)
+    if (!file || file.mimeType !== folderMimeType || file.name !== name || file.trashed || (parentId && !file.parents?.includes(parentId))) return unconfirmed(c, true)
+    return c.json({ ok: true, file })
+  })
+
+  app.get(`${base}/drive-files/:fileId`, routeDescription("getGoogleDriveFileMetadata", "Read Google Drive file metadata, including current parent IDs for a move", fileReceiptSchema), orgMemberRoute(), paramValidator(fileParams), queryValidator(z.object({}).strict()), async (c) => {
+    const { fileId } = c.req.valid("param")
+    const url = new URL(`${googleBase("https://www.googleapis.com")}/drive/v3/files/${fileId}`)
+    url.searchParams.set("fields", fileFields)
+    url.searchParams.set("supportsAllDrives", "true")
+    const result = await requestGoogleAction(c, deps, driveReadScopes, url)
+    if (!result.ok) return result.reply
+    const file = await confirmedBody(result.response, fileSchema)
+    if (!file || file.id !== fileId) return unconfirmed(c, false)
+    return c.json({ ok: true, file })
+  })
+
+  app.patch(`${base}/drive-files/:fileId`, routeDescription("updateGoogleDriveFileMetadata", "Rename, move, trash, or restore Google Drive file metadata; never permanently delete", fileReceiptSchema), orgMemberRoute(), boundedBody(), paramValidator(fileParams), queryValidator(z.object({}).strict()), jsonValidator(filePatchSchema), async (c) => {
+    const { fileId } = c.req.valid("param")
+    const { name, trashed, addParentId, removeParentId } = c.req.valid("json")
+    if (addParentId === fileId) return c.json({ error: "invalid_request", details: [{ message: "Cannot move a folder into itself." }] }, 400)
+    const url = new URL(`${googleBase("https://www.googleapis.com")}/drive/v3/files/${fileId}`)
+    url.searchParams.set("fields", fileFields)
+    url.searchParams.set("supportsAllDrives", "true")
+    if (addParentId) url.searchParams.set("addParents", addParentId)
+    if (removeParentId) url.searchParams.set("removeParents", removeParentId)
+    const result = await requestGoogleAction(c, deps, driveWriteScopes, url, { method: "PATCH", body: JSON.stringify({ name, trashed }) })
+    if (!result.ok) return result.reply
+    const file = await confirmedBody(result.response, fileSchema)
+    if (!file || file.id !== fileId || (name !== undefined && file.name !== name) || (trashed !== undefined && file.trashed !== trashed)
+      || (addParentId && !file.parents?.includes(addParentId)) || (removeParentId && file.parents?.includes(removeParentId))) return unconfirmed(c, true)
+    return c.json({ ok: true, file })
+  })
+  routeApp.route("/", app)
+}

--- a/ee/apps/den-api/src/routes/org/google-workspace-actions.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace-actions.ts
@@ -1,0 +1,86 @@
+import type { Context } from "hono"
+import type { GoogleWorkspaceAccessToken } from "./google-workspace.js"
+import type { OrgRouteVariables } from "./shared.js"
+
+export const GOOGLE_ACTION_MAX_BODY_BYTES = 6 * 1024 * 1024
+
+/** Bound decoded provider bytes before JSON parsing, including chunked responses. */
+export async function readGoogleActionJson(response: Response): Promise<unknown> {
+  if (!response.body) return null
+  const reader = response.body.getReader()
+  try {
+    if (Number(response.headers.get("content-length")) > GOOGLE_ACTION_MAX_BODY_BYTES) return null
+    const decoder = new TextDecoder()
+    let bytes = 0
+    let text = ""
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+      bytes += chunk.value.byteLength
+      if (bytes > GOOGLE_ACTION_MAX_BODY_BYTES) return null
+      text += decoder.decode(chunk.value, { stream: true })
+    }
+    return JSON.parse(text + decoder.decode())
+  } catch {
+    return null
+  } finally {
+    await reader.cancel().catch(() => {})
+    reader.releaseLock()
+  }
+}
+
+export type GoogleWorkspaceActionDependencies = {
+  token: (input: {
+    organizationId: NonNullable<OrgRouteVariables["organizationContext"]>["organization"]["id"]
+    orgMembershipId: NonNullable<OrgRouteVariables["organizationContext"]>["currentMember"]["id"]
+  }) => Promise<GoogleWorkspaceAccessToken>
+  fetch: (input: Parameters<typeof fetch>[0], init?: RequestInit) => Promise<Response>
+}
+
+/** Reuse the selected credential; require both account grants and current connector permissions. */
+export async function requestGoogleAction(
+  c: Context<{ Variables: OrgRouteVariables }>,
+  dependencies: GoogleWorkspaceActionDependencies,
+  scopes: readonly string[],
+  url: URL,
+  init: RequestInit = {},
+  requiredFeatures?: readonly string[],
+): Promise<{ ok: true; response: Response } | { ok: false; reply: Response }> {
+  const context = c.get("organizationContext")
+  if (!context) return { ok: false, reply: c.json({ error: "unauthorized", message: "Sign in to an organization first." }, 401) }
+  const token = await dependencies.token({ organizationId: context.organization.id, orgMembershipId: context.currentMember.id })
+  if (token.kind !== "ok") {
+    return { ok: false, reply: c.json({ error: token.kind, message: token.message }, token.kind === "needs_connection" ? 409 : 502) }
+  }
+  if (requiredFeatures && !token.enabledFeatures?.some((feature) => requiredFeatures.includes(feature))) {
+    return { ok: false, reply: c.json({ error: "needs_connection", message: "The administrator has not enabled this action for the selected Google connector. Enable it in connector setup before using it." }, 409) }
+  }
+  if (!token.account.scopes?.some((scope) => scopes.includes(scope))
+    || !token.enabledScopes?.some((scope) => scopes.includes(scope))) {
+    return { ok: false, reply: c.json({ error: "needs_connection", message: "Enable the required Google Workspace permission in connector setup, then reconnect this account. Existing or unknown grants do not authorize this operation." }, 409) }
+  }
+  const headers = new Headers(init.headers)
+  headers.set("authorization", `Bearer ${token.accessToken}`)
+  if (init.body) headers.set("content-type", "application/json")
+  let response: Response
+  try {
+    response = await dependencies.fetch(url, { ...init, headers, signal: c.req.raw.signal })
+  } catch {
+    return { ok: false, reply: c.json({
+      error: "google_api_error",
+      message: init.method && init.method !== "GET"
+        ? "Google did not confirm the operation. It may have completed; check the service before retrying."
+        : "Google could not be reached. Try the read again later.",
+    }, 502) }
+  }
+  if (!response.ok) {
+    const authorizationFailure = response.status === 401 || response.status === 403
+    return { ok: false, reply: c.json({
+      error: authorizationFailure ? "needs_connection" : "google_api_error",
+      message: authorizationFailure
+        ? "Google rejected this account's permissions. Check access to the item and reconnect with the required permissions."
+        : `Google returned HTTP ${response.status}.${init.method && init.method !== "GET" && response.status >= 500 ? " Check whether the operation completed before retrying." : ""}`,
+    }, authorizationFailure ? 409 : 502) }
+  }
+  return { ok: true, response }
+}

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -29,8 +29,10 @@ import {
   gmailBodyHasQuotedHistory,
   truncateText,
 } from "../../capability-sources/google-workspace-api.js"
-import type { ConnectedAccountRow } from "../../capability-sources/oauth-credentials.js"
-import { getNativeOAuthProvider } from "../../capability-sources/provider-registry.js"
+import { getOrgOAuthClient, type ConnectedAccountRow } from "../../capability-sources/oauth-credentials.js"
+import { clientSelectedFeatures, getNativeOAuthProvider, providerScopesSatisfy, resolveProviderScopes } from "../../capability-sources/provider-registry.js"
+import { registerGmailManagementRoutes } from "./gmail-management.js"
+import { registerGoogleProductivityManagementRoutes } from "./google-productivity-management.js"
 import { listTeamsForMember } from "../../orgs.js"
 import { readInternalCapabilityConnectorId } from "../../session.js"
 import type { OrgRouteVariables } from "./shared.js"
@@ -105,6 +107,7 @@ const upstreamErrorSchema = z.object({
 const gmailMessagesQuerySchema = z.object({
   q: z.string().trim().min(1).max(1_000).optional().describe("Optional Gmail search query, using Gmail's search syntax."),
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum messages to return, capped at 25."),
+  pageToken: z.string().min(1).max(2048).optional().describe("nextPageToken from a previous page of the same Gmail search."),
 })
 
 const gmailMessageParamSchema = z.object({
@@ -137,6 +140,7 @@ const gmailMessageSchema = gmailMessageSummarySchema.extend({
 const gmailMessagesResponseSchema = z.object({
   ok: z.literal(true),
   messages: z.array(gmailMessageSummarySchema),
+  nextPageToken: z.string().optional(),
 }).meta({ ref: "GoogleWorkspaceGmailMessagesResponse" })
 
 const gmailMessageResponseSchema = z.object({
@@ -221,8 +225,11 @@ const updateCalendarEventResponseSchema = z.object({
 }).meta({ ref: "GoogleWorkspaceUpdateCalendarEventResponse" })
 
 const driveFilesQuerySchema = z.object({
-  query: z.string().trim().min(1).max(500).describe("Text to search in Drive file names and full text."),
+  query: z.string().trim().min(1).max(500).optional().describe("Optional text to search in Drive file names and full text. Omit to list files."),
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum files to return, capped at 25."),
+  pageToken: z.string().min(1).max(2048).optional(),
+  modifiedAfter: z.string().datetime({ offset: true }).optional().describe("Only files modified after this RFC3339 timestamp; follow nextPageToken to enumerate all matching files."),
+  folderId: z.string().min(1).max(512).regex(/^[A-Za-z0-9_-]+$/).optional().describe("Limit to direct children of this folder."),
 })
 
 const driveFileParamSchema = z.object({
@@ -264,6 +271,8 @@ const driveFileSummarySchema = z.object({
 const driveFilesResponseSchema = z.object({
   ok: z.literal(true),
   files: z.array(driveFileSummarySchema),
+  nextPageToken: z.string().optional(),
+  incompleteSearch: z.boolean().optional().describe("Google reports some drives were not searched; do not claim these are all matching files."),
 }).meta({ ref: "GoogleWorkspaceDriveFilesResponse" })
 
 const uploadDriveFileResponseSchema = z.object({
@@ -290,8 +299,8 @@ const shareDriveFileResponseSchema = z.object({
   role: z.string(),
 }).meta({ ref: "GoogleWorkspaceShareDriveFileResponse" })
 
-type GoogleWorkspaceAccessToken =
-  | { kind: "ok"; accessToken: string; account: ConnectedAccountRow }
+export type GoogleWorkspaceAccessToken =
+  | { kind: "ok"; accessToken: string; account: ConnectedAccountRow; enabledScopes: string[]; enabledFeatures?: string[] }
   | { kind: "needs_connection"; message: string }
   | { kind: "google_api_error"; message: string }
 
@@ -333,7 +342,8 @@ export function missingScope(account: ConnectedAccountRow, anyOf: string[]): boo
     // general Drive retrieval uses the stricter, fail-closed check below.
     return false
   }
-  return !anyOf.some((scope) => scopes.includes(scope))
+  const provider = getNativeOAuthProvider("google-workspace")
+  return !anyOf.some((scope) => scopes.includes(scope) || (provider && providerScopesSatisfy(provider, scopes, scope)))
 }
 
 function missingPermissionMessage(label: string): string {
@@ -410,7 +420,10 @@ async function googleWorkspaceToken(input: {
     return { kind: "needs_connection", message: CONNECT_GOOGLE_ACCOUNT_MESSAGE }
   }
 
-  return { kind: "ok", accessToken: token.accessToken, account: token.account }
+  const client = await getOrgOAuthClient(input.organizationId, credentialProviderId)
+  const enabledFeatures = client ? clientSelectedFeatures(provider, client.extra) : []
+  const enabledScopes = client ? resolveProviderScopes(provider, enabledFeatures) : []
+  return { kind: "ok", accessToken: token.accessToken, account: token.account, enabledScopes, enabledFeatures }
 }
 
 async function googleApiError(operation: string, response: Response) {
@@ -730,6 +743,9 @@ async function executeGmailDraft(
 export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
   app.use("/v1/capabilities/google-workspace/*", contextStorage())
   app.use("/v1/direct-uploads/google-workspace/*", contextStorage())
+  const actionDependencies = { token: googleWorkspaceToken, fetch: googleWorkspaceApiFetch }
+  registerGmailManagementRoutes(app, actionDependencies)
+  registerGoogleProductivityManagementRoutes(app, actionDependencies)
 
   app.post(
     "/v1/direct-uploads/google-workspace/drive-files",
@@ -893,6 +909,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       const listUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages`)
       if (query.q) listUrl.searchParams.set("q", query.q)
       listUrl.searchParams.set("maxResults", String(query.maxResults))
+      if (query.pageToken) listUrl.searchParams.set("pageToken", query.pageToken)
 
       const listResponse = await googleWorkspaceApiFetch(listUrl, {
         headers: { authorization: `Bearer ${token.accessToken}` },
@@ -901,7 +918,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json(await googleApiError("Gmail messages list", listResponse), 502)
       }
 
-      const ids = extractGmailMessageIds(await readJson(listResponse), 25)
+      const listed = await readJson(listResponse)
+      const ids = extractGmailMessageIds(listed, 25)
       const metadata = await fetchGmailMetadata(ids, token.accessToken, c.req.raw.signal)
       if (!metadata.ok) {
         return c.json(metadata.error, 502)
@@ -920,7 +938,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         }
       })
 
-      return c.json({ ok: true, messages })
+      return c.json({ ok: true, messages, ...(isRecordValue(listed) && typeof listed.nextPageToken === "string" ? { nextPageToken: listed.nextPageToken } : {}) })
     },
   )
 
@@ -1206,7 +1224,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     describeRoute({
       tags: ["Capability Sources"],
       summary: "Search Google Drive files as the calling member",
-      description: "Searches the calling member's Google Drive files by name and full text, using their connected Google Workspace account.",
+      description: "Lists or searches Drive files, including an optional modifiedAfter date and direct-parent folder filter. Follow nextPageToken until absent, and honor incompleteSearch before claiming complete coverage.",
       responses: {
         200: jsonResponse("Google Drive files returned.", driveFilesResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
@@ -1235,13 +1253,17 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
 
       const query = c.req.valid("query")
       const url = new URL(`${driveApiBase()}/drive/v3/files`)
-      url.searchParams.set("q", buildDriveSearchQuery(query.query))
+      const filters = [query.query ? buildDriveSearchQuery(query.query) : "trashed = false"]
+      if (query.modifiedAfter) filters.push(`modifiedTime > '${query.modifiedAfter}'`)
+      if (query.folderId) filters.push(`'${query.folderId}' in parents`)
+      url.searchParams.set("q", filters.join(" and "))
+      if (query.pageToken) url.searchParams.set("pageToken", query.pageToken)
       url.searchParams.set("pageSize", String(query.maxResults))
       url.searchParams.set("corpora", "allDrives")
       url.searchParams.set("spaces", "drive")
       url.searchParams.set("supportsAllDrives", "true")
       url.searchParams.set("includeItemsFromAllDrives", "true")
-      url.searchParams.set("fields", "files(id,name,mimeType,modifiedTime,webViewLink,size)")
+      url.searchParams.set("fields", "files(id,name,mimeType,modifiedTime,webViewLink,size),nextPageToken,incompleteSearch")
 
       const response = await googleWorkspaceApiFetch(url, {
         headers: { authorization: `Bearer ${token.accessToken}` },
@@ -1251,7 +1273,11 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return error.status === 409 ? c.json(error.body, 409) : c.json(error.body, 502)
       }
 
-      return c.json({ ok: true, files: extractDriveFiles(await readJson(response)) })
+      const listed = await readJson(response)
+      return c.json({ ok: true, files: extractDriveFiles(listed),
+        ...(isRecordValue(listed) && typeof listed.nextPageToken === "string" ? { nextPageToken: listed.nextPageToken } : {}),
+        ...(isRecordValue(listed) && typeof listed.incompleteSearch === "boolean" ? { incompleteSearch: listed.incompleteSearch } : {}),
+      })
     },
   )
 
@@ -1260,7 +1286,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     describeRoute({
       tags: ["Capability Sources"],
       summary: "Read a Google Drive file's text or binary content as the calling member",
-      description: "Reads one Google Drive file, exporting Google Docs editors files as plain text. Downloaded files are content-sniffed with strict UTF-8 detection; declared text is bounded, and binary content is returned as standard base64 only up to the internal model-safety limit.",
+      description: "Reads a Drive file. Docs and Slides export as plain text; Sheets exports the first tab as CSV. For every spreadsheet tab or edits use the spreadsheet metadata and values capabilities. Downloaded content is bounded; binary files use standard base64 within the model-safety limit.",
       responses: {
         200: jsonResponse("Google Drive file returned.", driveFileResponseSchema),
         400: jsonResponse("The Drive item is not a readable file.", invalidRequestSchema),
@@ -1335,7 +1361,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         ? new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}/export`)
         : new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}`)
       if (isGoogleAppsFile) {
-        contentUrl.searchParams.set("mimeType", "text/plain")
+        contentUrl.searchParams.set("mimeType", file.mimeType === "application/vnd.google-apps.spreadsheet" ? "text/csv" : "text/plain")
       } else {
         contentUrl.searchParams.set("alt", "media")
         contentUrl.searchParams.set("supportsAllDrives", "true")

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -106,6 +106,8 @@ import {
   externalMcpOAuthConfigurationDefaults,
   pluginMcpRequiresPreRegisteredOAuthClient,
   requiredPluginMcpAuthType,
+  existingPluginMcpAuthTypeCompatible,
+  matchExternalMcpPresetForUrl,
 } from "../../capability-sources/external-mcp-auth-policy.js"
 import {
   EXTERNAL_MCP_DIAGNOSTIC_PHASES,
@@ -1153,7 +1155,8 @@ async function toConnectionResponse(
     : null
   if (requiredAuthTypes.length === 0 && presetRequiredAuthType) requiredAuthTypes.push(presetRequiredAuthType)
   const authPolicyConfirmed = options.identityManagedBy.length === 0 || requiredAuthTypes.length > 0
-  const authTypeMismatch = requiredAuthTypes.some((requiredAuthType) => requiredAuthType !== row.authType)
+    || (row.kind === "external_mcp" && matchExternalMcpPresetForUrl(row.url) !== null)
+  const authTypeMismatch = requiredAuthTypes.some((requiredAuthType) => !existingPluginMcpAuthTypeCompatible({ authType: row.authType, requiredAuthType }))
   const oauthClientRequired = row.kind === "external_mcp" && row.authType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(row.url)
   const oauthClientConfigured = Boolean(oauthClient)
   const setupRequired = options.identityManagedBy.length > 0 && (
@@ -1608,6 +1611,8 @@ async function createExternalConnectionResponse(
         await markExternalMcpConnectionConnected(created.id)
       }
     } catch (error) {
+      // Failed creation must not leave a saved API key looking ready or reserve its external key.
+      await deleteExternalMcpConnection({ organizationId: payload.organization.id, connectionId: created.id })
       const diagnostic = externalMcpDiagnosticForResponse(error, requestId, "MCP_INITIALIZE")
       logger.error("external_mcp_connection_validation_failed", {
         connection_id: created.id,

--- a/ee/apps/den-api/src/routes/org/microsoft-365.ts
+++ b/ee/apps/den-api/src/routes/org/microsoft-365.ts
@@ -1,5 +1,7 @@
 import type { Hono } from "hono"
 import type { MiddlewareHandler } from "hono"
+import { bodyLimit } from "hono/body-limit"
+import { contextStorage, getContext } from "hono/context-storage"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
@@ -7,12 +9,18 @@ import { env } from "../../env.js"
 import { jsonValidator, orgMemberRoute, paramValidator, queryValidator } from "../../middleware/index.js"
 import { jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
-import { MicrosoftGraphClient, MicrosoftGraphRequestError } from "../../capability-sources/microsoft-graph.js"
+import { MicrosoftGraphClient, MicrosoftGraphMutationOutcomeUnknownError, MicrosoftGraphRequestError } from "../../capability-sources/microsoft-graph.js"
 import { getOrgOAuthClient } from "../../capability-sources/oauth-credentials.js"
+import { listNativeProviderUsableEntries, resolveDefaultNativeProviderCredentialId } from "../../capability-sources/native-provider-connections.js"
 import { clientSelectedFeatures, getNativeOAuthProvider, providerScopesSatisfy } from "../../capability-sources/provider-registry.js"
+import { listTeamsForMember } from "../../orgs.js"
+import { INTERNAL_CAPABILITY_CONNECTOR_HEADER, readInternalCapabilityConnectorId } from "../../session.js"
 import type { OrgRouteVariables } from "./shared.js"
 
 const CONNECT_MICROSOFT_ACCOUNT_MESSAGE = "Connect your Microsoft work account first: open Settings > Connect and use Connect your account on the Microsoft 365 row, or connect from the OpenWork Cloud dashboard."
+
+const graphItemIdSchema = z.string().trim().min(1).max(512)
+  .refine((value) => value !== "." && value !== ".." && !/[\s/\\?#]/.test(value), "Use a Microsoft Graph item id, not a path or URL.")
 
 const emailAddressSchema = z.object({
   name: z.string(),
@@ -32,6 +40,10 @@ const mailMessageSummarySchema = z.object({
 }).meta({ ref: "Microsoft365MailMessageSummary" })
 
 const mailMessageSchema = mailMessageSummarySchema.extend({
+  isDraft: z.boolean(),
+  isRead: z.boolean(),
+  categories: z.array(z.string()),
+  parentFolderId: z.string(),
   cc: z.array(emailAddressSchema),
   body: z.string(),
   bodyContentType: z.string(),
@@ -44,7 +56,7 @@ const mailMessagesQuerySchema = z.object({
 })
 
 const mailMessageParamSchema = z.object({
-  messageId: z.string().trim().min(1).max(512).describe("Microsoft Graph message id."),
+  messageId: graphItemIdSchema.describe("Microsoft Graph message id."),
 })
 
 const mailMessagesResponseSchema = z.object({
@@ -69,6 +81,34 @@ const mailDraftResponseSchema = z.object({
   ok: z.literal(true),
   draft: mailMessageSchema,
 }).meta({ ref: "Microsoft365MailDraftResponse" })
+
+const mailSendBodySchema = z.object({
+  confirmSend: z.literal(true).describe("Must be true only after the user explicitly requests sending this existing draft. Creating or reviewing a draft is not send authorization."),
+}).strict().meta({ ref: "Microsoft365MailSendBody" })
+
+const mailSendResponseSchema = z.object({
+  ok: z.literal(true),
+  draftId: z.string(),
+  status: z.literal("accepted").describe("Graph accepted the send request. This is not confirmation of delivery."),
+}).meta({ ref: "Microsoft365MailSendResponse" })
+
+const mailReplyDraftBodySchema = z.object({
+  comment: z.string().trim().min(1).max(20_000).describe("Reply text to save in a draft for user review; this does not send mail."),
+}).strict().meta({ ref: "Microsoft365MailReplyDraftBody" })
+
+const mailMessageUpdateBodySchema = z.object({
+  isRead: z.boolean().optional(),
+  categories: z.array(z.string().trim().min(1).max(255)).max(25).optional()
+    .describe("Replace the message's categories with this list; an empty list clears them."),
+}).strict().refine((value) => value.isRead !== undefined || value.categories !== undefined, "Provide isRead or categories.")
+  .meta({ ref: "Microsoft365MailMessageUpdateBody" })
+
+const mailMessageMoveBodySchema = z.object({
+  destination: z.enum(["archive", "deleteditems", "inbox"]).describe("Named folder in the caller's mailbox. deleteditems moves to trash, never permanently deletes."),
+  confirmTrash: z.literal(true).optional().describe("Required when destination is deleteditems. Set true only when the user explicitly requested moving this message to trash."),
+}).strict().refine((value) => value.destination !== "deleteditems" || value.confirmTrash === true, {
+  message: "Moving a message to deleteditems requires confirmTrash: true.", path: ["confirmTrash"],
+}).meta({ ref: "Microsoft365MailMessageMoveBody" })
 
 const calendarEventsQuerySchema = z.object({
   timeMin: z.string().datetime().describe("Inclusive lower bound for event start time."),
@@ -115,13 +155,44 @@ const calendarEventResponseSchema = z.object({
   event: calendarEventSchema,
 }).meta({ ref: "Microsoft365CalendarEventResponse" })
 
+const calendarEventParamSchema = z.object({ eventId: graphItemIdSchema })
+const calendarEventUpdateBodySchema = z.object({
+  confirmNotifications: z.literal(true).describe("The user explicitly authorized this update and potential attendee email notifications from Microsoft Graph."),
+  subject: z.string().trim().min(1).max(255).optional(),
+  body: z.string().max(20_000).optional(),
+  start: z.string().max(40).datetime().optional().describe("New UTC start, with Z suffix. Rescheduling requires both start and end."),
+  end: z.string().max(40).datetime().optional().describe("New UTC end, with Z suffix."),
+  location: z.string().trim().max(255).optional(),
+}).strict()
+  .refine(({ confirmNotifications: _confirmation, ...fields }) => Object.values(fields).some((entry) => entry !== undefined), "Provide at least one event field.")
+  .refine((value) => (value.start === undefined && value.end === undefined)
+    || (value.start !== undefined && value.end !== undefined && Date.parse(value.end) > Date.parse(value.start)),
+  "Rescheduling requires both start and end, with end after start.")
+  .meta({ ref: "Microsoft365CalendarEventUpdateBody" })
+
+const calendarCancelBodySchema = z.object({
+  confirmCancel: z.literal(true).describe("The user explicitly requested cancellation, including attendee notifications."),
+  comment: z.string().max(20_000).optional(),
+}).strict().meta({ ref: "Microsoft365CalendarCancelBody" })
+
+const calendarDeleteBodySchema = z.object({
+  confirmDelete: z.literal(true).describe("The user explicitly requested deleting this event; organizer deletion can notify attendees."),
+}).strict().meta({ ref: "Microsoft365CalendarDeleteBody" })
+
+const calendarCancelResponseSchema = z.object({
+  ok: z.literal(true), eventId: z.string(), status: z.literal("accepted"),
+}).meta({ ref: "Microsoft365CalendarCancelResponse" })
+const calendarDeleteResponseSchema = z.object({
+  ok: z.literal(true), eventId: z.string(), status: z.literal("deleted"),
+}).meta({ ref: "Microsoft365CalendarDeleteResponse" })
+
 const driveFilesQuerySchema = z.object({
   query: z.string().trim().min(1).max(500).describe("Text to search in OneDrive file names and content."),
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum files to return, capped at 25."),
 })
 
 const driveFileParamSchema = z.object({
-  itemId: z.string().trim().min(1).max(512).describe("Microsoft Graph drive item id."),
+  itemId: graphItemIdSchema.describe("Microsoft Graph drive item id."),
 })
 
 const driveItemSchema = z.object({
@@ -161,6 +232,18 @@ const driveFileWriteResponseSchema = z.object({
   ok: z.literal(true),
   file: driveItemSchema,
 }).meta({ ref: "Microsoft365DriveFileWriteResponse" })
+
+const driveItemNameSchema = z.string().trim().min(1).max(255)
+  .refine((value) => value !== "." && value !== ".." && !/["*:<>?\/\\|\u0000-\u001f]/.test(value) && !value.endsWith("."), "Use one valid OneDrive file or folder name, not a path.")
+const driveItemUpdateBodySchema = z.object({
+  name: driveItemNameSchema.optional(),
+  parentId: graphItemIdSchema.optional().describe("Destination folder id within the calling member's same OneDrive; cross-drive moves are not supported."),
+}).strict().refine((value) => value.name !== undefined || value.parentId !== undefined, "Provide name or parentId.")
+  .meta({ ref: "Microsoft365DriveItemUpdateBody" })
+const driveFolderBodySchema = z.object({
+  parentId: graphItemIdSchema.describe("Existing parent folder id in the calling member's OneDrive."),
+  name: driveItemNameSchema,
+}).strict().meta({ ref: "Microsoft365DriveFolderBody" })
 
 const teamsChatsQuerySchema = z.object({
   maxResults: z.coerce.number().int().min(1).max(50).default(20),
@@ -217,6 +300,8 @@ const needsConnectionSchema = z.object({
 const upstreamErrorSchema = z.object({
   error: z.literal("microsoft_graph_error"),
   message: z.string(),
+  outcome: z.literal("unknown").optional(),
+  retryable: z.literal(false).optional(),
 }).meta({ ref: "Microsoft365GraphError" })
 
 export type Microsoft365AccessToken =
@@ -244,13 +329,31 @@ async function defaultAccessTokenResolver(input: {
   if (!provider) {
     return { kind: "microsoft_graph_error", message: "microsoft-365 provider is not registered." }
   }
-  const client = await getOrgOAuthClient(input.organizationId, provider.providerId)
+  const headers = getContext().req.raw.headers
+  const requestedConnectorId = readInternalCapabilityConnectorId(headers)
+  if (headers.has(INTERNAL_CAPABILITY_CONNECTOR_HEADER) && !requestedConnectorId) {
+    return { kind: "needs_connection", message: CONNECT_MICROSOFT_ACCOUNT_MESSAGE }
+  }
+  const memberTeams = await listTeamsForMember({ organizationId: input.organizationId, memberId: input.orgMembershipId })
+  const teamIds = memberTeams.map((team) => team.id)
+  let credentialProviderId: string | null
+  if (requestedConnectorId) {
+    const entries = await listNativeProviderUsableEntries({ ...input, teamIds })
+    const selected = entries.find((entry) => entry.id === requestedConnectorId)
+    credentialProviderId = selected?.nativeProviderKey === provider.providerId ? selected.id : null
+  } else {
+    credentialProviderId = await resolveDefaultNativeProviderCredentialId({ ...input, nativeProviderKey: provider.providerId, teamIds })
+  }
+  if (!credentialProviderId) {
+    return { kind: "needs_connection", message: CONNECT_MICROSOFT_ACCOUNT_MESSAGE }
+  }
+  const client = await getOrgOAuthClient(input.organizationId, credentialProviderId)
   if (!client) {
     return { kind: "needs_connection", message: CONNECT_MICROSOFT_ACCOUNT_MESSAGE }
   }
   let token: Awaited<ReturnType<typeof getValidAccessToken>>
   try {
-    token = await getValidAccessToken({ provider, credentialProviderId: provider.providerId, ...input })
+    token = await getValidAccessToken({ provider, credentialProviderId, ...input })
   } catch (error) {
     return { kind: "microsoft_graph_error", message: error instanceof Error ? error.message : "Microsoft OAuth token refresh failed." }
   }
@@ -270,12 +373,13 @@ function featureEnabled(token: Extract<Microsoft365AccessToken, { kind: "ok" }>,
 }
 
 function featureGranted(token: Extract<Microsoft365AccessToken, { kind: "ok" }>, features: readonly string[]): boolean {
-  if (!token.scopes || token.scopes.length === 0) return true
+  if (!token.scopes || token.scopes.length === 0) return false
   const provider = getNativeOAuthProvider("microsoft-365")
   if (!provider) return false
   return features.some((feature) => {
     if (!token.enabledFeatures.includes(feature)) return false
-    const requiredScopes = provider.optionalFeatures?.[feature] ?? []
+    const requiredScopes = provider.optionalFeatures?.[feature]
+    if (!requiredScopes || requiredScopes.length === 0) return false
     return requiredScopes.every((scope) => providerScopesSatisfy(provider, token.scopes, scope))
   })
 }
@@ -288,7 +392,10 @@ function disabledFeatureMessage(label: string): string {
   return `The workspace administrator has disabled ${label} for the Microsoft 365 connection.`
 }
 
-function graphError(error: unknown): { error: "microsoft_graph_error"; message: string } {
+function graphError(error: unknown): { error: "microsoft_graph_error"; message: string; outcome?: "unknown"; retryable?: false } {
+  if (error instanceof MicrosoftGraphMutationOutcomeUnknownError) {
+    return { error: "microsoft_graph_error", message: error.message, outcome: "unknown", retryable: false }
+  }
   if (error instanceof MicrosoftGraphRequestError) {
     return { error: "microsoft_graph_error", message: error.message }
   }
@@ -296,6 +403,22 @@ function graphError(error: unknown): { error: "microsoft_graph_error"; message: 
     error: "microsoft_graph_error",
     message: error instanceof Error ? error.message : "Microsoft Graph request failed.",
   }
+}
+
+function describeMutation(operationId: string, summary: string, description: string, responseSchema: z.ZodType) {
+  return describeRoute({
+    operationId,
+    tags: ["Capability Sources"],
+    summary,
+    description: `${description} Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.`,
+    responses: {
+      200: jsonResponse("Microsoft Graph mutation receipt returned.", responseSchema),
+      401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+      409: jsonResponse("The selected feature or delegated permission is missing.", needsConnectionSchema),
+      413: jsonResponse("Request body exceeds 1 MiB.", z.object({ error: z.literal("invalid_request"), message: z.string() })),
+      502: jsonResponse("Microsoft Graph rejected the request or the outcome is unknown.", upstreamErrorSchema),
+    },
+  })
 }
 
 /**
@@ -308,16 +431,149 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
   app: Hono<T>,
   options: Microsoft365RouteOptions = {},
 ) {
+  app.use("/v1/capabilities/microsoft-365/*", contextStorage())
   const resolveAccessToken = options.resolveAccessToken ?? defaultAccessTokenResolver
   const orgMemberRouteMiddleware = options.memberRoute ?? orgMemberRoute()
+  const boundedMutationBody = bodyLimit({
+    maxSize: 1024 * 1024,
+    onError: (c) => c.json({ error: "invalid_request", message: "Request exceeds 1 MiB." }, 413),
+  })
 
-  function graphClient(accessToken: string) {
+  function graphClient(accessToken: string, signal?: AbortSignal) {
     return new MicrosoftGraphClient({
       accessToken,
       baseUrl: options.graphBaseUrl ?? env.microsoftGraphBaseUrl,
       fetch: options.fetch,
+      signal,
     })
   }
+
+  async function mutationClient(payload: OrgRouteVariables["organizationContext"], signal: AbortSignal, features: readonly string[], label: string) {
+    if (!payload) return Response.json({ error: "unauthorized" }, { status: 401 })
+    const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
+    if (token.kind === "microsoft_graph_error") return Response.json({ error: token.kind, message: token.message }, { status: 502 })
+    if (token.kind === "needs_connection") return Response.json({ error: token.kind, message: token.message }, { status: 409 })
+    if (!featureEnabled(token, features)) return Response.json({ error: "needs_connection", message: disabledFeatureMessage(label) }, { status: 409 })
+    if (!featureGranted(token, features)) return Response.json({ error: "needs_connection", message: missingPermissionMessage(label) }, { status: 409 })
+    return graphClient(token.accessToken, signal)
+  }
+
+  app.post(
+    "/v1/capabilities/microsoft-365/mail-drafts/:messageId/send",
+    describeMutation("sendMicrosoft365MailDraft", "Send an existing Outlook draft after explicit user confirmation", "Requires Mail.Send and the mailSend feature. Only send an existing draft the user explicitly requested to send. Graph HTTP 202 means accepted, not delivered.", mailSendResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(mailMessageParamSchema), jsonValidator(mailSendBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["mailSend"], "Outlook mail sending")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, ...await client.sendMailDraft(c.req.valid("param").messageId) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.post(
+    "/v1/capabilities/microsoft-365/mail-message/:messageId/reply-draft",
+    describeMutation("createMicrosoft365ReplyDraft", "Create a reply draft for a selected Outlook message", "Uses Graph createReply with Mail.ReadWrite and mailDraft. Preserves the selected message's reply context. Saves a draft for user review and never sends it.", mailDraftResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(mailMessageParamSchema), jsonValidator(mailReplyDraftBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["mailDraft"], "Outlook draft creation")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, draft: await client.createMailReplyDraft(c.req.valid("param").messageId, c.req.valid("json").comment) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.patch(
+    "/v1/capabilities/microsoft-365/mail-message/:messageId",
+    describeMutation("updateMicrosoft365MailMessage", "Update Outlook message read state or categories", "Requires Mail.ReadWrite and mailManage. Only changes isRead and/or replaces categories; cannot alter recipients or send messages.", mailMessageResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(mailMessageParamSchema), jsonValidator(mailMessageUpdateBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["mailManage"], "Outlook mail management")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, message: await client.updateMailMessage(c.req.valid("param").messageId, c.req.valid("json")) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.post(
+    "/v1/capabilities/microsoft-365/mail-message/:messageId/move",
+    describeMutation("moveMicrosoft365MailMessage", "Move an Outlook message to archive, deleted items, or inbox", "Requires Mail.ReadWrite and mailManage. Moves one message to a fixed named folder, never permanently deletes it. Moving to deleteditems also requires confirmTrash: true. Use the returned message id after moving, since Graph can change it.", mailMessageResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(mailMessageParamSchema), jsonValidator(mailMessageMoveBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["mailManage"], "Outlook mail management")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, message: await client.moveMailMessage(c.req.valid("param").messageId, c.req.valid("json").destination) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.patch(
+    "/v1/capabilities/microsoft-365/calendar-events/:eventId",
+    describeMutation("updateMicrosoft365CalendarEvent", "Edit or reschedule an Outlook calendar event", "Requires Calendars.ReadWrite and calendarWrite. Updates only supplied subject, body, location, or paired UTC start/end. Requires confirmNotifications: true because updates may email attendees.", calendarEventResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(calendarEventParamSchema), jsonValidator(calendarEventUpdateBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["calendarWrite"], "Outlook calendar read/write")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, event: await client.updateCalendarEvent(c.req.valid("param").eventId, c.req.valid("json")) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.post(
+    "/v1/capabilities/microsoft-365/calendar-events/:eventId/cancel",
+    describeMutation("cancelMicrosoft365CalendarEvent", "Cancel an Outlook meeting and notify attendees", "Requires Calendars.ReadWrite and calendarWrite. Only the meeting organizer can cancel via Graph. Requires explicit user cancellation confirmation; a 202 receipt means cancellation was accepted.", calendarCancelResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(calendarEventParamSchema), jsonValidator(calendarCancelBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["calendarWrite"], "Outlook calendar read/write")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, ...await client.cancelCalendarEvent(c.req.valid("param").eventId, c.req.valid("json").comment) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.delete(
+    "/v1/capabilities/microsoft-365/calendar-events/:eventId",
+    describeMutation("deleteMicrosoft365CalendarEvent", "Delete a selected Outlook calendar event", "Requires Calendars.ReadWrite and calendarWrite, plus explicit user deletion confirmation. Deleting an organizer's meeting can send cancellations to attendees. Graph 204 confirms deletion.", calendarDeleteResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(calendarEventParamSchema), jsonValidator(calendarDeleteBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["calendarWrite"], "Outlook calendar read/write")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, ...await client.deleteCalendarEvent(c.req.valid("param").eventId) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.patch(
+    "/v1/capabilities/microsoft-365/drive-file/:itemId",
+    describeMutation("updateMicrosoft365DriveItem", "Rename or move a OneDrive item within the same drive", "Requires Files.ReadWrite (or Files.ReadWrite.All) and filesWrite (or filesFull). Updates only the name and/or parent folder id in the caller's OneDrive; cannot move across drives or upload content.", driveFileWriteResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, paramValidator(driveFileParamSchema), jsonValidator(driveItemUpdateBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["filesWrite", "filesFull"], "OneDrive write")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, file: await client.updateDriveItem(c.req.valid("param").itemId, c.req.valid("json")) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
+
+  app.post(
+    "/v1/capabilities/microsoft-365/drive-folders",
+    describeMutation("createMicrosoft365DriveFolder", "Create a folder in the calling member's OneDrive", "Requires Files.ReadWrite (or Files.ReadWrite.All) and filesWrite (or filesFull). Creates one folder under an existing parent id. Name conflicts fail without overwriting or silently renaming anything.", driveFileWriteResponseSchema),
+    orgMemberRouteMiddleware, boundedMutationBody, jsonValidator(driveFolderBodySchema),
+    async (c) => {
+      const client = await mutationClient(c.get("organizationContext"), c.req.raw.signal, ["filesWrite", "filesFull"], "OneDrive write")
+      if (client instanceof Response) return client
+      try {
+        return c.json({ ok: true, file: await client.createDriveFolder(c.req.valid("json")) })
+      } catch (error) { return c.json(graphError(error), 502) }
+    },
+  )
 
   app.get(
     "/v1/capabilities/microsoft-365/mail-messages",

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -107,6 +107,7 @@ import { openworkYourConnectionsUrl } from "../../../mcp/connection-navigation.j
 import {
   declaredPluginMcpAuthType,
   requiredPluginMcpAuthType,
+  pluginMcpAuthTypeCompatible,
   resolveGithubPluginMcpImportAuthType,
   type PluginMcpAuthType,
 } from "../../../capability-sources/external-mcp-auth-policy.js"
@@ -5466,15 +5467,23 @@ async function ensureImportedExternalMcpConnection(input: {
     .find((connection) => connection.kind === "external_mcp" && comparablePluginMcpRequirementUrl(connection.url) === comparablePluginMcpRequirementUrl(serverUrl))
 
   if (existing) {
+    const authType = resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: input.server.authType,
+      // Legacy none always used shared mode, regardless of the import's OAuth
+      // mode default. A shared PAT must not replace per-member OAuth.
+      existingAuthType: existing.authType === "none" || existing.credentialMode === input.credentialMode ? existing.authType : undefined,
+      requestedAuthType: input.authType,
+      url: serverUrl,
+    })
     await requireExistingExternalMcpConnectionMatchesImport({
-      authType: input.authType,
+      authType,
       credentialMode: input.credentialMode,
       existingAuthType: existing.authType,
       existingCredentialMode: existing.credentialMode,
     })
-    if (input.authType === "none") {
+    if (authType === "none") {
       try {
-        await validateConfiguredPluginMcpConnection({ authType: input.authType, connection: existing })
+        await validateConfiguredPluginMcpConnection({ authType, connection: existing })
       } catch (error) {
         await db.update(ExternalMcpConnectionTable).set({ connectedAt: null }).where(and(
           eq(ExternalMcpConnectionTable.organizationId, organizationId),
@@ -5594,11 +5603,13 @@ export async function configureMarketplacePluginMcpRequirement(input: {
     declaredAuthType: declaredPluginMcpAuthType(server.config),
     url: server.url,
   })
-  if (declaredRequiredAuthType && declaredRequiredAuthType !== input.authType) {
+  if (!pluginMcpAuthTypeCompatible({ authType: input.authType, requiredAuthType: declaredRequiredAuthType, url: server.url })) {
     throw new PluginArchRouteFailure(
       409,
       "mcp_auth_type_mismatch",
-      `This MCP requirement must use ${declaredRequiredAuthType} authentication.`,
+      declaredRequiredAuthType
+        ? `This MCP requirement must use ${declaredRequiredAuthType} authentication.`
+        : "This authentication type is not supported by the MCP server.",
     )
   }
   const requiredAuthType = declaredRequiredAuthType ?? input.authType
@@ -5788,19 +5799,20 @@ export async function importGithubPluginMcps(input: {
   const imported: Array<{ connectionId: string; name: string; url: string }> = []
   const importedSkills: Array<{ configObjectId: ConfigObjectId; name: string; sourcePath: string }> = []
   for (const server of supportedServers) {
-    const authType = resolveGithubPluginMcpImportAuthType({
+    const defaultAuthType = resolveGithubPluginMcpImportAuthType({
       declaredAuthType: server.authType,
       requestedAuthType: input.authType,
       url: server.url ?? "",
     })
     const importedConnection = await ensureImportedExternalMcpConnection({
       access,
-      authType,
+      authType: defaultAuthType,
       context: input.context,
       credentialMode: input.credentialMode,
       server,
     })
     const connection = importedConnection.connection
+    const authType = connection.authType
     if (importedConnection.ownedByImportedPlugin) importedOwnedConnectionIds.add(connection.id)
     const payload = importedConnectionBackedMcpPayload({
       authType,

--- a/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
+++ b/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
@@ -26,6 +26,7 @@ describe("External MCP preset OAuth defaults", () => {
     const slack = EXTERNAL_MCP_PRESETS.find((preset) => preset.presetId === "slack")
     expect(slack?.authorizationServerIssuer).toBe("https://mcp.slack.com")
     expect(slack?.defaultOAuthScopes).toEqual(slackDefaultScopes)
+    expect(slack?.description).toContain("eligible internal or Slack Marketplace-published app")
   })
 
   test("applies preset defaults only when admin values are absent", () => {
@@ -50,8 +51,15 @@ describe("External MCP preset OAuth defaults", () => {
 
   test("presets response schema exposes OAuth defaults", () => {
     const result = externalMcpPresetListResponseSchema.parse({ presets: EXTERNAL_MCP_PRESETS })
+    expect(result.presets.find((preset) => preset.presetId === "github")).toMatchObject({
+      authType: "oauth",
+      supportedAuthTypes: ["oauth", "apikey"],
+      requiresOAuthClient: true,
+    })
     const slack = result.presets.find((preset) => preset.presetId === "slack")
     expect(slack?.authorizationServerIssuer).toBe("https://mcp.slack.com")
     expect(slack?.defaultOAuthScopes).toEqual(slackDefaultScopes)
+    expect(result.presets.find((preset) => preset.presetId === "context7")?.description).toContain("rate-limited anonymous access")
+    expect(result.presets.find((preset) => preset.presetId === "exa")?.description).toContain("provider usage limits and billing apply")
   })
 })

--- a/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
+++ b/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   externalMcpOAuthConfigurationDefaults,
+  matchExternalMcpPresetForUrl,
 } from "../src/capability-sources/external-mcp-auth-policy.js"
 import {
   EXTERNAL_MCP_PRESETS,
@@ -22,6 +23,21 @@ const slackDefaultScopes = [
 ]
 
 describe("External MCP preset OAuth defaults", () => {
+  test("HTTP endpoints cannot inherit HTTPS preset authentication defaults", () => {
+    for (const preset of EXTERNAL_MCP_PRESETS) {
+      expect(matchExternalMcpPresetForUrl(preset.url)?.presetId).toBe(preset.presetId)
+      const insecureUrl = preset.url.replace(/^https:/, "http:")
+      expect(matchExternalMcpPresetForUrl(insecureUrl)).toBeNull()
+      expect(externalMcpOAuthConfigurationDefaults({ url: insecureUrl })).toEqual({
+        authorizationServerIssuer: null,
+        requestedScopes: [],
+      })
+    }
+    expect(matchExternalMcpPresetForUrl("https://MCP.SLACK.COM:443/mcp/")?.presetId).toBe("slack")
+    expect(matchExternalMcpPresetForUrl("http://mcp.slack.com:443/mcp")).toBeNull()
+    expect(matchExternalMcpPresetForUrl("https://mcp.slack.com:8443/mcp")).toBeNull()
+  })
+
   test("Slack pins its issuer and sane default scope subset", () => {
     const slack = EXTERNAL_MCP_PRESETS.find((preset) => preset.presetId === "slack")
     expect(slack?.authorizationServerIssuer).toBe("https://mcp.slack.com")

--- a/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
+++ b/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
@@ -36,6 +36,9 @@ describe("External MCP preset OAuth defaults", () => {
     expect(matchExternalMcpPresetForUrl("https://MCP.SLACK.COM:443/mcp/")?.presetId).toBe("slack")
     expect(matchExternalMcpPresetForUrl("http://mcp.slack.com:443/mcp")).toBeNull()
     expect(matchExternalMcpPresetForUrl("https://mcp.slack.com:8443/mcp")).toBeNull()
+    expect(matchExternalMcpPresetForUrl("wss://mcp.slack.com/mcp")).toBeNull()
+    expect(matchExternalMcpPresetForUrl("https://mcp.slack.com/other")).toBeNull()
+    expect(matchExternalMcpPresetForUrl("not a URL")).toBeNull()
   })
 
   test("Slack pins its issuer and sane default scope subset", () => {

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -170,7 +170,7 @@ test("GitHub plugin readiness preserves legacy ready and sign-in states but stil
   const orgMembershipId = createDenTypeId("member")
   const pluginId = createDenTypeId("plugin")
   const configObjectId = createDenTypeId("configObject")
-  const url = "https://api.githubcopilot.com/mcp/"
+  const baseUrl = "https://api.githubcopilot.com/mcp/"
   for (const input of [
     { authType: "apikey", oauth: false, client: false, state: "ready" },
     { authType: "apikey", oauth: true, client: false, state: "needs_admin_setup" },
@@ -185,7 +185,11 @@ test("GitHub plugin readiness preserves legacy ready and sign-in states but stil
     { authType: "oauth", oauth: false, client: false, state: "ready", perMember: true },
     { authType: "oauth", oauth: false, client: false, state: "needs_signin", perMember: true, disconnected: true },
     { authType: "oauth", oauth: true, client: false, state: "needs_admin_setup", perMember: true, disconnected: true },
+    { authType: "oauth", oauth: true, client: false, state: "ready", query: true },
+    { authType: "oauth", oauth: true, client: false, state: "ready", query: true, perMember: true },
+    { authType: "oauth", oauth: true, client: false, state: "needs_signin", query: true, perMember: true, disconnected: true },
   ]) {
+    const url = input.query ? `${baseUrl}?fixture=legacy` : baseUrl
     const candidate = {
       ...connection, organizationId, url, authType: input.authType, credentialMode: input.perMember ? "per_member" : "shared",
       apiKey: input.authType === "apikey" ? "fixture-pat" : null,
@@ -209,7 +213,7 @@ test("GitHub plugin readiness preserves legacy ready and sign-in states but stil
     expect(readiness.get(pluginId)?.connections[0]?.authTypeMismatch).toBe(input.oauth && input.authType !== "oauth")
     expect(readiness.get(pluginId)?.connections[0]?.connectedForMe).toBe(!input.disconnected)
     expect(readiness.get(pluginId)?.connections[0]?.oauthClientConfigured).toBe(input.oauth || input.authType === "oauth" ? input.client : undefined)
-    expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.oauth ? true : input.authType === "oauth" ? false : undefined)
+    expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.oauth && !input.query ? true : input.authType === "oauth" ? false : undefined)
     expect(selectResults).toHaveLength(0)
 
     const skillId = createDenTypeId("configObject")

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -165,7 +165,7 @@ test("GitHub plugin readiness preserves legacy ready and sign-in states but stil
     DEN_MCP_RESOURCES: ["http://127.0.0.1:8790/mcp"],
     DEN_MCP_TOKEN_USE_CLAIM: "https://openworklabs.com/token_use",
   }))
-  const { resolveMarketplacePluginCloudReadiness } = await import("../src/mcp/marketplace-capabilities.js")
+  const { resolveMarketplacePluginCloudReadiness, searchMarketplaceCapabilities, executeMarketplaceCapability } = await import("../src/mcp/marketplace-capabilities.js")
   const organizationId = createDenTypeId("organization")
   const orgMembershipId = createDenTypeId("member")
   const pluginId = createDenTypeId("plugin")
@@ -211,7 +211,60 @@ test("GitHub plugin readiness preserves legacy ready and sign-in states but stil
     expect(readiness.get(pluginId)?.connections[0]?.oauthClientConfigured).toBe(input.oauth || input.authType === "oauth" ? input.client : undefined)
     expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.oauth ? true : input.authType === "oauth" ? false : undefined)
     expect(selectResults).toHaveLength(0)
+
+    const skillId = createDenTypeId("configObject")
+    const row = {
+      configObject: { id: skillId, objectType: "skill", title: "Legacy GitHub", description: "Legacy readiness", searchText: "legacy github" },
+      plugin: { id: pluginId, name: "Legacy GitHub" },
+      marketplace: null,
+    }
+    const grants = [{ resourceId: pluginId, orgWide: true, role: "viewer", removedAt: null }]
+    const requirementRows = [
+      [{ configObjectId, pluginId, pluginName: "Legacy GitHub", title: "GitHub" }],
+      [{ configObjectId, normalizedPayloadJson: { mcpServers: { github: { url, oauth: input.oauth } } } }],
+      [], // Requirement bindings.
+      [candidate], // All connections.
+      [{ connection: candidate }], [], // Usable direct and plugin-sourced connections.
+    ]
+    const memberRows = input.perMember ? [input.disconnected ? [] : [{ ...account, organizationId, orgMembershipId }]] : []
+    const authMismatch = input.oauth && input.authType !== "oauth"
+    const discoveryState = authMismatch || (input.disconnected && !input.perMember)
+      ? "needs_admin_setup"
+      : input.disconnected ? "needs_connection" : "ready"
+    queueSelectResults([
+      [{ id: orgMembershipId, role: "member" }],
+      [row], [], [], // Marketplace rows, grant-only rows and their subquery.
+      [], grants,
+      ...requirementRows,
+      ...(!authMismatch ? memberRows : []),
+    ])
+    const matches = await searchMarketplaceCapabilities({ organizationId, member: { orgMembershipId, teamIds: [] }, query: "legacy github" })
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.status).toBe(discoveryState)
+    expect(matches[0]?.mcpRequirements?.[0]?.state).toBe(discoveryState)
+    if (discoveryState === "needs_connection") expect(matches[0]?.action?.surface).toBe("openwork_your_connections")
+    expect(selectResults).toHaveLength(0)
+
+    const missingClient = input.authType === "oauth" && !input.client
+    queueSelectResults([
+      [row], [{ id: orgMembershipId, role: "member" }], [], grants,
+      [{ rawSourceText: "Legacy instruction sentinel" }],
+      ...requirementRows,
+      ...(!authMismatch && input.authType === "oauth" ? [input.client ? [orgClient] : []] : []),
+      ...(!authMismatch && !missingClient ? memberRows : []),
+    ])
+    const executed = await executeMarketplaceCapability({ organizationId, member: { orgMembershipId, teamIds: [] }, pluginId, configObjectId: skillId })
+    if (!executed.ok) throw new Error(executed.message)
+    const executionState = missingClient ? "needs_admin_setup" : discoveryState
+    if (executionState === "ready") {
+      expect(executed.result.content).toBe("Legacy instruction sentinel")
+    } else {
+      expect(executed.result.status).toBe(executionState)
+      expect(executed.result.content).toBeUndefined()
+    }
+    expect(selectResults).toHaveLength(0)
   }
+  expect(transactionCalls).toBe(0)
 })
 
 test("per-member connection list readiness reads credentials without row locks", async () => {

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
 
 process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
 process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
@@ -9,6 +10,8 @@ process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
 type QueryRows = Record<string, unknown>[]
 type FakeQuery = {
   from: (table: unknown) => FakeQuery
+  innerJoin: () => FakeQuery
+  orderBy: () => FakeQuery
   where: (condition: unknown) => FakeQuery
   limit: (count: number) => FakeQuery
   for: (mode: string) => FakeQuery
@@ -19,6 +22,8 @@ function fakeQuery(rows: QueryRows): FakeQuery {
   const promise = Promise.resolve(rows)
   const query: FakeQuery = {
     from: () => query,
+    innerJoin: () => query,
+    orderBy: () => query,
     where: () => query,
     limit: () => query,
     for: () => {
@@ -91,6 +96,7 @@ function queueSelectResults(results: QueryRows[]): void {
 mock.module("../src/db.js", () => ({
   db: {
     select: () => fakeQuery(selectResults.shift() ?? []),
+    selectDistinct: () => fakeQuery(selectResults.shift() ?? []),
     transaction: () => {
       transactionCalls += 1
       throw new Error("Read-only external MCP checks must not open a transaction")
@@ -102,7 +108,102 @@ const {
   readConnectedAccountForExternalMcpIdentity,
   readOrgOAuthClientForExternalMcpIdentity,
   readyExternalMcpConnectionsForMember,
+  listUsableExternalMcpConnections,
 } = await import("../src/capability-sources/external-mcp-connections.js")
+
+test("plugin-sourced GitHub PATs and legacy none remain usable without bypassing access or explicit OAuth", async () => {
+  const organizationId = createDenTypeId("organization")
+  const orgMembershipId = createDenTypeId("member")
+  const pluginId = createDenTypeId("plugin")
+  const configObjectId = createDenTypeId("configObject")
+  const binding = { id: createDenTypeId("pluginMcpRequirementBinding"), pluginId, configObjectId, serverName: "github" }
+  const url = "https://api.githubcopilot.com/mcp/"
+  const cases = [
+    { authType: "apikey", oauth: false, granted: true, usable: true },
+    { authType: "oauth", oauth: false, granted: true, usable: true },
+    { authType: "none", oauth: false, granted: true, usable: true },
+    { authType: "none", oauth: true, granted: true, usable: false },
+    { authType: "apikey", oauth: true, granted: true, usable: false },
+    { authType: "oauth", oauth: true, granted: true, usable: true },
+    { authType: "apikey", oauth: false, granted: false, usable: false },
+    { authType: "none", oauth: false, granted: false, usable: false },
+  ]
+  for (const input of cases) {
+    const candidate = {
+      ...connection, organizationId, authType: input.authType, credentialMode: "shared", url,
+      apiKey: input.authType === "apikey" ? "fixture-pat" : null,
+      accessToken: input.authType === "oauth" ? "fixture-token" : null,
+      connectedAt: new Date(),
+    }
+    queueSelectResults([
+      [], // No direct grants: access must come from this plugin.
+      [{ binding, connection: candidate, configObjectTitle: "GitHub" }],
+      [{ configObjectId, normalizedPayloadJson: { mcpServers: { github: { url, oauth: input.oauth } } } }],
+      [],
+      input.granted ? [{ pluginId }] : [],
+      [],
+    ])
+    expect(await listUsableExternalMcpConnections({ organizationId, orgMembershipId, teamIds: [] }))
+      .toEqual(input.usable ? [candidate] : [])
+    expect(selectResults).toHaveLength(0)
+  }
+  expect(transactionCalls).toBe(0)
+})
+
+test("GitHub plugin readiness preserves connected legacy none but still enforces OAuth setup", async () => {
+  // The marketplace module imports the app graph; do not initialize auth's resource registry.
+  mock.module("../src/auth.js", () => ({
+    auth: { api: { getSession: async () => null }, handler: async () => new Response() },
+    DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX: "ow_mcp_at_",
+    DEN_MCP_FIRST_PARTY_CLIENT_ID: "openwork-desktop",
+    DEN_MCP_FIRST_PARTY_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+    DEN_MCP_GRANT_ID_CLAIM: "https://openworklabs.com/grant_id",
+    DEN_MCP_ORG_ID_CLAIM: "https://openworklabs.com/org_id",
+    DEN_MCP_OAUTH_RESOURCE: "http://127.0.0.1:8790/mcp",
+    DEN_MCP_RESOURCE: "http://127.0.0.1:8790/mcp",
+    DEN_MCP_RESOURCE_CLAIM: "https://openworklabs.com/resource",
+    DEN_MCP_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+    DEN_MCP_TOKEN_USE_CLAIM: "https://openworklabs.com/token_use",
+  }))
+  const { resolveMarketplacePluginCloudReadiness } = await import("../src/mcp/marketplace-capabilities.js")
+  const organizationId = createDenTypeId("organization")
+  const orgMembershipId = createDenTypeId("member")
+  const pluginId = createDenTypeId("plugin")
+  const configObjectId = createDenTypeId("configObject")
+  const url = "https://api.githubcopilot.com/mcp/"
+  for (const input of [
+    { authType: "apikey", oauth: false, client: false, state: "ready" },
+    { authType: "apikey", oauth: true, client: false, state: "needs_admin_setup" },
+    { authType: "none", oauth: false, client: false, state: "ready" },
+    { authType: "none", oauth: true, client: false, state: "needs_admin_setup" },
+    { authType: "none", oauth: false, client: false, state: "needs_admin_setup", disconnected: true },
+    { authType: "oauth", oauth: false, client: false, state: "needs_admin_setup" },
+    { authType: "oauth", oauth: false, client: true, state: "ready" },
+  ]) {
+    const candidate = {
+      ...connection, organizationId, url, authType: input.authType, credentialMode: "shared",
+      apiKey: input.authType === "apikey" ? "fixture-pat" : null,
+      accessToken: input.authType === "oauth" ? "fixture-token" : null,
+      connectedAt: input.disconnected ? null : new Date(),
+    }
+    queueSelectResults([
+      [{ id: configObjectId, objectType: "mcp", pluginId, title: "GitHub" }],
+      [{ configObjectId, normalizedPayloadJson: { mcpServers: { github: { url, oauth: input.oauth } } } }],
+      [{ connection: candidate }],
+      [],
+      [candidate],
+      [],
+      ...(input.oauth || input.authType === "oauth" ? [input.client ? [orgClient] : []] : []),
+    ])
+    const readiness = await resolveMarketplacePluginCloudReadiness({
+      organizationId, member: { orgMembershipId, teamIds: [] }, pluginIds: [pluginId],
+    })
+    expect(readiness.get(pluginId)?.state).toBe(input.state)
+    expect(readiness.get(pluginId)?.connections[0]?.authTypeMismatch).toBe(input.oauth && input.authType !== "oauth")
+    expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.authType === "oauth" ? true : input.oauth ? false : undefined)
+    expect(selectResults).toHaveLength(0)
+  }
+})
 
 test("per-member connection list readiness reads credentials without row locks", async () => {
   queueSelectResults([[connection], [account], [connection]])

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -150,7 +150,7 @@ test("plugin-sourced GitHub PATs and legacy none remain usable without bypassing
   expect(transactionCalls).toBe(0)
 })
 
-test("GitHub plugin readiness preserves connected legacy none but still enforces OAuth setup", async () => {
+test("GitHub plugin readiness preserves legacy ready and sign-in states but still enforces required OAuth setup", async () => {
   // The marketplace module imports the app graph; do not initialize auth's resource registry.
   mock.module("../src/auth.js", () => ({
     auth: { api: { getSession: async () => null }, handler: async () => new Response() },
@@ -177,13 +177,19 @@ test("GitHub plugin readiness preserves connected legacy none but still enforces
     { authType: "none", oauth: false, client: false, state: "ready" },
     { authType: "none", oauth: true, client: false, state: "needs_admin_setup" },
     { authType: "none", oauth: false, client: false, state: "needs_admin_setup", disconnected: true },
-    { authType: "oauth", oauth: false, client: false, state: "needs_admin_setup" },
+    { authType: "oauth", oauth: false, client: false, state: "ready" },
     { authType: "oauth", oauth: false, client: true, state: "ready" },
+    { authType: "oauth", oauth: true, client: false, state: "needs_admin_setup" },
+    { authType: "oauth", oauth: true, client: true, state: "ready" },
+    { authType: "oauth", oauth: false, client: false, state: "needs_admin_setup", disconnected: true },
+    { authType: "oauth", oauth: false, client: false, state: "ready", perMember: true },
+    { authType: "oauth", oauth: false, client: false, state: "needs_signin", perMember: true, disconnected: true },
+    { authType: "oauth", oauth: true, client: false, state: "needs_admin_setup", perMember: true, disconnected: true },
   ]) {
     const candidate = {
-      ...connection, organizationId, url, authType: input.authType, credentialMode: "shared",
+      ...connection, organizationId, url, authType: input.authType, credentialMode: input.perMember ? "per_member" : "shared",
       apiKey: input.authType === "apikey" ? "fixture-pat" : null,
-      accessToken: input.authType === "oauth" ? "fixture-token" : null,
+      accessToken: input.authType === "oauth" && !input.perMember && !input.disconnected ? "fixture-token" : null,
       connectedAt: input.disconnected ? null : new Date(),
     }
     queueSelectResults([
@@ -193,6 +199,7 @@ test("GitHub plugin readiness preserves connected legacy none but still enforces
       [],
       [candidate],
       [],
+      ...(input.perMember ? [input.disconnected ? [] : [{ ...account, organizationId, orgMembershipId }]] : []),
       ...(input.oauth || input.authType === "oauth" ? [input.client ? [orgClient] : []] : []),
     ])
     const readiness = await resolveMarketplacePluginCloudReadiness({
@@ -200,7 +207,9 @@ test("GitHub plugin readiness preserves connected legacy none but still enforces
     })
     expect(readiness.get(pluginId)?.state).toBe(input.state)
     expect(readiness.get(pluginId)?.connections[0]?.authTypeMismatch).toBe(input.oauth && input.authType !== "oauth")
-    expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.authType === "oauth" ? true : input.oauth ? false : undefined)
+    expect(readiness.get(pluginId)?.connections[0]?.connectedForMe).toBe(!input.disconnected)
+    expect(readiness.get(pluginId)?.connections[0]?.oauthClientConfigured).toBe(input.oauth || input.authType === "oauth" ? input.client : undefined)
+    expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.oauth ? true : input.authType === "oauth" ? false : undefined)
     expect(selectResults).toHaveLength(0)
   }
 })

--- a/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
+++ b/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
@@ -1,10 +1,94 @@
 import { describe, expect, test } from "bun:test"
 import {
   declaredPluginMcpAuthType,
+  existingPluginMcpAuthTypeCompatible,
+  pluginMcpAuthTypeCompatible,
+  pluginMcpRequiresPreRegisteredOAuthClient,
+  requiredPluginMcpAuthType,
   resolveGithubPluginMcpImportAuthType,
 } from "../src/capability-sources/external-mcp-auth-policy.js"
 
 describe("GitHub plugin MCP authentication", () => {
+  const githubUrl = "https://api.githubcopilot.com/mcp/"
+
+  test("GitHub defaults new imports to OAuth without making it the only supported authentication", () => {
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      requestedAuthType: "none",
+      url: githubUrl,
+    })).toBe("oauth")
+    expect(requiredPluginMcpAuthType({ declaredAuthType: null, url: githubUrl })).toBeNull()
+    expect(pluginMcpRequiresPreRegisteredOAuthClient(githubUrl)).toBe(true)
+    for (const authType of ["oauth", "apikey", "none"] as const) {
+      expect(pluginMcpAuthTypeCompatible({ authType, requiredAuthType: null, url: githubUrl })).toBe(authType !== "none")
+    }
+  })
+
+  test("existing PAT and legacy no-auth imports are preserved, but never override explicit OAuth", () => {
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      existingAuthType: "apikey",
+      requestedAuthType: "oauth",
+      url: githubUrl,
+    })).toBe("apikey")
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: "oauth",
+      existingAuthType: "apikey",
+      requestedAuthType: "none",
+      url: githubUrl,
+    })).toBe("oauth")
+    for (const requestedAuthType of ["none", "oauth"] as const) {
+      expect(resolveGithubPluginMcpImportAuthType({
+        declaredAuthType: null,
+        existingAuthType: "none",
+        requestedAuthType,
+        url: githubUrl,
+      })).toBe("none")
+    }
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: "oauth",
+      existingAuthType: "none",
+      requestedAuthType: "none",
+      url: githubUrl,
+    })).toBe("oauth")
+    const requiredAuthType = requiredPluginMcpAuthType({ declaredAuthType: "oauth", url: githubUrl })
+    expect(requiredAuthType).toBe("oauth")
+    expect(pluginMcpAuthTypeCompatible({ authType: "apikey", requiredAuthType, url: githubUrl })).toBe(false)
+    expect(pluginMcpAuthTypeCompatible({ authType: "oauth", requiredAuthType, url: githubUrl })).toBe(true)
+  })
+
+  test("stored GitHub none remains compatible without permitting a new anonymous setup", () => {
+    for (const requiredAuthType of [null, "none"] as const) {
+      expect(existingPluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType })).toBe(true)
+      expect(pluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType, url: githubUrl })).toBe(false)
+    }
+    expect(existingPluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType: "oauth" })).toBe(false)
+    expect(existingPluginMcpAuthTypeCompatible({ authType: "apikey", requiredAuthType: "oauth" })).toBe(false)
+  })
+
+  test("single-auth presets still reject unsupported and anonymous connections", () => {
+    for (const [url, authType] of [
+      ["https://mcp.slack.com/mcp/", "oauth"],
+      ["https://mcp.exa.ai/mcp", "apikey"],
+      ["https://mcp.context7.com/mcp", "none"],
+    ] as const) {
+      const requiredAuthType = requiredPluginMcpAuthType({ declaredAuthType: null, url })
+      expect(requiredAuthType).toBe(authType)
+      expect(pluginMcpAuthTypeCompatible({ authType, requiredAuthType, url })).toBe(true)
+      expect(pluginMcpAuthTypeCompatible({ authType: authType === "none" ? "apikey" : "none", requiredAuthType, url })).toBe(false)
+      expect(existingPluginMcpAuthTypeCompatible({ authType, requiredAuthType })).toBe(true)
+      expect(existingPluginMcpAuthTypeCompatible({ authType: authType === "none" ? "apikey" : "none", requiredAuthType })).toBe(false)
+    }
+  })
+
+  test("preset defaults cannot downgrade explicit OAuth even when the preset defaults to API key or no auth", () => {
+    for (const url of ["https://mcp.exa.ai/mcp", "https://mcp.context7.com/mcp"]) {
+      expect(requiredPluginMcpAuthType({ declaredAuthType: "oauth", url })).toBe("oauth")
+      expect(resolveGithubPluginMcpImportAuthType({ declaredAuthType: "oauth", requestedAuthType: "none", url })).toBe("oauth")
+      expect(pluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType: "oauth", url })).toBe(false)
+    }
+  })
+
   test("preserves an explicit OAuth declaration from the plugin", () => {
     const declaredAuthType = declaredPluginMcpAuthType({ oauth: { clientId: "public-client" } })
 

--- a/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
+++ b/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
@@ -11,6 +11,15 @@ import {
 describe("GitHub plugin MCP authentication", () => {
   const githubUrl = "https://api.githubcopilot.com/mcp/"
 
+  test("HTTP lookalikes do not inherit preset authentication policy", () => {
+    for (const url of ["http://api.githubcopilot.com/mcp/", "http://mcp.slack.com/mcp/"]) {
+      expect(requiredPluginMcpAuthType({ declaredAuthType: null, url })).toBeNull()
+      expect(pluginMcpRequiresPreRegisteredOAuthClient(url)).toBe(false)
+      expect(resolveGithubPluginMcpImportAuthType({ declaredAuthType: null, requestedAuthType: "none", url })).toBe("none")
+      expect(requiredPluginMcpAuthType({ declaredAuthType: "oauth", url })).toBe("oauth")
+    }
+  })
+
   test("GitHub defaults new imports to OAuth without making it the only supported authentication", () => {
     expect(resolveGithubPluginMcpImportAuthType({
       declaredAuthType: null,

--- a/ee/apps/den-api/test/gmail-management.test.ts
+++ b/ee/apps/den-api/test/gmail-management.test.ts
@@ -1,0 +1,432 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, expect, mock, test } from "bun:test"
+import { Hono, type MiddlewareHandler } from "hono"
+import { contextStorage, getContext } from "hono/context-storage"
+import { generateSpecs } from "hono-openapi"
+import { buildMcpCatalog } from "../src/mcp/catalog.js"
+import type { ConnectedAccountRow } from "../src/capability-sources/oauth-credentials.js"
+import type { OrganizationContext } from "../src/orgs.js"
+import type { GoogleWorkspaceActionDependencies } from "../src/routes/org/google-workspace-actions.js"
+import type { GoogleWorkspaceAccessToken } from "../src/routes/org/google-workspace.js"
+import type { OrgRouteVariables } from "../src/routes/org/shared.js"
+import { jsonValidator, paramValidator, queryValidator } from "../src/middleware/validation.js"
+
+// Only the outer organization lookup is synthetic. Hono validation, context storage,
+// the Gmail routes and requestGoogleAction execute normally, with no database/provider I/O.
+mock.module("../src/middleware/index.js", () => ({
+  jsonValidator, paramValidator, queryValidator,
+  orgMemberRoute: (): MiddlewareHandler<{ Variables: OrgRouteVariables }> => async (c, next) => {
+    if (!c.get("organizationContext")) return c.json({ error: "unauthorized" }, 401)
+    await next()
+  },
+}))
+mock.module("../src/env.js", () => ({ env: { googleApiBaseUrl: undefined } }))
+const { registerGmailManagementRoutes } = await import("../src/routes/org/gmail-management.js")
+afterAll(() => mock.restore())
+
+const MODIFY = "https://www.googleapis.com/auth/gmail.modify"
+const COMPOSE = "https://www.googleapis.com/auth/gmail.compose"
+const READ = "https://www.googleapis.com/auth/gmail.readonly"
+const LABELS = "https://www.googleapis.com/auth/gmail.labels"
+const prefix = "/v1/capabilities/google-workspace"
+const sentMessage = { id: "sent-message", threadId: "existing-thread", labelIds: ["SENT"] }
+const draft = { id: "draft-1", message: { id: "draft-message", threadId: "existing-thread", raw: "TWlNRSBjb250ZW50" } }
+const label = { id: "Label_1", name: "Follow up", type: "user" }
+
+function fixture(options: { scopes?: string[] | null; enabledScopes?: string[]; enabledFeatures?: string[]; tokenError?: "needs_connection" | "google_api_error"; reply?: () => Response | Promise<Response> } = {}) {
+  const now = new Date("2026-01-01T00:00:00Z")
+  const organizationId = createDenTypeId("organization")
+  const memberId = createDenTypeId("member")
+  const secondMemberId = createDenTypeId("member")
+  const context: OrganizationContext = {
+    organization: { id: organizationId, name: "Test", slug: "test", logo: null, allowedEmailDomains: null, metadata: null, createdAt: now, updatedAt: now },
+    currentMember: { id: memberId, userId: createDenTypeId("user"), role: "member", directRole: "member", adminTeams: [], createdAt: now, joinedAt: now, isOwner: false },
+    members: [], invitations: [], roles: [], teams: [],
+  }
+  const account: ConnectedAccountRow = {
+    id: createDenTypeId("connectedAccount"), organizationId, orgMembershipId: memberId,
+    providerId: "google-workspace", externalAccountId: "selected@example.test",
+    scopes: options.scopes === undefined ? [MODIFY] : options.scopes,
+    accessToken: "synthetic-selected-token", refreshToken: null, tokenType: "Bearer", expiresAt: null,
+    pendingCodeVerifier: null, credentialHealth: null, connectedAt: now, updatedAt: now,
+  }
+  const calls: { url: string; method: string; headers: Headers; body: unknown }[] = []
+  const selections: (Parameters<GoogleWorkspaceActionDependencies["token"]>[0] & { connector: string | undefined })[] = []
+  const dependencies: GoogleWorkspaceActionDependencies = {
+    token: async (input): Promise<GoogleWorkspaceAccessToken> => {
+      const connector = getContext().req.header("x-test-selected-connector")
+      selections.push({ ...input, connector })
+      if (options.tokenError) return { kind: options.tokenError, message: "Synthetic credential unavailable." }
+      const token: GoogleWorkspaceAccessToken = {
+        kind: "ok", accessToken: `${account.accessToken}-${input.orgMembershipId}-${connector}`,
+        account: { ...account, orgMembershipId: input.orgMembershipId },
+        enabledScopes: options.enabledScopes ?? [MODIFY, COMPOSE, READ, LABELS],
+        enabledFeatures: options.enabledFeatures ?? ["gmailManage"],
+      }
+      // Simulate a runtime dependency omitting the required field, without weakening the public type.
+      if ("enabledScopes" in options && options.enabledScopes === undefined) Reflect.deleteProperty(token, "enabledScopes")
+      return token
+    },
+    fetch: async (input, init) => {
+      calls.push({
+        url: String(input), method: init?.method ?? "GET", headers: new Headers(init?.headers),
+        body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+      })
+      return options.reply ? options.reply() : Response.json(sentMessage)
+    },
+  }
+  const app = new Hono<{ Variables: OrgRouteVariables }>()
+  app.use("*", contextStorage())
+  app.use("*", async (c, next) => {
+    if (c.req.header("x-test-member")) {
+      c.set("organizationContext", {
+        ...context, currentMember: { ...context.currentMember, id: c.req.header("x-test-member") === "second" ? secondMemberId : memberId },
+      })
+    }
+    await next()
+  })
+  registerGmailManagementRoutes(app, dependencies)
+  const request = (path: string, method = "GET", body?: unknown, member = "first", connector = "selected") => app.request(`${prefix}/${path}`, {
+    method, headers: { "content-type": "application/json", "x-test-member": member, "x-test-selected-connector": connector },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  return { app, calls, selections, request, organizationId, memberId, secondMemberId }
+}
+
+test("send preserves an existing draft, forwards only its ID and returns Google's actual sent identifiers", async () => {
+  const f = fixture({ scopes: [COMPOSE] })
+  const response = await f.request("gmail-draft/draft%2Fwith%3Freserved/send", "POST", { confirm: true })
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual(sentMessage)
+  expect(f.calls).toHaveLength(1)
+  expect(f.calls[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts/send")
+  expect(f.calls[0]?.method).toBe("POST")
+  expect(f.calls[0]?.body).toEqual({ id: "draft/with?reserved" })
+  expect(f.calls[0]?.headers.get("authorization")).toBe(`Bearer synthetic-selected-token-${f.memberId}-selected`)
+  expect(f.calls[0]?.headers.get("content-type")).toBe("application/json")
+  expect(f.selections).toEqual([{ organizationId: f.organizationId, orgMembershipId: f.memberId, connector: "selected" }])
+})
+
+test("enabling drafts alone never silently enables sending with the same OAuth grant", async () => {
+  const draftsOnly = fixture({ scopes: [COMPOSE], enabledScopes: [COMPOSE], enabledFeatures: ["gmailDraft"] })
+  expect((await draftsOnly.request("gmail-draft/draft-1/send", "POST", { confirm: true })).status).toBe(409)
+  expect(draftsOnly.calls).toHaveLength(0)
+  const sendEnabled = fixture({ scopes: [COMPOSE], enabledScopes: [COMPOSE], enabledFeatures: ["gmailSend"] })
+  expect((await sendEnabled.request("gmail-draft/draft-1/send", "POST", { confirm: true })).status).toBe(200)
+  expect(sendEnabled.calls).toHaveLength(1)
+})
+
+test("member and selected connector context reach credential resolution without cross-account fallback", async () => {
+  const f = fixture()
+  await f.request("gmail-draft/draft-1/send", "POST", { confirm: true }, "second", "other-selected")
+  expect(f.selections).toEqual([{ organizationId: f.organizationId, orgMembershipId: f.secondMemberId, connector: "other-selected" }])
+  expect(f.calls[0]?.headers.get("authorization")).toBe(`Bearer synthetic-selected-token-${f.secondMemberId}-other-selected`)
+  expect(f.calls[0]?.headers.get("authorization")).not.toContain(f.memberId)
+})
+
+for (const scopes of [null, [], [READ], [LABELS], ["https://www.googleapis.com/auth/gmail.send"], ["https://mail.google.com/"]]) {
+  test(`send fails closed on insufficient or unknown scopes: ${JSON.stringify(scopes)}`, async () => {
+    const f = fixture({ scopes })
+    const response = await f.request("gmail-draft/draft-1/send", "POST", { confirm: true })
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ error: "needs_connection" })
+    expect(f.calls).toHaveLength(0)
+  })
+}
+
+for (const enabledScopes of [undefined, [], [READ]]) {
+  test(`disabled or unknown connector permissions block stale Gmail write grants: ${JSON.stringify(enabledScopes)}`, async () => {
+    const f = fixture({ scopes: [MODIFY, COMPOSE, LABELS], enabledScopes })
+    for (const { path, method, body } of [
+      { path: "gmail-draft/draft-1/send", method: "POST", body: { confirm: true } },
+      { path: "gmail-draft/draft-1", method: "PUT", body: { confirm: true, message: { raw: draft.message.raw } } },
+      { path: "gmail-draft/draft-1", method: "DELETE", body: { confirm: true } },
+      { path: "gmail-message/message-1/modify", method: "POST", body: { addLabelIds: ["STARRED"] } },
+      { path: "gmail-message/message-1/trash", method: "POST", body: { confirm: true } },
+      { path: "gmail-message/message-1/untrash", method: "POST", body: { confirm: true } },
+      { path: "gmail-labels", method: "POST", body: { name: "Follow up" } },
+      { path: "gmail-label/Label_1", method: "PATCH", body: { name: "Renamed" } },
+      { path: "gmail-label/Label_1", method: "DELETE", body: { confirm: true } },
+    ]) {
+      const response = await f.request(path, method, body)
+      expect(response.status).toBe(409)
+      expect(await response.json()).toMatchObject({ error: "needs_connection" })
+    }
+    expect(f.calls).toHaveLength(0)
+  })
+}
+
+for (const tokenError of ["needs_connection", "google_api_error"] as const) {
+  test(`credential failure ${tokenError} makes no provider request`, async () => {
+    const f = fixture({ tokenError })
+    const response = await f.request("gmail-draft/draft-1/send", "POST", { confirm: true })
+    expect(response.status).toBe(tokenError === "needs_connection" ? 409 : 502)
+    expect(f.calls).toHaveLength(0)
+  })
+}
+
+const confirmedRoutes = [
+  { path: "gmail-draft/draft-1/send", method: "POST" },
+  { path: "gmail-draft/draft-1", method: "DELETE" },
+  { path: "gmail-message/message-1/trash", method: "POST" },
+  { path: "gmail-label/Label_1", method: "DELETE" },
+]
+for (const target of confirmedRoutes) {
+  test(`${target.method} ${target.path} requires explicit true confirmation before credentials or fetch`, async () => {
+    const f = fixture()
+    for (const body of [{}, { confirm: false }, { confirm: "true" }, { confirm: true, userId: "another-user" }]) {
+      expect((await f.request(target.path, target.method, body)).status).toBe(400)
+    }
+    expect(f.selections).toHaveLength(0)
+    expect(f.calls).toHaveLength(0)
+  })
+}
+
+for (const status of [401, 403, 404, 429, 500]) {
+  test(`provider HTTP ${status} is sanitized and never retried`, async () => {
+    const f = fixture({ reply: () => new Response("private provider error / token / raw mail", { status }) })
+    const response = await f.request("gmail-draft/draft-1/send", "POST", { confirm: true })
+    expect(response.status).toBe(status === 401 || status === 403 ? 409 : 502)
+    expect(await response.text()).not.toContain("private provider error")
+    expect(f.calls).toHaveLength(1)
+  })
+}
+
+test("network failure after sending remains uncertain, sanitized and is not retried", async () => {
+  const f = fixture({ reply: () => { throw new Error("private-network-detail") } })
+  const response = await f.request("gmail-draft/draft-1/send", "POST", { confirm: true })
+  expect(response.status).toBe(502)
+  const text = await response.text()
+  expect(text).toContain("may have completed")
+  expect(text).not.toContain("private-network-detail")
+  expect(f.calls).toHaveLength(1)
+})
+
+for (const body of ["not JSON", "null", "{}", '{"id":"sent"}', '{"id":"","threadId":"thread"}', '{"id":"sent","threadId":2}']) {
+  test(`malformed successful send is not confirmed: ${body}`, async () => {
+    const f = fixture({ reply: () => new Response(body, { status: 200 }) })
+    const response = await f.request("gmail-draft/draft-1/send", "POST", { confirm: true })
+    expect(response.status).toBe(502)
+    expect(await response.text()).toContain("may have completed")
+    expect(f.calls).toHaveLength(1)
+  })
+}
+
+test("draft list passes pagination/search and preserves nextPageToken", async () => {
+  const data = { drafts: [draft], nextPageToken: "page+2/next", resultSizeEstimate: 101 }
+  const f = fixture({ scopes: [READ], reply: () => Response.json(data) })
+  const response = await f.request("gmail-drafts?q=subject%3Areply&maxResults=100&pageToken=page%2B1%2Fnext&includeSpamTrash=false")
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual(data)
+  expect(f.calls[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts?q=subject%3Areply&maxResults=100&pageToken=page%2B1%2Fnext&includeSpamTrash=false")
+  expect((await f.request("gmail-drafts?maxResults=101")).status).toBe(400)
+  expect((await f.request("gmail-drafts?includeSpamTrash=not-boolean")).status).toBe(400)
+  expect(f.calls).toHaveLength(1)
+})
+
+test("draft read returns raw MIME and uses an encoded ID under users/me", async () => {
+  const f = fixture({ scopes: [COMPOSE], reply: () => Response.json(draft) })
+  const response = await f.request("gmail-draft/draft%2F%3F%23?format=raw")
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual(draft)
+  expect(f.calls[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts/draft%2F%3F%23?format=raw")
+})
+
+test("draft lists accept documented minimal messages and empty pages, not missing thread IDs", async () => {
+  for (const data of [{ drafts: [{ id: draft.id, message: { id: draft.message.id, threadId: draft.message.threadId } }] }, {}, { drafts: [], resultSizeEstimate: 0 }]) {
+    const f = fixture({ reply: () => Response.json(data) })
+    const response = await f.request("gmail-drafts")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(data)
+  }
+  const f = fixture({ reply: () => Response.json({ drafts: [{ id: draft.id, message: { id: draft.message.id } }] }) })
+  expect((await f.request("gmail-drafts")).status).toBe(502)
+})
+
+test("minimal and metadata draft reads allow an omitted threadId without weakening send confirmations", async () => {
+  const data = { id: draft.id, message: { id: draft.message.id, labelIds: ["DRAFT"] } }
+  const f = fixture({ reply: () => Response.json(data) })
+  for (const format of ["minimal", "metadata"]) {
+    const response = await f.request(`gmail-draft/draft-1?format=${format}`)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(data)
+  }
+  expect((await f.request("gmail-draft/draft-1?format=full")).status).toBe(502)
+  expect((await f.request("gmail-draft/draft-1/send", "POST", { confirm: true })).status).toBe(502)
+})
+
+test("Gmail rejects requests above 6 MiB before JSON validation, credentials or provider access", async () => {
+  const f = fixture()
+  const response = await f.request("gmail-draft/draft-1", "PUT", { confirm: true, message: { raw: "A".repeat(6 * 1024 * 1024) } })
+  expect(response.status).toBe(413)
+  expect(f.selections).toHaveLength(0)
+  expect(f.calls).toHaveLength(0)
+})
+
+test("Gmail accepts a complete response at the 6 MiB limit", async () => {
+  const data = { ...draft, message: { ...draft.message, raw: "" } }
+  data.message.raw = "A".repeat(6 * 1024 * 1024 - JSON.stringify(data).length)
+  const f = fixture({ reply: () => Response.json(data) })
+  const response = await f.request("gmail-draft/draft-1?format=raw")
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual(data)
+})
+
+test("Gmail cancels oversized decoded response streams even with absent or misleading content-length", async () => {
+  for (const contentLength of [undefined, "1", String(6 * 1024 * 1024 + 1)]) {
+    let cancelled = false
+    const f = fixture({ reply: () => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify({ ...sentMessage, extra: "\u00e9".repeat(3 * 1024 * 1024) })))
+      },
+      cancel() { cancelled = true },
+    }), { headers: contentLength === undefined ? {} : { "content-length": contentLength } }) })
+    const response = await f.request("gmail-draft/draft-1/send", "POST", { confirm: true })
+    expect(response.status).toBe(502)
+    expect(await response.text()).toContain("may have completed")
+    expect(cancelled).toBe(true)
+    expect(f.calls).toHaveLength(1)
+  }
+})
+
+test("draft replacement forwards full caller-provided MIME and threading without rebuilding it", async () => {
+  const f = fixture({ scopes: [COMPOSE], reply: () => Response.json(draft) })
+  const message = { raw: draft.message.raw, threadId: draft.message.threadId }
+  const response = await f.request("gmail-draft/draft-1", "PUT", { confirm: true, message })
+  expect(response.status).toBe(200)
+  expect(f.calls[0]?.method).toBe("PUT")
+  expect(f.calls[0]?.body).toEqual({ message })
+  expect((await f.request("gmail-draft/draft-1", "PUT", { message })).status).toBe(400)
+  expect((await f.request("gmail-draft/draft-1", "PUT", { confirm: true, message: { raw: "not base64url!" } })).status).toBe(400)
+  expect(f.calls).toHaveLength(1)
+})
+
+test("delete draft accepts Google's no-content response and sends no confirmation field upstream", async () => {
+  const f = fixture({ scopes: [COMPOSE], reply: () => new Response(null, { status: 204 }) })
+  const response = await f.request("gmail-draft/draft%2F1", "DELETE", { confirm: true })
+  expect(await response.json()).toEqual({ ok: true })
+  expect(f.calls[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts/draft%2F1")
+  expect(f.calls[0]?.method).toBe("DELETE")
+  expect(f.calls[0]?.body).toBeUndefined()
+})
+
+for (const change of [
+  { addLabelIds: [], removeLabelIds: ["INBOX"] },
+  { addLabelIds: ["INBOX"], removeLabelIds: [] },
+  { addLabelIds: [], removeLabelIds: ["UNREAD"] },
+  { addLabelIds: ["UNREAD"], removeLabelIds: [] },
+  { addLabelIds: ["STARRED", "Label_1"], removeLabelIds: [] },
+  { addLabelIds: [], removeLabelIds: ["STARRED"] },
+]) {
+  test(`message labels perform the actual requested mailbox change: ${JSON.stringify(change)}`, async () => {
+    const f = fixture()
+    const response = await f.request("gmail-message/message%2F1/modify", "POST", change)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(sentMessage)
+    expect(f.calls[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/messages/message%2F1/modify")
+    expect(f.calls[0]?.body).toEqual(change)
+    expect(f.calls).toHaveLength(1)
+  })
+}
+
+test("message modification cannot bypass trash confirmation or silently ignore invalid input", async () => {
+  const f = fixture()
+  for (const body of [{}, { addLabelIds: ["TRASH"] }, { removeLabelIds: ["TRASH"] }, { addLabelIds: ["SENT"] }, { addLabelIds: ["INBOX", "INBOX"] }, { addLabelIds: ["UNREAD"], removeLabelIds: ["UNREAD"] }, { addLabelIds: Array.from({ length: 101 }, (_, i) => `Label_${i}`) }, { addLabelIds: ["INBOX"], account: "other" }]) {
+    expect((await f.request("gmail-message/message-1/modify", "POST", body)).status).toBe(400)
+  }
+  expect(f.calls).toHaveLength(0)
+})
+
+for (const operation of ["modify", "trash", "untrash"]) {
+  test(`${operation} rejects compose, readonly and labels-only permissions`, async () => {
+    const body = operation === "modify" ? { addLabelIds: ["STARRED"] } : { confirm: true }
+    for (const scopes of [[COMPOSE], [READ], [LABELS], null]) {
+      const f = fixture({ scopes })
+      expect((await f.request(`gmail-message/message-1/${operation}`, "POST", body)).status).toBe(409)
+      expect(f.calls).toHaveLength(0)
+    }
+  })
+}
+
+for (const operation of ["trash", "untrash"]) {
+  test(`${operation} calls Google's dedicated endpoint with an empty upstream body`, async () => {
+    const f = fixture()
+    const response = await f.request(`gmail-message/message-1/${operation}`, "POST", { confirm: true })
+    expect(response.status).toBe(200)
+    expect(f.calls[0]?.url).toBe(`https://gmail.googleapis.com/gmail/v1/users/me/messages/message-1/${operation}`)
+    expect(f.calls[0]?.body).toBeUndefined()
+  })
+}
+
+test("list and create labels return actual provider resources with least privilege", async () => {
+  const f = fixture({ scopes: [LABELS], reply: () => Response.json(f.calls.length === 1 ? { labels: [label] } : label) })
+  expect(await (await f.request("gmail-labels")).json()).toEqual({ labels: [label] })
+  const input = { name: "Follow up", labelListVisibility: "labelShow" }
+  expect(await (await f.request("gmail-labels", "POST", input)).json()).toEqual(label)
+  expect(f.calls[1]?.body).toEqual(input)
+  expect(f.calls[1]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/labels")
+})
+
+test("label patch first verifies user ownership/type then performs a partial PATCH", async () => {
+  const f = fixture({ scopes: [LABELS], reply: () => Response.json(label) })
+  expect((await f.request("gmail-label/Label_1", "PATCH", { name: "Renamed" })).status).toBe(200)
+  expect(f.calls.map((call) => call.method)).toEqual(["GET", "PATCH"])
+  expect(f.calls[1]?.body).toEqual({ name: "Renamed" })
+})
+
+test("label deletion checks type and accepts documented empty JSON without deleting messages", async () => {
+  const f = fixture({ scopes: [LABELS], reply: () => Response.json(f.calls.length === 1 ? label : {}) })
+  expect(await (await f.request("gmail-label/Label_1", "DELETE", { confirm: true })).json()).toEqual({ ok: true })
+  expect(f.calls.map((call) => [call.url, call.method])).toEqual([
+    ["https://gmail.googleapis.com/gmail/v1/users/me/labels/Label_1", "GET"],
+    ["https://gmail.googleapis.com/gmail/v1/users/me/labels/Label_1", "DELETE"],
+  ])
+  expect(f.calls[1]?.body).toBeUndefined()
+})
+
+for (const method of ["PATCH", "DELETE"]) {
+  test(`${method} refuses system labels, wrong IDs, malformed reads and failed preflights without a write`, async () => {
+    for (const reply of [
+      () => Response.json({ id: "INBOX", name: "Inbox", type: "system" }),
+      () => Response.json({ ...label, id: "different-label" }),
+      () => Response.json({ id: "INBOX", name: "Inbox" }),
+      () => new Response("private", { status: 403 }),
+    ]) {
+      const f = fixture({ reply })
+      const response = await f.request("gmail-label/INBOX", method, method === "PATCH" ? { name: "Renamed" } : { confirm: true })
+      expect(response.status).not.toBe(200)
+      expect(f.calls).toHaveLength(1)
+      expect(f.calls[0]?.method).toBe("GET")
+    }
+  })
+}
+
+test("label schemas reject empty patches, invalid visibility and provider-controlled fields", async () => {
+  const f = fixture()
+  for (const body of [{}, { name: "" }, { name: "New", type: "system" }, { name: "New", id: "INBOX" }, { name: "New", labelListVisibility: "show" }]) {
+    expect((await f.request("gmail-labels", "POST", body)).status).toBe(400)
+  }
+  expect((await f.request("gmail-label/Label_1", "PATCH", {})).status).toBe(400)
+  expect(f.calls).toHaveLength(0)
+})
+
+test("all routes are discoverable Capability Sources and gated before credential resolution", async () => {
+  const f = fixture()
+  const spec = await generateSpecs(f.app)
+  expect(buildMcpCatalog(spec).map((operation) => operation.name).sort()).toEqual([
+    "createGmailLabel", "deleteGmailDraft", "deleteGmailLabel", "getGmailDraft", "listGmailDrafts", "listGmailLabels",
+    "sendGmailDraft", "trashGmailMessage", "untrashGmailMessage", "updateGmailDraft", "updateGmailLabel", "updateGmailMessageLabels",
+  ].sort())
+  let count = 0
+  for (const [path, methods] of Object.entries(spec.paths ?? {})) {
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!operation || typeof operation !== "object" || !("tags" in operation)) continue
+      expect(operation.tags).toContain("Capability Sources")
+      expect((await f.app.request(path.replace(/\{[^}]+\}/g, "resource-1"), { method: method.toUpperCase() })).status).toBe(401)
+      count += 1
+    }
+  }
+  expect(count).toBe(12)
+  expect(f.selections).toHaveLength(0)
+  expect(f.calls).toHaveLength(0)
+})

--- a/ee/apps/den-api/test/google-productivity-management.test.ts
+++ b/ee/apps/den-api/test/google-productivity-management.test.ts
@@ -1,0 +1,436 @@
+import { afterAll, describe, expect, mock, test } from "bun:test"
+import { Hono, type MiddlewareHandler } from "hono"
+import { generateSpecs } from "hono-openapi"
+import { buildMcpCatalog } from "../src/mcp/catalog.js"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import type { OrganizationContext } from "../src/orgs.js"
+import type { GoogleWorkspaceActionDependencies } from "../src/routes/org/google-workspace-actions.js"
+import type { GoogleWorkspaceAccessToken } from "../src/routes/org/google-workspace.js"
+import type { OrgRouteVariables } from "../src/routes/org/shared.js"
+
+// Only the session/org lookup is substituted. Hono validation and the real grant/fetch helper run.
+const memberGuard: MiddlewareHandler<{ Variables: OrgRouteVariables }> = async (c, next) => {
+  if (!c.get("organizationContext")) return c.json({ error: "unauthorized" }, 401)
+  await next()
+}
+mock.module("../src/middleware/route-access.js", () => ({ orgMemberRoute: () => memberGuard }))
+mock.module("../src/env.js", () => ({ env: { googleApiBaseUrl: undefined } }))
+const { registerGoogleProductivityManagementRoutes } = await import("../src/routes/org/google-productivity-management.js")
+afterAll(() => mock.restore())
+
+const base = "/v1/capabilities/google-workspace"
+const scope = "https://www.googleapis.com/auth/"
+const epoch = new Date("2026-01-01T00:00:00Z")
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+const secondMemberId = createDenTypeId("member")
+function organizationContext(id = memberId): OrganizationContext {
+  return {
+    organization: { id: organizationId, name: "Test", slug: "test", logo: null, allowedEmailDomains: null, metadata: null, createdAt: epoch, updatedAt: epoch },
+    currentMember: { id, userId: createDenTypeId("user"), role: "member", directRole: "member", adminTeams: [], createdAt: epoch, joinedAt: epoch, isOwner: false },
+    members: [], invitations: [], roles: [], teams: [],
+  }
+}
+type WitnessCall = { url: URL; method: string; headers: Headers; body: unknown }
+function harness(options: {
+  scopes?: string[] | null
+  enabledScopes?: string[]
+  member?: typeof memberId
+  signedIn?: boolean
+  tokenFailure?: "needs_connection" | "google_api_error"
+  respond?: (call: WitnessCall) => Response | Promise<Response>
+} = {}) {
+  const calls: WitnessCall[] = []
+  const tokenCalls: Parameters<GoogleWorkspaceActionDependencies["token"]>[0][] = []
+  const app = new Hono<{ Variables: OrgRouteVariables }>()
+  app.use("*", async (c, next) => {
+    if (options.signedIn !== false) c.set("organizationContext", organizationContext(options.member))
+    await next()
+  })
+  registerGoogleProductivityManagementRoutes(app, {
+    token: async (input) => {
+      tokenCalls.push(input)
+      if (options.tokenFailure) return { kind: options.tokenFailure, message: "Synthetic token lookup failure" }
+      const token: GoogleWorkspaceAccessToken = {
+        kind: "ok", accessToken: `synthetic-${input.orgMembershipId}`,
+        enabledScopes: options.enabledScopes ?? ["calendar.events", "calendar.readonly", "spreadsheets", "spreadsheets.readonly", "drive.file", "drive", "drive.readonly"].map((name) => scope + name),
+        account: {
+          id: createDenTypeId("connectedAccount"), organizationId: input.organizationId, orgMembershipId: input.orgMembershipId,
+          providerId: "google-workspace", scopes: options.scopes === undefined ? [scope + "calendar.events", scope + "spreadsheets", scope + "drive.file"] : options.scopes,
+          externalAccountId: "member@example.com", accessToken: null, refreshToken: null, tokenType: "Bearer", expiresAt: null,
+          pendingCodeVerifier: null, credentialHealth: null, connectedAt: epoch, updatedAt: epoch,
+        },
+      }
+      // Exercise absent runtime metadata while keeping it required for typed token resolvers.
+      if ("enabledScopes" in options && options.enabledScopes === undefined) Reflect.deleteProperty(token, "enabledScopes")
+      return token
+    },
+    fetch: async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString())
+      const call = { url, method: init?.method ?? "GET", headers: new Headers(init?.headers), body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined }
+      calls.push(call)
+      if (options.respond) return options.respond(call)
+      return Response.json({})
+    },
+  })
+  const request = (path: string, method = "GET", body?: unknown) => app.request(base + path, {
+    method, ...(body === undefined ? {} : { headers: { "content-type": "application/json" }, body: JSON.stringify(body) }),
+  })
+  return { app, calls, tokenCalls, request }
+}
+const event = { id: "event_1", status: "confirmed", summary: "Planning", start: { dateTime: "2026-09-10T10:00:00Z" }, end: { dateTime: "2026-09-10T11:00:00Z" }, attendees: [{ email: "guest@example.com" }] }
+const spreadsheet = { spreadsheetId: "sheet_1", spreadsheetUrl: "https://docs.google.com/spreadsheets/d/sheet_1/edit", properties: { title: "Plan" }, sheets: [{ properties: { sheetId: 0, title: "Sheet1", index: 0, gridProperties: { rowCount: 1000, columnCount: 26 } } }] }
+const update = { spreadsheetId: "sheet_1", updatedRange: "Sheet1!A1:C1", updatedRows: 1, updatedColumns: 3, updatedCells: 3 }
+const file = { id: "file_1", name: "Folder", mimeType: "application/vnd.google-apps.folder", trashed: false, parents: ["parent_1"] }
+const writes = [
+  { path: "/calendar-events/event_1", method: "PATCH", body: { summary: "Planning" } },
+  { path: "/calendar-events/event_1?confirmCancellation=true", method: "DELETE" },
+  { path: "/spreadsheets", method: "POST", body: { title: "Plan" } },
+  { path: "/spreadsheets/sheet_1/values", method: "PUT", body: { range: "A1:C1", values: [["=1+1", 2, true]] } },
+  { path: "/spreadsheets/sheet_1/values/append", method: "POST", body: { range: "A1:C10", values: [["=1+1", 2, true]] } },
+  { path: "/drive-folders", method: "POST", body: { name: "Folder" } },
+  { path: "/drive-files/file_1", method: "PATCH", body: { name: "Renamed" } },
+]
+
+describe("Calendar event management", () => {
+  test("reads a selected calendar event with the calling member's credential", async () => {
+    const h = harness({ scopes: [scope + "calendar.readonly"], member: secondMemberId, respond: () => Response.json(event) })
+    const response = await h.request("/calendar-events/event_1?calendarId=team%40group.calendar.google.com")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, calendarId: "team@group.calendar.google.com", event })
+    expect(h.calls).toHaveLength(1)
+    expect(h.calls[0].url.pathname).toBe("/calendar/v3/calendars/team%40group.calendar.google.com/events/event_1")
+    expect(h.calls[0].method).toBe("GET")
+    expect(h.calls[0].body).toBeUndefined()
+    expect(h.calls[0].headers.get("authorization")).toBe(`Bearer synthetic-${secondMemberId}`)
+    expect(h.tokenCalls).toEqual([{ organizationId, orgMembershipId: secondMemberId }])
+    expect(h.calls[0].headers.get("authorization")).not.toBe(`Bearer synthetic-${memberId}`)
+  })
+  test("reschedules using PATCH, preserving offset/time zone and only supplied fields", async () => {
+    const patch = { start: { dateTime: "2026-09-11T10:00:00+02:00", timeZone: "Europe/Paris" }, end: { dateTime: "2026-09-11T12:00:00+02:00", timeZone: "Europe/Paris" }, location: "Room 2" }
+    const h = harness({ respond: () => Response.json({ ...event, ...patch }) })
+    expect((await h.request("/calendar-events/event_1", "PATCH", patch)).status).toBe(200)
+    expect(h.calls[0].method).toBe("PATCH")
+    expect(h.calls[0].url.pathname).toContain("/calendars/primary/events/event_1")
+    expect(h.calls[0].url.searchParams.get("sendUpdates")).toBe("none")
+    expect(h.calls[0].body).toEqual(patch)
+    expect(h.calls[0].headers.get("content-type")).toBe("application/json")
+  })
+  test("supports all-day dates, empty descriptions, attendee replacement and confirmed notifications", async () => {
+    const patch = { start: { date: "2026-09-11" }, end: { date: "2026-09-12" }, description: "", attendees: [] }
+    const h = harness({ respond: () => Response.json({ ...event, ...patch }) })
+    expect((await h.request("/calendar-events/event_1?calendarId=selected", "PATCH", { ...patch, sendUpdates: "all", confirmNotifications: true })).status).toBe(200)
+    expect(h.calls[0].body).toEqual(patch)
+    expect(h.calls[0].url.searchParams.get("sendUpdates")).toBe("all")
+  })
+  test("reads all-day time zones and accepts omitted empty optional event fields after clearing", async () => {
+    const data = { id: event.id, status: "confirmed", start: { date: "2026-09-11", timeZone: "Europe/Paris" }, end: { date: "2026-09-12", timeZone: "Europe/Paris" } }
+    const h = harness({ respond: () => Response.json(data) })
+    const read = await h.request("/calendar-events/event_1")
+    expect(read.status).toBe(200)
+    expect((await read.json()).event).toEqual(data)
+    expect((await h.request("/calendar-events/event_1", "PATCH", { description: "", location: "", attendees: [] })).status).toBe(200)
+  })
+  test.each([
+    {}, { summary: "Title", sendUpdates: "all" }, { summary: "Title", sendUpdates: "invalid" },
+    { start: event.start }, { start: event.start, end: { date: "2026-09-12" } },
+    { start: event.end, end: event.start }, { start: { date: "2026-09-11" }, end: { date: "2026-09-11" } },
+    { start: { date: "2026-02-30" }, end: { date: "2026-03-02" } },
+    { start: { dateTime: "2026-09-11T10:00:00Z", timeZone: "Invalid/Zone" }, end: event.end },
+    { summary: "Title", attendees: Array.from({ length: 101 }, () => ({ email: "guest@example.com" })) },
+    { summary: "Title", status: "cancelled" },
+  ])("rejects invalid/unsafe event patches before credentials or fetch: %j", async (body) => {
+    const h = harness()
+    expect((await h.request("/calendar-events/event_1", "PATCH", body)).status).toBe(400)
+    expect(h.calls).toHaveLength(0)
+    expect(h.tokenCalls).toHaveLength(0)
+  })
+  test("cancellation requires confirmation and accepts only Google 204, with no provider request body", async () => {
+    const h = harness({ respond: () => new Response(null, { status: 204 }) })
+    expect((await h.request("/calendar-events/event_1", "DELETE")).status).toBe(400)
+    expect((await h.request("/calendar-events/event_1?confirmCancellation=true&sendUpdates=all", "DELETE")).status).toBe(400)
+    expect(h.calls).toHaveLength(0)
+    const response = await h.request("/calendar-events/event_1?calendarId=selected&confirmCancellation=true&sendUpdates=externalOnly&confirmNotifications=true", "DELETE")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, calendarId: "selected", eventId: "event_1", cancelled: true, sendUpdates: "externalOnly" })
+    expect(h.calls[0].method).toBe("DELETE")
+    expect(h.calls[0].body).toBeUndefined()
+    expect(h.calls[0].url.search).toBe("?sendUpdates=externalOnly")
+  })
+})
+
+describe("Sheets v4 metadata and cell operations", () => {
+  test("metadata excludes grid data and uses the real Sheets endpoint", async () => {
+    const h = harness({ scopes: [scope + "spreadsheets.readonly"], respond: () => Response.json(spreadsheet) })
+    const response = await h.request("/spreadsheets/sheet_1")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, spreadsheet })
+    expect(h.calls[0].url.origin).toBe("https://sheets.googleapis.com")
+    expect(h.calls[0].url.pathname).toBe("/v4/spreadsheets/sheet_1")
+    expect(h.calls[0].url.searchParams.get("includeGridData")).toBe("false")
+    expect(h.calls[0].url.searchParams.get("fields")).toContain("gridProperties(rowCount,columnCount)")
+  })
+  test("creates a spreadsheet resource, not a Drive text-file copy", async () => {
+    const h = harness({ respond: () => Response.json(spreadsheet) })
+    expect((await h.request("/spreadsheets", "POST", { title: "Plan" })).status).toBe(200)
+    expect(h.calls[0].method).toBe("POST")
+    expect(h.calls[0].url.origin + h.calls[0].url.pathname).toBe("https://sheets.googleapis.com/v4/spreadsheets")
+    expect(h.calls[0].body).toEqual({ properties: { title: "Plan" }, sheets: [{ properties: { title: "Sheet1", gridProperties: { rowCount: 1000, columnCount: 26 } } }] })
+  })
+  test("reads bounded quoted A1 ranges and normalizes Google's empty-cell response", async () => {
+    const range = "'Team''s Plan'!$A$1:$C$2"
+    const h = harness({ scopes: [scope + "drive.readonly"], respond: () => Response.json({ range, majorDimension: "ROWS" }) })
+    const response = await h.request(`/spreadsheets/sheet_1/values?range=${encodeURIComponent(range)}&valueRenderOption=FORMULA`)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, spreadsheetId: "sheet_1", range, majorDimension: "ROWS", values: [], valueRenderOption: "FORMULA" })
+    expect(decodeURIComponent(h.calls[0].url.pathname)).toBe(`/v4/spreadsheets/sheet_1/values/${range}`)
+    expect(h.calls[0].url.searchParams.get("majorDimension")).toBe("ROWS")
+    expect(h.calls[0].url.searchParams.get("valueRenderOption")).toBe("FORMULA")
+  })
+  test("accepts an empty values response without optional values or majorDimension", async () => {
+    const h = harness({ respond: () => Response.json({ range: "Sheet1!A1" }) })
+    const response = await h.request("/spreadsheets/sheet_1/values?range=A1")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ range: "Sheet1!A1", majorDimension: "ROWS", values: [] })
+  })
+  test("reads non-grid sheets and partial grid properties without requiring absent dimensions", async () => {
+    for (const properties of [{ sheetId: 0, title: "Chart" }, { sheetId: 0, title: "Data", gridProperties: { rowCount: 10 } }]) {
+      const data = { ...spreadsheet, sheets: [{ properties }] }
+      const h = harness({ respond: () => Response.json(data) })
+      const response = await h.request("/spreadsheets/sheet_1")
+      expect(response.status).toBe(200)
+      expect((await response.json()).spreadsheet).toEqual(data)
+    }
+  })
+  test("returns real cell values and rejects a provider response larger than the requested rectangle", async () => {
+    const h = harness({ respond: () => Response.json({ range: "Sheet1!A1:C2", majorDimension: "ROWS", values: [["Plan", 3, true], ["", 4, false]] }) })
+    const response = await h.request("/spreadsheets/sheet_1/values?range=Sheet1!A1:C2&valueRenderOption=UNFORMATTED_VALUE")
+    expect(response.status).toBe(200)
+    expect((await response.json()).values).toEqual([["Plan", 3, true], ["", 4, false]])
+    expect((await h.request("/spreadsheets/sheet_1/values?range=A1")).status).toBe(502)
+  })
+  test("accepts the maximum bounded rectangle but rejects arbitrary create properties", async () => {
+    const h = harness({ respond: () => Response.json({ range: "Sheet1!A1:J500", majorDimension: "ROWS" }) })
+    expect((await h.request("/spreadsheets/sheet_1/values?range=A1:J500")).status).toBe(200)
+    expect((await h.request("/spreadsheets", "POST", { title: "Plan", rowCount: 10_001 })).status).toBe(400)
+    expect((await h.request("/spreadsheets", "POST", { title: "Plan", sheets: [{ data: "unexpected grid data" }] })).status).toBe(400)
+    expect(h.calls).toHaveLength(1)
+  })
+  test.each(["A:A", "1:5", "Sheet1", "NamedRange", "A1:A501", "A1:DW1", "A1:Z500", "B2:A1", "A0", "A1000001", "https://example.com", "A1?key=bad", "Sheet1!A1:B2!C3"])("rejects unbounded or invalid range %s before fetch", async (range) => {
+    const h = harness()
+    expect((await h.request(`/spreadsheets/sheet_1/values?range=${encodeURIComponent(range)}`)).status).toBe(400)
+    expect((await h.request("/spreadsheets/sheet_1/values", "PUT", { range, values: [[1]] })).status).toBe(400)
+    expect(h.calls).toHaveLength(0)
+  })
+  test("writes literal formula-looking strings using PUT with RAW by default", async () => {
+    const h = harness({ respond: () => Response.json(update) })
+    const input = { range: "Sheet1!A1:C1", values: [["=IMPORTXML(\"https://example.com\",\"//x\")", 2, true]] }
+    const response = await h.request("/spreadsheets/sheet_1/values", "PUT", input)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, ...update, valueInputOption: "RAW" })
+    expect(h.calls[0].method).toBe("PUT")
+    expect(h.calls[0].url.searchParams.get("valueInputOption")).toBe("RAW")
+    expect(h.calls[0].body).toEqual({ ...input, majorDimension: "ROWS" })
+  })
+  test("USER_ENTERED is explicit and confirmed, never inferred from string contents", async () => {
+    const h = harness({ respond: () => Response.json(update) })
+    const body = { range: "A1:C1", values: [["=1+1", 2, true]], valueInputOption: "USER_ENTERED" }
+    expect((await h.request("/spreadsheets/sheet_1/values", "PUT", body)).status).toBe(400)
+    expect(h.calls).toHaveLength(0)
+    expect((await h.request("/spreadsheets/sheet_1/values", "PUT", { ...body, confirmUserEntered: true })).status).toBe(200)
+    expect(h.calls[0].url.searchParams.get("valueInputOption")).toBe("USER_ENTERED")
+    expect(h.calls[0].body).toEqual({ range: body.range, values: body.values, majorDimension: "ROWS" })
+  })
+  test("append inserts rows after the detected table and returns Google's actual written range", async () => {
+    const updates = { ...update, updatedRange: "Sheet1!A11:C11" }
+    const h = harness({ respond: () => Response.json({ spreadsheetId: "sheet_1", tableRange: "Sheet1!A1:C10", updates }) })
+    const response = await h.request("/spreadsheets/sheet_1/values/append", "POST", { range: "A1:C10", values: [["x", 2, true]] })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, ...updates, tableRange: "Sheet1!A1:C10", valueInputOption: "RAW" })
+    expect(h.calls[0].url.pathname).toEndWith("/values/A1%3AC10:append")
+    expect(h.calls[0].method).toBe("POST")
+    expect(h.calls[0].body).toEqual({ range: "A1:C10", majorDimension: "ROWS", values: [["x", 2, true]] })
+    expect(h.calls[0].url.searchParams.get("insertDataOption")).toBe("INSERT_ROWS")
+    expect(h.calls[0].url.searchParams.get("valueInputOption")).toBe("RAW")
+  })
+  test("append permits an empty or omitted preexisting table range while still requiring write counts", async () => {
+    for (const table of [{}, { tableRange: "" }]) {
+      const h = harness({ respond: () => Response.json({ spreadsheetId: "sheet_1", ...table, updates: update }) })
+      const response = await h.request("/spreadsheets/sheet_1/values/append", "POST", { range: "A1:C10", values: [["x", 2, true]] })
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({ ...update, tableRange: "", ok: true })
+    }
+  })
+  test.each([
+    { range: "A1", values: [[1, 2]] }, { range: "A1", values: [[1], [2]] },
+    { range: "A1", values: [] }, { range: "A1", values: [[null]] }, { range: "A1", values: [[{ formula: "1+1" }]] },
+    { range: "A1", values: [["x".repeat(50_001)]] },
+    { range: "A1:J500", values: Array.from({ length: 501 }, () => [1]) },
+    { range: "A1", values: [[1]], valueInputOption: "AUTOMATIC" },
+  ])("rejects invalid, oversized, or misaligned cells", async (body) => {
+    const h = harness()
+    expect((await h.request("/spreadsheets/sheet_1/values", "PUT", body)).status).toBe(400)
+    expect(h.calls).toHaveLength(0)
+  })
+  test("limits total JSON bytes before parsing or provider access", async () => {
+    const h = harness()
+    expect((await h.request("/spreadsheets/sheet_1/values", "PUT", { range: "A1:Z1", values: [Array.from({ length: 26 }, () => "x".repeat(50_000))] })).status).toBe(413)
+    expect(h.calls).toHaveLength(0)
+    expect(h.tokenCalls).toHaveLength(0)
+  })
+})
+
+describe("Drive metadata mutations", () => {
+  test("reads current parents with a read-only credential for a subsequent explicit move", async () => {
+    const h = harness({ scopes: [scope + "drive.readonly"], respond: () => Response.json(file) })
+    const response = await h.request("/drive-files/file_1")
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, file })
+    expect(h.calls[0].method).toBe("GET")
+    expect(h.calls[0].body).toBeUndefined()
+    expect(h.calls[0].url.searchParams.get("fields")).toContain("parents")
+    expect((await h.request("/drive-files/file_1", "PATCH", { addParentId: "parent_2", removeParentId: "parent_1" })).status).toBe(409)
+    expect(h.calls).toHaveLength(1)
+  })
+  test("creates a folder with files.create and selected parent", async () => {
+    const h = harness({ respond: () => Response.json(file) })
+    expect((await h.request("/drive-folders", "POST", { name: "Folder", parentId: "parent_1" })).status).toBe(200)
+    expect(h.calls[0].url.origin + h.calls[0].url.pathname).toBe("https://www.googleapis.com/drive/v3/files")
+    expect(h.calls[0].method).toBe("POST")
+    expect(h.calls[0].body).toEqual({ name: "Folder", mimeType: "application/vnd.google-apps.folder", parents: ["parent_1"] })
+    expect(h.calls[0].url.searchParams.get("supportsAllDrives")).toBe("true")
+  })
+  test("renames and moves using files.update with parent changes in query, not body", async () => {
+    const h = harness({ respond: () => Response.json({ ...file, name: "Moved", parents: ["parent_2"] }) })
+    const response = await h.request("/drive-files/file_1", "PATCH", { name: "Moved", addParentId: "parent_2", removeParentId: "parent_1" })
+    expect(response.status).toBe(200)
+    expect(h.calls[0].method).toBe("PATCH")
+    expect(h.calls[0].url.pathname).toBe("/drive/v3/files/file_1")
+    expect(h.calls[0].body).toEqual({ name: "Moved" })
+    expect(h.calls[0].url.searchParams.get("addParents")).toBe("parent_2")
+    expect(h.calls[0].url.searchParams.get("removeParents")).toBe("parent_1")
+  })
+  test("trashing is explicitly confirmed; restore also uses PATCH, never DELETE", async () => {
+    const h = harness({ respond: (call) => Response.json({ ...file, ...(typeof call.body === "object" && call.body !== null ? call.body : {}) }) })
+    expect((await h.request("/drive-files/file_1", "PATCH", { trashed: true })).status).toBe(400)
+    expect((await h.request("/drive-files/file_1", "PATCH", { trashed: true, confirmTrash: true })).status).toBe(200)
+    expect((await h.request("/drive-files/file_1", "PATCH", { trashed: false })).status).toBe(200)
+    expect(h.calls.map((call) => call.method)).toEqual(["PATCH", "PATCH"])
+    expect(h.calls.map((call) => call.body)).toEqual([{ trashed: true }, { trashed: false }])
+    expect((await h.request("/drive-files/file_1", "DELETE")).status).toBe(404)
+  })
+  test.each([{}, { addParentId: "parent_1" }, { addParentId: "parent_1", removeParentId: "parent_1" }, { addParentId: "file_1", removeParentId: "parent_1" }, { name: "x", parents: ["parent_1"] }])("rejects unsafe or empty metadata patches %j", async (body) => {
+    const h = harness()
+    expect((await h.request("/drive-files/file_1", "PATCH", body)).status).toBe(400)
+    expect(h.calls).toHaveLength(0)
+  })
+})
+
+describe("Provider grants and honest receipts", () => {
+  test.each(writes)("disabled or unknown connector permissions block stale write grants for $path", async ({ path, method, body }) => {
+    for (const enabledScopes of [undefined, [], [scope + "calendar.readonly", scope + "drive.readonly", scope + "spreadsheets.readonly"]]) {
+      const h = harness({ enabledScopes })
+      const response = await h.request(path, method, body)
+      expect(response.status).toBe(409)
+      expect(await response.json()).toMatchObject({ error: "needs_connection" })
+      expect(h.calls).toHaveLength(0)
+    }
+  })
+  test.each(writes)("read-only grants cannot mutate $path", async ({ path, method, body }) => {
+    for (const scopes of [[scope + "calendar.readonly", scope + "drive.readonly", scope + "spreadsheets.readonly"], [], null]) {
+      const h = harness({ scopes })
+      expect((await h.request(path, method, body)).status).toBe(409)
+      expect(h.calls).toHaveLength(0)
+    }
+  })
+  test.each(["drive.file", "drive", "spreadsheets"])("Sheets accepts official write grant %s", async (grant) => {
+    const h = harness({ scopes: [scope + grant], respond: () => Response.json(spreadsheet) })
+    expect((await h.request("/spreadsheets", "POST", { title: "Plan" })).status).toBe(200)
+  })
+  test("spreadsheets permission cannot mutate Drive metadata", async () => {
+    const h = harness({ scopes: [scope + "spreadsheets"] })
+    expect((await h.request("/drive-folders", "POST", { name: "Folder" })).status).toBe(409)
+    expect(h.calls).toHaveLength(0)
+  })
+  test("unauthenticated requests and failed token lookup never fetch Google", async () => {
+    const h = harness({ signedIn: false })
+    expect((await h.request("/spreadsheets/sheet_1")).status).toBe(401)
+    expect(h.tokenCalls).toHaveLength(0)
+    for (const tokenFailure of ["needs_connection", "google_api_error"] as const) {
+      const failed = harness({ tokenFailure })
+      expect((await failed.request("/spreadsheets/sheet_1")).status).toBe(tokenFailure === "needs_connection" ? 409 : 502)
+      expect(failed.calls).toHaveLength(0)
+    }
+  })
+  test.each(writes)("uncertain $method $path is never retried or reported successful", async ({ path, method, body }) => {
+    for (const respond of [
+      () => { throw new Error("synthetic transport loss after dispatch") },
+      () => new Response("not JSON", { status: 200 }),
+      () => Response.json({}, { status: 200 }),
+      () => Response.json({ error: "synthetic" }, { status: 503 }),
+      () => Response.json({}, { status: 202 }),
+    ]) {
+      const h = harness({ respond })
+      const response = await h.request(path, method, body)
+      expect(response.status).toBe(502)
+      const receipt = await response.json()
+      expect(receipt.ok).toBeUndefined()
+      expect(receipt.message).toMatch(/check.*before retrying|check whether.*before retrying/i)
+      expect(h.calls).toHaveLength(1)
+    }
+  })
+  test.each([401, 403, 404, 429])("provider HTTP %s remains a failure and is not retried", async (status) => {
+    const h = harness({ respond: () => Response.json({ error: "do not leak provider details" }, { status }) })
+    const response = await h.request("/drive-folders", "POST", { name: "Folder" })
+    expect(response.status).toBe(status === 401 || status === 403 ? 409 : 502)
+    expect(await response.text()).not.toContain("do not leak provider details")
+    expect(h.calls).toHaveLength(1)
+  })
+  test("read failure does not return success-shaped empty data", async () => {
+    const h = harness({ respond: () => Response.json({}) })
+    for (const path of ["/calendar-events/event_1", "/spreadsheets/sheet_1", "/spreadsheets/sheet_1/values?range=A1", "/drive-files/file_1"]) expect((await h.request(path)).status).toBe(502)
+  })
+  test("provider JSON is bounded before parsing, even for otherwise ignored fields", async () => {
+    const h = harness({ respond: () => Response.json({ ...spreadsheet, ignored: "x".repeat(6 * 1024 * 1024) }) })
+    expect((await h.request("/spreadsheets/sheet_1")).status).toBe(502)
+    expect(h.calls).toHaveLength(1)
+  })
+  test("mismatched IDs, unapplied metadata, and zero-cell receipts are not confirmations", async () => {
+    for (const [payload, path, method, body] of [
+      [{ ...event, id: "different_event" }, "/calendar-events/event_1", "PATCH", { summary: "Planning" }],
+      [{ id: "event_1", status: "confirmed" }, "/calendar-events/event_1", "PATCH", { summary: "Planning" }],
+      [event, "/calendar-events/event_1", "PATCH", { start: { date: "2026-09-12" }, end: { date: "2026-09-13" } }],
+      [event, "/calendar-events/event_1", "PATCH", { attendees: [{ email: "different@example.com" }] }],
+      [file, "/drive-files/file_1", "PATCH", { trashed: true, confirmTrash: true }],
+      [file, "/drive-files/file_1", "PATCH", { addParentId: "parent_2", removeParentId: "parent_1" }],
+      [file, "/drive-folders", "POST", { name: "Folder", parentId: "different_parent" }],
+      [{ ...update, updatedCells: 0 }, "/spreadsheets/sheet_1/values", "PUT", { range: "A1:C1", values: [[1, 2, 3]] }],
+      [{ ...update, updatedCells: 2 }, "/spreadsheets/sheet_1/values", "PUT", { range: "A1:C1", values: [[1, 2, 3]] }],
+      [{ ...spreadsheet, spreadsheetId: "different_sheet" }, "/spreadsheets/sheet_1", "GET", undefined],
+    ] as const) {
+      const h = harness({ respond: () => Response.json(payload) })
+      expect((await h.request(path, method, body)).status).toBe(502)
+    }
+  })
+  test("rejects arbitrary URL, query, and payload extensions instead of proxying them", async () => {
+    const h = harness()
+    expect((await h.request("/spreadsheets/sheet_1?includeGridData=true")).status).toBe(400)
+    expect((await h.request("/spreadsheets/sheet_1/values?range=A1&url=https://example.com")).status).toBe(400)
+    expect((await h.request("/drive-folders", "POST", { name: "x", url: "https://example.com" })).status).toBe(400)
+    expect((await h.request("/calendar-events/event_1?calendarId=selected&sendUpdates=all", "PATCH", { summary: "x" })).status).toBe(400)
+    expect(h.calls).toHaveLength(0)
+  })
+  test("emits explicit OpenAPI request and receipt schemas for parent discovery", async () => {
+    const h = harness()
+    const spec = await generateSpecs(h.app)
+    expect(buildMcpCatalog(spec).map((operation) => operation.name).sort()).toEqual([
+      "getGoogleCalendarEvent", "updateGoogleCalendarEvent", "deleteGoogleCalendarEvent", "getGoogleSpreadsheet",
+      "createGoogleSpreadsheet", "getGoogleSheetsValues", "updateGoogleSheetsValues", "appendGoogleSheetsValues",
+      "createGoogleDriveFolder", "getGoogleDriveFileMetadata", "updateGoogleDriveFileMetadata",
+    ].sort())
+    expect(spec.paths?.[base + "/calendar-events/{eventId}"]?.patch?.responses?.["200"]).toBeDefined()
+    expect(spec.paths?.[base + "/spreadsheets/{spreadsheetId}/values"]?.put?.requestBody).toBeDefined()
+    expect(spec.paths?.[base + "/spreadsheets/{spreadsheetId}/values/append"]?.post?.responses?.["200"]).toBeDefined()
+    expect(spec.paths?.[base + "/drive-files/{fileId}"]?.delete).toBeUndefined()
+  })
+})

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -77,6 +77,7 @@ function decodeDraftTextBody(): string {
 }
 
 const GMAIL_READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
+const GMAIL_MODIFY_SCOPE = "https://www.googleapis.com/auth/gmail.modify"
 const CALENDAR_READ_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
 const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
 const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
@@ -105,6 +106,9 @@ let forceDriveAuthorizationError = false
 let forceDriveShareForbidden = false
 let largeDriveContentHitCount = 0
 let gmailListMessageIds = ["msg_1"]
+let gmailNextPageToken: unknown = undefined
+let driveNextPageToken: unknown = undefined
+let driveIncompleteSearch: unknown = undefined
 let gmailMetadataDelayMs = 0
 let gmailMetadataFailureId: string | null = null
 let activeGmailMetadataRequests = 0
@@ -135,6 +139,9 @@ function resetFakeGoogle() {
   forceDriveShareForbidden = false
   largeDriveContentHitCount = 0
   gmailListMessageIds = ["msg_1"]
+  gmailNextPageToken = undefined
+  driveNextPageToken = undefined
+  driveIncompleteSearch = undefined
   gmailMetadataDelayMs = 0
   gmailMetadataFailureId = null
   activeGmailMetadataRequests = 0
@@ -191,7 +198,7 @@ const fakeGoogleServer = Bun.serve({
     }
 
     if (url.pathname === "/gmail/v1/users/me/messages") {
-      return json({ messages: gmailListMessageIds.map((id) => ({ id, threadId: `thread_${id.replace(/^msg_/, "")}` })) })
+      return json({ messages: gmailListMessageIds.map((id) => ({ id, threadId: `thread_${id.replace(/^msg_/, "")}` })), nextPageToken: gmailNextPageToken })
     }
     const gmailMessageMatch = url.pathname.match(/^\/gmail\/v1\/users\/me\/messages\/([^/]+)$/)
     if (gmailMessageMatch?.[1]) {
@@ -317,6 +324,8 @@ const fakeGoogleServer = Bun.serve({
         }, 403)
       }
       return json({
+        nextPageToken: driveNextPageToken,
+        incompleteSearch: driveIncompleteSearch,
         files: [
           {
             id: "file_1",
@@ -449,6 +458,18 @@ const fakeGoogleServer = Bun.serve({
     }
     if (url.pathname === "/drive/v3/files/doc_1/export") {
       return new Response(driveDocumentText, { headers: { "content-type": "text/plain" } })
+    }
+    if (url.pathname === "/drive/v3/files/sheet_1") {
+      return json({
+        id: "sheet_1",
+        name: "Planning workbook",
+        mimeType: "application/vnd.google-apps.spreadsheet",
+        webViewLink: "https://docs.google.com/spreadsheets/d/sheet_1/edit",
+      })
+    }
+    if (url.pathname === "/drive/v3/files/sheet_1/export") {
+      if (url.searchParams.get("mimeType") !== "text/csv") return new Response("Unsupported export type", { status: 400 })
+      return new Response("Task,Status\r\nPlanning,Ready\r\n", { headers: { "content-type": "text/csv" } })
     }
 
     return new Response(`Unhandled fake Google route: ${url.pathname}`, { status: 404 })
@@ -923,6 +944,60 @@ test("gmail list overlaps metadata requests with bounded concurrency and preserv
   expect(messages.map((message) => message.id)).toEqual(gmailListMessageIds)
   expect(maxActiveGmailMetadataRequests).toBeGreaterThan(1)
   expect(maxActiveGmailMetadataRequests).toBeLessThanOrEqual(4)
+})
+
+test("gmail list forwards opaque page tokens and preserves the provider's next page", async () => {
+  gmailNextPageToken = "next+/= page"
+  const query = new URLSearchParams({ q: "from:ada", maxResults: "5", pageToken: "current+/= page" })
+  const response = await request(`/v1/capabilities/google-workspace/gmail-messages?${query}`)
+  expect(response.status).toBe(200)
+  const url = new URL(expectString(googleCallUrls[0], "Gmail list URL"))
+  expect(url.pathname).toBe("/gmail/v1/users/me/messages")
+  expect(url.searchParams.get("q")).toBe("from:ada")
+  expect(url.searchParams.get("maxResults")).toBe("5")
+  expect(url.searchParams.get("pageToken")).toBe("current+/= page")
+  const body = expectRecord(await response.json(), "paginated Gmail response")
+  expect(body.nextPageToken).toBe(gmailNextPageToken)
+  expect(body.messages).toHaveLength(1)
+  expect(googleCallCount).toBe(2)
+})
+
+test("gmail empty pages retain continuation without requesting message metadata", async () => {
+  gmailListMessageIds = []
+  gmailNextPageToken = "next-empty-page"
+  const response = await request("/v1/capabilities/google-workspace/gmail-messages")
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ ok: true, messages: [], nextPageToken: "next-empty-page" })
+  expect(googleCallCount).toBe(1)
+  expect(new URL(expectString(googleCallUrls[0], "Gmail list URL")).searchParams.get("pageToken")).toBeNull()
+})
+
+test.each(["", "x".repeat(2049)])("gmail rejects invalid page token (case %#) before calling Google", async (pageToken) => {
+  const response = await request(`/v1/capabilities/google-workspace/gmail-messages?${new URLSearchParams({ pageToken })}`)
+  expect(response.status).toBe(400)
+  expect(expectRecord(await response.json(), "invalid Gmail pagination").error).toBe("invalid_request")
+  expect(googleCallCount).toBe(0)
+})
+
+test.each([
+  "/v1/capabilities/google-workspace/gmail-messages",
+  "/v1/capabilities/google-workspace/gmail-message/msg_1",
+  "/v1/capabilities/google-workspace/gmail-attachment/msg_1/att_1",
+])("gmail.modify authorizes existing read route %s", async (path) => {
+  await seedConnectedAccount([GMAIL_MODIFY_SCOPE])
+  const response = await request(path)
+  expect(response.status).toBe(200)
+  expect(expectRecord(await response.json(), "Gmail modify-scope read").ok).toBe(true)
+  expect(lastAuthorization).toBe("Bearer gws-token")
+  expect(googleCallCount).toBe(path.endsWith("gmail-messages") ? 2 : 1)
+})
+
+test("gmail scope implications reject lookalike grants before calling Google", async () => {
+  await seedConnectedAccount([`${GMAIL_MODIFY_SCOPE}.lookalike`, `prefix.${GMAIL_READ_SCOPE}`])
+  const response = await request("/v1/capabilities/google-workspace/gmail-messages")
+  expect(response.status).toBe(409)
+  expect(expectRecord(await response.json(), "Gmail lookalike grant response").error).toBe("needs_connection")
+  expect(googleCallCount).toBe(0)
 })
 
 test("gmail metadata failure stops new work and returns the existing upstream error shape", async () => {
@@ -1400,7 +1475,71 @@ test("drive search returns mapped files", async () => {
   expect(url.searchParams.get("supportsAllDrives")).toBe("true")
   expect(url.searchParams.get("includeItemsFromAllDrives")).toBe("true")
   expect(url.searchParams.get("orderBy")).toBeNull()
-  expect(url.searchParams.get("fields")).toBe("files(id,name,mimeType,modifiedTime,webViewLink,size)")
+  expect(url.searchParams.get("fields")).toBe("files(id,name,mimeType,modifiedTime,webViewLink,size),nextPageToken,incompleteSearch")
+  expect(url.searchParams.get("pageToken")).toBeNull()
+})
+
+test("Drive lists files without search text and retains continuation and incomplete coverage", async () => {
+  driveNextPageToken = "drive-next+/= page"
+  driveIncompleteSearch = true
+  const response = await request("/v1/capabilities/google-workspace/drive-files")
+  expect(response.status).toBe(200)
+  expect(lastDriveQuery).toBe("trashed = false")
+  const url = new URL(expectString(googleCallUrls[0], "Drive list URL"))
+  expect(url.searchParams.get("pageSize")).toBe("10")
+  expect(url.searchParams.get("pageToken")).toBeNull()
+  const body = expectRecord(await response.json(), "Drive list response")
+  expect(body.ok).toBe(true)
+  expect(body.files).toHaveLength(1)
+  expect(body.nextPageToken).toBe(driveNextPageToken)
+  expect(body.incompleteSearch).toBe(true)
+  expect(googleCallCount).toBe(1)
+})
+
+test.each([undefined, "quarterly"])("Drive combines date and folder filters with optional search (case %#)", async (query) => {
+  driveIncompleteSearch = false
+  const params = new URLSearchParams({
+    modifiedAfter: "2026-09-03T17:00:00+02:00", folderId: "folder_1-a", pageToken: "drive-current+/= page", maxResults: "3",
+  })
+  if (query) params.set("query", query)
+  const response = await request(`/v1/capabilities/google-workspace/drive-files?${params}`)
+  expect(response.status).toBe(200)
+  expect(lastDriveQuery).toBe(`${query ? "trashed = false and (name contains 'quarterly' or fullText contains 'quarterly')" : "trashed = false"} and modifiedTime > '2026-09-03T17:00:00+02:00' and 'folder_1-a' in parents`)
+  const url = new URL(expectString(googleCallUrls[0], "filtered Drive URL"))
+  expect(url.searchParams.get("pageToken")).toBe("drive-current+/= page")
+  expect(url.searchParams.get("pageSize")).toBe("3")
+  const body = expectRecord(await response.json(), "filtered Drive response")
+  expect(body.incompleteSearch).toBe(false)
+  expect(body).not.toHaveProperty("nextPageToken")
+  expect(googleCallCount).toBe(1)
+})
+
+test.each([
+  ["modifiedAfter", "2026-09-03"],
+  ["modifiedAfter", "2026-09-03T17:00:00"],
+  ["modifiedAfter", "2026-09-03T17:00:00Z' or trashed = true"],
+  ["folderId", "folder_1' or 'x' in parents"],
+  ["folderId", "folder/child"],
+  ["pageToken", ""],
+  ["pageToken", "x".repeat(2049)],
+])("Drive rejects invalid %s (case %#) before calling Google", async (key, value) => {
+  const response = await request(`/v1/capabilities/google-workspace/drive-files?${new URLSearchParams({ [key]: value })}`)
+  expect(response.status).toBe(400)
+  expect(expectRecord(await response.json(), "invalid Drive filter response").error).toBe("invalid_request")
+  expect(googleCallCount).toBe(0)
+})
+
+test("listing responses omit malformed provider pagination fields", async () => {
+  gmailNextPageToken = 123
+  driveNextPageToken = 123
+  driveIncompleteSearch = "false"
+  for (const path of ["gmail-messages", "drive-files"]) {
+    const response = await request(`/v1/capabilities/google-workspace/${path}`)
+    expect(response.status).toBe(200)
+    const body = expectRecord(await response.json(), "malformed provider pagination response")
+    expect(body).not.toHaveProperty("nextPageToken")
+    expect(body).not.toHaveProperty("incompleteSearch")
+  }
 })
 
 test("Google Drive authorization failures become an actionable connector response", async () => {
@@ -1565,6 +1704,27 @@ test("drive file read keeps the Google Apps text export branch", async () => {
   const file = expectRecord(expectRecord(body, "Google Apps response").file, "Google Apps file")
   expect(file.encoding).toBe("text")
   expect(file.content).toBe("Exported doc text")
+  const url = new URL(expectString(googleCallUrls[1], "Google Docs export URL"))
+  expect(url.pathname).toBe("/drive/v3/files/doc_1/export")
+  expect(url.searchParams.get("mimeType")).toBe("text/plain")
+})
+
+test("generic Drive spreadsheet read exports first-tab CSV rather than plain text", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file/sheet_1")
+  expect(response.status).toBe(200)
+  expect(lastAuthorization).toBe("Bearer gws-token")
+  expect(googleCallCount).toBe(2)
+  const file = expectRecord(expectRecord(await response.json(), "spreadsheet export response").file, "spreadsheet file")
+  expect(file.id).toBe("sheet_1")
+  expect(file.mimeType).toBe("application/vnd.google-apps.spreadsheet")
+  expect(file.encoding).toBe("text")
+  expect(file.content).toBe("Task,Status\r\nPlanning,Ready\r\n")
+  expect(file.contentBase64).toBeNull()
+  expect(file.truncated).toBe(false)
+  const url = new URL(expectString(googleCallUrls[1], "spreadsheet export URL"))
+  expect(url.pathname).toBe("/drive/v3/files/sheet_1/export")
+  expect(url.searchParams.get("mimeType")).toBe("text/csv")
+  expect(googleCallUrls.some((value) => new URL(value).pathname.startsWith("/v4/spreadsheets"))).toBe(false)
 })
 
 test("drive text retains the existing retrieval limit before MCP serialization", async () => {
@@ -1797,6 +1957,31 @@ test("legacy accounts without recorded scopes retain existing non-Drive behavior
   expect(googleCallCount).toBe(1)
 })
 
+test("new Google actions fail closed on unknown grants independently of legacy routes", async () => {
+  const grants: (string[] | null)[] = [null, [], ["openid"]]
+  const actions = [
+    { path: "gmail-labels" },
+    { path: "gmail-labels", method: "POST", body: { name: "Planning" } },
+    { path: "gmail-message/msg_1/modify", method: "POST", body: { removeLabelIds: ["UNREAD"] } },
+    { path: "spreadsheets/sheet_1" },
+    { path: "spreadsheets/sheet_1/values?range=A1:B2" },
+    { path: "spreadsheets/sheet_1/values", method: "PUT", body: { range: "A1", values: [["Planning"]] } },
+    { path: "drive-files/file_1" },
+    { path: "drive-folders", method: "POST", body: { name: "Planning" } },
+    { path: "calendar-events/event_1" },
+  ]
+  for (const scopes of grants) {
+    await seedConnectedAccount(scopes)
+    for (const action of actions) {
+      resetFakeGoogle()
+      const response = await request(`/v1/capabilities/google-workspace/${action.path}`, action)
+      expect(response.status).toBe(409)
+      expect(expectRecord(await response.json(), "unknown-grant action response").error).toBe("needs_connection")
+      expect(googleCallCount).toBe(0)
+    }
+  }
+})
+
 test("no connected account returns needs_connection", async () => {
   await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
   const response = await request("/v1/capabilities/google-workspace/calendar-events?timeMin=2026-07-08T00%3A00%3A00Z&timeMax=2026-07-11T00%3A00%3A00Z")
@@ -1845,13 +2030,13 @@ test("Google Workspace capability tools are discoverable and keep readable names
   expect(searchCapabilities(catalog, "add meet link existing event", 10)[0]?.name).toBe("patchCapabilitiesGoogleWorkspaceCalendarEvent")
   const driveMatch = searchCapabilities(catalog, "drive files", 10)[0]
   expect(driveMatch?.name).toBe("getCapabilitiesGoogleWorkspaceDriveFiles")
-  expect(driveMatch?.queryParams).toEqual(["query", "maxResults"])
+  expect(driveMatch?.queryParams).toEqual(["query", "maxResults", "pageToken", "modifiedAfter", "folderId"])
   expect(catalog.some((tool) => tool.name === "postCapabilitiesGoogleWorkspaceDriveFiles")).toBe(false)
   expect(catalog.some((tool) => tool.name.includes("DirectUploads"))).toBe(false)
   expect(searchCapabilities(catalog, "share drive file", 10)[0]?.name).toBe("postCapabilitiesGoogleWorkspaceDriveFileShare")
   const gmailMatch = searchCapabilities(catalog, "gmail search read messages", 10)[0]
   expect(gmailMatch?.name).toBe("getCapabilitiesGoogleWorkspaceGmailMessages")
-  expect(gmailMatch?.queryParams).toEqual(["q", "maxResults"])
+  expect(gmailMatch?.queryParams).toEqual(["q", "maxResults", "pageToken"])
   expect(searchCapabilities(catalog, "outlook mail messages", 20).find((match) => match.name === "getCapabilitiesMicrosoft365MailMessages")?.queryParams).toEqual(["search", "maxResults"])
   const draftMatch = searchCapabilities(catalog, "gmail draft attachments", 10)[0]
   expect(draftMatch?.name).toBe("postCapabilitiesGoogleWorkspaceGmailDrafts")

--- a/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
+++ b/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test"
 import { and, eq, inArray, sql } from "@openwork-ee/den-db/drizzle"
 import {
   AuthUserTable,
@@ -526,6 +526,56 @@ describe("marketplace cloud readiness payload", () => {
     const resolved = await resolvedPlugin({ context: org.context, marketplaceId: org.marketplaceId, pluginId: plugin.pluginId })
     expect(resolved.cloudReadiness?.state).toBe("ready")
     expect(resolved.cloudReadiness?.connections[0]).toMatchObject({ id: connectionId, credentialMode: "shared", connectedForMe: true })
+  })
+
+  test("GitHub reimport preserves stored none with either credential-mode default and rejects explicit OAuth", async () => {
+    const org = await seedOrg()
+    const url = "https://api.githubcopilot.com/mcp/"
+    const connectionId = await seedConnection({ org, name: "Legacy GitHub", url, credentialMode: "shared" })
+    let oauth = false
+    const files: Record<string, string> = {
+      ".claude-plugin/plugin.json": JSON.stringify({ name: "legacy-github", mcpServers: "./.mcp.json" }),
+    }
+    const fetchMock = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const requestUrl = new URL(typeof input === "string" || input instanceof URL ? input : input.url)
+      if (requestUrl.origin !== "https://api.github.com") throw new Error("Unexpected provider request")
+      const path = requestUrl.pathname.replace("/repos/fixture/legacy-plugin", "")
+      if (path === "") return Response.json({ default_branch: "main", private: false })
+      if (path === "/commits/main") return Response.json({ sha: "head", commit: { tree: { sha: "tree" } } })
+      if (path === "/git/trees/tree") return Response.json({ tree: [".claude-plugin/plugin.json", ".mcp.json"].map((path) => ({ path, type: "blob", sha: path })) })
+      const file = path.slice("/contents/".length)
+      const text = file === ".mcp.json" ? JSON.stringify({ mcpServers: { github: { url, oauth } } }) : files[file]
+      if (!path.startsWith("/contents/") || !text) throw new Error(`Unexpected import request: ${path}`)
+      return Response.json({ encoding: "base64", content: Buffer.from(text).toString("base64") })
+    })
+    try {
+      for (const credentialMode of ["shared", "per_member"] as const) {
+        await store.importGithubPluginMcps({
+          authType: "none", credentialMode, context: org.context,
+          name: `Legacy GitHub ${credentialMode}`,
+          githubUrl: "https://github.com/fixture/legacy-plugin", marketplaceId: org.marketplaceId,
+        })
+      }
+      const bindings = await db.select().from(PluginMcpRequirementBindingTable).where(eq(PluginMcpRequirementBindingTable.organizationId, org.organizationId))
+      expect(bindings).toHaveLength(2)
+      for (const binding of bindings) {
+        expect(binding).toMatchObject({ externalMcpConnectionId: connectionId, requiredAuthType: "none" })
+        expect((await resolvedPlugin({ context: org.context, marketplaceId: org.marketplaceId, pluginId: binding.pluginId })).cloudReadiness?.state).toBe("ready")
+      }
+      expect(connectExternalMcpMock).toHaveBeenCalledTimes(2)
+      oauth = true
+      await expect(store.importGithubPluginMcps({
+        authType: "none", credentialMode: "shared", context: org.context,
+        name: "Explicit OAuth GitHub",
+        githubUrl: "https://github.com/fixture/legacy-plugin",
+      })).rejects.toMatchObject({ status: 409, error: "external_mcp_connection_config_mismatch" })
+      expect(connectExternalMcpMock).toHaveBeenCalledTimes(2)
+      const connections = await db.select().from(ExternalMcpConnectionTable).where(eq(ExternalMcpConnectionTable.organizationId, org.organizationId))
+      expect(connections).toHaveLength(1)
+      expect(connections[0]).toMatchObject({ id: connectionId, authType: "none", credentialMode: "shared" })
+    } finally {
+      fetchMock.mockRestore()
+    }
   })
 
   test("misclassified Slack bindings stay blocked until an admin repairs OAuth setup", async () => {

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -1736,11 +1736,13 @@ test("shared-callback version-two state is rejected by the legacy callback even 
   expect(await response.json()).toEqual({ error: "invalid_request", message: "Invalid or expired state." })
 })
 
-test("non-OAuth create validation returns the same structured network diagnostic", async () => {
+test.each(["none", "apikey"] as const)("failed %s creation returns the diagnostic without retaining a ready connection", async (authType) => {
+  const name = `Broken ${authType} MCP`
   const response = await staleSessionRequest("/v1/mcp-connections", "POST", {
-    name: "Broken no-auth MCP",
+    name,
     url: "http://127.0.0.1:9/mcp",
-    authType: "none",
+    authType,
+    ...(authType === "apikey" ? { apiKey: "invalid-test-api-key" } : {}),
     credentialMode: "shared",
   })
   expect(response.status).toBe(502)
@@ -1757,6 +1759,14 @@ test("non-OAuth create validation returns the same structured network diagnostic
   })
   expect(typeof body.diagnostic.referenceId).toBe("string")
   expect(response.headers.get("x-request-id")).toBeNull()
+  const retained = await db.select().from(schema.ExternalMcpConnectionTable).where(drizzle.and(
+    drizzle.eq(schema.ExternalMcpConnectionTable.organizationId, organizationId),
+    drizzle.eq(schema.ExternalMcpConnectionTable.name, name),
+  ))
+  expect(retained).toHaveLength(0)
+  expect(await db.select().from(schema.ExternalMcpConnectionTable).where(
+    drizzle.eq(schema.ExternalMcpConnectionTable.id, seededConnectionId()),
+  )).toHaveLength(1)
 })
 
 test("connection configuration rejects credentials embedded in MCP URLs", async () => {

--- a/ee/apps/den-api/test/microsoft-365-routes.test.ts
+++ b/ee/apps/den-api/test/microsoft-365-routes.test.ts
@@ -1,6 +1,8 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-import { beforeAll, describe, expect, test } from "bun:test"
+import { beforeAll, describe, expect, spyOn, test } from "bun:test"
 import { Hono, type MiddlewareHandler } from "hono"
+import { generateSpecs } from "hono-openapi"
+import { buildMcpCatalog } from "../src/mcp/catalog.js"
 import type { OrganizationContext } from "../src/orgs.js"
 import type { OrgRouteVariables } from "../src/routes/org/shared.js"
 
@@ -73,6 +75,483 @@ function driveFileApp(graphFetch: typeof fetch): Hono<{ Variables: OrgRouteVaria
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
+
+const mutationCases: Array<{
+  name: string
+  method: "POST" | "PATCH" | "DELETE"
+  path: string
+  body: Record<string, unknown>
+  feature: string
+  scope: string
+  graphPath: string
+  graphBody: unknown
+  graphStatus: number
+  graphResponse: unknown
+  receipt: unknown
+}> = [
+  {
+    name: "send draft", method: "POST", path: "mail-drafts/draft_1/send", body: { confirmSend: true },
+    feature: "mailSend", scope: "Mail.Send", graphPath: "me/messages/draft_1/send", graphBody: null,
+    graphStatus: 202, graphResponse: null, receipt: { ok: true, draftId: "draft_1", status: "accepted" },
+  },
+  {
+    name: "reply draft", method: "POST", path: "mail-message/message_1/reply-draft", body: { comment: "Reply for review" },
+    feature: "mailDraft", scope: "Mail.ReadWrite", graphPath: "me/messages/message_1/createReply", graphBody: { comment: "Reply for review" },
+    graphStatus: 201, graphResponse: { id: "reply_1", isDraft: true, conversationId: "thread_1" },
+    receipt: { ok: true, draft: { id: "reply_1", isDraft: true, conversationId: "thread_1" } },
+  },
+  {
+    name: "update message", method: "PATCH", path: "mail-message/message_1", body: { isRead: false, categories: [] },
+    feature: "mailManage", scope: "Mail.ReadWrite", graphPath: "me/messages/message_1", graphBody: { isRead: false, categories: [] },
+    graphStatus: 200, graphResponse: { id: "message_1", isRead: false, categories: [] },
+    receipt: { ok: true, message: { id: "message_1", isRead: false, categories: [] } },
+  },
+  {
+    name: "move message", method: "POST", path: "mail-message/message_1/move", body: { destination: "deleteditems", confirmTrash: true },
+    feature: "mailManage", scope: "Mail.ReadWrite", graphPath: "me/messages/message_1/move", graphBody: { destinationId: "deleteditems" },
+    graphStatus: 201, graphResponse: { id: "moved_1", parentFolderId: "deleted_1" },
+    receipt: { ok: true, message: { id: "moved_1", parentFolderId: "deleted_1" } },
+  },
+  {
+    name: "reschedule event", method: "PATCH", path: "calendar-events/event_1",
+    body: { start: "2026-09-10T10:00:00Z", end: "2026-09-10T11:00:00Z", confirmNotifications: true },
+    feature: "calendarWrite", scope: "Calendars.ReadWrite", graphPath: "me/events/event_1",
+    graphBody: { start: { dateTime: "2026-09-10T10:00:00Z", timeZone: "UTC" }, end: { dateTime: "2026-09-10T11:00:00Z", timeZone: "UTC" } },
+    graphStatus: 200, graphResponse: { id: "event_1", start: { dateTime: "2026-09-10T10:00:00Z", timeZone: "UTC" } },
+    receipt: { ok: true, event: { id: "event_1", start: "2026-09-10T10:00:00Z" } },
+  },
+  {
+    name: "cancel event", method: "POST", path: "calendar-events/event_1/cancel", body: { confirmCancel: true, comment: "Cancelled" },
+    feature: "calendarWrite", scope: "Calendars.ReadWrite", graphPath: "me/events/event_1/cancel", graphBody: { comment: "Cancelled" },
+    graphStatus: 202, graphResponse: null, receipt: { ok: true, eventId: "event_1", status: "accepted" },
+  },
+  {
+    name: "delete event", method: "DELETE", path: "calendar-events/event_1", body: { confirmDelete: true },
+    feature: "calendarWrite", scope: "Calendars.ReadWrite", graphPath: "me/events/event_1", graphBody: null,
+    graphStatus: 204, graphResponse: null, receipt: { ok: true, eventId: "event_1", status: "deleted" },
+  },
+  {
+    name: "rename and move file", method: "PATCH", path: "drive-file/item_1", body: { name: "Plan.txt", parentId: "folder_1" },
+    feature: "filesWrite", scope: "Files.ReadWrite", graphPath: "me/drive/items/item_1", graphBody: { name: "Plan.txt", parentReference: { id: "folder_1" } },
+    graphStatus: 200, graphResponse: { id: "item_1", name: "Plan.txt", file: { mimeType: "text/plain" } },
+    receipt: { ok: true, file: { id: "item_1", name: "Plan.txt" } },
+  },
+  {
+    name: "create folder", method: "POST", path: "drive-folders", body: { name: "Plans", parentId: "folder_1" },
+    feature: "filesWrite", scope: "Files.ReadWrite", graphPath: "me/drive/items/folder_1/children",
+    graphBody: { name: "Plans", folder: {}, "@microsoft.graph.conflictBehavior": "fail" },
+    graphStatus: 201, graphResponse: { id: "folder_2", name: "Plans", folder: {} },
+    receipt: { ok: true, file: { id: "folder_2", name: "Plans", kind: "folder" } },
+  },
+]
+
+describe("Microsoft 365 bounded management routes", () => {
+  test("default resolver binds named connector configuration and token reads without a legacy fallback", async () => {
+    const credentials = await import("../src/capability-sources/oauth-credentials.js")
+    const connections = await import("../src/capability-sources/native-provider-connections.js")
+    const registry = await import("../src/capability-sources/provider-registry.js")
+    const orgs = await import("../src/orgs.js")
+    const session = await import("../src/session.js")
+    const context = organizationContext()
+    const otherContext = { ...context, currentMember: organizationContext().currentMember }
+    const teamId = createDenTypeId("team")
+    const writerId = createDenTypeId("externalMcpConnection")
+    const wrongProviderId = createDenTypeId("externalMcpConnection")
+    const unavailableId = createDenTypeId("externalMcpConnection")
+    const now = new Date()
+    let memberContext = context
+    let features = ["mailSend"]
+    let scopes: string[] | null = ["Mail.Send"]
+    let connected = true
+    let configured = true
+    let defaultCredentialId: string | null = "microsoft-365"
+    const provider = registry.getNativeOAuthProvider("microsoft-365")
+    const otherProvider = registry.getNativeOAuthProvider("google-workspace")
+    if (!provider || !otherProvider) throw new Error("Expected registered native providers")
+    const writer = connections.buildNativeProviderEntry(provider, { clientConfigured: true, connectedForMe: true, credentialProviderId: writerId, name: "Work mailbox" })
+    const other = connections.buildNativeProviderEntry(otherProvider, { clientConfigured: true, connectedForMe: true, credentialProviderId: wrongProviderId })
+    if (!writer || !other) throw new Error("Expected configured native entries")
+
+    const teams = spyOn(orgs, "listTeamsForMember").mockResolvedValue([
+      { id: teamId, organizationId: context.organization.id, name: "Writers", createdAt: now, updatedAt: now },
+    ])
+    const usable = spyOn(connections, "listNativeProviderUsableEntries").mockImplementation(async (input) => (
+      input.organizationId === context.organization.id && input.orgMembershipId === context.currentMember.id ? [writer, other] : []
+    ))
+    const defaults = spyOn(connections, "resolveDefaultNativeProviderCredentialId").mockImplementation(async () => defaultCredentialId)
+    const clients = spyOn(credentials, "getOrgOAuthClient").mockImplementation(async (organizationId, providerId) => {
+      if (!configured && providerId === writerId) return null
+      return {
+        id: createDenTypeId("orgOAuthClient"), organizationId, providerId, clientId: `client-${providerId}`,
+        clientSecret: null, extra: { features: providerId === writerId ? features : ["mailSend"] },
+        createdByOrgMembershipId: context.currentMember.id, createdAt: now, updatedAt: now,
+      }
+    })
+    const accounts = spyOn(credentials, "getConnectedAccount").mockImplementation(async (input) => {
+      if (input.providerId === writerId && !connected) return null
+      return {
+        id: createDenTypeId("connectedAccount"), ...input, externalAccountId: "fixture@example.test",
+        accessToken: input.providerId === writerId ? "named-writer-token" : "legacy-token",
+        scopes: input.providerId === writerId ? scopes : ["Mail.Send"], refreshToken: null, tokenType: "Bearer",
+        expiresAt: null, pendingCodeVerifier: null, credentialHealth: null, connectedAt: now, updatedAt: now,
+      }
+    })
+    const requests: Request[] = []
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerMicrosoft365Routes(app, {
+      memberRoute: async (c, next) => { c.set("organizationContext", memberContext); await next() },
+      fetch: async (input, init) => { requests.push(new Request(input, init)); return new Response(null, { status: 202 }) },
+    })
+    const request = (connectorId?: string, corruptHeader = false) => {
+      const identity = { userId: memberContext.currentMember.userId, organizationId: memberContext.organization.id }
+      const headers = new Headers({ "content-type": "application/json", "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader(identity) })
+      if (connectorId) headers.set(session.INTERNAL_CAPABILITY_CONNECTOR_HEADER,
+        corruptHeader ? "invalid-selection" : session.createInternalCapabilityConnectorHeader({ ...identity, connectorId }))
+      return app.request("http://den-api.local/v1/capabilities/microsoft-365/mail-drafts/draft_1/send", {
+        method: "POST", headers, body: JSON.stringify({ confirmSend: true }),
+      })
+    }
+    try {
+      const sent = await request(writerId)
+      expect(sent.status).toBe(200)
+      expect(await sent.json()).toEqual({ ok: true, draftId: "draft_1", status: "accepted" })
+      expect(teams).toHaveBeenCalledWith({ organizationId: context.organization.id, memberId: context.currentMember.id })
+      expect(usable).toHaveBeenCalledWith({ organizationId: context.organization.id, orgMembershipId: context.currentMember.id, teamIds: [teamId] })
+      expect(clients).toHaveBeenCalledWith(context.organization.id, writerId)
+      expect(accounts).toHaveBeenCalledWith({ organizationId: context.organization.id, orgMembershipId: context.currentMember.id, providerId: writerId })
+      expect(defaults).not.toHaveBeenCalled()
+      expect(requests[0]?.headers.get("authorization")).toBe("Bearer named-writer-token")
+
+      // A privileged legacy account must not rescue a disabled, under-scoped,
+      // disconnected, or inaccessible explicitly selected named connector.
+      features = ["mailRead"]
+      expect((await request(writerId)).status).toBe(409)
+      features = ["mailSend"]
+      scopes = ["Mail.ReadWrite"]
+      expect((await request(writerId)).status).toBe(409)
+      scopes = null
+      expect((await request(writerId)).status).toBe(409)
+      scopes = ["Mail.Send"]
+      connected = false
+      expect((await request(writerId)).status).toBe(409)
+      connected = true
+      configured = false
+      const accountReads = accounts.mock.calls.length
+      expect((await request(writerId)).status).toBe(409)
+      expect(accounts.mock.calls).toHaveLength(accountReads)
+      configured = true
+      clients.mockClear()
+      accounts.mockClear()
+      expect((await request(unavailableId)).status).toBe(409)
+      expect((await request(wrongProviderId)).status).toBe(409)
+      expect((await request(writerId, true)).status).toBe(409)
+      memberContext = otherContext
+      expect((await request(writerId)).status).toBe(409)
+      expect(clients).not.toHaveBeenCalled()
+      expect(accounts).not.toHaveBeenCalled()
+      expect(defaults).not.toHaveBeenCalled()
+      expect(requests).toHaveLength(1)
+
+      memberContext = context
+      defaultCredentialId = writerId
+      expect((await request()).status).toBe(200)
+      expect(defaults).toHaveBeenCalledWith({ organizationId: context.organization.id, orgMembershipId: context.currentMember.id, nativeProviderKey: "microsoft-365", teamIds: [teamId] })
+      expect(requests[1]?.headers.get("authorization")).toBe("Bearer named-writer-token")
+      defaultCredentialId = "microsoft-365"
+      expect((await request()).status).toBe(200)
+      expect(requests[2]?.headers.get("authorization")).toBe("Bearer legacy-token")
+      defaultCredentialId = null
+      expect((await request()).status).toBe(409)
+      expect(requests).toHaveLength(3)
+    } finally {
+      teams.mockRestore()
+      usable.mockRestore()
+      defaults.mockRestore()
+      clients.mockRestore()
+      accounts.mockRestore()
+    }
+  })
+
+  for (const mutation of mutationCases) {
+    test(`${mutation.name} uses only the authenticated member and returns the exact provider receipt`, async () => {
+      const context = organizationContext()
+      const otherContext = organizationContext()
+      const resolvedIds: Array<{ organizationId: string; orgMembershipId: string }> = []
+      const requests: Request[] = []
+      const graphFetch: typeof fetch = async (input, init) => {
+        const request = new Request(input, init)
+        requests.push(request)
+        expect(request.url).toBe(`https://graph.example.test/v1.0/${mutation.graphPath}`)
+        expect(request.method).toBe(mutation.method)
+        expect(request.headers.get("authorization")).toBe("Bearer selected-member-token")
+        expect(request.redirect).toBe("error")
+        expect(request.signal).toBeDefined()
+        expect(await request.text()).toBe(mutation.graphBody === null ? "" : JSON.stringify(mutation.graphBody))
+        return mutation.graphResponse === null ? new Response(null, { status: mutation.graphStatus }) : Response.json(mutation.graphResponse, { status: mutation.graphStatus })
+      }
+      function makeApp(memberContext: OrganizationContext) {
+        const app = new Hono<{ Variables: OrgRouteVariables }>()
+        routes.registerMicrosoft365Routes(app, {
+          graphBaseUrl: "https://graph.example.test/v1.0", fetch: graphFetch, memberRoute: contextMiddleware(memberContext),
+          resolveAccessToken: async (input) => {
+            resolvedIds.push(input)
+            if (input.organizationId !== context.organization.id || input.orgMembershipId !== context.currentMember.id) {
+              return { kind: "needs_connection", message: "This member has no connected account." }
+            }
+            return { kind: "ok", accessToken: "selected-member-token", scopes: [mutation.scope], enabledFeatures: [mutation.feature] }
+          },
+        })
+        return app
+      }
+      const init = { method: mutation.method, headers: { "content-type": "application/json" }, body: JSON.stringify(mutation.body) }
+      const response = await makeApp(context).request(`http://den-api.local/v1/capabilities/microsoft-365/${mutation.path}?orgMembershipId=${otherContext.currentMember.id}`, init)
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject(mutation.receipt)
+      expect(requests).toHaveLength(1)
+      const denied = await makeApp(otherContext).request(`http://den-api.local/v1/capabilities/microsoft-365/${mutation.path}?orgMembershipId=${context.currentMember.id}`, init)
+      expect(denied.status).toBe(409)
+      expect(requests).toHaveLength(1)
+      expect(resolvedIds).toEqual([
+        { organizationId: context.organization.id, orgMembershipId: context.currentMember.id },
+        { organizationId: otherContext.organization.id, orgMembershipId: otherContext.currentMember.id },
+      ])
+    })
+
+    test(`${mutation.name} fails closed for missing, unknown, mismatched, or disabled grants`, async () => {
+      const grants: Array<{ scopes: string[] | null; enabledFeatures: string[] }> = [
+        { scopes: null, enabledFeatures: [mutation.feature] },
+        { scopes: [], enabledFeatures: [mutation.feature] },
+        { scopes: ["Unknown.Scope"], enabledFeatures: [mutation.feature] },
+        { scopes: ["Mail.Read", "Calendars.Read", "Files.Read"], enabledFeatures: [mutation.feature] },
+        { scopes: [mutation.feature === "mailSend" ? "Mail.ReadWrite" : "Mail.Send"], enabledFeatures: [mutation.feature] },
+        { scopes: [mutation.scope], enabledFeatures: [] },
+        { scopes: [mutation.scope], enabledFeatures: ["unknownFeature"] },
+      ]
+      let calls = 0
+      for (const grant of grants) {
+        const app = new Hono<{ Variables: OrgRouteVariables }>()
+        routes.registerMicrosoft365Routes(app, {
+          memberRoute: contextMiddleware(organizationContext()),
+          fetch: async () => { calls += 1; throw new Error("Must not call Graph") },
+          resolveAccessToken: async () => ({ kind: "ok", accessToken: "token", ...grant }),
+        })
+        const response = await app.request(`http://den-api.local/v1/capabilities/microsoft-365/${mutation.path}`, {
+          method: mutation.method, headers: { "content-type": "application/json" }, body: JSON.stringify(mutation.body),
+        })
+        expect(response.status).toBe(409)
+        expect(await response.json()).toMatchObject({ error: "needs_connection" })
+      }
+      expect(calls).toBe(0)
+    })
+
+    test(`${mutation.name} rejects bodies over 1 MiB before JSON validation, including chunked bodies`, async () => {
+      let calls = 0
+      const app = new Hono<{ Variables: OrgRouteVariables }>()
+      routes.registerMicrosoft365Routes(app, {
+        memberRoute: contextMiddleware(organizationContext()),
+        resolveAccessToken: async () => { calls += 1; throw new Error("Must not resolve credentials") },
+        fetch: async () => { calls += 1; throw new Error("Must not call Graph") },
+      })
+      const bytes = new TextEncoder().encode(" ".repeat(1024 * 1024 + 1))
+      for (const framing of ["content-length", "chunked", "unframed"]) {
+        const headers = new Headers({ "content-type": "application/json" })
+        if (framing === "content-length") headers.set("content-length", String(bytes.byteLength))
+        if (framing === "chunked") headers.set("transfer-encoding", "chunked")
+        let offset = 0
+        const body = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (offset === bytes.byteLength) { controller.close(); return }
+            const end = Math.min(offset + 64 * 1024, bytes.byteLength)
+            controller.enqueue(bytes.slice(offset, end))
+            offset = end
+          },
+        })
+        const response = await app.request(`http://den-api.local/v1/capabilities/microsoft-365/${mutation.path}`, { method: mutation.method, headers, body })
+        expect(response.status).toBe(413)
+        expect(await response.json()).toMatchObject({ error: "invalid_request" })
+      }
+      expect(calls).toBe(0)
+    })
+  }
+
+  test("advertises every mutation with discovery tags, bounded bodies, and receipt schemas", async () => {
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    const { registerGoogleWorkspaceRoutes } = await import("../src/routes/org/google-workspace.js")
+    registerGoogleWorkspaceRoutes(app)
+    routes.registerMicrosoft365Routes(app, {
+      memberRoute: contextMiddleware(organizationContext()),
+      resolveAccessToken: async () => { throw new Error("Discovery must not resolve credentials") },
+      fetch: async () => { throw new Error("Discovery must not contact Graph") },
+    })
+    const spec = await generateSpecs(app)
+    const catalog = buildMcpCatalog(spec)
+    const mutationNames: string[] = []
+    for (const mutation of mutationCases) {
+      const path = `/v1/capabilities/microsoft-365/${mutation.path}`
+        .replace(/draft_1|message_1/, "{messageId}").replace("event_1", "{eventId}").replace("item_1", "{itemId}")
+      const pathItem = spec.paths[path]
+      const operation = mutation.method === "POST" ? pathItem?.post : mutation.method === "PATCH" ? pathItem?.patch : pathItem?.delete
+      expect(operation?.tags).toContain("Capability Sources")
+      expect(operation?.requestBody).toBeDefined()
+      expect(operation?.responses?.["200"]).toBeDefined()
+      expect(operation?.description).toContain("Never automatically retry")
+      const entry = catalog.find((entry) => entry.path === path && entry.method === mutation.method)
+      expect(entry?.name).toBe(operation?.operationId)
+      if (entry) mutationNames.push(entry.name)
+    }
+    expect(mutationNames.sort()).toEqual([
+      "sendMicrosoft365MailDraft", "createMicrosoft365ReplyDraft", "updateMicrosoft365MailMessage", "moveMicrosoft365MailMessage",
+      "updateMicrosoft365CalendarEvent", "cancelMicrosoft365CalendarEvent", "deleteMicrosoft365CalendarEvent",
+      "updateMicrosoft365DriveItem", "createMicrosoft365DriveFolder",
+    ].sort())
+    expect(catalog.find((entry) => entry.path === "/v1/capabilities/microsoft-365/mail-messages")?.name).toBe("getCapabilitiesMicrosoft365MailMessages")
+    for (const name of [
+      "getCapabilitiesGoogleWorkspaceGmailMessages", "getCapabilitiesGoogleWorkspaceGmailMessage",
+      "getCapabilitiesGoogleWorkspaceGmailAttachment", "getCapabilitiesGoogleWorkspaceCalendarEvents",
+      "postCapabilitiesGoogleWorkspaceCalendarEvents", "patchCapabilitiesGoogleWorkspaceCalendarEvent",
+      "getCapabilitiesGoogleWorkspaceDriveFiles", "getCapabilitiesGoogleWorkspaceDriveFile",
+      "postCapabilitiesGoogleWorkspaceDriveFileShare", "postCapabilitiesGoogleWorkspaceGmailDrafts",
+    ]) expect(catalog.some((entry) => entry.name === name)).toBe(true)
+    const management = catalog.filter((entry) => /^(?:\w+Gmail|\w+Google(?:Calendar|Spreadsheet|Sheets|Drive)|\w+Microsoft365)/.test(entry.name) && !entry.name.includes("Capabilities"))
+    expect(management).toHaveLength(32)
+    for (const entry of management) {
+      expect(entry.name).not.toContain("_")
+      expect(`openwork-cloud_${entry.name}`.length).toBeLessThanOrEqual(64)
+    }
+    expect(spec.components.schemas?.Microsoft365MailSendBody).toMatchObject({ additionalProperties: false, required: ["confirmSend"] })
+  })
+
+  test("unauthenticated mutation requests never resolve credentials or call Graph", async () => {
+    let calls = 0
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerMicrosoft365Routes(app, {
+      memberRoute: async (c) => c.json({ error: "unauthorized" }, 401),
+      resolveAccessToken: async () => { calls += 1; throw new Error("Must not resolve credentials") },
+      fetch: async () => { calls += 1; throw new Error("Must not call Graph") },
+    })
+    for (const mutation of mutationCases) {
+      const response = await app.request(`http://den-api.local/v1/capabilities/microsoft-365/${mutation.path}`, {
+        method: mutation.method, headers: { "content-type": "application/json" }, body: JSON.stringify(mutation.body),
+      })
+      expect(response.status).toBe(401)
+    }
+    expect(calls).toBe(0)
+  })
+
+  test("unknown scopes fail closed on existing reads too", async () => {
+    let calls = 0
+    for (const scopes of [null, []]) {
+      const app = new Hono<{ Variables: OrgRouteVariables }>()
+      routes.registerMicrosoft365Routes(app, {
+        memberRoute: contextMiddleware(organizationContext()),
+        fetch: async () => { calls += 1; return Response.json({ value: [] }) },
+        resolveAccessToken: async () => ({ kind: "ok", accessToken: "token", scopes, enabledFeatures: ["mailRead"] }),
+      })
+      expect((await app.request("http://den-api.local/v1/capabilities/microsoft-365/mail-messages")).status).toBe(409)
+    }
+    expect(calls).toBe(0)
+  })
+
+  test("draft permissions never grant sending or mail management", async () => {
+    let calls = 0
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerMicrosoft365Routes(app, {
+      memberRoute: contextMiddleware(organizationContext()),
+      fetch: async () => { calls += 1; throw new Error("Must not call Graph") },
+      resolveAccessToken: async () => ({ kind: "ok", accessToken: "token", scopes: ["Mail.ReadWrite", "Mail.Send"], enabledFeatures: ["mailDraft"] }),
+    })
+    for (const path of ["mail-drafts/draft_1/send", "mail-message/message_1/move"]) {
+      const response = await app.request(`http://den-api.local/v1/capabilities/microsoft-365/${path}`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(path.endsWith("send") ? { confirmSend: true } : { destination: "archive" }),
+      })
+      expect(response.status).toBe(409)
+    }
+    expect(calls).toBe(0)
+  })
+
+  test("rejects missing send confirmation, arbitrary fields, invalid bounds, paths, and partial reschedules before Graph", async () => {
+    let calls = 0
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerMicrosoft365Routes(app, {
+      memberRoute: contextMiddleware(organizationContext()),
+      fetch: async () => { calls += 1; throw new Error("Must not call Graph") },
+      resolveAccessToken: async () => { throw new Error("Invalid input should be rejected before resolving a token") },
+    })
+    const invalid: Array<{ method: string; path: string; body: unknown }> = [
+      { method: "POST", path: "mail-drafts/draft_1/send", body: {} },
+      { method: "POST", path: "mail-drafts/draft_1/send", body: { confirmSend: false } },
+      { method: "POST", path: "mail-drafts/draft_1/send", body: { confirmSend: true, to: ["other@example.test"] } },
+      { method: "POST", path: "mail-message/message_1/reply-draft", body: { comment: "x".repeat(20_001) } },
+      { method: "PATCH", path: "mail-message/message_1", body: {} },
+      { method: "PATCH", path: "mail-message/message_1", body: { isRead: "true" } },
+      { method: "PATCH", path: "mail-message/message_1", body: { categories: Array(26).fill("Category") } },
+      { method: "PATCH", path: "mail-message/message_1", body: { isRead: true, orgMembershipId: "other_member" } },
+      { method: "POST", path: "mail-message/message_1/move", body: { destination: "https://evil.example.test" } },
+      { method: "POST", path: "mail-message/message_1/move", body: { destination: "deleteditems" } },
+      { method: "POST", path: "mail-message/message_1/move", body: { destination: "deleteditems", confirmTrash: false } },
+      { method: "PATCH", path: "calendar-events/event_1", body: {} },
+      { method: "PATCH", path: "calendar-events/event_1", body: { subject: "Update" } },
+      { method: "PATCH", path: "calendar-events/event_1", body: { subject: "Update", confirmNotifications: false } },
+      { method: "PATCH", path: "calendar-events/event_1", body: { confirmNotifications: true } },
+      { method: "PATCH", path: "calendar-events/event_1", body: { start: "2026-09-10T10:00:00Z", confirmNotifications: true } },
+      { method: "PATCH", path: "calendar-events/event_1", body: { start: "2026-09-10T11:00:00Z", end: "2026-09-10T10:00:00Z", confirmNotifications: true } },
+      { method: "PATCH", path: "calendar-events/event_1", body: { subject: "Update", attendees: ["other@example.test"], confirmNotifications: true } },
+      { method: "POST", path: "calendar-events/event_1/cancel", body: { comment: "Not confirmed" } },
+      { method: "DELETE", path: "calendar-events/event_1", body: {} },
+      { method: "PATCH", path: "drive-file/item_1", body: {} },
+      { method: "PATCH", path: "drive-file/item_1", body: { name: "../bad" } },
+      { method: "PATCH", path: "drive-file/item_1", body: { parentId: ".." } },
+      { method: "PATCH", path: "drive-file/item_1", body: { parentId: "https://evil.example.test" } },
+      { method: "PATCH", path: "drive-file/item_1", body: { name: "Plan", driveId: "other_drive" } },
+      { method: "POST", path: "drive-folders", body: { name: "x".repeat(256), parentId: "folder_1" } },
+      { method: "POST", path: "drive-folders", body: { name: "Plans", parentId: "folder_1", "@microsoft.graph.conflictBehavior": "replace" } },
+    ]
+    for (const request of invalid) {
+      const response = await app.request(`http://den-api.local/v1/capabilities/microsoft-365/${request.path}`, {
+        method: request.method, headers: { "content-type": "application/json" }, body: JSON.stringify(request.body),
+      })
+      expect(response.status).toBe(400)
+    }
+    expect(calls).toBe(0)
+  })
+
+  test("archive and inbox moves remain available without trash confirmation", async () => {
+    const destinations: unknown[] = []
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerMicrosoft365Routes(app, {
+      memberRoute: contextMiddleware(organizationContext()),
+      resolveAccessToken: async () => ({ kind: "ok", accessToken: "token", scopes: ["Mail.ReadWrite"], enabledFeatures: ["mailManage"] }),
+      fetch: async (input, init) => {
+        const request = new Request(input, init)
+        destinations.push(await request.json())
+        return Response.json({ id: "moved_1" }, { status: 201 })
+      },
+    })
+    for (const destination of ["archive", "inbox"]) {
+      const response = await app.request("http://den-api.local/v1/capabilities/microsoft-365/mail-message/message_1/move", {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ destination }),
+      })
+      expect(response.status).toBe(200)
+    }
+    expect(destinations).toEqual([{ destinationId: "archive" }, { destinationId: "inbox" }])
+  })
+
+  test("ambiguous send returns unknown outcome and never issues a duplicate request", async () => {
+    let calls = 0
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerMicrosoft365Routes(app, {
+      memberRoute: contextMiddleware(organizationContext()),
+      resolveAccessToken: async () => ({ kind: "ok", accessToken: "token", scopes: ["Mail.Send"], enabledFeatures: ["mailSend"] }),
+      fetch: async () => { calls += 1; throw new TypeError("Send response lost") },
+    })
+    const response = await app.request("http://den-api.local/v1/capabilities/microsoft-365/mail-drafts/draft_1/send", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ confirmSend: true }),
+    })
+    expect(response.status).toBe(502)
+    expect(await response.json()).toMatchObject({ error: "microsoft_graph_error", outcome: "unknown", retryable: false })
+    expect(calls).toBe(1)
+  })
+})
 
 describe("Microsoft 365 injected routes", () => {
   test("maps Graph mail for the calling member and blocks disconnected or under-scoped accounts", async () => {

--- a/ee/apps/den-api/test/microsoft-graph.test.ts
+++ b/ee/apps/den-api/test/microsoft-graph.test.ts
@@ -10,6 +10,7 @@ import {
   extractMicrosoftTeamsChats,
   extractMicrosoftTeamsMessages,
   MicrosoftGraphClient,
+  MicrosoftGraphMutationOutcomeUnknownError,
   MicrosoftGraphRequestError,
 } from "../src/capability-sources/microsoft-graph.js"
 
@@ -189,25 +190,166 @@ describe("MicrosoftGraphClient", () => {
     expect(file.contentUnavailableReason).toBeNull()
   })
 
-  test("does not download oversized or binary OneDrive files", async () => {
+  test("does not download oversized OneDrive files and preserves supported binary bytes", async () => {
     let contentRequests = 0
     const fetchMock: typeof fetch = async (input, init) => {
       const request = new Request(input, init)
       const url = new URL(request.url)
       if (url.pathname.endsWith("/large")) {
-        return json({ id: "large", name: "Large.txt", size: 6_000_000, file: { mimeType: "text/plain" } })
+        return json({ id: "large", name: "Large.txt", size: 10 * 1024 * 1024 + 1, file: { mimeType: "text/plain" } })
       }
       if (url.pathname.endsWith("/binary")) {
         return json({ id: "binary", name: "Plan.docx", size: 2_000, file: { mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" } })
       }
       contentRequests += 1
-      return new Response("unexpected")
+      return new Response(new Uint8Array([0xff, 0x00, 0xab]))
     }
     const client = new MicrosoftGraphClient({ accessToken: "token", fetch: fetchMock })
 
     expect((await client.getDriveItemWithContent("large")).contentUnavailableReason).toBe("file_too_large")
-    expect((await client.getDriveItemWithContent("binary")).contentUnavailableReason).toBe("unsupported_content_type")
     expect(contentRequests).toBe(0)
+    expect(await client.getDriveItemWithContent("binary")).toMatchObject({ encoding: "base64", contentBase64: "/wCr", contentUnavailableReason: null })
+    expect(contentRequests).toBe(1)
+  })
+
+  test("sends exactly one existing draft and reports Graph 202 as accepted, not delivered", async () => {
+    const requests: Request[] = []
+    const client = new MicrosoftGraphClient({
+      accessToken: "member-token",
+      fetch: async (input, init) => {
+        const request = new Request(input, init)
+        requests.push(request)
+        expect(request.url).toBe("https://graph.microsoft.com/v1.0/me/messages/draft%2B1%3D/send")
+        expect(request.method).toBe("POST")
+        expect(request.redirect).toBe("error")
+        expect(request.headers.get("authorization")).toBe("Bearer member-token")
+        expect(await request.text()).toBe("")
+        return new Response(null, { status: 202 })
+      },
+    })
+    expect(await client.sendMailDraft("draft+1=")).toEqual({ draftId: "draft+1=", status: "accepted" })
+    expect(requests).toHaveLength(1)
+  })
+
+  test("never replays ambiguous sends, server failures, or unexpected successful statuses", async () => {
+    const failures: Array<() => Promise<Response>> = [
+      async () => { throw new TypeError("response lost after send") },
+      async () => new Response(null, { status: 503 }),
+      async () => new Response(null, { status: 204 }),
+      async () => json({ delivered: true }, 200),
+    ]
+    for (const failure of failures) {
+      let calls = 0
+      const client = new MicrosoftGraphClient({ accessToken: "member-token", fetch: async () => { calls += 1; return failure() } })
+      await expect(client.sendMailDraft("draft_1")).rejects.toBeInstanceOf(MicrosoftGraphMutationOutcomeUnknownError)
+      expect(calls).toBe(1)
+    }
+  })
+
+  test("propagates bounded provider rejections without retrying or claiming acceptance", async () => {
+    let calls = 0
+    const client = new MicrosoftGraphClient({ accessToken: "member-token", maxJsonResponseBytes: 40, fetch: async () => {
+      calls += 1
+      return new Response("denied".repeat(100), { status: 403 })
+    } })
+    await expect(client.sendMailDraft("draft_1")).rejects.toMatchObject({ status: 403, name: "MicrosoftGraphRequestError" })
+    expect(calls).toBe(1)
+  })
+
+  test("preserves cancellation and timeout bounds without retrying a send", async () => {
+    const controller = new AbortController()
+    let calls = 0
+    const client = new MicrosoftGraphClient({
+      accessToken: "member-token", signal: controller.signal, timeoutMs: 20,
+      fetch: async (_input, init) => {
+        calls += 1
+        const signal = init?.signal
+        if (!signal) throw new Error("Expected an abort signal")
+        controller.abort()
+        signal.throwIfAborted()
+        throw new Error("Must abort before returning")
+      },
+    })
+    await expect(client.sendMailDraft("draft_1")).rejects.toBeInstanceOf(MicrosoftGraphMutationOutcomeUnknownError)
+    expect(calls).toBe(1)
+  })
+
+  test("creates a reply draft and patches only selected mail state, preserving move receipts", async () => {
+    const requests: Request[] = []
+    const client = new MicrosoftGraphClient({ accessToken: "member-token", fetch: async (input, init) => {
+      const request = new Request(input, init)
+      requests.push(request)
+      if (request.url.endsWith("/createReply")) return json({ id: "reply_1", isDraft: true, conversationId: "thread_1", body: { content: "Reply" } }, 201)
+      if (request.url.endsWith("/move")) return json({ id: "moved_1", parentFolderId: "archive_1", isRead: true }, 201)
+      return json({ id: "message_1", isRead: false, categories: ["Follow up"] })
+    } })
+    expect(await client.createMailReplyDraft("message_1", "Reply")).toMatchObject({ id: "reply_1", isDraft: true, conversationId: "thread_1" })
+    expect(await client.updateMailMessage("message_1", { isRead: false, categories: ["Follow up"] })).toMatchObject({ isRead: false, categories: ["Follow up"] })
+    expect(await client.moveMailMessage("message_1", "archive")).toMatchObject({ id: "moved_1", parentFolderId: "archive_1" })
+    expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
+      ["POST", "/v1.0/me/messages/message_1/createReply"],
+      ["PATCH", "/v1.0/me/messages/message_1"],
+      ["POST", "/v1.0/me/messages/message_1/move"],
+    ])
+    expect(await requests[0]?.json()).toEqual({ comment: "Reply" })
+    expect(await requests[1]?.json()).toEqual({ isRead: false, categories: ["Follow up"] })
+    expect(await requests[2]?.json()).toEqual({ destinationId: "archive" })
+  })
+
+  test("patches paired UTC event times without erasing omitted fields and handles empty cancellation/deletion receipts", async () => {
+    const requests: Request[] = []
+    const client = new MicrosoftGraphClient({ accessToken: "member-token", fetch: async (input, init) => {
+      const request = new Request(input, init)
+      requests.push(request)
+      if (request.method === "DELETE") return new Response(null, { status: 204 })
+      if (request.url.endsWith("/cancel")) return new Response(null, { status: 202 })
+      return json({ id: "event_1", subject: "Updated" })
+    } })
+    expect((await client.updateCalendarEvent("event_1", { subject: "Updated" })).id).toBe("event_1")
+    await client.updateCalendarEvent("event_1", { start: "2026-09-10T10:00:00Z", end: "2026-09-10T11:00:00Z", location: "" })
+    expect(await client.cancelCalendarEvent("event_1", "Cancelled by organizer")).toEqual({ eventId: "event_1", status: "accepted" })
+    expect(await client.deleteCalendarEvent("event_1")).toEqual({ eventId: "event_1", status: "deleted" })
+    expect(await requests[0]?.json()).toEqual({ subject: "Updated" })
+    expect(await requests[1]?.json()).toEqual({
+      start: { dateTime: "2026-09-10T10:00:00Z", timeZone: "UTC" },
+      end: { dateTime: "2026-09-10T11:00:00Z", timeZone: "UTC" },
+      location: { displayName: "" },
+    })
+    expect(await requests[2]?.json()).toEqual({ comment: "Cancelled by organizer" })
+    expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
+      ["PATCH", "/v1.0/me/events/event_1"], ["PATCH", "/v1.0/me/events/event_1"],
+      ["POST", "/v1.0/me/events/event_1/cancel"], ["DELETE", "/v1.0/me/events/event_1"],
+    ])
+    expect(await requests[3]?.text()).toBe("")
+  })
+
+  test("renames or moves a OneDrive item and creates folders with conflict failure, never overwrite", async () => {
+    const requests: Request[] = []
+    const client = new MicrosoftGraphClient({ accessToken: "member-token", fetch: async (input, init) => {
+      const request = new Request(input, init)
+      requests.push(request)
+      return json({ id: "item_1", name: "Plans", folder: {} }, request.method === "POST" ? 201 : 200)
+    } })
+    await client.updateDriveItem("item_1", { name: "Plans", parentId: "folder_2" })
+    await client.updateDriveItem("item_1", { name: "Renamed" })
+    expect(await client.createDriveFolder({ parentId: "folder_2", name: "Plans" })).toMatchObject({ id: "item_1", kind: "folder" })
+    expect(await requests[0]?.json()).toEqual({ name: "Plans", parentReference: { id: "folder_2" } })
+    expect(await requests[1]?.json()).toEqual({ name: "Renamed" })
+    expect(await requests[2]?.json()).toEqual({ name: "Plans", folder: {}, "@microsoft.graph.conflictBehavior": "fail" })
+    expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
+      ["PATCH", "/v1.0/me/drive/items/item_1"], ["PATCH", "/v1.0/me/drive/items/item_1"],
+      ["POST", "/v1.0/me/drive/items/folder_2/children"],
+    ])
+  })
+
+  test("rejects malformed or oversized mutation JSON rather than manufacturing a success receipt", async () => {
+    for (const response of [json({}), json({ id: "x".repeat(100) }), new Response("invalid"), json({ id: "reply_1", isDraft: false }, 201)]) {
+      let calls = 0
+      const client = new MicrosoftGraphClient({ accessToken: "member-token", maxJsonResponseBytes: 50, fetch: async () => { calls += 1; return response } })
+      const operation = response.status === 201 ? client.createMailReplyDraft("message_1", "Reply") : client.updateMailMessage("message_1", { isRead: true })
+      await expect(operation).rejects.toBeInstanceOf(MicrosoftGraphMutationOutcomeUnknownError)
+      expect(calls).toBe(1)
+    }
   })
 
   test("creates drafts and events, writes OneDrive text, and reads/sends Teams chat", async () => {

--- a/ee/apps/den-api/test/native-provider-scopes.test.ts
+++ b/ee/apps/den-api/test/native-provider-scopes.test.ts
@@ -82,6 +82,47 @@ describe("google-workspace native provider scopes", () => {
     ])
   })
 
+  test.each([
+    ["gmailManage", "gmail.modify"],
+    ["gmailLabels", "gmail.labels"],
+    ["sheetsRead", "spreadsheets.readonly"],
+    ["sheetsWrite", "spreadsheets"],
+  ])("%s requests only its selected scope beyond identity", (feature, scope) => {
+    const provider = googleWorkspaceProvider()
+    const features = registry.clientSelectedFeatures(provider, { features: [feature, feature] })
+    expect(features).toEqual([feature])
+    expect(registry.resolveProviderScopes(provider, features)).toEqual([
+      ...GOOGLE_WORKSPACE_IDENTITY_SCOPES,
+      `https://www.googleapis.com/auth/${scope}`,
+    ])
+  })
+
+  test("Google scope implications accept broader grants without escalating narrower ones", () => {
+    const provider = googleWorkspaceProvider()
+    const scope = (name: string) => `https://www.googleapis.com/auth/${name}`
+    for (const required of ["gmail.readonly", "gmail.compose", "gmail.labels"]) {
+      expect(registry.providerScopesSatisfy(provider, [scope("gmail.modify")], scope(required))).toBe(true)
+      expect(registry.providerScopesSatisfy(provider, [scope(required)], scope("gmail.modify"))).toBe(false)
+    }
+    expect(registry.providerScopesSatisfy(provider, [scope("spreadsheets")], scope("spreadsheets.readonly"))).toBe(true)
+    expect(registry.providerScopesSatisfy(provider, [scope("spreadsheets.readonly")], scope("spreadsheets"))).toBe(false)
+    for (const required of ["drive.readonly", "drive.file", "spreadsheets", "spreadsheets.readonly"]) {
+      expect(registry.providerScopesSatisfy(provider, [scope("drive")], scope(required))).toBe(true)
+    }
+    expect(registry.providerScopesSatisfy(provider, [scope("gmail.modify.lookalike")], scope("gmail.readonly"))).toBe(false)
+    expect(registry.providerScopesSatisfy(provider, [scope("spreadsheets.lookalike")], scope("spreadsheets.readonly"))).toBe(false)
+  })
+
+  test("unknown grants do not satisfy the new feature scopes", () => {
+    const provider = googleWorkspaceProvider()
+    const grants: (string[] | null)[] = [null, [], GOOGLE_WORKSPACE_IDENTITY_SCOPES]
+    for (const granted of grants) {
+      for (const scope of ["gmail.modify", "gmail.labels", "spreadsheets.readonly", "spreadsheets"]) {
+        expect(registry.providerScopesSatisfy(provider, granted, `https://www.googleapis.com/auth/${scope}`)).toBe(false)
+      }
+    }
+  })
+
   test("clientSelectedFeatures ignores unknown keys and non-strings", () => {
     const provider = googleWorkspaceProvider()
 

--- a/ee/apps/den-web/app/(den)/_lib/brand-icon.ts
+++ b/ee/apps/den-web/app/(den)/_lib/brand-icon.ts
@@ -28,6 +28,8 @@ const BUNDLED_ICONS_BY_APEX: Record<string, string> = {
 };
 
 const SIMPLE_ICON_SLUG_BY_APEX: Record<string, string> = {
+  "githubcopilot.com": "github",
+  "github.com": "github",
   "slack.com": "slack",
   "granola.ai": "granola",
   "polar.sh": "polar",

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -687,6 +687,20 @@ export function getMcpConnectionsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/mcp-connections`;
 }
 
+export function getConfiguredMcpConnectionsRoute(orgSlug?: string | null, connectionId?: string | null): string {
+  const base = `${getMcpConnectionsRoute(orgSlug)}/configured`;
+  return connectionId ? `${base}?connectionId=${encodeURIComponent(connectionId)}` : base;
+}
+
+/**
+ * Detail page for one connector. `connectorId` is a configured connection id
+ * or, for connectors nobody has added yet, the catalog id (`gmail`, `notion`,
+ * `microsoft-365`) so the page can explain the connector and start setup.
+ */
+export function getMcpConnectionRoute(orgSlug: string | null | undefined, connectorId: string): string {
+  return `${getMcpConnectionsRoute(orgSlug)}/${encodeURIComponent(connectorId)}`;
+}
+
 export function getYourConnectionsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/your-connections`;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/[connectorId]/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/[connectorId]/page.tsx
@@ -1,0 +1,11 @@
+import { McpConnectionsScreen } from "../../../_components/mcp-connections-screen";
+
+export default async function McpConnectionDetailPage({
+  params,
+}: {
+  params: Promise<{ connectorId: string }>;
+}) {
+  const { connectorId } = await params;
+
+  return <McpConnectionsScreen view="detail" connectorId={connectorId} />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/configured/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/configured/page.tsx
@@ -1,0 +1,5 @@
+import { McpConnectionsScreen } from "../../../_components/mcp-connections-screen";
+
+export default function ConfiguredMcpConnectionsPage() {
+  return <McpConnectionsScreen view="configured" />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog-list.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog-list.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronRight, Loader2, MinusCircle, MoreHorizontal, Settings } from "lucide-react";
+import {
+  configuredConnectionForPopular,
+  connectionForPresetUrl,
+  connectorChatDeepLink,
+  connectorChatPrompt,
+  connectorMatchesFilter,
+  GOOGLE_WORKSPACE_QUICK_ADD_ID,
+  MICROSOFT_365_QUICK_ADD_ID,
+  POPULAR_CONNECTORS,
+  remainingPresets,
+  type PopularConnector,
+} from "./connector-catalog";
+import { IntegrationIcon } from "./integration-icon";
+import { connectorAccountStatus, connectorDetailPrimaryAction } from "./connector-detail";
+import { EFFORT_LABELS, presetEffort, type ConnectorEffort } from "./connector-effort";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
+
+const CONFIGURED_STRIP_LIMIT = 12;
+
+type CatalogRowIcon = { iconUrl?: string; simpleIconSlug?: string; serviceUrl?: string };
+
+export type ConnectorCatalogProps = {
+  connections: ExternalMcpConnection[];
+  presets: ExternalMcpPreset[];
+  filter: string;
+  configuredHref: string;
+  configuredConnectionHref: (connectionId: string) => string;
+  /**
+   * Detail page for a row. Receives the connection id when the row is
+   * configured, otherwise the catalog id (popular id, preset id, or
+   * `microsoft-365`), matching what the detail route resolves.
+   */
+  connectorHref: (connectorId: string) => string;
+  onAddPopular: (connector: PopularConnector) => void;
+  onAddPreset: (preset: ExternalMcpPreset) => void;
+  onAddMicrosoft365: () => void;
+  onManage: (connection: ExternalMcpConnection) => void;
+  onRemove: (connection: ExternalMcpConnection) => void;
+  onRecover?: (connection: ExternalMcpConnection) => void;
+  setupRequired?: (connection: ExternalMcpConnection) => boolean;
+  recoveringConnectionId?: string | null;
+  addingPresetId: string | null;
+  loading?: boolean;
+  unavailable?: boolean;
+  connectionsUnavailable?: boolean;
+};
+
+/**
+ * ConnectorChatLink
+ *
+ * "Chat" hands off to the desktop app: the deep link lands on a new chat with
+ * the connector chip and its starter prompt already in the composer.
+ */
+export function connectorChatHref(displayName: string): string {
+  return connectorChatDeepLink({ connector: displayName, prompt: connectorChatPrompt(displayName) });
+}
+
+function RowMenu({
+  name,
+  connection,
+  onManage,
+  onRemove,
+}: {
+  name: string;
+  connection: ExternalMcpConnection;
+  onManage: () => void;
+  onRemove: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const canRemove = connection.id !== GOOGLE_WORKSPACE_QUICK_ADD_ID && connection.id !== MICROSOFT_365_QUICK_ADD_ID;
+
+  useEffect(() => {
+    if (!open) return;
+    function handlePointerDown(event: PointerEvent) {
+      if (event.target instanceof Node && !menuRef.current?.contains(event.target)) setOpen(false);
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const itemClass = "flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-left text-[13.5px] text-gray-700 transition hover:bg-gray-50 hover:text-gray-900";
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition hover:bg-gray-100 hover:text-gray-900"
+        aria-label={`Options for ${name}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid={`connector-options-${connection.id}`}
+      >
+        <MoreHorizontal className="h-5 w-5" aria-hidden="true" />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          aria-label={`Options for ${name}`}
+          className="absolute right-0 top-10 z-30 w-52 overflow-hidden rounded-2xl border border-gray-100 bg-white p-1.5 shadow-xl shadow-gray-900/10"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onManage();
+            }}
+            className={itemClass}
+            data-testid={`connector-manage-${connection.id}`}
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+            Manage
+          </button>
+          {canRemove ? (
+            <>
+              <div className="my-1 border-t border-gray-100" />
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  onRemove();
+                }}
+                className={`${itemClass} text-red-600 hover:bg-red-50 hover:text-red-700`}
+                data-testid={`connector-uninstall-${connection.id}`}
+              >
+                <MinusCircle className="h-4 w-4" aria-hidden="true" />
+                Uninstall
+              </button>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CatalogRow({
+  id,
+  name,
+  description,
+  icon,
+  connection,
+  href,
+  adding,
+  onAdd,
+  onManage,
+  onRemove,
+  effort,
+  setupUnavailable = false,
+  setupRequired = false,
+  onRecover,
+  recovering = false,
+}: {
+  id: string;
+  name: string;
+  description: string;
+  icon: CatalogRowIcon;
+  connection: ExternalMcpConnection | undefined;
+  href: string;
+  adding: boolean;
+  onAdd: () => void;
+  onManage: (connection: ExternalMcpConnection) => void;
+  onRemove: (connection: ExternalMcpConnection) => void;
+  effort: ConnectorEffort;
+  setupUnavailable?: boolean;
+  setupRequired?: boolean;
+  onRecover?: (connection: ExternalMcpConnection) => void;
+  recovering?: boolean;
+}) {
+  const status = connection ? connectorAccountStatus(connection, setupRequired) : setupUnavailable ? "Setup unavailable" : EFFORT_LABELS[effort];
+  const primaryAction = connectorDetailPrimaryAction(effort);
+  return (
+    <div className="group flex items-center gap-1 py-1" data-testid={`connector-row-${id}`} data-connector-id={id}>
+      <Link
+        href={href}
+        className="flex min-w-0 flex-1 items-center gap-3.5 rounded-2xl px-2 py-1.5 transition hover:bg-gray-50"
+        data-testid={`connector-open-${id}`}
+      >
+        <IntegrationIcon
+          name={name}
+          iconUrl={icon.iconUrl}
+          simpleIconSlug={icon.simpleIconSlug}
+          serviceUrl={icon.serviceUrl}
+          className="h-12 w-12 rounded-[14px]"
+          imageClassName="h-6 w-6"
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[15px] font-medium leading-5 text-gray-900">{name}</span>
+          <span className="block text-[13px] leading-5 text-gray-500">{description}</span>
+          <span className="mt-0.5 block text-[12px] leading-5 text-gray-500" data-testid={`connector-status-${id}`}>{status}</span>
+        </span>
+      </Link>
+      <a
+        href={connectorChatHref(name)}
+        className="flex min-h-9 shrink-0 items-center rounded-lg px-2 text-[12px] font-medium text-gray-700 hover:bg-gray-100"
+        aria-label={`Chat with ${name} in OpenWork`}
+        data-testid={`connector-chat-${id}`}
+      >
+        Chat
+      </a>
+      {connection && status !== "Connected" && status !== "Connected as you" ? (
+        <button
+          type="button"
+          onClick={() => (onRecover ?? onManage)(connection)}
+          disabled={recovering}
+          className="min-h-9 shrink-0 rounded-lg px-2 text-[12px] font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+          data-testid={`connector-recover-${id}`}
+        >
+          {recovering ? "Connecting..." : status === "Setup required" ? "Set up" : status === "OAuth settings need review" ? "Review OAuth" : status === "Reconnect required" ? "Reconnect" : "Connect"}
+        </button>
+      ) : null}
+      {connection ? (
+        <RowMenu
+          name={name}
+          connection={connection}
+          onManage={() => onManage(connection)}
+          onRemove={() => onRemove(connection)}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={onAdd}
+          disabled={adding || setupUnavailable}
+          className="flex min-h-9 shrink-0 items-center justify-center gap-1.5 rounded-lg px-2 text-[12px] font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={`${primaryAction.label} ${name}`}
+          data-testid={`connector-add-${id}`}
+        >
+          {adding ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+          {primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return <h3 className="mb-2 text-[15px] font-semibold text-gray-900">{children}</h3>;
+}
+
+export function ConfiguredConnectorStrip({
+  connections,
+  href,
+  connectionHref,
+}: {
+  connections: ExternalMcpConnection[];
+  href: string;
+  connectionHref: (connectionId: string) => string;
+}) {
+  const shown = connections.slice(0, CONFIGURED_STRIP_LIMIT);
+  const overflow = connections.length - shown.length;
+
+  return (
+    <section className="mb-8" data-testid="configured-connector-strip">
+      <Link
+        href={href}
+        className="inline-flex items-center gap-1 text-[15px] font-semibold text-gray-900 transition hover:text-gray-600"
+        data-testid="configured-connectors-link"
+      >
+        Configured ({connections.length})
+        <ChevronRight className="h-4 w-4" aria-hidden="true" />
+      </Link>
+      {shown.length === 0 ? (
+        <p className="mt-2 text-[13px] text-gray-500">Nothing configured yet. Add a connector below and it shows up here.</p>
+      ) : (
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          {shown.map((connection) => (
+            <Link
+              key={connection.id}
+              href={connectionHref(connection.id)}
+              title={connection.name}
+              aria-label={`Manage ${connection.name}`}
+              className="rounded-[14px] transition hover:-translate-y-0.5 hover:shadow-md"
+            >
+              <IntegrationIcon
+                name={connection.name}
+                serviceUrl={connection.url}
+                className="h-12 w-12 rounded-[14px]"
+                imageClassName="h-6 w-6"
+              />
+            </Link>
+          ))}
+          {overflow > 0 ? (
+            <Link
+              href={href}
+              className="flex h-12 w-12 items-center justify-center rounded-[14px] border border-gray-100 bg-gray-50 text-[12px] font-semibold text-gray-600"
+            >
+              +{overflow}
+            </Link>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function ConnectorCatalog({
+  connections,
+  presets,
+  filter,
+  configuredHref,
+  configuredConnectionHref,
+  connectorHref,
+  onAddPopular,
+  onAddPreset,
+  onAddMicrosoft365,
+  onManage,
+  onRemove,
+  addingPresetId,
+  loading = false,
+  unavailable = false,
+  connectionsUnavailable = false,
+  onRecover,
+  setupRequired,
+  recoveringConnectionId,
+}: ConnectorCatalogProps) {
+  const [moreOpen, setMoreOpen] = useState(false);
+  const filtering = filter.trim().length > 0;
+  const availablePopular = POPULAR_CONNECTORS.filter((connector) => {
+    const target = connector.target;
+    return loading || unavailable || target.kind !== "preset" || presets.some((preset) => preset.presetId === target.presetId);
+  });
+  const popular = availablePopular.filter((connector) =>
+    connectorMatchesFilter(filter, connector.displayName, connector.description, connector.id));
+  const more = remainingPresets(presets).filter((preset) =>
+    connectorMatchesFilter(filter, preset.displayName, preset.description, preset.presetId));
+  const microsoftVisible = connectorMatchesFilter(filter, "Microsoft 365", "Outlook Email", "Outlook", "OneDrive", "microsoft-365");
+  const microsoftConnection = connections.find((connection) => connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365");
+  const showMore = filtering || moreOpen;
+  const nothingMatches = filtering && popular.length === 0 && more.length === 0 && !microsoftVisible;
+  const total = availablePopular.length + remainingPresets(presets).length + 1;
+  const matching = popular.length + more.length + Number(microsoftVisible);
+  const shown = popular.length + (showMore ? more.length + Number(microsoftVisible) : 0);
+
+  return (
+    <div data-testid="connector-catalog">
+      {loading ? <p role="status" className="mb-4 text-[13px] text-gray-500">Loading connection setup options. Chat is still available.</p> : null}
+      {!filtering && !connectionsUnavailable ? (
+        <ConfiguredConnectorStrip connections={connections} href={configuredHref} connectionHref={configuredConnectionHref} />
+      ) : null}
+
+      <p role="status" className="mb-4 text-[13px] text-gray-500" data-testid="connector-catalog-count">
+        {filtering ? `${matching} of ${total} integrations match` : `Showing ${shown} of ${total} integrations`}
+      </p>
+
+      {nothingMatches ? (
+        <p className="text-[13px] text-gray-400">No connectors match &quot;{filter}&quot;. Paste an MCP server URL to add it directly.</p>
+      ) : null}
+
+      {popular.length > 0 ? (
+        <section className="mb-8" data-testid="popular-connectors">
+          <SectionTitle>Popular</SectionTitle>
+          <div className="grid gap-x-8 sm:grid-cols-2">
+            {popular.map((connector) => {
+              const connection = configuredConnectionForPopular(connector, connections, presets);
+              const presetId = connector.target.kind === "preset" ? connector.target.presetId : null;
+              const preset = presets.find((entry) => entry.presetId === presetId);
+              const adding = connector.target.kind === "preset" && addingPresetId === connector.target.presetId;
+              return (
+                <CatalogRow
+                  key={connector.id}
+                  id={connector.id}
+                  name={connector.displayName}
+                  description={connector.description}
+                  icon={connector.icon}
+                  connection={connection}
+                  href={connectorHref(connector.id)}
+                  effort={preset ? presetEffort(preset) : "guided"}
+                  adding={adding}
+                  setupUnavailable={connectionsUnavailable || (Boolean(presetId) && (loading || unavailable || !preset))}
+                  setupRequired={connection ? setupRequired?.(connection) : false}
+                  onRecover={onRecover}
+                  recovering={Boolean(connection && recoveringConnectionId === connection.id)}
+                  onAdd={() => onAddPopular(connector)}
+                  onManage={onManage}
+                  onRemove={onRemove}
+                />
+              );
+            })}
+          </div>
+          {!showMore ? (
+            <button
+              type="button"
+              onClick={() => setMoreOpen(true)}
+              className="mt-3 inline-flex items-center gap-3 rounded-2xl px-2 py-2 text-[15px] text-gray-700 transition hover:bg-gray-50 hover:text-gray-900"
+              data-testid="connector-catalog-more"
+            >
+              <span className="flex -space-x-2">
+                <IntegrationIcon name="Microsoft 365" simpleIconSlug="microsoft" className="h-7 w-7 rounded-[8px]" imageClassName="h-3.5 w-3.5" />
+                <IntegrationIcon name="Granola" serviceUrl="https://mcp.granola.ai/mcp" className="h-7 w-7 rounded-[8px]" imageClassName="h-3.5 w-3.5" />
+                <IntegrationIcon name="Linear" serviceUrl="https://mcp.linear.app/mcp" className="h-7 w-7 rounded-[8px]" imageClassName="h-3.5 w-3.5" />
+              </span>
+              Browse all {total} integrations
+            </button>
+          ) : null}
+        </section>
+      ) : null}
+
+      {showMore && (more.length > 0 || microsoftVisible) ? (
+        <section className="mb-8" data-testid="more-connectors">
+          <SectionTitle>More connectors</SectionTitle>
+          <div className="grid gap-x-8 sm:grid-cols-2">
+            {microsoftVisible ? (
+              <CatalogRow
+                id={MICROSOFT_365_QUICK_ADD_ID}
+                name="Microsoft 365"
+                description="Outlook email, calendar, and OneDrive"
+                icon={{ simpleIconSlug: "microsoft" }}
+                connection={microsoftConnection}
+                href={connectorHref(microsoftConnection?.id ?? MICROSOFT_365_QUICK_ADD_ID)}
+                effort="guided"
+                adding={false}
+                setupUnavailable={connectionsUnavailable}
+                setupRequired={microsoftConnection ? setupRequired?.(microsoftConnection) : false}
+                onRecover={onRecover}
+                recovering={Boolean(microsoftConnection && recoveringConnectionId === microsoftConnection.id)}
+                onAdd={onAddMicrosoft365}
+                onManage={onManage}
+                onRemove={onRemove}
+              />
+            ) : null}
+            {more.map((preset) => {
+              const connection = connectionForPresetUrl(connections, preset.url);
+              return (
+              <CatalogRow
+                key={preset.presetId}
+                id={preset.presetId}
+                name={preset.displayName}
+                description={preset.description}
+                icon={{ serviceUrl: preset.url }}
+                connection={connection}
+                href={connectorHref(preset.presetId)}
+                effort={presetEffort(preset)}
+                adding={addingPresetId === preset.presetId}
+                setupUnavailable={connectionsUnavailable || loading || unavailable}
+                setupRequired={connection ? setupRequired?.(connection) : false}
+                onRecover={onRecover}
+                recovering={connection?.id === recoveringConnectionId}
+                onAdd={() => onAddPreset(preset)}
+                onManage={onManage}
+                onRemove={onRemove}
+              />
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog.ts
@@ -1,0 +1,147 @@
+import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
+
+/** Native provider connections keep fixed ids in Den. */
+export const GOOGLE_WORKSPACE_QUICK_ADD_ID = "google-workspace";
+export const MICROSOFT_365_QUICK_ADD_ID = "microsoft-365";
+
+/**
+ * Where a popular connector row lands when someone adds it. Gmail, Drive, and
+ * Calendar are one Google Workspace connection in Den; Outlook is Microsoft
+ * 365; everything else is a curated MCP preset.
+ */
+export type PopularConnectorTarget =
+  | { kind: "google-workspace" }
+  | { kind: "microsoft-365" }
+  | { kind: "preset"; presetId: string };
+
+export type PopularConnector = {
+  id: string;
+  displayName: string;
+  description: string;
+  icon: { iconUrl?: string; simpleIconSlug?: string; serviceUrl?: string };
+  target: PopularConnectorTarget;
+  /** Starter prompt seeded after the connector chip when someone picks Chat. */
+  chatPrompt: string;
+};
+
+export const POPULAR_CONNECTORS: PopularConnector[] = [
+  {
+    id: "gmail",
+    displayName: "Gmail",
+    description: "Read, send, and manage Gmail",
+    icon: { simpleIconSlug: "gmail" },
+    target: { kind: "google-workspace" },
+    chatPrompt: "Explain how I can triage my Gmail inbox. If access is available, search and summarize unread threads and suggest reply priorities. Otherwise, help me plan a triage routine without accessing my inbox.",
+  },
+  {
+    id: "github",
+    displayName: "GitHub",
+    description: "PRs, issues, code, and CI — OAuth app or personal access token",
+    icon: { simpleIconSlug: "github", serviceUrl: "https://api.githubcopilot.com/mcp/" },
+    target: { kind: "preset", presetId: "github" },
+    chatPrompt: "Explain how I can review a GitHub repo's authentication. Ask which repo to use; if access is available, inspect its code and docs. Otherwise, outline a review checklist without accessing the repo.",
+  },
+  {
+    id: "google-drive",
+    displayName: "Google Drive",
+    description: "Organize files, read Docs and Slides, and edit Sheets",
+    icon: { simpleIconSlug: "googledrive" },
+    target: { kind: "google-workspace" },
+    chatPrompt: "Explain what changed in Google Drive this week. If access is available, list files modified in the last 7 days, follow pagination, and call out any incomplete search before summarizing the results. Otherwise, help me plan a file review without accessing Drive.",
+  },
+  {
+    id: "google-calendar",
+    displayName: "Google Calendar",
+    description: "Create, reschedule, and manage Google Calendar events",
+    icon: { simpleIconSlug: "googlecalendar" },
+    target: { kind: "google-workspace" },
+    chatPrompt: "Explain how I can plan my week with Google Calendar. If access is available, list my meetings, point out conflicts, and suggest focus time without changing events. Otherwise, help me plan a weekly schedule without accessing my calendar.",
+  },
+  {
+    id: "notion",
+    displayName: "Notion",
+    description: "Notion docs and workflows",
+    icon: { serviceUrl: "https://mcp.notion.com/mcp" },
+    target: { kind: "preset", presetId: "notion" },
+    chatPrompt: "Explain how I can organize a Notion workspace. If access is available, ask which pages to review and summarize their structure. Otherwise, suggest a workspace outline without accessing Notion.",
+  },
+  {
+    id: "slack",
+    displayName: "Slack",
+    description: "Messages and search — requires an internal or Marketplace-published Slack app",
+    icon: { simpleIconSlug: "slack", serviceUrl: "https://mcp.slack.com/mcp" },
+    target: { kind: "preset", presetId: "slack" },
+    chatPrompt: "Explain how I can catch up on Slack. If access is available, ask which channels or topics to search and summarize the messages found. Otherwise, help me plan a catch-up routine without accessing Slack.",
+  },
+];
+
+export const MORE_CONNECTORS_TEASER = "See Outlook Email, Granola, and more";
+
+/** Starter prompt for connectors without a curated one. */
+export function connectorChatPrompt(displayName: string): string {
+  const popular = POPULAR_CONNECTORS.find((connector) => connector.displayName === displayName);
+  return popular?.chatPrompt
+    ?? `Explain how I could use ${displayName}: suggest three useful tasks and distinguish general ideas from tools available here. If access is unavailable, help me plan without connecting.`;
+}
+
+/**
+ * Deep link that opens the desktop app on a new chat with the connector chip
+ * and starter prompt already in the composer. The app parses this in
+ * apps/app/src/app/lib/openwork-links.ts (parseChatDeepLink).
+ */
+export function connectorChatDeepLink(input: { connector: string; prompt: string }): string {
+  const params = new URLSearchParams({ connector: input.connector, prompt: input.prompt });
+  return `openwork://chat?${params.toString()}`;
+}
+
+function comparableMcpUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname;
+    return `${url.host.toLowerCase()}${pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+export function connectionForPresetUrl(
+  connections: readonly ExternalMcpConnection[],
+  presetUrl: string,
+): ExternalMcpConnection | undefined {
+  const target = comparableMcpUrl(presetUrl);
+  if (!target) return undefined;
+  return connections.find((connection) => comparableMcpUrl(connection.url) === target);
+}
+
+/** The configured connection a popular row represents, when one exists. */
+export function configuredConnectionForPopular(
+  connector: PopularConnector,
+  connections: readonly ExternalMcpConnection[],
+  presets: readonly ExternalMcpPreset[],
+): ExternalMcpConnection | undefined {
+  switch (connector.target.kind) {
+    case "google-workspace":
+      return connections.find((connection) => connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID || connection.nativeProviderKey === "google-workspace");
+    case "microsoft-365":
+      return connections.find((connection) => connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365");
+    case "preset": {
+      const presetId = connector.target.presetId;
+      const preset = presets.find((entry) => entry.presetId === presetId);
+      return preset ? connectionForPresetUrl(connections, preset.url) : undefined;
+    }
+  }
+}
+
+/** Curated presets that are not already represented by a popular row. */
+export function remainingPresets(presets: readonly ExternalMcpPreset[]): ExternalMcpPreset[] {
+  const popularPresetIds = new Set(
+    POPULAR_CONNECTORS.flatMap((connector) => connector.target.kind === "preset" ? [connector.target.presetId] : []),
+  );
+  return presets.filter((preset) => !popularPresetIds.has(preset.presetId));
+}
+
+export function connectorMatchesFilter(filter: string, ...haystack: string[]): boolean {
+  const normalized = filter.trim().toLowerCase();
+  if (!normalized) return true;
+  return haystack.some((value) => value.toLowerCase().includes(normalized));
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-detail.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-detail.ts
@@ -1,0 +1,317 @@
+import { apexDomain } from "../../_lib/brand-icon";
+import {
+  configuredConnectionForPopular,
+  connectionForPresetUrl,
+  GOOGLE_WORKSPACE_QUICK_ADD_ID,
+  MICROSOFT_365_QUICK_ADD_ID,
+  POPULAR_CONNECTORS,
+  type PopularConnector,
+} from "./connector-catalog";
+import { EFFORT_LABELS, presetEffort, type ConnectorEffort } from "./connector-effort";
+import { isNativeProviderConnectionId, type ExternalMcpConnection, type ExternalMcpPreset } from "./mcp-connections-data";
+import { connectionNeedsOAuthClientConfiguration } from "./mcp-connection-setup";
+
+/** Native clients have usable entries even when they have no managed MCP row. */
+export function displayedConnectorConnections(
+  manageable: readonly ExternalMcpConnection[],
+  usable: readonly ExternalMcpConnection[],
+): ExternalMcpConnection[] {
+  return [
+    ...usable.filter((connection) => isNativeProviderConnectionId(connection.id, connection.nativeProviderKey)
+      && !manageable.some((entry) => entry.id === connection.id)),
+    ...manageable,
+  ];
+}
+
+export function connectorAccountReady(connection: ExternalMcpConnection): boolean {
+  return !connection.setupRequired
+    && !connectionNeedsOAuthClientConfiguration(connection)
+    && !connection.issuerReviewRequired
+    && !connection.needsReconnect
+    && connection.credentialHealth !== "reconnect_required"
+    && (connection.credentialMode === "per_member" ? connection.connectedForMe : connection.connected);
+}
+
+/** Account readiness is personal, even on an organization management page. */
+export function connectorAccountStatus(connection: ExternalMcpConnection, setupRequired = false): string {
+  if (setupRequired || connection.setupRequired || connectionNeedsOAuthClientConfiguration(connection)) return "Setup required";
+  if (connection.issuerReviewRequired) return "OAuth settings need review";
+  if (connection.needsReconnect || connection.credentialHealth === "reconnect_required") return "Reconnect required";
+  if (connection.credentialMode === "per_member") return connection.connectedForMe ? "Connected as you" : "Needs your account";
+  return connection.connected ? "Connected" : "Not connected";
+}
+
+export const CONNECTOR_DOCS_URL = "https://openworklabs.com/docs/cloud/share-with-your-team/shared-mcp-connections";
+
+/**
+ * What a connector detail page is about. The route accepts one id that may
+ * name a configured connection, a popular catalog entry (Gmail, GitHub…), a
+ * curated preset, or the Microsoft 365 native provider. Configured entries
+ * always resolve to their connection so the page can offer connect,
+ * disconnect, tools, and removal; unconfigured ones keep their catalog
+ * identity so the page can explain and start setup.
+ */
+export type ConnectorDetailSubject =
+  | {
+      kind: "connection";
+      connection: ExternalMcpConnection;
+      /** Catalog identity when the connection came from a popular row or preset. */
+      popular?: PopularConnector;
+      preset?: ExternalMcpPreset;
+    }
+  | { kind: "popular"; popular: PopularConnector; preset?: ExternalMcpPreset }
+  | { kind: "preset"; preset: ExternalMcpPreset }
+  | { kind: "microsoft-365" }
+  | { kind: "not_found"; connectorId: string };
+
+function presetForConnection(
+  connection: ExternalMcpConnection,
+  presets: readonly ExternalMcpPreset[],
+): ExternalMcpPreset | undefined {
+  return presets.find((preset) => connectionForPresetUrl([connection], preset.url) !== undefined);
+}
+
+/**
+ * Only preset-backed popular rows map 1:1 to a connection. Gmail, Drive, and
+ * Calendar all share the Google Workspace connection, so a connection opened
+ * by its own id keeps the Google Workspace identity instead of adopting the
+ * first popular row that happens to point at it.
+ */
+function popularForConnection(
+  connection: ExternalMcpConnection,
+  presets: readonly ExternalMcpPreset[],
+): PopularConnector | undefined {
+  return POPULAR_CONNECTORS.find((connector) =>
+    connector.target.kind === "preset" && configuredConnectionForPopular(connector, [connection], presets)?.id === connection.id);
+}
+
+export function resolveConnectorDetailSubject(
+  connectorId: string,
+  connections: readonly ExternalMcpConnection[],
+  presets: readonly ExternalMcpPreset[],
+): ConnectorDetailSubject {
+  const connection = connections.find((entry) => entry.id === connectorId);
+  if (connection) {
+    return {
+      kind: "connection",
+      connection,
+      popular: popularForConnection(connection, presets),
+      preset: presetForConnection(connection, presets),
+    };
+  }
+
+  const popular = POPULAR_CONNECTORS.find((connector) => connector.id === connectorId);
+  if (popular) {
+    const target = popular.target;
+    const preset = target.kind === "preset"
+      ? presets.find((entry) => entry.presetId === target.presetId)
+      : undefined;
+    const configured = configuredConnectionForPopular(popular, connections, presets);
+    return configured
+      ? { kind: "connection", connection: configured, popular, preset }
+      : { kind: "popular", popular, preset };
+  }
+
+  const preset = presets.find((entry) => entry.presetId === connectorId);
+  if (preset) {
+    const configured = connectionForPresetUrl(connections, preset.url);
+    return configured
+      ? { kind: "connection", connection: configured, preset, popular: popularForConnection(configured, presets) }
+      : { kind: "preset", preset };
+  }
+
+  if (connectorId === MICROSOFT_365_QUICK_ADD_ID) {
+    const configured = connections.find((entry) => entry.id === MICROSOFT_365_QUICK_ADD_ID || entry.nativeProviderKey === "microsoft-365");
+    return configured ? { kind: "connection", connection: configured } : { kind: "microsoft-365" };
+  }
+
+  return { kind: "not_found", connectorId };
+}
+
+export type ConnectorDetailIdentity = {
+  name: string;
+  description: string;
+  icon: { iconUrl?: string; simpleIconSlug?: string; serviceUrl?: string };
+};
+
+const GOOGLE_WORKSPACE_IDENTITY: ConnectorDetailIdentity = {
+  name: "Google Workspace",
+  description: "Gmail, Google Drive, and Google Calendar for everyone in the org",
+  icon: { simpleIconSlug: "google", serviceUrl: "https://www.google.com" },
+};
+
+const MICROSOFT_365_IDENTITY: ConnectorDetailIdentity = {
+  name: "Microsoft 365",
+  description: "Outlook email, calendar, and OneDrive",
+  icon: { simpleIconSlug: "microsoft" },
+};
+
+/** Name, blurb, and icon for the page header. Catalog identity wins over the raw connection row. */
+export function connectorDetailIdentity(subject: ConnectorDetailSubject): ConnectorDetailIdentity {
+  switch (subject.kind) {
+    case "popular":
+      return { name: subject.popular.displayName, description: subject.popular.description, icon: subject.popular.icon };
+    case "preset":
+      return { name: subject.preset.displayName, description: subject.preset.description, icon: { serviceUrl: subject.preset.url } };
+    case "microsoft-365":
+      return MICROSOFT_365_IDENTITY;
+    case "connection": {
+      if (subject.popular) {
+        return { name: subject.popular.displayName, description: subject.popular.description, icon: subject.popular.icon };
+      }
+      if (subject.connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID || subject.connection.nativeProviderKey === "google-workspace") {
+        return { ...GOOGLE_WORKSPACE_IDENTITY, name: subject.connection.name || GOOGLE_WORKSPACE_IDENTITY.name };
+      }
+      if (subject.connection.id === MICROSOFT_365_QUICK_ADD_ID || subject.connection.nativeProviderKey === "microsoft-365") {
+        return { ...MICROSOFT_365_IDENTITY, name: subject.connection.name || MICROSOFT_365_IDENTITY.name };
+      }
+      return {
+        name: subject.connection.name,
+        description: subject.preset?.description ?? describeConnectionFallback(subject.connection),
+        icon: { serviceUrl: subject.connection.url },
+      };
+    }
+    case "not_found":
+      return { name: "Connector not found", description: "", icon: {} };
+  }
+}
+
+function describeConnectionFallback(connection: ExternalMcpConnection): string {
+  const host = apexDomain(connection.url);
+  return host ? `MCP server at ${host}` : "MCP server";
+}
+
+/** How much setup adding this connector takes, before it exists in the org. */
+export function connectorDetailEffort(subject: ConnectorDetailSubject): ConnectorEffort | null {
+  switch (subject.kind) {
+    case "popular":
+      if (subject.popular.target.kind !== "preset") return "guided";
+      return subject.preset ? presetEffort(subject.preset) : "guided";
+    case "preset":
+      return presetEffort(subject.preset);
+    case "microsoft-365":
+      return "guided";
+    default:
+      return null;
+  }
+}
+
+/** Primary call to action for an unconfigured connector. */
+export function connectorDetailPrimaryAction(effort: ConnectorEffort): { label: string; explanation: string } {
+  switch (effort) {
+    case "instant":
+      return { label: "Add", explanation: "Adds it for everyone in the org right away. No sign-in is needed." };
+    case "one_click":
+      return { label: "Connect", explanation: "Adds it for everyone in the org and opens the provider sign-in so your own account is connected in the same step. Everyone else connects theirs from Your Connections." };
+    case "api_key":
+      return { label: "Set up", explanation: "Needs your org's API key for this provider. You'll paste it in the next step." };
+    case "oauth_app":
+      return { label: "Set up", explanation: "Needs an OAuth app registered with this provider. You'll enter its client id and secret in the next step." };
+    case "guided":
+      return { label: "Set up", explanation: "A short guided setup collects what this provider needs before anyone can connect." };
+  }
+}
+
+export type ConnectorFact = {
+  label: string;
+  value: string;
+  href?: string;
+  mono?: boolean;
+};
+
+function formatDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function accessLabel(connection: ExternalMcpConnection, orgName: string): string | null {
+  const access = connection.access;
+  if (!access) return null;
+  if (access.orgWide) return `Everyone in ${orgName}`;
+  const parts: string[] = [];
+  if (access.teamIds.length > 0) parts.push(`${access.teamIds.length} ${access.teamIds.length === 1 ? "team" : "teams"}`);
+  if (access.memberIds.length > 0) parts.push(`${access.memberIds.length} ${access.memberIds.length === 1 ? "person" : "people"}`);
+  return parts.length > 0 ? parts.join(", ") : "Nobody yet";
+}
+
+function signInLabel(authType: ExternalMcpConnection["authType"], credentialMode?: ExternalMcpConnection["credentialMode"]): string {
+  const auth = authType === "oauth" ? "OAuth sign-in" : authType === "apikey" ? "API key" : "No sign-in";
+  if (!credentialMode) return auth;
+  return `${auth} · ${credentialMode === "per_member" ? "each person connects their own account" : "one shared org account"}`;
+}
+
+/**
+ * The "Information" table. Everything here is already known to the page from
+ * the connection list and preset catalog; nothing needs a second request.
+ */
+export function connectorDetailFacts(
+  subject: ConnectorDetailSubject,
+  context: { orgName: string; pluginHref: (pluginId: string) => string },
+): ConnectorFact[] {
+  const facts: ConnectorFact[] = [];
+
+  if (subject.kind === "connection") {
+    const { connection } = subject;
+    const native = isNativeProviderConnectionId(connection.id, connection.nativeProviderKey);
+    const host = apexDomain(connection.url);
+    if (native) {
+      const provider = connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365" ? "Microsoft" : "Google";
+      facts.push({ label: "Provider", value: provider });
+      facts.push({ label: "Type", value: "Native OpenWork connector" });
+    } else {
+      if (host) facts.push({ label: "Provider", value: host, href: `https://${host}` });
+      facts.push({ label: "Type", value: subject.connection.identityManagedBy.length > 0 ? "MCP server from a plugin" : "Remote MCP server" });
+      facts.push({ label: "Server", value: connection.url, mono: true });
+    }
+    facts.push({ label: "Sign-in", value: signInLabel(connection.authType, connection.credentialMode) });
+    if (connection.exposeDirectly) facts.push({ label: "Exposure", value: "Available as a standard MCP server with its own tool catalog" });
+    const access = accessLabel(connection, context.orgName);
+    if (access) facts.push({ label: "Access", value: access });
+    const added = formatDate(connection.connectedAt ?? connection.updatedAt);
+    if (added) facts.push({ label: "Added", value: added });
+    for (const owner of connection.identityManagedBy) {
+      facts.push({ label: "Managed by", value: owner.name, href: context.pluginHref(owner.pluginId) });
+    }
+    const requiredBy = connection.requiredBy.filter((plugin) => !connection.identityManagedBy.some((owner) => owner.pluginId === plugin.pluginId));
+    for (const plugin of requiredBy) {
+      facts.push({ label: "Required by", value: plugin.name, href: context.pluginHref(plugin.pluginId) });
+    }
+    if (subject.popular?.target.kind === "google-workspace") {
+      facts.push({ label: "Part of", value: "Google Workspace — one connection covers Gmail, Drive, and Calendar" });
+    }
+  } else if (subject.kind === "popular" || subject.kind === "preset") {
+    const preset = subject.kind === "preset" ? subject.preset : subject.preset;
+    if (subject.kind === "popular" && subject.popular.target.kind === "google-workspace") {
+      facts.push({ label: "Provider", value: "Google" });
+      facts.push({ label: "Type", value: "Native OpenWork connector" });
+      facts.push({ label: "Sign-in", value: "Google sign-in · each person connects their own account" });
+      facts.push({ label: "Part of", value: "Google Workspace — one connection covers Gmail, Drive, and Calendar" });
+    } else if (preset) {
+      const host = apexDomain(preset.url);
+      if (host) facts.push({ label: "Provider", value: host, href: `https://${host}` });
+      facts.push({ label: "Type", value: "Remote MCP server" });
+      facts.push({ label: "Server", value: preset.url, mono: true });
+      facts.push({ label: "Sign-in", value: signInLabel(preset.authType, preset.authType === "oauth" ? "per_member" : preset.authType === "none" ? undefined : "shared") });
+      facts.push({ label: "Setup", value: EFFORT_LABELS[presetEffort(preset)] });
+    } else if (subject.kind === "popular") {
+      const host = apexDomain(subject.popular.icon.serviceUrl);
+      if (host) facts.push({ label: "Provider", value: host, href: `https://${host}` });
+      facts.push({ label: "Type", value: "Remote MCP server" });
+      facts.push({ label: "Setup", value: EFFORT_LABELS.guided });
+    }
+  } else if (subject.kind === "microsoft-365") {
+    facts.push({ label: "Provider", value: "Microsoft" });
+    facts.push({ label: "Type", value: "Native OpenWork connector" });
+    facts.push({ label: "Sign-in", value: "Microsoft sign-in · each person connects their own account" });
+  }
+
+  facts.push({ label: "Docs", value: "Shared MCP connections", href: CONNECTOR_DOCS_URL });
+  return facts;
+}
+
+/** The stable id a catalog row or connection should link to for its detail page. */
+export function connectorDetailId(input: { connection?: ExternalMcpConnection; catalogId: string }): string {
+  return input.connection?.id ?? input.catalogId;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { ArrowRight, Check, Loader2, Plus } from "lucide-react";
+import { GOOGLE_WORKSPACE_QUICK_ADD_ID, MICROSOFT_365_QUICK_ADD_ID } from "./connector-catalog";
 import { EFFORT_LABELS, type ConnectorEffort, presetEffort } from "./connector-effort";
 import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
 import { IntegrationIcon } from "./integration-icon";
 
-export const GOOGLE_WORKSPACE_QUICK_ADD_ID = "google-workspace";
-export const MICROSOFT_365_QUICK_ADD_ID = "microsoft-365";
+export { GOOGLE_WORKSPACE_QUICK_ADD_ID, MICROSOFT_365_QUICK_ADD_ID };
 
 const SUITE_CONNECTORS = [
   {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-form-controls.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-form-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ExternalMcpAuthType, ExternalMcpCredentialMode } from "./mcp-connections-data";
+import type { ExternalMcpAuthType, ExternalMcpCredentialMode, ExternalMcpPreset } from "./mcp-connections-data";
 
 /**
  * Form controls shared by every surface that configures an MCP connection:
@@ -56,6 +56,12 @@ export const AUTH_TYPE_OPTIONS: SegmentedControlOption<ExternalMcpAuthType>[] = 
   { value: "apikey", label: "API key" },
   { value: "none", label: "None" },
 ];
+
+export function presetAuthTypeOptions(preset: ExternalMcpPreset | null): SegmentedControlOption<ExternalMcpAuthType>[] {
+  if (!preset) return AUTH_TYPE_OPTIONS;
+  const allowed = preset.supportedAuthTypes ?? [preset.authType];
+  return AUTH_TYPE_OPTIONS.filter((option) => allowed.includes(option.value));
+}
 
 export const CREDENTIAL_MODE_OPTIONS: SegmentedControlOption<ExternalMcpCredentialMode>[] = [
   { value: "per_member", label: "Individual accounts" },

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -235,6 +235,7 @@ export type ExternalMcpPreset = {
   url: string;
   authType: ExternalMcpAuthType;
   requiresOAuthClient?: boolean;
+  supportedAuthTypes?: ExternalMcpAuthType[];
 };
 
 export type CreatedMcpConnection = ExternalMcpConnection & {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -109,14 +109,17 @@ const GOOGLE_WORKSPACE_PERMISSION_GROUPS = [
     name: "Calendar",
     permissions: [
       { key: "calendarRead", label: "Read calendar" },
-      { key: "calendarWrite", label: "Create calendar events" },
+      { key: "calendarWrite", label: "Create, edit, and cancel calendar events" },
     ],
   },
   {
     name: "Gmail",
     permissions: [
-      { key: "gmailDraft", label: "Draft emails" },
+      { key: "gmailDraft", label: "Create and edit email drafts" },
+      { key: "gmailSend", label: "Send email drafts after confirmation" },
       { key: "gmailRead", label: "Read Gmail" },
+      { key: "gmailManage", label: "Manage Gmail — send, archive, read status, labels, and trash" },
+      { key: "gmailLabels", label: "Create and manage Gmail labels" },
     ],
   },
   {
@@ -125,6 +128,13 @@ const GOOGLE_WORKSPACE_PERMISSION_GROUPS = [
       { key: "driveFile", label: "Work with selected Drive files" },
       { key: "driveRead", label: "Read all Drive files" },
       { key: "driveFull", label: "Full Drive access" },
+    ],
+  },
+  {
+    name: "Sheets",
+    permissions: [
+      { key: "sheetsRead", label: "Read spreadsheets" },
+      { key: "sheetsWrite", label: "Create spreadsheets and edit cells" },
     ],
   },
   {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1,32 +1,48 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { type ReactNode, type Ref, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ArrowLeft, Check, Loader2, Minus, MoreHorizontal, Pencil, Plug, Puzzle, Search, Server, Trash2, Users, Wrench } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Check, ChevronRight, Link2, Loader2, MessageCircle, Minus, MoreHorizontal, Pencil, Plus, Puzzle, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
 import { DenSelect } from "../../_components/ui/select";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
-import { getPluginRoute, getToolTesterRoute } from "../../_lib/den-org";
+import { DenChip } from "../../_components/ui/chip";
+import { DenPageHeader } from "../../_components/ui/page-header";
+import { getConfiguredMcpConnectionsRoute, getMcpConnectionRoute, getMcpConnectionsRoute, getPluginRoute, getToolTesterRoute, getYourConnectionsRoute } from "../../_lib/den-org";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
+import { ConnectorCatalog, connectorChatHref } from "./connector-catalog-list";
+import type { PopularConnector } from "./connector-catalog";
+import {
+  connectorAccountStatus,
+  connectorAccountReady,
+  displayedConnectorConnections,
+  connectorDetailEffort,
+  connectorDetailFacts,
+  connectorDetailIdentity,
+  connectorDetailPrimaryAction,
+  resolveConnectorDetailSubject,
+} from "./connector-detail";
+import { EFFORT_LABELS, presetEffort } from "./connector-effort";
 import { IntegrationIcon } from "./integration-icon";
 import { Microsoft365Dialog } from "./microsoft-365-dialog";
 import { openMcpAuthorizationTab, safeMcpAuthorizationUrl, showMcpAuthorizationFailure } from "./mcp-authorization-url";
+import { MCP_AUTHORIZATION_TIMEOUT_MESSAGE, MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE, MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE, resolveMcpAuthorizationPollOutcome } from "./mcp-account-authorization-state";
 import {
   editableMcpIdentityChanged,
   marketplaceIdentityOwnerNames,
   mcpAccessMode,
   type McpConnectionAccessMode,
 } from "./mcp-connection-editing";
-import { formatConnectionCreatorAttribution } from "./mcp-connection-display";
+import { formatConnectionCreatorAttribution, sortConnectionsForFocus, trustedConnectionFocusId } from "./mcp-connection-display";
 import {
   AUTH_TYPE_OPTIONS,
   CREDENTIAL_MODE_OPTIONS,
   credentialModeDescription,
   MCP_OAUTH_REDIRECT_DOCS_URL,
+  presetAuthTypeOptions,
   SegmentedControl,
   type SegmentedControlOption,
 } from "./mcp-connection-form-controls";
@@ -81,10 +97,13 @@ import {
 } from "./mcp-scope-selection";
 import { getPluginPartsSummary, pluginQueryKeys, usePlugins } from "./plugin-data";
 import {
-  ConnectorQuickAddGrid,
   GOOGLE_WORKSPACE_QUICK_ADD_ID,
   MICROSOFT_365_QUICK_ADD_ID,
 } from "./connector-quick-add-grid";
+
+export type McpConnectionsScreenView = "catalog" | "configured" | "detail";
+type OAuthOutcome = "connected" | "pending" | "configuration_required" | "failed";
+type CreateOutcome = "created" | OAuthOutcome;
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
@@ -264,12 +283,13 @@ function importServerStatus(server: GithubPluginImportServer): string {
   return "unsupported";
 }
 
-export function McpConnectionsScreen() {
+export function McpConnectionsScreen({ view = "catalog", connectorId }: { view?: McpConnectionsScreenView; connectorId?: string }) {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
-  const { data: usableConnections = [], isLoading: usableConnectionsLoading } = useMcpConnections("usable");
-  const { data: presets = [] } = useMcpConnectionPresets();
+  const { data: usableConnections = [], isLoading: usableConnectionsLoading, error: usableConnectionsError } = useMcpConnections("usable");
+  const { data: presets = [], isLoading: presetsLoading, error: presetsError, refetch: refetchPresets } = useMcpConnectionPresets();
   const createConnection = useCreateMcpConnection();
   const createNativeConnection = useCreateNativeProviderConnection();
   const updateConnection = useUpdateMcpConnection();
@@ -290,7 +310,7 @@ export function McpConnectionsScreen() {
   const [issuerReviewConnection, setIssuerReviewConnection] = useState<ExternalMcpConnection | null>(null);
   const [issuerReviewPreview, setIssuerReviewPreview] = useState<McpIssuerReview | null>(null);
   const [googleDialogMode, setGoogleDialogMode] = useState<"create" | "legacy" | null>(null);
-  const [microsoftDialogOpen, setMicrosoftDialogOpen] = useState(false);
+  const [microsoftDialogConnectionId, setMicrosoftDialogConnectionId] = useState<string | null>(null);
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const [oauthClientConfigurationRequiredIds, setOAuthClientConfigurationRequiredIds] = useState<string[]>([]);
@@ -302,9 +322,11 @@ export function McpConnectionsScreen() {
   const [smartBarResolution, setSmartBarResolution] = useState<McpConnectionResolution | null>(null);
   const [smartBarSubmitting, setSmartBarSubmitting] = useState(false);
   const [instantAddingPresetId, setInstantAddingPresetId] = useState<string | null>(null);
+  const [detailLinkCopied, setDetailLinkCopied] = useState(false);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const handledQuickAddId = useRef<string | null>(null);
   const smartBarRequestId = useRef(0);
+  const focusedRowRef = useRef<HTMLDivElement | null>(null);
 
   function openQuickAdd(id: string) {
     if (id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
@@ -313,7 +335,8 @@ export function McpConnectionsScreen() {
       return;
     }
     if (id === MICROSOFT_365_QUICK_ADD_ID) {
-      setMicrosoftDialogOpen(true);
+      saveNativeClient.reset();
+      setMicrosoftDialogConnectionId(MICROSOFT_365_QUICK_ADD_ID);
       return;
     }
 
@@ -326,21 +349,53 @@ export function McpConnectionsScreen() {
     setFormOpen(true);
   }
 
-  function openAdvancedSetup(initialName = "", initialUrl = "") {
+  function openAdvancedSetup(initialName = "", initialUrl = "", preset: ExternalMcpPreset | null = null) {
     createConnection.reset();
-    setFormPreset(null);
+    setFormPreset(preset);
     setFormInitialView("advanced");
     setFormInitialName(initialName);
     setFormInitialUrl(initialUrl);
     setFormOpen(true);
   }
 
-  function manageConnection(connectionId: string) {
-    const connection = connections.find((entry) => entry.id === connectionId);
-    if (!connection) return;
-    updateConnection.reset();
-    setConfiguringOAuthClient(false);
-    setEditingConnection(connection);
+  function manageConnection(connection: ExternalMcpConnection) {
+    router.push(getMcpConnectionRoute(orgSlug, connection.id));
+  }
+
+  /**
+   * Catalog "+" for curated presets: connectors that need nothing from the
+   * org are added on the spot. OAuth servers with automatic app registration
+   * are added for everyone and the authorization tab opens right away so the
+   * admin's own account is connected in the same gesture. Presets that need
+   * an org secret (API key, pre-registered OAuth app) land in the guided form.
+   */
+  function addPreset(preset: ExternalMcpPreset) {
+    if (presetsLoading || presetsError) return;
+    const effort = presetEffort(preset);
+    if (effort === "instant") {
+      void handleInstantAdd(preset);
+      return;
+    }
+    if (effort === "one_click") {
+      void handleOneClickAdd(preset);
+      return;
+    }
+    openQuickAdd(preset.presetId);
+  }
+
+  function addPopularConnector(connector: PopularConnector) {
+    if (connector.target.kind === "google-workspace") {
+      openQuickAdd(GOOGLE_WORKSPACE_QUICK_ADD_ID);
+      return;
+    }
+    if (connector.target.kind === "microsoft-365") {
+      openQuickAdd(MICROSOFT_365_QUICK_ADD_ID);
+      return;
+    }
+    const presetId = connector.target.presetId;
+    const preset = presets.find((entry) => entry.presetId === presetId);
+    if (preset) addPreset(preset);
+    else setConnectionActionError({ connectionId: connector.id, message: "Setup options are unavailable. Reload setup options and try again." });
   }
 
   const smartBarInputKind = classifySmartAddInput(smartQuery);
@@ -387,7 +442,9 @@ export function McpConnectionsScreen() {
         ? ["This provider needs a pre-registered OAuth app."]
         : smartBarResolution?.preset?.authType === "apikey"
           ? ["This provider needs your org's API key."]
-          : []
+          : smartBarResolution?.preset && smartBarResolution.preset.authType !== smartBarPlan.input.authType
+            ? ["The server check differs from this provider's required authentication. Continue with the provider setup."]
+            : []
     : [];
   const smartBarOneClick = smartBarPlan?.readiness === "one_click" && smartBarBlockers.length === 0
     ? smartBarPlan
@@ -410,10 +467,7 @@ export function McpConnectionsScreen() {
     };
   }, []);
 
-  const legacyGoogleConnection = usableConnections.find((connection) => connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID);
-  const listedConnections = legacyGoogleConnection && !connections.some((connection) => connection.id === legacyGoogleConnection.id)
-    ? [legacyGoogleConnection, ...connections]
-    : connections;
+  const listedConnections = displayedConnectorConnections(connections, usableConnections);
 
   function stopPolling() {
     if (pollTimer.current) {
@@ -423,32 +477,54 @@ export function McpConnectionsScreen() {
     setPollingConnectionId(null);
   }
 
-  function pollUntilConnected(connectionId: string) {
+  function pollUntilConnected(connectionId: string, authorizationTab: Window) {
+    stopPolling();
     setPollingConnectionId(connectionId);
     const startedAt = Date.now();
-    pollTimer.current = setInterval(async () => {
+    let fetching = false;
+    const timer = setInterval(async () => {
+      if (fetching) return;
+      fetching = true;
       const result = await refetch();
+      fetching = false;
+      if (pollTimer.current !== timer) return;
       const connection = result.data?.find((entry) => entry.id === connectionId);
-      if (connection?.connected || Date.now() - startedAt > OAUTH_POLL_TIMEOUT_MS) {
+      const outcome = resolveMcpAuthorizationPollOutcome({
+        connected: !result.error && Boolean(connection && connectorAccountReady(connection)),
+        authorizationWindowClosed: authorizationTab.closed,
+        elapsedMs: Date.now() - startedAt,
+        timeoutMs: OAUTH_POLL_TIMEOUT_MS,
+      });
+      if (outcome !== "pending") {
         stopPolling();
+        if (outcome !== "connected") {
+          setConnectionActionNotice(null);
+          setConnectionActionError({ connectionId, message: outcome === "timeout" ? MCP_AUTHORIZATION_TIMEOUT_MESSAGE : MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE });
+        }
       }
     }, OAUTH_POLL_INTERVAL_MS);
+    pollTimer.current = timer;
   }
 
-  async function handleConnectOAuth(connectionId: string, connectionName: string, pendingAuthorizationTab?: Window) {
+  async function handleConnectOAuth(connectionId: string, connectionName: string, pendingAuthorizationTab?: Window): Promise<OAuthOutcome> {
     setConnectionActionError(null);
+    setConnectionActionNotice(null);
+    stopPolling();
     let authorizationTab: Window | null = pendingAuthorizationTab ?? null;
     try {
       authorizationTab = authorizationTab ?? openMcpAuthorizationTab({ connectionId, connectionName });
       const result = await startOAuth.mutateAsync(connectionId);
       if (result.status === "connected") {
+        const refreshed = await refetch();
+        const connection = refreshed.data?.find((entry) => entry.id === connectionId);
+        if (refreshed.error || !connection || !connectorAccountReady(connection)) throw new Error(MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE);
         authorizationTab.close();
-        void refetch();
-        return;
+        return "connected";
       }
       if (!result.authorizeUrl) throw new Error("The MCP provider did not return an authorization URL.");
       authorizationTab.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
-      pollUntilConnected(connectionId);
+      pollUntilConnected(connectionId, authorizationTab);
+      return "pending";
     } catch (connectError) {
       const message = connectError instanceof Error ? connectError.message : "Failed to connect the MCP server.";
       showMcpAuthorizationFailure(authorizationTab, {
@@ -459,23 +535,21 @@ export function McpConnectionsScreen() {
           ? { details: connectError.details }
           : {}),
       });
+      setConnectionActionError({ connectionId, message });
       if (connectError instanceof McpOAuthConfigurationRequiredError) {
         setOAuthClientConfigurationRequiredIds((current) => current.includes(connectionId)
           ? current
           : [...current, connectionId]);
-        return;
+        return "configuration_required";
       }
-      setConnectionActionError({
-        connectionId,
-        message,
-      });
+      return "failed";
     }
   }
 
   async function handleCreate(
     input: CreateMcpConnectionInput,
     options: { startOAuth: boolean },
-  ): Promise<void> {
+  ): Promise<CreateOutcome> {
     const authorizationTab = options.startOAuth
       ? openMcpAuthorizationTab({ connectionId: "", connectionName: input.name })
       : undefined;
@@ -483,12 +557,11 @@ export function McpConnectionsScreen() {
       const created = await createConnection.mutateAsync(input);
       setFormOpen(false);
       setFormPreset(null);
-      // Shared-credential OAuth: the admin authorizes the org's single account
-      // right now. Per-member: nothing to authorize here — each granted person
-      // connects their own account from Your Connections.
+      // Only flows that explicitly request sign-in start authorization here.
       if (options.startOAuth) {
-        await handleConnectOAuth(created.id, input.name, authorizationTab);
+        return await handleConnectOAuth(created.id, input.name, authorizationTab);
       }
+      return "created";
     } catch (createError) {
       showMcpAuthorizationFailure(authorizationTab ?? null, {
         connectionId: "",
@@ -505,11 +578,12 @@ export function McpConnectionsScreen() {
     setConnectionActionError(null);
     setConnectionActionNotice(null);
     try {
-      await handleCreate(smartBarOneClick.input, {
+      const outcome = await handleCreate(smartBarOneClick.input, {
         startOAuth: smartBarOneClick.input.authType === "oauth" && smartBarOneClick.input.credentialMode === "shared",
       });
+      if (outcome === "failed" || outcome === "configuration_required") return;
       setSmartQuery("");
-      setConnectionActionNotice(`${smartBarOneClick.input.name} added for everyone in ${orgContext?.organization.name ?? "the organization"}.`);
+      setConnectionActionNotice(`${smartBarOneClick.input.name} added for everyone in ${orgContext?.organization.name ?? "the organization"}.${outcome === "pending" ? " Finish signing in to connect your account." : ""}`);
       await refetch();
     } catch (submitError) {
       setConnectionActionError({
@@ -563,6 +637,34 @@ export function McpConnectionsScreen() {
           </button>
         </>,
       );
+      await refetch();
+    } catch (createError) {
+      setConnectionActionError({
+        connectionId: preset.presetId,
+        message: createError instanceof Error ? createError.message : "Failed to add the MCP connection.",
+      });
+    } finally {
+      setInstantAddingPresetId(null);
+    }
+  }
+
+  async function handleOneClickAdd(preset: ExternalMcpPreset) {
+    setInstantAddingPresetId(preset.presetId);
+    setConnectionActionError(null);
+    setConnectionActionNotice(null);
+    try {
+      // Each person connects their own account; the admin's starts right now
+      // in the authorization tab handleCreate opens.
+      const outcome = await handleCreate({
+        name: preset.displayName,
+        url: preset.url,
+        authType: "oauth",
+        credentialMode: "per_member",
+        access: { orgWide: true, memberIds: [], teamIds: [] },
+      }, { startOAuth: true });
+      if (outcome === "failed" || outcome === "configuration_required") return;
+      const orgName = orgContext?.organization.name ?? "the organization";
+      setConnectionActionNotice(`${preset.displayName} added for everyone in ${orgName}. ${outcome === "connected" ? "Your account is connected." : "Finish signing in to connect your own account."}`);
       await refetch();
     } catch (createError) {
       setConnectionActionError({
@@ -645,13 +747,171 @@ export function McpConnectionsScreen() {
       : `${connection.name}'s current issuer was confirmed from live provider metadata.`);
   }
 
+  const configuredView = view === "configured";
+  const configuredRoute = getConfiguredMcpConnectionsRoute(orgSlug);
+  const focusConnectionId = configuredView ? trustedConnectionFocusId(listedConnections, searchParams.get("connectionId")) : null;
+  const configuredConnections = sortConnectionsForFocus(listedConnections, focusConnectionId);
+  const detailView = view === "detail";
+  const detailSubject = detailView ? resolveConnectorDetailSubject(connectorId ?? "", listedConnections, presets) : null;
+  const detailConnection = detailSubject?.kind === "connection" ? detailSubject.connection : null;
+  const detailIdentity = detailSubject ? connectorDetailIdentity(detailSubject) : null;
+  const detailEffort = detailSubject ? connectorDetailEffort(detailSubject) : null;
+  const detailPrimary = detailEffort ? connectorDetailPrimaryAction(detailEffort) : null;
+  const detailFacts = detailSubject
+    ? connectorDetailFacts(detailSubject, {
+      orgName: orgContext?.organization.name ?? "the org",
+      pluginHref: (pluginId) => getPluginRoute(orgSlug, pluginId),
+    })
+    : [];
+  const detailConnectionSetup = detailConnection ? connectionSetupState(detailConnection) : null;
+  const detailAccountStatus = detailConnection ? connectorAccountStatus(detailConnection, detailConnectionSetup?.setupRequired) : null;
+  const detailCanInspectTools = detailConnection && detailConnectionSetup
+    ? !isNativeProviderConnectionId(detailConnection.id, detailConnection.nativeProviderKey)
+      && !detailConnectionSetup.setupRequired
+      && connectorAccountReady(detailConnection)
+    : false;
+  const detailIsBusy = detailSubject?.kind === "popular"
+    ? detailSubject.popular.target.kind === "preset" && instantAddingPresetId === detailSubject.popular.target.presetId
+    : detailSubject?.kind === "preset"
+      ? instantAddingPresetId === detailSubject.preset.presetId
+      : false;
+  const detailSetupUnavailable = detailSubject?.kind === "popular" && detailSubject.popular.target.kind === "preset"
+    ? presetsLoading || Boolean(presetsError) || !detailSubject.preset
+    : detailSubject?.kind === "preset" && (presetsLoading || Boolean(presetsError));
+  const detailSetupDisabled = detailSetupUnavailable || isLoading || usableConnectionsLoading || Boolean(error || usableConnectionsError);
+
+  function connectionSetupState(connection: ExternalMcpConnection) {
+    const connectAttemptRequiresConfiguration = oauthClientConfigurationRequiredIds.includes(connection.id);
+    const needsOAuthClientConfiguration = connectionNeedsOAuthClientConfiguration(connection, connectAttemptRequiresConfiguration);
+    const needsPluginSetup = marketplaceConnectionNeedsAdminSetup(connection, presets) && !needsOAuthClientConfiguration;
+    return { needsOAuthClientConfiguration, needsPluginSetup, setupRequired: Boolean(connection.setupRequired) || needsPluginSetup || needsOAuthClientConfiguration };
+  }
+
+  function editConnection(connection: ExternalMcpConnection, configureOAuthClient = false) {
+    if (connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365") {
+      saveNativeClient.reset();
+      setMicrosoftDialogConnectionId(connection.id);
+      return;
+    }
+    if (connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
+      saveNativeClient.reset();
+      setGoogleDialogMode("legacy");
+      return;
+    }
+    updateConnection.reset();
+    setConfiguringOAuthClient(configureOAuthClient);
+    setEditingConnection(connection);
+  }
+
+  function recoverConnection(connection: ExternalMcpConnection) {
+    const setup = connectionSetupState(connection);
+    if (setup.needsOAuthClientConfiguration) return editConnection(connection, true);
+    if (setup.needsPluginSetup && connection.identityManagedBy[0]) {
+      router.push(getPluginRoute(orgSlug, connection.identityManagedBy[0].pluginId));
+      return;
+    }
+    if (setup.setupRequired) return editConnection(connection);
+    if (connection.authType !== "oauth") return editConnection(connection);
+    if (isNativeProviderConnectionId(connection.id, connection.nativeProviderKey)) {
+      router.push(`${getYourConnectionsRoute(orgSlug)}?connectionId=${encodeURIComponent(connection.id)}`);
+      return;
+    }
+    if (connection.issuerReviewRequired) return void handleOpenIssuerReview(connection);
+    void handleConnectOAuth(connection.id, connection.name);
+  }
+
+  /** Detail-page primary action: same paths the catalog "+" takes. */
+  function startDetailSetup() {
+    if (!detailSubject || detailSetupDisabled) return;
+    if (detailSubject.kind === "popular") {
+      addPopularConnector(detailSubject.popular);
+      return;
+    }
+    if (detailSubject.kind === "preset") {
+      addPreset(detailSubject.preset);
+      return;
+    }
+    if (detailSubject.kind === "microsoft-365") openQuickAdd(MICROSOFT_365_QUICK_ADD_ID);
+  }
+
+  async function copyDetailLink() {
+    if (typeof window === "undefined") return;
+    if (await copyTextToClipboard(window.location.href)) {
+      setDetailLinkCopied(true);
+      window.setTimeout(() => setDetailLinkCopied(false), 2000);
+    }
+  }
+
+  function renderConnectionRow(
+    connection: ExternalMcpConnection,
+    options: { highlighted?: boolean; rowRef?: Ref<HTMLDivElement> } = {},
+  ) {
+    const setup = connectionSetupState(connection);
+    const setupPluginId = connection.identityManagedBy[0]?.pluginId;
+    return <ConnectionRow
+      key={connection.id}
+      orgSlug={orgSlug}
+      connection={connection}
+      highlighted={options.highlighted ?? false}
+      rowRef={options.rowRef}
+      needsPluginSetup={setup.needsPluginSetup}
+      needsOAuthClientConfiguration={setup.needsOAuthClientConfiguration}
+      setupHref={setup.needsPluginSetup && setupPluginId ? getPluginRoute(orgSlug, setupPluginId) : null}
+      polling={pollingConnectionId === connection.id}
+      connecting={startOAuth.isPending && startOAuth.variables === connection.id}
+      errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
+      onEdit={() => editConnection(connection)}
+      onConfigure={() => editConnection(connection, true)}
+      onReviewIssuer={() => void handleOpenIssuerReview(connection)}
+      onConnect={() => void handleConnectOAuth(connection.id, connection.name)}
+      onDisconnect={() => void handleDisconnect(connection)}
+      onRemove={() => handleRemove(connection)}
+      disconnecting={disconnectConnection.isPending && disconnectConnection.variables === connection.id}
+      removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
+    />;
+  }
+
+  useEffect(() => {
+    if (!focusConnectionId || !focusedRowRef.current) return;
+    focusedRowRef.current.scrollIntoView({ block: "center" });
+    focusedRowRef.current.focus({ preventScroll: true });
+  }, [focusConnectionId, configuredConnections.length]);
+
   return (
-    <DashboardPageTemplate
-      icon={Plug}
-      title="Connectors"
-      description="Connectors is where you can add MCP servers that your whole team can use."
-      colors={["#E2E8F0", "#020617", "#0F172A", "#94A3B8"]}
-    >
+    <div className="mx-auto max-w-[860px] px-4 pb-16 pt-6 sm:px-6 md:px-8" data-testid="mcp-connections-page" data-view={view}>
+      {detailView ? (
+        <Link
+          href={getMcpConnectionsRoute(orgSlug)}
+          className="mb-6 inline-flex items-center gap-1.5 text-[13px] text-gray-400 transition hover:text-gray-700"
+          data-testid="connector-detail-back"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Connectors
+        </Link>
+      ) : (
+        <DenPageHeader
+          className="mb-8"
+          title={configuredView ? "Configured connectors" : "Connectors"}
+          description={configuredView
+            ? "Everything your team has set up: connect accounts, review tools, change access, or uninstall."
+            : "Connectors is where you can add MCP servers that your whole team can use."}
+          action={configuredView ? (
+            <Link
+              href={getMcpConnectionsRoute(orgSlug)}
+              className={buttonVariants({ variant: "primary" })}
+              data-testid="configured-add-connector"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add connector
+            </Link>
+          ) : (
+            <Link href={configuredRoute} className={buttonVariants({ variant: "secondary" })} data-testid="connectors-open-configured">
+              Configured
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          )}
+        />
+      )}
       {showStagingBanner ? (
         <div data-testid="mcp-connections-staging-banner" className="mb-6 rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] leading-6 text-amber-800">
           <p className="font-semibold text-amber-900">OpenWork Connect (beta) is staged for this org.</p>
@@ -667,9 +927,23 @@ export function McpConnectionsScreen() {
         </div>
       ) : null}
 
+      {usableConnectionsError ? (
+        <div className="mb-6 text-[14px] text-red-700" role="alert">Native connection status could not be loaded. Refresh before changing setup.</div>
+      ) : null}
+
+      {presetsError || detailSetupUnavailable ? (
+        <div className="mb-6 flex items-center gap-3 text-[14px] text-gray-600" role={presetsError ? "alert" : "status"}>
+          <span>{presetsLoading ? "Loading setup options. Chat is still available." : "Setup options are unavailable. Chat is still available."}</span>
+          {!presetsLoading ? <DenButton variant="secondary" size="sm" onClick={() => void refetchPresets()}>Reload setup options</DenButton> : null}
+        </div>
+      ) : null}
+
       {connectionActionError ? (
         <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700" role="alert">
           {connectionActionError.message}
+          {listedConnections.some((connection) => connection.id === connectionActionError.connectionId) ? (
+            <Link className="ml-2 font-semibold underline" href={getMcpConnectionRoute(orgSlug, connectionActionError.connectionId)}>Review connection</Link>
+          ) : null}
         </div>
       ) : null}
 
@@ -679,7 +953,7 @@ export function McpConnectionsScreen() {
         </div>
       ) : null}
 
-      <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Quick add</h3>
+      {configuredView || detailView ? null : (
       <div className="mb-8">
         <div className="flex items-center gap-3">
           <div className="min-w-0 flex-1">
@@ -695,14 +969,14 @@ export function McpConnectionsScreen() {
           <button
             type="button"
             onClick={() => openAdvancedSetup()}
-            className="shrink-0 text-[12px] font-medium text-gray-500 underline decoration-gray-300 underline-offset-4 transition hover:text-gray-900"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 transition hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900"
+            aria-label="Advanced setup"
+            title="Advanced setup — add any MCP server by URL"
+            data-testid="connector-advanced-setup"
           >
-            Advanced setup
+            <Plus className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
-        <p className="mt-1.5 text-[11px] text-gray-400">
-          Typing filters the tiles below. Pasting a URL checks the server and offers to add it right here.
-        </p>
 
         {smartBarState === "waiting" || smartBarState === "resolving" ? (
           <div className="mt-4 flex items-center gap-2.5 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3.5 text-[13px] text-gray-500" role="status">
@@ -727,6 +1001,7 @@ export function McpConnectionsScreen() {
               onClick={() => openAdvancedSetup(
                 smartBarResolution?.preset?.displayName ?? "",
                 smartBarResolution?.preset?.url ?? (smartBarInputKind === "domain" ? `https://${smartQuery.trim()}` : smartQuery.trim()),
+                smartBarResolution?.preset ?? null,
               )}
               className="shrink-0 font-medium underline underline-offset-2"
             >
@@ -749,7 +1024,7 @@ export function McpConnectionsScreen() {
                 <DenButton
                   variant="secondary"
                   size="sm"
-                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url)}
+                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url, smartBarResolution?.preset ?? null)}
                 >
                   Options
                 </DenButton>
@@ -781,7 +1056,7 @@ export function McpConnectionsScreen() {
                 Needs a little more setup: {smartBarBlockers.join(" · ")}{" "}
                 <button
                   type="button"
-                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url)}
+                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url, smartBarResolution?.preset ?? null)}
                   className="font-semibold underline underline-offset-2"
                 >
                   Continue setup
@@ -791,73 +1066,188 @@ export function McpConnectionsScreen() {
           </div>
         ) : null}
 
-        <div className="mt-5">
-          <ConnectorQuickAddGrid
-            connections={connections}
+        <div className="mt-8">
+          <ConnectorCatalog
+            connections={listedConnections}
             presets={presets}
-            onSelect={openQuickAdd}
             filter={smartBarResolutionMode ? "" : smartQuery}
+            configuredHref={configuredRoute}
+            configuredConnectionHref={(connectionId) => getMcpConnectionRoute(orgSlug, connectionId)}
+            connectorHref={(id) => getMcpConnectionRoute(orgSlug, id)}
+            onAddPopular={addPopularConnector}
+            onAddPreset={addPreset}
+            onAddMicrosoft365={() => openQuickAdd(MICROSOFT_365_QUICK_ADD_ID)}
             onManage={manageConnection}
-            onInstantAdd={(preset) => void handleInstantAdd(preset)}
-            instantAddingPresetId={instantAddingPresetId}
+            onRemove={handleRemove}
+            onRecover={recoverConnection}
+            setupRequired={(connection) => connectionSetupState(connection).setupRequired}
+            recoveringConnectionId={pollingConnectionId ?? (startOAuth.isPending ? startOAuth.variables : null)}
+            addingPresetId={instantAddingPresetId}
+            loading={presetsLoading}
+            unavailable={Boolean(presetsError)}
+            connectionsUnavailable={isLoading || usableConnectionsLoading || Boolean(error || usableConnectionsError)}
           />
         </div>
       </div>
+      )}
 
-      <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Your connectors</h3>
+      {!configuredView ? null : (
+      <>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Configured</h3>
+        <span className="text-[12px] text-gray-400">{configuredConnections.length} {configuredConnections.length === 1 ? "connector" : "connectors"}</span>
+      </div>
       {isLoading || usableConnectionsLoading ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
           Loading MCP connectors…
         </div>
-      ) : listedConnections.length === 0 ? (
+      ) : configuredConnections.length === 0 ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-center text-[14px] text-gray-500">
-          No MCP connectors yet.
+          No MCP connectors yet.{" "}
+          <Link href={getMcpConnectionsRoute(orgSlug)} className="font-semibold underline underline-offset-2">Browse connectors</Link>
         </div>
       ) : (
         <div className="divide-y divide-gray-100 rounded-2xl border border-gray-100 bg-white">
-          {listedConnections.map((connection) => {
-            const connectAttemptRequiresConfiguration = oauthClientConfigurationRequiredIds.includes(connection.id);
-            const needsOAuthClientConfiguration = connectionNeedsOAuthClientConfiguration(
-              connection,
-              connectAttemptRequiresConfiguration,
-            );
-            const needsPluginSetup = marketplaceConnectionNeedsAdminSetup(connection, presets)
-              && !needsOAuthClientConfiguration;
-            const setupPluginId = connection.identityManagedBy[0]?.pluginId;
-            return <ConnectionRow
-              key={connection.id}
-              orgSlug={orgSlug}
-              connection={connection}
-              needsPluginSetup={needsPluginSetup}
-              needsOAuthClientConfiguration={needsOAuthClientConfiguration}
-              setupHref={needsPluginSetup && setupPluginId ? getPluginRoute(orgSlug, setupPluginId) : null}
-              polling={pollingConnectionId === connection.id}
-              connecting={startOAuth.isPending && startOAuth.variables === connection.id}
-              errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
-              onEdit={() => {
-                if (connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
-                  saveNativeClient.reset();
-                  setGoogleDialogMode("legacy");
-                  return;
-                }
-                updateConnection.reset();
-                setConfiguringOAuthClient(false);
-                setEditingConnection(connection);
-              }}
-              onConfigure={() => {
-                updateConnection.reset();
-                setConfiguringOAuthClient(true);
-                setEditingConnection(connection);
-              }}
-              onReviewIssuer={() => void handleOpenIssuerReview(connection)}
-              onConnect={() => void handleConnectOAuth(connection.id, connection.name)}
-              onDisconnect={() => void handleDisconnect(connection)}
-              onRemove={() => handleRemove(connection)}
-              disconnecting={disconnectConnection.isPending && disconnectConnection.variables === connection.id}
-              removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
-            />;
-          })}
+          {configuredConnections.map((connection) => renderConnectionRow(connection, {
+            highlighted: focusConnectionId === connection.id,
+            rowRef: focusConnectionId === connection.id ? focusedRowRef : undefined,
+          }))}
         </div>
+      )}
+      </>
+      )}
+
+      {!detailView || !detailSubject || !detailIdentity ? null : detailSubject.kind === "not_found" ? (
+        <div
+          className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-center text-[14px] text-gray-500"
+          data-testid="connector-detail-not-found"
+        >
+          {isLoading || usableConnectionsLoading || presetsLoading ? "Loading connector…" : presetsError ? "Reload setup options to find this connector." : (
+            <>
+              We couldn&apos;t find that connector.{" "}
+              <Link href={getMcpConnectionsRoute(orgSlug)} className="font-semibold underline underline-offset-2">Browse connectors</Link>
+            </>
+          )}
+        </div>
+      ) : (
+        <article data-testid="connector-detail" data-connector-kind={detailSubject.kind}>
+          <header className="flex flex-col gap-5">
+            <IntegrationIcon
+              name={detailIdentity.name}
+              iconUrl={detailIdentity.icon.iconUrl}
+              simpleIconSlug={detailIdentity.icon.simpleIconSlug}
+              serviceUrl={detailIdentity.icon.serviceUrl}
+              className="h-[72px] w-[72px] rounded-[20px]"
+              imageClassName="h-9 w-9"
+            />
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h1 data-testid="connector-detail-title" className="flex flex-wrap items-center gap-2.5 text-[28px] font-medium leading-[34px] tracking-[-0.5px] text-gray-950">
+                  {detailIdentity.name}
+                  {detailConnection ? (
+                    <DenChip tone="neutral" size="sm" data-testid="connector-detail-state">
+                      {detailAccountStatus}
+                    </DenChip>
+                  ) : detailEffort ? (
+                    <DenChip tone="neutral" size="sm" data-testid="connector-detail-state">{EFFORT_LABELS[detailEffort]}</DenChip>
+                  ) : null}
+                </h1>
+                {detailIdentity.description ? (
+                  <p className="mt-2 text-[14px] leading-[20px] text-gray-500">{detailIdentity.description}</p>
+                ) : null}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <DenButton
+                  variant="secondary"
+                  size="sm"
+                  icon={detailLinkCopied ? Check : Link2}
+                  onClick={() => void copyDetailLink()}
+                  data-testid="connector-detail-copy-link"
+                >
+                  {detailLinkCopied ? "Copied" : "Copy link"}
+                </DenButton>
+                <DenButton size="sm" icon={MessageCircle} href={connectorChatHref(detailIdentity.name)} data-testid="connector-detail-chat">
+                  Chat
+                </DenButton>
+                {!detailConnection && detailPrimary ? (
+                  <DenButton size="sm" variant="secondary" loading={detailIsBusy} disabled={detailSetupDisabled} onClick={startDetailSetup} data-testid="connector-detail-primary">
+                    {detailPrimary.label}
+                  </DenButton>
+                ) : null}
+              </div>
+            </div>
+          </header>
+
+          <section className="mt-10" data-testid="connector-detail-connection">
+            <DetailSectionTitle>Connection</DetailSectionTitle>
+            {detailConnection ? (
+              <div className="rounded-2xl border border-gray-100 bg-white">
+                {renderConnectionRow(detailConnection)}
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4 rounded-2xl border border-dashed border-gray-200 bg-gray-50/60 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-[14px] font-medium text-gray-900">{isLoading || usableConnectionsLoading ? "Checking connection setup..." : error || usableConnectionsError || detailSetupUnavailable ? "Connection setup could not be confirmed" : `Not set up for ${orgContext?.organization.name ?? "your org"} yet`}</p>
+                  {detailPrimary ? <p className="mt-1 max-w-[520px] text-[13px] leading-5 text-gray-500">{detailPrimary.explanation}</p> : null}
+                </div>
+                {detailPrimary ? (
+                  <DenButton className="shrink-0" loading={detailIsBusy} disabled={detailSetupDisabled} onClick={startDetailSetup} data-testid="connector-detail-setup">
+                    {detailPrimary.label}
+                  </DenButton>
+                ) : null}
+              </div>
+            )}
+          </section>
+
+          {detailConnection ? (
+            <section className="mt-10" data-testid="connector-detail-tools">
+              <DetailSectionTitle>Tools</DetailSectionTitle>
+              {detailCanInspectTools ? (
+                <div className="flex flex-col gap-4 rounded-2xl border border-gray-100 bg-white px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-[13px] leading-5 text-gray-500">
+                    Browse this connector&apos;s live tool catalog and run a tool against your connected account in the Tool Tester.
+                  </p>
+                  <Link
+                    href={`${getToolTesterRoute(orgSlug)}?connectionId=${encodeURIComponent(detailConnection.id)}`}
+                    className={buttonVariants({ variant: "secondary", size: "sm" })}
+                    data-testid="connector-detail-test-tools"
+                  >
+                    <Wrench className="h-3.5 w-3.5" aria-hidden="true" />
+                    Test tools
+                  </Link>
+                </div>
+              ) : (
+                <p className="text-[13px] leading-5 text-gray-500">
+                  {isNativeProviderConnectionId(detailConnection.id, detailConnection.nativeProviderKey)
+                    ? "Native connectors expose their capabilities through OpenWork Connect rather than an MCP tool catalog."
+                    : "Tools appear here once the connection is connected for you."}
+                </p>
+              )}
+            </section>
+          ) : null}
+
+          <section className="mt-10" data-testid="connector-detail-information">
+            <DetailSectionTitle>Information</DetailSectionTitle>
+            <dl className="divide-y divide-gray-100">
+              {detailFacts.map((fact) => (
+                <div key={`${fact.label}-${fact.value}`} className="grid gap-1 py-3 sm:grid-cols-[160px_1fr] sm:gap-6">
+                  <dt className="text-[13px] text-gray-400">{fact.label}</dt>
+                  <dd className={`min-w-0 text-[14px] text-gray-900 ${fact.mono ? "truncate font-mono text-[12.5px]" : ""}`}>
+                    {fact.href?.startsWith("/") ? (
+                      <Link href={fact.href} className="underline-offset-2 hover:underline">{fact.value}</Link>
+                    ) : fact.href ? (
+                      <a href={fact.href} target="_blank" rel="noopener noreferrer" className="underline-offset-2 hover:underline">{fact.value}</a>
+                    ) : fact.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <p className="mt-10 text-[12px] leading-5 text-gray-400">
+            When a connector is connected, OpenWork agents can use its tools with the connected account whenever a request calls for it. Tool calls follow the connector&apos;s tool policy, and anyone can disconnect their own account from Your Connections at any time.
+          </p>
+        </article>
       )}
 
       <AddConnectionDialog
@@ -930,17 +1320,19 @@ export function McpConnectionsScreen() {
         }}
       />
 
-      <Microsoft365Dialog
-        open={microsoftDialogOpen}
+      {microsoftDialogConnectionId ? <Microsoft365Dialog
+        key={microsoftDialogConnectionId}
+        providerId={microsoftDialogConnectionId}
+        open
         submitting={saveNativeClient.isPending}
         error={saveNativeClient.error}
-        onClose={() => setMicrosoftDialogOpen(false)}
+        onClose={() => setMicrosoftDialogConnectionId(null)}
         onSubmit={async (input) => {
-          await saveNativeClient.mutateAsync({ providerId: "microsoft-365", ...input });
-          setMicrosoftDialogOpen(false);
+          await saveNativeClient.mutateAsync({ providerId: microsoftDialogConnectionId, ...input });
+          setMicrosoftDialogConnectionId(null);
         }}
-      />
-    </DashboardPageTemplate>
+      /> : null}
+    </div>
   );
 }
 
@@ -1649,6 +2041,10 @@ function IssuerReviewDialog({
   );
 }
 
+function DetailSectionTitle({ children }: { children: ReactNode }) {
+  return <h2 className="mb-3 border-b border-gray-100 pb-3 text-[16px] font-medium tracking-[-0.02em] text-gray-950">{children}</h2>;
+}
+
 function accessSummaryLabel(connection: ExternalMcpConnection): string {
   const access = connection.access;
   if (!access) return "";
@@ -1662,6 +2058,8 @@ function accessSummaryLabel(connection: ExternalMcpConnection): string {
 function ConnectionRow({
   orgSlug,
   connection,
+  highlighted = false,
+  rowRef,
   needsPluginSetup,
   needsOAuthClientConfiguration,
   setupHref,
@@ -1679,6 +2077,8 @@ function ConnectionRow({
 }: {
   orgSlug: string | null;
   connection: ExternalMcpConnection;
+  highlighted?: boolean;
+  rowRef?: Ref<HTMLDivElement>;
   needsPluginSetup: boolean;
   needsOAuthClientConfiguration: boolean;
   setupHref: string | null;
@@ -1697,16 +2097,16 @@ function ConnectionRow({
   const isPerMember = connection.credentialMode === "per_member";
   const isNativeProvider = isNativeProviderConnectionId(connection.id, connection.nativeProviderKey);
   const isLegacyGoogleConnection = connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID;
+  const isLegacyNativeConnection = isLegacyGoogleConnection || connection.id === MICROSOFT_365_QUICK_ADD_ID;
   const creatorAttribution = formatConnectionCreatorAttribution(connection.createdByName);
   const [actionsOpen, setActionsOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement>(null);
   const actionsTriggerRef = useRef<HTMLButtonElement>(null);
-  const setupRequired = needsPluginSetup || needsOAuthClientConfiguration;
-  const displayedConnected = connection.connected && !setupRequired;
-  const canConnectOAuth = !isLegacyGoogleConnection && !setupRequired && !connection.issuerReviewRequired && connection.authType === "oauth"
-    && (isPerMember ? !connection.connectedForMe : !connection.connected);
-  const canInspectTools = !isNativeProvider && !setupRequired && !connection.issuerReviewRequired
-    && (connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe);
+  const setupRequired = Boolean(connection.setupRequired) || needsPluginSetup || needsOAuthClientConfiguration;
+  const displayedConnected = connectorAccountReady(connection) && !setupRequired;
+  const canConnectOAuth = !isNativeProvider && !setupRequired && !connection.issuerReviewRequired && connection.authType === "oauth"
+    && !displayedConnected;
+  const canInspectTools = !isNativeProvider && !setupRequired && connectorAccountReady(connection);
 
   useEffect(() => {
     if (!actionsOpen) return;
@@ -1732,7 +2132,12 @@ function ConnectionRow({
   }, [actionsOpen]);
 
   return (
-    <div data-testid={`mcp-connection-row-${connection.id}`}>
+    <div
+      ref={rowRef}
+      tabIndex={highlighted ? -1 : undefined}
+      className={`outline-none transition ${highlighted ? "bg-blue-50/70 ring-2 ring-inset ring-blue-200" : ""}`}
+      data-testid={`mcp-connection-row-${connection.id}`}
+    >
       <div className="flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <IntegrationIcon name={connection.name} serviceUrl={connection.url} />
@@ -1749,9 +2154,9 @@ function ConnectionRow({
                   OAuth settings need review
                 </span>
               ) : isPerMember ? (
-                <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${connection.connected ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${displayedConnected ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
                   <Users className="h-3 w-3" />
-                  {connection.connected ? "Individual accounts connected" : "Not connected"}
+                  {polling ? "Waiting for authorization..." : connectorAccountStatus(connection, setupRequired)}
                 </span>
               ) : displayedConnected ? (
                 <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
@@ -1765,7 +2170,7 @@ function ConnectionRow({
                 </span>
               ) : (
                 <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-                  Not connected
+                  {connectorAccountStatus(connection, setupRequired)}
                 </span>
               )}
               {connection.access ? (
@@ -1793,6 +2198,14 @@ function ConnectionRow({
               Configure
             </DenButton>
           ) : null}
+          {setupRequired && !needsOAuthClientConfiguration && !setupHref ? (
+            <DenButton variant="primary" size="sm" onClick={onEdit}>Set up</DenButton>
+          ) : null}
+          {isNativeProvider && !setupRequired ? (
+            <DenButton variant="secondary" size="sm" href={`${getYourConnectionsRoute(orgSlug)}?connectionId=${encodeURIComponent(connection.id)}`}>
+              {displayedConnected ? "Your account" : connection.needsReconnect ? "Reconnect" : "Connect your account"}
+            </DenButton>
+          ) : null}
           {setupHref ? (
             <Link href={setupHref} className={buttonVariants({ variant: "primary", size: "sm" })}>
               Set up
@@ -1810,10 +2223,10 @@ function ConnectionRow({
               loading={connecting || polling}
               onClick={onConnect}
             >
-              Connect
+              {connection.needsReconnect || connection.credentialHealth === "reconnect_required" ? "Reconnect" : "Connect"}
             </DenButton>
           ) : null}
-          {displayedConnected && !isLegacyGoogleConnection ? (
+          {connection.connected && !isNativeProvider ? (
             <DenButton
               variant="secondary"
               size="sm"
@@ -1844,6 +2257,17 @@ function ConnectionRow({
                 aria-label={`Actions for ${connection.name}`}
                 className="absolute right-0 top-10 z-30 w-44 overflow-hidden rounded-2xl border border-gray-100 bg-white p-1.5 text-[13px] shadow-xl shadow-gray-900/10"
               >
+                <a
+                  role="menuitem"
+                  href={connectorChatHref(connection.name)}
+                  onClick={() => setActionsOpen(false)}
+                  className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900"
+                  aria-label={`Chat with ${connection.name} in OpenWork`}
+                  data-testid={`chat-mcp-connection-${connection.id}`}
+                >
+                  <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                  Chat
+                </a>
                 <button
                   type="button"
                   role="menuitem"
@@ -1851,7 +2275,7 @@ function ConnectionRow({
                     setActionsOpen(false);
                     onEdit();
                   }}
-                  disabled={!connection.updatedAt && !isLegacyGoogleConnection}
+                  disabled={!connection.updatedAt && !isNativeProvider}
                   className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
                   aria-label={`Edit ${connection.name}`}
                   data-testid={`edit-mcp-connection-${connection.id}`}
@@ -1878,7 +2302,7 @@ function ConnectionRow({
                   <Wrench className="h-3.5 w-3.5" aria-hidden="true" />
                   Test tools
                 </Link>
-                {!isLegacyGoogleConnection ? (
+                {!isLegacyNativeConnection ? (
                   <>
                     <div className="my-1 border-t border-gray-100" />
                     <button
@@ -2331,7 +2755,7 @@ function AddConnectionDialog({
   onSubmit: (
     input: CreateMcpConnectionInput,
     options: { startOAuth: boolean },
-  ) => Promise<void>;
+  ) => Promise<CreateOutcome>;
 }) {
   const { orgContext } = useOrgDashboard();
   const discoverRequirements = useDiscoverMcpConnectionRequirements();
@@ -2358,12 +2782,17 @@ function AddConnectionDialog({
   const [requirements, setRequirements] = useState<McpRequirementsDiscovery | null>(null);
   const [discoveryState, setDiscoveryState] = useState<"idle" | "waiting" | "checking" | "ready" | "error">("idle");
   const [discoveryError, setDiscoveryError] = useState<unknown>(null);
+  const [submissionError, setSubmissionError] = useState<unknown>(null);
   const [authorizationServerIssuer, setAuthorizationServerIssuer] = useState("");
   const [requestedScopes, setRequestedScopes] = useState<string[]>([]);
   const [accessMode, setAccessMode] = useState<AddConnectionAccessMode>("everyone");
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
   const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
   const discoveryRequestId = useRef(0);
+  const authTypeEdited = useRef(false);
+  const activePreset = preset ?? resolution?.preset ?? null;
+  const authTypeOptions = presetAuthTypeOptions(activePreset);
+  const formError = error ?? submissionError;
 
   useEffect(() => {
     if (!open) return;
@@ -2378,6 +2807,7 @@ function AddConnectionDialog({
     setName(preset?.displayName ?? initialName ?? "");
     setUrl(preset?.url ?? initialUrl ?? "");
     setAuthType(preset?.authType ?? "oauth");
+    authTypeEdited.current = false;
     setCredentialMode("per_member");
     setExposeDirectly(false);
     setApiKey("");
@@ -2387,6 +2817,7 @@ function AddConnectionDialog({
     setRequirements(null);
     setDiscoveryState("idle");
     setDiscoveryError(null);
+    setSubmissionError(null);
     discoveryRequestId.current += 1;
     setAuthorizationServerIssuer("");
     setRequestedScopes([]);
@@ -2406,7 +2837,7 @@ function AddConnectionDialog({
     return list.includes(id) ? list.filter((entry) => entry !== id) : [...list, id];
   }
 
-  const showOAuthClientFields = authType === "oauth" && (Boolean(preset?.requiresOAuthClient) || showOAuthClient);
+  const showOAuthClientFields = authType === "oauth" && (Boolean(activePreset?.requiresOAuthClient) || showOAuthClient);
   const authorizationServers = requirements?.authentication.authorizationServers ?? [];
   const selectedAuthorizationServer = authorizationServers.find((server) => server.issuer === authorizationServerIssuer);
   const requiredScopes = requirements?.authentication.requiredScopes ?? [];
@@ -2425,14 +2856,15 @@ function AddConnectionDialog({
     // A curated preset's auth type stays authoritative over the live probe,
     // matching the smart-add rule: an API-key server that also advertises
     // OAuth metadata (or initializes anonymously) must not lose its key field.
-    if (!preset) {
+    if (!activePreset && !authTypeEdited.current) {
       if (result.authentication.kind === "none") setAuthType("none");
       else if (result.authentication.kind === "oauth") setAuthType("oauth");
+      else if (result.authentication.kind === "manual_bearer") setAuthType("apikey");
     }
     const servers = result.authentication.authorizationServers;
     setAuthorizationServerIssuer(servers.length === 1 ? servers[0].issuer : "");
     setRequestedScopes(result.authentication.recommendedScopes);
-    setShowOAuthClient(Boolean(preset?.requiresOAuthClient) || result.authentication.recommendedRegistrationMethod === "pre_registered");
+    setShowOAuthClient(Boolean(activePreset?.requiresOAuthClient) || result.authentication.recommendedRegistrationMethod === "pre_registered");
   }
 
   async function discover(targetUrl: string, requestId: number) {
@@ -2526,7 +2958,9 @@ function AddConnectionDialog({
         ? ["This provider needs a pre-registered OAuth app."]
         : resolution?.preset?.authType === "apikey"
           ? ["This provider needs your org's API key."]
-          : []
+          : resolution?.preset && resolution.preset.authType !== smartPlan.input.authType
+            ? ["The server check differs from this provider's required authentication. Continue with the provider setup."]
+            : []
     : [];
   const smartOneClick = smartPlan?.readiness === "one_click" && smartBlockers.length === 0 ? smartPlan : null;
 
@@ -2557,12 +2991,13 @@ function AddConnectionDialog({
 
   async function submitSmart() {
     if (!smartOneClick) return;
+    setSubmissionError(null);
     try {
       await onSubmit(smartOneClick.input, {
         startOAuth: smartOneClick.input.authType === "oauth" && smartOneClick.input.credentialMode === "shared",
       });
-    } catch {
-      // The mutation's typed error is rendered by the dialog's error prop.
+    } catch (submitError) {
+      setSubmissionError(submitError);
     }
   }
 
@@ -2575,6 +3010,7 @@ function AddConnectionDialog({
   }
 
   async function submit() {
+    setSubmissionError(null);
     const trimmedClientId = oauthClientId.trim();
     const trimmedClientSecret = oauthClientSecret.trim();
     const input: CreateMcpConnectionInput = {
@@ -2600,10 +3036,8 @@ function AddConnectionDialog({
       await onSubmit(input, {
         startOAuth: authType === "oauth" && credentialMode === "shared" && !showOAuthClientFields,
       });
-    } catch {
-      // The mutation's typed error is rendered by the dialog's error prop.
-      // Consume the rejected promise so a clear validation failure does not
-      // also become an opaque browser-level unhandled rejection.
+    } catch (submitError) {
+      setSubmissionError(submitError);
     }
   }
 
@@ -2722,8 +3156,8 @@ function AddConnectionDialog({
               </div>
             ) : null}
 
-            {error ? (
-              <p className="mt-3 text-[13px] text-red-600">{error instanceof Error ? error.message : "Failed to add connection."}</p>
+            {formError ? (
+              <p role="alert" className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : "Failed to add connection."}</p>
             ) : null}
 
             <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -2763,7 +3197,7 @@ function AddConnectionDialog({
           </button>
         ) : null}
         <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
-          {preset ? `Add ${preset.displayName}` : "Add a custom MCP server"}
+          {activePreset ? `Add ${activePreset.displayName}` : "Add a custom MCP server"}
         </h2>
 
         <div className="mt-5 space-y-4">
@@ -2785,7 +3219,7 @@ function AddConnectionDialog({
                 setDiscoveryError(null);
               }}
               placeholder="https://mcp.example.com/mcp"
-              disabled={Boolean(preset)}
+              disabled={Boolean(activePreset)}
             />
             {discoveryState === "waiting" || discoveryState === "checking" ? (
               <p className="mt-2 flex items-center gap-2 text-[12px] text-gray-500" role="status">
@@ -2801,14 +3235,25 @@ function AddConnectionDialog({
                 </button>
               </div>
             ) : null}
+            {discoveryState === "ready" && requirements && (requirements.status !== "ready" || requirements.server.initialize === "failed" || requirements.tools.visibility === "unavailable") ? (
+              <div className="mt-2 text-[12px] text-amber-800" role="alert">
+                <p>{requirements.server.initialize === "failed" || requirements.tools.visibility === "unavailable"
+                  ? "The server check did not verify usable tools. Review the requirements before adding it."
+                  : "The server needs additional setup before its tools can be used."}</p>
+                {requirements.manualRequirements.map((requirement) => <p key={requirement.code}>{requirement.label}: {requirement.reason}</p>)}
+                {requirements.warnings.map((warning) => <p key={warning.code}>{warning.message}</p>)}
+                <button type="button" className="mt-1 font-medium underline underline-offset-2" onClick={retryDiscovery}>Retry check</button>
+              </div>
+            ) : null}
           </div>
-          {!preset ? (
+          {authTypeOptions.length > 1 ? (
             <div>
               <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Authentication</label>
               <SegmentedControl
-                options={AUTH_TYPE_OPTIONS}
+                options={authTypeOptions}
                 value={authType}
                 onChange={(option) => {
+                  authTypeEdited.current = true;
                   setAuthType(option);
                   if (option !== "oauth") setShowOAuthClient(false);
                 }}
@@ -2828,7 +3273,7 @@ function AddConnectionDialog({
             </div>
           ) : null}
 
-          {authType === "oauth" && !preset?.requiresOAuthClient && !showOAuthClient ? (
+          {authType === "oauth" && !activePreset?.requiresOAuthClient && !showOAuthClient ? (
             <button
               type="button"
               onClick={() => setShowOAuthClient(true)}
@@ -3006,8 +3451,8 @@ function AddConnectionDialog({
           </div>
         </div>
 
-        {error ? (
-          <p className="mt-3 text-[13px] text-red-600">{error instanceof Error ? error.message : "Failed to add connection."}</p>
+        {formError ? (
+          <p role="alert" className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : "Failed to add connection."}</p>
         ) : null}
 
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
@@ -22,18 +22,20 @@ async function copyText(text: string): Promise<boolean> {
 
 export function Microsoft365Dialog({
   open,
+  providerId,
   submitting,
   error,
   onClose,
   onSubmit,
 }: {
   open: boolean;
+  providerId: string;
   submitting: boolean;
   error: unknown;
   onClose: () => void;
   onSubmit: (input: { clientId?: string; clientSecret?: string; tenantId?: string; features: string[] }) => void;
 }) {
-  const clientConfig = useNativeProviderClient("microsoft-365", open);
+  const clientConfig = useNativeProviderClient(providerId, open);
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [tenantId, setTenantId] = useState("");
@@ -51,13 +53,13 @@ export function Microsoft365Dialog({
     setCopiedRedirectUri(false);
     setReplacingCredentials(false);
     featuresPrefilled.current = false;
-  }, [open]);
+  }, [open, providerId]);
 
   useEffect(() => {
     if (!open || featuresPrefilled.current || !clientConfig.isSuccess || clientConfig.isFetching) return;
     setFeatures(clientConfig.data.features);
     featuresPrefilled.current = true;
-  }, [open, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
+  }, [open, providerId, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
 
   if (!open) return null;
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-permissions.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-permissions.ts
@@ -40,6 +40,8 @@ export const MICROSOFT_365_PERMISSION_GROUPS: readonly Microsoft365PermissionGro
         detail: "Microsoft grants mailbox read/write access. This option does not send mail.",
       },
       { key: "mailRead", label: "Read Outlook mail", scope: "Mail.Read" },
+      { key: "mailSend", label: "Send Outlook email", scope: "Mail.Send", detail: "Sending requires an explicit request and confirmation; a saved draft is not sent automatically." },
+      { key: "mailManage", label: "Manage read status, categories, and mailbox folders", scope: "Mail.ReadWrite" },
     ],
   },
   {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -302,7 +302,7 @@ function YourConnectionRow({
             </DenButton>
           ) : null}
           {needsReconnect || needsMyConnect || needsAdminConnect ? (
-            <DenButton variant="primary" size="sm" loading={connecting || polling} onClick={onConnect}>
+            <DenButton variant="primary" size="sm" loading={connecting || polling} onClick={onConnect} data-testid={`connect-my-mcp-account-${connection.id}`}>
               {needsReconnect ? "Reconnect" : "Connect"}
             </DenButton>
           ) : null}

--- a/ee/apps/den-web/tests/connector-catalog-render.test.tsx
+++ b/ee/apps/den-web/tests/connector-catalog-render.test.tsx
@@ -1,0 +1,129 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "bun:test";
+import { ConnectorCatalog } from "../app/(den)/dashboard/_components/connector-catalog-list";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
+
+const PRESETS: ExternalMcpPreset[] = [
+  { presetId: "github", displayName: "GitHub", description: "PRs", url: "https://api.githubcopilot.com/mcp/", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "notion", displayName: "Notion", description: "Docs", url: "https://mcp.notion.com/mcp", authType: "oauth" },
+  { presetId: "slack", displayName: "Slack", description: "Chat", url: "https://mcp.slack.com/mcp", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "granola", displayName: "Granola", description: "Meeting notes", url: "https://mcp.granola.ai/mcp", authType: "oauth" },
+  { presetId: "context7", displayName: "Context7", description: "Docs", url: "https://mcp.context7.com/mcp", authType: "none" },
+];
+
+const NOTION: ExternalMcpConnection = {
+  id: "conn-notion",
+  name: "Notion",
+  url: "https://mcp.notion.com/mcp",
+  authType: "oauth",
+  credentialMode: "per_member",
+  exposeDirectly: false,
+  connected: true,
+  connectedAt: null,
+  updatedAt: null,
+  connectedForMe: true,
+  requiredBy: [],
+  identityManagedBy: [],
+  access: null,
+};
+
+const noop = () => {};
+
+function render(overrides: Partial<Parameters<typeof ConnectorCatalog>[0]> = {}) {
+  return renderToStaticMarkup(
+    createElement(ConnectorCatalog, {
+      connections: [NOTION],
+      presets: PRESETS,
+      filter: "",
+      configuredHref: "/dashboard/mcp-connections/configured",
+      configuredConnectionHref: (connectionId: string) => `/dashboard/mcp-connections/configured?connectionId=${connectionId}`,
+      connectorHref: (connectorId: string) => `/dashboard/mcp-connections/${connectorId}`,
+      onAddPopular: noop,
+      onAddPreset: noop,
+      onAddMicrosoft365: noop,
+      onManage: noop,
+      onRemove: noop,
+      addingPresetId: null,
+      ...overrides,
+    }),
+  );
+}
+
+describe("ConnectorCatalog", () => {
+  test("shows the configured strip, six popular rows, and the collapsed More teaser", () => {
+    const markup = render();
+
+    expect(markup.indexOf('data-testid="configured-connector-strip"')).toBeLessThan(markup.indexOf('data-testid="popular-connectors"'));
+    expect(markup).toContain('href="/dashboard/mcp-connections/configured"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/configured?connectionId=conn-notion"');
+    for (const id of ["gmail", "github", "google-drive", "google-calendar", "notion", "slack"]) {
+      expect(markup).toContain(`data-testid="connector-row-${id}"`);
+    }
+    expect(markup).toContain("Browse all 9 integrations");
+    expect(markup).not.toContain('data-testid="more-connectors"');
+  });
+
+  test("configured rows get the options menu while unconfigured rows explain the next step", () => {
+    const markup = render();
+
+    expect(markup).toContain('data-testid="connector-options-conn-notion"');
+    expect(markup).not.toContain('data-testid="connector-add-notion"');
+    expect(markup).toContain('data-testid="connector-add-github"');
+    expect(markup).toContain('aria-label="Set up GitHub"');
+    expect(markup).toContain('data-testid="connector-chat-github"');
+    expect(markup).toContain('data-testid="connector-chat-notion"');
+    expect(markup).not.toContain("autoSend");
+    expect(markup).not.toContain("auto-send");
+  });
+
+  test("preset outages keep Chat and native setup available while disabling dependent setup", () => {
+    for (const state of [{ loading: true }, { unavailable: true }]) {
+      const markup = render({ ...state, presets: [], filter: "github" });
+      expect(markup).toContain('data-testid="connector-chat-github"');
+      expect(markup).toMatch(/<button[^>]*disabled=""[^>]*data-testid="connector-add-github"/);
+      const nativeMarkup = render({ ...state, presets: [], filter: "microsoft" });
+      expect(nativeMarkup).toContain('data-testid="connector-chat-microsoft-365"');
+      expect(nativeMarkup).toContain('data-testid="connector-add-microsoft-365"');
+      expect(nativeMarkup).not.toContain('disabled=""');
+    }
+  });
+
+  test("configured rows expose personal sign-in and setup recovery alongside Chat", () => {
+    const markup = render({ connections: [{ ...NOTION, connectedForMe: false }], filter: "notion" });
+    expect(markup).toContain("Needs your account");
+    expect(markup).toContain('data-testid="connector-recover-notion"');
+    expect(markup).toContain('data-testid="connector-chat-notion"');
+    expect(markup).not.toContain("Connected as you");
+    const setupMarkup = render({ setupRequired: () => true, filter: "notion" });
+    expect(setupMarkup).toContain("Setup required");
+    expect(setupMarkup).toContain('data-testid="connector-recover-notion"');
+    expect(setupMarkup).toContain("Set up");
+  });
+
+  test("filtering opens the More section and hides the configured strip", () => {
+    const markup = render({ filter: "gran" });
+
+    expect(markup).not.toContain('data-testid="configured-connector-strip"');
+    expect(markup).not.toContain('data-testid="popular-connectors"');
+    expect(markup).toContain('data-testid="more-connectors"');
+    expect(markup).toContain('data-testid="connector-row-granola"');
+    expect(markup).not.toContain('data-testid="connector-row-context7"');
+  });
+
+  test("a filter with no matches says so", () => {
+    expect(render({ filter: "zzzz" })).toContain("No connectors match");
+  });
+
+  test("every row opens its detail page: stable catalog identity even when configured", () => {
+    const markup = render({ filter: "o" });
+
+    expect(markup).toContain('href="/dashboard/mcp-connections/notion"');
+    expect(markup).toContain('data-testid="connector-open-notion"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/github"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/google-drive"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/microsoft-365"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/granola"');
+    expect(markup).not.toContain('href="/dashboard/mcp-connections/conn-notion"');
+  });
+});

--- a/ee/apps/den-web/tests/connector-catalog.test.ts
+++ b/ee/apps/den-web/tests/connector-catalog.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+import {
+  configuredConnectionForPopular,
+  connectionForPresetUrl,
+  connectorChatDeepLink,
+  connectorChatPrompt,
+  POPULAR_CONNECTORS,
+  remainingPresets,
+} from "../app/(den)/dashboard/_components/connector-catalog";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
+
+function readDashboardFile(relativePath: string) {
+  return readFileSync(fileURLToPath(new URL(`../app/(den)/dashboard/${relativePath}`, import.meta.url)), "utf8");
+}
+
+const PRESETS: ExternalMcpPreset[] = [
+  { presetId: "github", displayName: "GitHub", description: "PRs", url: "https://api.githubcopilot.com/mcp/", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "notion", displayName: "Notion", description: "Docs", url: "https://mcp.notion.com/mcp", authType: "oauth" },
+  { presetId: "slack", displayName: "Slack", description: "Chat", url: "https://mcp.slack.com/mcp", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "linear", displayName: "Linear", description: "Issues", url: "https://mcp.linear.app/mcp", authType: "oauth" },
+  { presetId: "context7", displayName: "Context7", description: "Docs", url: "https://mcp.context7.com/mcp", authType: "none" },
+];
+
+function connection(overrides: Partial<ExternalMcpConnection> & Pick<ExternalMcpConnection, "id" | "name" | "url">): ExternalMcpConnection {
+  return {
+    authType: "oauth",
+    credentialMode: "per_member",
+    connected: false,
+    connectedAt: null,
+    updatedAt: null,
+    connectedForMe: false,
+    requiredBy: [],
+    identityManagedBy: [],
+    access: null,
+    ...overrides,
+  };
+}
+
+describe("popular connector catalog", () => {
+  test("lists the six popular connectors in the approved order with starter prompts", () => {
+    expect(POPULAR_CONNECTORS.map((connector) => connector.displayName)).toEqual([
+      "Gmail",
+      "GitHub",
+      "Google Drive",
+      "Google Calendar",
+      "Notion",
+      "Slack",
+    ]);
+    for (const connector of POPULAR_CONNECTORS) {
+      expect(connector.chatPrompt.startsWith("Explain")).toBe(true);
+      expect(connector.chatPrompt.toLowerCase()).toContain("if access is available");
+      expect(connector.chatPrompt).toContain("Otherwise,");
+      expect(connector.chatPrompt).toContain("without accessing");
+    }
+  });
+
+  test("describes the native service management delivered with the catalog", () => {
+    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "gmail")?.description).toBe("Read, send, and manage Gmail");
+    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "google-calendar")?.description).toBe("Create, reschedule, and manage Google Calendar events");
+    const drive = POPULAR_CONNECTORS.find((connector) => connector.id === "google-drive");
+    expect(drive?.description).toBe("Organize files, read Docs and Slides, and edit Sheets");
+    expect(drive?.chatPrompt).toContain("last 7 days");
+    expect(drive?.chatPrompt).toContain("follow pagination");
+    expect(drive?.chatPrompt).toContain("incomplete search");
+    expect(drive?.chatPrompt).toContain("without accessing Drive");
+  });
+
+  test("builds an openwork:// chat deep link carrying the connector and its prompt", () => {
+    const href = connectorChatDeepLink({ connector: "GitHub", prompt: connectorChatPrompt("GitHub") });
+    const url = new URL(href);
+    expect(url.protocol).toBe("openwork:");
+    expect(url.hostname).toBe("chat");
+    expect(url.searchParams.get("connector")).toBe("GitHub");
+    expect(url.searchParams.get("prompt")).toBe(
+      "Explain how I can review a GitHub repo's authentication. Ask which repo to use; if access is available, inspect its code and docs. Otherwise, outline a review checklist without accessing the repo.",
+    );
+  });
+
+  test("falls back to an explain prompt for connectors without a curated one", () => {
+    expect(connectorChatPrompt("Render")).toBe(
+      "Explain how I could use Render: suggest three useful tasks and distinguish general ideas from tools available here. If access is unavailable, help me plan without connecting.",
+    );
+  });
+
+  test("resolves Gmail, Drive, and Calendar to the single Google Workspace connection", () => {
+    const google = connection({ id: "conn-google", name: "Google Workspace", url: "https://www.googleapis.com", nativeProviderKey: "google-workspace" });
+    for (const id of ["gmail", "google-drive", "google-calendar"]) {
+      const popular = POPULAR_CONNECTORS.find((connector) => connector.id === id);
+      expect(popular).toBeDefined();
+      expect(configuredConnectionForPopular(popular!, [google], PRESETS)?.id).toBe("conn-google");
+      expect(configuredConnectionForPopular(popular!, [], PRESETS)).toBeUndefined();
+    }
+  });
+
+  test("matches preset-backed rows by comparable URL, ignoring a trailing slash", () => {
+    const github = connection({ id: "conn-github", name: "GitHub", url: "https://api.githubcopilot.com/mcp" });
+    const popularGithub = POPULAR_CONNECTORS.find((connector) => connector.id === "github")!;
+    expect(configuredConnectionForPopular(popularGithub, [github], PRESETS)?.id).toBe("conn-github");
+    expect(connectionForPresetUrl([github], "https://api.githubcopilot.com/mcp/")?.id).toBe("conn-github");
+    expect(connectionForPresetUrl([github], "https://mcp.notion.com/mcp")).toBeUndefined();
+  });
+
+  test("keeps only non-popular presets for the More section", () => {
+    expect(remainingPresets(PRESETS).map((preset) => preset.presetId)).toEqual(["linear", "context7"]);
+  });
+});
+
+describe("connector pages", () => {
+  test("the catalog page shows Configured first, then Popular, then More, and never the configured list", () => {
+    const screen = readDashboardFile("_components/mcp-connections-screen.tsx");
+    const catalog = readDashboardFile("_components/connector-catalog-list.tsx");
+
+    expect(screen).toContain("<ConnectorCatalog");
+    expect(screen).not.toContain("<ConnectorQuickAddGrid");
+    expect(catalog.indexOf("ConfiguredConnectorStrip connections")).toBeLessThan(catalog.indexOf('data-testid="popular-connectors"'));
+    expect(catalog.indexOf('data-testid="popular-connectors"')).toBeLessThan(catalog.indexOf('data-testid="more-connectors"'));
+    expect(catalog).toContain("Manage\n          </button>");
+    expect(catalog).toContain("Uninstall\n              </button>");
+  });
+
+  test("the configured page reuses the admin screen in its configured view", () => {
+    const page = readDashboardFile("(admin)/mcp-connections/configured/page.tsx");
+    const screen = readDashboardFile("_components/mcp-connections-screen.tsx");
+
+    expect(page).toContain('<McpConnectionsScreen view="configured" />');
+    expect(screen).toContain('title={configuredView ? "Configured connectors" : "Connectors"}');
+    expect(screen).toContain('data-testid="configured-add-connector"');
+    expect(screen).toContain("chat-mcp-connection-");
+  });
+
+  test("one-click OAuth presets are added for everyone and open the authorization tab in the same gesture", () => {
+    const screen = readDashboardFile("_components/mcp-connections-screen.tsx");
+    const oneClick = screen.slice(screen.indexOf("async function handleOneClickAdd"), screen.indexOf("async function handleUpdate"));
+
+    expect(oneClick).toContain('credentialMode: "per_member"');
+    expect(oneClick).toContain("{ startOAuth: true }");
+    expect(screen).toContain('if (effort === "one_click") {');
+  });
+});

--- a/ee/apps/den-web/tests/connector-detail.test.ts
+++ b/ee/apps/den-web/tests/connector-detail.test.ts
@@ -1,0 +1,225 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  connectorAccountStatus,
+  connectorAccountReady,
+  displayedConnectorConnections,
+  connectorDetailEffort,
+  connectorDetailFacts,
+  connectorDetailIdentity,
+  connectorDetailPrimaryAction,
+  resolveConnectorDetailSubject,
+} from "../app/(den)/dashboard/_components/connector-detail";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
+
+const PRESETS: ExternalMcpPreset[] = [
+  { presetId: "github", displayName: "GitHub", description: "PRs", url: "https://api.githubcopilot.com/mcp/", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "notion", displayName: "Notion", description: "Docs", url: "https://mcp.notion.com/mcp", authType: "oauth" },
+  { presetId: "context7", displayName: "Context7", description: "Library docs", url: "https://mcp.context7.com/mcp", authType: "none" },
+];
+
+const NOTION: ExternalMcpConnection = {
+  id: "conn-notion",
+  name: "Notion",
+  url: "https://mcp.notion.com/mcp/",
+  authType: "oauth",
+  credentialMode: "per_member",
+  exposeDirectly: false,
+  connected: true,
+  connectedAt: "2026-09-02T10:00:00.000Z",
+  createdByName: "Jalil",
+  updatedAt: "2026-09-02T10:00:00.000Z",
+  connectedForMe: true,
+  requiredBy: [{ pluginId: "plg_1", name: "Research kit" }],
+  identityManagedBy: [],
+  access: { orgWide: true, memberIds: [], teamIds: [] },
+};
+
+const GOOGLE: ExternalMcpConnection = {
+  id: "google-workspace",
+  name: "Google Workspace",
+  url: "https://www.googleapis.com/",
+  authType: "oauth",
+  credentialMode: "per_member",
+  exposeDirectly: false,
+  connected: false,
+  connectedAt: null,
+  updatedAt: null,
+  connectedForMe: false,
+  nativeProviderKey: "google-workspace",
+  requiredBy: [],
+  identityManagedBy: [],
+  access: null,
+};
+
+const PLUGIN_OWNED: ExternalMcpConnection = {
+  ...NOTION,
+  id: "conn-plugin",
+  name: "Team wiki",
+  url: "https://wiki.example.com/mcp",
+  requiredBy: [{ pluginId: "plg_wiki", name: "Wiki plugin" }],
+  identityManagedBy: [{ pluginId: "plg_wiki", name: "Wiki plugin" }],
+};
+
+const context = { orgName: "Acme", pluginHref: (pluginId: string) => `/dashboard/plugins/${pluginId}` };
+
+describe("resolveConnectorDetailSubject", () => {
+  test("a connection id resolves to the connection with its catalog identity", () => {
+    const subject = resolveConnectorDetailSubject("conn-notion", [NOTION], PRESETS);
+    expect(subject.kind).toBe("connection");
+    if (subject.kind !== "connection") return;
+    expect(subject.preset?.presetId).toBe("notion");
+    expect(subject.popular?.id).toBe("notion");
+  });
+
+  test("a popular id resolves to its configured connection when one exists, else stays a catalog entry", () => {
+    const configured = resolveConnectorDetailSubject("notion", [NOTION], PRESETS);
+    expect(configured.kind).toBe("connection");
+
+    const unconfigured = resolveConnectorDetailSubject("notion", [], PRESETS);
+    expect(unconfigured.kind).toBe("popular");
+    if (unconfigured.kind === "popular") expect(unconfigured.preset?.presetId).toBe("notion");
+  });
+
+  test("Gmail keeps its own identity while the Google Workspace connection keeps Google's", () => {
+    const gmail = resolveConnectorDetailSubject("gmail", [GOOGLE], PRESETS);
+    expect(gmail.kind).toBe("connection");
+    expect(connectorDetailIdentity(gmail).name).toBe("Gmail");
+
+    const google = resolveConnectorDetailSubject("google-workspace", [GOOGLE], PRESETS);
+    expect(google.kind).toBe("connection");
+    expect(connectorDetailIdentity(google).name).toBe("Google Workspace");
+  });
+
+  test("a preset id outside the popular list resolves by URL and Microsoft 365 has a page before setup", () => {
+    expect(resolveConnectorDetailSubject("context7", [], PRESETS).kind).toBe("preset");
+    expect(resolveConnectorDetailSubject("microsoft-365", [], PRESETS).kind).toBe("microsoft-365");
+    expect(resolveConnectorDetailSubject("nope", [NOTION], PRESETS)).toEqual({ kind: "not_found", connectorId: "nope" });
+  });
+});
+
+describe("connector detail copy", () => {
+  test("effort drives the primary action for unconfigured connectors", () => {
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("context7", [], PRESETS))).toBe("instant");
+    expect(connectorDetailPrimaryAction("instant").label).toBe("Add");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("notion", [], PRESETS))).toBe("one_click");
+    expect(connectorDetailPrimaryAction("one_click").label).toBe("Connect");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("github", [], PRESETS))).toBe("oauth_app");
+    expect(connectorDetailPrimaryAction("oauth_app").label).toBe("Set up");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("gmail", [], PRESETS))).toBe("guided");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("conn-notion", [NOTION], PRESETS))).toBeNull();
+  });
+
+  test("information facts come from what the page already knows", () => {
+    const facts = connectorDetailFacts(resolveConnectorDetailSubject("conn-notion", [NOTION], PRESETS), context);
+    const byLabel = Object.fromEntries(facts.map((fact) => [fact.label, fact]));
+    expect(byLabel.Provider).toMatchObject({ value: "notion.com", href: "https://notion.com" });
+    expect(byLabel.Type.value).toBe("Remote MCP server");
+    expect(byLabel.Server).toMatchObject({ value: "https://mcp.notion.com/mcp/", mono: true });
+    expect(byLabel["Sign-in"].value).toBe("OAuth sign-in · each person connects their own account");
+    expect(byLabel.Access.value).toBe("Everyone in Acme");
+    expect(byLabel.Added.value).toBe(new Date(NOTION.connectedAt!).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }));
+    expect(facts.some((fact) => fact.value.includes("Added by"))).toBe(false);
+    expect(byLabel["Required by"]).toMatchObject({ value: "Research kit", href: "/dashboard/plugins/plg_1" });
+    expect(byLabel.Docs.href).toContain("shared-mcp-connections");
+  });
+
+  test("plugin-owned connections say so once, and native providers skip the server URL", () => {
+    const pluginFacts = connectorDetailFacts(resolveConnectorDetailSubject("conn-plugin", [PLUGIN_OWNED], PRESETS), context);
+    expect(pluginFacts.filter((fact) => fact.label === "Managed by")).toHaveLength(1);
+    expect(pluginFacts.some((fact) => fact.label === "Required by")).toBe(false);
+    expect(pluginFacts.find((fact) => fact.label === "Type")?.value).toBe("MCP server from a plugin");
+
+    const googleFacts = connectorDetailFacts(resolveConnectorDetailSubject("gmail", [GOOGLE], PRESETS), context);
+    expect(googleFacts.find((fact) => fact.label === "Provider")?.value).toBe("Google");
+    expect(googleFacts.some((fact) => fact.label === "Server")).toBe(false);
+    expect(googleFacts.find((fact) => fact.label === "Part of")?.value).toContain("Google Workspace");
+  });
+
+  test("information facts never project the creator's name or email fallback", () => {
+    for (const createdByName of ["Connector creator", "creator@example.test"]) {
+      const connection = { ...NOTION, createdByName };
+      const facts = connectorDetailFacts({ kind: "connection", connection }, context);
+      expect(facts.some((fact) => fact.value.includes(createdByName))).toBe(false);
+      expect(facts.find((fact) => fact.label === "Added")).toBeDefined();
+    }
+  });
+});
+
+describe("connectors screen surface", () => {
+  const root = join(import.meta.dir, "..", "app", "(den)", "dashboard");
+  const screen = readFileSync(join(root, "_components", "mcp-connections-screen.tsx"), "utf8");
+
+  test("leads with the flat page header instead of the gradient hero", () => {
+    expect(screen).toContain("<DenPageHeader");
+    expect(screen).not.toContain("DashboardPageTemplate");
+    expect(screen).toContain('title={configuredView ? "Configured connectors" : "Connectors"}');
+    expect(screen).toContain('data-testid="connectors-open-configured"');
+  });
+
+  test("has a detail view that composes the connection row, tools, and information", () => {
+    expect(screen).toContain('export type McpConnectionsScreenView = "catalog" | "configured" | "detail";');
+    for (const testId of [
+      "connector-detail-back",
+      "connector-detail",
+      "connector-detail-state",
+      "connector-detail-copy-link",
+      "connector-detail-chat",
+      "connector-detail-primary",
+      "connector-detail-connection",
+      "connector-detail-tools",
+      "connector-detail-information",
+      "connector-detail-not-found",
+    ]) {
+      expect(screen).toContain(`data-testid="${testId}"`);
+    }
+    expect(screen).toContain("router.push(getMcpConnectionRoute(orgSlug, connection.id));");
+    expect(screen).toContain('connectorHref={(id) => getMcpConnectionRoute(orgSlug, id)}');
+  });
+
+  test("the detail route renders the screen in detail view", () => {
+    const route = readFileSync(join(root, "(admin)", "mcp-connections", "[connectorId]", "page.tsx"), "utf8");
+    expect(route).toContain('<McpConnectionsScreen view="detail" connectorId={connectorId} />');
+  });
+});
+
+
+describe("connectorAccountStatus", () => {
+  test("another member's authorization never makes this account connected", () => {
+    expect(connectorAccountStatus({ ...NOTION, connected: true, connectedForMe: false })).toBe("Needs your account");
+    expect(connectorAccountStatus(NOTION)).toBe("Connected as you");
+    expect(connectorAccountStatus({ ...NOTION, credentialMode: "shared", connectedForMe: false })).toBe("Connected");
+  });
+
+  test("setup and credential recovery take precedence over old connected flags", () => {
+    expect(connectorAccountStatus({ ...NOTION, setupRequired: true })).toBe("Setup required");
+    expect(connectorAccountStatus({ ...NOTION, issuerReviewRequired: true })).toBe("OAuth settings need review");
+    expect(connectorAccountStatus({ ...NOTION, credentialHealth: "reconnect_required" })).toBe("Reconnect required");
+    expect(connectorAccountStatus({ ...NOTION, oauthClientRequired: true, oauthClientConfigured: false })).toBe("Setup required");
+  });
+});
+
+describe("displayed connections and personal readiness", () => {
+  test("includes both synthetic native providers without duplicating managed entries or importing other usable MCPs", () => {
+    const microsoft = { ...GOOGLE, id: "microsoft-365", name: "Microsoft 365", nativeProviderKey: "microsoft-365" };
+    const managedGoogle = { ...GOOGLE, id: "conn-google", name: "Work Google" };
+    const displayed = displayedConnectorConnections([NOTION, managedGoogle], [GOOGLE, microsoft, managedGoogle, PLUGIN_OWNED]);
+    expect(displayed.map((connection) => connection.id)).toEqual(["google-workspace", "microsoft-365", "conn-notion", "conn-google"]);
+    const subject = resolveConnectorDetailSubject("microsoft-365", displayed, PRESETS);
+    expect(subject.kind).toBe("connection");
+    expect(connectorDetailIdentity(subject).name).toBe("Microsoft 365");
+    expect(connectorAccountStatus(microsoft)).toBe("Needs your account");
+  });
+
+  test("OAuth polling waits for this member's healthy token, not another member's authorization", () => {
+    expect(connectorAccountReady({ ...NOTION, connectedForMe: false })).toBe(false);
+    expect(connectorAccountReady(NOTION)).toBe(true);
+    expect(connectorAccountReady({ ...NOTION, credentialMode: "shared", connectedForMe: false })).toBe(true);
+    expect(connectorAccountReady({ ...NOTION, setupRequired: true })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, issuerReviewRequired: true })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, needsReconnect: true })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, credentialHealth: "reconnect_required" })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, oauthClientRequired: true, oauthClientConfigured: false })).toBe(false);
+  });
+});

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -35,9 +35,9 @@ describe("connector and marketplace polish", () => {
   test("uses the smart connector bar and the approved connector copy", () => {
     const screen = readDashboardComponent("mcp-connections-screen.tsx");
 
-    expect(screen).toContain('title="Connectors"');
+    expect(screen).toContain('title={configuredView ? "Configured connectors" : "Connectors"}');
     expect(screen).not.toContain("badgeLabel");
-    expect(screen).toContain('description="Connectors is where you can add MCP servers that your whole team can use."');
+    expect(screen).toContain(': "Connectors is where you can add MCP servers that your whole team can use."');
     expect(screen).toContain('data-testid="connector-smart-bar"');
     expect(screen).not.toMatch(/>\s*Add MCP\s*</);
     expect(screen).not.toContain("<ImportPluginConnectionDialog");

--- a/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { presetAuthTypeOptions, SegmentedControl } from "../app/(den)/dashboard/_components/mcp-connection-form-controls";
+import type { ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
 
 const screenPath = fileURLToPath(
   new URL("../app/(den)/dashboard/_components/mcp-connections-screen.tsx", import.meta.url),
@@ -13,7 +17,6 @@ describe("MCP URL entry UI contract", () => {
     expect(screen).toContain('useState<"smart" | "advanced">(preset ? "advanced" : "smart")');
     expect(screen).toContain("Add an MCP server");
     expect(screen).toContain("Paste the MCP server URL");
-    expect(screen).toContain("Paste a server URL and we&apos;ll check it for you.");
     expect(screen).toContain('placeholder="https://mcp.example.com/mcp"');
     expect(screen).toContain('if (kind !== "url" && kind !== "domain")');
     expect(screen).not.toContain('data-testid="select-custom-mcp"');
@@ -27,8 +30,9 @@ describe("MCP URL entry UI contract", () => {
     const screen = readFileSync(screenPath, "utf8");
 
     expect(screen).toContain("setFormPreset(preset);");
-    expect(screen).toContain("{preset ? `Add ${preset.displayName}` : \"Add a custom MCP server\"}");
-    expect(screen).toContain("disabled={Boolean(preset)}");
+    expect(screen).toContain("const activePreset = preset ?? resolution?.preset ?? null;");
+    expect(screen).toContain("{activePreset ? `Add ${activePreset.displayName}` : \"Add a custom MCP server\"}");
+    expect(screen).toContain("disabled={Boolean(activePreset)}");
     expect(screen).not.toContain("existingConnectionUrls");
     expect(screen).not.toContain("onSelectPreset");
   });
@@ -42,5 +46,27 @@ describe("MCP URL entry UI contract", () => {
     expect(screen).toContain('"Deselect all" : "Select all"');
     expect(screen).toContain('data-testid="toggle-all-optional-permissions"');
     expect(screen).toContain("toggleAllOptionalScopes(current, optionalScopes)");
+  });
+
+  test("GitHub offers OAuth and PAT without allowing anonymous auth or changing the OAuth default", () => {
+    const preset: ExternalMcpPreset = {
+      presetId: "github", displayName: "GitHub", description: "Code", url: "https://api.githubcopilot.com/mcp/",
+      authType: "oauth", supportedAuthTypes: ["oauth", "apikey"], requiresOAuthClient: true,
+    };
+    const options = presetAuthTypeOptions(preset);
+    expect(options.map((option) => option.value)).toEqual(["oauth", "apikey"]);
+    const render = (value: string) => renderToStaticMarkup(createElement(SegmentedControl, { options, value, onChange: () => {} }));
+    expect(render(preset.authType)).toMatch(/aria-pressed="true"[^>]*>OAuth<\/button>/);
+    expect(render("apikey")).toMatch(/aria-pressed="true"[^>]*>API key<\/button>/);
+    expect(render("apikey")).not.toContain(">None<");
+    expect(presetAuthTypeOptions({ ...preset, supportedAuthTypes: undefined }).map((option) => option.value)).toEqual(["oauth"]);
+    expect(presetAuthTypeOptions(null).map((option) => option.value)).toEqual(["oauth", "apikey", "none"]);
+
+    const screen = readFileSync(screenPath, "utf8");
+    expect(screen).toContain("const authTypeOptions = presetAuthTypeOptions(activePreset);");
+    expect(screen).toContain("authTypeOptions.length > 1");
+    expect(screen).toContain("options={authTypeOptions}");
+    expect(screen).toContain("if (!activePreset && !authTypeEdited.current)");
+    expect(screen).toContain("authTypeEdited.current = true;");
   });
 });

--- a/ee/apps/den-web/tests/microsoft-365-permissions.test.ts
+++ b/ee/apps/den-web/tests/microsoft-365-permissions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { MICROSOFT_365_DEFAULT_FEATURES } from "@openwork/types/den/microsoft-365";
 import {
   MICROSOFT_365_DISPLAY_SCOPES,
@@ -41,5 +42,25 @@ describe("Microsoft 365 permission picker", () => {
 
   test("keeps write permissions opt-in", () => {
     expect(MICROSOFT_365_DEFAULT_FEATURES).toEqual(["mailRead", "calendarRead", "filesRead"]);
+  });
+
+  test("edits load and save the selected Microsoft client, using the alias only for catalog setup", () => {
+    const screen = readFileSync(new URL("../app/(den)/dashboard/_components/mcp-connections-screen.tsx", import.meta.url), "utf8");
+    const dialog = readFileSync(new URL("../app/(den)/dashboard/_components/microsoft-365-dialog.tsx", import.meta.url), "utf8");
+    const edit = screen.slice(screen.indexOf("function editConnection("), screen.indexOf("function recoverConnection("));
+    expect(edit).toContain("setMicrosoftDialogConnectionId(connection.id)");
+    expect(edit).not.toContain("openQuickAdd(MICROSOFT_365_QUICK_ADD_ID)");
+    expect(screen).toContain("setMicrosoftDialogConnectionId(MICROSOFT_365_QUICK_ADD_ID)");
+    expect(screen).toContain("key={microsoftDialogConnectionId}");
+    expect(screen).toContain("providerId={microsoftDialogConnectionId}");
+    expect(screen).toContain("providerId: microsoftDialogConnectionId, ...input");
+    expect(dialog).toContain("useNativeProviderClient(providerId, open)");
+    expect(dialog).not.toContain('useNativeProviderClient("microsoft-365"');
+
+    // Google's legacy alias path is unchanged; named connections retain their exact row for edits.
+    expect(edit).toContain("if (connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID)");
+    expect(edit).not.toContain('connection.nativeProviderKey === "google-workspace"');
+    expect(edit).toContain("setEditingConnection(connection)");
+    expect(screen).toContain("connectionId: connection.id,");
   });
 });

--- a/evals/packages/behaviors/src/connector-catalog.ts
+++ b/evals/packages/behaviors/src/connector-catalog.ts
@@ -1,0 +1,43 @@
+import type { Surface } from "@openwork/cdp";
+import { evalIn } from "./desktop.ts";
+
+export interface ConnectorCatalogFacts {
+  summary: string;
+  entries: { id: string; text: string; href: string; status: string }[];
+  chatLinks: { testId: string; href: string }[];
+  horizontalOverflow: boolean;
+}
+
+/** Observe rendered catalog rows, never React state or product source. */
+export async function readConnectorCatalog(surface: Surface): Promise<ConnectorCatalogFacts> {
+  const value = await evalIn(surface, () => ({
+    summary: document.querySelector('[data-testid="connector-catalog-count"]')?.textContent?.trim() ?? "",
+    entries: Array.from(document.querySelectorAll<HTMLElement>('[data-connector-id]'), row => ({
+      id: row.getAttribute('data-connector-id') ?? "",
+      text: row.innerText,
+      href: row.querySelector('a')?.getAttribute('href') ?? "",
+      status: row.querySelector('[data-testid^="connector-status-"]')?.textContent?.trim() ?? "",
+    })),
+    chatLinks: Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href^="openwork://chat?"]'), link => ({
+      testId: link.getAttribute('data-testid') ?? "",
+      href: link.href,
+    })),
+    horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  }));
+  if (!value || typeof value !== "object" || !("summary" in value) || typeof value.summary !== "string"
+    || !("entries" in value) || !Array.isArray(value.entries)
+    || !("horizontalOverflow" in value) || typeof value.horizontalOverflow !== "boolean") {
+    throw new Error("The connector catalog did not expose its rendered summary and entries.");
+  }
+  const entries = value.entries.map((entry: unknown) => {
+    if (!entry || typeof entry !== "object"
+      || !("id" in entry) || typeof entry.id !== "string"
+      || !("text" in entry) || typeof entry.text !== "string"
+      || !("href" in entry) || typeof entry.href !== "string"
+      || !("status" in entry) || typeof entry.status !== "string") {
+      throw new Error("A connector row is missing its identity, link or setup status.");
+    }
+    return { id: entry.id, text: entry.text, href: entry.href, status: entry.status };
+  });
+  return { summary: value.summary, entries, chatLinks: value.chatLinks, horizontalOverflow: value.horizontalOverflow };
+}

--- a/evals/packages/behaviors/src/index.ts
+++ b/evals/packages/behaviors/src/index.ts
@@ -8,6 +8,7 @@ export * from "./diagnostics.ts";
 export * from "./engine-session-probe.ts";
 export * from "./onboarding.ts";
 export * from "./composer.ts";
+export * from "./connector-catalog.ts";
 export * from "./models.ts";
 export * from "./skills.ts";
 export * from "./sessions.ts";

--- a/evals/packages/cdp/src/cdp.ts
+++ b/evals/packages/cdp/src/cdp.ts
@@ -359,6 +359,9 @@ export async function navigate(client: CdpClient, url: string): Promise<void> {
 }
 
 export async function captureScreenshot(client: CdpClient): Promise<Buffer> {
+  // OAuth can foreground another tab. Activate this explicit target so its
+  // compositor can produce the requested frame instead of stalling in the background.
+  await client.send("Page.bringToFront");
   const payload = await client.send("Page.captureScreenshot", { format: "png" });
   if (!isRecord(payload) || typeof payload.data !== "string") {
     throw new Error("Page.captureScreenshot did not return base64 PNG data.");

--- a/evals/packages/env/src/seed.ts
+++ b/evals/packages/env/src/seed.ts
@@ -107,6 +107,8 @@ export interface Seed {
   denLink(den: Den, options?: SeedDenLinkOptions): Promise<SeedDenLink>;
   tmpPath(label: string): string;
   composerText(app: Surface, text: string): Promise<void>;
+  /** Deliver a fixture-owned link at the renderer ingress; does not exercise OS protocol registration. */
+  deepLink(app: Surface, url: string): Promise<void>;
   browserFixtureDiscovery(app: Surface, origin: string, action: "hold" | "release"): Promise<void>;
   /** Migration-only raw write escape hatch. New specs must not use it. */
   evalIn<T>(surface: Surface, expression: BrowserEvaluation<T>, options?: EvaluateOptions): Promise<Awaited<T>>;

--- a/evals/packages/labs/src/mock-google-server.ts
+++ b/evals/packages/labs/src/mock-google-server.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 
 import { buildOidcClaims, signOidcJwt } from "./idp.ts";
+import { serviceActionsWitness } from "./mock-service-actions.ts";
 
 interface MockGoogleServerOptions {
   accounts: string[];
@@ -87,6 +88,7 @@ interface MockGoogleState {
   drafts: Map<string, RecordedDraft[]>;
   driveUploads: Map<string, RecordedDriveUpload[]>;
   keys: SigningKeys;
+  actions: ReturnType<typeof serviceActionsWitness>;
 }
 
 const HTML_ENTITIES: Record<string, string> = {
@@ -611,6 +613,12 @@ async function handleRequest(state: MockGoogleState, request: IncomingMessage, r
     sendJson(response, 200, { requests: state.requests });
     return;
   }
+  if (requestMethod === "GET" && url.pathname === "/__mock-google/actions") {
+    sendJson(response, 200, state.actions.snapshot(url.searchParams.get("email") ?? ""));
+    return;
+  }
+  const accessToken = bearerToken(request);
+  if (await state.actions.handle(request, response, url, accountForRequest(state, request)?.email ?? null, accessToken ? tokenId(accessToken) : null)) return;
   if (requestMethod === "GET" && url.pathname === "/__mock-google/pending-authorizations") {
     sendJson(response, 200, pendingAuthorizations(state));
     return;
@@ -712,6 +720,7 @@ export async function startMockGoogleServer(options: MockGoogleServerOptions): P
     drafts: new Map(),
     driveUploads: new Map(),
     keys: createSigningKeys(),
+    actions: serviceActionsWitness(),
   };
   const server = createServer((request, response) => {
     void handleRequest(state, request, response).catch((error) => {

--- a/evals/packages/labs/src/mock-service-actions.ts
+++ b/evals/packages/labs/src/mock-service-actions.ts
@@ -1,0 +1,81 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+// A deliberately small provider, not a Den substitute. Only exact fixture
+// resources exist; valid OAuth credentials identify the account on every call.
+export function serviceActionsWitness() {
+  const requests: { method: string; path: string; query: Record<string, string>; body: unknown; email: string | null; tokenId: string | null }[] = [];
+  const accounts = new Map<string, {
+    labelIds: string[]; draftIds: string[]; sent: string[];
+    event: Record<string, unknown>; values: unknown[][]; outlookDraftIds: string[]; outlookAccepted: string[];
+  }>();
+  function account(email: string) {
+    let state = accounts.get(email);
+    if (!state) {
+      state = { labelIds: ["INBOX", "UNREAD"], draftIds: ["draft-1"], sent: [],
+        event: { id: "event-1", status: "confirmed", summary: "Before" }, values: [["Before", 0]],
+        outlookDraftIds: ["outlook-draft-1"], outlookAccepted: [] };
+      accounts.set(email, state);
+    }
+    return state;
+  }
+  return {
+    snapshot(email: string) { return { requests: requests.filter((entry) => entry.email === email), state: account(email), totalRequests: requests.length }; },
+    async handle(request: IncomingMessage, response: ServerResponse, url: URL, email: string | null, tokenId: string | null) {
+      const path = decodeURIComponent(url.pathname);
+      const known = ["/gmail/v1/users/me/messages/message-1", "/gmail/v1/users/me/messages/message-1/modify",
+        "/gmail/v1/users/me/drafts/send", "/calendar/v3/calendars/primary/events/event-1",
+        "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B1", "/v1.0/me/messages/outlook-draft-1/send"];
+      if (!known.includes(path)) return false;
+      const method = request.method ?? "GET";
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const raw = Buffer.concat(chunks).toString("utf8");
+      const body: unknown = raw ? JSON.parse(raw) : null;
+      requests.push({ method, path, query: Object.fromEntries(url.searchParams), body, email, tokenId });
+      const reply = (status: number, value?: unknown) => {
+        response.writeHead(status, { "content-type": "application/json" });
+        response.end(value === undefined ? undefined : JSON.stringify(value));
+        return true;
+      };
+      if (!email || !tokenId) return reply(401, { error: "invalid_token" });
+      const state = account(email);
+      const fields = typeof body === "object" && body !== null && !Array.isArray(body) ? body : {};
+      if (method === "POST" && path.endsWith("/modify") && "addLabelIds" in fields && "removeLabelIds" in fields
+        && Array.isArray(fields.addLabelIds) && fields.addLabelIds.every((id) => typeof id === "string")
+        && Array.isArray(fields.removeLabelIds) && fields.removeLabelIds.every((id) => typeof id === "string")) {
+        const removed = new Set(fields.removeLabelIds);
+        state.labelIds = [...new Set([...state.labelIds, ...fields.addLabelIds])].filter((id) => !removed.has(id));
+        return reply(200, { id: "message-1", threadId: "thread-1", labelIds: state.labelIds });
+      }
+      if (method === "GET" && path.endsWith("/messages/message-1")) {
+        return reply(200, { id: "message-1", threadId: "thread-1", labelIds: state.labelIds });
+      }
+      if (method === "POST" && path.endsWith("/drafts/send") && "id" in fields && fields.id === "draft-1") {
+        if (!state.draftIds.includes(fields.id)) return reply(404, { error: "draft_not_found" });
+        state.draftIds = [];
+        state.sent.push("sent-1");
+        return reply(200, { id: "sent-1", threadId: "thread-1", labelIds: ["SENT"] });
+      }
+      if (path.includes("/calendar/v3/") && (method === "PATCH" || method === "GET")) {
+        if (method === "PATCH") Object.assign(state.event, fields);
+        return reply(200, state.event);
+      }
+      if (path.includes("/v4/spreadsheets/") && method === "PUT" && "values" in fields && Array.isArray(fields.values)
+        && fields.values.every((row) => Array.isArray(row))) {
+        state.values = fields.values;
+        return reply(200, { spreadsheetId: "sheet-1", updatedRange: "Sheet1!A1:B1", updatedRows: state.values.length,
+          updatedColumns: Math.max(...state.values.map((row) => row.length)), updatedCells: state.values.flat().length });
+      }
+      if (path.includes("/v4/spreadsheets/") && method === "GET") {
+        return reply(200, { range: "Sheet1!A1:B1", majorDimension: "ROWS", values: state.values });
+      }
+      if (path.startsWith("/v1.0/") && method === "POST") {
+        if (!state.outlookDraftIds.includes("outlook-draft-1")) return reply(404, { error: "draft_not_found" });
+        state.outlookDraftIds = [];
+        state.outlookAccepted.push("outlook-draft-1");
+        return reply(202);
+      }
+      return reply(400, { error: "unexpected_provider_request" });
+    },
+  };
+}

--- a/evals/packages/labs/src/mock-service-actions.ts
+++ b/evals/packages/labs/src/mock-service-actions.ts
@@ -7,13 +7,27 @@ export function serviceActionsWitness() {
   const accounts = new Map<string, {
     labelIds: string[]; draftIds: string[]; sent: string[];
     event: Record<string, unknown>; values: unknown[][]; outlookDraftIds: string[]; outlookAccepted: string[];
+    draftMessage: Record<string, unknown>; labels: Record<string, unknown>[];
+    spreadsheet: Record<string, unknown>; file: Record<string, unknown>; folders: Record<string, unknown>[];
+    outlookMessage: Record<string, unknown>; outlookReply: Record<string, unknown> | null;
+    outlookEvent: Record<string, unknown> | null; outlookCancelled: string[]; outlookDeleted: string[];
+    onedriveFile: Record<string, unknown>; onedriveFolders: Record<string, unknown>[];
   }>();
   function account(email: string) {
     let state = accounts.get(email);
     if (!state) {
-      state = { labelIds: ["INBOX", "UNREAD"], draftIds: ["draft-1"], sent: [],
+      state = { labelIds: ["INBOX", "UNREAD"], draftIds: ["draft-1", "draft-2"], sent: [],
         event: { id: "event-1", status: "confirmed", summary: "Before" }, values: [["Before", 0]],
-        outlookDraftIds: ["outlook-draft-1"], outlookAccepted: [] };
+        outlookDraftIds: ["outlook-draft-1"], outlookAccepted: [],
+        draftMessage: { id: "draft-message-1", threadId: "thread-1" },
+        labels: [{ id: "INBOX", name: "INBOX", type: "system" }],
+        spreadsheet: { spreadsheetId: "sheet-1", spreadsheetUrl: "https://example.test/sheets/sheet-1",
+          properties: { title: "Before" }, sheets: [{ properties: { sheetId: 0, title: "Sheet1" } }] },
+        file: { id: "file-1", name: "Before.txt", mimeType: "text/plain", trashed: false, parents: ["parent-1"] }, folders: [],
+        outlookMessage: { id: "outlook-message-1", conversationId: "conversation-1", subject: "Before", isRead: false,
+          isDraft: false, categories: [], parentFolderId: "inbox", body: { contentType: "Text", content: "Original" } }, outlookReply: null,
+        outlookEvent: { id: "outlook-event-1", subject: "Before" }, outlookCancelled: [], outlookDeleted: [],
+        onedriveFile: { id: "item-1", name: "Before.txt", file: { mimeType: "text/plain" }, parentReference: { id: "parent-1" } }, onedriveFolders: [] };
       accounts.set(email, state);
     }
     return state;
@@ -24,9 +38,19 @@ export function serviceActionsWitness() {
       const path = decodeURIComponent(url.pathname);
       const known = ["/gmail/v1/users/me/messages/message-1", "/gmail/v1/users/me/messages/message-1/modify",
         "/gmail/v1/users/me/drafts/send", "/calendar/v3/calendars/primary/events/event-1",
-        "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B1", "/v1.0/me/messages/outlook-draft-1/send"];
+        "/gmail/v1/users/me/messages/message-1/trash", "/gmail/v1/users/me/messages/message-1/untrash",
+        "/gmail/v1/users/me/drafts", "/gmail/v1/users/me/drafts/draft-1", "/gmail/v1/users/me/drafts/draft-2",
+        "/gmail/v1/users/me/labels", "/gmail/v1/users/me/labels/label-1", "/gmail/v1/users/me/labels/INBOX",
+        "/v4/spreadsheets", "/v4/spreadsheets/sheet-1", "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B1",
+        "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B1:append", "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B2",
+        "/drive/v3/files", "/drive/v3/files/file-1", "/v1.0/me/messages/outlook-draft-1/send",
+        "/v1.0/me/messages/outlook-message-1", "/v1.0/me/messages/outlook-message-1/createReply", "/v1.0/me/messages/outlook-message-1/move",
+        "/v1.0/me/events/outlook-event-1", "/v1.0/me/events/outlook-event-1/cancel",
+        "/v1.0/me/drive/items/item-1", "/v1.0/me/drive/items/parent-2/children"];
       if (!known.includes(path)) return false;
       const method = request.method ?? "GET";
+      // Preserve the existing MIME/attachment draft-creation witness.
+      if (path === "/gmail/v1/users/me/drafts" && method === "POST") return false;
       const chunks: Buffer[] = [];
       for await (const chunk of request) chunks.push(Buffer.from(chunk));
       const raw = Buffer.concat(chunks).toString("utf8");
@@ -39,7 +63,8 @@ export function serviceActionsWitness() {
       };
       if (!email || !tokenId) return reply(401, { error: "invalid_token" });
       const state = account(email);
-      const fields = typeof body === "object" && body !== null && !Array.isArray(body) ? body : {};
+      const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+      const fields = isRecord(body) ? body : {};
       if (method === "POST" && path.endsWith("/modify") && "addLabelIds" in fields && "removeLabelIds" in fields
         && Array.isArray(fields.addLabelIds) && fields.addLabelIds.every((id) => typeof id === "string")
         && Array.isArray(fields.removeLabelIds) && fields.removeLabelIds.every((id) => typeof id === "string")) {
@@ -50,30 +75,122 @@ export function serviceActionsWitness() {
       if (method === "GET" && path.endsWith("/messages/message-1")) {
         return reply(200, { id: "message-1", threadId: "thread-1", labelIds: state.labelIds });
       }
+      if (method === "POST" && (path.endsWith("/message-1/trash") || path.endsWith("/message-1/untrash"))) {
+        state.labelIds = state.labelIds.filter((id) => id !== "TRASH");
+        if (path.endsWith("/trash")) state.labelIds.push("TRASH");
+        return reply(200, { id: "message-1", threadId: "thread-1", labelIds: state.labelIds });
+      }
+      if (method === "GET" && path.endsWith("/drafts")) {
+        return reply(200, { drafts: state.draftIds.map((id) => ({ id, message: id === "draft-1" ? state.draftMessage : { id: "draft-message-2", threadId: "thread-2" } })), resultSizeEstimate: state.draftIds.length });
+      }
+      if (/\/drafts\/draft-[12]$/.test(path)) {
+        const id = path.split("/").at(-1);
+        if (!id || !state.draftIds.includes(id)) return reply(404, { error: "draft_not_found" });
+        if (method === "DELETE") {
+          state.draftIds = state.draftIds.filter((draft) => draft !== id);
+          return reply(204);
+        }
+        if (id === "draft-1") {
+          if (method === "PUT" && isRecord(fields.message)) Object.assign(state.draftMessage, fields.message);
+          if (method === "GET" || method === "PUT") return reply(200, { id, message: state.draftMessage });
+        }
+      }
       if (method === "POST" && path.endsWith("/drafts/send") && "id" in fields && fields.id === "draft-1") {
         if (!state.draftIds.includes(fields.id)) return reply(404, { error: "draft_not_found" });
-        state.draftIds = [];
+        state.draftIds = state.draftIds.filter((id) => id !== fields.id);
         state.sent.push("sent-1");
         return reply(200, { id: "sent-1", threadId: "thread-1", labelIds: ["SENT"] });
+      }
+      if (path.endsWith("/labels")) {
+        if (method === "GET") return reply(200, { labels: state.labels });
+        if (method === "POST" && typeof fields.name === "string") {
+          const label = { ...fields, id: "label-1", type: "user" };
+          state.labels.push(label);
+          return reply(200, label);
+        }
+      }
+      if (path.includes("/labels/")) {
+        const label = state.labels.find((entry) => entry.id === path.split("/").at(-1));
+        if (!label) return reply(404, { error: "label_not_found" });
+        if (method === "GET") return reply(200, label);
+        if (method === "PATCH") { Object.assign(label, fields); return reply(200, label); }
+        if (method === "DELETE") { state.labels = state.labels.filter((entry) => entry !== label); return reply(204); }
+      }
+      if (path.includes("/calendar/v3/") && method === "DELETE") {
+        state.event.status = "cancelled";
+        return reply(204);
       }
       if (path.includes("/calendar/v3/") && (method === "PATCH" || method === "GET")) {
         if (method === "PATCH") Object.assign(state.event, fields);
         return reply(200, state.event);
       }
-      if (path.includes("/v4/spreadsheets/") && method === "PUT" && "values" in fields && Array.isArray(fields.values)
+      if (path === "/v4/spreadsheets" && method === "POST") {
+        if (!isRecord(fields.properties) || !Array.isArray(fields.sheets)) return reply(400, { error: "invalid_spreadsheet" });
+        state.spreadsheet = { ...state.spreadsheet, properties: fields.properties,
+          sheets: fields.sheets.filter(isRecord).map((sheet) => ({ properties: { sheetId: 0, ...(isRecord(sheet.properties) ? sheet.properties : {}) } })) };
+        return reply(200, state.spreadsheet);
+      }
+      if (path === "/v4/spreadsheets/sheet-1" && method === "GET") return reply(200, state.spreadsheet);
+      if (path.includes("/values/") && (method === "PUT" || (method === "POST" && path.endsWith(":append"))) && "values" in fields && Array.isArray(fields.values)
         && fields.values.every((row) => Array.isArray(row))) {
-        state.values = fields.values;
-        return reply(200, { spreadsheetId: "sheet-1", updatedRange: "Sheet1!A1:B1", updatedRows: state.values.length,
-          updatedColumns: Math.max(...state.values.map((row) => row.length)), updatedCells: state.values.flat().length });
+        const append = method === "POST";
+        state.values = append ? [...state.values, ...fields.values] : fields.values;
+        const updates = { spreadsheetId: "sheet-1", updatedRange: append ? "Sheet1!A2:B2" : "Sheet1!A1:B1", updatedRows: fields.values.length,
+          updatedColumns: Math.max(...fields.values.map((row) => row.length)), updatedCells: fields.values.flat().length };
+        return reply(200, append ? { spreadsheetId: "sheet-1", tableRange: "Sheet1!A1:B1", updates } : updates);
       }
-      if (path.includes("/v4/spreadsheets/") && method === "GET") {
-        return reply(200, { range: "Sheet1!A1:B1", majorDimension: "ROWS", values: state.values });
+      if (path.includes("/values/") && method === "GET") {
+        return reply(200, { range: path.split("/values/")[1], majorDimension: "ROWS", values: state.values });
       }
-      if (path.startsWith("/v1.0/") && method === "POST") {
+      if (path === "/drive/v3/files" && method === "POST") {
+        const folder = { ...fields, id: "folder-1", trashed: false };
+        state.folders.push(folder);
+        return reply(200, folder);
+      }
+      if (path === "/drive/v3/files/file-1") {
+        if (method === "PATCH") {
+          Object.assign(state.file, fields);
+          if (url.searchParams.has("addParents")) state.file.parents = [url.searchParams.get("addParents")];
+        }
+        if (method === "GET" || method === "PATCH") return reply(200, state.file);
+      }
+      if (path.endsWith("/outlook-draft-1/send") && method === "POST") {
         if (!state.outlookDraftIds.includes("outlook-draft-1")) return reply(404, { error: "draft_not_found" });
-        state.outlookDraftIds = [];
+        state.outlookDraftIds = state.outlookDraftIds.filter((id) => id !== "outlook-draft-1");
         state.outlookAccepted.push("outlook-draft-1");
         return reply(202);
+      }
+      if (path.endsWith("/outlook-message-1/createReply") && method === "POST") {
+        state.outlookReply = { ...state.outlookMessage, id: "outlook-reply-1", isDraft: true,
+          body: { contentType: "Text", content: fields.comment } };
+        state.outlookDraftIds.push("outlook-reply-1");
+        return reply(201, state.outlookReply);
+      }
+      if (path.endsWith("/outlook-message-1") && method === "PATCH") {
+        Object.assign(state.outlookMessage, fields);
+        return reply(200, state.outlookMessage);
+      }
+      if (path.endsWith("/outlook-message-1/move") && method === "POST") {
+        Object.assign(state.outlookMessage, { id: "outlook-moved-1", parentFolderId: fields.destinationId });
+        return reply(201, state.outlookMessage);
+      }
+      if (path.endsWith("/outlook-event-1")) {
+        if (!state.outlookEvent) return reply(404, { error: "event_not_found" });
+        if (method === "PATCH") { Object.assign(state.outlookEvent, fields); return reply(200, state.outlookEvent); }
+        if (method === "DELETE") { state.outlookEvent = null; state.outlookDeleted.push("outlook-event-1"); return reply(204); }
+      }
+      if (path.endsWith("/outlook-event-1/cancel") && method === "POST") {
+        state.outlookCancelled.push("outlook-event-1");
+        return reply(202);
+      }
+      if (path === "/v1.0/me/drive/items/item-1" && method === "PATCH") {
+        Object.assign(state.onedriveFile, fields);
+        return reply(200, state.onedriveFile);
+      }
+      if (path === "/v1.0/me/drive/items/parent-2/children" && method === "POST") {
+        const folder = { ...fields, id: "onedrive-folder-1", parentReference: { id: "parent-2" } };
+        state.onedriveFolders.push(folder);
+        return reply(201, folder);
       }
       return reply(400, { error: "unexpected_provider_request" });
     },

--- a/evals/packages/test-evidence/test/test-evidence.test.ts
+++ b/evals/packages/test-evidence/test/test-evidence.test.ts
@@ -194,9 +194,12 @@ test("screenshot automatically records an artifact in ambient test evidence", as
   const dir = await mkdtemp(join(tmpdir(), "openwork-test-evidence-screenshot-"));
   try {
     const png = Buffer.from("ambient screenshot pixels");
+    const methods: string[] = [];
     const client: CdpClient = {
       close() {},
       async send(method) {
+        methods.push(method);
+        if (method === "Page.bringToFront") return {};
         if (method === "Page.captureScreenshot") return { data: png.toString("base64") };
         if (method === "Runtime.evaluate") {
           return { result: { value: { route: "#/ambient", visibleText: "Ambient screenshot" } } };
@@ -210,6 +213,7 @@ test("screenshot automatically records an artifact in ambient test evidence", as
     };
     const testEvidence = createTestEvidence({ name: "ambient screenshot", outDir: dir });
     const captured = await withTestEvidence(testEvidence, () => screenshot(app));
+    assert.deepEqual(methods.slice(0, 2), ["Page.bringToFront", "Page.captureScreenshot"]);
     assert.equal(captured.route, "#/ambient");
     await testEvidence.close();
 

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -11,6 +11,7 @@ import {
   readComposerState,
   readBrowserState,
   readBrowserTabMetrics,
+  readConnectorCatalog,
   renameSessionAndWait,
   signInDesktopAs,
   waitUntilInteractive,
@@ -596,6 +597,15 @@ export class SeedChannel implements Seed {
     });
   }
 
+  deepLink(app: Surface, url: string) {
+    return this.#runtime.call("seed", "deepLink", "deepLink(renderer ingress)", app, async () => {
+      if (new URL(url).protocol !== "openwork:") throw new Error("Expected an OpenWork deep link.");
+      await callFunctionOnSurface(app, (url) => {
+        window.dispatchEvent(new CustomEvent("openwork:deep-link", { detail: { urls: [url] } }));
+      }, [url]);
+    });
+  }
+
   browserFixtureDiscovery(app: Surface, origin: string, action: "hold" | "release") {
     return this.#runtime.call("seed", "browserFixtureDiscovery", `browserFixtureDiscovery(${action})`, app,
       () => setBrowserFixtureDiscovery(app, origin, action));
@@ -938,6 +948,11 @@ export class ProbeChannel implements Probe {
   composer() {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("probe", "composer", "composer", surface, () => readComposerState(surface));
+  }
+
+  connectorCatalog() {
+    const surface = requireSurface(this.#surface);
+    return this.#runtime.call("probe", "connectorCatalog", "connectorCatalog", surface, () => readConnectorCatalog(surface));
   }
 
   storage(key: string): Promise<unknown>;

--- a/evals/packages/testkit/src/spec/types.ts
+++ b/evals/packages/testkit/src/spec/types.ts
@@ -73,6 +73,7 @@ export interface Probe {
   dom(selector: string): ReturnType<typeof import("@openwork/cdp").readDom>;
   has(text: string): Promise<boolean>;
   composer(): ReturnType<typeof import("@openwork/behaviors").readComposerState>;
+  connectorCatalog(): ReturnType<typeof import("@openwork/behaviors").readConnectorCatalog>;
   storage(key: string): Promise<unknown>;
   storage<T>(key: string, pick: (value: unknown) => T): Promise<T>;
   hash(): Promise<string>;

--- a/evals/specs/connected-service-actions.test.ts
+++ b/evals/specs/connected-service-actions.test.ts
@@ -1,0 +1,247 @@
+import { expect } from "vitest";
+import { createNativeConnector, denFetch, type DenSession } from "@openwork/behaviors";
+import { startMockGoogle } from "@openwork/labs";
+import { needs, server, test } from "@openwork/testkit";
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected an object");
+  return value;
+}
+function rows(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) throw new Error("Expected a list");
+  return value.map(record);
+}
+function text(value: unknown): string {
+  if (typeof value !== "string") throw new Error("Expected a string");
+  return value;
+}
+
+// OAuth/discovery journeys do not cover this management journey: a member
+// selects one native account and performs actual provider mutations via MCP.
+test("connected service actions reach only the selected account and enforce write boundaries", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun", "pnpm"], placement: "local" });
+  const primary = "primary@example.test";
+  const selected = "selected@example.test";
+  const readonly = "readonly@example.test";
+  await using provider = await startMockGoogle({ accounts: [primary, selected, readonly], port: 0 });
+  await using den = await server({
+    place, web: false, org: { name: `Service Actions ${Date.now()}`, members: { writer: {}, reader: {} } },
+    env: {
+      DEN_GOOGLE_OAUTH_AUTHORIZE_URL: provider.authorizeUrl,
+      DEN_GOOGLE_OAUTH_TOKEN_URL: provider.tokenUrl,
+      DEN_GOOGLE_OAUTH_USERINFO_URL: provider.userinfoUrl,
+      DEN_GOOGLE_API_BASE_URL: provider.apiUrl,
+      DEN_MICROSOFT_OAUTH_AUTHORIZE_URL: `${provider.authorizeUrl}?tenantId={tenantId}`,
+      DEN_MICROSOFT_OAUTH_TOKEN_URL: `${provider.tokenUrl}?tenantId={tenantId}`,
+      DEN_MICROSOFT_GRAPH_BASE_URL: `${provider.apiUrl}/v1.0`,
+    },
+  });
+  expect(den.database, "Must cold-boot an owned isolated database, never attach a shared Den").toBeDefined();
+  const writer = den.members.writer;
+  const reader = den.members.reader;
+  const writeFeatures = ["gmailManage", "calendarWrite", "sheetsWrite", "driveFile"];
+  const connect = async (member: DenSession, providerKey: string, name: string, features: string[], email: string) => {
+    const connection = await createNativeConnector(den.admin, {
+      providerKey, name, features, clientId: `synthetic-${name}`, clientSecret: "synthetic-service-actions-secret",
+    });
+    if (providerKey === "microsoft-365") {
+      const configured = await denFetch(den.admin, `/v1/oauth-providers/${connection.id}/client`, {
+        method: "POST", headers: { authorization: `Bearer ${den.admin.token}` },
+        body: JSON.stringify({ tenantId: "12345678-1234-1234-1234-123456789abc" }),
+      });
+      expect(configured.response.status, configured.text).toBe(200);
+    }
+    const started = await denFetch(member, `/v1/mcp-connections/${connection.id}/connect/start`, {
+      headers: { authorization: `Bearer ${member.token}` },
+    });
+    expect(started.response.status, started.text).toBe(200);
+    const authorize = new URL(text(record(started.body).authorizeUrl));
+    expect(`${authorize.origin}${authorize.pathname}`).toBe(provider.authorizeUrl);
+    // Exercise the real native OAuth callback, not a seeded token table.
+    authorize.searchParams.set("prompt", "select_account");
+    const page = await fetch(authorize, { redirect: "manual", signal: AbortSignal.timeout(15_000) });
+    expect(page.status).toBe(200);
+    await provider.chooseAccount(email, { timeoutMs: 30_000 });
+    const status = await denFetch(member, `/v1/oauth-providers/${connection.id}/status`, {
+      headers: { authorization: `Bearer ${member.token}` },
+    });
+    expect(status.response.status, status.text).toBe(200);
+    expect(status.body).toMatchObject({ connected: true, externalAccountId: email });
+    return connection;
+  };
+  const first = await connect(writer, "google-workspace", "Primary Google", writeFeatures, primary);
+  const google = await connect(writer, "google-workspace", "Selected Google", writeFeatures, selected);
+  const readGoogle = await connect(reader, "google-workspace", "Readonly Google", ["gmailRead", "calendarRead", "sheetsRead"], readonly);
+  const microsoft = await connect(writer, "microsoft-365", "Selected Outlook", ["mailSend", "mailRead"], selected);
+  expect(google.id).not.toBe(first.id);
+
+  async function mint(member: DenSession, scopes = ["mcp:read", "mcp:write"]) {
+    const response = await denFetch(member, "/v1/mcp/token", {
+      method: "POST", headers: { authorization: `Bearer ${member.token}` }, body: JSON.stringify({ scopes }),
+    });
+    expect(response.response.status, response.text).toBe(200);
+    expect(record(response.body).scopes).toEqual(scopes);
+    return text(record(response.body).token);
+  }
+  const writerToken = await mint(writer);
+  const readScopeToken = await mint(writer, ["mcp:read"]);
+  const readerToken = await mint(reader);
+  let requestId = 0;
+  async function gateway(token: string, name: string, args: Record<string, unknown>) {
+    const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
+      method: "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method: "tools/call", params: { name, arguments: args } }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    const raw = await response.text();
+    expect(response.status, raw).toBe(200);
+    const line = raw.split("\n").find((value) => value.startsWith("data:"));
+    const rpc = record(JSON.parse(line ? line.slice(5) : raw));
+    expect(rpc.error, JSON.stringify(rpc.error)).toBeUndefined();
+    const result = record(rpc.result);
+    return { result, payload: record(JSON.parse(text(rows(result.content)[0]?.text))) };
+  }
+  const found = new Map<string, Record<string, unknown>>();
+  async function discover(connection: { id: string; name: string }, providerKey: string, suffix: string, methods: string[], token = writerToken) {
+    const path = `/v1/capabilities/${providerKey}/${suffix}`;
+    // Search is relevance-ranked and capped at 20, not an exact URL lookup.
+    // Avoid common API-prefix words crowding out the selected resource.
+    const search = await gateway(token, "search_capabilities", { query: `${connection.name} ${suffix}`, type: "api", limit: 20 });
+    expect(search.result.isError, JSON.stringify(search.payload)).not.toBe(true);
+    const matches = rows(search.payload.matches).filter((match) => text(match.name).startsWith(`native:${connection.id}:`) && match.path === path);
+    for (const method of methods) {
+      const exact = matches.filter((match) => match.method === method);
+      expect(exact, `Discovery must retain ${method} ${path} for ${connection.id}: ${JSON.stringify(rows(search.payload.matches).map(({ name, method, path }) => ({ name, method, path })))}`).toHaveLength(1);
+      const match = exact[0];
+      const previous = found.get(text(match.name));
+      if (previous) expect([previous.method, previous.path]).toEqual([method, path]);
+      found.set(text(match.name), match);
+    }
+    return matches;
+  }
+  // Explicit public paths protect the catalog against singular/plural name
+  // collisions; nothing imports route code or computes the expected names.
+  const googleOperations: [string, string[]][] = [
+    ["gmail-draft/{draftId}/send", ["POST"]], ["gmail-drafts", ["GET", "POST"]],
+    ["gmail-draft/{draftId}", ["GET", "PUT", "DELETE"]],
+    ["gmail-message/{messageId}/modify", ["POST"]], ["gmail-message/{messageId}/trash", ["POST"]],
+    ["gmail-message/{messageId}/untrash", ["POST"]], ["gmail-labels", ["GET", "POST"]],
+    ["gmail-label/{labelId}", ["PATCH", "DELETE"]],
+    ["calendar-events/{eventId}", ["GET", "PATCH", "DELETE"]],
+    ["spreadsheets/{spreadsheetId}", ["GET"]], ["spreadsheets", ["POST"]],
+    ["spreadsheets/{spreadsheetId}/values", ["GET", "PUT"]], ["spreadsheets/{spreadsheetId}/values/append", ["POST"]],
+    ["drive-folders", ["POST"]], ["drive-files/{fileId}", ["GET", "PATCH"]],
+  ];
+  const microsoftOperations: [string, string[]][] = [
+    ["mail-drafts/{messageId}/send", ["POST"]], ["mail-message/{messageId}/reply-draft", ["POST"]],
+    ["mail-message/{messageId}", ["PATCH"]], ["mail-message/{messageId}/move", ["POST"]],
+    ["calendar-events/{eventId}", ["PATCH", "DELETE"]], ["calendar-events/{eventId}/cancel", ["POST"]],
+    ["drive-file/{itemId}", ["PATCH"]], ["drive-folders", ["POST"]],
+  ];
+  for (const [suffix, methods] of googleOperations) await discover(google, "google-workspace", suffix, methods);
+  for (const [suffix, methods] of microsoftOperations) await discover(microsoft, "microsoft-365", suffix, methods);
+  expect(found.size).toBe(33);
+  evidence.recordAssertionEvidence("All new native operation paths are discoverable without tool-name collisions", "Gateway search returned one exact connector-namespaced method/path match for each of 33 operations (32 new and existing Gmail draft creation); no name mapped to another path or method.", true);
+
+  const snapshot = async (email: string) => {
+    const response = await fetch(`${provider.apiUrl}/__mock-google/actions?email=${encodeURIComponent(email)}`, { signal: AbortSignal.timeout(10_000) });
+    expect(response.status).toBe(200);
+    return record(await response.json());
+  };
+  const untouched = await snapshot(primary);
+  const readerBefore = await snapshot(readonly);
+  const cases = [
+    { providerKey: "google-workspace", connection: google, method: "POST", suffix: "gmail-message/{messageId}/modify",
+      path: { messageId: "message-1" }, body: { addLabelIds: ["STARRED"], removeLabelIds: ["INBOX", "UNREAD"] },
+      providerPath: "/gmail/v1/users/me/messages/message-1/modify", providerBody: { addLabelIds: ["STARRED"], removeLabelIds: ["INBOX", "UNREAD"] }, providerQuery: {},
+      receipt: { id: "message-1", threadId: "thread-1", labelIds: ["STARRED"] } },
+    { providerKey: "google-workspace", connection: google, method: "POST", suffix: "gmail-draft/{draftId}/send",
+      path: { draftId: "draft-1" }, body: { confirm: true }, unconfirmed: {},
+      providerPath: "/gmail/v1/users/me/drafts/send", providerBody: { id: "draft-1" }, providerQuery: {}, receipt: { id: "sent-1", threadId: "thread-1" } },
+    { providerKey: "google-workspace", connection: google, method: "PATCH", suffix: "calendar-events/{eventId}",
+      path: { eventId: "event-1" }, body: { summary: "After", sendUpdates: "all", confirmNotifications: true }, unconfirmed: { summary: "After", sendUpdates: "all" },
+      providerPath: "/calendar/v3/calendars/primary/events/event-1", providerBody: { summary: "After" }, providerQuery: { sendUpdates: "all", maxAttendees: "100" },
+      receipt: { ok: true, event: { id: "event-1", status: "confirmed", summary: "After" }, sendUpdates: "all" } },
+    { providerKey: "google-workspace", connection: google, method: "PUT", suffix: "spreadsheets/{spreadsheetId}/values",
+      path: { spreadsheetId: "sheet-1" }, body: { range: "Sheet1!A1:B1", values: [["=1+1", 7]] },
+      unconfirmed: { range: "Sheet1!A1:B1", values: [["=1+1", 7]], valueInputOption: "USER_ENTERED" },
+      providerPath: "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B1", providerBody: { range: "Sheet1!A1:B1", majorDimension: "ROWS", values: [["=1+1", 7]] },
+      providerQuery: { valueInputOption: "RAW" }, receipt: { ok: true, spreadsheetId: "sheet-1", updatedCells: 2, valueInputOption: "RAW" } },
+    { providerKey: "microsoft-365", connection: microsoft, method: "POST", suffix: "mail-drafts/{messageId}/send",
+      path: { messageId: "outlook-draft-1" }, body: { confirmSend: true }, unconfirmed: {},
+      providerPath: "/v1.0/me/messages/outlook-draft-1/send", providerBody: null, providerQuery: {},
+      receipt: { ok: true, draftId: "outlook-draft-1", status: "accepted" } },
+  ];
+  for (const action of cases) {
+    const fullPath = `/v1/capabilities/${action.providerKey}/${action.suffix}`;
+    const match = [...found.values()].find((entry) => entry.method === action.method && entry.path === fullPath);
+    if (!match) throw new Error(`Missing discovered action ${action.method} ${fullPath}`);
+    expect(match.hasBody).toBe(true);
+    // The gateway returns the OpenAPI schema unchanged, including named refs.
+    if (action.providerKey === "microsoft-365") {
+      expect(match.bodySchema).toEqual({ $ref: "#/components/schemas/Microsoft365MailSendBody" });
+    } else {
+      expect(record(match.bodySchema).type).toBe("object");
+    }
+    expect(match.pathParams).toEqual(Object.keys(action.path));
+    const args = { name: text(match.name), path: action.path, body: action.body };
+    const before = await snapshot(selected);
+    const denied = await gateway(readScopeToken, "execute_capability", args);
+    expect(denied.result.isError).toBe(true);
+    expect(denied.payload).toMatchObject({ error: "insufficient_mcp_scope", requiredScope: "mcp:write" });
+    expect(await snapshot(selected)).toEqual(before);
+    if (action.providerKey === "google-workspace") {
+      const readerMatches = await discover(readGoogle, "google-workspace", action.suffix, [action.method], readerToken);
+      const readerMatch = readerMatches.find((entry) => entry.method === action.method);
+      if (!readerMatch) throw new Error("Read-only member's operation missing");
+      const deniedGrant = await gateway(readerToken, "execute_capability", { ...args, name: readerMatch.name });
+      expect(deniedGrant.result.isError).toBe(true);
+      expect(deniedGrant.payload).toMatchObject({ error: "needs_connection" });
+      expect(await snapshot(selected)).toEqual(before);
+      expect((await snapshot(readonly)).state).toEqual(readerBefore.state);
+      expect((await snapshot(readonly)).requests).toEqual([]);
+    }
+    if (action.unconfirmed) {
+      const rejected = await gateway(writerToken, "execute_capability", { ...args, body: action.unconfirmed });
+      expect(rejected.result.isError).toBe(true);
+      expect(rejected.payload).toMatchObject({ error: "invalid_request" });
+      expect(await snapshot(selected)).toEqual(before);
+    }
+    const executed = await gateway(writerToken, "execute_capability", args);
+    expect(executed.result.isError, JSON.stringify(executed.payload)).not.toBe(true);
+    expect(executed.payload).toMatchObject(action.receipt);
+    const after = await snapshot(selected);
+    expect(after.totalRequests).toBe(Number(before.totalRequests) + 1);
+    const observed = rows(after.requests).at(-1);
+    expect(observed).toEqual({ method: action.method, path: action.providerPath, query: action.providerQuery,
+      body: action.providerBody, email: selected, tokenId: expect.stringMatching(/^[a-f0-9]{12}$/) });
+    expect((await snapshot(primary)).state).toEqual(untouched.state);
+    expect((await snapshot(primary)).requests).toEqual([]);
+    evidence.recordAssertionEvidence(`${action.method} ${action.suffix} crosses the provider boundary only with write authority`,
+      "Read-only MCP scope and applicable provider-grant/confirmation denials produced zero HTTP calls. The authorized call produced exactly one authenticated provider request with the exact method, path, query, and body for the selected account, never the other account.", true);
+  }
+  const final = await snapshot(selected);
+  expect(final.state).toEqual({ labelIds: ["STARRED"], draftIds: [], sent: ["sent-1"],
+    event: { id: "event-1", status: "confirmed", summary: "After" }, values: [["=1+1", 7]],
+    outlookDraftIds: [], outlookAccepted: ["outlook-draft-1"] });
+  expect(final.totalRequests).toBe(5);
+  expect((await snapshot(readonly)).state).toEqual(readerBefore.state);
+  evidence.recordAssertionEvidence("Provider state reflects five actual mutations, not UI text or canned gateway success", "Selected account is archived/read/starred; Gmail draft is consumed into sent mail; Calendar summary changed; Sheets stores literal RAW values; Outlook accepted and consumed its draft (not a delivery claim). Both other accounts remain unchanged.", true);
+  for (const [connection, features, action] of [
+    [google, ["gmailRead", "calendarRead", "sheetsRead"], cases[0]],
+    [microsoft, ["mailRead"], cases[4]],
+  ] as const) {
+    const disabled = await denFetch(den.admin, `/v1/oauth-providers/${connection.id}/client`, {
+      method: "POST", headers: { authorization: `Bearer ${den.admin.token}` }, body: JSON.stringify({ features }),
+    });
+    expect(disabled.response.status, disabled.text).toBe(200);
+    const path = `/v1/capabilities/${action.providerKey}/${action.suffix}`;
+    const match = [...found.values()].find((entry) => entry.path === path && entry.method === action.method);
+    if (!match) throw new Error("Missing previously discovered action.");
+    const denied = await gateway(writerToken, "execute_capability", { name: match.name, path: action.path, body: action.body });
+    expect(denied.result.isError).toBe(true);
+    expect(denied.payload).toMatchObject({ error: "needs_connection" });
+    expect(await snapshot(selected)).toEqual(final);
+  }
+  evidence.recordAssertionEvidence("Administrator write revocation is enforced despite previously granted provider tokens", "Disabled Google mailbox management and Microsoft mail sending through the actual selected-client configuration routes. Both previously discovered actions were rejected without any additional provider request or state change.", true);
+});

--- a/evals/specs/connected-service-actions.test.ts
+++ b/evals/specs/connected-service-actions.test.ts
@@ -3,8 +3,11 @@ import { createNativeConnector, denFetch, type DenSession } from "@openwork/beha
 import { startMockGoogle } from "@openwork/labs";
 import { needs, server, test } from "@openwork/testkit";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 function record(value: unknown): Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected an object");
+  if (!isRecord(value)) throw new Error("Expected an object");
   return value;
 }
 function rows(value: unknown): Record<string, unknown>[] {
@@ -71,8 +74,9 @@ test("connected service actions reach only the selected account and enforce writ
   };
   const first = await connect(writer, "google-workspace", "Primary Google", writeFeatures, primary);
   const google = await connect(writer, "google-workspace", "Selected Google", writeFeatures, selected);
-  const readGoogle = await connect(reader, "google-workspace", "Readonly Google", ["gmailRead", "calendarRead", "sheetsRead"], readonly);
-  const microsoft = await connect(writer, "microsoft-365", "Selected Outlook", ["mailSend", "mailRead"], selected);
+  const readGoogle = await connect(reader, "google-workspace", "Readonly Google", ["gmailRead", "calendarRead", "sheetsRead", "driveRead"], readonly);
+  const microsoft = await connect(writer, "microsoft-365", "Selected Outlook", ["mailSend", "mailRead", "mailDraft", "mailManage", "calendarWrite", "filesWrite"], selected);
+  const readMicrosoft = await connect(reader, "microsoft-365", "Readonly Outlook", ["mailRead", "calendarRead", "filesRead"], readonly);
   expect(google.id).not.toBe(first.id);
 
   async function mint(member: DenSession, scopes = ["mcp:read", "mcp:write"]) {
@@ -150,48 +154,152 @@ test("connected service actions reach only the selected account and enforce writ
   };
   const untouched = await snapshot(primary);
   const readerBefore = await snapshot(readonly);
-  const cases = [
-    { providerKey: "google-workspace", connection: google, method: "POST", suffix: "gmail-message/{messageId}/modify",
+  type Action = {
+    method: string; suffix: string; path?: Record<string, string>; query?: Record<string, string>;
+    body?: Record<string, unknown>; unconfirmed?: Record<string, unknown>; unconfirmedQuery?: Record<string, string>;
+    providerPath: string; providerBody?: unknown; providerQuery?: Record<string, string>; preflight?: boolean;
+    receipt: Record<string, unknown>; state?: Record<string, unknown>;
+  };
+  const raw = Buffer.from("To: recipient@example.test\r\nSubject: Revised\r\n\r\nRevised draft").toString("base64url");
+  const fileQuery = { fields: "id,name,mimeType,trashed,parents,webViewLink", supportsAllDrives: "true" };
+  const spreadsheetFields = "spreadsheetId,spreadsheetUrl,properties(title,locale,timeZone),sheets(properties(sheetId,title,index,gridProperties(rowCount,columnCount)))";
+  const googleCases: Action[] = [
+    { method: "POST", suffix: "gmail-message/{messageId}/modify",
       path: { messageId: "message-1" }, body: { addLabelIds: ["STARRED"], removeLabelIds: ["INBOX", "UNREAD"] },
       providerPath: "/gmail/v1/users/me/messages/message-1/modify", providerBody: { addLabelIds: ["STARRED"], removeLabelIds: ["INBOX", "UNREAD"] }, providerQuery: {},
-      receipt: { id: "message-1", threadId: "thread-1", labelIds: ["STARRED"] } },
-    { providerKey: "google-workspace", connection: google, method: "POST", suffix: "gmail-draft/{draftId}/send",
+      receipt: { id: "message-1", threadId: "thread-1", labelIds: ["STARRED"] }, state: { labelIds: ["STARRED"] } },
+    { method: "POST", suffix: "gmail-message/{messageId}/trash", path: { messageId: "message-1" }, body: { confirm: true }, unconfirmed: {},
+      providerPath: "/gmail/v1/users/me/messages/message-1/trash", receipt: { id: "message-1", labelIds: ["STARRED", "TRASH"] }, state: { labelIds: ["STARRED", "TRASH"] } },
+    { method: "POST", suffix: "gmail-message/{messageId}/untrash", path: { messageId: "message-1" },
+      providerPath: "/gmail/v1/users/me/messages/message-1/untrash", receipt: { id: "message-1", labelIds: ["STARRED"] }, state: { labelIds: ["STARRED"] } },
+    { method: "GET", suffix: "gmail-drafts", query: { maxResults: "2", q: "in:drafts", includeSpamTrash: "false" },
+      providerPath: "/gmail/v1/users/me/drafts", providerQuery: { maxResults: "2", q: "in:drafts", includeSpamTrash: "false" },
+      receipt: { drafts: [{ id: "draft-1" }, { id: "draft-2" }], resultSizeEstimate: 2 } },
+    { method: "PUT", suffix: "gmail-draft/{draftId}", path: { draftId: "draft-1" },
+      body: { confirm: true, message: { raw, threadId: "thread-1" } }, unconfirmed: { message: { raw } },
+      providerPath: "/gmail/v1/users/me/drafts/draft-1", providerBody: { message: { raw, threadId: "thread-1" } },
+      receipt: { id: "draft-1", message: { raw, threadId: "thread-1" } }, state: { draftMessage: { raw, threadId: "thread-1" }, sent: [] } },
+    { method: "GET", suffix: "gmail-draft/{draftId}", path: { draftId: "draft-1" }, query: { format: "raw" },
+      providerPath: "/gmail/v1/users/me/drafts/draft-1", providerQuery: { format: "raw" }, receipt: { id: "draft-1", message: { raw, threadId: "thread-1" } } },
+    { method: "DELETE", suffix: "gmail-draft/{draftId}", path: { draftId: "draft-2" }, body: { confirm: true }, unconfirmed: {},
+      providerPath: "/gmail/v1/users/me/drafts/draft-2", receipt: { ok: true }, state: { draftIds: ["draft-1"], sent: [] } },
+    { method: "POST", suffix: "gmail-draft/{draftId}/send",
       path: { draftId: "draft-1" }, body: { confirm: true }, unconfirmed: {},
-      providerPath: "/gmail/v1/users/me/drafts/send", providerBody: { id: "draft-1" }, providerQuery: {}, receipt: { id: "sent-1", threadId: "thread-1" } },
-    { providerKey: "google-workspace", connection: google, method: "PATCH", suffix: "calendar-events/{eventId}",
-      path: { eventId: "event-1" }, body: { summary: "After", sendUpdates: "all", confirmNotifications: true }, unconfirmed: { summary: "After", sendUpdates: "all" },
-      providerPath: "/calendar/v3/calendars/primary/events/event-1", providerBody: { summary: "After" }, providerQuery: { sendUpdates: "all", maxAttendees: "100" },
-      receipt: { ok: true, event: { id: "event-1", status: "confirmed", summary: "After" }, sendUpdates: "all" } },
-    { providerKey: "google-workspace", connection: google, method: "PUT", suffix: "spreadsheets/{spreadsheetId}/values",
+      providerPath: "/gmail/v1/users/me/drafts/send", providerBody: { id: "draft-1" }, receipt: { id: "sent-1", threadId: "thread-1" }, state: { draftIds: [], sent: ["sent-1"] } },
+    { method: "POST", suffix: "gmail-labels", body: { name: "Review", labelListVisibility: "labelShow" },
+      providerPath: "/gmail/v1/users/me/labels", providerBody: { name: "Review", labelListVisibility: "labelShow" },
+      receipt: { id: "label-1", name: "Review", type: "user" } },
+    { method: "PATCH", suffix: "gmail-label/{labelId}", path: { labelId: "label-1" }, body: { name: "Reviewed", messageListVisibility: "hide" }, preflight: true,
+      providerPath: "/gmail/v1/users/me/labels/label-1", providerBody: { name: "Reviewed", messageListVisibility: "hide" },
+      receipt: { id: "label-1", name: "Reviewed", type: "user", messageListVisibility: "hide" } },
+    { method: "GET", suffix: "gmail-labels", providerPath: "/gmail/v1/users/me/labels",
+      receipt: { labels: [{ id: "INBOX", type: "system" }, { id: "label-1", name: "Reviewed", type: "user" }] } },
+    { method: "DELETE", suffix: "gmail-label/{labelId}", path: { labelId: "label-1" }, body: { confirm: true }, unconfirmed: {}, preflight: true,
+      providerPath: "/gmail/v1/users/me/labels/label-1", receipt: { ok: true }, state: { labels: [{ id: "INBOX", name: "INBOX", type: "system" }], labelIds: ["STARRED"] } },
+    { method: "PATCH", suffix: "calendar-events/{eventId}", path: { eventId: "event-1" },
+      body: { summary: "After", start: { date: "2026-10-01" }, end: { date: "2026-10-02" }, attendees: [], sendUpdates: "all", confirmNotifications: true },
+      unconfirmed: { summary: "After", sendUpdates: "all" },
+      providerPath: "/calendar/v3/calendars/primary/events/event-1",
+      providerBody: { summary: "After", start: { date: "2026-10-01" }, end: { date: "2026-10-02" }, attendees: [] }, providerQuery: { sendUpdates: "all", maxAttendees: "100" },
+      receipt: { ok: true, event: { id: "event-1", status: "confirmed", summary: "After", start: { date: "2026-10-01" }, end: { date: "2026-10-02" }, attendees: [] }, sendUpdates: "all" } },
+    { method: "GET", suffix: "calendar-events/{eventId}", path: { eventId: "event-1" },
+      providerPath: "/calendar/v3/calendars/primary/events/event-1", providerQuery: { maxAttendees: "100" }, receipt: { ok: true, calendarId: "primary", event: { id: "event-1", summary: "After" } } },
+    { method: "DELETE", suffix: "calendar-events/{eventId}", path: { eventId: "event-1" },
+      query: { confirmCancellation: "true", sendUpdates: "externalOnly", confirmNotifications: "true" }, unconfirmedQuery: { confirmCancellation: "true", sendUpdates: "externalOnly" },
+      providerPath: "/calendar/v3/calendars/primary/events/event-1", providerQuery: { sendUpdates: "externalOnly" },
+      receipt: { ok: true, eventId: "event-1", cancelled: true, sendUpdates: "externalOnly" }, state: { event: { status: "cancelled" } } },
+    { method: "POST", suffix: "spreadsheets", body: { title: "Action sheet", sheetTitle: "Sheet1", rowCount: 10, columnCount: 2 },
+      providerPath: "/v4/spreadsheets", providerQuery: { fields: spreadsheetFields },
+      providerBody: { properties: { title: "Action sheet" }, sheets: [{ properties: { title: "Sheet1", gridProperties: { rowCount: 10, columnCount: 2 } } }] },
+      receipt: { ok: true, spreadsheet: { spreadsheetId: "sheet-1", properties: { title: "Action sheet" }, sheets: [{ properties: { sheetId: 0, title: "Sheet1", gridProperties: { rowCount: 10, columnCount: 2 } } }] } } },
+    { method: "GET", suffix: "spreadsheets/{spreadsheetId}", path: { spreadsheetId: "sheet-1" },
+      providerPath: "/v4/spreadsheets/sheet-1", providerQuery: { fields: spreadsheetFields, includeGridData: "false" },
+      receipt: { ok: true, spreadsheet: { spreadsheetId: "sheet-1", properties: { title: "Action sheet" } } } },
+    { method: "PUT", suffix: "spreadsheets/{spreadsheetId}/values",
       path: { spreadsheetId: "sheet-1" }, body: { range: "Sheet1!A1:B1", values: [["=1+1", 7]] },
       unconfirmed: { range: "Sheet1!A1:B1", values: [["=1+1", 7]], valueInputOption: "USER_ENTERED" },
       providerPath: "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B1", providerBody: { range: "Sheet1!A1:B1", majorDimension: "ROWS", values: [["=1+1", 7]] },
-      providerQuery: { valueInputOption: "RAW" }, receipt: { ok: true, spreadsheetId: "sheet-1", updatedCells: 2, valueInputOption: "RAW" } },
-    { providerKey: "microsoft-365", connection: microsoft, method: "POST", suffix: "mail-drafts/{messageId}/send",
+      providerQuery: { valueInputOption: "RAW" }, receipt: { ok: true, spreadsheetId: "sheet-1", updatedCells: 2, valueInputOption: "RAW" }, state: { values: [["=1+1", 7]] } },
+    { method: "POST", suffix: "spreadsheets/{spreadsheetId}/values/append", path: { spreadsheetId: "sheet-1" },
+      body: { range: "Sheet1!A1:B1", values: [["Next", true]] },
+      providerPath: "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B1:append", providerQuery: { valueInputOption: "RAW", insertDataOption: "INSERT_ROWS" },
+      providerBody: { range: "Sheet1!A1:B1", majorDimension: "ROWS", values: [["Next", true]] },
+      receipt: { ok: true, spreadsheetId: "sheet-1", updatedRange: "Sheet1!A2:B2", updatedRows: 1, updatedColumns: 2, updatedCells: 2, tableRange: "Sheet1!A1:B1", valueInputOption: "RAW" },
+      state: { values: [["=1+1", 7], ["Next", true]] } },
+    { method: "GET", suffix: "spreadsheets/{spreadsheetId}/values", path: { spreadsheetId: "sheet-1" }, query: { range: "Sheet1!A1:B2", valueRenderOption: "UNFORMATTED_VALUE" },
+      providerPath: "/v4/spreadsheets/sheet-1/values/Sheet1!A1:B2", providerQuery: { majorDimension: "ROWS", valueRenderOption: "UNFORMATTED_VALUE" },
+      receipt: { ok: true, spreadsheetId: "sheet-1", range: "Sheet1!A1:B2", values: [["=1+1", 7], ["Next", true]], valueRenderOption: "UNFORMATTED_VALUE" } },
+    { method: "POST", suffix: "drive-folders", body: { name: "Review", parentId: "parent-2" },
+      providerPath: "/drive/v3/files", providerQuery: fileQuery, providerBody: { name: "Review", mimeType: "application/vnd.google-apps.folder", parents: ["parent-2"] },
+      receipt: { ok: true, file: { id: "folder-1", name: "Review", mimeType: "application/vnd.google-apps.folder", parents: ["parent-2"], trashed: false } } },
+    { method: "PATCH", suffix: "drive-files/{fileId}", path: { fileId: "file-1" },
+      body: { name: "After.txt", addParentId: "parent-2", removeParentId: "parent-1", trashed: true, confirmTrash: true }, unconfirmed: { trashed: true },
+      providerPath: "/drive/v3/files/file-1", providerQuery: { ...fileQuery, addParents: "parent-2", removeParents: "parent-1" }, providerBody: { name: "After.txt", trashed: true },
+      receipt: { ok: true, file: { id: "file-1", name: "After.txt", parents: ["parent-2"], trashed: true } } },
+    { method: "GET", suffix: "drive-files/{fileId}", path: { fileId: "file-1" }, providerPath: "/drive/v3/files/file-1", providerQuery: fileQuery,
+      receipt: { ok: true, file: { id: "file-1", name: "After.txt", parents: ["parent-2"], trashed: true } } },
+  ];
+  const microsoftCases: Action[] = [
+    { method: "POST", suffix: "mail-drafts/{messageId}/send",
       path: { messageId: "outlook-draft-1" }, body: { confirmSend: true }, unconfirmed: {},
       providerPath: "/v1.0/me/messages/outlook-draft-1/send", providerBody: null, providerQuery: {},
-      receipt: { ok: true, draftId: "outlook-draft-1", status: "accepted" } },
+      receipt: { ok: true, draftId: "outlook-draft-1", status: "accepted" }, state: { outlookDraftIds: [], outlookAccepted: ["outlook-draft-1"] } },
+    { method: "POST", suffix: "mail-message/{messageId}/reply-draft", path: { messageId: "outlook-message-1" }, body: { comment: "Reply for review" },
+      providerPath: "/v1.0/me/messages/outlook-message-1/createReply", providerBody: { comment: "Reply for review" },
+      receipt: { ok: true, draft: { id: "outlook-reply-1", conversationId: "conversation-1", isDraft: true, body: "Reply for review" } },
+      state: { outlookDraftIds: ["outlook-reply-1"], outlookAccepted: ["outlook-draft-1"] } },
+    { method: "PATCH", suffix: "mail-message/{messageId}", path: { messageId: "outlook-message-1" }, body: { isRead: true, categories: ["Reviewed"] },
+      providerPath: "/v1.0/me/messages/outlook-message-1", providerBody: { isRead: true, categories: ["Reviewed"] },
+      receipt: { ok: true, message: { id: "outlook-message-1", isRead: true, categories: ["Reviewed"] } } },
+    { method: "POST", suffix: "mail-message/{messageId}/move", path: { messageId: "outlook-message-1" }, body: { destination: "deleteditems", confirmTrash: true }, unconfirmed: { destination: "deleteditems" },
+      providerPath: "/v1.0/me/messages/outlook-message-1/move", providerBody: { destinationId: "deleteditems" },
+      receipt: { ok: true, message: { id: "outlook-moved-1", parentFolderId: "deleteditems", isRead: true, categories: ["Reviewed"] } } },
+    { method: "PATCH", suffix: "calendar-events/{eventId}", path: { eventId: "outlook-event-1" },
+      body: { confirmNotifications: true, subject: "After", body: "Agenda", location: "Room 1", start: "2026-10-01T10:00:00Z", end: "2026-10-01T11:00:00Z" }, unconfirmed: { subject: "After" },
+      providerPath: "/v1.0/me/events/outlook-event-1", providerBody: { subject: "After", body: { contentType: "Text", content: "Agenda" }, location: { displayName: "Room 1" },
+        start: { dateTime: "2026-10-01T10:00:00Z", timeZone: "UTC" }, end: { dateTime: "2026-10-01T11:00:00Z", timeZone: "UTC" } },
+      receipt: { ok: true, event: { id: "outlook-event-1", subject: "After", location: "Room 1", start: "2026-10-01T10:00:00Z", end: "2026-10-01T11:00:00Z", startTimeZone: "UTC", endTimeZone: "UTC" } },
+      state: { outlookEvent: { subject: "After", body: { contentType: "Text", content: "Agenda" } } } },
+    { method: "POST", suffix: "calendar-events/{eventId}/cancel", path: { eventId: "outlook-event-1" }, body: { confirmCancel: true, comment: "Cancelled" }, unconfirmed: { comment: "Cancelled" },
+      providerPath: "/v1.0/me/events/outlook-event-1/cancel", providerBody: { comment: "Cancelled" },
+      receipt: { ok: true, eventId: "outlook-event-1", status: "accepted" }, state: { outlookCancelled: ["outlook-event-1"] } },
+    { method: "DELETE", suffix: "calendar-events/{eventId}", path: { eventId: "outlook-event-1" }, body: { confirmDelete: true }, unconfirmed: {},
+      providerPath: "/v1.0/me/events/outlook-event-1", receipt: { ok: true, eventId: "outlook-event-1", status: "deleted" }, state: { outlookDeleted: ["outlook-event-1"] } },
+    { method: "PATCH", suffix: "drive-file/{itemId}", path: { itemId: "item-1" }, body: { name: "After.txt", parentId: "parent-2" },
+      providerPath: "/v1.0/me/drive/items/item-1", providerBody: { name: "After.txt", parentReference: { id: "parent-2" } },
+      receipt: { ok: true, file: { id: "item-1", name: "After.txt", kind: "file" } }, state: { onedriveFile: { name: "After.txt", parentReference: { id: "parent-2" } } } },
+    { method: "POST", suffix: "drive-folders", body: { name: "Review", parentId: "parent-2" },
+      providerPath: "/v1.0/me/drive/items/parent-2/children", providerBody: { name: "Review", folder: {}, "@microsoft.graph.conflictBehavior": "fail" },
+      receipt: { ok: true, file: { id: "onedrive-folder-1", name: "Review", kind: "folder" } }, state: { onedriveFolders: [{ id: "onedrive-folder-1", name: "Review", parentReference: { id: "parent-2" } }] } },
   ];
+  const cases = [
+    ...googleCases.map((action) => ({ ...action, providerKey: "google-workspace", connection: google, readConnection: readGoogle })),
+    ...microsoftCases.map((action) => ({ ...action, providerKey: "microsoft-365", connection: microsoft, readConnection: readMicrosoft })),
+  ];
+  expect(new Set(cases.map((action) => `${action.providerKey} ${action.method} ${action.suffix}`)).size).toBe(32);
+  const selectedTokens = new Map<string, string>();
   for (const action of cases) {
     const fullPath = `/v1/capabilities/${action.providerKey}/${action.suffix}`;
-    const match = [...found.values()].find((entry) => entry.method === action.method && entry.path === fullPath);
+    const match = [...found.values()].find((entry) => text(entry.name).startsWith(`native:${action.connection.id}:`) && entry.method === action.method && entry.path === fullPath);
     if (!match) throw new Error(`Missing discovered action ${action.method} ${fullPath}`);
-    expect(match.hasBody).toBe(true);
+    expect(match.hasBody).toBe(action.body !== undefined);
     // The gateway returns the OpenAPI schema unchanged, including named refs.
-    if (action.providerKey === "microsoft-365") {
-      expect(match.bodySchema).toEqual({ $ref: "#/components/schemas/Microsoft365MailSendBody" });
-    } else {
-      expect(record(match.bodySchema).type).toBe("object");
+    if (action.body) {
+      if (action.providerKey === "microsoft-365") {
+        expect(record(match.bodySchema).$ref).toMatch(/^#\/components\/schemas\/Microsoft365/);
+      } else {
+        expect(record(match.bodySchema).type).toBe("object");
+      }
     }
-    expect(match.pathParams).toEqual(Object.keys(action.path));
-    const args = { name: text(match.name), path: action.path, body: action.body };
+    expect(match.pathParams).toEqual(Object.keys(action.path ?? {}));
+    const args = { name: text(match.name), path: action.path, query: action.query, body: action.body };
     const before = await snapshot(selected);
-    const denied = await gateway(readScopeToken, "execute_capability", args);
-    expect(denied.result.isError).toBe(true);
-    expect(denied.payload).toMatchObject({ error: "insufficient_mcp_scope", requiredScope: "mcp:write" });
-    expect(await snapshot(selected)).toEqual(before);
-    if (action.providerKey === "google-workspace") {
-      const readerMatches = await discover(readGoogle, "google-workspace", action.suffix, [action.method], readerToken);
+    if (action.method !== "GET") {
+      const denied = await gateway(readScopeToken, "execute_capability", args);
+      expect(denied.result.isError).toBe(true);
+      expect(denied.payload).toMatchObject({ error: "insufficient_mcp_scope", requiredScope: "mcp:write" });
+      expect(await snapshot(selected)).toEqual(before);
+      const readerMatches = await discover(action.readConnection, action.providerKey, action.suffix, [action.method], readerToken);
       const readerMatch = readerMatches.find((entry) => entry.method === action.method);
       if (!readerMatch) throw new Error("Read-only member's operation missing");
       const deniedGrant = await gateway(readerToken, "execute_capability", { ...args, name: readerMatch.name });
@@ -201,35 +309,68 @@ test("connected service actions reach only the selected account and enforce writ
       expect((await snapshot(readonly)).state).toEqual(readerBefore.state);
       expect((await snapshot(readonly)).requests).toEqual([]);
     }
-    if (action.unconfirmed) {
-      const rejected = await gateway(writerToken, "execute_capability", { ...args, body: action.unconfirmed });
+    if (action.unconfirmed || action.unconfirmedQuery) {
+      const rejected = await gateway(writerToken, "execute_capability", { ...args,
+        body: action.unconfirmed ?? action.body, query: action.unconfirmedQuery ?? action.query });
       expect(rejected.result.isError).toBe(true);
       expect(rejected.payload).toMatchObject({ error: "invalid_request" });
       expect(await snapshot(selected)).toEqual(before);
     }
-    const executed = await gateway(writerToken, "execute_capability", args);
+    const executed = await gateway(action.method === "GET" ? readScopeToken : writerToken, "execute_capability", args);
     expect(executed.result.isError, JSON.stringify(executed.payload)).not.toBe(true);
     expect(executed.payload).toMatchObject(action.receipt);
     const after = await snapshot(selected);
-    expect(after.totalRequests).toBe(Number(before.totalRequests) + 1);
-    const observed = rows(after.requests).at(-1);
-    expect(observed).toEqual({ method: action.method, path: action.providerPath, query: action.providerQuery,
-      body: action.providerBody, email: selected, tokenId: expect.stringMatching(/^[a-f0-9]{12}$/) });
+    const observed = rows(after.requests).slice(rows(before.requests).length);
+    const expected = { method: action.method, path: action.providerPath, query: action.providerQuery ?? {},
+      body: action.providerBody ?? null, email: selected, tokenId: expect.stringMatching(/^[a-f0-9]{12}$/) };
+    expect(observed).toEqual(action.preflight ? [{ ...expected, method: "GET", body: null }, expected] : [expected]);
+    expect(after.totalRequests).toBe(Number(before.totalRequests) + observed.length);
+    for (const request of observed) {
+      const token = text(request.tokenId);
+      if (!selectedTokens.has(action.connection.id)) selectedTokens.set(action.connection.id, token);
+      expect(token).toBe(selectedTokens.get(action.connection.id));
+    }
+    if (action.method === "GET") expect(after.state).toEqual(before.state);
+    if (action.state) expect(after.state).toMatchObject(action.state);
     expect((await snapshot(primary)).state).toEqual(untouched.state);
     expect((await snapshot(primary)).requests).toEqual([]);
-    evidence.recordAssertionEvidence(`${action.method} ${action.suffix} crosses the provider boundary only with write authority`,
-      "Read-only MCP scope and applicable provider-grant/confirmation denials produced zero HTTP calls. The authorized call produced exactly one authenticated provider request with the exact method, path, query, and body for the selected account, never the other account.", true);
+    evidence.recordAssertionEvidence(`${action.providerKey} ${action.method} ${action.suffix} uses only the selected account`,
+      action.method === "GET"
+        ? "Read-scoped execution returned the provider state through the exact authenticated method/path/query, without changing any account."
+        : "MCP write-scope, provider-grant, and applicable confirmation denials produced zero provider calls. Authorized execution matched the exact method/path/query/body and selected credential, including any label-type preflight; the other accounts stayed unchanged.", true);
   }
-  const final = await snapshot(selected);
-  expect(final.state).toEqual({ labelIds: ["STARRED"], draftIds: [], sent: ["sent-1"],
-    event: { id: "event-1", status: "confirmed", summary: "After" }, values: [["=1+1", 7]],
-    outlookDraftIds: [], outlookAccepted: ["outlook-draft-1"] });
-  expect(final.totalRequests).toBe(5);
+  const completed = await snapshot(selected);
+  expect(completed.state).toMatchObject({ labelIds: ["STARRED"], draftIds: [], sent: ["sent-1"],
+    event: { id: "event-1", status: "cancelled", summary: "After" }, values: [["=1+1", 7], ["Next", true]],
+    folders: [{ id: "folder-1", name: "Review", parents: ["parent-2"] }], file: { id: "file-1", name: "After.txt", trashed: true, parents: ["parent-2"] },
+    outlookDraftIds: ["outlook-reply-1"], outlookAccepted: ["outlook-draft-1"],
+    outlookMessage: { id: "outlook-moved-1", parentFolderId: "deleteditems", isRead: true, categories: ["Reviewed"] },
+    outlookReply: { id: "outlook-reply-1", isDraft: true, conversationId: "conversation-1", body: { content: "Reply for review" } },
+    outlookEvent: null,
+    outlookCancelled: ["outlook-event-1"], outlookDeleted: ["outlook-event-1"] });
+  expect(completed.totalRequests).toBe(34);
+  expect(new Set(selectedTokens.values()).size).toBe(2);
   expect((await snapshot(readonly)).state).toEqual(readerBefore.state);
-  evidence.recordAssertionEvidence("Provider state reflects five actual mutations, not UI text or canned gateway success", "Selected account is archived/read/starred; Gmail draft is consumed into sent mail; Calendar summary changed; Sheets stores literal RAW values; Outlook accepted and consumed its draft (not a delivery claim). Both other accounts remain unchanged.", true);
+  evidence.recordAssertionEvidence("All 32 new native operations execute against stateful synthetic providers", "Seven reads and 25 writes produced 34 exact provider requests (two user-label preflights). Readbacks reflect previous writes; send consumes drafts, reply stays unsent, moves preserve account identity, and cancellation/deletion have distinct receipts. Google and Microsoft use distinct selected credentials; neither other account changed.", true);
+  for (const method of ["PATCH", "DELETE"]) {
+    const match = [...found.values()].find((entry) => text(entry.name).startsWith(`native:${google.id}:`) && entry.method === method
+      && entry.path === "/v1/capabilities/google-workspace/gmail-label/{labelId}");
+    if (!match) throw new Error("Missing label action");
+    const before = await snapshot(selected);
+    const denied = await gateway(writerToken, "execute_capability", { name: match.name, path: { labelId: "INBOX" }, body: method === "PATCH" ? { name: "Forbidden" } : { confirm: true } });
+    expect(denied.result.isError).toBe(true);
+    expect(denied.payload).toMatchObject({ error: "protected_label" });
+    const after = await snapshot(selected);
+    expect(after.state).toEqual(before.state);
+    expect(after.totalRequests).toBe(Number(before.totalRequests) + 1);
+    expect(rows(after.requests).slice(rows(before.requests).length)).toEqual([{ method: "GET", path: "/gmail/v1/users/me/labels/INBOX", query: {}, body: null,
+      email: selected, tokenId: selectedTokens.get(google.id) }]);
+  }
+  evidence.recordAssertionEvidence("Gmail system labels cannot be renamed or deleted", "Both operations read the selected label type and return protected_label. Only the authenticated GET reaches the provider; no mutation or state change occurs.", true);
+  const final = await snapshot(selected);
   for (const [connection, features, action] of [
     [google, ["gmailRead", "calendarRead", "sheetsRead"], cases[0]],
-    [microsoft, ["mailRead"], cases[4]],
+    [microsoft, ["mailRead"], cases[googleCases.length]],
   ] as const) {
     const disabled = await denFetch(den.admin, `/v1/oauth-providers/${connection.id}/client`, {
       method: "POST", headers: { authorization: `Bearer ${den.admin.token}` }, body: JSON.stringify({ features }),

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -4,7 +4,7 @@ import { allConnectorsPrompt, allConnectorsReply, connectorCatalogDiscovery, con
 
 const test = spec.world(connectorCatalogDiscovery, { timeout: 600_000 });
 
-test("chat suggests Slack setup and lets an admin browse every quick-add connector", async ({ world, agent, user, probe, evidence }) => {
+test("chat suggests Slack setup and lets an admin browse every quick-add connector", async ({ world, seed, agent, user, probe, evidence, step }) => {
   const appUser = user.on(world.app);
   const appProbe = probe.on(world.app);
   const webUser = user.on(world.web);
@@ -65,8 +65,12 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
   expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
   await appUser.click({ role: "button", label: "New session" });
-  await appUser.see({ text: "Try one of these:" });
-  await agent.on(world.app).send(allConnectorsPrompt);
+  await appUser.see("composer", { editable: true });
+  await probe.eventually(() => appProbe.composer(), {
+    within: 15_000, label: "new session has an empty transcript", until: state => state.userMessageCount === 0,
+  });
+  await appUser.type("composer", allConnectorsPrompt, { replace: true, verify: true });
+  await appUser.click({ role: "button", label: "Run task" });
   await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
   const listed = await appProbe.eval(() => {
     const cards = Array.from(document.querySelectorAll<HTMLElement>('[data-testid="connector-catalog"]'));
@@ -76,4 +80,46 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await appUser.screenshot();
   evidence.recordAssertionEvidence("Asking for all quick adds immediately opens the complete catalog", JSON.stringify(listed), true);
   evidence.recordAssertionEvidence("Filtering selects Slack and its setup destination opens the OAuth client form", "Clicking Set up Slack emitted exactly one OS browser request for the expected Den origin, connector page, and quickAdd=slack. Navigating that captured URL renders client fields; the agent only searched and did not execute setup or authorize an account", true);
+
+  await step("unconfigured catalog and detail Chat links seed a draft without sending or connecting", async () => {
+    const webProbe = probe.on(world.web);
+    const before = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    expect(before.response.ok).toBe(true);
+    const modelRequests = await world.den.mocks.connector.agentRequests();
+    const authRequests = (await world.den.mocks.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token");
+    const openedBefore = await world.browserUrls.opened();
+    await webUser.navigate(`${world.den.ref.webUrl}/dashboard/mcp-connections`);
+    await webUser.see({ testId: "connector-add-slack" }, { timeoutMs: 90_000 });
+    await webUser.see({ testId: "connector-chat-slack" });
+    const catalogLink = (await webProbe.connectorCatalog()).chatLinks.find((link) => link.testId === "connector-chat-slack");
+    if (!catalogLink) throw new Error("Unconfigured Slack has no catalog Chat link.");
+    await webUser.click({ testId: "connector-open-slack" });
+    await webUser.see({ testId: "connector-detail-chat" });
+    await webUser.see({ testId: "connector-detail-setup" }, { text: "Set up" });
+    const detailLink = (await webProbe.connectorCatalog()).chatLinks.find((link) => link.testId === "connector-detail-chat");
+    expect(detailLink?.href).toBe(catalogLink.href);
+    const link = new URL(catalogLink.href);
+    expect(`${link.protocol}//${link.host}`).toBe("openwork://chat");
+    expect(link.searchParams.get("connector")).toBe("Slack");
+    expect([...link.searchParams.keys()].sort()).toEqual(["connector", "prompt"]);
+    const prompt = link.searchParams.get("prompt");
+    if (!prompt) throw new Error("Chat link has no starter prompt.");
+    expect(prompt).not.toContain(world.connection.id);
+    // Bridge only OS delivery. The real desktop listener must parse the rendered link and seed its own composer.
+    await seed.deepLink(world.app, catalogLink.href);
+    await appUser.see("composer", { editable: true, text: new RegExp(prompt.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")) });
+    const composer = await appProbe.composer();
+    expect(composer.draftText).toContain("Slack");
+    expect(composer.draftText).toContain(prompt);
+    expect(composer.userMessageCount).toBe(0);
+    expect(composer.assistantMessageCount).toBe(0);
+    await appUser.notSee({ testId: "desktop-connection-card" });
+    await appUser.notSee({ testId: "connector-catalog" });
+    expect((await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable")).body).toEqual(before.body);
+    expect(await world.den.mocks.connector.agentRequests()).toEqual(modelRequests);
+    expect((await world.den.mocks.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(authRequests);
+    expect(await probe.toolCalls(world.den.mocks.connector)).toEqual([]);
+    expect(await world.browserUrls.opened()).toEqual(openedBefore);
+    await appUser.screenshot();
+  });
 });

--- a/evals/specs/den-connector-catalog.e2e.test.ts
+++ b/evals/specs/den-connector-catalog.e2e.test.ts
@@ -1,0 +1,180 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { connectorCatalogManagement, isRecord, records } from "../worlds/library.ts";
+
+const test = spec.world(connectorCatalogManagement, { timeout: 600_000 });
+
+test("Den catalog shows its full inventory, preserves service identity, and keeps account readiness personal", async ({ world, user, probe, step }) => {
+  const admin = user.on(world.web);
+  const member = user.on(world.memberWeb);
+  const catalog = probe.on(world.web);
+  const catalogUrl = `${world.den.ref.webUrl}/dashboard/mcp-connections`;
+  const presetResponse = await probe.api(world.den.admin, "/v1/mcp-connections/presets");
+  expect(presetResponse.response.ok).toBe(true);
+  if (!isRecord(presetResponse.body)) throw new Error("Den returned no preset inventory.");
+  const presets = records(presetResponse.body.presets);
+  const presetIds = presets.map((entry) => entry.presetId);
+  expect(presetIds).toEqual(expect.arrayContaining(["github", "notion", "slack", "context7", "exa"]));
+  expect(new Set(presetIds).size).toBe(presetIds.length);
+  const popularIds = ["gmail", "github", "google-drive", "google-calendar", "notion", "slack"];
+  const expectedIds = [...popularIds, "microsoft-365", ...presetIds.filter((id) => !popularIds.includes(String(id)))];
+  const before = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+  expect(before.response.ok).toBe(true);
+  const requestsBefore = (await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token");
+
+  await step("browse every integration with an accurate total and setup requirements", async () => {
+    await admin.see({ testId: "connector-catalog-count" }, { text: `Showing 6 of ${expectedIds.length} integrations`, timeoutMs: 90_000 });
+    await admin.see({ role: "button", label: "Set up Slack" });
+    await admin.see({ role: "button", label: "Connect Notion" });
+    await admin.click({ testId: "connector-catalog-more" });
+    const facts = await catalog.connectorCatalog();
+    expect(facts.entries.map((entry) => entry.id)).toEqual(expectedIds);
+    expect(facts.summary).toBe(`Showing ${expectedIds.length} of ${expectedIds.length} integrations`);
+    expect(facts.horizontalOverflow).toBe(false);
+    expect(facts.entries.find((entry) => entry.id === "slack")?.status).toBe("OAuth app required");
+    expect(facts.entries.find((entry) => entry.id === "exa")?.status).toBe("API key");
+    expect(facts.entries.find((entry) => entry.id === "context7")?.status).toBe("Instant — no sign-in");
+    expect(facts.chatLinks.map((link) => link.testId)).toEqual(expectedIds.map((id) => `connector-chat-${id}`));
+    for (const entry of facts.entries) {
+      expect(entry.text.trim().length).toBeGreaterThan(entry.id.length);
+      expect(entry.href).toContain(`/mcp-connections/${entry.id}`);
+      expect(entry.status.length).toBeGreaterThan(0);
+    }
+    await admin.screenshot();
+  });
+
+  await step("an unconfigured connector keeps Chat separate from setup", async () => {
+    const slackChat = (await catalog.connectorCatalog()).chatLinks.find((link) => link.testId === "connector-chat-slack");
+    expect(slackChat).toBeDefined();
+    await admin.click({ testId: "connector-open-slack" });
+    await admin.see({ testId: "connector-detail-chat" });
+    await admin.see({ testId: "connector-detail-setup" }, { text: "Set up" });
+    expect((await catalog.connectorCatalog()).chatLinks).toContainEqual({ testId: "connector-detail-chat", href: slackChat?.href });
+    await admin.reload();
+    await admin.see({ testId: "connector-detail-chat" });
+    await admin.see({ testId: "connector-detail-setup" }, { text: "Set up" });
+    await admin.navigate(catalogUrl);
+  });
+
+  await step("filter the full inventory and recover from an empty result", async () => {
+    await admin.type({ testId: "connector-smart-bar" }, "granola", { replace: true });
+    await admin.see({ testId: "connector-catalog-count" }, { text: `1 of ${expectedIds.length} integrations match` });
+    expect((await catalog.connectorCatalog()).entries.map((entry) => entry.id)).toEqual(["granola"]);
+    await admin.type({ testId: "connector-smart-bar" }, "catalog-no-match", { replace: true });
+    await admin.see({ testId: "connector-catalog-count" }, { text: `0 of ${expectedIds.length} integrations match` });
+    expect((await catalog.connectorCatalog()).entries).toEqual([]);
+    await admin.type({ testId: "connector-smart-bar" }, "gmail", { replace: true });
+    await admin.click({ testId: "connector-open-gmail" });
+    await admin.see({ testId: "connector-detail-title" }, { text: /^Gmail\b/ });
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    await admin.reload();
+    await admin.see({ testId: "connector-detail-title" }, { text: /^Gmail\b/ });
+    await admin.see({ text: "Google Workspace — one connection covers Gmail, Drive, and Calendar" });
+    await admin.screenshot();
+    for (const [id, label] of [["google-drive", "Google Drive"], ["google-calendar", "Google Calendar"]]) {
+      await admin.navigate(catalogUrl);
+      await admin.click({ testId: `connector-open-${id}` });
+      await admin.see({ testId: "connector-detail-title" }, { text: new RegExp(`^${label}\\b`) });
+    }
+    const after = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    expect(after.body).toEqual(before.body);
+    expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(requestsBefore);
+    expect(await probe.toolCalls(world.connector)).toEqual([]);
+  });
+
+  await step("native Microsoft setup survives reload alongside Google without claiming account authorization", async () => {
+    await admin.navigate(catalogUrl);
+    await admin.type({ testId: "connector-smart-bar" }, "Microsoft", { replace: true });
+    await admin.click({ testId: "connector-add-microsoft-365" });
+    await admin.see({ testId: "microsoft-365-dialog" });
+    await admin.type({ testId: "microsoft-tenant-id" }, "11111111-1111-4111-8111-111111111111");
+    await admin.type({ placeholder: "00000000-0000-0000-0000-000000000000", nth: 1 }, "22222222-2222-4222-8222-222222222222");
+    await admin.type({ placeholder: "Paste the secret value, not its ID" }, "catalog-microsoft-test-secret");
+    await admin.click({ testId: "save-microsoft-365" });
+    await admin.notSee({ testId: "microsoft-365-dialog" });
+    await admin.reload();
+    await admin.see({ testId: "connector-catalog-count" }, { timeoutMs: 90_000 });
+    await admin.type({ testId: "connector-smart-bar" }, "", { replace: true });
+    await admin.click({ testId: "connector-catalog-more" });
+    for (const id of ["gmail", "google-drive", "google-calendar", "microsoft-365"]) {
+      await admin.see({ testId: `connector-status-${id}` }, { text: "Needs your account" });
+      await admin.see({ testId: `connector-recover-${id}` }, { text: "Connect" });
+      await admin.notSee({ testId: `connector-add-${id}` });
+    }
+    const manageable = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    expect(manageable.body).toEqual(before.body);
+    const usable = await probe.api(world.den.admin, "/v1/mcp-connections?scope=usable");
+    expect(usable.response.ok).toBe(true);
+    if (!isRecord(usable.body)) throw new Error("Den returned no usable connections.");
+    for (const id of ["google-workspace", "microsoft-365"]) {
+      // Legacy native entries use connected for configured client presence, not account authorization.
+      expect(records(usable.body.connections).filter((entry) => entry.id === id)).toMatchObject([
+        { id, connectedForMe: false, connected: true, credentialMode: "per_member" },
+      ]);
+      await admin.navigate(`${catalogUrl}/${id}`);
+      await admin.reload();
+      await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+      await admin.see({ role: "link", label: "Connect your account" });
+      await admin.notSee({ testId: "connector-detail-setup" });
+      await admin.notSee({ testId: "connector-detail-test-tools" });
+    }
+    await admin.click({ testId: "mcp-connection-more-microsoft-365" });
+    await admin.click({ testId: "edit-mcp-connection-microsoft-365" });
+    await admin.see({ testId: "microsoft-365-dialog" }, { text: /Credentials saved/ });
+    await admin.see({ text: /Saved client ID:.*22222222-2222-4222-8222-222222222222/ });
+    await admin.click({ role: "button", label: "Cancel" });
+    expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(requestsBefore);
+    expect(await probe.toolCalls(world.connector)).toEqual([]);
+  });
+
+  await step("a member connects without making the admin personally connected", async () => {
+    await member.see({ text: "Catalog Notes" }, { timeoutMs: 90_000 });
+    await member.click({ testId: `connect-my-mcp-account-${world.connection.id}` });
+    await member.see({ testId: `disconnect-my-mcp-account-${world.connection.id}` }, { timeoutMs: 120_000 });
+    const memberState = await probe.api(world.den.members.member, "/v1/mcp-connections?scope=usable");
+    if (!isRecord(memberState.body)) throw new Error("Den returned no member connections.");
+    expect(records(memberState.body.connections).find((entry) => entry.id === world.connection.id)).toMatchObject({ connectedForMe: true });
+    await admin.navigate(`${catalogUrl}/${world.connection.id}`);
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    const information = await catalog.dom('[data-testid="connector-detail-information"]');
+    expect(JSON.stringify(information)).not.toContain("Added by");
+    await admin.notSee({ testId: "connector-detail-test-tools" });
+    const adminState = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    if (!isRecord(adminState.body)) throw new Error("Den returned no admin connections.");
+    expect(records(adminState.body.connections).find((entry) => entry.id === world.connection.id)).toMatchObject({ connectedForMe: false, connected: true });
+    // Trusted, hit-tested clicks must reach below the detail row, not merely find menu text.
+    await admin.click({ testId: `mcp-connection-more-${world.connection.id}` });
+    await admin.click({ testId: `edit-mcp-connection-${world.connection.id}` });
+    await admin.see({ testId: "edit-mcp-connection-dialog" });
+    await admin.see({ testId: "edit-mcp-name" }, { value: "Catalog Notes" });
+    await admin.click({ role: "button", label: "Cancel" });
+    await admin.notSee({ testId: "edit-mcp-connection-dialog" });
+    expect((await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable")).body).toEqual(adminState.body);
+    await admin.screenshot();
+  });
+
+  await step("OAuth startup rejection offers recovery without a success notice", async () => {
+    await admin.navigate(`${catalogUrl}/${world.rejectedConnection.id}`);
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    const requestsBefore = (await world.rejected.requestLog()).length;
+    const authBefore = (await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token");
+    await admin.click({ role: "button", label: "Connect" });
+    await admin.see({ text: /Could not connect "Catalog Recovery"/ }, { timeoutMs: 60_000 });
+    await admin.see({ role: "link", label: "Review connection" });
+    await admin.notSee({ text: /added for everyone|Finish signing in|Your account is connected/ });
+    const requests = (await world.rejected.requestLog()).slice(requestsBefore);
+    expect(requests, "the provider endpoint receives the declared failure before authorization").toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "/mcp", faulted: true, status: 503 }),
+    ]));
+    expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(authBefore);
+    expect(await probe.toolCalls(world.connector)).toEqual([]);
+    await admin.click({ role: "link", label: "Review connection" });
+    await admin.see({ testId: "connector-detail-title" }, { text: /^Catalog Recovery\b/ });
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    await admin.notSee({ testId: "connector-detail-test-tools" });
+    const state = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    if (!isRecord(state.body)) throw new Error("Den returned no connections after the failed sign-in.");
+    expect(records(state.body.connections).find((entry) => entry.id === world.rejectedConnection.id)).toMatchObject({ connectedForMe: false, connected: false });
+    await admin.screenshot();
+  });
+});

--- a/evals/specs/plugin-mcp-connector-parity.test.ts
+++ b/evals/specs/plugin-mcp-connector-parity.test.ts
@@ -1,3 +1,4 @@
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
@@ -171,7 +172,8 @@ test("persisted GitHub bindings preserve desktop readiness without allowing new 
   needs({ placement: "local" });
   if (!await localMysqlIsRunning() || !await localRedisIsRunning()) skip("needs: local MySQL and Redis");
   const organizationName = `Legacy Connector ${Date.now().toString(36)}`;
-  await using den = await server({ place, web: false, org: { name: organizationName, members: { reader: {} } } });
+  const encryptionSecret = "legacy-connector-fixture-encryption-key";
+  await using den = await server({ place, web: false, env: { DEN_DB_ENCRYPTION_KEY: encryptionSecret }, org: { name: organizationName, members: { reader: {} } } });
   if (!den.database) throw new Error("Persisted legacy connector coverage requires an isolated database");
   const orgId = await organizationId(den.admin, organizationName);
   const headers = orgHeaders(den.admin, orgId);
@@ -340,12 +342,48 @@ test("persisted GitHub bindings preserve desktop readiness without allowing new 
     state: "needs_signin",
     connections: [{ id: connectionId, authType: "oauth", connectedForMe: false, oauthClientConfigured: false, oauthClientRequired: false, authTypeMismatch: false }],
   });
+  const signinSearch = await callTool("search_capabilities", { query: "legacy-github-readiness", type: "skills", limit: 20 });
+  const signinMatches = Array.isArray(signinSearch.matches) ? signinSearch.matches.filter(isRecord) : [];
+  expect(signinMatches.find((entry) => entry.name === skill.name)).toMatchObject({
+    status: "needs_connection",
+    action: { surface: "openwork_your_connections" },
+    mcpRequirements: [{ connectionId, state: "needs_connection", connectedForMe: false }],
+  });
   const blocked = await callTool("execute_capability", { name: skill.name });
   expect(blocked).toMatchObject({ status: "needs_admin_setup", action: { surface: "openwork_organization_connections" } });
   expect(blocked.content).toBeUndefined();
   evidence.recordAssertionEvidence(
     "Legacy OAuth desktop sign-in readiness does not authorize execution",
-    "An authorized non-admin member still sees needs_signin for the existing GitHub OAuth connection when the dependency permits alternative auth. With no registered OAuth client, instructional execution still returns needs_admin_setup without skill content.",
+    "An authorized non-admin member still sees needs_signin for the existing GitHub OAuth connection when the dependency permits alternative auth. Search retains the member Connect action. With no registered OAuth client, instructional execution still returns needs_admin_setup without skill content.",
+    true,
+  );
+
+  // A persisted shared token is enough for legacy display readiness, not for
+  // mandatory-client execution. The isolated fixture never contacts GitHub.
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", createHash("sha256").update(encryptionSecret).digest(), iv);
+  const ciphertext = Buffer.concat([cipher.update("legacy-fixture-token", "utf8"), cipher.final()]);
+  const encryptedToken = `enc:v1:${iv.toString("base64")}.${cipher.getAuthTag().toString("base64")}.${ciphertext.toString("base64")}`;
+  await queryDenDatabase(databaseUrl,
+    "UPDATE external_mcp_connection SET credential_mode = 'shared', access_token = ?, connected_at = NOW() WHERE organization_id = ? AND id = ?",
+    [encryptedToken, orgId, connectionId],
+  );
+  expect(await desktopReadiness(den.members.reader)).toMatchObject({
+    state: "ready",
+    connections: [{ id: connectionId, authType: "oauth", connectedForMe: true, oauthClientConfigured: false, oauthClientRequired: false }],
+  });
+  const legacySearch = await callTool("search_capabilities", { query: "legacy-github-readiness", type: "skills", limit: 20 });
+  const legacyMatches = Array.isArray(legacySearch.matches) ? legacySearch.matches.filter(isRecord) : [];
+  expect(legacyMatches.find((entry) => entry.name === skill.name)).toMatchObject({
+    status: "ready",
+    mcpRequirements: [{ connectionId, state: "ready", connectedForMe: true }],
+  });
+  const credentialedBlocked = await callTool("execute_capability", { name: skill.name });
+  expect(credentialedBlocked).toMatchObject({ status: "needs_admin_setup", action: { surface: "openwork_organization_connections" } });
+  expect(credentialedBlocked.content).toBeUndefined();
+  evidence.recordAssertionEvidence(
+    "Legacy OAuth credentials preserve readiness and search without bypassing mandatory-client execution",
+    "A persisted shared OAuth token with no organization OAuth client remains ready in resolved desktop readiness and skill search. Executing the same skill still returns needs_admin_setup and no instruction content.",
     true,
   );
 });

--- a/evals/specs/plugin-mcp-connector-parity.test.ts
+++ b/evals/specs/plugin-mcp-connector-parity.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
-import { localMysqlIsRunning, localRedisIsRunning, server, test } from "@openwork/testkit";
+import { queryDenDatabase } from "@openwork/env";
+import { localMysqlIsRunning, localRedisIsRunning, needs, server, test } from "@openwork/testkit";
 import {
   denLibraryPluginCreateRequest,
   emptyLibraryMcpConnectionForm,
@@ -162,6 +163,103 @@ test.skipIf(!mysqlOpen || !redisOpen)(title, { timeout: 300_000 }, async ({ evid
   evidence.recordAssertionEvidence(
     "A plugin-owned connector follows the plugin's archive and restore",
     "After POST /v1/plugins/:id/archive the manageable Connectors list no longer contained the plugin-owned connection; after POST /v1/plugins/:id/restore it was listed again with the plugin as its identity manager.",
+    true,
+  );
+});
+
+test("persisted GitHub no-auth bindings stay discoverable without allowing new anonymous setup or overriding OAuth", { timeout: 300_000 }, async ({ evidence, place, skip }) => {
+  needs({ placement: "local" });
+  if (!await localMysqlIsRunning() || !await localRedisIsRunning()) skip("needs: local MySQL and Redis");
+  const organizationName = `Legacy Connector ${Date.now().toString(36)}`;
+  await using den = await server({ place, web: false, org: { name: organizationName, members: {} } });
+  if (!den.database) throw new Error("Persisted legacy connector coverage requires an isolated database");
+  const orgId = await organizationId(den.admin, organizationName);
+  const headers = orgHeaders(den.admin, orgId);
+  const url = "https://api.githubcopilot.com/mcp/";
+  const databaseUrl = den.database.url;
+
+  async function createPlugin(authType: "none" | "oauth") {
+    return denFetch(den.admin, "/v1/plugins", {
+      method: "POST", headers,
+      body: JSON.stringify({ name: "Legacy GitHub", orgWide: true, components: [mcpComponent(url, { authType, credentialMode: "shared" })] }),
+    });
+  }
+
+  const rejected = await createPlugin("none");
+  expect(rejected.response.status, rejected.text).toBe(409);
+  expect(rejected.body).toMatchObject({ error: "mcp_auth_type_mismatch" });
+  const created = await createPlugin("oauth");
+  expect(created.response.status, created.text).toBe(201);
+  const plugin = isRecord(created.body) && isRecord(created.body.item) ? created.body.item : null;
+  if (!plugin || typeof plugin.id !== "string") throw new Error("Missing created plugin");
+  const bindings = await queryDenDatabase(databaseUrl,
+    "SELECT external_mcp_connection_id AS connectionId, config_object_id AS configObjectId FROM plugin_mcp_requirement_binding WHERE organization_id = ? AND plugin_id = ?",
+    [orgId, plugin.id],
+  );
+  const binding = bindings[0];
+  if (!isRecord(binding) || typeof binding.connectionId !== "string" || typeof binding.configObjectId !== "string") throw new Error("Missing created binding");
+  const connectionId = binding.connectionId;
+
+  // Only the isolated fixture bypasses current setup validation to model a row
+  // accepted before the GitHub preset existed. No provider request is needed.
+  await queryDenDatabase(databaseUrl,
+    "UPDATE external_mcp_connection SET auth_type = 'none', connected_at = NOW() WHERE organization_id = ? AND id = ?",
+    [orgId, connectionId],
+  );
+
+  const minted = await denFetch(den.admin, "/v1/mcp/token", {
+    method: "POST", headers, body: JSON.stringify({ scopes: ["mcp:read"] }),
+  });
+  expect(minted.response.status, minted.text).toBe(200);
+  if (!isRecord(minted.body) || typeof minted.body.appHostToken !== "string") throw new Error("Missing desktop MCP token");
+  const token = minted.body.appHostToken;
+
+  async function desktopServerIndex() {
+    const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
+      method: "POST", signal: AbortSignal.timeout(30_000),
+      headers: { authorization: `Bearer ${token}`, accept: "application/json, text/event-stream", "content-type": "application/json", "x-openwork-mcp-client-capabilities": "mcp-app-host-v1" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "resources/read", params: { uri: "openwork://connect/mcp-servers/index.json" } }),
+    });
+    const text = await response.text();
+    expect(response.status, text).toBe(200);
+    const data = text.split("\n").find((line) => line.startsWith("data:"));
+    const rpc: unknown = JSON.parse(data ? data.slice(5) : text);
+    if (!isRecord(rpc) || !isRecord(rpc.result) || !Array.isArray(rpc.result.contents)) throw new Error(`Missing MCP index: ${text}`);
+    const content = rpc.result.contents[0];
+    if (!isRecord(content) || typeof content.text !== "string") throw new Error("Missing MCP index content");
+    const index: unknown = JSON.parse(content.text);
+    if (!isRecord(index) || !Array.isArray(index.servers)) throw new Error("Invalid MCP index");
+    return index.servers.filter(isRecord).map((entry) => entry.connectionId);
+  }
+
+  for (const requiredAuthType of [null, "none", "oauth"]) {
+    if (requiredAuthType === "oauth") {
+      const versioned = await denFetch(den.admin, `/v1/config-objects/${binding.configObjectId}/versions`, {
+        method: "POST", headers,
+        body: JSON.stringify({ input: { normalizedPayloadJson: { mcpServers: { crm: { type: "remote", url, oauth: true } } } } }),
+      });
+      expect(versioned.response.status, versioned.text).toBe(201);
+    }
+    await queryDenDatabase(databaseUrl,
+      "UPDATE plugin_mcp_requirement_binding SET required_auth_type = ? WHERE organization_id = ? AND plugin_id = ?",
+      [requiredAuthType, orgId, plugin.id],
+    );
+    const listed = await denFetch(den.admin, "/v1/mcp-connections?scope=usable", { headers });
+    expect(listed.response.status, listed.text).toBe(200);
+    const rows = isRecord(listed.body) && Array.isArray(listed.body.connections) ? listed.body.connections.filter(isRecord) : [];
+    expect(rows.find((row) => row.id === connectionId)).toMatchObject({
+      authType: "none", connected: true, authPolicyConfirmed: true,
+      authTypeMismatch: requiredAuthType === "oauth", setupRequired: requiredAuthType === "oauth",
+    });
+    const index = await desktopServerIndex();
+    expect(index.includes(connectionId), `required auth: ${requiredAuthType}`).toBe(requiredAuthType !== "oauth");
+  }
+  expect(await queryDenDatabase(databaseUrl,
+    "SELECT auth_type AS authType FROM external_mcp_connection WHERE organization_id = ? AND id = ?", [orgId, connectionId],
+  )).toEqual([{ authType: "none" }]);
+  evidence.recordAssertionEvidence(
+    "Legacy GitHub discovery does not relax new setup or explicit OAuth",
+    "New anonymous plugin configuration was rejected. A persisted connected none binding, with either no required auth or required none, remained setup-ready and present in the desktop MCP index. Explicit OAuth blocked it without rewriting the stored auth type. No GitHub endpoint was contacted.",
     true,
   );
 });

--- a/evals/specs/plugin-mcp-connector-parity.test.ts
+++ b/evals/specs/plugin-mcp-connector-parity.test.ts
@@ -387,6 +387,29 @@ test("persisted GitHub bindings preserve desktop readiness without allowing new 
     true,
   );
 
+  const queryUrl = `${url}?fixture=legacy`;
+  await queryDenDatabase(databaseUrl,
+    "UPDATE external_mcp_connection SET url = ? WHERE organization_id = ? AND id = ?",
+    [queryUrl, orgId, connectionId],
+  );
+  const queryVersion = await denFetch(den.admin, `/v1/config-objects/${binding.configObjectId}/versions`, {
+    method: "POST", headers,
+    body: JSON.stringify({ input: { normalizedPayloadJson: { mcpServers: { crm: { type: "remote", url: queryUrl, oauth: true } } } } }),
+  });
+  expect(queryVersion.response.status, queryVersion.text).toBe(201);
+  expect(await desktopReadiness(den.members.reader)).toMatchObject({
+    state: "ready",
+    connections: [{ id: connectionId, connectedForMe: true, oauthClientRequired: false }],
+  });
+  const queryBlocked = await callTool("execute_capability", { name: skill.name });
+  expect(queryBlocked).toMatchObject({ status: "needs_admin_setup" });
+  expect(queryBlocked.content).toBeUndefined();
+  evidence.recordAssertionEvidence(
+    "Query-variant URLs preserve legacy desktop readiness without bypassing execution",
+    "An existing OAuth connection with a query-bearing URL remains ready under the published desktop URL comparison. The execution preset policy still requires the missing OAuth client and withholds instruction content.",
+    true,
+  );
+
   // A plaintext lookalike must not inherit the trusted HTTPS preset policy.
   const httpUrl = "http://api.githubcopilot.com/mcp/";
   await queryDenDatabase(databaseUrl,

--- a/evals/specs/plugin-mcp-connector-parity.test.ts
+++ b/evals/specs/plugin-mcp-connector-parity.test.ts
@@ -167,21 +167,35 @@ test.skipIf(!mysqlOpen || !redisOpen)(title, { timeout: 300_000 }, async ({ evid
   );
 });
 
-test("persisted GitHub no-auth bindings stay discoverable without allowing new anonymous setup or overriding OAuth", { timeout: 300_000 }, async ({ evidence, place, skip }) => {
+test("persisted GitHub bindings preserve desktop readiness without allowing new anonymous setup or bypassing OAuth execution gates", { timeout: 300_000 }, async ({ evidence, place, skip }) => {
   needs({ placement: "local" });
   if (!await localMysqlIsRunning() || !await localRedisIsRunning()) skip("needs: local MySQL and Redis");
   const organizationName = `Legacy Connector ${Date.now().toString(36)}`;
-  await using den = await server({ place, web: false, org: { name: organizationName, members: {} } });
+  await using den = await server({ place, web: false, org: { name: organizationName, members: { reader: {} } } });
   if (!den.database) throw new Error("Persisted legacy connector coverage requires an isolated database");
   const orgId = await organizationId(den.admin, organizationName);
   const headers = orgHeaders(den.admin, orgId);
   const url = "https://api.githubcopilot.com/mcp/";
   const databaseUrl = den.database.url;
+  const skillSource = "---\nname: legacy-github-readiness\ndescription: Checks legacy GitHub readiness.\n---\n\nLegacy GitHub instruction sentinel.";
+  const marketplaceCreated = await denFetch(den.admin, "/v1/marketplaces", {
+    method: "POST", headers, body: JSON.stringify({ name: "Legacy GitHub collection" }),
+  });
+  expect(marketplaceCreated.response.status, marketplaceCreated.text).toBe(201);
+  const marketplace = isRecord(marketplaceCreated.body) && isRecord(marketplaceCreated.body.item) ? marketplaceCreated.body.item : null;
+  if (!marketplace || typeof marketplace.id !== "string") throw new Error("Missing created marketplace");
+  const shared = await denFetch(den.admin, `/v1/marketplaces/${marketplace.id}/access`, {
+    method: "POST", headers, body: JSON.stringify({ orgWide: true, role: "viewer" }),
+  });
+  expect(shared.response.status, shared.text).toBe(201);
 
   async function createPlugin(authType: "none" | "oauth") {
     return denFetch(den.admin, "/v1/plugins", {
       method: "POST", headers,
-      body: JSON.stringify({ name: "Legacy GitHub", orgWide: true, components: [mcpComponent(url, { authType, credentialMode: "shared" })] }),
+      body: JSON.stringify({ name: "Legacy GitHub", orgWide: true, marketplaceId: marketplace.id, components: [
+        mcpComponent(url, { authType, credentialMode: "shared" }),
+        { type: "skill", input: { rawSourceText: skillSource } },
+      ] }),
     });
   }
 
@@ -200,6 +214,16 @@ test("persisted GitHub no-auth bindings stay discoverable without allowing new a
   if (!isRecord(binding) || typeof binding.connectionId !== "string" || typeof binding.configObjectId !== "string") throw new Error("Missing created binding");
   const connectionId = binding.connectionId;
 
+  async function desktopReadiness(member: DenSession = den.admin) {
+    const resolved = await denFetch(member, `/v1/marketplaces/${marketplace.id}/resolved`, { headers: orgHeaders(member, orgId) });
+    expect(resolved.response.status, resolved.text).toBe(200);
+    const item = isRecord(resolved.body) && isRecord(resolved.body.item) ? resolved.body.item : null;
+    const plugins = item && Array.isArray(item.plugins) ? item.plugins.filter(isRecord) : [];
+    const found = plugins.find((entry) => entry.id === plugin.id);
+    if (!found || !isRecord(found.cloudReadiness)) throw new Error("Missing desktop cloud readiness");
+    return found.cloudReadiness;
+  }
+
   // Only the isolated fixture bypasses current setup validation to model a row
   // accepted before the GitHub preset existed. No provider request is needed.
   await queryDenDatabase(databaseUrl,
@@ -211,26 +235,49 @@ test("persisted GitHub no-auth bindings stay discoverable without allowing new a
     method: "POST", headers, body: JSON.stringify({ scopes: ["mcp:read"] }),
   });
   expect(minted.response.status, minted.text).toBe(200);
-  if (!isRecord(minted.body) || typeof minted.body.appHostToken !== "string") throw new Error("Missing desktop MCP token");
+  if (!isRecord(minted.body) || typeof minted.body.appHostToken !== "string" || typeof minted.body.token !== "string") throw new Error("Missing MCP tokens");
   const token = minted.body.appHostToken;
+  const toolToken = minted.body.token;
 
-  async function desktopServerIndex() {
+  async function mcpRequest(method: string, params: Record<string, unknown>, bearerToken: string) {
     const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
       method: "POST", signal: AbortSignal.timeout(30_000),
-      headers: { authorization: `Bearer ${token}`, accept: "application/json, text/event-stream", "content-type": "application/json", "x-openwork-mcp-client-capabilities": "mcp-app-host-v1" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "resources/read", params: { uri: "openwork://connect/mcp-servers/index.json" } }),
+      headers: { authorization: `Bearer ${bearerToken}`, accept: "application/json, text/event-stream", "content-type": "application/json", "x-openwork-mcp-client-capabilities": "mcp-app-host-v1" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
     });
     const text = await response.text();
     expect(response.status, text).toBe(200);
     const data = text.split("\n").find((line) => line.startsWith("data:"));
     const rpc: unknown = JSON.parse(data ? data.slice(5) : text);
-    if (!isRecord(rpc) || !isRecord(rpc.result) || !Array.isArray(rpc.result.contents)) throw new Error(`Missing MCP index: ${text}`);
-    const content = rpc.result.contents[0];
+    if (!isRecord(rpc) || !isRecord(rpc.result)) throw new Error(`Missing MCP result: ${text}`);
+    expect(rpc.error).toBeUndefined();
+    return rpc.result;
+  }
+
+  async function desktopServerIndex() {
+    const result = await mcpRequest("resources/read", { uri: "openwork://connect/mcp-servers/index.json" }, token);
+    if (!Array.isArray(result.contents)) throw new Error("Missing MCP index");
+    const content = result.contents[0];
     if (!isRecord(content) || typeof content.text !== "string") throw new Error("Missing MCP index content");
     const index: unknown = JSON.parse(content.text);
     if (!isRecord(index) || !Array.isArray(index.servers)) throw new Error("Invalid MCP index");
     return index.servers.filter(isRecord).map((entry) => entry.connectionId);
   }
+
+  async function callTool(name: string, args: Record<string, unknown>) {
+    const result = await mcpRequest("tools/call", { name, arguments: args }, toolToken);
+    expect(result.isError).not.toBe(true);
+    const content = Array.isArray(result.content) ? result.content[0] : null;
+    if (!isRecord(content) || typeof content.text !== "string") throw new Error("Missing tool content");
+    const payload: unknown = JSON.parse(content.text);
+    if (!isRecord(payload)) throw new Error("Invalid tool payload");
+    return payload;
+  }
+
+  const search = await callTool("search_capabilities", { query: "legacy-github-readiness", type: "skills", limit: 20 });
+  const matches = Array.isArray(search.matches) ? search.matches.filter(isRecord) : [];
+  const skill = matches.find((entry) => entry.kind === "skill" && typeof entry.name === "string" && entry.name.startsWith(`plugin:${plugin.id}:`));
+  if (!skill || typeof skill.name !== "string") throw new Error("Missing assigned GitHub skill");
 
   for (const requiredAuthType of [null, "none", "oauth"]) {
     if (requiredAuthType === "oauth") {
@@ -253,13 +300,52 @@ test("persisted GitHub no-auth bindings stay discoverable without allowing new a
     });
     const index = await desktopServerIndex();
     expect(index.includes(connectionId), `required auth: ${requiredAuthType}`).toBe(requiredAuthType !== "oauth");
+    expect(await desktopReadiness()).toMatchObject({
+      state: requiredAuthType === "oauth" ? "needs_admin_setup" : "ready",
+      connections: [{ id: connectionId, authType: "none", connectedForMe: true, authTypeMismatch: requiredAuthType === "oauth" }],
+    });
+    const executed = await callTool("execute_capability", { name: skill.name });
+    if (requiredAuthType === "oauth") {
+      expect(executed).toMatchObject({ status: "needs_admin_setup", action: { surface: "openwork_organization_connections" } });
+      expect(executed.content).toBeUndefined();
+    } else {
+      expect(executed.content).toBe(skillSource);
+    }
   }
   expect(await queryDenDatabase(databaseUrl,
     "SELECT auth_type AS authType FROM external_mcp_connection WHERE organization_id = ? AND id = ?", [orgId, connectionId],
   )).toEqual([{ authType: "none" }]);
   evidence.recordAssertionEvidence(
     "Legacy GitHub discovery does not relax new setup or explicit OAuth",
-    "New anonymous plugin configuration was rejected. A persisted connected none binding, with either no required auth or required none, remained setup-ready and present in the desktop MCP index. Explicit OAuth blocked it without rewriting the stored auth type. No GitHub endpoint was contacted.",
+    "New anonymous plugin configuration was rejected. A persisted connected none binding, with either no required auth or required none, remained ready in desktop marketplace readiness and the MCP index, and allowed its skill. Explicit OAuth blocked discovery and skill content without rewriting the stored auth type. No GitHub endpoint was contacted.",
+    true,
+  );
+
+  // Model an existing per-member OAuth connection without a registered client.
+  // Legacy desktop readiness offers sign-in; execution must still require setup.
+  await queryDenDatabase(databaseUrl,
+    "UPDATE external_mcp_connection SET auth_type = 'oauth', credential_mode = 'per_member', connected_at = NULL WHERE organization_id = ? AND id = ?",
+    [orgId, connectionId],
+  );
+  await queryDenDatabase(databaseUrl,
+    "UPDATE plugin_mcp_requirement_binding SET required_auth_type = NULL WHERE organization_id = ? AND plugin_id = ?",
+    [orgId, plugin.id],
+  );
+  const versioned = await denFetch(den.admin, `/v1/config-objects/${binding.configObjectId}/versions`, {
+    method: "POST", headers,
+    body: JSON.stringify({ input: { normalizedPayloadJson: { mcpServers: { crm: { type: "remote", url, oauth: false } } } } }),
+  });
+  expect(versioned.response.status, versioned.text).toBe(201);
+  expect(await desktopReadiness(den.members.reader)).toMatchObject({
+    state: "needs_signin",
+    connections: [{ id: connectionId, authType: "oauth", connectedForMe: false, oauthClientConfigured: false, oauthClientRequired: false, authTypeMismatch: false }],
+  });
+  const blocked = await callTool("execute_capability", { name: skill.name });
+  expect(blocked).toMatchObject({ status: "needs_admin_setup", action: { surface: "openwork_organization_connections" } });
+  expect(blocked.content).toBeUndefined();
+  evidence.recordAssertionEvidence(
+    "Legacy OAuth desktop sign-in readiness does not authorize execution",
+    "An authorized non-admin member still sees needs_signin for the existing GitHub OAuth connection when the dependency permits alternative auth. With no registered OAuth client, instructional execution still returns needs_admin_setup without skill content.",
     true,
   );
 });

--- a/evals/specs/plugin-mcp-connector-parity.test.ts
+++ b/evals/specs/plugin-mcp-connector-parity.test.ts
@@ -386,4 +386,29 @@ test("persisted GitHub bindings preserve desktop readiness without allowing new 
     "A persisted shared OAuth token with no organization OAuth client remains ready in resolved desktop readiness and skill search. Executing the same skill still returns needs_admin_setup and no instruction content.",
     true,
   );
+
+  // A plaintext lookalike must not inherit the trusted HTTPS preset policy.
+  const httpUrl = "http://api.githubcopilot.com/mcp/";
+  await queryDenDatabase(databaseUrl,
+    "UPDATE external_mcp_connection SET url = ?, auth_type = 'none', access_token = NULL WHERE organization_id = ? AND id = ?",
+    [httpUrl, orgId, connectionId],
+  );
+  const httpVersion = await denFetch(den.admin, `/v1/config-objects/${binding.configObjectId}/versions`, {
+    method: "POST", headers,
+    body: JSON.stringify({ input: { normalizedPayloadJson: { mcpServers: { crm: { type: "remote", url: httpUrl } } } } }),
+  });
+  expect(httpVersion.response.status, httpVersion.text).toBe(201);
+  await queryDenDatabase(databaseUrl,
+    "UPDATE plugin_mcp_requirement_binding SET required_auth_type = NULL WHERE organization_id = ? AND plugin_id = ?",
+    [orgId, plugin.id],
+  );
+  const httpListed = await denFetch(den.admin, "/v1/mcp-connections?scope=usable", { headers });
+  expect(httpListed.response.status, httpListed.text).toBe(200);
+  const httpRows = isRecord(httpListed.body) && Array.isArray(httpListed.body.connections) ? httpListed.body.connections.filter(isRecord) : [];
+  expect(httpRows.find((row) => row.id === connectionId)).toMatchObject({ authPolicyConfirmed: false, setupRequired: true });
+  evidence.recordAssertionEvidence(
+    "HTTP lookalikes do not inherit HTTPS preset authentication policy",
+    "The persisted HTTPS GitHub positive control was recognized; after changing both declaration and connection to HTTP, the connection-list boundary reported unconfirmed auth policy and required setup. No provider endpoint was contacted.",
+    true,
+  );
 });

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -368,10 +368,33 @@ export async function connectorBranding(seed: Seed) {
   return { app, den, prompt, failurePrompt, proof };
 }
 
-export async function connectorsQuickAdd(seed: Seed) {
+export async function connectorCatalogManagement(seed: Seed) {
   const den = await seed.den({
-    org: { name: `Connectors Quick Add ${Date.now()}`, admin: { name: "Sarah" } },
+    org: { name: `Connector Catalog ${Date.now()}`, admin: { name: "Catalog Admin" }, members: { member: { name: "Catalog Member" } } },
     mocks: { connector: seed.mock() },
+  });
+  const connection = await seed.orgConnection(den.admin, {
+    name: "Catalog Notes",
+    url: den.mocks.connector.mcpUrl,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
+  });
+  // Native OAuth clients intentionally have no managed MCP row.
+  const google = await seed.api(den.admin, "/v1/oauth-providers/google-workspace/client", {
+    method: "POST",
+    body: JSON.stringify({ clientId: "catalog-test-client", clientSecret: "catalog-test-secret" }),
+  });
+  if (!google.response.ok) throw new Error("Could not arrange the native Google client.");
+  // Fault the provider boundary, not Den's startup response or persisted readiness.
+  const rejected = await seed.faultProxy(den);
+  await rejected.faults.status("/mcp", 503, { times: 1000, body: { error: "catalog_provider_unavailable" } });
+  const rejectedConnection = await seed.orgConnection(den.admin, {
+    name: "Catalog Recovery",
+    url: `${rejected.ref.webUrl}/mcp`,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
   });
   const web = await seed.web({
     den,
@@ -380,7 +403,10 @@ export async function connectorsQuickAdd(seed: Seed) {
     headless: true,
     viewport: { width: 1440, height: 1200 },
   });
-  return { web, connector: den.mocks.connector };
+  const memberWeb = await seed.web({
+    den, signedInAs: den.members.member, startPath: `/dashboard/your-connections?connectionId=${connection.id}`, headless: true,
+  });
+  return { den, web, memberWeb, connection, rejectedConnection, connector: den.mocks.connector, rejected };
 }
 
 export async function libraryConnectorDiscovery(seed: Seed) {

--- a/packages/docs/start-here/connect-your-stack/connect-services.mdx
+++ b/packages/docs/start-here/connect-your-stack/connect-services.mdx
@@ -68,6 +68,54 @@ support return `file_input_requires_host` and create no draft. Do not retry
 without the requested attachments. If an upload's result is uncertain, check
 Gmail Drafts before attempting creation again.
 
+## Manage connected services
+
+Google Workspace and Microsoft 365 connections can perform service actions, not
+only retrieve information. An administrator chooses the enabled permissions;
+each member authorizes their own account. Additional sending, mailbox-management,
+and spreadsheet permission choices are **off by default**. Existing draft-only
+access does not automatically enable sending.
+
+| Service | Available actions |
+| --- | --- |
+| Gmail | Search/read messages and attachments; create/read/update drafts; send an existing draft, including its reply threading and attachments; archive/unarchive, mark read/unread, star, trash/restore, and manage user labels. |
+| Google Calendar | List/create events; read, edit/reschedule, and cancel events in a selected calendar; add Meet to an existing event. |
+| Drive | Search/list with date, folder, and pagination controls; read files, upload/share, create folders, rename/move, and trash/restore. |
+| Sheets | Create spreadsheets, inspect their tabs, read cell ranges, write cells, and append rows. Writes default to literal values; formula parsing requires explicit approval. |
+| Outlook | Read mail, create drafts and reply drafts, send existing drafts, change read status/categories, and move messages between inbox/archive/deleted items. |
+| Outlook Calendar | List/create, edit/reschedule, cancel, and delete events. |
+| OneDrive | Search/read, write text files, create folders, and rename/move items. |
+
+For Gmail mailbox management enable **Manage Gmail**; for sending without mailbox
+management enable **Send email drafts after confirmation**. Google uses the same
+OAuth grant for draft editing and draft sending, but OpenWork enforces the
+administrator's separate action choices. For Sheets, enable spreadsheet read or
+write access, or use the applicable selected-file Drive access. Microsoft mail
+sending and mailbox management have separate permission choices as well.
+
+After enabling a new provider permission, reconnect and grant the requested
+access. Disabling a write permission in OpenWork blocks the new management
+actions even when an older provider token still carries that grant. A selected
+connection always uses that member's selected account, not another available
+account.
+
+Ask for an outcome, for example “Archive this thread and mark it read,” “Move
+tomorrow's meeting to 3 pm,” or “Append these rows to the budget spreadsheet.”
+Sending mail, deleting/trashing content, notifying meeting guests, and enabling
+spreadsheet formula parsing require explicit requests and the corresponding
+confirmation inputs. Creating or selecting a connector does not authorize them.
+If a write times out, check the service before retrying: it may already have
+completed. Microsoft accepts sends asynchronously, so its receipt means
+**accepted**, not delivered.
+
+Drive's generic file reader exports the first Sheets tab as CSV. Use the Sheets
+metadata and range operations to work with other tabs. Cell operations are
+bounded to 5,000 cells per request; split larger work into explicit ranges.
+These operations do not claim every provider feature: rich Docs/Slides editing,
+spreadsheet formatting/pivots, and permanent mailbox/file deletion are separate
+from the actions above. External MCP connectors expose their provider's actual
+tools and remain subject to that provider's account, plan, and approval rules.
+
 ## Connect, connectors, and connections
 
 - **Connect** is the member-facing page in the desktop app for signing in to

--- a/packages/sdk/src/gen/sdk.gen.ts
+++ b/packages/sdk/src/gen/sdk.gen.ts
@@ -5,20 +5,42 @@ import { buildClientParams, type Client, type Options as Options2, type TDataSha
 import type {
   ActivateAutomationErrors,
   ActivateAutomationResponses,
+  AppendGoogleSheetsValuesErrors,
+  AppendGoogleSheetsValuesResponses,
   ArchiveAutomationErrors,
   ArchiveAutomationResponses,
   CancelAutomationRunErrors,
   CancelAutomationRunResponses,
+  CancelMicrosoft365CalendarEventErrors,
+  CancelMicrosoft365CalendarEventResponses,
   CreateAutomationErrors,
   CreateAutomationResponses,
   CreateCloudAutomationErrors,
   CreateCloudAutomationResponses,
+  CreateGmailLabelErrors,
+  CreateGmailLabelResponses,
+  CreateGoogleDriveFolderErrors,
+  CreateGoogleDriveFolderResponses,
+  CreateGoogleSpreadsheetErrors,
+  CreateGoogleSpreadsheetResponses,
   CreateInstallLinkRequest,
+  CreateMicrosoft365DriveFolderErrors,
+  CreateMicrosoft365DriveFolderResponses,
+  CreateMicrosoft365ReplyDraftErrors,
+  CreateMicrosoft365ReplyDraftResponses,
   CreateOrganizationApiKeyRequest,
   DashboardElement,
   DeactivateAutomationErrors,
   DeactivateAutomationResponses,
   DeleteApiAuthScimV2GroupsByGroupIdResponses,
+  DeleteGmailDraftErrors,
+  DeleteGmailDraftResponses,
+  DeleteGmailLabelErrors,
+  DeleteGmailLabelResponses,
+  DeleteGoogleCalendarEventErrors,
+  DeleteGoogleCalendarEventResponses,
+  DeleteMicrosoft365CalendarEventErrors,
+  DeleteMicrosoft365CalendarEventResponses,
   DeleteV1AdminAdminsByAdminIdResponses,
   DeleteV1AdminUsersByUserIdResponses,
   DeleteV1ConfigObjectsByConfigObjectIdAccessByGrantIdErrors,
@@ -98,6 +120,16 @@ import type {
   GetAutomationResponses,
   GetAutomationRunErrors,
   GetAutomationRunResponses,
+  GetGmailDraftErrors,
+  GetGmailDraftResponses,
+  GetGoogleCalendarEventErrors,
+  GetGoogleCalendarEventResponses,
+  GetGoogleDriveFileMetadataErrors,
+  GetGoogleDriveFileMetadataResponses,
+  GetGoogleSheetsValuesErrors,
+  GetGoogleSheetsValuesResponses,
+  GetGoogleSpreadsheetErrors,
+  GetGoogleSpreadsheetResponses,
   GetHealthResponses,
   GetMcpAdminWellKnownOauthProtectedResourceResponses,
   GetMcpAgentWellKnownOauthProtectedResourceResponses,
@@ -366,12 +398,27 @@ import type {
   ListAutomationRunsResponses,
   ListAutomationsErrors,
   ListAutomationsResponses,
+  ListGmailDraftsErrors,
+  ListGmailDraftsResponses,
+  ListGmailLabelsErrors,
+  ListGmailLabelsResponses,
+  Microsoft365CalendarCancelBody,
+  Microsoft365CalendarDeleteBody,
   Microsoft365CalendarEventBody,
+  Microsoft365CalendarEventUpdateBody,
   Microsoft365DriveFileWriteBody,
+  Microsoft365DriveFolderBody,
+  Microsoft365DriveItemUpdateBody,
   Microsoft365MailDraftBody,
+  Microsoft365MailMessageMoveBody,
+  Microsoft365MailMessageUpdateBody,
+  Microsoft365MailReplyDraftBody,
+  Microsoft365MailSendBody,
   Microsoft365TeamsMessageBody,
   MintAutomationRunnerTokenErrors,
   MintAutomationRunnerTokenResponses,
+  MoveMicrosoft365MailMessageErrors,
+  MoveMicrosoft365MailMessageResponses,
   PatchApiAuthScimV2GroupsByGroupIdResponses,
   PatchApiAuthScimV2UsersByUserIdResponses,
   PatchV1AdminOrganizationsByOrganizationIdDpaErrors,
@@ -677,8 +724,34 @@ import type {
   RunAutomationNowResponses,
   SaveWorkflowErrors,
   SaveWorkflowResponses,
+  SendGmailDraftErrors,
+  SendGmailDraftResponses,
+  SendMicrosoft365MailDraftErrors,
+  SendMicrosoft365MailDraftResponses,
+  TrashGmailMessageErrors,
+  TrashGmailMessageResponses,
+  UntrashGmailMessageErrors,
+  UntrashGmailMessageResponses,
   UpdateAutomationErrors,
   UpdateAutomationResponses,
+  UpdateGmailDraftErrors,
+  UpdateGmailDraftResponses,
+  UpdateGmailLabelErrors,
+  UpdateGmailLabelResponses,
+  UpdateGmailMessageLabelsErrors,
+  UpdateGmailMessageLabelsResponses,
+  UpdateGoogleCalendarEventErrors,
+  UpdateGoogleCalendarEventResponses,
+  UpdateGoogleDriveFileMetadataErrors,
+  UpdateGoogleDriveFileMetadataResponses,
+  UpdateGoogleSheetsValuesErrors,
+  UpdateGoogleSheetsValuesResponses,
+  UpdateMicrosoft365CalendarEventErrors,
+  UpdateMicrosoft365CalendarEventResponses,
+  UpdateMicrosoft365DriveItemErrors,
+  UpdateMicrosoft365DriveItemResponses,
+  UpdateMicrosoft365MailMessageErrors,
+  UpdateMicrosoft365MailMessageResponses,
 } from "./types.gen.js";
 
 export type Options<
@@ -5524,6 +5597,902 @@ export class DenClient extends HeyApiClient {
   }
 
   /**
+   * Send an existing Gmail draft
+   *
+   * Sends the existing draft unchanged, including To/Cc/Bcc, reply threading and attachments. Create or inspect the draft first. Requires gmail.compose or gmail.modify (gmail.send alone does not authorize drafts.send). A successful response contains the actual sent message id and threadId, not the old draft message ID. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public sendGmailDraft<ThrowOnError extends boolean = false>(
+    parameters: {
+      draftId: string;
+      confirm: true;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "draftId" },
+            { in: "body", key: "confirm" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<SendGmailDraftResponses, SendGmailDraftErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}/send",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * List or search Gmail drafts
+   *
+   * Returns one page of drafts and the actual nextPageToken, if any. Pass it as pageToken for the next page. Requires gmail.readonly, gmail.compose or gmail.modify. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public listGmailDrafts<ThrowOnError extends boolean = false>(
+    parameters?: {
+      q?: string;
+      maxResults?: number;
+      pageToken?: string;
+      includeSpamTrash?: "true" | "false";
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "q" },
+            { in: "query", key: "maxResults" },
+            { in: "query", key: "pageToken" },
+            { in: "query", key: "includeSpamTrash" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).get<ListGmailDraftsResponses, ListGmailDraftsErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-drafts",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Create a Gmail draft or threaded reply with optional workspace attachments
+   *
+   * Creates a plain-text Gmail draft in the calling member own mailbox. Optional attachments are workspace paths, up to 10 files totaling at most 4 MiB, fulfilled outside model context by a supporting OpenWork host on direct execute_capability calls. Code Mode and other MCP hosts cannot fulfill attachments and create no draft. Set threadId for replies and forwards. Always share the returned draftUrl.
+   */
+  public postV1CapabilitiesGoogleWorkspaceGmailDrafts<ThrowOnError extends boolean = false>(
+    parameters: {
+      to: string;
+      cc?: string;
+      bcc?: string;
+      subject: string;
+      body: string;
+      threadId?: string;
+      attachments?: Array<string>;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "to" },
+            { in: "body", key: "cc" },
+            { in: "body", key: "bcc" },
+            { in: "body", key: "subject" },
+            { in: "body", key: "body" },
+            { in: "body", key: "threadId" },
+            { in: "body", key: "attachments" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses,
+      PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/gmail-drafts",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Permanently delete a Gmail draft
+   *
+   * Permanently discards the specified draft; this is not a move to trash. Requires gmail.compose or gmail.modify and explicit user confirmation. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public deleteGmailDraft<ThrowOnError extends boolean = false>(
+    parameters: {
+      draftId: string;
+      confirm: true;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "draftId" },
+            { in: "body", key: "confirm" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).delete<DeleteGmailDraftResponses, DeleteGmailDraftErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Read a Gmail draft
+   *
+   * Returns Google's draft and message content, capped at 6 MiB. Use format=raw for the base64url RFC 2822 message including MIME attachments. Requires gmail.readonly, gmail.compose or gmail.modify. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public getGmailDraft<ThrowOnError extends boolean = false>(
+    parameters: {
+      draftId: string;
+      format?: "minimal" | "full" | "raw" | "metadata";
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "draftId" },
+            { in: "query", key: "format" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).get<GetGmailDraftResponses, GetGmailDraftErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Replace a Gmail draft's full content
+   *
+   * Replaces the draft message, not a partial text edit. Supply the complete base64url RFC 2822 MIME message, preserving intended recipients, reply headers, threadId and attachments. Read the existing draft first; omitted content is lost. Does not send. Requires gmail.compose or gmail.modify. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public updateGmailDraft<ThrowOnError extends boolean = false>(
+    parameters: {
+      draftId: string;
+      confirm: true;
+      message: {
+        /**
+         * Complete base64url RFC 2822 MIME message, not just body text.
+         */
+        raw: string;
+        /**
+         * Preserve the existing conversation's threadId for a reply, with matching subject and References/In-Reply-To headers in raw.
+         */
+        threadId?: string;
+      };
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "draftId" },
+            { in: "body", key: "confirm" },
+            { in: "body", key: "message" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).put<UpdateGmailDraftResponses, UpdateGmailDraftErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Archive, unarchive, mark read or unread, star or change Gmail message labels
+   *
+   * Changes labels on one message. Archive removes INBOX; unarchive adds INBOX; mark read removes UNREAD; mark unread adds UNREAD; star adds STARRED; unstar removes STARRED. Supports user label IDs from gmail-labels. Requires gmail.modify, not gmail.labels or gmail.compose. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public updateGmailMessageLabels<ThrowOnError extends boolean = false>(
+    parameters: {
+      messageId: string;
+      addLabelIds?: Array<string>;
+      removeLabelIds?: Array<string>;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "messageId" },
+            { in: "body", key: "addLabelIds" },
+            { in: "body", key: "removeLabelIds" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      UpdateGmailMessageLabelsResponses,
+      UpdateGmailMessageLabelsErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/gmail-message/{messageId}/modify",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Move a Gmail message to trash
+   *
+   * Moves one message to Gmail trash, not permanent deletion. Requires gmail.modify and explicit user confirmation. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public trashGmailMessage<ThrowOnError extends boolean = false>(
+    parameters: {
+      messageId: string;
+      confirm: true;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "messageId" },
+            { in: "body", key: "confirm" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<TrashGmailMessageResponses, TrashGmailMessageErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-message/{messageId}/trash",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Restore a Gmail message from trash
+   *
+   * Removes one message from trash. Requires gmail.modify. To put it in the inbox, also add INBOX using the modify capability. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public untrashGmailMessage<ThrowOnError extends boolean = false>(
+    parameters: {
+      messageId: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "messageId" }] }]);
+    return (options?.client ?? this.client).post<UntrashGmailMessageResponses, UntrashGmailMessageErrors, ThrowOnError>(
+      {
+        url: "/v1/capabilities/google-workspace/gmail-message/{messageId}/untrash",
+        ...options,
+        ...params,
+      },
+    );
+  }
+
+  /**
+   * List Gmail labels
+   *
+   * Returns user and system labels with IDs and types; only user labels can be edited or deleted. Requires gmail.labels, gmail.readonly, gmail.metadata or gmail.modify. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public listGmailLabels<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<ListGmailLabelsResponses, ListGmailLabelsErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-labels",
+      ...options,
+    });
+  }
+
+  /**
+   * Create a Gmail user label
+   *
+   * Creates a custom user label with its name and optional visibility settings. Requires gmail.labels or gmail.modify. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public createGmailLabel<ThrowOnError extends boolean = false>(
+    parameters: {
+      name: string;
+      messageListVisibility?: "show" | "hide";
+      labelListVisibility?: "labelShow" | "labelShowIfUnread" | "labelHide";
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "name" },
+            { in: "body", key: "messageListVisibility" },
+            { in: "body", key: "labelListVisibility" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<CreateGmailLabelResponses, CreateGmailLabelErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-labels",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Permanently delete a Gmail user label
+   *
+   * Permanently removes the user label and its assignment from every message and thread, without deleting the messages. Reads its type first and refuses system labels. Requires gmail.labels or gmail.modify and explicit user confirmation. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public deleteGmailLabel<ThrowOnError extends boolean = false>(
+    parameters: {
+      labelId: string;
+      confirm: true;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "labelId" },
+            { in: "body", key: "confirm" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).delete<DeleteGmailLabelResponses, DeleteGmailLabelErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-label/{labelId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Update a Gmail user label
+   *
+   * Renames or changes visibility of a user label. Reads its type first and refuses system labels. Requires gmail.labels or gmail.modify. Uses only the calling member's selected connected Google account. Perform writes only when explicitly requested by the user; capability discovery or selection is not authorization. Never automatically retry an uncertain write.
+   */
+  public updateGmailLabel<ThrowOnError extends boolean = false>(
+    parameters: {
+      labelId: string;
+      name?: string;
+      messageListVisibility?: "show" | "hide";
+      labelListVisibility?: "labelShow" | "labelShowIfUnread" | "labelHide";
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "labelId" },
+            { in: "body", key: "name" },
+            { in: "body", key: "messageListVisibility" },
+            { in: "body", key: "labelListVisibility" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).patch<UpdateGmailLabelResponses, UpdateGmailLabelErrors, ThrowOnError>({
+      url: "/v1/capabilities/google-workspace/gmail-label/{labelId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Delete/cancel a Google Calendar event after explicit confirmation
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public deleteGoogleCalendarEvent<ThrowOnError extends boolean = false>(
+    parameters: {
+      eventId: string;
+      calendarId?: string;
+      sendUpdates?: "none" | "all" | "externalOnly";
+      confirmCancellation: "true";
+      confirmNotifications?: "true" | "false";
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "eventId" },
+            { in: "query", key: "calendarId" },
+            { in: "query", key: "sendUpdates" },
+            { in: "query", key: "confirmCancellation" },
+            { in: "query", key: "confirmNotifications" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).delete<
+      DeleteGoogleCalendarEventResponses,
+      DeleteGoogleCalendarEventErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/calendar-events/{eventId}",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Read an individual Google Calendar event on a selected calendar
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public getGoogleCalendarEvent<ThrowOnError extends boolean = false>(
+    parameters: {
+      eventId: string;
+      calendarId?: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "eventId" },
+            { in: "query", key: "calendarId" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).get<
+      GetGoogleCalendarEventResponses,
+      GetGoogleCalendarEventErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/calendar-events/{eventId}",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Update or reschedule a Google Calendar event; explicitly approve guest notifications
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public updateGoogleCalendarEvent<ThrowOnError extends boolean = false>(
+    parameters: {
+      eventId: string;
+      calendarId?: string;
+      summary?: string;
+      description?: string;
+      location?: string;
+      start?:
+        | {
+            dateTime: string;
+            timeZone?: string;
+          }
+        | {
+            date: string;
+          };
+      end?:
+        | {
+            dateTime: string;
+            timeZone?: string;
+          }
+        | {
+            date: string;
+          };
+      attendees?: Array<{
+        email: string;
+        optional?: boolean;
+      }>;
+      sendUpdates?: "none" | "all" | "externalOnly";
+      confirmNotifications?: boolean;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "eventId" },
+            { in: "query", key: "calendarId" },
+            { in: "body", key: "summary" },
+            { in: "body", key: "description" },
+            { in: "body", key: "location" },
+            { in: "body", key: "start" },
+            { in: "body", key: "end" },
+            { in: "body", key: "attendees" },
+            { in: "body", key: "sendUpdates" },
+            { in: "body", key: "confirmNotifications" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).patch<
+      UpdateGoogleCalendarEventResponses,
+      UpdateGoogleCalendarEventErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/calendar-events/{eventId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Read Google Sheets spreadsheet metadata and sheet names without grid data
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public getGoogleSpreadsheet<ThrowOnError extends boolean = false>(
+    parameters: {
+      spreadsheetId: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "spreadsheetId" }] }]);
+    return (options?.client ?? this.client).get<
+      GetGoogleSpreadsheetResponses,
+      GetGoogleSpreadsheetErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Create a real Google Sheets spreadsheet with one bounded initial sheet
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public createGoogleSpreadsheet<ThrowOnError extends boolean = false>(
+    parameters: {
+      title: string;
+      sheetTitle?: string;
+      rowCount?: number;
+      columnCount?: number;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "title" },
+            { in: "body", key: "sheetTitle" },
+            { in: "body", key: "rowCount" },
+            { in: "body", key: "columnCount" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      CreateGoogleSpreadsheetResponses,
+      CreateGoogleSpreadsheetErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/spreadsheets",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Read a bounded rectangle of Google Sheets cells
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public getGoogleSheetsValues<ThrowOnError extends boolean = false>(
+    parameters: {
+      spreadsheetId: string;
+      range: string;
+      valueRenderOption?: "FORMATTED_VALUE" | "UNFORMATTED_VALUE" | "FORMULA";
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "spreadsheetId" },
+            { in: "query", key: "range" },
+            { in: "query", key: "valueRenderOption" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).get<
+      GetGoogleSheetsValuesResponses,
+      GetGoogleSheetsValuesErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}/values",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Write Google Sheets cells, RAW by default; USER_ENTERED requires explicit approval
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public updateGoogleSheetsValues<ThrowOnError extends boolean = false>(
+    parameters: {
+      spreadsheetId: string;
+      range: string;
+      values: Array<Array<string | number | boolean>>;
+      valueInputOption?: "RAW" | "USER_ENTERED";
+      confirmUserEntered?: boolean;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "spreadsheetId" },
+            { in: "body", key: "range" },
+            { in: "body", key: "values" },
+            { in: "body", key: "valueInputOption" },
+            { in: "body", key: "confirmUserEntered" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).put<
+      UpdateGoogleSheetsValuesResponses,
+      UpdateGoogleSheetsValuesErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}/values",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Append rows after a Google Sheets table found in a bounded range; inserts rows, RAW by default
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public appendGoogleSheetsValues<ThrowOnError extends boolean = false>(
+    parameters: {
+      spreadsheetId: string;
+      range: string;
+      values: Array<Array<string | number | boolean>>;
+      valueInputOption?: "RAW" | "USER_ENTERED";
+      confirmUserEntered?: boolean;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "spreadsheetId" },
+            { in: "body", key: "range" },
+            { in: "body", key: "values" },
+            { in: "body", key: "valueInputOption" },
+            { in: "body", key: "confirmUserEntered" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      AppendGoogleSheetsValuesResponses,
+      AppendGoogleSheetsValuesErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}/values/append",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Create a Google Drive folder, optionally in a selected parent
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public createGoogleDriveFolder<ThrowOnError extends boolean = false>(
+    parameters: {
+      name: string;
+      parentId?: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "name" },
+            { in: "body", key: "parentId" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      CreateGoogleDriveFolderResponses,
+      CreateGoogleDriveFolderErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/drive-folders",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Read Google Drive file metadata, including current parent IDs for a move
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public getGoogleDriveFileMetadata<ThrowOnError extends boolean = false>(
+    parameters: {
+      fileId: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "fileId" }] }]);
+    return (options?.client ?? this.client).get<
+      GetGoogleDriveFileMetadataResponses,
+      GetGoogleDriveFileMetadataErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/drive-files/{fileId}",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Rename, move, trash, or restore Google Drive file metadata; never permanently delete
+   *
+   * Uses the calling member's selected Google account. Perform mutations only when explicitly requested; selecting or discovering a connector does not authorize a write. Do not automatically retry an uncertain mutation.
+   */
+  public updateGoogleDriveFileMetadata<ThrowOnError extends boolean = false>(
+    parameters: {
+      fileId: string;
+      name?: string;
+      addParentId?: string;
+      removeParentId?: string;
+      trashed?: boolean;
+      confirmTrash?: boolean;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "fileId" },
+            { in: "body", key: "name" },
+            { in: "body", key: "addParentId" },
+            { in: "body", key: "removeParentId" },
+            { in: "body", key: "trashed" },
+            { in: "body", key: "confirmTrash" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).patch<
+      UpdateGoogleDriveFileMetadataResponses,
+      UpdateGoogleDriveFileMetadataErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/google-workspace/drive-files/{fileId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
    * Upload one multipart workspace file directly to Google Drive
    *
    * Authenticated host transport for openwork-cloud-uploads. The route immediately forwards the file to Google and does not persist it or expose its bytes to the model.
@@ -5562,6 +6531,7 @@ export class DenClient extends HeyApiClient {
     parameters?: {
       q?: string;
       maxResults?: number;
+      pageToken?: string;
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5572,6 +6542,7 @@ export class DenClient extends HeyApiClient {
           args: [
             { in: "query", key: "q" },
             { in: "query", key: "maxResults" },
+            { in: "query", key: "pageToken" },
           ],
         },
       ],
@@ -5753,12 +6724,15 @@ export class DenClient extends HeyApiClient {
   /**
    * Search Google Drive files as the calling member
    *
-   * Searches the calling member's Google Drive files by name and full text, using their connected Google Workspace account.
+   * Lists or searches Drive files, including an optional modifiedAfter date and direct-parent folder filter. Follow nextPageToken until absent, and honor incompleteSearch before claiming complete coverage.
    */
   public getV1CapabilitiesGoogleWorkspaceDriveFiles<ThrowOnError extends boolean = false>(
-    parameters: {
-      query: string;
+    parameters?: {
+      query?: string;
       maxResults?: number;
+      pageToken?: string;
+      modifiedAfter?: string;
+      folderId?: string;
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5769,6 +6743,9 @@ export class DenClient extends HeyApiClient {
           args: [
             { in: "query", key: "query" },
             { in: "query", key: "maxResults" },
+            { in: "query", key: "pageToken" },
+            { in: "query", key: "modifiedAfter" },
+            { in: "query", key: "folderId" },
           ],
         },
       ],
@@ -5787,7 +6764,7 @@ export class DenClient extends HeyApiClient {
   /**
    * Read a Google Drive file's text or binary content as the calling member
    *
-   * Reads one Google Drive file, exporting Google Docs editors files as plain text. Downloaded files are content-sniffed with strict UTF-8 detection; declared text is bounded, and binary content is returned as standard base64 only up to the internal model-safety limit.
+   * Reads a Drive file. Docs and Slides export as plain text; Sheets exports the first tab as CSV. For every spreadsheet tab or edits use the spreadsheet metadata and values capabilities. Downloaded content is bounded; binary files use standard base64 within the model-safety limit.
    */
   public getV1CapabilitiesGoogleWorkspaceDriveFileByFileId<ThrowOnError extends boolean = false>(
     parameters: {
@@ -5847,19 +6824,14 @@ export class DenClient extends HeyApiClient {
   }
 
   /**
-   * Create a Gmail draft or threaded reply with optional workspace attachments
+   * Send an existing Outlook draft after explicit user confirmation
    *
-   * Creates a plain-text Gmail draft in the calling member own mailbox. Optional attachments are workspace paths, up to 10 files totaling at most 4 MiB, fulfilled outside model context by a supporting OpenWork host on direct execute_capability calls. Code Mode and other MCP hosts cannot fulfill attachments and create no draft. Set threadId for replies and forwards. Always share the returned draftUrl.
+   * Requires Mail.Send and the mailSend feature. Only send an existing draft the user explicitly requested to send. Graph HTTP 202 means accepted, not delivered. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
    */
-  public postV1CapabilitiesGoogleWorkspaceGmailDrafts<ThrowOnError extends boolean = false>(
+  public sendMicrosoft365MailDraft<ThrowOnError extends boolean = false>(
     parameters: {
-      to: string;
-      cc?: string;
-      bcc?: string;
-      subject: string;
-      body: string;
-      threadId?: string;
-      attachments?: Array<string>;
+      messageId: string;
+      microsoft365MailSendBody: Microsoft365MailSendBody;
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5868,23 +6840,365 @@ export class DenClient extends HeyApiClient {
       [
         {
           args: [
-            { in: "body", key: "to" },
-            { in: "body", key: "cc" },
-            { in: "body", key: "bcc" },
-            { in: "body", key: "subject" },
-            { in: "body", key: "body" },
-            { in: "body", key: "threadId" },
-            { in: "body", key: "attachments" },
+            { in: "path", key: "messageId" },
+            { key: "microsoft365MailSendBody", map: "body" },
           ],
         },
       ],
     );
     return (options?.client ?? this.client).post<
-      PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses,
-      PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors,
+      SendMicrosoft365MailDraftResponses,
+      SendMicrosoft365MailDraftErrors,
       ThrowOnError
     >({
-      url: "/v1/capabilities/google-workspace/gmail-drafts",
+      url: "/v1/capabilities/microsoft-365/mail-drafts/{messageId}/send",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Create a reply draft for a selected Outlook message
+   *
+   * Uses Graph createReply with Mail.ReadWrite and mailDraft. Preserves the selected message's reply context. Saves a draft for user review and never sends it. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public createMicrosoft365ReplyDraft<ThrowOnError extends boolean = false>(
+    parameters: {
+      messageId: string;
+      microsoft365MailReplyDraftBody: Microsoft365MailReplyDraftBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "messageId" },
+            { key: "microsoft365MailReplyDraftBody", map: "body" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      CreateMicrosoft365ReplyDraftResponses,
+      CreateMicrosoft365ReplyDraftErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/mail-message/{messageId}/reply-draft",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Read an Outlook message as the calling member
+   *
+   * Reads one Outlook message and requests its body as plain text, using the calling member's delegated Microsoft 365 connection.
+   */
+  public getV1CapabilitiesMicrosoft365MailMessageByMessageId<ThrowOnError extends boolean = false>(
+    parameters: {
+      messageId: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "messageId" }] }]);
+    return (options?.client ?? this.client).get<
+      GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses,
+      GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/mail-message/{messageId}",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Update Outlook message read state or categories
+   *
+   * Requires Mail.ReadWrite and mailManage. Only changes isRead and/or replaces categories; cannot alter recipients or send messages. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public updateMicrosoft365MailMessage<ThrowOnError extends boolean = false>(
+    parameters: {
+      messageId: string;
+      microsoft365MailMessageUpdateBody: Microsoft365MailMessageUpdateBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "messageId" },
+            { key: "microsoft365MailMessageUpdateBody", map: "body" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).patch<
+      UpdateMicrosoft365MailMessageResponses,
+      UpdateMicrosoft365MailMessageErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/mail-message/{messageId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Move an Outlook message to archive, deleted items, or inbox
+   *
+   * Requires Mail.ReadWrite and mailManage. Moves one message to a fixed named folder, never permanently deletes it. Moving to deleteditems also requires confirmTrash: true. Use the returned message id after moving, since Graph can change it. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public moveMicrosoft365MailMessage<ThrowOnError extends boolean = false>(
+    parameters: {
+      messageId: string;
+      microsoft365MailMessageMoveBody: Microsoft365MailMessageMoveBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "messageId" },
+            { key: "microsoft365MailMessageMoveBody", map: "body" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      MoveMicrosoft365MailMessageResponses,
+      MoveMicrosoft365MailMessageErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/mail-message/{messageId}/move",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Delete a selected Outlook calendar event
+   *
+   * Requires Calendars.ReadWrite and calendarWrite, plus explicit user deletion confirmation. Deleting an organizer's meeting can send cancellations to attendees. Graph 204 confirms deletion. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public deleteMicrosoft365CalendarEvent<ThrowOnError extends boolean = false>(
+    parameters: {
+      eventId: string;
+      microsoft365CalendarDeleteBody: Microsoft365CalendarDeleteBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "eventId" },
+            { key: "microsoft365CalendarDeleteBody", map: "body" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).delete<
+      DeleteMicrosoft365CalendarEventResponses,
+      DeleteMicrosoft365CalendarEventErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/calendar-events/{eventId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Edit or reschedule an Outlook calendar event
+   *
+   * Requires Calendars.ReadWrite and calendarWrite. Updates only supplied subject, body, location, or paired UTC start/end. Requires confirmNotifications: true because updates may email attendees. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public updateMicrosoft365CalendarEvent<ThrowOnError extends boolean = false>(
+    parameters: {
+      eventId: string;
+      microsoft365CalendarEventUpdateBody: Microsoft365CalendarEventUpdateBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "eventId" },
+            { key: "microsoft365CalendarEventUpdateBody", map: "body" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).patch<
+      UpdateMicrosoft365CalendarEventResponses,
+      UpdateMicrosoft365CalendarEventErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/calendar-events/{eventId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Cancel an Outlook meeting and notify attendees
+   *
+   * Requires Calendars.ReadWrite and calendarWrite. Only the meeting organizer can cancel via Graph. Requires explicit user cancellation confirmation; a 202 receipt means cancellation was accepted. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public cancelMicrosoft365CalendarEvent<ThrowOnError extends boolean = false>(
+    parameters: {
+      eventId: string;
+      microsoft365CalendarCancelBody: Microsoft365CalendarCancelBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "eventId" },
+            { key: "microsoft365CalendarCancelBody", map: "body" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      CancelMicrosoft365CalendarEventResponses,
+      CancelMicrosoft365CalendarEventErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/calendar-events/{eventId}/cancel",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Read a OneDrive text or binary file as the calling member
+   *
+   * Returns OneDrive metadata and content using strict-UTF-8 content sniffing: text is returned regardless of MIME type, while binary files are returned as standard base64 up to 10 MiB. Folders and oversized files return metadata with an explicit contentUnavailableReason.
+   */
+  public getV1CapabilitiesMicrosoft365DriveFileByItemId<ThrowOnError extends boolean = false>(
+    parameters: {
+      itemId: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "itemId" }] }]);
+    return (options?.client ?? this.client).get<
+      GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses,
+      GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/drive-file/{itemId}",
+      ...options,
+      ...params,
+    });
+  }
+
+  /**
+   * Rename or move a OneDrive item within the same drive
+   *
+   * Requires Files.ReadWrite (or Files.ReadWrite.All) and filesWrite (or filesFull). Updates only the name and/or parent folder id in the caller's OneDrive; cannot move across drives or upload content. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public updateMicrosoft365DriveItem<ThrowOnError extends boolean = false>(
+    parameters: {
+      itemId: string;
+      microsoft365DriveItemUpdateBody: Microsoft365DriveItemUpdateBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "itemId" },
+            { key: "microsoft365DriveItemUpdateBody", map: "body" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).patch<
+      UpdateMicrosoft365DriveItemResponses,
+      UpdateMicrosoft365DriveItemErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/drive-file/{itemId}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    });
+  }
+
+  /**
+   * Create a folder in the calling member's OneDrive
+   *
+   * Requires Files.ReadWrite (or Files.ReadWrite.All) and filesWrite (or filesFull). Creates one folder under an existing parent id. Name conflicts fail without overwriting or silently renaming anything. Uses only the calling member's delegated Microsoft 365 connection. Never automatically retry a mutation after a timeout, cancellation, or ambiguous response; inspect current state first.
+   */
+  public createMicrosoft365DriveFolder<ThrowOnError extends boolean = false>(
+    parameters: {
+      microsoft365DriveFolderBody: Microsoft365DriveFolderBody;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ key: "microsoft365DriveFolderBody", map: "body" }] }]);
+    return (options?.client ?? this.client).post<
+      CreateMicrosoft365DriveFolderResponses,
+      CreateMicrosoft365DriveFolderErrors,
+      ThrowOnError
+    >({
+      url: "/v1/capabilities/microsoft-365/drive-folders",
       ...options,
       ...params,
       headers: {
@@ -5924,29 +7238,6 @@ export class DenClient extends HeyApiClient {
       ThrowOnError
     >({
       url: "/v1/capabilities/microsoft-365/mail-messages",
-      ...options,
-      ...params,
-    });
-  }
-
-  /**
-   * Read an Outlook message as the calling member
-   *
-   * Reads one Outlook message and requests its body as plain text, using the calling member's delegated Microsoft 365 connection.
-   */
-  public getV1CapabilitiesMicrosoft365MailMessageByMessageId<ThrowOnError extends boolean = false>(
-    parameters: {
-      messageId: string;
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "messageId" }] }]);
-    return (options?.client ?? this.client).get<
-      GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses,
-      GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors,
-      ThrowOnError
-    >({
-      url: "/v1/capabilities/microsoft-365/mail-message/{messageId}",
       ...options,
       ...params,
     });
@@ -6078,29 +7369,6 @@ export class DenClient extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
-    });
-  }
-
-  /**
-   * Read a OneDrive text or binary file as the calling member
-   *
-   * Returns OneDrive metadata and content using strict-UTF-8 content sniffing: text is returned regardless of MIME type, while binary files are returned as standard base64 up to 10 MiB. Folders and oversized files return metadata with an explicit contentUnavailableReason.
-   */
-  public getV1CapabilitiesMicrosoft365DriveFileByItemId<ThrowOnError extends boolean = false>(
-    parameters: {
-      itemId: string;
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "itemId" }] }]);
-    return (options?.client ?? this.client).get<
-      GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses,
-      GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors,
-      ThrowOnError
-    >({
-      url: "/v1/capabilities/microsoft-365/drive-file/{itemId}",
-      ...options,
-      ...params,
     });
   }
 

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -1982,6 +1982,7 @@ export type ExternalMcpPresetResponse = {
   description: string;
   url: string;
   authType: "oauth" | "apikey" | "none";
+  supportedAuthTypes?: Array<"oauth" | "apikey" | "none">;
   requiresOAuthClient?: boolean;
   authorizationServerIssuer?: string;
   defaultOAuthScopes?: Array<string>;

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -1397,6 +1397,7 @@ export type GoogleWorkspaceGmailMessageSummary = {
 export type GoogleWorkspaceGmailMessagesResponse = {
   ok: true;
   messages: Array<GoogleWorkspaceGmailMessageSummary>;
+  nextPageToken?: string;
 };
 
 export type GoogleWorkspaceGmailAttachment = {
@@ -1521,6 +1522,11 @@ export type GoogleWorkspaceUpdateCalendarEventBody = {
 export type GoogleWorkspaceDriveFilesResponse = {
   ok: true;
   files: Array<GoogleWorkspaceDriveFileSummary>;
+  nextPageToken?: string;
+  /**
+   * Google reports some drives were not searched; do not claim these are all matching files.
+   */
+  incompleteSearch?: boolean;
 };
 
 export type GoogleWorkspaceDriveFileResponse = {
@@ -1579,9 +1585,190 @@ export type GoogleWorkspaceMissingThreadIdError = {
   message: string;
 };
 
+export type Microsoft365MailSendResponse = {
+  ok: true;
+  draftId: string;
+  /**
+   * Graph accepted the send request. This is not confirmation of delivery.
+   */
+  status: "accepted";
+};
+
+export type Microsoft365NeedsConnectionError = {
+  error: "needs_connection";
+  message: string;
+};
+
+export type Microsoft365GraphError = {
+  error: "microsoft_graph_error";
+  message: string;
+  outcome?: "unknown";
+  retryable?: false;
+};
+
+export type Microsoft365MailSendBody = {
+  /**
+   * Must be true only after the user explicitly requests sending this existing draft. Creating or reviewing a draft is not send authorization.
+   */
+  confirmSend: true;
+};
+
 export type Microsoft365EmailAddress = {
   name: string;
   address: string;
+};
+
+export type Microsoft365MailMessage = {
+  id: string;
+  conversationId: string;
+  subject: string;
+  receivedDateTime: string;
+  preview: string;
+  from: Microsoft365EmailAddress | null;
+  to: Array<Microsoft365EmailAddress>;
+  webLink: string;
+  hasAttachments: boolean;
+  isDraft: boolean;
+  isRead: boolean;
+  categories: Array<string>;
+  parentFolderId: string;
+  cc: Array<Microsoft365EmailAddress>;
+  body: string;
+  bodyContentType: string;
+  bodyTruncated: boolean;
+};
+
+export type Microsoft365MailDraftResponse = {
+  ok: true;
+  draft: Microsoft365MailMessage;
+};
+
+export type Microsoft365MailReplyDraftBody = {
+  /**
+   * Reply text to save in a draft for user review; this does not send mail.
+   */
+  comment: string;
+};
+
+export type Microsoft365MailMessageResponse = {
+  ok: true;
+  message: Microsoft365MailMessage;
+};
+
+export type Microsoft365MailMessageUpdateBody = {
+  isRead?: boolean;
+  /**
+   * Replace the message's categories with this list; an empty list clears them.
+   */
+  categories?: Array<string>;
+};
+
+export type Microsoft365MailMessageMoveBody = {
+  /**
+   * Named folder in the caller's mailbox. deleteditems moves to trash, never permanently deletes.
+   */
+  destination: "archive" | "deleteditems" | "inbox";
+  /**
+   * Required when destination is deleteditems. Set true only when the user explicitly requested moving this message to trash.
+   */
+  confirmTrash?: true;
+};
+
+export type Microsoft365CalendarEvent = {
+  id: string;
+  subject: string;
+  preview: string;
+  start: string;
+  startTimeZone: string;
+  end: string;
+  endTimeZone: string;
+  isAllDay: boolean;
+  location: string;
+  organizer: Microsoft365EmailAddress | null;
+  attendees: Array<Microsoft365EmailAddress>;
+  webLink: string;
+  onlineMeetingUrl: string | null;
+};
+
+export type Microsoft365CalendarEventResponse = {
+  ok: true;
+  event: Microsoft365CalendarEvent;
+};
+
+export type Microsoft365CalendarEventUpdateBody = {
+  /**
+   * The user explicitly authorized this update and potential attendee email notifications from Microsoft Graph.
+   */
+  confirmNotifications: true;
+  subject?: string;
+  body?: string;
+  /**
+   * New UTC start, with Z suffix. Rescheduling requires both start and end.
+   */
+  start?: string;
+  /**
+   * New UTC end, with Z suffix.
+   */
+  end?: string;
+  location?: string;
+};
+
+export type Microsoft365CalendarCancelResponse = {
+  ok: true;
+  eventId: string;
+  status: "accepted";
+};
+
+export type Microsoft365CalendarCancelBody = {
+  /**
+   * The user explicitly requested cancellation, including attendee notifications.
+   */
+  confirmCancel: true;
+  comment?: string;
+};
+
+export type Microsoft365CalendarDeleteResponse = {
+  ok: true;
+  eventId: string;
+  status: "deleted";
+};
+
+export type Microsoft365CalendarDeleteBody = {
+  /**
+   * The user explicitly requested deleting this event; organizer deletion can notify attendees.
+   */
+  confirmDelete: true;
+};
+
+export type Microsoft365DriveItem = {
+  id: string;
+  name: string;
+  size: number | null;
+  modifiedTime: string;
+  webUrl: string;
+  mimeType: string;
+  kind: "file" | "folder" | "unknown";
+};
+
+export type Microsoft365DriveFileWriteResponse = {
+  ok: true;
+  file: Microsoft365DriveItem;
+};
+
+export type Microsoft365DriveItemUpdateBody = {
+  name?: string;
+  /**
+   * Destination folder id within the calling member's same OneDrive; cross-drive moves are not supported.
+   */
+  parentId?: string;
+};
+
+export type Microsoft365DriveFolderBody = {
+  /**
+   * Existing parent folder id in the calling member's OneDrive.
+   */
+  parentId: string;
+  name: string;
 };
 
 export type Microsoft365MailMessageSummary = {
@@ -1601,66 +1788,9 @@ export type Microsoft365MailMessagesResponse = {
   messages: Array<Microsoft365MailMessageSummary>;
 };
 
-export type Microsoft365NeedsConnectionError = {
-  error: "needs_connection";
-  message: string;
-};
-
-export type Microsoft365GraphError = {
-  error: "microsoft_graph_error";
-  message: string;
-};
-
-export type Microsoft365MailMessage = {
-  id: string;
-  conversationId: string;
-  subject: string;
-  receivedDateTime: string;
-  preview: string;
-  from: Microsoft365EmailAddress | null;
-  to: Array<Microsoft365EmailAddress>;
-  webLink: string;
-  hasAttachments: boolean;
-  cc: Array<Microsoft365EmailAddress>;
-  body: string;
-  bodyContentType: string;
-  bodyTruncated: boolean;
-};
-
-export type Microsoft365MailMessageResponse = {
-  ok: true;
-  message: Microsoft365MailMessage;
-};
-
-export type Microsoft365CalendarEvent = {
-  id: string;
-  subject: string;
-  preview: string;
-  start: string;
-  startTimeZone: string;
-  end: string;
-  endTimeZone: string;
-  isAllDay: boolean;
-  location: string;
-  organizer: Microsoft365EmailAddress | null;
-  attendees: Array<Microsoft365EmailAddress>;
-  webLink: string;
-  onlineMeetingUrl: string | null;
-};
-
 export type Microsoft365CalendarEventsResponse = {
   ok: true;
   events: Array<Microsoft365CalendarEvent>;
-};
-
-export type Microsoft365DriveItem = {
-  id: string;
-  name: string;
-  size: number | null;
-  modifiedTime: string;
-  webUrl: string;
-  mimeType: string;
-  kind: "file" | "folder" | "unknown";
 };
 
 export type Microsoft365DriveFilesResponse = {
@@ -1690,22 +1820,12 @@ export type Microsoft365DriveFileResponse = {
   };
 };
 
-export type Microsoft365MailDraftResponse = {
-  ok: true;
-  draft: Microsoft365MailMessage;
-};
-
 export type Microsoft365MailDraftBody = {
   to: Array<string>;
   cc?: Array<string>;
   bcc?: Array<string>;
   subject: string;
   body: string;
-};
-
-export type Microsoft365CalendarEventResponse = {
-  ok: true;
-  event: Microsoft365CalendarEvent;
 };
 
 export type Microsoft365CalendarEventBody = {
@@ -1716,11 +1836,6 @@ export type Microsoft365CalendarEventBody = {
   timeZone?: string;
   location?: string;
   attendees?: Array<string>;
-};
-
-export type Microsoft365DriveFileWriteResponse = {
-  ok: true;
-  file: Microsoft365DriveItem;
 };
 
 export type Microsoft365DriveFileWriteBody = {
@@ -12948,6 +13063,1716 @@ export type PostV1OauthProvidersByProviderIdDisconnectResponses = {
   200: unknown;
 };
 
+export type SendGmailDraftData = {
+  body: {
+    /**
+     * True only when the user explicitly requested this action on this resource. Discovering or selecting a capability is not authorization.
+     */
+    confirm: true;
+  };
+  path: {
+    /**
+     * Existing Gmail draft ID, not its message ID.
+     */
+    draftId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}/send";
+};
+
+export type SendGmailDraftErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type SendGmailDraftError = SendGmailDraftErrors[keyof SendGmailDraftErrors];
+
+export type SendGmailDraftResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    threadId: string;
+    [key: string]: unknown;
+  };
+};
+
+export type SendGmailDraftResponse = SendGmailDraftResponses[keyof SendGmailDraftResponses];
+
+export type ListGmailDraftsData = {
+  body?: never;
+  path?: never;
+  query?: {
+    q?: string;
+    maxResults?: number;
+    pageToken?: string;
+    includeSpamTrash?: "true" | "false";
+  };
+  url: "/v1/capabilities/google-workspace/gmail-drafts";
+};
+
+export type ListGmailDraftsErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type ListGmailDraftsError = ListGmailDraftsErrors[keyof ListGmailDraftsErrors];
+
+export type ListGmailDraftsResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    drafts?: Array<{
+      id: string;
+      message: {
+        id: string;
+        threadId: string;
+        [key: string]: unknown;
+      };
+      [key: string]: unknown;
+    }>;
+    nextPageToken?: string;
+    resultSizeEstimate?: number;
+    [key: string]: unknown;
+  };
+};
+
+export type ListGmailDraftsResponse = ListGmailDraftsResponses[keyof ListGmailDraftsResponses];
+
+export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsData = {
+  body: {
+    /**
+     * Recipient email address.
+     */
+    to: string;
+    /**
+     * Optional comma-separated Cc email addresses.
+     */
+    cc?: string;
+    /**
+     * Optional comma-separated Bcc email addresses.
+     */
+    bcc?: string;
+    /**
+     * Draft subject line. For replies or forwards, include threadId; subjects starting with Re: or Fwd: are rejected without threadId so the draft stays on the existing conversation.
+     */
+    subject: string;
+    /**
+     * Plain-text draft body. Write plain prose with no markdown syntax, separate paragraphs with blank lines, and do not hard-wrap prose. For threaded drafts, the server appends the quoted conversation automatically; do not include quoted history.
+     */
+    body: string;
+    /**
+     * Gmail thread id to reply on. Required for replies and forwards; get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …').
+     */
+    threadId?: string;
+    /**
+     * Optional workspace file paths, 1 to 10 files totaling at most 4 MiB. File bytes stay outside model context. Requires a direct execute_capability call from a supporting OpenWork host; Code Mode and other MCP hosts are unsupported and create no draft. Do not retry without attachments.
+     */
+    attachments?: Array<string>;
+  };
+  path?: never;
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-drafts";
+};
+
+export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors = {
+  /**
+   * The draft request was invalid.
+   */
+  400: InvalidRequestError | GoogleWorkspaceMissingThreadIdError;
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The calling member has not connected their Google account or is missing permission.
+   */
+  409: GoogleWorkspaceNeedsConnectionError;
+  /**
+   * Workspace attachments require a supporting OpenWork host; no draft was created.
+   */
+  422: {
+    ok: false;
+    error: "file_input_requires_host";
+    created: false;
+    message: "Workspace attachments require a supporting OpenWork host. No draft was created. Do not retry without attachments.";
+  };
+  /**
+   * Google rejected the request.
+   */
+  502: GoogleWorkspaceUpstreamError;
+};
+
+export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsError =
+  PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors[keyof PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors];
+
+export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses = {
+  /**
+   * Draft created.
+   */
+  200: GoogleWorkspaceDraftResponse;
+};
+
+export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponse =
+  PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses[keyof PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses];
+
+export type DeleteGmailDraftData = {
+  body: {
+    /**
+     * True only when the user explicitly requested this action on this resource. Discovering or selecting a capability is not authorization.
+     */
+    confirm: true;
+  };
+  path: {
+    /**
+     * Existing Gmail draft ID, not its message ID.
+     */
+    draftId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}";
+};
+
+export type DeleteGmailDraftErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type DeleteGmailDraftError = DeleteGmailDraftErrors[keyof DeleteGmailDraftErrors];
+
+export type DeleteGmailDraftResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    ok: true;
+  };
+};
+
+export type DeleteGmailDraftResponse = DeleteGmailDraftResponses[keyof DeleteGmailDraftResponses];
+
+export type GetGmailDraftData = {
+  body?: never;
+  path: {
+    /**
+     * Existing Gmail draft ID, not its message ID.
+     */
+    draftId: string;
+  };
+  query?: {
+    format?: "minimal" | "full" | "raw" | "metadata";
+  };
+  url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}";
+};
+
+export type GetGmailDraftErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type GetGmailDraftError = GetGmailDraftErrors[keyof GetGmailDraftErrors];
+
+export type GetGmailDraftResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    message: {
+      id: string;
+      threadId?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+
+export type GetGmailDraftResponse = GetGmailDraftResponses[keyof GetGmailDraftResponses];
+
+export type UpdateGmailDraftData = {
+  body: {
+    /**
+     * True only when the user explicitly requested this action on this resource. Discovering or selecting a capability is not authorization.
+     */
+    confirm: true;
+    message: {
+      /**
+       * Complete base64url RFC 2822 MIME message, not just body text.
+       */
+      raw: string;
+      /**
+       * Preserve the existing conversation's threadId for a reply, with matching subject and References/In-Reply-To headers in raw.
+       */
+      threadId?: string;
+    };
+  };
+  path: {
+    /**
+     * Existing Gmail draft ID, not its message ID.
+     */
+    draftId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-draft/{draftId}";
+};
+
+export type UpdateGmailDraftErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type UpdateGmailDraftError = UpdateGmailDraftErrors[keyof UpdateGmailDraftErrors];
+
+export type UpdateGmailDraftResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    message: {
+      id: string;
+      threadId: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+
+export type UpdateGmailDraftResponse = UpdateGmailDraftResponses[keyof UpdateGmailDraftResponses];
+
+export type UpdateGmailMessageLabelsData = {
+  body: {
+    /**
+     * Add INBOX to unarchive, UNREAD to mark unread, STARRED to star, or user label IDs. Use the dedicated trash action for TRASH.
+     */
+    addLabelIds?: Array<string>;
+    /**
+     * Remove INBOX to archive, UNREAD to mark read, STARRED to unstar, or user label IDs. Use the dedicated untrash action for TRASH.
+     */
+    removeLabelIds?: Array<string>;
+  };
+  path: {
+    messageId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-message/{messageId}/modify";
+};
+
+export type UpdateGmailMessageLabelsErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type UpdateGmailMessageLabelsError = UpdateGmailMessageLabelsErrors[keyof UpdateGmailMessageLabelsErrors];
+
+export type UpdateGmailMessageLabelsResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    threadId: string;
+    [key: string]: unknown;
+  };
+};
+
+export type UpdateGmailMessageLabelsResponse =
+  UpdateGmailMessageLabelsResponses[keyof UpdateGmailMessageLabelsResponses];
+
+export type TrashGmailMessageData = {
+  body: {
+    /**
+     * True only when the user explicitly requested this action on this resource. Discovering or selecting a capability is not authorization.
+     */
+    confirm: true;
+  };
+  path: {
+    messageId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-message/{messageId}/trash";
+};
+
+export type TrashGmailMessageErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type TrashGmailMessageError = TrashGmailMessageErrors[keyof TrashGmailMessageErrors];
+
+export type TrashGmailMessageResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    threadId: string;
+    [key: string]: unknown;
+  };
+};
+
+export type TrashGmailMessageResponse = TrashGmailMessageResponses[keyof TrashGmailMessageResponses];
+
+export type UntrashGmailMessageData = {
+  body?: never;
+  path: {
+    messageId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-message/{messageId}/untrash";
+};
+
+export type UntrashGmailMessageErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type UntrashGmailMessageError = UntrashGmailMessageErrors[keyof UntrashGmailMessageErrors];
+
+export type UntrashGmailMessageResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    threadId: string;
+    [key: string]: unknown;
+  };
+};
+
+export type UntrashGmailMessageResponse = UntrashGmailMessageResponses[keyof UntrashGmailMessageResponses];
+
+export type ListGmailLabelsData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-labels";
+};
+
+export type ListGmailLabelsErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type ListGmailLabelsError = ListGmailLabelsErrors[keyof ListGmailLabelsErrors];
+
+export type ListGmailLabelsResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    labels?: Array<{
+      id: string;
+      name: string;
+      type: "user" | "system";
+      [key: string]: unknown;
+    }>;
+    [key: string]: unknown;
+  };
+};
+
+export type ListGmailLabelsResponse = ListGmailLabelsResponses[keyof ListGmailLabelsResponses];
+
+export type CreateGmailLabelData = {
+  body: {
+    /**
+     * User label name.
+     */
+    name: string;
+    messageListVisibility?: "show" | "hide";
+    labelListVisibility?: "labelShow" | "labelShowIfUnread" | "labelHide";
+  };
+  path?: never;
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-labels";
+};
+
+export type CreateGmailLabelErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type CreateGmailLabelError = CreateGmailLabelErrors[keyof CreateGmailLabelErrors];
+
+export type CreateGmailLabelResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    name: string;
+    type: "user" | "system";
+    [key: string]: unknown;
+  };
+};
+
+export type CreateGmailLabelResponse = CreateGmailLabelResponses[keyof CreateGmailLabelResponses];
+
+export type DeleteGmailLabelData = {
+  body: {
+    /**
+     * True only when the user explicitly requested this action on this resource. Discovering or selecting a capability is not authorization.
+     */
+    confirm: true;
+  };
+  path: {
+    labelId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-label/{labelId}";
+};
+
+export type DeleteGmailLabelErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type DeleteGmailLabelError = DeleteGmailLabelErrors[keyof DeleteGmailLabelErrors];
+
+export type DeleteGmailLabelResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    ok: true;
+  };
+};
+
+export type DeleteGmailLabelResponse = DeleteGmailLabelResponses[keyof DeleteGmailLabelResponses];
+
+export type UpdateGmailLabelData = {
+  body: {
+    /**
+     * User label name.
+     */
+    name?: string;
+    messageListVisibility?: "show" | "hide";
+    labelListVisibility?: "labelShow" | "labelShowIfUnread" | "labelHide";
+  };
+  path: {
+    labelId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/gmail-label/{labelId}";
+};
+
+export type UpdateGmailLabelErrors = {
+  /**
+   * Invalid input.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign-in required.
+   */
+  401: UnauthorizedError;
+  /**
+   * Missing permission or protected system label.
+   */
+  409: {
+    error: string;
+    message: string;
+  };
+  /**
+   * Request exceeds 6 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google rejected or did not confirm the operation.
+   */
+  502: {
+    error: string;
+    message: string;
+  };
+};
+
+export type UpdateGmailLabelError = UpdateGmailLabelErrors[keyof UpdateGmailLabelErrors];
+
+export type UpdateGmailLabelResponses = {
+  /**
+   * Google's validated response.
+   */
+  200: {
+    id: string;
+    name: string;
+    type: "user" | "system";
+    [key: string]: unknown;
+  };
+};
+
+export type UpdateGmailLabelResponse = UpdateGmailLabelResponses[keyof UpdateGmailLabelResponses];
+
+export type DeleteGoogleCalendarEventData = {
+  body?: never;
+  path: {
+    eventId: string;
+  };
+  query: {
+    calendarId?: string;
+    /**
+     * Notification policy. all/externalOnly requires confirmNotifications=true after explicit user approval. Google may still send some service emails with none.
+     */
+    sendUpdates?: "none" | "all" | "externalOnly";
+    /**
+     * Required explicit user confirmation to delete/cancel this event. A recurring master ID cancels the whole series; use an instance ID for one occurrence.
+     */
+    confirmCancellation: "true";
+    confirmNotifications?: "true" | "false";
+  };
+  url: "/v1/capabilities/google-workspace/calendar-events/{eventId}";
+};
+
+export type DeleteGoogleCalendarEventErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type DeleteGoogleCalendarEventError = DeleteGoogleCalendarEventErrors[keyof DeleteGoogleCalendarEventErrors];
+
+export type DeleteGoogleCalendarEventResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    calendarId: string;
+    eventId: string;
+    cancelled: true;
+    /**
+     * Notification policy. all/externalOnly requires confirmNotifications=true after explicit user approval. Google may still send some service emails with none.
+     */
+    sendUpdates?: "none" | "all" | "externalOnly";
+  };
+};
+
+export type DeleteGoogleCalendarEventResponse =
+  DeleteGoogleCalendarEventResponses[keyof DeleteGoogleCalendarEventResponses];
+
+export type GetGoogleCalendarEventData = {
+  body?: never;
+  path: {
+    eventId: string;
+  };
+  query?: {
+    calendarId?: string;
+  };
+  url: "/v1/capabilities/google-workspace/calendar-events/{eventId}";
+};
+
+export type GetGoogleCalendarEventErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type GetGoogleCalendarEventError = GetGoogleCalendarEventErrors[keyof GetGoogleCalendarEventErrors];
+
+export type GetGoogleCalendarEventResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    calendarId: string;
+    event: {
+      id: string;
+      status: "confirmed" | "tentative" | "cancelled";
+      summary?: string;
+      description?: string;
+      location?: string;
+      start?:
+        | {
+            dateTime: string;
+            timeZone?: string;
+          }
+        | {
+            date: string;
+            timeZone?: string;
+          };
+      end?:
+        | {
+            dateTime: string;
+            timeZone?: string;
+          }
+        | {
+            date: string;
+            timeZone?: string;
+          };
+      htmlLink?: string;
+      etag?: string;
+      recurringEventId?: string;
+      attendeesOmitted?: boolean;
+      attendees?: Array<{
+        email?: string;
+        displayName?: string;
+        responseStatus?: string;
+        optional?: boolean;
+      }>;
+    };
+    /**
+     * Notification policy. all/externalOnly requires confirmNotifications=true after explicit user approval. Google may still send some service emails with none.
+     */
+    sendUpdates?: "none" | "all" | "externalOnly";
+  };
+};
+
+export type GetGoogleCalendarEventResponse = GetGoogleCalendarEventResponses[keyof GetGoogleCalendarEventResponses];
+
+export type UpdateGoogleCalendarEventData = {
+  body: {
+    summary?: string;
+    description?: string;
+    location?: string;
+    /**
+     * Rescheduling requires both start and end, of the same type. All-day end dates are exclusive.
+     */
+    start?:
+      | {
+          dateTime: string;
+          timeZone?: string;
+        }
+      | {
+          date: string;
+        };
+    end?:
+      | {
+          dateTime: string;
+          timeZone?: string;
+        }
+      | {
+          date: string;
+        };
+    /**
+     * Replaces the entire attendee list; [] removes all attendees. Read the event first to preserve existing guests.
+     */
+    attendees?: Array<{
+      email: string;
+      optional?: boolean;
+    }>;
+    /**
+     * Notification policy. all/externalOnly requires confirmNotifications=true after explicit user approval. Google may still send some service emails with none.
+     */
+    sendUpdates?: "none" | "all" | "externalOnly";
+    confirmNotifications?: boolean;
+  };
+  path: {
+    eventId: string;
+  };
+  query?: {
+    calendarId?: string;
+  };
+  url: "/v1/capabilities/google-workspace/calendar-events/{eventId}";
+};
+
+export type UpdateGoogleCalendarEventErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type UpdateGoogleCalendarEventError = UpdateGoogleCalendarEventErrors[keyof UpdateGoogleCalendarEventErrors];
+
+export type UpdateGoogleCalendarEventResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    calendarId: string;
+    event: {
+      id: string;
+      status: "confirmed" | "tentative" | "cancelled";
+      summary?: string;
+      description?: string;
+      location?: string;
+      start?:
+        | {
+            dateTime: string;
+            timeZone?: string;
+          }
+        | {
+            date: string;
+            timeZone?: string;
+          };
+      end?:
+        | {
+            dateTime: string;
+            timeZone?: string;
+          }
+        | {
+            date: string;
+            timeZone?: string;
+          };
+      htmlLink?: string;
+      etag?: string;
+      recurringEventId?: string;
+      attendeesOmitted?: boolean;
+      attendees?: Array<{
+        email?: string;
+        displayName?: string;
+        responseStatus?: string;
+        optional?: boolean;
+      }>;
+    };
+    /**
+     * Notification policy. all/externalOnly requires confirmNotifications=true after explicit user approval. Google may still send some service emails with none.
+     */
+    sendUpdates?: "none" | "all" | "externalOnly";
+  };
+};
+
+export type UpdateGoogleCalendarEventResponse =
+  UpdateGoogleCalendarEventResponses[keyof UpdateGoogleCalendarEventResponses];
+
+export type GetGoogleSpreadsheetData = {
+  body?: never;
+  path: {
+    spreadsheetId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}";
+};
+
+export type GetGoogleSpreadsheetErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type GetGoogleSpreadsheetError = GetGoogleSpreadsheetErrors[keyof GetGoogleSpreadsheetErrors];
+
+export type GetGoogleSpreadsheetResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    spreadsheet: {
+      spreadsheetId: string;
+      spreadsheetUrl: string;
+      properties: {
+        title: string;
+        locale?: string;
+        timeZone?: string;
+      };
+      sheets: Array<{
+        properties: {
+          sheetId: number;
+          title: string;
+          index?: number;
+          gridProperties?: {
+            rowCount?: number;
+            columnCount?: number;
+          };
+        };
+      }>;
+    };
+  };
+};
+
+export type GetGoogleSpreadsheetResponse = GetGoogleSpreadsheetResponses[keyof GetGoogleSpreadsheetResponses];
+
+export type CreateGoogleSpreadsheetData = {
+  body: {
+    title: string;
+    sheetTitle?: string;
+    rowCount?: number;
+    columnCount?: number;
+  };
+  path?: never;
+  query?: never;
+  url: "/v1/capabilities/google-workspace/spreadsheets";
+};
+
+export type CreateGoogleSpreadsheetErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type CreateGoogleSpreadsheetError = CreateGoogleSpreadsheetErrors[keyof CreateGoogleSpreadsheetErrors];
+
+export type CreateGoogleSpreadsheetResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    spreadsheet: {
+      spreadsheetId: string;
+      spreadsheetUrl: string;
+      properties: {
+        title: string;
+        locale?: string;
+        timeZone?: string;
+      };
+      sheets: Array<{
+        properties: {
+          sheetId: number;
+          title: string;
+          index?: number;
+          gridProperties?: {
+            rowCount?: number;
+            columnCount?: number;
+          };
+        };
+      }>;
+    };
+  };
+};
+
+export type CreateGoogleSpreadsheetResponse = CreateGoogleSpreadsheetResponses[keyof CreateGoogleSpreadsheetResponses];
+
+export type GetGoogleSheetsValuesData = {
+  body?: never;
+  path: {
+    spreadsheetId: string;
+  };
+  query: {
+    range: string;
+    valueRenderOption?: "FORMATTED_VALUE" | "UNFORMATTED_VALUE" | "FORMULA";
+  };
+  url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}/values";
+};
+
+export type GetGoogleSheetsValuesErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type GetGoogleSheetsValuesError = GetGoogleSheetsValuesErrors[keyof GetGoogleSheetsValuesErrors];
+
+export type GetGoogleSheetsValuesResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    spreadsheetId: string;
+    range: string;
+    majorDimension: "ROWS";
+    values: Array<Array<string | number | boolean>>;
+    valueRenderOption?: "FORMATTED_VALUE" | "UNFORMATTED_VALUE" | "FORMULA";
+  };
+};
+
+export type GetGoogleSheetsValuesResponse = GetGoogleSheetsValuesResponses[keyof GetGoogleSheetsValuesResponses];
+
+export type UpdateGoogleSheetsValuesData = {
+  body: {
+    range: string;
+    /**
+     * Rows of literal strings, numbers, and booleans. Empty strings clear cells; missing trailing cells stay unchanged.
+     */
+    values: Array<Array<string | number | boolean>>;
+    /**
+     * RAW stores strings literally, including =formulas. USER_ENTERED parses formulas/dates and can execute formulas or fetch external data; requires explicit approval via confirmUserEntered.
+     */
+    valueInputOption?: "RAW" | "USER_ENTERED";
+    confirmUserEntered?: boolean;
+  };
+  path: {
+    spreadsheetId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}/values";
+};
+
+export type UpdateGoogleSheetsValuesErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type UpdateGoogleSheetsValuesError = UpdateGoogleSheetsValuesErrors[keyof UpdateGoogleSheetsValuesErrors];
+
+export type UpdateGoogleSheetsValuesResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    spreadsheetId: string;
+    updatedRange: string;
+    updatedRows: number;
+    updatedColumns: number;
+    updatedCells: number;
+    /**
+     * RAW stores strings literally, including =formulas. USER_ENTERED parses formulas/dates and can execute formulas or fetch external data; requires explicit approval via confirmUserEntered.
+     */
+    valueInputOption?: "RAW" | "USER_ENTERED";
+  };
+};
+
+export type UpdateGoogleSheetsValuesResponse =
+  UpdateGoogleSheetsValuesResponses[keyof UpdateGoogleSheetsValuesResponses];
+
+export type AppendGoogleSheetsValuesData = {
+  body: {
+    range: string;
+    /**
+     * Rows of literal strings, numbers, and booleans. Empty strings clear cells; missing trailing cells stay unchanged.
+     */
+    values: Array<Array<string | number | boolean>>;
+    /**
+     * RAW stores strings literally, including =formulas. USER_ENTERED parses formulas/dates and can execute formulas or fetch external data; requires explicit approval via confirmUserEntered.
+     */
+    valueInputOption?: "RAW" | "USER_ENTERED";
+    confirmUserEntered?: boolean;
+  };
+  path: {
+    spreadsheetId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/spreadsheets/{spreadsheetId}/values/append";
+};
+
+export type AppendGoogleSheetsValuesErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type AppendGoogleSheetsValuesError = AppendGoogleSheetsValuesErrors[keyof AppendGoogleSheetsValuesErrors];
+
+export type AppendGoogleSheetsValuesResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    spreadsheetId: string;
+    updatedRange: string;
+    updatedRows: number;
+    updatedColumns: number;
+    updatedCells: number;
+    /**
+     * RAW stores strings literally, including =formulas. USER_ENTERED parses formulas/dates and can execute formulas or fetch external data; requires explicit approval via confirmUserEntered.
+     */
+    valueInputOption?: "RAW" | "USER_ENTERED";
+    tableRange: string;
+  };
+};
+
+export type AppendGoogleSheetsValuesResponse =
+  AppendGoogleSheetsValuesResponses[keyof AppendGoogleSheetsValuesResponses];
+
+export type CreateGoogleDriveFolderData = {
+  body: {
+    name: string;
+    parentId?: string;
+  };
+  path?: never;
+  query?: never;
+  url: "/v1/capabilities/google-workspace/drive-folders";
+};
+
+export type CreateGoogleDriveFolderErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type CreateGoogleDriveFolderError = CreateGoogleDriveFolderErrors[keyof CreateGoogleDriveFolderErrors];
+
+export type CreateGoogleDriveFolderResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    file: {
+      id: string;
+      name: string;
+      mimeType: string;
+      trashed: boolean;
+      parents?: Array<string>;
+      webViewLink?: string;
+    };
+  };
+};
+
+export type CreateGoogleDriveFolderResponse = CreateGoogleDriveFolderResponses[keyof CreateGoogleDriveFolderResponses];
+
+export type GetGoogleDriveFileMetadataData = {
+  body?: never;
+  path: {
+    fileId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/drive-files/{fileId}";
+};
+
+export type GetGoogleDriveFileMetadataErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type GetGoogleDriveFileMetadataError = GetGoogleDriveFileMetadataErrors[keyof GetGoogleDriveFileMetadataErrors];
+
+export type GetGoogleDriveFileMetadataResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    file: {
+      id: string;
+      name: string;
+      mimeType: string;
+      trashed: boolean;
+      parents?: Array<string>;
+      webViewLink?: string;
+    };
+  };
+};
+
+export type GetGoogleDriveFileMetadataResponse =
+  GetGoogleDriveFileMetadataResponses[keyof GetGoogleDriveFileMetadataResponses];
+
+export type UpdateGoogleDriveFileMetadataData = {
+  body: {
+    name?: string;
+    /**
+     * Move destination folder ID. Also supply removeParentId from current file metadata; folder changes use Google addParents/removeParents query parameters.
+     */
+    addParentId?: string;
+    removeParentId?: string;
+    /**
+     * true moves to trash; false restores. Never permanently deletes.
+     */
+    trashed?: boolean;
+    /**
+     * Required explicit user approval when trashed=true; trashing a folder affects its children.
+     */
+    confirmTrash?: boolean;
+  };
+  path: {
+    fileId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/google-workspace/drive-files/{fileId}";
+};
+
+export type UpdateGoogleDriveFileMetadataErrors = {
+  /**
+   * Invalid bounded request or missing confirmation.
+   */
+  400: InvalidRequestError;
+  /**
+   * Sign in first.
+   */
+  401: UnauthorizedError;
+  /**
+   * Connect with the required provider permission.
+   */
+  409: {
+    error: "needs_connection";
+    message: string;
+  };
+  /**
+   * Request exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Google did not confirm the operation; do not blindly retry mutations.
+   */
+  502: {
+    error: "google_api_error";
+    message: string;
+  };
+};
+
+export type UpdateGoogleDriveFileMetadataError =
+  UpdateGoogleDriveFileMetadataErrors[keyof UpdateGoogleDriveFileMetadataErrors];
+
+export type UpdateGoogleDriveFileMetadataResponses = {
+  /**
+   * Google-confirmed result.
+   */
+  200: {
+    ok: true;
+    file: {
+      id: string;
+      name: string;
+      mimeType: string;
+      trashed: boolean;
+      parents?: Array<string>;
+      webViewLink?: string;
+    };
+  };
+};
+
+export type UpdateGoogleDriveFileMetadataResponse =
+  UpdateGoogleDriveFileMetadataResponses[keyof UpdateGoogleDriveFileMetadataResponses];
+
 export type PostV1DirectUploadsGoogleWorkspaceDriveFilesData = {
   body?: never;
   path?: never;
@@ -13038,6 +14863,10 @@ export type GetV1CapabilitiesGoogleWorkspaceGmailMessagesData = {
      * Maximum messages to return, capped at 25.
      */
     maxResults?: number;
+    /**
+     * nextPageToken from a previous page of the same Gmail search.
+     */
+    pageToken?: string;
   };
   url: "/v1/capabilities/google-workspace/gmail-messages";
 };
@@ -13280,15 +15109,24 @@ export type PatchV1CapabilitiesGoogleWorkspaceCalendarEventByEventIdResponse =
 export type GetV1CapabilitiesGoogleWorkspaceDriveFilesData = {
   body?: never;
   path?: never;
-  query: {
+  query?: {
     /**
-     * Text to search in Drive file names and full text.
+     * Optional text to search in Drive file names and full text. Omit to list files.
      */
-    query: string;
+    query?: string;
     /**
      * Maximum files to return, capped at 25.
      */
     maxResults?: number;
+    pageToken?: string;
+    /**
+     * Only files modified after this RFC3339 timestamp; follow nextPageToken to enumerate all matching files.
+     */
+    modifiedAfter?: string;
+    /**
+     * Limit to direct children of this folder.
+     */
+    folderId?: string;
   };
   url: "/v1/capabilities/google-workspace/drive-files";
 };
@@ -13409,82 +15247,493 @@ export type PostV1CapabilitiesGoogleWorkspaceDriveFileShareByFileIdResponses = {
 export type PostV1CapabilitiesGoogleWorkspaceDriveFileShareByFileIdResponse =
   PostV1CapabilitiesGoogleWorkspaceDriveFileShareByFileIdResponses[keyof PostV1CapabilitiesGoogleWorkspaceDriveFileShareByFileIdResponses];
 
-export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsData = {
-  body: {
+export type SendMicrosoft365MailDraftData = {
+  body: Microsoft365MailSendBody;
+  path: {
     /**
-     * Recipient email address.
+     * Microsoft Graph message id.
      */
-    to: string;
-    /**
-     * Optional comma-separated Cc email addresses.
-     */
-    cc?: string;
-    /**
-     * Optional comma-separated Bcc email addresses.
-     */
-    bcc?: string;
-    /**
-     * Draft subject line. For replies or forwards, include threadId; subjects starting with Re: or Fwd: are rejected without threadId so the draft stays on the existing conversation.
-     */
-    subject: string;
-    /**
-     * Plain-text draft body. Write plain prose with no markdown syntax, separate paragraphs with blank lines, and do not hard-wrap prose. For threaded drafts, the server appends the quoted conversation automatically; do not include quoted history.
-     */
-    body: string;
-    /**
-     * Gmail thread id to reply on. Required for replies and forwards; get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …').
-     */
-    threadId?: string;
-    /**
-     * Optional workspace file paths, 1 to 10 files totaling at most 4 MiB. File bytes stay outside model context. Requires a direct execute_capability call from a supporting OpenWork host; Code Mode and other MCP hosts are unsupported and create no draft. Do not retry without attachments.
-     */
-    attachments?: Array<string>;
+    messageId: string;
   };
-  path?: never;
   query?: never;
-  url: "/v1/capabilities/google-workspace/gmail-drafts";
+  url: "/v1/capabilities/microsoft-365/mail-drafts/{messageId}/send";
 };
 
-export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors = {
-  /**
-   * The draft request was invalid.
-   */
-  400: InvalidRequestError | GoogleWorkspaceMissingThreadIdError;
+export type SendMicrosoft365MailDraftErrors = {
   /**
    * The caller must be signed in.
    */
   401: UnauthorizedError;
   /**
-   * The calling member has not connected their Google account or is missing permission.
+   * The selected feature or delegated permission is missing.
    */
-  409: GoogleWorkspaceNeedsConnectionError;
+  409: Microsoft365NeedsConnectionError;
   /**
-   * Workspace attachments require a supporting OpenWork host; no draft was created.
+   * Request body exceeds 1 MiB.
    */
-  422: {
-    ok: false;
-    error: "file_input_requires_host";
-    created: false;
-    message: "Workspace attachments require a supporting OpenWork host. No draft was created. Do not retry without attachments.";
+  413: {
+    error: "invalid_request";
+    message: string;
   };
   /**
-   * Google rejected the request.
+   * Microsoft Graph rejected the request or the outcome is unknown.
    */
-  502: GoogleWorkspaceUpstreamError;
+  502: Microsoft365GraphError;
 };
 
-export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsError =
-  PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors[keyof PostV1CapabilitiesGoogleWorkspaceGmailDraftsErrors];
+export type SendMicrosoft365MailDraftError = SendMicrosoft365MailDraftErrors[keyof SendMicrosoft365MailDraftErrors];
 
-export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses = {
+export type SendMicrosoft365MailDraftResponses = {
   /**
-   * Draft created.
+   * Microsoft Graph mutation receipt returned.
    */
-  200: GoogleWorkspaceDraftResponse;
+  200: Microsoft365MailSendResponse;
 };
 
-export type PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponse =
-  PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses[keyof PostV1CapabilitiesGoogleWorkspaceGmailDraftsResponses];
+export type SendMicrosoft365MailDraftResponse =
+  SendMicrosoft365MailDraftResponses[keyof SendMicrosoft365MailDraftResponses];
+
+export type CreateMicrosoft365ReplyDraftData = {
+  body: Microsoft365MailReplyDraftBody;
+  path: {
+    /**
+     * Microsoft Graph message id.
+     */
+    messageId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/mail-message/{messageId}/reply-draft";
+};
+
+export type CreateMicrosoft365ReplyDraftErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type CreateMicrosoft365ReplyDraftError =
+  CreateMicrosoft365ReplyDraftErrors[keyof CreateMicrosoft365ReplyDraftErrors];
+
+export type CreateMicrosoft365ReplyDraftResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365MailDraftResponse;
+};
+
+export type CreateMicrosoft365ReplyDraftResponse =
+  CreateMicrosoft365ReplyDraftResponses[keyof CreateMicrosoft365ReplyDraftResponses];
+
+export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdData = {
+  body?: never;
+  path: {
+    /**
+     * Microsoft Graph message id.
+     */
+    messageId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/mail-message/{messageId}";
+};
+
+export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The calling member has not connected their Microsoft account or is missing permission.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Microsoft Graph rejected the request.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdError =
+  GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors[keyof GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors];
+
+export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses = {
+  /**
+   * Outlook message returned.
+   */
+  200: Microsoft365MailMessageResponse;
+};
+
+export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponse =
+  GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses[keyof GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses];
+
+export type UpdateMicrosoft365MailMessageData = {
+  body: Microsoft365MailMessageUpdateBody;
+  path: {
+    /**
+     * Microsoft Graph message id.
+     */
+    messageId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/mail-message/{messageId}";
+};
+
+export type UpdateMicrosoft365MailMessageErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type UpdateMicrosoft365MailMessageError =
+  UpdateMicrosoft365MailMessageErrors[keyof UpdateMicrosoft365MailMessageErrors];
+
+export type UpdateMicrosoft365MailMessageResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365MailMessageResponse;
+};
+
+export type UpdateMicrosoft365MailMessageResponse =
+  UpdateMicrosoft365MailMessageResponses[keyof UpdateMicrosoft365MailMessageResponses];
+
+export type MoveMicrosoft365MailMessageData = {
+  body: Microsoft365MailMessageMoveBody;
+  path: {
+    /**
+     * Microsoft Graph message id.
+     */
+    messageId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/mail-message/{messageId}/move";
+};
+
+export type MoveMicrosoft365MailMessageErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type MoveMicrosoft365MailMessageError =
+  MoveMicrosoft365MailMessageErrors[keyof MoveMicrosoft365MailMessageErrors];
+
+export type MoveMicrosoft365MailMessageResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365MailMessageResponse;
+};
+
+export type MoveMicrosoft365MailMessageResponse =
+  MoveMicrosoft365MailMessageResponses[keyof MoveMicrosoft365MailMessageResponses];
+
+export type DeleteMicrosoft365CalendarEventData = {
+  body: Microsoft365CalendarDeleteBody;
+  path: {
+    eventId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/calendar-events/{eventId}";
+};
+
+export type DeleteMicrosoft365CalendarEventErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type DeleteMicrosoft365CalendarEventError =
+  DeleteMicrosoft365CalendarEventErrors[keyof DeleteMicrosoft365CalendarEventErrors];
+
+export type DeleteMicrosoft365CalendarEventResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365CalendarDeleteResponse;
+};
+
+export type DeleteMicrosoft365CalendarEventResponse =
+  DeleteMicrosoft365CalendarEventResponses[keyof DeleteMicrosoft365CalendarEventResponses];
+
+export type UpdateMicrosoft365CalendarEventData = {
+  body: Microsoft365CalendarEventUpdateBody;
+  path: {
+    eventId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/calendar-events/{eventId}";
+};
+
+export type UpdateMicrosoft365CalendarEventErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type UpdateMicrosoft365CalendarEventError =
+  UpdateMicrosoft365CalendarEventErrors[keyof UpdateMicrosoft365CalendarEventErrors];
+
+export type UpdateMicrosoft365CalendarEventResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365CalendarEventResponse;
+};
+
+export type UpdateMicrosoft365CalendarEventResponse =
+  UpdateMicrosoft365CalendarEventResponses[keyof UpdateMicrosoft365CalendarEventResponses];
+
+export type CancelMicrosoft365CalendarEventData = {
+  body: Microsoft365CalendarCancelBody;
+  path: {
+    eventId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/calendar-events/{eventId}/cancel";
+};
+
+export type CancelMicrosoft365CalendarEventErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type CancelMicrosoft365CalendarEventError =
+  CancelMicrosoft365CalendarEventErrors[keyof CancelMicrosoft365CalendarEventErrors];
+
+export type CancelMicrosoft365CalendarEventResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365CalendarCancelResponse;
+};
+
+export type CancelMicrosoft365CalendarEventResponse =
+  CancelMicrosoft365CalendarEventResponses[keyof CancelMicrosoft365CalendarEventResponses];
+
+export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdData = {
+  body?: never;
+  path: {
+    /**
+     * Microsoft Graph drive item id.
+     */
+    itemId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/drive-file/{itemId}";
+};
+
+export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The calling member has not connected their Microsoft account or is missing permission.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Microsoft Graph rejected the request.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdError =
+  GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors[keyof GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors];
+
+export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses = {
+  /**
+   * OneDrive file returned.
+   */
+  200: Microsoft365DriveFileResponse;
+};
+
+export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponse =
+  GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses[keyof GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses];
+
+export type UpdateMicrosoft365DriveItemData = {
+  body: Microsoft365DriveItemUpdateBody;
+  path: {
+    /**
+     * Microsoft Graph drive item id.
+     */
+    itemId: string;
+  };
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/drive-file/{itemId}";
+};
+
+export type UpdateMicrosoft365DriveItemErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type UpdateMicrosoft365DriveItemError =
+  UpdateMicrosoft365DriveItemErrors[keyof UpdateMicrosoft365DriveItemErrors];
+
+export type UpdateMicrosoft365DriveItemResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365DriveFileWriteResponse;
+};
+
+export type UpdateMicrosoft365DriveItemResponse =
+  UpdateMicrosoft365DriveItemResponses[keyof UpdateMicrosoft365DriveItemResponses];
+
+export type CreateMicrosoft365DriveFolderData = {
+  body: Microsoft365DriveFolderBody;
+  path?: never;
+  query?: never;
+  url: "/v1/capabilities/microsoft-365/drive-folders";
+};
+
+export type CreateMicrosoft365DriveFolderErrors = {
+  /**
+   * The caller must be signed in.
+   */
+  401: UnauthorizedError;
+  /**
+   * The selected feature or delegated permission is missing.
+   */
+  409: Microsoft365NeedsConnectionError;
+  /**
+   * Request body exceeds 1 MiB.
+   */
+  413: {
+    error: "invalid_request";
+    message: string;
+  };
+  /**
+   * Microsoft Graph rejected the request or the outcome is unknown.
+   */
+  502: Microsoft365GraphError;
+};
+
+export type CreateMicrosoft365DriveFolderError =
+  CreateMicrosoft365DriveFolderErrors[keyof CreateMicrosoft365DriveFolderErrors];
+
+export type CreateMicrosoft365DriveFolderResponses = {
+  /**
+   * Microsoft Graph mutation receipt returned.
+   */
+  200: Microsoft365DriveFileWriteResponse;
+};
+
+export type CreateMicrosoft365DriveFolderResponse =
+  CreateMicrosoft365DriveFolderResponses[keyof CreateMicrosoft365DriveFolderResponses];
 
 export type GetV1CapabilitiesMicrosoft365MailMessagesData = {
   body?: never;
@@ -13529,46 +15778,6 @@ export type GetV1CapabilitiesMicrosoft365MailMessagesResponses = {
 
 export type GetV1CapabilitiesMicrosoft365MailMessagesResponse =
   GetV1CapabilitiesMicrosoft365MailMessagesResponses[keyof GetV1CapabilitiesMicrosoft365MailMessagesResponses];
-
-export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdData = {
-  body?: never;
-  path: {
-    /**
-     * Microsoft Graph message id.
-     */
-    messageId: string;
-  };
-  query?: never;
-  url: "/v1/capabilities/microsoft-365/mail-message/{messageId}";
-};
-
-export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors = {
-  /**
-   * The caller must be signed in.
-   */
-  401: UnauthorizedError;
-  /**
-   * The calling member has not connected their Microsoft account or is missing permission.
-   */
-  409: Microsoft365NeedsConnectionError;
-  /**
-   * Microsoft Graph rejected the request.
-   */
-  502: Microsoft365GraphError;
-};
-
-export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdError =
-  GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors[keyof GetV1CapabilitiesMicrosoft365MailMessageByMessageIdErrors];
-
-export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses = {
-  /**
-   * Outlook message returned.
-   */
-  200: Microsoft365MailMessageResponse;
-};
-
-export type GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponse =
-  GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses[keyof GetV1CapabilitiesMicrosoft365MailMessageByMessageIdResponses];
 
 export type GetV1CapabilitiesMicrosoft365CalendarEventsData = {
   body?: never;
@@ -13731,46 +15940,6 @@ export type PutV1CapabilitiesMicrosoft365DriveFilesResponses = {
 
 export type PutV1CapabilitiesMicrosoft365DriveFilesResponse =
   PutV1CapabilitiesMicrosoft365DriveFilesResponses[keyof PutV1CapabilitiesMicrosoft365DriveFilesResponses];
-
-export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdData = {
-  body?: never;
-  path: {
-    /**
-     * Microsoft Graph drive item id.
-     */
-    itemId: string;
-  };
-  query?: never;
-  url: "/v1/capabilities/microsoft-365/drive-file/{itemId}";
-};
-
-export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors = {
-  /**
-   * The caller must be signed in.
-   */
-  401: UnauthorizedError;
-  /**
-   * The calling member has not connected their Microsoft account or is missing permission.
-   */
-  409: Microsoft365NeedsConnectionError;
-  /**
-   * Microsoft Graph rejected the request.
-   */
-  502: Microsoft365GraphError;
-};
-
-export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdError =
-  GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors[keyof GetV1CapabilitiesMicrosoft365DriveFileByItemIdErrors];
-
-export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses = {
-  /**
-   * OneDrive file returned.
-   */
-  200: Microsoft365DriveFileResponse;
-};
-
-export type GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponse =
-  GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses[keyof GetV1CapabilitiesMicrosoft365DriveFileByItemIdResponses];
 
 export type PostV1CapabilitiesMicrosoft365MailDraftsData = {
   body: Microsoft365MailDraftBody;

--- a/packages/types/src/den/microsoft-365.ts
+++ b/packages/types/src/den/microsoft-365.ts
@@ -1,6 +1,8 @@
 export type Microsoft365Feature =
   | "mailRead"
   | "mailDraft"
+  | "mailSend"
+  | "mailManage"
   | "calendarRead"
   | "calendarWrite"
   | "filesRead"
@@ -20,6 +22,8 @@ export const MICROSOFT_365_FEATURES: readonly Microsoft365Feature[] = [
   "calendarRead",
   "calendarWrite",
   "mailDraft",
+  "mailSend",
+  "mailManage",
   "mailRead",
   "filesRead",
   "filesWrite",


### PR DESCRIPTION
## Summary

Connectors must perform service work, not just display setup cards. Add **32 native service operations** behind Google Workspace and Microsoft 365, with discoverable schemas, account-scoped execution, and provider-confirmed results.

Companion implementation for #4305. This is independent of its UI changes and preserves the authentication work in progress there. The service-management outcome should be delivered with real operations, not by narrowing the catalog descriptions.

### Working operations

- **Gmail:** send existing drafts (including their threading and attachments), list/read/replace/delete drafts, archive/unarchive, mark read/unread, star/unstar, trash/restore messages, and list/create/update/delete user labels. Existing draft creation is reused.
- **Calendar:** read, edit/reschedule and cancel events in a selected calendar, including timed/all-day events and explicit guest-notification controls.
- **Drive:** create folders, read metadata, rename/move, trash/restore; add date/folder/pagination controls to existing file search. Generic Sheets file reads use CSV instead of an unsupported text export.
- **Sheets:** create spreadsheets, inspect tabs, read/write cell ranges, append rows. RAW is the default; parsing formulas requires explicit confirmation.
- **Microsoft 365:** send drafts with an accepted receipt, create reply drafts, update read state/categories, move mail, edit/cancel/delete calendar events, and create/rename/move OneDrive items.
- Expose the new permission choices and generate the SDK. Stable short operation IDs fit the gateway's name limits without changing existing names.

### Permission and identity boundaries

- Every operation uses the selected connector and calling member, never a different available account. Microsoft native credential resolution now honors selected connector IDs rather than always resolving the legacy alias.
- New Google management actions check both recorded provider grants and currently enabled administrator permissions. Disabling writes takes effect even when an old token retains a broader grant.
- Gmail draft-only access does not implicitly become send access. Sending requires the new send feature or mailbox management, plus an explicit confirmation. Microsoft send remains separate from read/write mail permissions.
- Require confirmation for sending, trash/destructive actions, meeting notifications and formula parsing. Body/response limits are enforced; uncertain mutations are never automatically retried or reported as completed. Outlook HTTP 202 means accepted, not delivered.
- Default permissions are unchanged. No migration, production credential changes, real emails, or real provider writes are included.

## Verification

**Selected final-head proof: Passed.** Tested head `d5c3c2ffa4f1cdf489acd635e7245f9599ba1ca9`, merged as `440504bb9010ea7be822f5f9144e2627c84d32d3`; their Git trees match.

- `pnpm evals:pr specs/plugin-mcp-connector-parity.test.ts`: **2 passed, 0 failed, 0 skipped**.
- `pnpm evals:pr specs/connected-service-actions.test.ts`: **1 passed, 0 failed, 0 skipped**.
- **44 passed assertion groups** with cold isolated local Den and stateful synthetic providers. All 32 new operations execute with exact-account/request checks and permission negatives; no real provider mutations.
- The disk-full failure and temporary prerequisite skips were followed by successful runs on this exact final head after restoring the existing runtime without replacing volumes.
- Final GitHub review completed all four skills with zero findings and cleared the approval gate. Required tests/builds, SDK and CodeQL passed.

[Final-head assertion evidence and original run references](https://github.com/different-ai/openwork/pull/4693#issuecomment-5607734994). Earlier reports remain historical.

**Separate gaps:** this shell cannot complete local policy preflight or publish a new hosted report without its approved credentials/Infisical login. No local preflight clearance, broader UI proof, live-provider certification or deployment verification is claimed.

## Scope and integration notes

- The UI proof gaps recorded on #4305 are not silently cleared by this backend journey. That PR keeps its separate result until its own journeys pass.
- #4685 owns automatic workspace attachment fulfillment; this change does not duplicate that work. Existing Gmail drafts, including attached/threaded drafts, are sent unchanged.
- #4627's legacy Google retirement/reply refinements remain separate and may need mechanical reconciliation in the existing Google route/test files.
- The native gateway journey executes all 32 new operations against stateful synthetic providers, including permission and account-isolation assertions. No live-provider certification is claimed.
- Real-provider OAuth approval, account entitlements, refresh behavior and production rollout remain separate. External MCP services continue to expose their provider-maintained tools.
- Rich Docs/Slides editing, spreadsheet formatting/pivots, permanent message/file deletion, and OneDrive recycling are not implemented here. These are not substitutes for the core operations implemented above.
