### PR TITLE
fix(app): load the whole transcript when opening a session

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1275,16 +1275,19 @@ export function SessionSurface(props: SessionSurfaceProps) {
         throw new Error("eval: forced session snapshot failure");
       }
       const startedAt = Date.now();
+      // No `limit`: OpenCode pages `limit` as the NEWEST n messages and only
+      // signals older pages through a Link header nothing here follows, so a
+      // cap silently drops the start of any longer conversation.
       const item = useDesktopLoopbackSnapshotRetry
         ? await opencodeSessionNative.composeNativeSessionSnapshotWithRetry(
           sessionOwner,
           () => snapshotTargetRef.current,
-          { limit: 140, signal },
+          { signal },
         )
         : await opencodeSessionNative.composeNativeSessionSnapshot(
           { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
           props.sessionId,
-          { limit: 140, signal },
+          { signal },
         );
       markSessionSnapshotFetchStart(item, startedAt);
       return item;

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -77,7 +77,7 @@ test("opening a long conversation shows it from its first message", async ({ use
     await user.see({ text: longHistoryFirst }, { timeoutMs: 30_000 });
     await user.looks([
       `The conversation transcript visibly starts with a user message reading "${longHistoryFirst}"`,
-      "No loading, error, or sign-in state is visible in the conversation",
+      "The transcript shows no loading indicator, error card, or empty-conversation placeholder",
     ]);
   });
 });

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import {
+  longHistory,
+  longHistoryCount,
+  longHistoryFirst,
+  longHistoryLast,
+  longHistoryTitle,
+} from "../worlds/chat.ts";
+
+const test = spec.world(longHistory, { timeout: 600_000 });
+
+/** The page size the transcript read used to request; OpenCode returns the newest n. */
+const oldPageSize = 140;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function messageTexts(body: unknown): string[] {
+  if (!Array.isArray(body)) throw new Error(`Engine did not return a message list: ${JSON.stringify(body).slice(0, 200)}`);
+  return body.flatMap((message) => {
+    if (!isRecord(message) || !Array.isArray(message.parts)) return [];
+    return message.parts.flatMap((part) => (isRecord(part) && part.type === "text" && typeof part.text === "string" ? [part.text] : []));
+  });
+}
+
+function renderedCount(value: unknown): number {
+  if (!isRecord(value) || value.ok !== true || typeof value.messageCount !== "number") {
+    throw new Error(`session.read_transcript did not report a rendered count: ${JSON.stringify(value)}`);
+  }
+  return value.messageCount;
+}
+
+test("opening a long conversation shows it from its first message", async ({ user, agent, probe, step, world }) => {
+  const messagesPath = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/opencode/session/${encodeURIComponent(world.session.sessionId)}/message`;
+
+  await step("the engine stores more messages than one newest-first page holds", async () => {
+    const stored = await probe.desktopApi(messagesPath);
+    expect(stored.status).toBe(200);
+    const texts = messageTexts(stored.body);
+    expect(texts).toHaveLength(longHistoryCount);
+    expect(texts[0]).toBe(longHistoryFirst);
+    expect(texts.at(-1)).toBe(longHistoryLast);
+
+    // Witness for the trap: a `limit` page is the NEWEST n messages, so the
+    // first message is outside it. The spec would be vacuous otherwise.
+    const page = await probe.desktopApi(`${messagesPath}?limit=${oldPageSize}`);
+    expect(page.status).toBe(200);
+    const pageTexts = messageTexts(page.body);
+    expect(pageTexts).toHaveLength(oldPageSize);
+    expect(pageTexts).not.toContain(longHistoryFirst);
+    expect(pageTexts.at(-1)).toBe(longHistoryLast);
+  });
+
+  await step("a cold start lands on the other session with no transcript cached for the long one", async () => {
+    await user.reload();
+    await user.see({ role: "button", label: new RegExp(`^${longHistoryTitle}`) }, { timeoutMs: 60_000 });
+    await user.notSee({ text: longHistoryLast });
+    await user.notSee({ text: longHistoryFirst });
+  });
+
+  await step("clicking the long conversation renders every stored message", async () => {
+    await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });
+    await user.see({ text: longHistoryLast }, { timeoutMs: 60_000 });
+    const rendered = await probe.eventually(async () => renderedCount(await agent.run("session.read_transcript", { count: 1 })), {
+      within: 60_000,
+      label: "rendered transcript length",
+      until: (count) => count >= longHistoryCount,
+    });
+    expect(rendered).toBe(longHistoryCount);
+    expect(rendered).not.toBe(oldPageSize);
+  });
+
+  await step("the first message is reachable at the top of the transcript", async () => {
+    await agent.run("session.scroll_top");
+    await user.see({ text: longHistoryFirst }, { timeoutMs: 30_000 });
+    await user.looks([
+      `The conversation transcript visibly starts with a user message reading "${longHistoryFirst}"`,
+      "No loading, error, or sign-in state is visible in the conversation",
+    ]);
+  });
+});

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1658,6 +1658,46 @@ export async function snapshotFailure(seed: Seed) {
   return { app, workspace, session };
 }
 
+/** More stored messages than OpenCode's `limit`-paged transcript read used to fetch. */
+export const longHistoryCount = 150;
+export const longHistoryTitle = "Long conversation";
+export const longHistoryOtherTitle = "Unrelated short task";
+export const longHistoryFirst = "LONG-HISTORY-FIRST-MESSAGE 7c31";
+export const longHistoryLast = "LONG-HISTORY-LAST-MESSAGE 7c31";
+
+/** A long stored conversation opened cold, from another selected session. */
+export async function longHistory(seed: Seed) {
+  const app = await seed.desktop({ name: "session-full-history" });
+  const workspace = await seed.workspace(app, seed.tmpPath("session-full-history"));
+  const session = await seedSessionRetry(seed, app, { title: longHistoryTitle });
+  // TODO(primitive): store many engine messages without a model turn.
+  const seeded = await seed.evalIn(app, browserScript(async (workspaceId, sessionId, count, first, last) => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const base = "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId)
+      + "/opencode/session/" + encodeURIComponent(sessionId) + "/message";
+    const headers = { Authorization: "Bearer " + token, "Content-Type": "application/json" };
+    for (let index = 0; index < count; index += 1) {
+      const text = index === 0 ? first : index === count - 1 ? last : "Stored history message " + (index + 1) + " of " + count + ".";
+      const response = await fetch(base, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ noReply: true, parts: [{ type: "text", text }] }),
+        signal: AbortSignal.timeout(15000),
+      });
+      if (!response.ok) return "seed:" + index + ":" + response.status + ":" + (await response.text()).slice(0, 200);
+    }
+    const stored = await fetch(base, { headers, signal: AbortSignal.timeout(15000) });
+    if (!stored.ok) return "stored:" + stored.status;
+    const storedMessages = await stored.json();
+    return Array.isArray(storedMessages) ? storedMessages.length : "stored:not-an-array";
+  }, [workspace.workspaceId, session.sessionId, longHistoryCount, longHistoryFirst, longHistoryLast]), { awaitPromise: true, timeoutMs: 180_000 });
+  if (seeded !== longHistoryCount) throw new Error(`Long history was not stored: ${String(seeded)}`);
+  const other = await seedSessionRetry(seed, app, { title: longHistoryOtherTitle });
+  return { app, workspace, session, other };
+}
+
 export async function taskActivity(seed: Seed) {
   const app = await seed.desktop({ name: "task-activity-shimmer" });
   const workspace = await seed.workspace(app, seed.tmpPath("task-activity-shimmer"));


### PR DESCRIPTION
## Problem

Opening a long session (e.g. *Today: Vercel, Cal.com & Render MCP — support action plans*) shows the conversation starting mid-way — the first visible turn was an assistant message, and the user's opening prompt and ~117 earlier messages were nowhere to be found.

## Root cause

`session-surface.tsx` fetched the transcript snapshot with `limit: 140`. OpenCode's `GET /session/:id/message?limit=n` returns the **newest** `n` messages and only signals older pages through `x-next-cursor` / `Link: rel="next"` headers. Nothing in the app ever read those headers or sent `before`, and there is no "load older" affordance, so every conversation longer than 140 messages opened at message `total − 139` with no way back.

Verified against the live engine for the reported session: 258 messages stored; `limit=140` returned exactly 140, whose first item is the assistant turn the user saw ("Quality-review edits applied…"); the real first message is the Sep 8 investigation prompt. Locally 40 of 353 sessions exceed 140 messages, so ~11% of sessions were affected.

Introduced with the incremental React session path (#1362) and carried through the SDK refactor (#4193); OpenCode has honoured `limit` server-side since its cursor-pagination work, which is when the cap started dropping history.

## Fix

Drop the `limit` on the transcript read: without one, OpenCode returns every message. The queue drainer's status-only probes keep their small page (they never render messages). The transcript cache already grows unbounded for live-watched sessions and its merges are union-preserving, so this changes only what a cold open fetches. Payload impact on the largest local session (512 messages): 15 MB served in ~0.2 s vs 1.4 MB for the 140 tail.

Follow-up (not in this PR): cursor-based "load older" + virtualization for very large sessions.

## Proof

New journey `evals/specs/session-full-history-on-open.e2e.test.ts` (world `longHistory` in `evals/worlds/chat.ts`): stores 150 messages via the engine (`noReply`), cold-starts on another session, clicks the long one in the sidebar, and asserts the rendered transcript has all 150 messages (not 140) with the first message visible at the top. It also witnesses the trap: the engine's own `limit=140` page lacks the first message.

- Daytona, fix commit `197c8bfb6`: **1 passed, 0 skipped** (`pnpm evals:e2e session-full-history-on-open --daytona`, `OPENWORK_EVAL_REF=fix/session-transcript-full-history`).
- Daytona, negative control on unfixed `dev` (`df3b1670b`): **fails** at `Timed out waiting for rendered transcript length…; last value: 140`.
- `pnpm typecheck` clean; `bun test tests/opencode-session-native.test.ts` 21 pass; channel/boundary ratchets report nothing for the new spec.

Evidence comment follows via `evals:e2e --publish`.