### PR TITLE
ci(desktop): boot the packaged cloud and enterprise flavors on a fresh profile

### DIFF
--- a/apps/app/src/react-app/shell/providers.test.tsx
+++ b/apps/app/src/react-app/shell/providers.test.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource react */
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toContain: (expected: string) => void;
+  toEqual: (expected: unknown) => void;
+  not: { toThrow: () => void };
+};
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DenAuthProvider } from "@/react-app/domains/cloud/den-auth-provider";
+import { DesktopUpdaterProvider } from "@/react-app/domains/settings/state/desktop-updater-provider";
+import { EnterpriseAwareAppProviders } from "./providers";
+
+// Mirrors ENTERPRISE_DESKTOP_DISTRIBUTION from the desktop shell: the flavor
+// that gates every feature behind Den activation.
+const ENTERPRISE_DISTRIBUTION = {
+  flavor: "enterprise",
+  appName: "OpenWork Enterprise",
+  appIdentifier: "com.differentai.openwork",
+  protocolScheme: "openwork",
+  requireSignin: true,
+  requireActivation: true,
+} as const;
+
+// Minimal browser stand-in: the renderer reads distribution from the preload
+// bridge and persists local prefs through localStorage. No gateway marker is
+// installed, so readDenBootstrapConfig falls back to its module default
+// (no enterpriseActivation) — exactly the pre-activation state.
+// Returns a restore function so the stub never leaks into other test files
+// sharing this bun test process.
+function installFakeWindow() {
+  const globals = globalThis as Record<string, unknown>;
+  const previousWindow = globals.window;
+  const storage = new Map<string, string>();
+  globals.window = {
+    __OPENWORK_ELECTRON__: { meta: { distribution: ENTERPRISE_DISTRIBUTION } },
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    location: { origin: "http://localhost:5173" },
+  };
+  return () => {
+    if (previousWindow === undefined) delete globals.window;
+    else globals.window = previousWindow;
+  };
+}
+
+// The real AppRoot-level consumer that renders before activation completes
+// (added in #4482). Its useUpdater() hook pulls in the full context chain the
+// pre-activation branch must provide.
+function UpdaterProbe() {
+  return (
+    <DesktopUpdaterProvider>
+      <div data-testid="updater-probe">updater-context-ok</div>
+    </DesktopUpdaterProvider>
+  );
+}
+
+describe("EnterpriseAwareAppProviders pre-activation branch", () => {
+  test("supports AppRoot-level updater consumers before enterprise activation", () => {
+    const restoreWindow = installFakeWindow();
+    try {
+      let markup = "";
+      expect(() => {
+        markup = renderToStaticMarkup(
+          // DenAuthProvider sits outside EnterpriseAwareAppProviders in the
+          // production AppProviders tree; mirror that nesting here.
+          <DenAuthProvider>
+            <EnterpriseAwareAppProviders>
+              <UpdaterProbe />
+            </EnterpriseAwareAppProviders>
+          </DenAuthProvider>,
+        );
+      }).not.toThrow();
+      expect(markup).toContain("updater-context-ok");
+    } finally {
+      restoreWindow();
+    }
+  });
+});

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -50,10 +50,19 @@ type AppProvidersProps = {
   children: ReactNode;
 };
 
-function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
+export function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
   const activationRequired = useEnterpriseActivationRequired();
   if (activationRequired) {
-    return <ConnectLinkProvider>{children}</ConnectLinkProvider>;
+    // Pre-activation children still include AppRoot-level consumers
+    // (DesktopUpdaterProvider since #4482) whose hooks read the local and
+    // desktop-config contexts, so those providers must stay mounted here too.
+    return (
+      <ConnectLinkProvider>
+        <DesktopConfigProvider>
+          <LocalProvider>{children}</LocalProvider>
+        </DesktopConfigProvider>
+      </ConnectLinkProvider>
+    );
   }
   return (
     <>

--- a/apps/app/tests/enterprise-activation.test.ts
+++ b/apps/app/tests/enterprise-activation.test.ts
@@ -107,9 +107,17 @@ describe("enterprise desktop activation", () => {
   });
 
   test("keeps the branded connect-link activation consumer mounted before activation", () => {
-    expect(providersSource).toContain(
-      "return <ConnectLinkProvider>{children}</ConnectLinkProvider>;",
+    // The pre-activation branch keeps ConnectLinkProvider mounted (the branded
+    // connect-link consumer) and also provides the contexts AppRoot-level
+    // consumers need — DesktopUpdaterProvider's useUpdater() reads Local and
+    // DesktopConfig contexts before activation completes (#4482).
+    const activationBranch = providersSource.slice(
+      providersSource.indexOf("if (activationRequired)"),
+      providersSource.indexOf("<DesktopRuntimeBoot"),
     );
+    expect(activationBranch).toContain("<ConnectLinkProvider>");
+    expect(activationBranch).toContain("<DesktopConfigProvider>");
+    expect(activationBranch).toContain("<LocalProvider>");
     expect(connectConfirmDialogSource).toContain(
       "const trustedBrandUrl = transport ? claims?.brand.iconUrl ?? claims?.brand.logoUrl : null;",
     );

--- a/apps/desktop/scripts/packaged-smoke.mjs
+++ b/apps/desktop/scripts/packaged-smoke.mjs
@@ -24,14 +24,41 @@ function run(name, command, args, timeout, extraEnv = {}, cwd = repo) {
   if (result.status !== 0) throw new Error(`${name} failed (${result.signal || result.status})`);
 }
 
+// The cloud and enterprise flavors render a gate above the routes on first
+// launch. Only these artifacts contain that code path, so each one is packaged
+// and booted on a fresh profile; the public flavor is covered by app-smoke.
+const gatedFlavors = [
+  { flavor: "enterprise", config: "electron-builder.enterprise.yml", executable: "openwork-enterprise" },
+  { flavor: "cloud", config: "electron-builder.cloud.yml", executable: "openwork-cloud" },
+];
+const flavorOutput = (flavor) => join(output, flavor);
+
+function packageFlavor(name, config, directory) {
+  run(name, "pnpm", ["--dir", "apps/desktop", "exec", "electron-builder",
+    "--config", config, "--linux", "--dir", "--publish", "never",
+    `--config.directories.output=${directory}`], 120_000,
+  { CSC_IDENTITY_AUTO_DISCOVERY: "false" });
+}
+
+function bootPackagedDesktop(name, journey, binary, timeout) {
+  run(name, "xvfb-run", ["-a", "pnpm", "evals:e2e", journey, "--local"], timeout, {
+    OPENWORK_EVAL_ELECTRON_BINARY: binary,
+    OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED: "1",
+    OPENWORK_EVAL_ENGINE: "v1",
+    OPENWORK_EVAL_SURFACES_DIR: join(output, "profiles"),
+    ELECTRON_RUN_AS_NODE: "",
+    NODE_PATH: "", NODE_OPTIONS: "",
+  });
+}
+
 try {
   if (!process.argv.includes("--artifact-only")) {
     run("prepare", process.execPath, ["apps/desktop/scripts/electron-build.mjs",
       ...(process.argv.includes("--server-built") ? ["--server-built"] : [])], 240_000);
-    run("package", "pnpm", ["--dir", "apps/desktop", "exec", "electron-builder",
-      "--config", "electron-builder.yml", "--linux", "--dir", "--publish", "never",
-      `--config.directories.output=${output}`], 120_000,
-    { CSC_IDENTITY_AUTO_DISCOVERY: "false" });
+    packageFlavor("package", "electron-builder.yml", output);
+    for (const { flavor, config } of gatedFlavors) {
+      packageFlavor(`package-${flavor}`, config, flavorOutput(flavor));
+    }
   }
   const binary = join(output, "linux-unpacked/openwork");
   const resources = join(output, "linux-unpacked/resources");
@@ -45,14 +72,12 @@ try {
   run("server-import", binary, ["--input-type=module", "-e",
     `const server = await import(${JSON.stringify(embedded)}); if (typeof server.startEmbeddedServer !== "function") throw new Error("Missing embedded server export");`],
   15_000, { ELECTRON_RUN_AS_NODE: "1", NODE_PATH: "", NODE_OPTIONS: "" }, output);
-  run("desktop-boot", "xvfb-run", ["-a", "pnpm", "evals:e2e", "app-smoke", "--local"], 90_000, {
-    OPENWORK_EVAL_ELECTRON_BINARY: binary,
-    OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED: "1",
-    OPENWORK_EVAL_ENGINE: "v1",
-    OPENWORK_EVAL_SURFACES_DIR: join(output, "profiles"),
-    ELECTRON_RUN_AS_NODE: "",
-    NODE_PATH: "", NODE_OPTIONS: "",
-  });
+  bootPackagedDesktop("desktop-boot", "app-smoke", binary, 90_000);
+  for (const { flavor, executable } of gatedFlavors) {
+    const flavorBinary = join(flavorOutput(flavor), "linux-unpacked", executable);
+    accessSync(flavorBinary, constants.X_OK);
+    bootPackagedDesktop(`desktop-boot-${flavor}`, "packaged-first-launch", flavorBinary, 150_000);
+  }
   report.passed = true;
 } finally {
   report.totalMilliseconds = Math.round(performance.now() - started);

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -6,6 +6,8 @@ const definitions = {
   // Fixes a fault proxy in front of den-api before Den boots; only the local lane can do that.
   'mcp-oauth-start-unreadable-response.e2e.test.ts': { name: 'Read why a connection sign-in could not start', placement: 'local' },
   'app-smoke.e2e.test.ts': { name: 'Open a working desktop', critical: true },
+  // Boots the packaged cloud and enterprise artifacts; only packaged-smoke provides those binaries.
+  'packaged-first-launch.e2e.test.ts': { name: 'Open a fresh cloud or enterprise install', placement: 'local' },
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
   'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },

--- a/evals/specs/packaged-first-launch.e2e.test.ts
+++ b/evals/specs/packaged-first-launch.e2e.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { isRenderCrash, packagedFirstLaunchWorld } from "../worlds/packaged-first-launch.ts";
+import type { PackagedFlavor } from "../worlds/packaged-first-launch.ts";
+
+const test = spec.world(packagedFirstLaunchWorld, { timeout: 180_000 });
+
+/**
+ * What a brand-new machine sees on first launch. The cloud and enterprise
+ * flavors render a gate above the routes, before any provider that needs a
+ * signed-in or activated desktop exists. 0.18.43 and 0.18.44 shipped with the
+ * enterprise gate throwing during render, which left customers a blank window.
+ * The public flavor has no gate and is covered by app-smoke.
+ */
+const FIRST_LAUNCH_HEADING: Partial<Record<PackagedFlavor, string>> = {
+  cloud: "Welcome to OpenWork",
+  enterprise: "Link this app to your organization",
+};
+
+test("a packaged flavor renders its first-launch gate without a render crash", async ({ world, user, probe, evidence }) => {
+  const flavor = await probe.eventually(() => world.flavor(), {
+    within: 30_000,
+    label: "packaged distribution flavor",
+    until: (value) => value !== null,
+  });
+  if (flavor === null) throw new Error("The packaged desktop did not report its distribution flavor");
+  const heading = FIRST_LAUNCH_HEADING[flavor];
+  if (!heading) throw new Error(`The ${flavor} flavor has no first-launch gate; point OPENWORK_EVAL_ELECTRON_BINARY at a cloud or enterprise build`);
+
+  // A render throw unmounts the whole tree, so an empty #root and the crash
+  // arrive together. Stop on the first crash so the failure names it instead of
+  // timing out on a blank window.
+  const rootText = await probe.eventually(() => world.rootText(), {
+    within: 60_000,
+    label: `${flavor} first-launch gate mounted in #root`,
+    until: (text) => text.includes(heading) || world.exceptions().some(isRenderCrash),
+  });
+  const exceptions = world.exceptions();
+  const crashes = exceptions.filter(isRenderCrash);
+  const contextCrashes = exceptions.filter((exception) => /context is missing|must be used within/i.test(`${exception.text} ${exception.description}`));
+  expect(contextCrashes, "a provider context was missing during first launch").toEqual([]);
+  expect(crashes, "the renderer threw during first launch").toEqual([]);
+
+  expect(rootText).toContain(heading);
+  await user.see({ text: heading });
+  await user.notSee({ text: /Something went wrong/ });
+  await user.screenshot();
+
+  const rejections = exceptions.length - crashes.length;
+  evidence.recordAssertionEvidence(
+    `The ${flavor} desktop mounts "${heading}" on first launch without a render crash`,
+    `#root text: ${JSON.stringify(rootText.slice(0, 200))}; render crashes: ${crashes.length}; unhandled promise rejections (not gating): ${rejections}`,
+    crashes.length === 0,
+  );
+});

--- a/evals/worlds/packaged-first-launch.ts
+++ b/evals/worlds/packaged-first-launch.ts
@@ -1,0 +1,134 @@
+import { attachSurface, evaluateOnSurface } from "@openwork/cdp";
+import type { AttachedSurface } from "@openwork/cdp";
+import { SkipError } from "@openwork/env";
+import type { Seed } from "@openwork/env";
+import { localHost } from "@openwork/hosts";
+
+/**
+ * First launch of a packaged desktop flavor on a machine that has never run
+ * OpenWork: no bootstrap, no activation, no sign-in. The cloud and enterprise
+ * flavors render a gate above the routes here, which is the one code path
+ * dogfooding never exercises. `desktop()` cannot be used because its readiness
+ * probe only recognises signed-in surfaces, so this world attaches directly.
+ */
+
+export type PackagedFlavor = "public" | "cloud" | "enterprise";
+
+export interface RendererException {
+  text: string;
+  description: string;
+}
+
+/**
+ * A synchronous uncaught exception is what unmounts the React tree and leaves a
+ * blank window. Unhandled promise rejections surface as "Uncaught (in promise)"
+ * and never take the UI down, so they are reported but do not gate.
+ */
+export function isRenderCrash(exception: RendererException): boolean {
+  return !/\(in promise\)/i.test(exception.text);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function exceptionFrom(params: unknown): RendererException | null {
+  if (!isRecord(params) || !isRecord(params.exceptionDetails)) return null;
+  const details = params.exceptionDetails;
+  const exception = isRecord(details.exception) ? details.exception : {};
+  return {
+    text: readString(details.text),
+    description: readString(exception.description) || readString(exception.value),
+  };
+}
+
+/**
+ * The eval CDP client ignores protocol events, so boot-time exceptions need a
+ * second session on the same page target. Enabling the Runtime domain replays
+ * exceptions recorded before the session attached.
+ */
+async function observeRendererExceptions(surface: AttachedSurface) {
+  const debuggerUrl = surface.client.webSocketDebuggerUrl;
+  if (!debuggerUrl) throw new Error("Renderer exception witness needs a page debugger URL");
+  const socket = new WebSocket(debuggerUrl);
+  const exceptions: RendererException[] = [];
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Renderer exception witness did not attach")), 15_000);
+    socket.addEventListener("open", () => socket.send(JSON.stringify({ id: 1, method: "Runtime.enable", params: {} })));
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout);
+      reject(new Error("Renderer exception witness connection failed"));
+    });
+    socket.addEventListener("message", (event) => {
+      const message: unknown = JSON.parse(String(event.data));
+      if (!isRecord(message)) return;
+      if (message.id === 1) {
+        clearTimeout(timeout);
+        if (message.error) reject(new Error("Runtime.enable failed for the exception witness"));
+        else resolve();
+      }
+      if (message.method !== "Runtime.exceptionThrown") return;
+      const exception = exceptionFrom(message.params);
+      if (exception) exceptions.push(exception);
+    });
+  });
+  return {
+    exceptions,
+    close() {
+      socket.close();
+    },
+  };
+}
+
+export async function packagedFirstLaunchWorld(_seed: Seed) {
+  if (!process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim()) {
+    throw new SkipError("OPENWORK_EVAL_ELECTRON_BINARY points at a packaged desktop binary");
+  }
+  const host = localHost();
+  const handle = await host.spawnElectron("packaged-first-launch", {
+    profile: "fresh",
+    prepareSharedResources: false,
+    env: { OPENWORK_DEV_MODE: "0", OPENWORK_ELECTRON_START_URL: "", ELECTRON_START_URL: "" },
+  });
+  let app: AttachedSurface | null = null;
+  let witness: Awaited<ReturnType<typeof observeRendererExceptions>> | null = null;
+  const dispose = async () => {
+    witness?.close();
+    try {
+      await app?.stop();
+    } finally {
+      await host.disposeSurface(handle);
+    }
+  };
+  try {
+    app = await attachSurface(handle, { timeoutMs: 60_000 });
+    witness = await observeRendererExceptions(app);
+  } catch (error) {
+    await dispose().catch(() => undefined);
+    throw error;
+  }
+  const attached = app;
+  const observed = witness;
+  return {
+    app: attached,
+    /** Flavor baked into the packaged artifact, as the renderer sees it. */
+    flavor: () => evaluateOnSurface(attached, (): PackagedFlavor | null => {
+      const electron: unknown = Reflect.get(window, "__OPENWORK_ELECTRON__");
+      if (typeof electron !== "object" || electron === null) return null;
+      const meta: unknown = Reflect.get(electron, "meta");
+      if (typeof meta !== "object" || meta === null) return null;
+      const distribution: unknown = Reflect.get(meta, "distribution");
+      if (typeof distribution !== "object" || distribution === null) return null;
+      const flavor: unknown = Reflect.get(distribution, "flavor");
+      return flavor === "public" || flavor === "cloud" || flavor === "enterprise" ? flavor : null;
+    }),
+    /** Text React actually mounted, as opposed to the body chrome. */
+    rootText: () => evaluateOnSurface(attached, () => document.getElementById("root")?.innerText ?? ""),
+    exceptions: () => [...observed.exceptions],
+    [Symbol.asyncDispose]: dispose,
+  };
+}


### PR DESCRIPTION
## Problem

The cloud and enterprise desktop artifacts render a gate above the routes on first launch (sign-in, or "Link this app to your organization"). That code path never ran in CI: `packaged-smoke.mjs` booted only the public flavor, and the enterprise gate was covered by `readFileSync(...).toContain(...)` assertions on source text.

0.18.43 and 0.18.44 shipped with `DesktopUpdaterProvider` (#4482) reading `Local` and `DesktopConfig` contexts that the pre-activation branch of `EnterpriseAwareAppProviders` never mounted. Every fresh self-hosted install (Airwallex report, 2026-09-09) opened to a blank window with `Error: Local context is missing`. Our telemetry cannot see this by design (Sentry only sends after sign-in), so CI is the only place it can be caught.

## What this PR does

1. **Carries the fix from #4606** (author preserved, @tianlinzx). Fork PRs cannot receive Warden clearance, and the gate below is red on `dev` without the fix, so they land together. This gives the fix the runtime proof AGENTS.md requires.
2. **New journey `packaged-first-launch.e2e.test.ts`** with world `evals/worlds/packaged-first-launch.ts`: boots the packaged binary on a fresh profile (no bootstrap, no activation), attaches without the signed-in readiness gate, opens a second CDP session for `Runtime.exceptionThrown`, and asserts the flavor's gate heading is mounted in `#root` with zero synchronous render crashes (unhandled promise rejections are recorded, not gating; the pre-activation `openwork:desktop` IPC rejection predates this and is harmless).
3. **`packaged-smoke.mjs`** now packages `electron-builder.enterprise.yml` and `electron-builder.cloud.yml` and boots each through that journey, in the same `openwork-tests-build` step that already blocks merges. No workflow file changes; package ≈ 9 s and boot ≈ 10 s per flavor on the warm runner.
4. Registers the journey in `journey-catalog.mjs` with `placement: local` (only packaged-smoke has the binaries).

## Proof (local lane, macOS arm64)

| Binary under test | Result |
|---|---|
| Shipped `openwork-enterprise-mac-arm64-0.18.44` | **Failed** in 12 s: `a provider context was missing during first launch … Error: Local context is missing at Sb (app-DqZb8wH-.js:1082)` |
| Shipped `openwork-enterprise-mac-arm64-0.18.42` | Passed (10.2 s) |
| This branch, `electron-builder.enterprise.yml --mac --dir` | Passed (10.1 s) |
| This branch, `electron-builder.cloud.yml --mac --dir` | Passed (6.1 s) |

Commands:
```
OPENWORK_EVAL_ELECTRON_BINARY="<app>/Contents/MacOS/<exe>" OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED=1 \
OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_SURFACES_DIR=/tmp/profiles pnpm evals:e2e packaged-first-launch --local
```
Also: `apps/app` `bun test src/react-app/shell/providers.test.tsx tests/enterprise-activation.test.ts` 11 pass (the new unit test fails when `providers.tsx` is reverted to `dev`); `evals` typecheck, `lint:layers`, channel and boundary ratchets report nothing for the new files (remaining findings are pre-existing on `dev`); `node --test evals/scripts/journey-ci.test.mjs` 12 pass.

The Linux packaged-smoke lane runs in this PR's `openwork-tests-build` job and is the authoritative evidence.

## Follow-ups (not in this PR)
- Root error boundary so a render throw shows a recovery screen instead of an empty window (#3402, being revived separately).
- Collapse the two provider trees in `EnterpriseAwareAppProviders` so AppRoot-level consumers cannot depend on a branch they cannot see.
- Replace the remaining source-string assertions in `apps/app/tests/enterprise-activation.test.ts` with render tests.

Closes #4606.
