### PR TITLE
feat(warden): add consolidated review summaries and observed metrics

### DIFF
--- a/.github/scripts/warden-review.mjs
+++ b/.github/scripts/warden-review.mjs
@@ -1,0 +1,919 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const KNOWN_SKILLS = [
+  "diff-security-review",
+  "confidentiality-review",
+  "spec-provenance-review",
+  "desktop-den-sync-review",
+];
+const MANDATORY_SKILLS = KNOWN_SKILLS.slice(0, 2);
+const SECURITY_SKILLS = new Set(MANDATORY_SKILLS);
+const SEVERITIES = new Set(["high", "medium", "low"]);
+const CONFIDENCES = new Set(["high", "medium", "low"]);
+const SUMMARY_MARKER = "<!-- openwork:warden-review-summary:v1 -->";
+const STATE_START = "<!-- openwork:warden-review-state:v1\n";
+const STATE_END = "\n-->";
+const MAX_ITEMS = 20;
+const MAX_OBSERVATIONS = 20;
+const MAX_THREAD_SNAPSHOT = 500;
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isInteger(value, minimum = 0) {
+  return Number.isInteger(value) && value >= minimum;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function validDate(value) {
+  return typeof value === "string" && /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z$/.test(value) &&
+    !Number.isNaN(Date.parse(value));
+}
+
+function validSha(value) {
+  return typeof value === "string" && /^[0-9a-f]{40}$/i.test(value);
+}
+
+function validateLocation(location, label) {
+  assert(isObject(location), `${label} must be an object`);
+  assert(typeof location.path === "string", `${label}.path must be a string`);
+  assert(isInteger(location.startLine, 1), `${label}.startLine must be positive`);
+  assert(location.endLine === undefined || isInteger(location.endLine, 1), `${label}.endLine is invalid`);
+}
+
+function validateFinding(finding, label) {
+  assert(isObject(finding), `${label} must be an object`);
+  assert(typeof finding.id === "string" && finding.id.length > 0, `${label}.id must be a string`);
+  assert(typeof finding.severity === "string", `${label}.severity must be a string`);
+  assert(
+    finding.confidence === undefined || typeof finding.confidence === "string",
+    `${label}.confidence must be a string`,
+  );
+  assert(typeof finding.title === "string", `${label}.title must be a string`);
+  assert(typeof finding.description === "string", `${label}.description must be a string`);
+  if (finding.location !== undefined) validateLocation(finding.location, `${label}.location`);
+  if (finding.additionalLocations !== undefined) {
+    assert(Array.isArray(finding.additionalLocations), `${label}.additionalLocations must be an array`);
+    finding.additionalLocations.forEach((location, index) =>
+      validateLocation(location, `${label}.additionalLocations[${index}]`),
+    );
+  }
+  if (finding.sourceSnippet !== undefined) {
+    const snippet = finding.sourceSnippet;
+    assert(isObject(snippet) && typeof snippet.path === "string" && Array.isArray(snippet.lines),
+      `${label}.sourceSnippet is invalid`);
+    for (const key of ["startLine", "endLine", "targetStartLine", "targetEndLine"]) {
+      assert(isInteger(snippet[key], 1), `${label}.sourceSnippet.${key} is invalid`);
+    }
+    snippet.lines.forEach((line, index) => assert(isObject(line) && isInteger(line.line, 1) &&
+      typeof line.content === "string" && (line.highlighted === undefined || typeof line.highlighted === "boolean"),
+    `${label}.sourceSnippet.lines[${index}] is invalid`));
+  }
+}
+
+function validateRaw(raw) {
+  assert(isObject(raw), "findings document must be an object");
+  assert(raw.version === "1", "unsupported findings version");
+  assert(validDate(raw.timestamp), "findings timestamp is invalid");
+  assert(isObject(raw.repository), "repository is missing");
+  for (const key of ["owner", "name", "fullName"]) {
+    assert(typeof raw.repository[key] === "string", `repository.${key} must be a string`);
+  }
+  assert(raw.event === "pull_request", "findings event must be pull_request");
+  assert(isObject(raw.pullRequest), "pullRequest is missing");
+  assert(isInteger(raw.pullRequest.number, 1), "pullRequest.number is invalid");
+  for (const key of ["author", "title", "baseBranch", "headBranch", "headSha"]) {
+    assert(typeof raw.pullRequest[key] === "string", `pullRequest.${key} must be a string`);
+  }
+  assert(typeof raw.runId === "string" && /^\d+$/.test(raw.runId), "runId is invalid");
+  assert(isObject(raw.summary), "summary is missing");
+  assert(isInteger(raw.summary.totalFindings), "summary.totalFindings is invalid");
+  assert(isInteger(raw.summary.totalSkills), "summary.totalSkills is invalid");
+  assert(isObject(raw.summary.findingsBySeverity), "summary.findingsBySeverity is missing");
+  for (const severity of SEVERITIES) {
+    assert(isInteger(raw.summary.findingsBySeverity[severity]), `summary ${severity} count is invalid`);
+  }
+  assert(Array.isArray(raw.skills), "skills must be an array");
+  raw.skills.forEach((skill, skillIndex) => {
+    assert(isObject(skill), `skills[${skillIndex}] must be an object`);
+    assert(typeof skill.name === "string", `skills[${skillIndex}].name must be a string`);
+    assert(typeof skill.summary === "string", `skills[${skillIndex}].summary must be a string`);
+    assert(Array.isArray(skill.findings), `skills[${skillIndex}].findings must be an array`);
+    assert(skill.durationMs === undefined || Number.isFinite(skill.durationMs) && skill.durationMs >= 0,
+      `skills[${skillIndex}].durationMs is invalid`);
+    for (const field of ["failedHunks", "failedExtractions"]) {
+      assert(skill[field] === undefined || isInteger(skill[field]), `skills[${skillIndex}].${field} is invalid`);
+    }
+    if (skill.error !== undefined) {
+      assert(isObject(skill.error) && typeof skill.error.code === "string" &&
+        typeof skill.error.message === "string" &&
+        (skill.error.timestamp === undefined || validDate(skill.error.timestamp)),
+      `skills[${skillIndex}].error is invalid`);
+    }
+    skill.findings.forEach((finding, findingIndex) =>
+      validateFinding(finding, `skills[${skillIndex}].findings[${findingIndex}]`),
+    );
+  });
+  assert(raw.triggerResults === undefined || Array.isArray(raw.triggerResults), "triggerResults must be an array");
+  for (const [index, result] of (raw.triggerResults ?? []).entries()) {
+    assert(isObject(result), `triggerResults[${index}] must be an object`);
+    assert(result.triggerId === undefined || typeof result.triggerId === "string",
+      `triggerResults[${index}].triggerId is invalid`);
+    assert(typeof result.triggerName === "string", `triggerResults[${index}].triggerName is invalid`);
+    assert(typeof result.skillName === "string", `triggerResults[${index}].skillName is invalid`);
+    assert(result.status === "success" || result.status === "error", `triggerResults[${index}].status is invalid`);
+    if (result.status === "success") {
+      assert(isObject(result.report), `triggerResults[${index}].report is missing`);
+      assert(typeof result.report.skill === "string", `triggerResults[${index}].report.skill is invalid`);
+      assert(typeof result.report.summary === "string", `triggerResults[${index}].report.summary is invalid`);
+      assert(Array.isArray(result.report.findings), `triggerResults[${index}].report.findings is invalid`);
+      assert(result.report.durationMs === undefined ||
+        Number.isFinite(result.report.durationMs) && result.report.durationMs >= 0,
+      `triggerResults[${index}].report.durationMs is invalid`);
+      result.report.findings.forEach((finding, findingIndex) =>
+        validateFinding(finding, `triggerResults[${index}].report.findings[${findingIndex}]`),
+      );
+    } else {
+      assert(isObject(result.error) && typeof result.error.message === "string",
+        `triggerResults[${index}].error is invalid`);
+    }
+  }
+  assert(Array.isArray(raw.findingObservations), "findingObservations must be an array");
+  raw.findingObservations.forEach((observation, index) => {
+    const label = `findingObservations[${index}]`;
+    assert(isObject(observation) && ["posted", "deduped", "skipped", "resolved", "failed"]
+      .includes(observation.outcome), `${label}.outcome is invalid`);
+    validateFinding(observation.finding, `${label}.finding`);
+    assert(observation.skill === undefined || typeof observation.skill === "string", `${label}.skill is invalid`);
+    if (observation.outcome === "deduped") {
+      assert(isObject(observation.dedupe) && ["warden", "external"].includes(observation.dedupe.source) &&
+        ["hash", "semantic"].includes(observation.dedupe.matchType), `${label}.dedupe is invalid`);
+    }
+    if (observation.outcome === "skipped") {
+      assert(["max_findings", "duplicate_in_batch", "no_inline_location"].includes(observation.skippedReason),
+        `${label}.skippedReason is invalid`);
+    }
+    if (observation.outcome === "resolved") {
+      assert(["fix_evaluation", "stale_check"].includes(observation.resolvedReason),
+        `${label}.resolvedReason is invalid`);
+    }
+  });
+}
+
+function safeFindingId(value) {
+  return /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/.test(value);
+}
+
+function safeLocation(finding, skill) {
+  if (skill === "confidentiality-review" || !finding.location) return undefined;
+  const { path, startLine } = finding.location;
+  if (
+    path.length > 240 || path.startsWith("/") || path.split("/").includes("..") ||
+    !/^[A-Za-z0-9._/@+ -]+$/.test(path)
+  ) return undefined;
+  return { file: path, line: startLine };
+}
+
+function disposition(skill, severity) {
+  if (SECURITY_SKILLS.has(skill)) return "blocker";
+  if (skill === "desktop-den-sync-review") {
+    return severity === "medium" || severity === "low" ? "advisory" : "blocker";
+  }
+  return skill === "spec-provenance-review" ? "advisory" : "needs-recheck";
+}
+
+function signature(finding) {
+  return JSON.stringify({
+    severity: finding.severity,
+    confidence: finding.confidence ?? null,
+    title: finding.title,
+    description: finding.description,
+    location: finding.location ?? null,
+    additionalLocations: finding.additionalLocations ?? [],
+    sourceSnippet: finding.sourceSnippet ?? null,
+  });
+}
+
+function addReason(reasons, reason) {
+  if (!reasons.includes(reason)) reasons.push(reason);
+}
+
+function consolidateFindings(skills, reasons) {
+  const consolidated = [];
+  const byId = new Map();
+  const rank = { advisory: 0, "needs-recheck": 1, blocker: 2 };
+  for (const skillReport of skills) {
+    const knownSkill = KNOWN_SKILLS.includes(skillReport.name) ? skillReport.name : "unknown";
+    for (const finding of skillReport.findings) {
+      if (!SEVERITIES.has(finding.severity)) addReason(reasons, "unknown-severity");
+      if (finding.confidence !== undefined && !CONFIDENCES.has(finding.confidence)) {
+        addReason(reasons, "unknown-confidence");
+      }
+      if (!safeFindingId(finding.id)) {
+        addReason(reasons, "unsafe-finding-id");
+        continue;
+      }
+      const item = {
+        id: finding.id,
+        severity: SEVERITIES.has(finding.severity) ? finding.severity : "unknown",
+        skills: [knownSkill],
+        disposition: disposition(knownSkill, finding.severity),
+        ...(safeLocation(finding, knownSkill) && { location: safeLocation(finding, knownSkill) }),
+      };
+      const previous = byId.get(finding.id);
+      const findingSignature = signature(finding);
+      if (previous && previous.signature === findingSignature) {
+        if (!previous.item.skills.includes(knownSkill)) previous.item.skills.push(knownSkill);
+        if (rank[item.disposition] > rank[previous.item.disposition]) previous.item.disposition = item.disposition;
+        if (knownSkill === "confidentiality-review") delete previous.item.location;
+        continue;
+      }
+      if (previous) addReason(reasons, "stable-id-conflict");
+      consolidated.push(item);
+      if (!previous) byId.set(finding.id, { signature: findingSignature, item });
+    }
+  }
+  for (const item of consolidated) item.skills.sort();
+  return consolidated;
+}
+
+function exportedFinding(finding) {
+  return {
+    id: finding.id,
+    severity: finding.severity,
+    ...(finding.confidence !== undefined && { confidence: finding.confidence }),
+    title: finding.title,
+    description: finding.description,
+    ...(finding.location !== undefined && { location: finding.location }),
+    ...(finding.additionalLocations !== undefined && { additionalLocations: finding.additionalLocations }),
+    ...(finding.sourceSnippet !== undefined && { sourceSnippet: finding.sourceSnippet }),
+  };
+}
+
+function replayReportSignature(skillName, report) {
+  return JSON.stringify({
+    skill: skillName,
+    summary: report.summary,
+    findings: report.findings.map(exportedFinding),
+    ...(report.durationMs !== undefined && { durationMs: report.durationMs }),
+  });
+}
+
+export function prepareReceipt(raw, metadata) {
+  validateRaw(raw);
+  const [owner, name, extra] = metadata.repository.split("/");
+  assert(owner && name && !extra && /^[A-Za-z0-9_.-]+$/.test(owner) && /^[A-Za-z0-9_.-]+$/.test(name),
+    "repository must be owner/name");
+  assert(isInteger(metadata.pr, 1), "pr must be a positive integer");
+  assert(validSha(metadata.head), "head must be a 40-character SHA");
+  assert(validSha(metadata.base), "base must be a 40-character SHA");
+  assert(/^\d+$/.test(metadata.runId), "run-id must contain digits only");
+  assert(isInteger(metadata.attempt, 1), "attempt must be a positive integer");
+  assert(raw.repository.owner === owner && raw.repository.name === name && raw.repository.fullName === metadata.repository,
+    "findings repository does not match trusted metadata");
+  assert(raw.pullRequest.number === metadata.pr, "findings PR does not match trusted metadata");
+  assert(raw.pullRequest.headSha === metadata.head, "findings head does not match trusted metadata");
+  assert(raw.runId === metadata.runId, "findings runId does not match trusted metadata");
+
+  const reasons = [];
+  const skillNames = raw.skills.map((skill) => skill.name);
+  for (const mandatory of MANDATORY_SKILLS) {
+    if (!skillNames.includes(mandatory)) addReason(reasons, `missing-mandatory-skill:${mandatory}`);
+  }
+  if (skillNames.some((skill) => !KNOWN_SKILLS.includes(skill))) addReason(reasons, "unknown-skill");
+  for (const skill of raw.skills) {
+    const safeName = KNOWN_SKILLS.includes(skill.name) ? skill.name : "unknown";
+    if ((skill.failedHunks ?? 0) > 0) addReason(reasons, `partial-failed-hunks:${safeName}`);
+    if ((skill.failedExtractions ?? 0) > 0) addReason(reasons, `partial-failed-extractions:${safeName}`);
+    if (skill.error !== undefined) addReason(reasons, `skill-error:${safeName}`);
+  }
+  const unmatchedReports = new Set(raw.skills.map((_, index) => index));
+  const triggerSuccesses = new Set();
+  const replayKeys = new Set();
+  if (!raw.triggerResults || raw.triggerResults.length === 0) addReason(reasons, "missing-trigger-results");
+  for (const result of raw.triggerResults ?? []) {
+    const safeName = KNOWN_SKILLS.includes(result.skillName) ? result.skillName : "unknown";
+    const replayKey = result.triggerId ?? `${result.triggerName}\0${result.skillName}`;
+    if (replayKeys.has(replayKey)) addReason(reasons, "duplicate-trigger-result");
+    replayKeys.add(replayKey);
+    if (safeName === "unknown") addReason(reasons, "unknown-trigger-skill");
+    if (result.status === "error") addReason(reasons, `trigger-error:${safeName}`);
+    else {
+      const reportNameMatches = result.report.skill === result.skillName;
+      if (!reportNameMatches) addReason(reasons, `trigger-report-skill-mismatch:${safeName}`);
+      const expectedSignature = replayReportSignature(result.report.skill, result.report);
+      const reportIndex = [...unmatchedReports].find((index) => {
+        const report = raw.skills[index];
+        return replayReportSignature(report.name, report) === expectedSignature;
+      });
+      if (reportIndex === undefined) {
+        addReason(reasons, `trigger-report-mismatch:${safeName}`);
+      } else {
+        unmatchedReports.delete(reportIndex);
+        if (reportNameMatches && safeName !== "unknown") triggerSuccesses.add(result.skillName);
+      }
+      if (result.report.findings.some((finding) => !SEVERITIES.has(finding.severity))) {
+        addReason(reasons, "unknown-severity");
+      }
+      if (result.report.findings.some((finding) =>
+        finding.confidence !== undefined && !CONFIDENCES.has(finding.confidence))) {
+        addReason(reasons, "unknown-confidence");
+      }
+    }
+  }
+  for (const reportIndex of unmatchedReports) {
+    const reportName = raw.skills[reportIndex].name;
+    addReason(reasons, `trigger-report-mismatch:${KNOWN_SKILLS.includes(reportName) ? reportName : "unknown"}`);
+  }
+  for (const mandatory of MANDATORY_SKILLS) {
+    if (!triggerSuccesses.has(mandatory)) addReason(reasons, `missing-mandatory-trigger:${mandatory}`);
+  }
+
+  const allFindings = raw.skills.flatMap((skill) => skill.findings);
+  const severityCounts = Object.fromEntries([...SEVERITIES].map((severity) => [
+    severity,
+    allFindings.filter((finding) => finding.severity === severity).length,
+  ]));
+  if (
+    raw.summary.totalFindings !== allFindings.length || raw.summary.totalSkills !== raw.skills.length ||
+    [...SEVERITIES].some((severity) => raw.summary.findingsBySeverity[severity] !== severityCounts[severity])
+  ) addReason(reasons, "summary-count-mismatch");
+
+  const findings = consolidateFindings(raw.skills, reasons);
+  const securityCount = raw.skills
+    .filter((skill) => SECURITY_SKILLS.has(skill.name))
+    .reduce((count, skill) => count + skill.findings.length, 0);
+  const syncFindings = raw.skills
+    .filter((skill) => skill.name === "desktop-den-sync-review")
+    .flatMap((skill) => skill.findings);
+  const syncAdvisoryCount = syncFindings.filter((finding) =>
+    finding.severity === "medium" || finding.severity === "low").length;
+  const syncBlockingCount = syncFindings.length - syncAdvisoryCount;
+  const blockingCount = securityCount + syncBlockingCount;
+  const reviewComplete = reasons.length === 0;
+  const verdict = reviewComplete ? (blockingCount === 0 ? "clear" : "blocked") : "incomplete";
+  const coverage = [...new Set(skillNames.map((skillName) =>
+    KNOWN_SKILLS.includes(skillName) ? skillName : "unknown"))].map((skillName) => {
+    const reports = raw.skills.filter((skill) =>
+      (KNOWN_SKILLS.includes(skill.name) ? skill.name : "unknown") === skillName);
+    const durationMs = reports.length === 1 && Number.isFinite(reports[0].durationMs)
+      ? reports[0].durationMs
+      : undefined;
+    return {
+      name: skillName,
+      status: "reported",
+      ...(Number.isFinite(durationMs) && { durationMs }),
+    };
+  });
+
+  return {
+    schema_version: "1",
+    producer: {
+      repository: metadata.repository,
+      pr: metadata.pr,
+      headSha: metadata.head,
+      baseSha: metadata.base,
+      runId: metadata.runId,
+      attempt: metadata.attempt,
+    },
+    analysisAt: raw.timestamp,
+    head_sha: metadata.head,
+    findings_count: allFindings.length,
+    high_count: severityCounts.high,
+    blocking_count: blockingCount,
+    security_count: securityCount,
+    sync_blocking_count: syncBlockingCount,
+    sync_advisory_count: syncAdvisoryCount,
+    review_complete: reviewComplete,
+    verdict,
+    coverage: { label: "reported-trigger-coverage", skills: coverage },
+    findings,
+    needs_recheck: reasons,
+  };
+}
+
+export function validateReceipt(receipt) {
+  assert(isObject(receipt) && receipt.schema_version === "1", "receipt version is invalid");
+  assert(isObject(receipt.producer), "receipt producer is missing");
+  const producer = receipt.producer;
+  assert(typeof producer.repository === "string" && /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(producer.repository),
+    "receipt repository is invalid");
+  assert(isInteger(producer.pr, 1) && validSha(producer.headSha) && validSha(producer.baseSha),
+    "receipt pull request identity is invalid");
+  assert(typeof producer.runId === "string" && /^\d+$/.test(producer.runId) && isInteger(producer.attempt, 1),
+    "receipt run identity is invalid");
+  assert(validDate(receipt.analysisAt) && receipt.head_sha === producer.headSha, "receipt analysis identity is invalid");
+  for (const key of ["findings_count", "high_count", "blocking_count", "security_count", "sync_blocking_count", "sync_advisory_count"]) {
+    assert(isInteger(receipt[key]), `receipt ${key} is invalid`);
+  }
+  assert(receipt.blocking_count === receipt.security_count + receipt.sync_blocking_count,
+    "receipt blocking counts are inconsistent");
+  assert(typeof receipt.review_complete === "boolean", "receipt review_complete is invalid");
+  assert(["clear", "blocked", "incomplete"].includes(receipt.verdict), "receipt verdict is invalid");
+  const expectedVerdict = receipt.review_complete ? (receipt.blocking_count === 0 ? "clear" : "blocked") : "incomplete";
+  assert(receipt.verdict === expectedVerdict, "receipt verdict is inconsistent");
+  assert(isObject(receipt.coverage) && receipt.coverage.label === "reported-trigger-coverage" &&
+    Array.isArray(receipt.coverage.skills), "receipt coverage is invalid");
+  assert(Array.isArray(receipt.findings) && Array.isArray(receipt.needs_recheck), "receipt findings are invalid");
+  for (const skill of receipt.coverage.skills) {
+    assert(isObject(skill) && [...KNOWN_SKILLS, "unknown"].includes(skill.name) && skill.status === "reported",
+      "receipt coverage skill is invalid");
+    assert(skill.durationMs === undefined || Number.isFinite(skill.durationMs) && skill.durationMs >= 0,
+      "receipt coverage duration is invalid");
+  }
+  for (const finding of receipt.findings) {
+    assert(isObject(finding) && safeFindingId(finding.id), "receipt finding id is invalid");
+    assert([...SEVERITIES, "unknown"].includes(finding.severity), "receipt finding severity is invalid");
+    assert(Array.isArray(finding.skills) && finding.skills.length > 0 &&
+      new Set(finding.skills).size === finding.skills.length &&
+      finding.skills.every((skill) => [...KNOWN_SKILLS, "unknown"].includes(skill)),
+      "receipt finding skills are invalid");
+    assert(["blocker", "advisory", "needs-recheck"].includes(finding.disposition),
+      "receipt finding disposition is invalid");
+    if (finding.location !== undefined) {
+      assert(isObject(finding.location) && typeof finding.location.file === "string" &&
+        isInteger(finding.location.line, 1) && safeLocation({ location: {
+        path: finding.location.file,
+        startLine: finding.location.line,
+      } }, finding.skills.includes("confidentiality-review") ? "confidentiality-review" : "") !== undefined,
+      "receipt finding location is invalid");
+    }
+    const rank = { advisory: 0, "needs-recheck": 1, blocker: 2 };
+    const expectedDisposition = finding.skills.reduce((current, skill) => {
+      const projected = disposition(skill, finding.severity);
+      return rank[projected] > rank[current] ? projected : current;
+    }, "advisory");
+    assert(finding.disposition === expectedDisposition, "receipt finding disposition is inconsistent");
+  }
+  assert(receipt.needs_recheck.every((reason) => typeof reason === "string" &&
+    /^(missing-trigger-results|missing-mandatory-(skill|trigger):(diff-security-review|confidentiality-review)|duplicate-trigger-result|unknown-(skill|trigger-skill|severity|confidence)|trigger-report-(skill-mismatch|mismatch):(diff-security-review|confidentiality-review|spec-provenance-review|desktop-den-sync-review|unknown)|partial-failed-(hunks|extractions):(diff-security-review|confidentiality-review|spec-provenance-review|desktop-den-sync-review|unknown)|skill-error:(diff-security-review|confidentiality-review|spec-provenance-review|desktop-den-sync-review|unknown)|trigger-error:(diff-security-review|confidentiality-review|spec-provenance-review|desktop-den-sync-review|unknown)|summary-count-mismatch|stable-id-conflict|unsafe-finding-id)$/.test(reason)),
+    "receipt recheck reason is invalid");
+  assert(new Set(receipt.needs_recheck).size === receipt.needs_recheck.length,
+    "receipt recheck reasons must be unique");
+  assert(receipt.review_complete === (receipt.needs_recheck.length === 0),
+    "receipt completeness and recheck reasons are inconsistent");
+  const coverageNames = receipt.coverage.skills.map((skill) => skill.name);
+  assert(new Set(coverageNames).size === coverageNames.length, "receipt coverage skills must be unique");
+  if (receipt.review_complete) {
+    assert(MANDATORY_SKILLS.every((skill) => coverageNames.includes(skill)),
+      "complete receipt is missing mandatory coverage");
+    assert(!coverageNames.includes("unknown"), "complete receipt has unknown coverage");
+    assert(receipt.findings.every((finding) => finding.severity !== "unknown" &&
+      !finding.skills.includes("unknown") && finding.disposition !== "needs-recheck"),
+    "complete receipt has an unknown policy projection");
+    assert(receipt.findings_count === 0 || receipt.findings.length > 0,
+      "complete receipt omitted reported findings");
+  }
+  const blockerFindings = receipt.findings.filter((finding) => finding.disposition === "blocker").length;
+  const securityFindings = receipt.findings.filter((finding) =>
+    finding.skills.some((skill) => SECURITY_SKILLS.has(skill))).length;
+  const syncBlockingFindings = receipt.findings.filter((finding) =>
+    finding.skills.includes("desktop-den-sync-review") &&
+    disposition("desktop-den-sync-review", finding.severity) === "blocker").length;
+  const syncAdvisoryFindings = receipt.findings.filter((finding) =>
+    finding.skills.includes("desktop-den-sync-review") &&
+    disposition("desktop-den-sync-review", finding.severity) === "advisory").length;
+  const highFindings = receipt.findings.filter((finding) => finding.severity === "high").length;
+  assert(receipt.findings_count >= receipt.findings.length && receipt.high_count >= highFindings,
+    "receipt finding counts are inconsistent");
+  assert(receipt.security_count >= securityFindings && receipt.sync_blocking_count >= syncBlockingFindings &&
+    receipt.sync_advisory_count >= syncAdvisoryFindings && receipt.blocking_count >= blockerFindings,
+  "receipt policy counts are inconsistent");
+  assert(receipt.security_count <= receipt.findings_count &&
+    receipt.sync_blocking_count + receipt.sync_advisory_count <= receipt.findings_count,
+  "receipt policy counts exceed findings count");
+  assert(blockerFindings === 0 || receipt.verdict !== "clear", "receipt with blockers cannot be clear");
+  return receipt;
+}
+
+function apiUrl(base, path) {
+  return `${base.replace(/\/$/, "")}${path}`;
+}
+
+export async function githubRequest(fetchImpl, url, token, options = {}) {
+  const { timeoutMs = 15_000, ...requestOptions } = options;
+  assert(Number.isFinite(timeoutMs) && timeoutMs > 0, "GitHub request timeout is invalid");
+  const timeoutController = new AbortController();
+  const timeout = setTimeout(() => timeoutController.abort(new Error("GitHub request timed out")), timeoutMs);
+  const signal = requestOptions.signal
+    ? AbortSignal.any([requestOptions.signal, timeoutController.signal])
+    : timeoutController.signal;
+  try {
+    const response = await fetchImpl(url, {
+      ...requestOptions,
+      signal,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...requestOptions.headers,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub ${requestOptions.method ?? "GET"} ${new URL(url).pathname} returned ${response.status}`);
+    }
+    if (response.status === 204) return null;
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function allIssueComments(fetchImpl, apiBase, token, owner, name, pr) {
+  const comments = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await githubRequest(fetchImpl,
+      apiUrl(apiBase, `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${pr}/comments?per_page=100&page=${page}`),
+      token);
+    assert(Array.isArray(batch), "GitHub issue comments response is invalid");
+    comments.push(...batch);
+    if (batch.length < 100) return comments;
+  }
+}
+
+async function wardenThreads(fetchImpl, graphqlUrl, token, owner, name, pr) {
+  const threads = new Map();
+  const cursors = new Set();
+  let after = null;
+  do {
+    const payload = await githubRequest(fetchImpl, graphqlUrl, token, {
+      method: "POST",
+      body: JSON.stringify({
+        query: `query($owner:String!,$name:String!,$pr:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{body author{login __typename}}}}}}}}`,
+        variables: { owner, name, pr, after },
+      }),
+    });
+    assert(isObject(payload), "GitHub GraphQL response is invalid");
+    assert(!payload.errors, "GitHub GraphQL returned errors");
+    const connection = payload.data?.repository?.pullRequest?.reviewThreads;
+    assert(connection && Array.isArray(connection.nodes), "GitHub review thread response is invalid");
+    assert(isObject(connection.pageInfo) && typeof connection.pageInfo.hasNextPage === "boolean" &&
+      (connection.pageInfo.endCursor === null || typeof connection.pageInfo.endCursor === "string"),
+    "GitHub review thread pageInfo is invalid");
+    for (const thread of connection.nodes) {
+      const initial = thread.comments?.nodes?.[0];
+      if (
+        typeof thread.id === "string" && typeof thread.isResolved === "boolean" &&
+        initial?.author?.login === "github-actions" && initial.author.__typename === "Bot" &&
+        typeof initial.body === "string" && initial.body.includes("<!-- warden:finding:v1:")
+      ) {
+        assert(!/[<>\r\n]/.test(thread.id) && !thread.id.includes("--"), "GitHub review thread id is unsafe");
+        threads.set(thread.id, thread.isResolved);
+      }
+    }
+    if (connection.pageInfo.hasNextPage) {
+      const next = connection.pageInfo.endCursor;
+      assert(typeof next === "string" && next.length > 0 && next !== after && !cursors.has(next),
+        "GitHub review thread cursor did not advance");
+      cursors.add(next);
+      after = next;
+    } else {
+      after = null;
+    }
+  } while (after !== null);
+  return [...threads];
+}
+
+function parseState(body) {
+  const start = body.indexOf(STATE_START);
+  if (start === -1) return null;
+  const contentStart = start + STATE_START.length;
+  const end = body.indexOf(STATE_END, contentStart);
+  if (end === -1) throw new Error("trusted Warden summary state is malformed");
+  const state = JSON.parse(body.slice(contentStart, end));
+  assert(isObject(state) && state.version === 1 && isObject(state.latest), "trusted Warden summary state is invalid");
+  assert(Array.isArray(state.history) && Array.isArray(state.threads), "trusted Warden summary history is invalid");
+  assert(/^\d+$/.test(state.latest.runId) && isInteger(state.latest.attempt, 1) &&
+    isInteger(state.latest.runNumber, 1), "trusted Warden summary run identity is invalid");
+  assert(state.history.length <= MAX_OBSERVATIONS && state.history.every((item) =>
+    isObject(item) && /^\d+$/.test(item.runId) && isInteger(item.attempt, 1) &&
+    isInteger(item.runNumber, 1) && validSha(item.headSha) && validDate(item.observedAt) &&
+    ["firstObservedResolved", "firstObservedUnresolved", "resolvedTransitions", "unresolvedTransitions"]
+      .every((key) => isInteger(item[key]))), "trusted Warden summary observation history is invalid");
+  assert(state.threads.length <= MAX_THREAD_SNAPSHOT && state.threads.every((thread) =>
+    Array.isArray(thread) && thread.length === 2 &&
+    typeof thread[0] === "string" && !/[<>\r\n]/.test(thread[0]) && !thread[0].includes("--") &&
+    typeof thread[1] === "boolean"),
+  "trusted Warden summary thread snapshot is invalid");
+  assert(isObject(state.metrics), "trusted Warden summary metrics are invalid");
+  return state;
+}
+
+function compareRun(latest, run) {
+  if (String(latest.runId) === String(run.id)) {
+    if (latest.attempt === run.run_attempt) return "same";
+    return run.run_attempt < latest.attempt ? "older" : "newer";
+  }
+  if (run.run_number !== latest.runNumber) return run.run_number < latest.runNumber ? "older" : "newer";
+  return BigInt(run.id) < BigInt(latest.runId) ? "older" : "newer";
+}
+
+function metricsSnapshot(previous, threads, run, receipt) {
+  const retainedThreads = [...threads]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .slice(0, MAX_THREAD_SNAPSHOT);
+  const previousThreads = new Map(previous?.threads ?? []);
+  let firstObservedResolved = 0;
+  let firstObservedUnresolved = 0;
+  let resolvedTransitions = 0;
+  let unresolvedTransitions = 0;
+  for (const [id, resolved] of retainedThreads) {
+    if (!previousThreads.has(id)) {
+      if (resolved) firstObservedResolved += 1;
+      else firstObservedUnresolved += 1;
+    } else if (previousThreads.get(id) !== resolved) {
+      if (resolved) resolvedTransitions += 1;
+      else unresolvedTransitions += 1;
+    }
+  }
+  const observation = {
+    runId: String(run.id),
+    attempt: run.run_attempt,
+    runNumber: run.run_number,
+    headSha: receipt.producer.headSha,
+    observedAt: new Date().toISOString(),
+    firstObservedResolved,
+    firstObservedUnresolved,
+    resolvedTransitions,
+    unresolvedTransitions,
+  };
+  const unbounded = [...(previous?.history ?? []), observation];
+  const history = unbounded.slice(-MAX_OBSERVATIONS);
+  const truncated = Boolean(previous?.truncated) || unbounded.length > MAX_OBSERVATIONS;
+  const metrics = {
+    uniqueObservedRunAttempts: new Set(history.map((item) => `${item.runId}:${item.attempt}`)).size,
+    distinctHeads: new Set(history.map((item) => item.headSha).filter(Boolean)).size,
+    currentUnresolvedThreads: threads.filter(([, resolved]) => !resolved).length,
+    currentObservedThreads: threads.length,
+    observedTransitions: {
+      resolved: history.reduce((sum, item) => sum + item.resolvedTransitions, 0),
+      unresolved: history.reduce((sum, item) => sum + item.unresolvedTransitions, 0),
+    },
+    firstObserved: {
+      resolved: history.reduce((sum, item) => sum + item.firstObservedResolved, 0),
+      unresolved: history.reduce((sum, item) => sum + item.firstObservedUnresolved, 0),
+    },
+    precision: null,
+    collectionWindow: { retainedRunAttempts: history.length, limit: MAX_OBSERVATIONS, truncated },
+    threadSnapshot: {
+      retained: retainedThreads.length,
+      observed: threads.length,
+      limit: MAX_THREAD_SNAPSHOT,
+      truncated: threads.length > retainedThreads.length,
+    },
+  };
+  return {
+    state: {
+      version: 1,
+      latest: { runId: String(run.id), attempt: run.run_attempt, runNumber: run.run_number },
+      history,
+      threads: retainedThreads,
+      truncated,
+      metrics,
+    },
+    metrics,
+  };
+}
+
+function html(value) {
+  return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function findingLines(receipt, disposition) {
+  const findings = receipt.findings.filter((finding) => finding.disposition === disposition);
+  const shown = findings.slice(0, MAX_ITEMS).map((finding) => {
+    const location = finding.location ? ` · <code>${html(finding.location.file)}:${finding.location.line}</code>` : "";
+    return `- <code>${html(finding.id)}</code> · ${html(finding.severity)} · ${finding.skills.map(html).join(", ")}${location}`;
+  });
+  if (findings.length > shown.length) shown.push(`- ${findings.length - shown.length} more consolidated finding(s) not displayed.`);
+  return shown.length > 0 ? shown.join("\n") : "- None.";
+}
+
+export function renderComment(receipt, metrics, state, runUrl) {
+  const verdict = receipt.verdict[0].toUpperCase() + receipt.verdict.slice(1);
+  const findingCount = receipt.review_complete
+    ? `Native findings: **${receipt.findings_count}**.`
+    : `Native finding records present: **${receipt.findings_count}**; total findings are unknown because review was incomplete.`;
+  const reasons = receipt.needs_recheck.slice(0, MAX_ITEMS).map((reason) => `- <code>${html(reason)}</code>`);
+  if (receipt.needs_recheck.length > reasons.length) {
+    reasons.push(`- ${receipt.needs_recheck.length - reasons.length} more recheck reason(s) not displayed.`);
+  }
+  const coverage = receipt.coverage.skills.map((skill) =>
+    `${html(skill.name)}${skill.durationMs === undefined ? "" : ` (${skill.durationMs} ms)`}`).join(", ") || "none reported";
+  return `${SUMMARY_MARKER}
+## Warden review summary — ${verdict}
+
+${findingCount} Blocking policy matches before consolidation: **${receipt.blocking_count}**. Full finding text remains in Warden's native checks and review threads. This comment retains only native IDs, severity, skill attribution, and safe locations. [Analysis run](${runUrl})
+
+Reported trigger coverage (not proof of complete repository or context coverage): ${coverage}.
+
+### Blockers
+${findingLines(receipt, "blocker")}
+
+### Advisories
+${findingLines(receipt, "advisory")}
+
+### Needs recheck
+${reasons.length > 0 ? reasons.join("\n") : findingLines(receipt, "needs-recheck")}
+
+### Observed review-thread metrics
+- Unique observed run attempts in retained window: **${metrics.uniqueObservedRunAttempts}**
+- Distinct heads in retained window: **${metrics.distinctHeads}**
+- Current unresolved Warden threads: **${metrics.currentUnresolvedThreads}** of **${metrics.currentObservedThreads}** observed
+- Observed resolved/unresolved transitions in retained snapshots: **${metrics.observedTransitions.resolved} / ${metrics.observedTransitions.unresolved}**
+- First observed resolved/unresolved (state at first collection, not event time): **${metrics.firstObserved.resolved} / ${metrics.firstObserved.unresolved}**
+- Precision: **unavailable** (no adjudications; no TP/FP values are inferred)
+- Observation window: **${metrics.collectionWindow.retainedRunAttempts}/${metrics.collectionWindow.limit}** run attempts retained; truncated: **${metrics.collectionWindow.truncated}**
+- Transition snapshot: **${metrics.threadSnapshot.retained}/${metrics.threadSnapshot.observed}** current attributed threads retained (limit ${metrics.threadSnapshot.limit}); truncated: **${metrics.threadSnapshot.truncated}**
+
+Thread states are read-only collection snapshots. These metrics are neither lifetime totals nor exact resolution times, and this summary is not clearance authority.
+
+${STATE_START}${JSON.stringify(state)}${STATE_END}`;
+}
+
+export async function publishReceipt(receiptInput, options = {}) {
+  const receipt = validateReceipt(receiptInput);
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const token = env.GITHUB_TOKEN;
+  assert(token, "GITHUB_TOKEN is required");
+  const apiBase = env.GITHUB_API_URL || "https://api.github.com";
+  const graphqlUrl = env.GITHUB_GRAPHQL_URL || "https://api.github.com/graphql";
+  const serverUrl = (env.GITHUB_SERVER_URL || "https://github.com").replace(/\/$/, "");
+  const [owner, name] = receipt.producer.repository.split("/");
+  const root = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+
+  const expected = options.expectedProducer ?? {
+    repository: env.WARDEN_EXPECTED_REPOSITORY,
+    runId: env.WARDEN_EXPECTED_RUN_ID,
+    attempt: env.WARDEN_EXPECTED_RUN_ATTEMPT === undefined
+      ? undefined
+      : Number(env.WARDEN_EXPECTED_RUN_ATTEMPT),
+    headSha: env.WARDEN_EXPECTED_HEAD_SHA,
+  };
+  const expectedValues = [expected.repository, expected.runId, expected.attempt, expected.headSha];
+  if (expectedValues.some((value) => value !== undefined)) {
+    assert(expectedValues.every((value) => value !== undefined), "trusted producer metadata is incomplete");
+    assert(expected.repository === receipt.producer.repository && expected.runId === receipt.producer.runId &&
+      expected.attempt === receipt.producer.attempt && expected.headSha === receipt.producer.headSha,
+    "receipt producer does not match trusted workflow metadata");
+  }
+
+  const currentPullRequest = (pr) => {
+    assert(isObject(pr) && isInteger(pr.number, 1) && typeof pr.state === "string" &&
+      typeof pr.merged === "boolean" && (pr.merged_at === null || typeof pr.merged_at === "string") &&
+      isObject(pr.head) && validSha(pr.head.sha) && typeof pr.head.ref === "string" &&
+      isObject(pr.head.repo) && typeof pr.head.repo.full_name === "string" &&
+      isObject(pr.base) && validSha(pr.base.sha) && typeof pr.base.ref === "string" &&
+      isObject(pr.base.repo) && typeof pr.base.repo.full_name === "string",
+    "GitHub pull request response is invalid");
+    return pr.number === receipt.producer.pr && pr.state === "open" && !pr.merged && pr.merged_at === null &&
+      pr.head.sha === receipt.producer.headSha && pr.base.sha === receipt.producer.baseSha &&
+      pr.head.repo.full_name === receipt.producer.repository &&
+      pr.base.repo.full_name === receipt.producer.repository;
+  };
+  const responsePath = (value) => {
+    if (typeof value !== "string") return null;
+    try {
+      return new URL(value).pathname;
+    } catch {
+      return null;
+    }
+  };
+  const repositoryMatches = (repository) => isObject(repository) &&
+    (repository.full_name === receipt.producer.repository || responsePath(repository.url) === root);
+
+  const pr = await githubRequest(fetchImpl, apiUrl(apiBase, `${root}/pulls/${receipt.producer.pr}`), token);
+  if (!currentPullRequest(pr)) return { status: "stale", verdict: receipt.verdict, metrics: null };
+  const run = await githubRequest(fetchImpl,
+    apiUrl(apiBase, `${root}/actions/runs/${receipt.producer.runId}`), token);
+  assert(isObject(run) && String(run.id) === receipt.producer.runId &&
+    isInteger(run.run_attempt, 1) && run.run_attempt === receipt.producer.attempt,
+    "producer run identity does not match receipt");
+  assert(run.event === "pull_request" && run.head_sha === receipt.producer.headSha,
+    "producer run is not for the receipt pull request head");
+  assert(repositoryMatches(run.repository) && repositoryMatches(run.head_repository),
+    "producer run repository does not match receipt");
+  assert(run.status === "completed" && run.conclusion === "success", "producer run is not successfully completed");
+  assert(typeof run.path === "string" && run.path.split("@")[0] === ".github/workflows/warden.yml",
+    "producer run did not use the Warden workflow");
+  assert(Array.isArray(run.pull_requests), "producer run pull request associations are invalid");
+  if (run.pull_requests.length > 0) {
+    assert(run.pull_requests.some((item) => isObject(item) && item.number === receipt.producer.pr &&
+      responsePath(item.url) === `${root}/pulls/${receipt.producer.pr}` &&
+      isObject(item.head) && item.head.sha === receipt.producer.headSha && repositoryMatches(item.head.repo) &&
+      isObject(item.base) && item.base.sha === receipt.producer.baseSha && repositoryMatches(item.base.repo)),
+    "producer run is not repository-qualified to the receipt pull request");
+  } else {
+    assert(typeof run.head_branch === "string" && run.head_branch === pr.head.ref,
+      "producer run cannot be attributed to the receipt pull request");
+  }
+  assert(isInteger(run.run_number, 1), "producer run number is invalid");
+
+  const comments = await allIssueComments(fetchImpl, apiBase, token, owner, name, receipt.producer.pr);
+  const trusted = comments
+    .filter((comment) => isInteger(comment.id, 1) &&
+      comment.user?.login === "github-actions[bot]" && comment.user?.type === "Bot" &&
+      typeof comment.body === "string" && comment.body.includes(SUMMARY_MARKER))
+    .sort((left, right) => right.id - left.id)[0];
+  const previous = trusted ? parseState(trusted.body) : null;
+  if (trusted) assert(previous, "trusted Warden summary comment has no state snapshot");
+  if (previous) {
+    const order = compareRun(previous.latest, run);
+    if (order === "older") {
+      return { status: "stale", commentId: trusted.id, verdict: receipt.verdict, metrics: previous.metrics };
+    }
+    if (order === "same") {
+      return { status: "published", commentId: trusted.id, verdict: receipt.verdict, metrics: previous.metrics };
+    }
+  }
+
+  const threads = await wardenThreads(fetchImpl, graphqlUrl, token, owner, name, receipt.producer.pr);
+  const { state, metrics } = metricsSnapshot(previous, threads, run, receipt);
+  const runUrl = `${serverUrl}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/actions/runs/${receipt.producer.runId}`;
+  const body = renderComment(receipt, metrics, state, runUrl);
+  const latestPr = await githubRequest(fetchImpl,
+    apiUrl(apiBase, `${root}/pulls/${receipt.producer.pr}`), token);
+  if (!currentPullRequest(latestPr)) {
+    return { status: "stale", ...(trusted && { commentId: trusted.id }), verdict: receipt.verdict, metrics: null };
+  }
+  let comment;
+  if (trusted) {
+    comment = await githubRequest(fetchImpl, apiUrl(apiBase, `${root}/issues/comments/${trusted.id}`), token, {
+      method: "PATCH",
+      body: JSON.stringify({ body }),
+    });
+  } else {
+    comment = await githubRequest(fetchImpl, apiUrl(apiBase, `${root}/issues/${receipt.producer.pr}/comments`), token, {
+      method: "POST",
+      body: JSON.stringify({ body }),
+    });
+  }
+  assert(isInteger(comment?.id, 1), "GitHub comment write response is invalid");
+  return { status: "published", commentId: comment.id, verdict: receipt.verdict, metrics };
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    assert(key?.startsWith("--") && args[index + 1] !== undefined, `invalid argument ${key ?? ""}`);
+    parsed[key.slice(2)] = args[index + 1];
+  }
+  return parsed;
+}
+
+function help() {
+  return `Usage:
+  node .github/scripts/warden-review.mjs prepare --findings <path> --repository <owner/repo> --pr <N> --head <SHA> --base <SHA> --run-id <digits> --attempt <N> --output <receipt.json>
+  node .github/scripts/warden-review.mjs publish --receipt <receipt.json>`;
+}
+
+async function main(argv) {
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "help") {
+    console.log(help());
+    return;
+  }
+  const [command, ...rest] = argv;
+  const args = parseArgs(rest);
+  if (command === "prepare") {
+    for (const key of ["findings", "repository", "pr", "head", "base", "run-id", "attempt", "output"]) {
+      assert(args[key] !== undefined, `--${key} is required`);
+    }
+    const raw = JSON.parse(await readFile(args.findings, "utf8"));
+    const receipt = prepareReceipt(raw, {
+      repository: args.repository,
+      pr: Number(args.pr),
+      head: args.head,
+      base: args.base,
+      runId: args["run-id"],
+      attempt: Number(args.attempt),
+    });
+    await writeFile(args.output, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+    console.log(JSON.stringify(receipt));
+    return;
+  }
+  if (command === "publish") {
+    assert(args.receipt !== undefined, "--receipt is required");
+    const receipt = JSON.parse(await readFile(args.receipt, "utf8"));
+    console.log(JSON.stringify(await publishReceipt(receipt)));
+    return;
+  }
+  throw new Error(`unknown command: ${command}`);
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`warden-review: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/warden-review.test.mjs
+++ b/.github/scripts/warden-review.test.mjs
@@ -470,6 +470,47 @@ const clearanceWorkflow = readFileSync(
   new URL("../workflows/warden-clearance.yml", import.meta.url),
   "utf8",
 );
+const wardenWorkflow = readFileSync(
+  new URL("../workflows/warden.yml", import.meta.url),
+  "utf8",
+);
+
+test("analysis workflow executes only the immutable base helper", () => {
+  const fetchStep = wardenWorkflow.slice(
+    wardenWorkflow.indexOf("- name: Fetch trusted review helper"),
+    wardenWorkflow.indexOf("- name: Prepare review receipt"),
+  );
+  const prepareStep = wardenWorkflow.slice(
+    wardenWorkflow.indexOf("- name: Prepare review receipt"),
+    wardenWorkflow.indexOf("- name: Report"),
+  );
+  assert.match(wardenWorkflow, /persist-credentials: false/);
+  assert.match(fetchStep, /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.match(fetchStep,
+    /repos\/\$GITHUB_REPOSITORY\/contents\/\.github\/scripts\/warden-review\.mjs\?ref=\$BASE_SHA/);
+  assert.match(fetchStep, /helper="\$RUNNER_TEMP\/warden-review-base\.mjs"/);
+  assert.match(fetchStep, /actual_blob="\$\(git hash-object --no-filters "\$partial"\)"/);
+  assert.match(fetchStep, /WARDEN_OPENAI_API_KEY: ""/);
+  assert.match(prepareStep, /if: steps\.trusted-helper\.outputs\.available == 'true'/);
+  assert.match(prepareStep, /node "\$TRUSTED_HELPER" prepare/);
+  assert.match(prepareStep, /rm -f "\$receipt"/);
+  assert.doesNotMatch(wardenWorkflow, /node \.github\/scripts\/warden-review\.mjs prepare/);
+});
+
+test("analysis workflow bootstrap 404 never falls back or uploads a receipt", () => {
+  const missingBase = wardenWorkflow.slice(
+    wardenWorkflow.indexOf('if [ "$http_status" = "404" ]'),
+    wardenWorkflow.indexOf('if [ "$api_exit" -ne 0 ]'),
+  );
+  const uploadStep = wardenWorkflow.slice(
+    wardenWorkflow.indexOf("- name: Upload sanitized review receipt"),
+  );
+  assert.match(missingBase, /available=false/);
+  assert.match(missingBase, /exit 0/);
+  assert.match(missingBase, /cannot emit a clearance receipt/);
+  assert.doesNotMatch(missingBase, /TRUSTED_HELPER|node|cp |mv /);
+  assert.match(uploadStep, /if: steps\.prepare\.outputs\.completed == 'true'/);
+});
 
 test("clearance workflow isolates the untrusted receipt from the trusted checkout", () => {
   assert.match(clearanceWorkflow,

--- a/.github/scripts/warden-review.test.mjs
+++ b/.github/scripts/warden-review.test.mjs
@@ -1,0 +1,504 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  githubRequest,
+  prepareReceipt,
+  publishReceipt,
+  renderComment,
+  validateReceipt,
+} from "./warden-review.mjs";
+
+const HEAD = "a".repeat(40);
+const BASE = "b".repeat(40);
+const metadata = {
+  repository: "openworklabs/openwork",
+  pr: 42,
+  head: HEAD,
+  base: BASE,
+  runId: "123456",
+  attempt: 2,
+};
+
+function finding(id, severity = "low", confidence = "low", extra = {}) {
+  return {
+    id,
+    severity,
+    confidence,
+    title: "private title",
+    description: "private description",
+    location: { path: "apps/app/src/main.ts", startLine: 12 },
+    ...extra,
+  };
+}
+
+function raw(skills = []) {
+  const all = skills.flatMap((skill) => skill.findings);
+  return {
+    version: "1",
+    timestamp: "2026-09-09T12:00:00.000Z",
+    repository: { owner: "openworklabs", name: "openwork", fullName: "openworklabs/openwork" },
+    event: "pull_request",
+    pullRequest: {
+      number: 42,
+      author: "private-author",
+      title: "private PR title",
+      baseBranch: "dev",
+      headBranch: "private-branch",
+      headSha: HEAD,
+    },
+    runId: "123456",
+    summary: {
+      totalFindings: all.length,
+      findingsBySeverity: {
+        high: all.filter((item) => item.severity === "high").length,
+        medium: all.filter((item) => item.severity === "medium").length,
+        low: all.filter((item) => item.severity === "low").length,
+      },
+      totalSkills: skills.length,
+    },
+    skills,
+    triggerResults: skills.map((report, index) => ({
+      triggerId: `trigger-${index}`,
+      triggerName: `${report.name}-pull-request`,
+      skillName: report.name,
+      status: "success",
+      report: {
+        skill: report.name,
+        summary: report.summary,
+        findings: report.findings,
+        ...(report.durationMs !== undefined && { durationMs: report.durationMs }),
+      },
+    })),
+    findingObservations: [],
+  };
+}
+
+function skill(name, findings = [], extra = {}) {
+  return { name, summary: "private model summary", durationMs: 25, findings, ...extra };
+}
+
+test("sanitizes configuration and model-authored free text", () => {
+  const input = raw([
+    skill("diff-security-review", []),
+    skill("confidentiality-review", [finding("CONF-1", "low")]),
+  ]);
+  const receipt = prepareReceipt(input, metadata);
+  const serialized = JSON.stringify(receipt);
+  for (const secret of ["private-author", "private PR title", "private-branch", "private model summary", "private title", "private description"]) {
+    assert.equal(serialized.includes(secret), false);
+  }
+  assert.equal(receipt.findings[0].location, undefined);
+  assert.equal(receipt.verdict, "blocked");
+});
+
+test("applies blocker and advisory policy across severity and confidence", () => {
+  const receipt = prepareReceipt(raw([
+    skill("diff-security-review", [finding("SEC-LOW", "low", "low")]),
+    skill("confidentiality-review", [finding("CONF-MED", "medium", "high")]),
+    skill("desktop-den-sync-review", [finding("SYNC-HIGH", "high"), finding("SYNC-MED", "medium")]),
+    skill("spec-provenance-review", [finding("PROV-HIGH", "high")]),
+  ]), metadata);
+  assert.equal(receipt.review_complete, true);
+  assert.equal(receipt.blocking_count, 3);
+  assert.equal(receipt.sync_advisory_count, 1);
+  assert.deepEqual(receipt.findings.map((item) => item.disposition), [
+    "blocker", "blocker", "blocker", "advisory", "advisory",
+  ]);
+});
+
+test("marks partial, error, unknown, and inconsistent reports incomplete", () => {
+  const input = raw([
+    skill("diff-security-review", [], { failedHunks: 1 }),
+    skill("unknown-skill", [finding("UNKNOWN", "urgent")]),
+  ]);
+  input.summary.totalFindings = 99;
+  input.triggerResults = [{
+    triggerName: "pull-request",
+    skillName: "diff-security-review",
+    status: "error",
+    error: { message: "private provider failure" },
+  }];
+  const receipt = prepareReceipt(input, metadata);
+  assert.equal(receipt.verdict, "incomplete");
+  assert.equal(receipt.review_complete, false);
+  assert.ok(receipt.needs_recheck.includes("missing-mandatory-skill:confidentiality-review"));
+  assert.ok(receipt.needs_recheck.includes("unknown-severity"));
+  assert.ok(receipt.needs_recheck.includes("summary-count-mismatch"));
+  assert.equal(JSON.stringify(receipt).includes("private provider failure"), false);
+});
+
+test("rejects malformed and trusted-metadata-mismatched input", () => {
+  const input = raw([skill("diff-security-review"), skill("confidentiality-review")]);
+  delete input.summary;
+  assert.throws(() => prepareReceipt(input, metadata), /summary is missing/);
+  const valid = raw([skill("diff-security-review"), skill("confidentiality-review")]);
+  assert.throws(() => prepareReceipt(valid, { ...metadata, pr: 43 }), /PR does not match/);
+});
+
+test("dedupes only a consistent native ID and lets blocking attribution win", () => {
+  const shared = finding("SHARED-1", "high", "high");
+  const receipt = prepareReceipt(raw([
+    skill("diff-security-review", [shared]),
+    skill("confidentiality-review", []),
+    skill("spec-provenance-review", [{ ...shared }]),
+  ]), metadata);
+  assert.equal(receipt.findings.length, 1);
+  assert.deepEqual(receipt.findings[0].skills, ["diff-security-review", "spec-provenance-review"]);
+  assert.equal(receipt.findings[0].disposition, "blocker");
+});
+
+test("keeps conflicting native IDs separate and requires a recheck", () => {
+  const receipt = prepareReceipt(raw([
+    skill("diff-security-review", [finding("CONFLICT", "high")]),
+    skill("confidentiality-review", []),
+    skill("spec-provenance-review", [finding("CONFLICT", "low")]),
+  ]), metadata);
+  assert.equal(receipt.findings.length, 2);
+  assert.equal(receipt.verdict, "incomplete");
+  assert.ok(receipt.needs_recheck.includes("stable-id-conflict"));
+});
+
+test("renders bounded identifiers and honest unavailable precision", () => {
+  const receipt = prepareReceipt(raw([
+    skill("diff-security-review", []),
+    skill("confidentiality-review", []),
+    skill("spec-provenance-review", [finding("PROV-1")]),
+  ]), metadata);
+  const metrics = {
+    uniqueObservedRunAttempts: 1,
+    distinctHeads: 1,
+    currentUnresolvedThreads: 0,
+    currentObservedThreads: 1,
+    observedTransitions: { resolved: 0, unresolved: 0 },
+    firstObserved: { resolved: 1, unresolved: 0 },
+    precision: null,
+    collectionWindow: { retainedRunAttempts: 1, limit: 20, truncated: false },
+    threadSnapshot: { retained: 1, observed: 1, limit: 500, truncated: false },
+  };
+  const body = renderComment(receipt, metrics, { version: 1 }, "https://github.com/openworklabs/openwork/actions/runs/123456");
+  assert.match(body, /Precision: \*\*unavailable\*\*/);
+  assert.match(body, /PROV-1/);
+  assert.equal(body.includes("private title"), false);
+});
+
+test("requires a nonempty reconciled replay roster for mandatory skills", () => {
+  for (const triggerResults of [undefined, []]) {
+    const input = raw([skill("diff-security-review"), skill("confidentiality-review")]);
+    input.triggerResults = triggerResults;
+    const receipt = prepareReceipt(input, metadata);
+    assert.equal(receipt.review_complete, false);
+    assert.equal(receipt.verdict, "incomplete");
+    assert.ok(receipt.needs_recheck.includes("missing-trigger-results"));
+    assert.ok(receipt.needs_recheck.includes("missing-mandatory-trigger:diff-security-review"));
+    assert.ok(receipt.needs_recheck.includes("missing-mandatory-trigger:confidentiality-review"));
+  }
+});
+
+test("rejects contradictory replay reports instead of clearing from empty top-level security", () => {
+  const input = raw([skill("diff-security-review"), skill("confidentiality-review")]);
+  input.triggerResults[0].report.findings = [finding("HIDDEN-BLOCKER", "high")];
+  const receipt = prepareReceipt(input, metadata);
+  assert.equal(receipt.verdict, "incomplete");
+  assert.ok(receipt.needs_recheck.includes("trigger-report-mismatch:diff-security-review"));
+
+  const wrongSkill = raw([skill("diff-security-review"), skill("confidentiality-review")]);
+  wrongSkill.triggerResults[0].report.skill = "confidentiality-review";
+  const wrongSkillReceipt = prepareReceipt(wrongSkill, metadata);
+  assert.equal(wrongSkillReceipt.verdict, "incomplete");
+  assert.ok(wrongSkillReceipt.needs_recheck.includes(
+    "trigger-report-skill-mismatch:diff-security-review",
+  ));
+});
+
+test("accepts multiple native trigger reports for one skill and emits unique coverage", () => {
+  const receipt = prepareReceipt(raw([
+    skill("diff-security-review", [finding("SEC-A", "high")]),
+    skill("diff-security-review", [finding("SEC-B", "low")]),
+    skill("confidentiality-review"),
+    skill("desktop-den-sync-review", [finding("SYNC-A", "medium")]),
+    skill("desktop-den-sync-review", [finding("SYNC-B", "high")]),
+  ]), metadata);
+  assert.equal(receipt.review_complete, true);
+  assert.equal(receipt.findings_count, 4);
+  assert.equal(receipt.security_count, 2);
+  assert.equal(receipt.sync_advisory_count, 1);
+  assert.equal(receipt.sync_blocking_count, 1);
+  assert.deepEqual(receipt.coverage.skills.map((item) => item.name), [
+    "diff-security-review",
+    "confidentiality-review",
+    "desktop-den-sync-review",
+  ]);
+});
+
+test("receipt validation recomputes the minimum policy projection", () => {
+  const receipt = prepareReceipt(raw([
+    skill("diff-security-review", [finding("SEC-BLOCK", "low")]),
+    skill("confidentiality-review"),
+  ]), metadata);
+  const forgedClear = structuredClone(receipt);
+  forgedClear.security_count = 0;
+  forgedClear.blocking_count = 0;
+  forgedClear.verdict = "clear";
+  assert.throws(() => validateReceipt(forgedClear), /policy counts|blockers cannot be clear/);
+
+  const forgedDisposition = structuredClone(receipt);
+  forgedDisposition.findings[0].disposition = "advisory";
+  assert.throws(() => validateReceipt(forgedDisposition), /disposition is inconsistent/);
+
+  const duplicateCoverage = structuredClone(receipt);
+  duplicateCoverage.coverage.skills.push(structuredClone(duplicateCoverage.coverage.skills[0]));
+  assert.throws(() => validateReceipt(duplicateCoverage), /coverage skills must be unique/);
+
+  const emptyAttribution = structuredClone(receipt);
+  emptyAttribution.findings[0].skills = [];
+  assert.throws(() => validateReceipt(emptyAttribution), /finding skills are invalid/);
+
+  const shared = finding("SHARED-POLICY", "medium");
+  assert.doesNotThrow(() => validateReceipt(prepareReceipt(raw([
+    skill("diff-security-review", [shared]),
+    skill("confidentiality-review"),
+    skill("desktop-den-sync-review", [{ ...shared }]),
+  ]), metadata)));
+});
+
+function response(body, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+function clearReceipt() {
+  return prepareReceipt(raw([
+    skill("diff-security-review"),
+    skill("confidentiality-review"),
+  ]), metadata);
+}
+
+function currentPr(head = HEAD) {
+  return {
+    number: 42,
+    state: "open",
+    merged: false,
+    merged_at: null,
+    head: { sha: head, ref: "feature", repo: { full_name: metadata.repository } },
+    base: { sha: BASE, ref: "dev", repo: { full_name: metadata.repository } },
+  };
+}
+
+function producerRun(overrides = {}) {
+  const repo = {
+    full_name: metadata.repository,
+    url: `https://api.github.com/repos/${metadata.repository}`,
+  };
+  return {
+    id: Number(metadata.runId),
+    run_attempt: metadata.attempt,
+    run_number: 7,
+    event: "pull_request",
+    head_sha: HEAD,
+    head_branch: "feature",
+    repository: repo,
+    head_repository: repo,
+    status: "completed",
+    conclusion: "success",
+    path: ".github/workflows/warden.yml",
+    pull_requests: [],
+    ...overrides,
+  };
+}
+
+function githubMock({ prs = [currentPr(), currentPr()], run = producerRun(), comments = [], pages } = {}) {
+  const requests = [];
+  let prRead = 0;
+  let graphRead = 0;
+  const graphPages = pages ?? [{
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+      },
+    },
+  }];
+  const fetchImpl = async (url, options = {}) => {
+    requests.push({ url, options });
+    const path = new URL(url).pathname;
+    if (path.endsWith("/pulls/42") && (options.method ?? "GET") === "GET") {
+      return response(prs[Math.min(prRead++, prs.length - 1)]);
+    }
+    if (path.endsWith(`/actions/runs/${metadata.runId}`)) return response(run);
+    if (path.endsWith("/issues/42/comments") && new URL(url).search) return response(comments);
+    if (path === "/graphql") return response(graphPages[Math.min(graphRead++, graphPages.length - 1)]);
+    if (path.endsWith("/issues/42/comments") && options.method === "POST") return response({ id: 9001 });
+    if (path.includes("/issues/comments/") && options.method === "PATCH") return response({ id: 9002 });
+    throw new Error(`unexpected GitHub request: ${options.method ?? "GET"} ${url}`);
+  };
+  return { fetchImpl, requests };
+}
+
+test("GitHub requests have a bounded timeout", async () => {
+  const never = (_url, options) => new Promise((_resolve, reject) => {
+    options.signal.addEventListener("abort", () => reject(options.signal.reason), { once: true });
+  });
+  await assert.rejects(
+    githubRequest(never, "https://api.github.test/rate_limit", "token", { timeoutMs: 5 }),
+    /timed out|timeout|aborted/i,
+  );
+});
+
+test("publisher attributes only exact bot markers and counts unique thread IDs", async () => {
+  const marker = "<!-- warden:finding:v1:eyJpZCI6IlNFQy0xIiwic2V2ZXJpdHkiOiJsb3cifQ -->";
+  const spoofedSummary = {
+    id: 1,
+    user: { login: "human", type: "User" },
+    body: "<!-- openwork:warden-review-summary:v1 -->",
+  };
+  const nodes = [
+    { id: "human", isResolved: true, comments: { nodes: [{ body: marker, author: { login: "human", __typename: "User" } }] } },
+    { id: "rest-style-login", isResolved: true, comments: { nodes: [{ body: marker, author: { login: "github-actions[bot]", __typename: "Bot" } }] } },
+    { id: "generic", isResolved: true, comments: { nodes: [{ body: "warden:finding", author: { login: "github-actions", __typename: "Bot" } }] } },
+    { id: "thread-1", isResolved: false, comments: { nodes: [{ body: marker, author: { login: "github-actions", __typename: "Bot" } }] } },
+    { id: "thread-1", isResolved: true, comments: { nodes: [{ body: marker, author: { login: "github-actions", __typename: "Bot" } }] } },
+  ];
+  const mock = githubMock({
+    comments: [spoofedSummary],
+    pages: [{ data: { repository: { pullRequest: { reviewThreads: {
+      pageInfo: { hasNextPage: false, endCursor: null }, nodes,
+    } } } } }],
+  });
+  const result = await publishReceipt(clearReceipt(), {
+    env: { GITHUB_TOKEN: "token" },
+    fetchImpl: mock.fetchImpl,
+  });
+  assert.equal(result.status, "published");
+  assert.equal(result.metrics.currentObservedThreads, 1);
+  assert.equal(result.metrics.currentUnresolvedThreads, 0);
+  const write = mock.requests.find((request) => request.options.method === "POST" &&
+    new URL(request.url).pathname.endsWith("/issues/42/comments"));
+  assert.ok(write);
+  assert.match(JSON.parse(write.options.body).body,
+    /First observed resolved\/unresolved \(state at first collection, not event time\): \*\*1 \/ 0\*\*/);
+  assert.equal(mock.requests.some((request) => request.options.method === "PATCH"), false);
+});
+
+test("publisher rechecks current PR identity immediately before writing", async () => {
+  const mock = githubMock({ prs: [currentPr(), currentPr("c".repeat(40))] });
+  const result = await publishReceipt(clearReceipt(), {
+    env: { GITHUB_TOKEN: "token" },
+    fetchImpl: mock.fetchImpl,
+  });
+  assert.deepEqual(result, { status: "stale", verdict: "clear", metrics: null });
+  assert.equal(mock.requests.some((request) => ["POST", "PATCH"].includes(request.options.method) &&
+    new URL(request.url).pathname !== "/graphql"), false);
+
+  for (const stalePr of [
+    { ...currentPr(), state: "closed" },
+    { ...currentPr(), merged: true, merged_at: "2026-09-09T12:00:00Z" },
+  ]) {
+    const closedOrMerged = githubMock({ prs: [stalePr] });
+    const staleResult = await publishReceipt(clearReceipt(), {
+      env: { GITHUB_TOKEN: "token" },
+      fetchImpl: closedOrMerged.fetchImpl,
+    });
+    assert.deepEqual(staleResult, { status: "stale", verdict: "clear", metrics: null });
+    assert.equal(closedOrMerged.requests.length, 1);
+  }
+});
+
+test("publisher rejects malformed GraphQL pagination without mutating a comment", async () => {
+  const missingPageInfo = githubMock({
+    pages: [{ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }],
+  });
+  await assert.rejects(
+    publishReceipt(clearReceipt(), { env: { GITHUB_TOKEN: "token" }, fetchImpl: missingPageInfo.fetchImpl }),
+    /pageInfo is invalid/,
+  );
+  assert.equal(missingPageInfo.requests.some((request) => request.options.method === "PATCH" ||
+    (request.options.method === "POST" && new URL(request.url).pathname !== "/graphql")), false);
+
+  const repeatedCursor = githubMock({ pages: [
+    { data: { repository: { pullRequest: { reviewThreads: {
+      nodes: [], pageInfo: { hasNextPage: true, endCursor: "same" },
+    } } } } },
+    { data: { repository: { pullRequest: { reviewThreads: {
+      nodes: [], pageInfo: { hasNextPage: true, endCursor: "same" },
+    } } } } },
+  ] });
+  await assert.rejects(
+    publishReceipt(clearReceipt(), { env: { GITHUB_TOKEN: "token" }, fetchImpl: repeatedCursor.fetchImpl }),
+    /cursor did not advance/,
+  );
+});
+
+test("publisher binds the receipt to trusted outer workflow metadata before API reads", async () => {
+  const mock = githubMock();
+  await assert.rejects(publishReceipt(clearReceipt(), {
+    env: {
+      GITHUB_TOKEN: "token",
+      WARDEN_EXPECTED_REPOSITORY: metadata.repository,
+      WARDEN_EXPECTED_RUN_ID: "999",
+      WARDEN_EXPECTED_RUN_ATTEMPT: String(metadata.attempt),
+      WARDEN_EXPECTED_HEAD_SHA: HEAD,
+    },
+    fetchImpl: mock.fetchImpl,
+  }), /trusted workflow metadata/);
+  assert.equal(mock.requests.length, 0);
+});
+
+test("publisher rejects non-repository-qualified producer associations", async () => {
+  const foreign = "other/repository";
+  const foreignRepo = { full_name: foreign, url: `https://api.github.com/repos/${foreign}` };
+  const run = producerRun({ pull_requests: [{
+    number: 42,
+    url: `https://api.github.com/repos/${foreign}/pulls/42`,
+    head: { sha: HEAD, repo: foreignRepo },
+    base: { sha: BASE, repo: foreignRepo },
+  }] });
+  const mock = githubMock({ run });
+  await assert.rejects(
+    publishReceipt(clearReceipt(), { env: { GITHUB_TOKEN: "token" }, fetchImpl: mock.fetchImpl }),
+    /repository-qualified/,
+  );
+  assert.equal(mock.requests.some((request) => request.options.method === "PATCH" ||
+    (request.options.method === "POST" && new URL(request.url).pathname !== "/graphql")), false);
+});
+
+const clearanceWorkflow = readFileSync(
+  new URL("../workflows/warden-clearance.yml", import.meta.url),
+  "utf8",
+);
+
+test("clearance workflow isolates the untrusted receipt from the trusted checkout", () => {
+  assert.match(clearanceWorkflow,
+    /path: \$\{\{ runner\.temp \}\}\/warden-summary-artifact/);
+  assert.match(clearanceWorkflow,
+    /RECEIPT_PATH: \$\{\{ runner\.temp \}\}\/warden-summary-artifact\/warden-summary\.json/);
+  assert.match(clearanceWorkflow,
+    /\[ ! -f "\$RECEIPT_PATH" \] \|\| \[ -L "\$RECEIPT_PATH" \]/);
+  assert.match(clearanceWorkflow,
+    /node "\$GITHUB_WORKSPACE\/\.github\/scripts\/warden-review\.mjs" publish --receipt "\$RECEIPT_PATH"/);
+  assert.doesNotMatch(clearanceWorkflow,
+    /node \.github\/scripts\/warden-review\.mjs publish --receipt warden-summary\.json/);
+});
+
+test("clearance workflow fails closed before guard matching and revokes every app approval", () => {
+  const guardStart = clearanceWorkflow.indexOf("changed_files=\"");
+  const guardMatch = clearanceWorkflow.indexOf("guarded=\"");
+  assert.ok(guardStart >= 0 && guardMatch > guardStart);
+  const changedFilesCommand = clearanceWorkflow.slice(guardStart, guardMatch);
+  assert.match(changedFilesCommand,
+    /gh api --paginate "repos\/\$REPO\/pulls\/\$pr\/files\?per_page=100"/);
+  assert.equal(changedFilesCommand.includes("|| true"), false);
+  assert.match(clearanceWorkflow.slice(guardMatch), /<<< "\$changed_files" \|\| true/);
+
+  const revoke = clearanceWorkflow.slice(clearanceWorkflow.indexOf("- name: Revoke stale clearance"));
+  assert.match(revoke,
+    /gh api --paginate "repos\/\$REPO\/pulls\/\$PR\/reviews\?per_page=100"/);
+  assert.match(revoke, /\[ -z "\$APP_SLUG" \]/);
+  assert.match(revoke, /\.user\.login == .*\[bot\].*\.user\.type == .*Bot.*\.state == .*APPROVED/);
+  assert.match(revoke, /while IFS= read -r rid;/);
+  assert.doesNotMatch(revoke, /\| last|\|\| echo "Could not dismiss/);
+});

--- a/.github/workflows/warden-clearance.yml
+++ b/.github/workflows/warden-clearance.yml
@@ -38,10 +38,108 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: warden-clearance
     steps:
+      - name: Validate trusted workflow revision
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          if [[ ! "$WORKFLOW_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "github.workflow_sha is not an immutable commit SHA."
+            exit 1
+          fi
+
+      # workflow_run checks out the immutable revision that contains this
+      # trusted workflow. Receipt parsing and decisions never execute PR code.
+      - name: Checkout trusted reporting helper
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Download review receipt
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: warden-summary
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/warden-summary-artifact
+
+      - name: Verify receipt producer binding
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/warden-summary-artifact
+          RECEIPT_PATH: ${{ runner.temp }}/warden-summary-artifact/warden-summary.json
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
+          EXPECTED_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob dotglob
+          entries=("$ARTIFACT_DIR"/*)
+          if [ ! -d "$ARTIFACT_DIR" ] || [ -L "$ARTIFACT_DIR" ] || \
+             [ ! -f "$RECEIPT_PATH" ] || [ -L "$RECEIPT_PATH" ] || \
+             [ "${#entries[@]}" -ne 1 ] || [ "${entries[0]}" != "$RECEIPT_PATH" ]; then
+            echo "Review receipt artifact layout is invalid."
+            exit 1
+          fi
+          jq -e \
+            --arg repository "$EXPECTED_REPOSITORY" \
+            --arg run "$EXPECTED_RUN_ID" \
+            --argjson attempt "$EXPECTED_RUN_ATTEMPT" \
+            --arg head "$EXPECTED_HEAD_SHA" \
+            '.producer.repository == $repository and
+             .producer.runId == $run and
+             .producer.attempt == $attempt and
+             .producer.headSha == $head and
+             .head_sha == $head' \
+            "$RECEIPT_PATH" >/dev/null
+
+      # The helper validates the current PR head/base and the completed producer
+      # run before its only write: one ordinary github-actions[bot] PR comment.
+      - name: Publish consolidated review summary
+        id: publish
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RECEIPT_PATH: ${{ runner.temp }}/warden-summary-artifact/warden-summary.json
+          PUBLISH_RESULT_PATH: ${{ runner.temp }}/warden-publish-result.json
+          WARDEN_EXPECTED_REPOSITORY: ${{ github.repository }}
+          WARDEN_EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
+          WARDEN_EXPECTED_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          WARDEN_EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          result="$(node "$GITHUB_WORKSPACE/.github/scripts/warden-review.mjs" publish --receipt "$RECEIPT_PATH")"
+          echo "$result"
+          echo "status=$(jq -r '.status' <<< "$result")" >> "$GITHUB_OUTPUT"
+          echo "verdict=$(jq -r '.verdict' <<< "$result")" >> "$GITHUB_OUTPUT"
+          jq -ce \
+            --arg repository "$WARDEN_EXPECTED_REPOSITORY" \
+            --arg run "$WARDEN_EXPECTED_RUN_ID" \
+            --argjson attempt "$WARDEN_EXPECTED_RUN_ATTEMPT" \
+            --arg head "$WARDEN_EXPECTED_HEAD_SHA" \
+            '{schema_version: "1",
+              producer: {repository: $repository, runId: $run, attempt: $attempt, headSha: $head},
+              publication: {
+                status: .status,
+                verdict: .verdict,
+                commentId: (.commentId // null),
+                metrics: (.metrics // null)
+              }}' <<< "$result" > "$PUBLISH_RESULT_PATH"
+
+      - name: Upload bounded publish measurement
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: warden-publish-result-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: ${{ runner.temp }}/warden-publish-result.json
+          retention-days: 90
+
       - name: Check clearance identity is configured
         id: identity
         env:
@@ -54,14 +152,6 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Download clearance summary
-        if: steps.identity.outputs.configured == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: warden-summary
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
-
       - name: Evaluate verdict
         if: steps.identity.outputs.configured == 'true'
         id: verdict
@@ -69,48 +159,71 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RECEIPT_PATH: ${{ runner.temp }}/warden-summary-artifact/warden-summary.json
         run: |
           set -euo pipefail
 
           verdict() { echo "verdict=$1" >> "$GITHUB_OUTPUT"; exit 0; }
 
-          summary_sha="$(jq -r '.head_sha' warden-summary.json)"
-          blocking="$(jq -r '.blocking_count // .findings_count' warden-summary.json)"
-          advisory="$(jq -r '.sync_advisory_count // 0' warden-summary.json)"
+          summary_sha="$(jq -r '.head_sha' "$RECEIPT_PATH")"
+          summary_run="$(jq -r '.producer.runId' "$RECEIPT_PATH")"
+          summary_attempt="$(jq -r '.producer.attempt' "$RECEIPT_PATH")"
+          summary_pr="$(jq -r '.producer.pr' "$RECEIPT_PATH")"
+          summary_base="$(jq -r '.producer.baseSha' "$RECEIPT_PATH")"
+          complete="$(jq -r '.review_complete' "$RECEIPT_PATH")"
+          receipt_verdict="$(jq -r '.verdict' "$RECEIPT_PATH")"
+          blocking="$(jq -r '.blocking_count' "$RECEIPT_PATH")"
+          advisory="$(jq -r '.sync_advisory_count' "$RECEIPT_PATH")"
           echo "advisory=$advisory" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ steps.publish.outputs.status }}" != "published" ]; then
+            echo "Summary publication was stale; skipping clearance."
+            verdict skip
+          fi
 
           if [ "$summary_sha" != "$HEAD_SHA" ]; then
             echo "Summary SHA ($summary_sha) does not match analyzed SHA ($HEAD_SHA); skipping."
             verdict skip
           fi
 
-          pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')"
-          if [ -z "$pr" ]; then
-            echo "No PR associated with $HEAD_SHA; skipping."
+          if [ "$summary_run" != "${{ github.event.workflow_run.id }}" ] || \
+             [ "$summary_attempt" != "${{ github.event.workflow_run.run_attempt }}" ]; then
+            echo "Summary producer does not match this workflow run; skipping."
             verdict skip
           fi
-          echo "pr=$pr" >> "$GITHUB_OUTPUT"
 
-          current_head="$(gh api "repos/$REPO/pulls/$pr" --jq '.head.sha')"
-          if [ "$current_head" != "$HEAD_SHA" ]; then
-            echo "PR #$pr head moved to $current_head; skipping stale run."
+          pr="$summary_pr"
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "base=$summary_base" >> "$GITHUB_OUTPUT"
+
+          current_pr="$(gh api "repos/$REPO/pulls/$pr")"
+          if ! jq -e \
+            --arg repository "$REPO" \
+            --arg head "$HEAD_SHA" \
+            --arg base "$summary_base" \
+            '.state == "open" and .merged == false and .merged_at == null and
+             .head.sha == $head and .base.sha == $base and
+             .head.repo.full_name == $repository and .base.repo.full_name == $repository' \
+            <<< "$current_pr" >/dev/null; then
+            echo "PR #$pr is closed, merged, foreign, or no longer at the analyzed head/base; skipping."
             verdict skip
           fi
 
           # Never self-clear a PR that touches the review machinery.
-          guarded="$(gh api --paginate "repos/$REPO/pulls/$pr/files" --jq '.[].filename' \
-            | grep -E '^(\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
+          changed_files="$(gh api --paginate "repos/$REPO/pulls/$pr/files?per_page=100" --jq '.[].filename')"
+          guarded="$(grep -E '^(\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' \
+            <<< "$changed_files" || true)"
           if [ -n "$guarded" ]; then
             echo "PR #$pr touches review machinery; human review required:"
             echo "$guarded"
             verdict guarded
           fi
 
-          if [ "$blocking" = "0" ]; then
-            echo "No blocking findings for $HEAD_SHA."
+          if [ "$complete" = "true" ] && [ "$receipt_verdict" = "clear" ] && [ "$blocking" = "0" ]; then
+            echo "Complete review with no blocking findings for $HEAD_SHA."
             verdict clear
           else
-            echo "$blocking blocking finding(s) on $HEAD_SHA."
+            echo "Review is blocked or incomplete on $HEAD_SHA ($blocking known blocking finding(s))."
             verdict flagged
           fi
 
@@ -129,10 +242,20 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ steps.verdict.outputs.pr }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASE_SHA: ${{ steps.verdict.outputs.base }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           ADVISORY: ${{ steps.verdict.outputs.advisory }}
         run: |
           set -euo pipefail
+          current_pr="$(gh api "repos/$REPO/pulls/$PR")"
+          jq -e \
+            --arg repository "$REPO" \
+            --arg head "$HEAD_SHA" \
+            --arg base "$BASE_SHA" \
+            '.state == "open" and .merged == false and .merged_at == null and
+             .head.sha == $head and .base.sha == $base and
+             .head.repo.full_name == $repository and .base.repo.full_name == $repository' \
+            <<< "$current_pr" >/dev/null
           BODY="**Warden security clearance: clear.** No blocking findings (security or desktop↔den sync) in this diff (\`$HEAD_SHA\`)."
           if [[ "$ADVISORY" =~ ^[0-9]+$ ]] && [ "$ADVISORY" -gt 0 ]; then
             BODY="$BODY $ADVISORY advisory desktop↔den sync note(s) are listed in Warden check summaries instead of creating new review threads."
@@ -152,12 +275,18 @@ jobs:
           APP_SLUG: ${{ steps.app.outputs.app-slug }}
         run: |
           set -euo pipefail
-          rid="$(gh api "repos/$REPO/pulls/$PR/reviews" \
-            --jq "[.[] | select(.user.login == \"${APP_SLUG}[bot]\" and .state == \"APPROVED\")] | last | .id // empty")"
-          if [ -n "$rid" ]; then
-            gh api -X PUT "repos/$REPO/pulls/$PR/reviews/$rid/dismissals" \
-              -f message="Warden found new blocking findings (security or desktop↔den sync) on the latest diff; clearance revoked." \
-              || echo "Could not dismiss review $rid (may already be dismissed)."
+          if [ -z "$APP_SLUG" ]; then
+            echo "Clearance App slug is unavailable; revocation cannot be scoped safely."
+            exit 1
+          fi
+          review_ids="$(gh api --paginate "repos/$REPO/pulls/$PR/reviews?per_page=100" \
+            --jq ".[] | select(.user.login == \"${APP_SLUG}[bot]\" and .user.type == \"Bot\" and .state == \"APPROVED\") | .id")"
+          if [ -n "$review_ids" ]; then
+            while IFS= read -r rid; do
+              [ -n "$rid" ] || continue
+              gh api -X PUT "repos/$REPO/pulls/$PR/reviews/$rid/dismissals" \
+                -f message="The latest Warden review is blocked or incomplete; clearance revoked."
+            done <<< "$review_ids"
           else
             echo "No active clearance to revoke."
           fi

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -35,30 +35,106 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: Analyze
         id: analyze
         uses: getsentry/warden@8759014a14130cd2b82e59d3fb450a7385721221 # v0
         with:
           mode: analyze
 
+      # Never execute the pull request's copy of this helper: the job has
+      # write-capable permissions and the analyzer needs the model secret.
+      - name: Fetch trusted review helper
+        id: trusted-helper
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+          WARDEN_MODEL: ""
+          WARDEN_OPENAI_API_KEY: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Pull request base SHA is invalid"
+            exit 1
+          fi
+
+          endpoint="repos/$GITHUB_REPOSITORY/contents/.github/scripts/warden-review.mjs?ref=$BASE_SHA"
+          headers="$RUNNER_TEMP/warden-review-base.headers"
+          metadata="$RUNNER_TEMP/warden-review-base.json"
+          partial="$RUNNER_TEMP/warden-review-base.mjs.partial"
+          helper="$RUNNER_TEMP/warden-review-base.mjs"
+
+          set +e
+          gh api --include --silent "$endpoint" > "$headers"
+          api_exit=$?
+          set -e
+          http_status="$(awk 'NR == 1 { print $2 }' "$headers")"
+          if [ "$http_status" = "404" ]; then
+            echo "::warning::The immutable PR base does not contain the review helper. Native Warden reporting will continue, but this bootstrap run cannot emit a clearance receipt and requires independent review."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$api_exit" -ne 0 ] || [ "$http_status" != "200" ]; then
+            echo "::error::Could not verify the trusted review helper (HTTP ${http_status:-unknown}, gh exit $api_exit)"
+            exit 1
+          fi
+
+          gh api "$endpoint" > "$metadata"
+          if ! jq -e --arg path ".github/scripts/warden-review.mjs" \
+            '.type == "file" and .path == $path and (.sha | strings | test("^[0-9a-f]{40}$"))' \
+            "$metadata" > /dev/null; then
+            echo "::error::Trusted review helper metadata is invalid"
+            exit 1
+          fi
+          expected_blob="$(jq -r '.sha' "$metadata")"
+          gh api -H "Accept: application/vnd.github.raw+json" "$endpoint" > "$partial"
+          if [ ! -s "$partial" ] || [ -L "$partial" ]; then
+            echo "::error::Trusted review helper download is not a regular non-empty file"
+            exit 1
+          fi
+          actual_blob="$(git hash-object --no-filters "$partial")"
+          if [ "$actual_blob" != "$expected_blob" ]; then
+            echo "::error::Trusted review helper failed blob integrity verification"
+            exit 1
+          fi
+          mv "$partial" "$helper"
+          chmod 0444 "$helper"
+          echo "path=$helper" >> "$GITHUB_OUTPUT"
+          echo "available=true" >> "$GITHUB_OUTPUT"
+
       # Report mode overwrites the analyzer output and omits partial-analysis
       # metadata, so prepare the fail-closed, redacted receipt first.
       - name: Prepare review receipt
+        id: prepare
+        if: steps.trusted-helper.outputs.available == 'true'
         env:
           FINDINGS_FILE: ${{ steps.analyze.outputs.findings-file }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: >-
-          node .github/scripts/warden-review.mjs prepare
-          --findings "$FINDINGS_FILE"
-          --repository "$GITHUB_REPOSITORY"
-          --pr "$PR_NUMBER"
-          --head "$HEAD_SHA"
-          --base "$BASE_SHA"
-          --run-id "$GITHUB_RUN_ID"
-          --attempt "$GITHUB_RUN_ATTEMPT"
-          --output warden-summary.json
+          TRUSTED_HELPER: ${{ steps.trusted-helper.outputs.path }}
+          WARDEN_OPENAI_API_KEY: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          receipt="$GITHUB_WORKSPACE/warden-summary.json"
+          rm -f "$receipt"
+          node "$TRUSTED_HELPER" prepare \
+            --findings "$FINDINGS_FILE" \
+            --repository "$GITHUB_REPOSITORY" \
+            --pr "$PR_NUMBER" \
+            --head "$HEAD_SHA" \
+            --base "$BASE_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --attempt "$GITHUB_RUN_ATTEMPT" \
+            --output "$receipt"
+          if [ ! -s "$receipt" ] || [ -L "$receipt" ]; then
+            echo "::error::Trusted review helper did not create a regular non-empty receipt"
+            exit 1
+          fi
+          echo "completed=true" >> "$GITHUB_OUTPUT"
 
       - name: Report
         uses: getsentry/warden@8759014a14130cd2b82e59d3fb450a7385721221 # v0
@@ -67,6 +143,7 @@ jobs:
           findings-file: ${{ steps.analyze.outputs.findings-file }}
 
       - name: Upload sanitized review receipt
+        if: steps.prepare.outputs.completed == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: warden-summary

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -41,66 +41,34 @@ jobs:
         with:
           mode: analyze
 
+      # Report mode overwrites the analyzer output and omits partial-analysis
+      # metadata, so prepare the fail-closed, redacted receipt first.
+      - name: Prepare review receipt
+        env:
+          FINDINGS_FILE: ${{ steps.analyze.outputs.findings-file }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          node .github/scripts/warden-review.mjs prepare
+          --findings "$FINDINGS_FILE"
+          --repository "$GITHUB_REPOSITORY"
+          --pr "$PR_NUMBER"
+          --head "$HEAD_SHA"
+          --base "$BASE_SHA"
+          --run-id "$GITHUB_RUN_ID"
+          --attempt "$GITHUB_RUN_ATTEMPT"
+          --output warden-summary.json
+
       - name: Report
         uses: getsentry/warden@8759014a14130cd2b82e59d3fb450a7385721221 # v0
         with:
           mode: report
           findings-file: ${{ steps.analyze.outputs.findings-file }}
 
-      # Consumed by warden-clearance.yml (workflow_run). security_count also
-      # includes confidentiality-review findings (all blocking). blocking_count excludes
-      # advisory desktop↔den sync findings so they notify without withholding
-      # clearance. The clearance workflow refuses to act on PRs that touch review
-      # machinery, so this artifact cannot be forged without tripping that guard.
-      - name: Write clearance summary
-        env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          FINDINGS_COUNT: ${{ steps.analyze.outputs.findings-count }}
-          HIGH_COUNT: ${{ steps.analyze.outputs.high-count }}
-          FINDINGS_FILE: ${{ steps.analyze.outputs.findings-file }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "$FINDINGS_FILE" ] && [ -f "$FINDINGS_FILE" ] && counts="$(jq -ce '
-            {
-              security_count: ([.skills[] | select(.name == "diff-security-review" or .name == "confidentiality-review") | .findings | length] | add // 0),
-              sync_blocking_count: ([.skills[] | select(.name == "desktop-den-sync-review") | .findings[] | select(.severity != "medium" and .severity != "low")] | length),
-              sync_advisory_count: ([.skills[] | select(.name == "desktop-den-sync-review") | .findings[] | select(.severity == "medium" or .severity == "low")] | length)
-            }
-          ' "$FINDINGS_FILE" 2>/dev/null)"; then
-            security_count="$(jq -r '.security_count' <<< "$counts")"
-            sync_blocking_count="$(jq -r '.sync_blocking_count' <<< "$counts")"
-            sync_advisory_count="$(jq -r '.sync_advisory_count' <<< "$counts")"
-            blocking_count="$((security_count + sync_blocking_count))"
-          else
-            security_count="$FINDINGS_COUNT"
-            sync_blocking_count=0
-            sync_advisory_count=0
-            blocking_count="$FINDINGS_COUNT"
-          fi
-
-          jq -n \
-            --arg sha "$HEAD_SHA" \
-            --arg count "$FINDINGS_COUNT" \
-            --arg high "$HIGH_COUNT" \
-            --arg blocking "$blocking_count" \
-            --arg security "$security_count" \
-            --arg sync_blocking "$sync_blocking_count" \
-            --arg sync_advisory "$sync_advisory_count" \
-            '{
-              head_sha: $sha,
-              findings_count: ($count | tonumber),
-              high_count: ($high | tonumber),
-              blocking_count: ($blocking | tonumber),
-              security_count: ($security | tonumber),
-              sync_blocking_count: ($sync_blocking | tonumber),
-              sync_advisory_count: ($sync_advisory | tonumber)
-            }' \
-            > warden-summary.json
-          cat warden-summary.json
-
-      - name: Upload clearance summary
+      - name: Upload sanitized review receipt
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: warden-summary
           path: warden-summary.json
+          retention-days: 90

--- a/.warden/reporting.md
+++ b/.warden/reporting.md
@@ -1,0 +1,166 @@
+# Warden review reporting
+
+OpenWork uses Warden's existing GitHub Actions identity and native checks. The
+reporting helper adds one consolidated ordinary pull-request comment and one
+sanitized analysis receipt plus one bounded publish-measurement artifact; it
+does not add a bot, service, cache, approval
+source, review-thread mutation, or immutable event ledger.
+
+## Data flow and authority
+
+1. `.github/workflows/warden.yml` runs pinned Warden `0.43.0` analyze mode.
+2. Before Warden report mode overwrites the analyze output, `prepare` validates
+   the analyzer document against trusted workflow metadata and writes
+   `warden-summary.json`. A non-empty replay roster is required, both mandatory
+   security triggers must have successful reports, and replay reports must
+   reconcile one-for-one with the native top-level reports. Multiple successful
+   triggers may report the same skill; receipt coverage names remain unique.
+   Partial-analysis fields are read from this pre-report output. Missing or
+   contradictory reports are unknown/incomplete, never inferred as zero.
+3. `warden-clearance.yml` checks out the immutable `github.workflow_sha`,
+   downloads the receipt into a dedicated `RUNNER_TEMP` directory outside the
+   trusted checkout, rejects anything except one regular, non-symlink
+   `warden-summary.json`, binds it to the outer workflow-run repository, ID,
+   attempt, and head, and then calls the helper by its trusted checkout path.
+   Publication validates the open, unmerged current PR head/base and completed
+   producer run before writing one ordinary `github-actions[bot]` issue comment,
+   and repeats the PR check immediately before that write.
+4. The receipt and comment are display data, not approval authority. The
+   clearance workflow separately preserves the same-repository, current-head,
+   and review-machinery guards. The GitHub App can approve only when
+   `review_complete` is true, `verdict` is `clear`, and the recomputed blocking
+   count is zero. Missing receipts, partial analysis, publication failure, and
+   unknown data cannot grant clearance. Review-machinery file enumeration must
+   complete before path matching; an API failure stops approval. A blocked or
+   incomplete run dismisses every still-active approval authored by the
+   dedicated App Bot, never a human review, and dismissal failure is fatal.
+
+Security and confidentiality findings block at every severity and confidence.
+Desktop↔Den sync findings block unless their severity is `medium` or `low`.
+Provenance findings are advisory. Optional path-scoped skills are reported only
+when Warden emitted them; their absence is not presented as completed coverage.
+
+## Sanitized receipt
+
+The artifact preserves the legacy `head_sha`, `findings_count`, `high_count`,
+`blocking_count`, `security_count`, `sync_blocking_count`, and
+`sync_advisory_count` fields. It adds bound producer metadata,
+`review_complete`, `verdict`, reported-trigger coverage, safe finding IDs and
+attribution, and machine-safe recheck reason codes. PR titles, authors, branch
+names, finding titles/descriptions/hunks, model summaries, and error messages
+are excluded. Confidentiality locations are always omitted. IDs are copied from
+the current native report; advisory ID stability across runs is not promised.
+
+Example non-empty shape:
+
+```json
+{
+  "schema_version": "1",
+  "producer": {
+    "repository": "openworklabs/openwork",
+    "pr": 42,
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "baseSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "runId": "123456",
+    "attempt": 1
+  },
+  "analysisAt": "2026-09-09T12:00:00.000Z",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "findings_count": 2,
+  "high_count": 1,
+  "blocking_count": 1,
+  "security_count": 1,
+  "sync_blocking_count": 0,
+  "sync_advisory_count": 1,
+  "review_complete": true,
+  "verdict": "blocked",
+  "coverage": {
+    "label": "reported-trigger-coverage",
+    "skills": [
+      { "name": "diff-security-review", "status": "reported", "durationMs": 1200 },
+      { "name": "confidentiality-review", "status": "reported", "durationMs": 900 },
+      { "name": "desktop-den-sync-review", "status": "reported", "durationMs": 800 }
+    ]
+  },
+  "findings": [
+    { "id": "SEC-1", "severity": "high", "skills": ["diff-security-review"], "disposition": "blocker" },
+    { "id": "SYNC-1", "severity": "medium", "skills": ["desktop-den-sync-review"], "disposition": "advisory" }
+  ],
+  "needs_recheck": []
+}
+```
+
+The analyzer contract is pinned to these Warden sources:
+
+- [`output.ts`](https://github.com/getsentry/warden/blob/8759014a14130cd2b82e59d3fb450a7385721221/packages/warden/src/action/reporting/output.ts)
+- [`types/index.ts`](https://github.com/getsentry/warden/blob/8759014a14130cd2b82e59d3fb450a7385721221/packages/warden/src/types/index.ts)
+- [`outcomes.ts`](https://github.com/getsentry/warden/blob/8759014a14130cd2b82e59d3fb450a7385721221/packages/warden/src/action/reporting/outcomes.ts)
+- [`pr-workflow.ts`](https://github.com/getsentry/warden/blob/8759014a14130cd2b82e59d3fb450a7385721221/packages/warden/src/action/workflow/pr-workflow.ts)
+- [`dedup.ts`](https://github.com/getsentry/warden/blob/8759014a14130cd2b82e59d3fb450a7385721221/packages/warden/src/output/dedup.ts)
+
+## Publish reads and write
+
+`publish` uses `GITHUB_TOKEN`, `GITHUB_API_URL` (default
+`https://api.github.com`), and `GITHUB_GRAPHQL_URL` (default
+`https://api.github.com/graphql`). The trusted parent additionally sets the
+all-or-none `WARDEN_EXPECTED_REPOSITORY`, `WARDEN_EXPECTED_RUN_ID`,
+`WARDEN_EXPECTED_RUN_ATTEMPT`, and `WARDEN_EXPECTED_HEAD_SHA` binding. The
+standalone `publish --receipt` interface remains valid without those optional
+values and still requires the same GitHub API identity checks. Its REST
+endpoints are:
+
+- `GET /repos/{owner}/{repo}/pulls/{pr}`
+- `GET /repos/{owner}/{repo}/actions/runs/{runId}`
+- paginated `GET /repos/{owner}/{repo}/issues/{pr}/comments`
+- one `POST /repos/{owner}/{repo}/issues/{pr}/comments` or
+  `PATCH /repos/{owner}/{repo}/issues/comments/{commentId}`
+
+GraphQL reads every `reviewThreads` page and only each thread's initial comment.
+A thread is attributed to Warden only when that initial comment has the exact
+`<!-- warden:finding:v1:` marker prefix and its actual author is the
+`github-actions` GraphQL Bot. GitHub's REST issue-comment identity remains
+`github-actions[bot]`; the two API identity spellings are deliberately not
+interchangeable.
+Bodies are never retained in receipt, metrics, or hidden comment state.
+Existing review threads are not migrated, resolved, dismissed, or otherwise
+mutated by the publisher.
+
+Every GitHub request has a 15-second timeout. GraphQL pagination requires a
+well-formed `pageInfo` and a non-empty advancing cursor while another page is
+advertised. Duplicate thread IDs count once. A producer run with associations
+must carry a repository-qualified association for the receipt PR, head, and
+base. Because GitHub can return an empty association list for historical runs,
+that case is accepted only when the run repository/head and its head branch all
+match the directly fetched, same-repository PR. There is no arbitrary commit-to-
+first-PR fallback.
+
+## Metric limits
+
+Metrics describe a bounded sequence of collection snapshots stored in the one
+trusted summary comment. The current implementation retains at most 20 unique
+observed run attempts and at most 500 attributed thread states for transition
+comparison, and says when either window has truncated. It reports
+distinct heads in that window, current unresolved attributed threads, and
+resolved/unresolved state changes observed between snapshots. A thread already
+resolved at its first collection is labelled **first observed resolved**, not a
+resolution event or time. A missing receipt or cancelled analysis produces no
+replacement observation; its findings and thread metrics are unknown, never
+recorded as zero. The clearance workflow runs only for successful Warden runs,
+so failed or cancelled producer runs (and successful runs with missing
+artifacts or failed publication) have no publish-measurement artifact rather
+than a zero-valued row.
+REST or GraphQL failures stop publication and therefore cannot publish a false
+clear or empty observation count.
+
+Precision is `null`/unavailable because no human adjudication labels establish
+true or false positives. The metrics are not lifetime totals, exact event
+times, evidence of who resolved a thread, proof of full analysis context, or an
+immutable ledger.
+
+The sanitized `warden-summary` analysis receipt and separate
+`warden-publish-result-{runId}-{attempt}` publication result use GitHub artifact
+storage with an explicit 90-day retention period. The publication artifact
+contains only bound producer identity, publication status/verdict/comment ID,
+and the same bounded metrics rendered in the mutable comment. It is retained
+measurement evidence, not an infinite or immutable all-runs ledger and not
+clearance authority.

--- a/.warden/reporting.md
+++ b/.warden/reporting.md
@@ -9,15 +9,22 @@ source, review-thread mutation, or immutable event ledger.
 ## Data flow and authority
 
 1. `.github/workflows/warden.yml` runs pinned Warden `0.43.0` analyze mode.
-2. Before Warden report mode overwrites the analyze output, `prepare` validates
-   the analyzer document against trusted workflow metadata and writes
-   `warden-summary.json`. A non-empty replay roster is required, both mandatory
-   security triggers must have successful reports, and replay reports must
-   reconcile one-for-one with the native top-level reports. Multiple successful
-   triggers may report the same skill; receipt coverage names remain unique.
+2. Before Warden report mode overwrites the analyze output, the workflow fetches
+   `warden-review.mjs` from the immutable pull-request base SHA through GitHub's
+   authenticated Contents API. It validates the SHA syntax, requires regular
+   file metadata, verifies the downloaded bytes against GitHub's blob SHA, and
+   runs only that read-only `RUNNER_TEMP` copy. Checkout credentials are not
+   persisted, and the fetch and `prepare` steps do not receive the model API
+   key. The pull request's checked-out helper is never executed.
+3. `prepare` validates the analyzer document against trusted workflow metadata
+   and writes `warden-summary.json` only after removing any checked-out file at
+   that path. A non-empty replay roster is required, both mandatory security
+   triggers must have successful reports, and replay reports must reconcile
+   one-for-one with the native top-level reports. Multiple successful triggers
+   may report the same skill; receipt coverage names remain unique.
    Partial-analysis fields are read from this pre-report output. Missing or
    contradictory reports are unknown/incomplete, never inferred as zero.
-3. `warden-clearance.yml` checks out the immutable `github.workflow_sha`,
+4. `warden-clearance.yml` checks out the immutable `github.workflow_sha`,
    downloads the receipt into a dedicated `RUNNER_TEMP` directory outside the
    trusted checkout, rejects anything except one regular, non-symlink
    `warden-summary.json`, binds it to the outer workflow-run repository, ID,
@@ -25,7 +32,7 @@ source, review-thread mutation, or immutable event ledger.
    Publication validates the open, unmerged current PR head/base and completed
    producer run before writing one ordinary `github-actions[bot]` issue comment,
    and repeats the PR check immediately before that write.
-4. The receipt and comment are display data, not approval authority. The
+5. The receipt and comment are display data, not approval authority. The
    clearance workflow separately preserves the same-repository, current-head,
    and review-machinery guards. The GitHub App can approve only when
    `review_complete` is true, `verdict` is `clear`, and the recomputed blocking
@@ -39,6 +46,22 @@ Security and confidentiality findings block at every severity and confidence.
 Desktop↔Den sync findings block unless their severity is `medium` or `low`.
 Provenance findings are advisory. Optional path-scoped skills are reported only
 when Warden emitted them; their absence is not presented as completed coverage.
+
+## Trusted-helper bootstrap
+
+The first pull request that introduces the helper can have a base SHA where the
+known path does not exist. Only an exact GitHub API `404` is treated as this
+bootstrap case: native Warden report mode still runs, but `prepare` is skipped
+and no `warden-summary` artifact is uploaded. The existing clearance consumer
+may therefore fail because its expected artifact is absent; that is an honest
+incomplete result and requires independent review, not a fallback to pull-
+request-controlled code. Every non-404 fetch failure, malformed response, or
+blob-integrity mismatch fails closed.
+
+After the helper lands on the protected base branch, rerun or synchronize a
+subsequent pull request against that base. Hosted proof still must show that the
+trusted-base helper produced the receipt and that the normal clearance flow
+consumed it; the bootstrap run alone cannot provide that deployment proof.
 
 ## Sanitized receipt
 

--- a/evals/packages/labs/src/mock-github.ts
+++ b/evals/packages/labs/src/mock-github.ts
@@ -46,6 +46,68 @@ export interface StartMockGithubOptions {
   port?: number;
 }
 
+export interface MockWardenGithubComment {
+  id: number;
+  body: string;
+  user: { login: string; type: "Bot" | "User" };
+}
+
+export interface MockWardenGithubThread {
+  id: string;
+  isResolved: boolean;
+  body: string;
+  author: { login: string; type: "Bot" | "User" };
+}
+
+export interface MockWardenGithubRun {
+  id: string;
+  runNumber: number;
+  attempt: number;
+  headSha: string;
+  headBranch?: string;
+  repository?: string;
+  status?: string;
+  conclusion?: string;
+  workflowPath?: string;
+  pullRequest?: number;
+}
+
+export interface MockWardenGithubRequest {
+  method: string;
+  path: string;
+  url: string;
+  authorization: string | null;
+  body: string;
+}
+
+export interface StartMockWardenGithubOptions {
+  token: string;
+  repository: string;
+  pullRequest: number;
+  headSha: string;
+  baseSha: string;
+  headBranch: string;
+  baseBranch: string;
+  comments?: MockWardenGithubComment[];
+  threads?: MockWardenGithubThread[];
+  port?: number;
+}
+
+export interface MockWardenGithubHandle {
+  apiUrl: string;
+  graphqlUrl: string;
+  seedRun(run: MockWardenGithubRun): void;
+  seedComments(comments: MockWardenGithubComment[]): void;
+  seedThreads(threads: MockWardenGithubThread[]): void;
+  setPullHead(headSha: string): void;
+  changeHeadAfterGraphql(headSha: string): void;
+  setGraphqlErrors(enabled: boolean): void;
+  comments(): MockWardenGithubComment[];
+  requests(): MockWardenGithubRequest[];
+  stop(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
 interface RepositorySnapshot {
   headSha: string;
   treeSha: string;
@@ -96,6 +158,20 @@ function authorizationHeader(request: IncomingMessage): string | null {
   if (typeof value === "string") return value;
   if (Array.isArray(value)) return value[0] ?? null;
   return null;
+}
+
+function requestBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolveBody, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => { body += chunk; });
+    request.on("end", () => resolveBody(body));
+    request.on("error", reject);
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function contentDigest(files: Record<string, string>): string {
@@ -388,6 +464,281 @@ export async function startMockGithub(options: StartMockGithubOptions): Promise<
     },
     async requests() {
       return requests.map((request) => ({ ...request }));
+    },
+    stop,
+    [Symbol.asyncDispose]: stop,
+  };
+}
+
+/**
+ * A repository-scoped GitHub HTTP witness for the production Warden reporter.
+ * It intentionally implements only pull/run reads, issue-comment writes, and
+ * the read-only reviewThreads query. Review decisions and thread mutations
+ * have no successful route.
+ */
+export async function startMockWardenGithub(
+  options: StartMockWardenGithubOptions,
+): Promise<MockWardenGithubHandle> {
+  const [owner, name, extra] = options.repository.split("/");
+  if (!owner || !name || extra) throw new Error("Mock Warden repository must be owner/name.");
+
+  const recorded: MockWardenGithubRequest[] = [];
+  const runs = new Map<string, MockWardenGithubRun>();
+  let comments = (options.comments ?? []).map((comment) => ({
+    ...comment,
+    user: { ...comment.user },
+  }));
+  let threads = (options.threads ?? []).map((thread) => ({
+    ...thread,
+    author: { ...thread.author },
+  }));
+  let nextCommentId = Math.max(0, ...comments.map((comment) => comment.id)) + 1;
+  let pullHeadSha = options.headSha;
+  let headAfterGraphql: string | null = null;
+  let graphqlErrors = false;
+  let apiUrl = "http://127.0.0.1";
+  const repositoryId = 9001;
+  const root = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+
+  const handleRequest = async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
+    try {
+      const url = new URL(request.url ?? "/", apiUrl);
+      const method = requestMethod(request);
+      const body = await requestBody(request);
+      recorded.push({
+        method,
+        path: url.pathname,
+        url: `${url.pathname}${url.search}`,
+        authorization: authorizationHeader(request),
+        body,
+      });
+
+      if (authorizationHeader(request) !== `Bearer ${options.token}`) {
+        sendJson(response, 401, { message: "bad credentials" });
+        return;
+      }
+
+      if (method === "POST" && url.pathname === "/graphql") {
+        const payload: unknown = JSON.parse(body);
+        if (!isObject(payload) || typeof payload.query !== "string" || !isObject(payload.variables)) {
+          sendJson(response, 400, { message: "invalid GraphQL request" });
+          return;
+        }
+        if (/\bmutation\b/.test(payload.query)) {
+          sendJson(response, 405, { message: "review mutations are not implemented" });
+          return;
+        }
+        if (
+          payload.variables.owner !== owner || payload.variables.name !== name ||
+          payload.variables.pr !== options.pullRequest
+        ) {
+          sendJson(response, 404, { message: "not found" });
+          return;
+        }
+        if (graphqlErrors) {
+          sendJson(response, 200, { errors: [{ message: "fixture GraphQL failure" }] });
+          return;
+        }
+        const after = payload.variables.after;
+        if (after !== null && typeof after !== "string") {
+          sendJson(response, 400, { message: "invalid GraphQL cursor" });
+          return;
+        }
+        let start = 0;
+        if (typeof after === "string") {
+          const match = /^warden-thread-cursor-(\d+)$/.exec(after);
+          if (!match?.[1]) {
+            sendJson(response, 400, { message: "invalid GraphQL cursor" });
+            return;
+          }
+          start = Number(match[1]);
+        }
+        const pageSize = 100;
+        const page = threads.slice(start, start + pageSize);
+        const nextStart = start + page.length;
+        const hasNextPage = nextStart < threads.length;
+        sendJson(response, 200, {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: {
+                    hasNextPage,
+                    endCursor: hasNextPage ? `warden-thread-cursor-${nextStart}` : null,
+                  },
+                  nodes: page.map((thread) => ({
+                    id: thread.id,
+                    isResolved: thread.isResolved,
+                    comments: {
+                      nodes: [{
+                        body: thread.body,
+                        author: {
+                          login: thread.author.login,
+                          __typename: thread.author.type,
+                        },
+                      }],
+                    },
+                  })),
+                },
+              },
+            },
+          },
+        });
+        if (headAfterGraphql !== null) {
+          pullHeadSha = headAfterGraphql;
+          headAfterGraphql = null;
+        }
+        return;
+      }
+
+      if (!url.pathname.startsWith(`${root}/`)) {
+        sendJson(response, 404, { message: "not found" });
+        return;
+      }
+
+      if (method === "GET" && url.pathname === `${root}/pulls/${options.pullRequest}`) {
+        sendJson(response, 200, {
+          number: options.pullRequest,
+          state: "open",
+          merged: false,
+          merged_at: null,
+          head: {
+            sha: pullHeadSha,
+            ref: options.headBranch,
+            repo: { id: repositoryId, full_name: options.repository },
+          },
+          base: {
+            sha: options.baseSha,
+            ref: options.baseBranch,
+            repo: { id: repositoryId, full_name: options.repository },
+          },
+        });
+        return;
+      }
+
+      const runPrefix = `${root}/actions/runs/`;
+      if (method === "GET" && url.pathname.startsWith(runPrefix)) {
+        const runId = decodeURIComponent(url.pathname.slice(runPrefix.length));
+        const run = runs.get(runId);
+        if (!run) {
+          sendJson(response, 404, { message: "not found" });
+          return;
+        }
+        const runRepository = run.repository ?? options.repository;
+        sendJson(response, 200, {
+          id: Number(run.id),
+          run_number: run.runNumber,
+          run_attempt: run.attempt,
+          event: "pull_request",
+          head_sha: run.headSha,
+          head_branch: run.headBranch ?? options.headBranch,
+          head_repository: { full_name: runRepository },
+          repository: { full_name: options.repository },
+          status: run.status ?? "completed",
+          conclusion: run.conclusion ?? "success",
+          path: run.workflowPath ?? ".github/workflows/warden.yml",
+          pull_requests: [{
+            number: run.pullRequest ?? options.pullRequest,
+            url: `https://api.github.com/repos/${owner}/${name}/pulls/${run.pullRequest ?? options.pullRequest}`,
+            head: { sha: run.headSha, repo: { id: repositoryId, full_name: runRepository } },
+            base: { sha: options.baseSha, repo: { full_name: options.repository } },
+          }],
+        });
+        return;
+      }
+
+      if (method === "GET" && url.pathname === `${root}/issues/${options.pullRequest}/comments`) {
+        const perPage = positiveInteger(url.searchParams.get("per_page"), 30);
+        const page = positiveInteger(url.searchParams.get("page"), 1);
+        const start = (page - 1) * perPage;
+        sendJson(response, 200, comments.slice(start, start + perPage));
+        return;
+      }
+
+      if (method === "POST" && url.pathname === `${root}/issues/${options.pullRequest}/comments`) {
+        const payload: unknown = JSON.parse(body);
+        if (!isObject(payload) || typeof payload.body !== "string") {
+          sendJson(response, 422, { message: "body is required" });
+          return;
+        }
+        const comment: MockWardenGithubComment = {
+          id: nextCommentId,
+          body: payload.body,
+          user: { login: "github-actions[bot]", type: "Bot" },
+        };
+        nextCommentId += 1;
+        comments.push(comment);
+        sendJson(response, 201, comment);
+        return;
+      }
+
+      const commentPrefix = `${root}/issues/comments/`;
+      if (method === "PATCH" && url.pathname.startsWith(commentPrefix)) {
+        const id = Number(decodeURIComponent(url.pathname.slice(commentPrefix.length)));
+        const index = comments.findIndex((comment) => comment.id === id);
+        const payload: unknown = JSON.parse(body);
+        if (index < 0) {
+          sendJson(response, 404, { message: "not found" });
+          return;
+        }
+        if (!isObject(payload) || typeof payload.body !== "string") {
+          sendJson(response, 422, { message: "body is required" });
+          return;
+        }
+        const previous = comments[index];
+        if (!previous) throw new Error("Mock Warden comment disappeared during update.");
+        const updated = { ...previous, body: payload.body, user: { ...previous.user } };
+        comments[index] = updated;
+        sendJson(response, 200, updated);
+        return;
+      }
+
+      sendJson(response, 404, { message: "not found" });
+    } catch (error) {
+      console.error(`[mock-warden-github] request handler failed: ${error instanceof Error ? error.message : String(error)}`);
+      sendJson(response, 500, { message: "mock github internal error" });
+    }
+  };
+
+  const server = createServer((request, response) => {
+    void handleRequest(request, response);
+  });
+  const address = await listen(server, options.port ?? 0);
+  apiUrl = `http://127.0.0.1:${address.port}`;
+  let stopped = false;
+  const stop = async (): Promise<void> => {
+    if (stopped) return;
+    stopped = true;
+    await close(server);
+  };
+
+  return {
+    apiUrl,
+    graphqlUrl: `${apiUrl}/graphql`,
+    seedRun(run) {
+      runs.set(run.id, { ...run });
+    },
+    seedComments(nextComments) {
+      comments = nextComments.map((comment) => ({ ...comment, user: { ...comment.user } }));
+      nextCommentId = Math.max(0, ...comments.map((comment) => comment.id)) + 1;
+    },
+    seedThreads(nextThreads) {
+      threads = nextThreads.map((thread) => ({ ...thread, author: { ...thread.author } }));
+    },
+    setPullHead(headSha) {
+      pullHeadSha = headSha;
+    },
+    changeHeadAfterGraphql(headSha) {
+      headAfterGraphql = headSha;
+    },
+    setGraphqlErrors(enabled) {
+      graphqlErrors = enabled;
+    },
+    comments() {
+      return comments.map((comment) => ({ ...comment, user: { ...comment.user } }));
+    },
+    requests() {
+      return recorded.map((request) => ({ ...request }));
     },
     stop,
     [Symbol.asyncDispose]: stop,

--- a/evals/specs/warden-review-lifecycle.test.ts
+++ b/evals/specs/warden-review-lifecycle.test.ts
@@ -1,0 +1,379 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { wardenReviewLifecycle } from "../worlds/warden-review-lifecycle.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`Expected ${label} to be an object.`);
+  }
+  return value;
+}
+
+test("A contributor can publish and safely refresh a Warden PR review report", { timeout: 120_000 }, async ({ evidence }) => {
+  await using world = await wardenReviewLifecycle();
+
+  const advisory = await world.prepare("advisory");
+  expect(advisory.result.code).toBe(0);
+  expect(advisory.result.stderr).toBe("");
+  expect(advisory.receipt).toMatchObject({
+    findings_count: 2,
+    high_count: 0,
+    blocking_count: 0,
+    security_count: 0,
+    sync_blocking_count: 0,
+    sync_advisory_count: 1,
+    review_complete: true,
+  });
+  expect(JSON.stringify(advisory.receipt)).not.toContain(world.privateMarker);
+  expect(advisory.receipt?.verdict).toBe("clear");
+  world.seedRun(advisory, 7);
+
+  const firstPublish = await world.publish(advisory);
+  const firstJson = record(firstPublish.json, "first publish output");
+  const firstMetrics = record(firstJson.metrics, "first publish metrics");
+  const firstBotSummaries = world.comments().filter((comment) =>
+    comment.user.login === "github-actions[bot]" && comment.body.includes("openwork:warden-review-summary"),
+  );
+  const spoof = world.comments().find((comment) => comment.id === 100);
+  expect(firstPublish.code).toBe(0);
+  expect(firstBotSummaries).toHaveLength(1);
+  expect(firstBotSummaries[0]?.body).toContain("### Advisories\n- <code>SYNC-ADVISORY</code>");
+  expect(firstBotSummaries[0]?.body).toContain("<code>PROV-ADVISORY</code>");
+  expect(firstBotSummaries[0]?.body).toContain("### Blockers\n- None.");
+  expect(firstBotSummaries[0]?.body).toContain("https://github.example.invalid/openworklabs/openwork/actions/runs/123456");
+  expect(firstBotSummaries[0]?.body).toContain("this summary is not clearance authority");
+  expect(firstBotSummaries[0]?.body).toContain("state at first collection, not event time");
+  expect(firstBotSummaries[0]?.body).not.toContain(world.privateMarker);
+  expect(spoof).toMatchObject({
+    id: 100,
+    body: expect.stringContaining("spoofed summary must remain human-owned"),
+    user: { login: "fixture-human", type: "User" },
+  });
+  expect(world.writes()).toHaveLength(1);
+  expect(world.writes()[0]).toMatchObject({
+    method: "POST",
+    path: "/repos/openworklabs/openwork/issues/42/comments",
+    authorization: "Bearer test-token",
+  });
+  expect(world.requests().some((request) => request.url.includes("page=2"))).toBe(true);
+  expect(world.reviewMutations()).toEqual([]);
+  expect(firstMetrics).toMatchObject({
+    uniqueObservedRunAttempts: 1,
+    distinctHeads: 1,
+    currentUnresolvedThreads: 1,
+    currentObservedThreads: 2,
+    observedTransitions: { resolved: 0, unresolved: 0 },
+    firstObserved: { resolved: 1, unresolved: 1 },
+    precision: null,
+    collectionWindow: { retainedRunAttempts: 1, limit: 20, truncated: false },
+    threadSnapshot: { retained: 2, observed: 2, limit: 500, truncated: false },
+  });
+  expect(firstJson.status).toBe("published");
+  expect(firstJson.verdict).toBe("clear");
+  evidence.recordAssertionEvidence(
+    "Advisory findings publish one redacted ordinary PR summary",
+    "The production CLI classified medium sync and provenance findings as advisories, created one bot-owned issue comment after scanning both comment pages, labeled the summary as non-clearance authority, left a spoofed human summary unchanged, and made no review, approval, dismissal, or thread mutation. Clear is Warden analysis, not GitHub mergeability.",
+    true,
+  );
+
+  const writesAfterFirst = world.writes().length;
+  const graphReadsAfterFirst = world.requests().filter((request) => request.path === "/graphql").length;
+  const repeated = await world.publish(advisory);
+  const repeatedJson = record(repeated.json, "repeated publish output");
+  expect(repeated.code).toBe(0);
+  expect(world.writes()).toHaveLength(writesAfterFirst);
+  expect(world.comments().filter((comment) =>
+    comment.user.login === "github-actions[bot]" && comment.body.includes("openwork:warden-review-summary"),
+  )).toHaveLength(1);
+  expect(world.requests().filter((request) => request.path === "/graphql")).toHaveLength(graphReadsAfterFirst);
+  expect(repeatedJson.metrics).toEqual(firstMetrics);
+  expect(world.reviewMutations()).toEqual([]);
+  expect(repeatedJson.status).toBe("published");
+  expect(repeatedJson.verdict).toBe("clear");
+
+  const mixed = await world.prepare("mixed", { attempt: 2 });
+  expect(mixed.result.code).toBe(0);
+  expect(mixed.receipt).toMatchObject({
+    findings_count: 3,
+    high_count: 1,
+    blocking_count: 3,
+    security_count: 2,
+    sync_blocking_count: 1,
+    sync_advisory_count: 0,
+    review_complete: true,
+  });
+  expect(JSON.stringify(mixed.receipt)).not.toContain(world.privateMarker);
+  expect(mixed.receipt?.verdict).toBe("blocked");
+  world.seedRun(mixed, 7);
+  const mixedPublish = await world.publish(mixed);
+  const mixedJson = record(mixedPublish.json, "mixed publish output");
+  const mixedBotSummaries = world.comments().filter((comment) =>
+    comment.user.login === "github-actions[bot]" && comment.body.includes("openwork:warden-review-summary"),
+  );
+  expect(mixedPublish.code).toBe(0);
+  expect(world.writes()).toHaveLength(writesAfterFirst + 1);
+  expect(world.writes().at(-1)).toMatchObject({
+    method: "PATCH",
+    path: `/repos/openworklabs/openwork/issues/comments/${firstBotSummaries[0]?.id}`,
+    authorization: "Bearer test-token",
+  });
+  expect(mixedBotSummaries).toHaveLength(1);
+  expect(mixedBotSummaries[0]?.body).toContain("Native findings: **3**");
+  expect(mixedBotSummaries[0]?.body).toContain("Blocking policy matches before consolidation: **3**");
+  expect(mixedBotSummaries[0]?.body).toContain("<code>SEC-LOW</code> · low");
+  expect(mixedBotSummaries[0]?.body).toContain("<code>CONF-MED</code> · medium");
+  expect(mixedBotSummaries[0]?.body).toContain("<code>SYNC-HIGH</code> · high");
+  expect(mixedBotSummaries[0]?.body).not.toContain(world.privateMarker);
+  expect(world.comments().find((comment) => comment.id === 100)?.body).toContain("spoofed summary must remain human-owned");
+  expect(mixedJson.metrics).toMatchObject({
+    uniqueObservedRunAttempts: 2,
+    distinctHeads: 1,
+    observedTransitions: { resolved: 0, unresolved: 0 },
+    firstObserved: { resolved: 1, unresolved: 1 },
+    precision: null,
+  });
+  expect(world.reviewMutations()).toEqual([]);
+  expect(mixedJson.status).toBe("published");
+  expect(mixedJson.verdict).toBe("blocked");
+
+  const writesAfterSecondAttempt = world.writes().length;
+  const oldAttempt = await world.publish(advisory);
+  expect(oldAttempt.code).not.toBe(0);
+  expect(oldAttempt.stderr).toContain("producer run identity does not match receipt");
+  expect(world.writes()).toHaveLength(writesAfterSecondAttempt);
+  expect(world.comments().filter((comment) => comment.user.login === "github-actions[bot]")).toHaveLength(1);
+  expect(world.reviewMutations()).toEqual([]);
+  evidence.recordAssertionEvidence(
+    "Run attempts update one trusted summary without replay overwrite",
+    "Repeating the same receipt returned the retained metrics without a write or another thread read. A newer attempt patched only the page-two bot summary, retained one distinct head across two attempts, preserved blocker policy despite low confidence, and an older producer attempt could not overwrite it.",
+    true,
+  );
+
+  const transitioned = await world.prepare("advisory", {
+    headSha: world.heads.second,
+    runId: "123457",
+    attempt: 1,
+  });
+  expect(transitioned.result.code).toBe(0);
+  world.setPullHead(world.heads.second);
+  world.seedRun(transitioned, 8);
+  world.resolveToggleThread();
+  const transitionPublish = await world.publish(transitioned);
+  const transitionJson = record(transitionPublish.json, "transition publish output");
+  expect(transitionPublish.code).toBe(0);
+  expect(transitionJson.metrics).toMatchObject({
+    uniqueObservedRunAttempts: 3,
+    distinctHeads: 2,
+    currentUnresolvedThreads: 0,
+    currentObservedThreads: 2,
+    observedTransitions: { resolved: 1, unresolved: 0 },
+    firstObserved: { resolved: 1, unresolved: 1 },
+    precision: null,
+    collectionWindow: { retainedRunAttempts: 3, limit: 20, truncated: false },
+  });
+  expect(transitionPublish.stdout).not.toContain("resolvedAt");
+  expect(world.comments().at(-1)?.body).not.toContain("resolvedAt");
+  expect(world.reviewMutations()).toEqual([]);
+  expect(transitionJson.status).toBe("published");
+  expect(transitionJson.verdict).toBe("clear");
+  evidence.recordAssertionEvidence(
+    "Thread metrics distinguish first observation from a later transition",
+    "A Warden thread first seen resolved increased firstObserved.resolved without inventing a transition. A later unresolved-to-resolved snapshot increased only the resolved transition count; a clearance-like human thread was excluded, precision stayed null, and no exact resolution time or mutation was reported.",
+    true,
+  );
+
+  const paginated = await world.prepare("advisory", {
+    headSha: world.heads.second,
+    runId: "123458",
+  });
+  expect(paginated.result.code).toBe(0);
+  world.seedRun(paginated, 9);
+  const paginatedThreadCounts = world.seedPaginatedThreads();
+  const paginatedRequestStart = world.requests().length;
+  const paginatedPublish = await world.publish(paginated);
+  const paginatedJson = record(paginatedPublish.json, "paginated publish output");
+  const paginatedGraphql = world.requests().slice(paginatedRequestStart)
+    .filter((request) => request.path === "/graphql");
+  expect(paginatedPublish.code).toBe(0);
+  expect(paginatedThreadCounts).toEqual({ warden: 101, total: 102 });
+  expect(paginatedGraphql).toHaveLength(2);
+  expect(paginatedGraphql[0]?.body).toContain('"after":null');
+  expect(paginatedGraphql[1]?.body).toContain('"after":"warden-thread-cursor-100"');
+  expect(paginatedJson.metrics).toMatchObject({
+    uniqueObservedRunAttempts: 4,
+    distinctHeads: 2,
+    currentUnresolvedThreads: 99,
+    currentObservedThreads: 101,
+    observedTransitions: { resolved: 1, unresolved: 0 },
+    firstObserved: { resolved: 1, unresolved: 100 },
+    precision: null,
+    collectionWindow: { retainedRunAttempts: 4, limit: 20, truncated: false },
+    threadSnapshot: { retained: 101, observed: 101, limit: 500, truncated: false },
+  });
+  expect(world.comments().filter((comment) => comment.user.login === "github-actions[bot]")).toHaveLength(1);
+  expect(world.reviewMutations()).toEqual([]);
+  expect(paginatedJson.status).toBe("published");
+  expect(paginatedJson.verdict).toBe("clear");
+  evidence.recordAssertionEvidence(
+    "GraphQL thread collection crosses a real cursor page without trusting a human lookalike",
+    "Two reviewThreads requests collected 101 Warden-authored threads across the 100-node cursor boundary. A marker from the same github-actions login with GraphQL typename User remained outside the metrics, while the REST summary retained github-actions[bot] ownership.",
+    true,
+  );
+
+  const stale = await world.prepare("advisory", {
+    headSha: world.heads.second,
+    runId: "123459",
+  });
+  expect(stale.result.code).toBe(0);
+  world.setPullHead(world.heads.second);
+  world.seedRun(stale, 10);
+  world.changeHeadAfterGraphql(world.heads.stale);
+  const staleWriteCount = world.writes().length;
+  const staleRequestStart = world.requests().length;
+  const stalePublish = await world.publish(stale);
+  const staleJson = record(stalePublish.json, "stale publish output");
+  const staleRequests = world.requests().slice(staleRequestStart);
+  expect(stalePublish.code).toBe(0);
+  expect(staleRequests.filter((request) => request.path === "/repos/openworklabs/openwork/pulls/42")).toHaveLength(2);
+  expect(world.writes()).toHaveLength(staleWriteCount);
+  expect(world.reviewMutations()).toEqual([]);
+  expect(staleJson.status).toBe("stale");
+  expect(staleJson.verdict).toBe("clear");
+
+  world.setPullHead(world.heads.second);
+  const graphqlFailure = await world.prepare("advisory", {
+    headSha: world.heads.second,
+    runId: "123460",
+  });
+  expect(graphqlFailure.result.code).toBe(0);
+  world.seedRun(graphqlFailure, 11);
+  world.setGraphqlErrors(true);
+  const graphqlWriteCount = world.writes().length;
+  const failedGraphqlPublish = await world.publish(graphqlFailure);
+  expect(failedGraphqlPublish.code).not.toBe(0);
+  expect(failedGraphqlPublish.stderr).toContain("GitHub GraphQL returned errors");
+  expect(world.writes()).toHaveLength(graphqlWriteCount);
+  expect(world.reviewMutations()).toEqual([]);
+  world.setGraphqlErrors(false);
+
+  const mismatchedRun = await world.prepare("advisory", {
+    headSha: world.heads.second,
+    runId: "123461",
+  });
+  expect(mismatchedRun.result.code).toBe(0);
+  world.seedRun(mismatchedRun, 12, { repository: "fixture/wrong-run-repository" });
+  const mismatchedRunWriteCount = world.writes().length;
+  const mismatchedRunPublish = await world.publish(mismatchedRun);
+  expect(mismatchedRunPublish.code).not.toBe(0);
+  expect(mismatchedRunPublish.stderr).toContain("producer run repository does not match receipt");
+  expect(world.writes()).toHaveLength(mismatchedRunWriteCount);
+  expect(world.reviewMutations()).toEqual([]);
+
+  const repositoryMismatchRequestCount = world.requests().length;
+  const repositoryMismatch = await world.prepare("repository-mismatch");
+  expect(repositoryMismatch.result.code).not.toBe(0);
+  expect(repositoryMismatch.result.stderr).toContain("findings repository does not match trusted metadata");
+  expect(repositoryMismatch.result.stdout + repositoryMismatch.result.stderr).not.toContain(world.privateMarker);
+  expect(world.requests()).toHaveLength(repositoryMismatchRequestCount);
+  expect(world.writes()).toHaveLength(mismatchedRunWriteCount);
+
+  const boundProducer = await world.prepare("advisory", {
+    headSha: world.heads.second,
+    runId: "123462",
+  });
+  expect(boundProducer.result.code).toBe(0);
+  const forgedReceipt = await world.forgeReceiptProducer(boundProducer, {
+    headSha: world.heads.forged,
+    runId: "999999",
+  });
+  expect(forgedReceipt.receipt).toMatchObject({
+    head_sha: world.heads.forged,
+    producer: { headSha: world.heads.forged, runId: "999999" },
+  });
+  const forgedRequestCount = world.requests().length;
+  const forgedWriteCount = world.writes().length;
+  const deniedForgedReceipt = await world.publish(forgedReceipt);
+  expect(deniedForgedReceipt.code).not.toBe(0);
+  expect(deniedForgedReceipt.stderr).toContain("receipt producer does not match trusted workflow metadata");
+  expect(world.requests()).toHaveLength(forgedRequestCount);
+  expect(world.writes()).toHaveLength(forgedWriteCount);
+
+  const authFailure = await world.prepare("advisory", {
+    headSha: world.heads.second,
+    runId: "123463",
+  });
+  expect(authFailure.result.code).toBe(0);
+  world.seedRun(authFailure, 13);
+  const authWriteCount = world.writes().length;
+  const deniedToken = await world.publish(authFailure, "wrong-token");
+  expect(deniedToken.code).not.toBe(0);
+  expect(deniedToken.stderr).toContain("returned 401");
+  expect(world.writes()).toHaveLength(authWriteCount);
+  expect(world.requests().at(-1)).toMatchObject({
+    method: "GET",
+    path: "/repos/openworklabs/openwork/pulls/42",
+    authorization: "Bearer wrong-token",
+  });
+
+  const wrongRepository = await world.prepare("wrong-repository", { runId: "123464" });
+  expect(wrongRepository.result.code).toBe(0);
+  const wrongRepositoryWriteCount = world.writes().length;
+  const deniedRepository = await world.publish(wrongRepository);
+  expect(deniedRepository.code).not.toBe(0);
+  expect(deniedRepository.stderr).toContain("returned 404");
+  expect(world.writes()).toHaveLength(wrongRepositoryWriteCount);
+  expect(world.requests().at(-1)).toMatchObject({
+    method: "GET",
+    path: "/repos/fixture/not-openwork/pulls/42",
+    authorization: "Bearer test-token",
+  });
+  expect(world.writes().every((request) => request.authorization === "Bearer test-token")).toBe(true);
+  expect(world.reviewMutations()).toEqual([]);
+  evidence.recordAssertionEvidence(
+    "Stale heads, untrusted identity, and provider errors fail closed before writes",
+    "The witness changed the head after GraphQL and the CLI re-read the PR before declining the stale write. GraphQL errors, mismatched run provenance, raw/metadata repository mismatch, a forged receipt that disagreed with trusted caller metadata, a wrong token, and a repository outside the fixture all produced no GitHub write; every accepted write used the scoped test token.",
+    true,
+  );
+
+  const missingTrigger = await world.prepare("missing-trigger", { runId: "123465" });
+  expect(missingTrigger.result.code).toBe(0);
+  expect(missingTrigger.receipt).toMatchObject({ review_complete: false });
+  expect(missingTrigger.receipt?.needs_recheck).toEqual(expect.arrayContaining([
+    "missing-mandatory-trigger:confidentiality-review",
+    "trigger-report-mismatch:confidentiality-review",
+  ]));
+  expect(JSON.stringify(missingTrigger.receipt)).not.toContain(world.privateMarker);
+  expect(missingTrigger.receipt?.verdict).toBe("incomplete");
+
+  const partial = await world.prepare("partial", { runId: "123466" });
+  expect(partial.result.code).toBe(0);
+  expect(partial.receipt).toMatchObject({ review_complete: false });
+  expect(partial.receipt?.needs_recheck).toEqual(expect.arrayContaining([
+    "partial-failed-hunks:diff-security-review",
+    "partial-failed-extractions:confidentiality-review",
+    "skill-error:diff-security-review",
+  ]));
+  expect(partial.result.stdout + partial.result.stderr + JSON.stringify(partial.receipt)).not.toContain(world.privateMarker);
+  expect(partial.receipt?.verdict).toBe("incomplete");
+
+  const malformed = await world.prepare("malformed", { runId: "123467" });
+  expect(malformed.result.code).not.toBe(0);
+  expect(malformed.receipt).toBeNull();
+  expect(malformed.result.stdout + malformed.result.stderr).not.toContain(world.privateMarker);
+  expect(world.reviewMutations()).toEqual([]);
+  evidence.recordAssertionEvidence(
+    "Incomplete and malformed analyzer output cannot become false clearance",
+    "The production prepare command marked a missing mandatory trigger and partial hunk/extraction coverage incomplete while redacting model and error text. Structurally malformed native output exited nonzero and produced no receipt.",
+    true,
+  );
+
+  evidence.recordAssertionEvidence(
+    "Proof scope is the reporter HTTP contract and classification lifecycle",
+    "This hermetic journey executes the production Warden CLI against a deterministic GitHub HTTP witness. It does not claim native upstream model precision, real GitHub merge-button behavior, or any provider write.",
+    true,
+  );
+});

--- a/evals/specs/warden-review-lifecycle.test.ts
+++ b/evals/specs/warden-review-lifecycle.test.ts
@@ -371,6 +371,79 @@ test("A contributor can publish and safely refresh a Warden PR review report", {
     true,
   );
 
+  const consolidated = await world.prepare("consolidated", {
+    headSha: world.heads.second,
+    runId: "123468",
+  });
+  expect(consolidated.result.code).toBe(0);
+  expect(consolidated.receipt).toMatchObject({
+    findings_count: 2,
+    high_count: 0,
+    blocking_count: 1,
+    security_count: 1,
+    sync_blocking_count: 0,
+    sync_advisory_count: 0,
+    review_complete: true,
+    needs_recheck: [],
+    coverage: {
+      skills: [
+        { name: "diff-security-review", status: "reported" },
+        { name: "confidentiality-review", status: "reported" },
+        { name: "spec-provenance-review", status: "reported" },
+      ],
+    },
+    findings: [{
+      id: "SHARED-NATIVE-ID",
+      severity: "medium",
+      skills: ["diff-security-review", "spec-provenance-review"],
+      disposition: "blocker",
+    }],
+  });
+  expect(consolidated.receipt?.findings).toHaveLength(1);
+  expect(consolidated.receipt?.verdict).toBe("blocked");
+
+  world.setPullHead(world.heads.second);
+  world.seedRun(consolidated, 14);
+  const humanCommentsBefore = world.comments().filter((comment) => comment.user.type === "User");
+  const consolidatedWriteCount = world.writes().length;
+  const consolidatedPublish = await world.publish(consolidated);
+  const consolidatedJson = record(consolidatedPublish.json, "consolidated publish output");
+  const consolidatedSummaries = world.comments().filter((comment) =>
+    comment.user.login === "github-actions[bot]" && comment.body.includes("openwork:warden-review-summary"),
+  );
+  expect(consolidatedPublish.code).toBe(0);
+  expect(consolidatedSummaries).toHaveLength(1);
+  const consolidatedBody = consolidatedSummaries[0]?.body;
+  if (!consolidatedBody) throw new Error("Missing consolidated Warden summary.");
+  const blockersStart = consolidatedBody.indexOf("### Blockers\n");
+  const advisoriesStart = consolidatedBody.indexOf("\n\n### Advisories");
+  const needsRecheckStart = consolidatedBody.indexOf("\n\n### Needs recheck");
+  expect(blockersStart).toBeGreaterThanOrEqual(0);
+  expect(advisoriesStart).toBeGreaterThan(blockersStart);
+  expect(needsRecheckStart).toBeGreaterThan(advisoriesStart);
+  const blockerSection = consolidatedBody.slice(blockersStart, advisoriesStart);
+  const advisorySection = consolidatedBody.slice(advisoriesStart, needsRecheckStart);
+  expect(consolidatedBody).toContain("Native findings: **2**");
+  expect(consolidatedBody.match(/<code>SHARED-NATIVE-ID<\/code>/g)).toHaveLength(1);
+  expect(blockerSection).toContain("<code>SHARED-NATIVE-ID</code> · medium · diff-security-review, spec-provenance-review");
+  expect(advisorySection).not.toContain("SHARED-NATIVE-ID");
+  expect(consolidatedJson.metrics).toMatchObject({ currentObservedThreads: 101 });
+  expect(world.comments().filter((comment) => comment.user.type === "User")).toEqual(humanCommentsBefore);
+  expect(world.writes()).toHaveLength(consolidatedWriteCount + 1);
+  expect(world.writes().at(-1)).toMatchObject({
+    method: "PATCH",
+    path: `/repos/openworklabs/openwork/issues/comments/${consolidatedSummaries[0]?.id}`,
+    authorization: "Bearer test-token",
+  });
+  expect(world.reviewMutations()).toEqual([]);
+  expect(consolidatedJson.status).toBe("published");
+  expect(consolidatedJson.verdict).toBe("blocked");
+  evidence.recordAssertionEvidence(
+    "One native ID shared by security and provenance remains one blocking report entry",
+    "Two identical native records retained raw count 2 while consolidating to one rendered ID with both skill attributions. Security policy won over provenance advisory policy: the ID appeared once under Blockers and never under Advisories, while generic human comments and all review/thread mutation surfaces remained untouched.",
+    true,
+  );
+
   evidence.recordAssertionEvidence(
     "Proof scope is the reporter HTTP contract and classification lifecycle",
     "This hermetic journey executes the production Warden CLI against a deterministic GitHub HTTP witness. It does not claim native upstream model precision, real GitHub merge-button behavior, or any provider write.",

--- a/evals/worlds/warden-review-lifecycle.ts
+++ b/evals/worlds/warden-review-lifecycle.ts
@@ -21,6 +21,7 @@ const cliPath = join(repoRoot, ".github", "scripts", "warden-review.mjs");
 
 export type WardenFixture =
   | "advisory"
+  | "consolidated"
   | "mixed"
   | "missing-trigger"
   | "partial"
@@ -118,6 +119,13 @@ function nativeRaw(
       skill("confidentiality-review"),
       skill("desktop-den-sync-review", [finding("SYNC-ADVISORY", "medium", "medium")]),
       skill("spec-provenance-review", [finding("PROV-ADVISORY", "medium", "medium")]),
+    ];
+  } else if (fixture === "consolidated") {
+    const shared = finding("SHARED-NATIVE-ID", "medium", "low");
+    skills = [
+      skill("diff-security-review", [shared]),
+      skill("confidentiality-review"),
+      skill("spec-provenance-review", [shared]),
     ];
   } else if (fixture === "mixed") {
     skills = [

--- a/evals/worlds/warden-review-lifecycle.ts
+++ b/evals/worlds/warden-review-lifecycle.ts
@@ -1,0 +1,454 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  startMockWardenGithub,
+  type MockWardenGithubComment,
+  type MockWardenGithubRequest,
+  type MockWardenGithubRun,
+  type MockWardenGithubThread,
+} from "@openwork/labs";
+
+const REPOSITORY = "openworklabs/openwork";
+const OTHER_REPOSITORY = "fixture/not-openwork";
+const PULL_REQUEST = 42;
+const BASE_SHA = "b".repeat(40);
+const SUMMARY_MARKER = "<!-- openwork:warden-review-summary:v1 -->";
+const PRIVATE_MARKER = "PRIVATE-WARDEN-FIXTURE-MARKER";
+const repoRoot = resolve(import.meta.dirname, "../..");
+const cliPath = join(repoRoot, ".github", "scripts", "warden-review.mjs");
+
+export type WardenFixture =
+  | "advisory"
+  | "mixed"
+  | "missing-trigger"
+  | "partial"
+  | "malformed"
+  | "repository-mismatch"
+  | "wrong-repository";
+
+export interface WardenIdentity {
+  repository: string;
+  pr: number;
+  headSha: string;
+  baseSha: string;
+  runId: string;
+  attempt: number;
+}
+
+export interface WardenCliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  json: Record<string, unknown> | null;
+}
+
+export interface PreparedWardenReceipt {
+  key: string;
+  identity: WardenIdentity;
+  result: WardenCliResult;
+  receipt: Record<string, unknown> | null;
+}
+
+interface NativeFinding {
+  id: string;
+  severity: "high" | "medium" | "low";
+  confidence: "high" | "medium" | "low";
+  title: string;
+  description: string;
+  location: { path: string; startLine: number };
+}
+
+interface NativeSkill {
+  name: string;
+  summary: string;
+  durationMs: number;
+  findings: NativeFinding[];
+  failedHunks?: number;
+  failedExtractions?: number;
+  error?: { code: string; message: string; timestamp: string };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parsedLastLine(stdout: string): Record<string, unknown> | null {
+  const line = stdout.trim().split(/\r?\n/).at(-1);
+  if (!line) return null;
+  try {
+    const value: unknown = JSON.parse(line);
+    return isObject(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function finding(id: string, severity: NativeFinding["severity"], confidence: NativeFinding["confidence"]): NativeFinding {
+  return {
+    id,
+    severity,
+    confidence,
+    title: `${PRIVATE_MARKER} title`,
+    description: `${PRIVATE_MARKER} description`,
+    location: { path: "src/fixture.ts", startLine: 1 },
+  };
+}
+
+function skill(name: string, findings: NativeFinding[] = [], partial: Partial<Pick<NativeSkill, "failedHunks" | "failedExtractions" | "error">> = {}): NativeSkill {
+  return {
+    name,
+    summary: `${PRIVATE_MARKER} model summary`,
+    durationMs: 5,
+    findings,
+    ...partial,
+  };
+}
+
+function nativeRaw(
+  fixture: Exclude<WardenFixture, "malformed" | "repository-mismatch" | "wrong-repository">,
+  identity: WardenIdentity,
+  rawRepository: string,
+): Record<string, unknown> {
+  let skills: NativeSkill[];
+  if (fixture === "advisory") {
+    skills = [
+      skill("diff-security-review"),
+      skill("confidentiality-review"),
+      skill("desktop-den-sync-review", [finding("SYNC-ADVISORY", "medium", "medium")]),
+      skill("spec-provenance-review", [finding("PROV-ADVISORY", "medium", "medium")]),
+    ];
+  } else if (fixture === "mixed") {
+    skills = [
+      skill("diff-security-review", [finding("SEC-LOW", "low", "low")]),
+      skill("confidentiality-review", [finding("CONF-MED", "medium", "low")]),
+      skill("desktop-den-sync-review", [finding("SYNC-HIGH", "high", "low")]),
+    ];
+  } else if (fixture === "partial") {
+    skills = [
+      skill("diff-security-review", [], {
+        failedHunks: 1,
+        error: {
+          code: "fixture-partial",
+          message: `${PRIVATE_MARKER} partial error`,
+          timestamp: "2026-09-09T12:00:00.000Z",
+        },
+      }),
+      skill("confidentiality-review", [], { failedExtractions: 1 }),
+    ];
+  } else {
+    skills = [skill("diff-security-review"), skill("confidentiality-review")];
+  }
+
+  const findings = skills.flatMap((entry) => entry.findings);
+  const [owner, name] = rawRepository.split("/");
+  const triggerResults = skills.map((entry) => ({
+    triggerName: "local-reference-name",
+    skillName: entry.name,
+    status: "success",
+    report: {
+      skill: entry.name,
+      summary: entry.summary,
+      durationMs: 5,
+      findings: entry.findings,
+    },
+  }));
+  if (fixture === "missing-trigger") triggerResults.splice(1, 1);
+
+  return {
+    version: "1",
+    timestamp: "2026-09-09T12:00:00.000Z",
+    repository: { owner, name, fullName: rawRepository },
+    event: "pull_request",
+    pullRequest: {
+      number: identity.pr,
+      author: `${PRIVATE_MARKER}-author`,
+      title: `${PRIVATE_MARKER} pull request`,
+      baseBranch: "dev",
+      headBranch: `${PRIVATE_MARKER}-branch`,
+      headSha: identity.headSha,
+    },
+    runId: identity.runId,
+    summary: {
+      totalFindings: findings.length,
+      totalSkills: skills.length,
+      findingsBySeverity: {
+        high: findings.filter((entry) => entry.severity === "high").length,
+        medium: findings.filter((entry) => entry.severity === "medium").length,
+        low: findings.filter((entry) => entry.severity === "low").length,
+      },
+    },
+    skills,
+    triggerResults,
+    findingObservations: [],
+  };
+}
+
+function nativeFixture(fixture: WardenFixture, identity: WardenIdentity): unknown {
+  if (fixture === "malformed") return { version: "1", private: PRIVATE_MARKER };
+  const rawRepository = fixture === "repository-mismatch" ? REPOSITORY : identity.repository;
+  const rawFixture = fixture === "repository-mismatch" || fixture === "wrong-repository" ? "advisory" : fixture;
+  return nativeRaw(rawFixture, identity, rawRepository);
+}
+
+function cloneThread(thread: MockWardenGithubThread): MockWardenGithubThread {
+  return { ...thread, author: { ...thread.author } };
+}
+
+export async function wardenReviewLifecycle() {
+  const directory = await mkdtemp(join(tmpdir(), "openwork-warden-review-"));
+  const home = join(directory, "home");
+  const scratch = join(directory, "scratch");
+  await mkdir(home, { recursive: true });
+  await mkdir(scratch, { recursive: true });
+
+  const initialThreads: MockWardenGithubThread[] = [
+    {
+      id: "RT_initial_resolved",
+      isResolved: true,
+      body: "<!-- warden:finding:v1:INITIAL -->",
+      author: { login: "github-actions", type: "Bot" },
+    },
+    {
+      id: "RT_toggle",
+      isResolved: false,
+      body: "<!-- warden:finding:v1:TOGGLE -->",
+      author: { login: "github-actions", type: "Bot" },
+    },
+    {
+      id: "RT_human_clearance",
+      isResolved: false,
+      body: "<!-- warden:finding:v1:HUMAN --> Clearance granted by a person",
+      author: { login: "github-actions", type: "User" },
+    },
+  ];
+  const initialComments: MockWardenGithubComment[] = Array.from({ length: 99 }, (_unused, index) => ({
+    id: index + 1,
+    body: `ordinary fixture comment ${index + 1}`,
+    user: { login: "fixture-human", type: "User" },
+  }));
+  initialComments.push({
+    id: 100,
+    body: `${SUMMARY_MARKER}\nspoofed summary must remain human-owned`,
+    user: { login: "fixture-human", type: "User" },
+  });
+
+  const witness = await startMockWardenGithub({
+    token: "test-token",
+    repository: REPOSITORY,
+    pullRequest: PULL_REQUEST,
+    headSha: "a".repeat(40),
+    baseSha: BASE_SHA,
+    headBranch: "fixture-branch",
+    baseBranch: "dev",
+    comments: initialComments,
+    threads: initialThreads,
+  });
+  const children = new Set<ChildProcess>();
+  let sequence = 0;
+  const baseEnv: NodeJS.ProcessEnv = {
+    HOME: home,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    XDG_DATA_HOME: join(home, ".local", "share"),
+    XDG_CACHE_HOME: join(home, ".cache"),
+    XDG_STATE_HOME: join(home, ".local", "state"),
+    TMPDIR: scratch,
+    PATH: process.env.PATH ?? "",
+    LANG: "C.UTF-8",
+  };
+
+  const runCli = (args: string[], env: NodeJS.ProcessEnv): Promise<WardenCliResult> => new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    children.add(child);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      children.delete(child);
+      reject(new Error(`Warden CLI timed out.\n${stderr.slice(-2_000)}`));
+    }, 20_000);
+    child.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf8"); });
+    child.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf8"); });
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      children.delete(child);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      children.delete(child);
+      resolveRun({ code: code ?? 1, stdout, stderr, json: parsedLastLine(stdout) });
+    });
+  });
+
+  const dispose = async (): Promise<void> => {
+    for (const child of children) child.kill("SIGKILL");
+    children.clear();
+    await witness.stop();
+    await rm(directory, { recursive: true, force: true });
+  };
+
+  try {
+    return {
+      repository: REPOSITORY,
+      pullRequest: PULL_REQUEST,
+      baseSha: BASE_SHA,
+      privateMarker: PRIVATE_MARKER,
+      heads: {
+        first: "a".repeat(40),
+        second: "c".repeat(40),
+        stale: "d".repeat(40),
+        forged: "e".repeat(40),
+      },
+      async prepare(
+        fixture: WardenFixture,
+        overrides: Partial<Pick<WardenIdentity, "headSha" | "baseSha" | "runId" | "attempt">> = {},
+      ): Promise<PreparedWardenReceipt> {
+        sequence += 1;
+        const repository = fixture === "repository-mismatch" || fixture === "wrong-repository"
+          ? OTHER_REPOSITORY
+          : REPOSITORY;
+        const identity: WardenIdentity = {
+          repository,
+          pr: PULL_REQUEST,
+          headSha: overrides.headSha ?? "a".repeat(40),
+          baseSha: overrides.baseSha ?? BASE_SHA,
+          runId: overrides.runId ?? "123456",
+          attempt: overrides.attempt ?? 1,
+        };
+        const key = `receipt-${sequence}`;
+        const findingsPath = join(scratch, `${key}-raw.json`);
+        const receiptPath = join(scratch, `${key}.json`);
+        await writeFile(findingsPath, `${JSON.stringify(nativeFixture(fixture, identity), null, 2)}\n`, "utf8");
+        const result = await runCli([
+          "prepare",
+          "--findings", findingsPath,
+          "--repository", identity.repository,
+          "--pr", String(identity.pr),
+          "--head", identity.headSha,
+          "--base", identity.baseSha,
+          "--run-id", identity.runId,
+          "--attempt", String(identity.attempt),
+          "--output", receiptPath,
+        ], baseEnv);
+        let receipt: Record<string, unknown> | null = null;
+        if (result.code === 0) {
+          const parsed: unknown = JSON.parse(await readFile(receiptPath, "utf8"));
+          receipt = isObject(parsed) ? parsed : null;
+        }
+        return { key: receiptPath, identity, result, receipt };
+      },
+      publish(prepared: PreparedWardenReceipt, token = "test-token"): Promise<WardenCliResult> {
+        return runCli(["publish", "--receipt", prepared.key], {
+          ...baseEnv,
+          GITHUB_TOKEN: token,
+          GITHUB_API_URL: witness.apiUrl,
+          GITHUB_GRAPHQL_URL: witness.graphqlUrl,
+          GITHUB_SERVER_URL: "https://github.example.invalid",
+          WARDEN_EXPECTED_REPOSITORY: prepared.identity.repository,
+          WARDEN_EXPECTED_RUN_ID: prepared.identity.runId,
+          WARDEN_EXPECTED_RUN_ATTEMPT: String(prepared.identity.attempt),
+          WARDEN_EXPECTED_HEAD_SHA: prepared.identity.headSha,
+        });
+      },
+      async forgeReceiptProducer(
+        prepared: PreparedWardenReceipt,
+        producer: Pick<WardenIdentity, "headSha" | "runId">,
+      ): Promise<PreparedWardenReceipt> {
+        const parsed: unknown = JSON.parse(await readFile(prepared.key, "utf8"));
+        if (!isObject(parsed) || !isObject(parsed.producer)) {
+          throw new Error("Cannot forge a receipt without a producer.");
+        }
+        sequence += 1;
+        const receipt = {
+          ...parsed,
+          head_sha: producer.headSha,
+          producer: {
+            ...parsed.producer,
+            headSha: producer.headSha,
+            runId: producer.runId,
+          },
+        };
+        const key = join(scratch, `receipt-${sequence}-forged.json`);
+        await writeFile(key, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+        return {
+          key,
+          identity: { ...prepared.identity },
+          result: prepared.result,
+          receipt,
+        };
+      },
+      seedRun(prepared: PreparedWardenReceipt, runNumber: number, overrides: Partial<Omit<MockWardenGithubRun, "id" | "runNumber" | "attempt" | "headSha">> = {}): void {
+        witness.seedRun({
+          id: prepared.identity.runId,
+          runNumber,
+          attempt: prepared.identity.attempt,
+          headSha: prepared.identity.headSha,
+          ...overrides,
+        });
+      },
+      setPullHead(headSha: string): void {
+        witness.setPullHead(headSha);
+      },
+      resolveToggleThread(): void {
+        witness.seedThreads(initialThreads.map((thread) => ({
+          ...cloneThread(thread),
+          isResolved: thread.id === "RT_toggle" ? true : thread.isResolved,
+        })));
+      },
+      seedPaginatedThreads(): { warden: number; total: number } {
+        const additional: MockWardenGithubThread[] = Array.from({ length: 99 }, (_unused, index) => ({
+          id: `RT_page_${String(index + 1).padStart(3, "0")}`,
+          isResolved: false,
+          body: `<!-- warden:finding:v1:PAGE_${String(index + 1).padStart(3, "0")} -->`,
+          author: { login: "github-actions", type: "Bot" },
+        }));
+        const human = initialThreads[2];
+        if (!human) throw new Error("Missing human review-thread fixture.");
+        const paginated: MockWardenGithubThread[] = [
+          ...initialThreads.slice(0, 2).map((thread) => ({ ...cloneThread(thread), isResolved: true })),
+          ...additional,
+          cloneThread(human),
+        ];
+        witness.seedThreads(paginated);
+        return { warden: 101, total: paginated.length };
+      },
+      changeHeadAfterGraphql(headSha: string): void {
+        witness.changeHeadAfterGraphql(headSha);
+      },
+      setGraphqlErrors(enabled: boolean): void {
+        witness.setGraphqlErrors(enabled);
+      },
+      comments: witness.comments,
+      requests: witness.requests,
+      writes(): MockWardenGithubRequest[] {
+        return witness.requests().filter((request) =>
+          request.method === "PATCH" ||
+          request.method === "POST" && request.path === `/repos/openworklabs/openwork/issues/${PULL_REQUEST}/comments`,
+        );
+      },
+      reviewMutations(): MockWardenGithubRequest[] {
+        return witness.requests().filter((request) =>
+          request.path.includes("/reviews") || request.path.includes("/dismissals") ||
+          request.path === "/graphql" && /\bmutation\b/.test(request.body),
+        );
+      },
+      [Symbol.asyncDispose]: dispose,
+    };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a consolidated, sanitized Warden review summary before report mode overwrites analyzer output.
- Publish one bot-owned ordinary comment without mutating review threads.
- Deduplicate only by identical native finding ID; the journey now proves a shared security/provenance ID renders once with blocking policy preserved.
- Fail closed on unknown, partial, contradictory, stale, provider-error, or untrusted-helper states.
- Record bounded observed metrics without claiming exact lifecycle times or model precision.
- Preserve existing CodeQL and human-review policy.

## Trust and bootstrap
- Preparation executes only the helper fetched from the immutable PR base SHA, downloaded to `RUNNER_TEMP` and verified against the GitHub blob ID; checkout credentials are not persisted and PR-controlled helper code is never used as a fallback.
- Because the current protected base does not yet contain the helper, an exact bootstrap 404 leaves native Warden reporting running but emits no receipt or approval. A subsequent protected-base run is required after the helper lands.
- Changes under `.github/` remain guarded, so independent human review is required and this PR cannot self-clear.
- [PR #4692](https://github.com/different-ai/openwork/pull/4692) is an independent companion with no stack dependency.

## Verification
- `node --test .github/scripts/warden-review.test.mjs` — 21 passed, 0 skipped.
- `pnpm evals:pr specs/warden-review-lifecycle.test.ts` — 1 journey passed with 8 behavior assertions, 0 skipped.
- `actionlint .github/workflows/warden.yml .github/workflows/warden-clearance.yml` — passed.
- Reporter HTTP-contract and static workflow verdict: **Passed**.
- Overall hosted-integration verdict: **Incomplete** pending a protected-base run proving trusted-helper receipt handoff and approval/revocation behavior.

Known repository-wide controls remain pre-existing: `pnpm --dir evals typecheck` reports the same normalized 361-error multiset as clean base `9a8aeba`, and the boundary ratchet reports the same 14 violations in 5 files; none are Warden files.