### PR TITLE
fix(app): show a recovery screen instead of a blank window when a render throws

### DIFF
--- a/apps/app/src/index.react.tsx
+++ b/apps/app/src/index.react.tsx
@@ -17,6 +17,7 @@ import {
   PlatformProvider,
 } from "./react-app/kernel/platform";
 import { AppProviders } from "./react-app/shell/providers";
+import { AppErrorBoundary } from "./react-app/shell/app-error-boundary";
 import { AppRoot } from "./react-app/shell/app-root";
 import { setWebNotificationHandler } from "./react-app/shell/desktop-notifications";
 import { startDeepLinkBridge } from "./react-app/shell/startup-deep-links";
@@ -43,16 +44,18 @@ const Router = isDesktopRuntime() ? HashRouter : BrowserRouter;
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <PlatformProvider value={platform}>
-          <AppProviders>
-            <Router>
-              <AppRoot />
-            </Router>
-          </AppProviders>
-        </PlatformProvider>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <AppErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <PlatformProvider value={platform}>
+            <AppProviders>
+              <Router>
+                <AppRoot />
+              </Router>
+            </AppProviders>
+          </PlatformProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </AppErrorBoundary>
   </React.StrictMode>,
 );

--- a/apps/app/src/react-app/shell/app-error-boundary.tsx
+++ b/apps/app/src/react-app/shell/app-error-boundary.tsx
@@ -1,0 +1,82 @@
+/** @jsxImportSource react */
+
+import * as React from "react";
+
+interface AppErrorBoundaryState {
+  error: Error | null;
+}
+
+function formatError(error: Error): string {
+  return error.stack ?? `${error.name}: ${error.message}`;
+}
+
+/**
+ * Last-resort boundary around the whole application.
+ *
+ * React unmounts the entire tree when a render throws, so before this existed a
+ * single bad value rendered the app as a blank white window with nothing in the
+ * UI to explain it. The same failure mode is documented on the tool-part
+ * boundary in components/chat/message-list.tsx, which was added after it was
+ * seen in production.
+ *
+ * This deliberately renders plain elements and does not call `t()`: locale
+ * initialization runs before the tree mounts and has itself been a source of
+ * startup failures, so the screen that reports a crash must not depend on it.
+ */
+export class AppErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("[app] render failed", error, info.componentStack);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
+        <div className="flex w-full max-w-lg flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-lg font-semibold text-foreground">
+              OpenWork hit an unexpected error
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              The window recovered instead of going blank. Reloading usually clears it.
+            </p>
+          </div>
+
+          <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs text-muted-foreground">
+            {formatError(error)}
+          </pre>
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
+              onClick={() => window.location.reload()}
+            >
+              Reload
+            </button>
+            <button
+              type="button"
+              className="rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground"
+              onClick={() => {
+                void navigator.clipboard?.writeText(formatError(error));
+              }}
+            >
+              Copy details
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/app/src/react-app/shell/app-error-boundary.tsx
+++ b/apps/app/src/react-app/shell/app-error-boundary.tsx
@@ -1,36 +1,157 @@
 /** @jsxImportSource react */
 
 import * as React from "react";
+import { openworkServerInfo, readDesktopDistributionInfo, revealDesktopItemInDir } from "@/app/lib/desktop";
+import { getOpenWorkDeployment } from "@/app/lib/openwork-deployment";
+
+const APP_VERSION = String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
+
+export type CrashDetails = {
+  message: string;
+  stack: string;
+};
+
+export type CrashContext = {
+  version: string;
+  deployment: string;
+  flavor: string;
+};
 
 interface AppErrorBoundaryState {
-  error: Error | null;
+  crash: CrashDetails | null;
 }
 
-function formatError(error: Error): string {
-  return error.stack ?? `${error.name}: ${error.message}`;
+/** React hands the boundary whatever was thrown; only Error carries a stack. */
+export function describeCrash(thrown: unknown): CrashDetails {
+  if (thrown instanceof Error) {
+    return { message: thrown.message, stack: thrown.stack ?? "" };
+  }
+  return { message: String(thrown), stack: "" };
+}
+
+/** Clipboard payload: message, stack, app version and distribution flavor. */
+export function buildCrashReport(crash: CrashDetails, context: CrashContext): string {
+  const header = `OpenWork ${context.version} (${context.deployment}, ${context.flavor})`;
+  return [header, crash.message, crash.stack].filter((line) => line.length > 0).join("\n\n");
+}
+
+function readCrashContext(): CrashContext {
+  return {
+    version: APP_VERSION,
+    deployment: getOpenWorkDeployment(),
+    flavor: readDesktopDistributionInfo().flavor,
+  };
+}
+
+/**
+ * The server log lives under the desktop profile and is only reachable through
+ * the desktop bridge. On the web, or before an enterprise install is activated,
+ * the bridge refuses the call and the action stays hidden.
+ */
+async function resolveLogFilePath(): Promise<string | null> {
+  try {
+    return (await openworkServerInfo()).logFilePath;
+  } catch {
+    return null;
+  }
+}
+
+function RecoveryScreen({ crash }: { crash: CrashDetails }) {
+  const [copied, setCopied] = React.useState(false);
+  const [logFilePath, setLogFilePath] = React.useState<string | null>(null);
+  const [logsError, setLogsError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void resolveLogFilePath().then((path) => {
+      if (!cancelled) setLogFilePath(path);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const copy = () => {
+    void navigator.clipboard.writeText(buildCrashReport(crash, readCrashContext())).then(() => setCopied(true));
+  };
+
+  const openLogs = (path: string) => {
+    revealDesktopItemInDir(path).catch((error: unknown) => {
+      setLogsError(error instanceof Error ? error.message : String(error));
+    });
+  };
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center bg-background p-6" role="alert">
+      <div className="flex w-full max-w-lg flex-col gap-4 text-sm">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-lg font-semibold text-foreground">OpenWork hit an unexpected error</h1>
+          <p className="text-muted-foreground">
+            The window recovered instead of going blank. Reloading usually clears it.
+          </p>
+        </div>
+
+        <p className="break-words font-medium text-foreground">{crash.message}</p>
+        {crash.stack ? (
+          <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs text-muted-foreground">
+            {crash.stack}
+          </pre>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="rounded-md bg-primary px-3 py-2 font-medium text-primary-foreground"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-border px-3 py-2 font-medium text-foreground"
+            onClick={copy}
+          >
+            {copied ? "Copied" : "Copy details"}
+          </button>
+          {logFilePath ? (
+            <button
+              type="button"
+              className="rounded-md border border-border px-3 py-2 font-medium text-foreground"
+              onClick={() => openLogs(logFilePath)}
+            >
+              Open logs folder
+            </button>
+          ) : null}
+        </div>
+        {logsError ? <p className="text-muted-foreground">{logsError}</p> : null}
+      </div>
+    </div>
+  );
 }
 
 /**
  * Last-resort boundary around the whole application.
  *
  * React unmounts the entire tree when a render throws, so before this existed a
- * single bad value rendered the app as a blank white window with nothing in the
- * UI to explain it. The same failure mode is documented on the tool-part
- * boundary in components/chat/message-list.tsx, which was added after it was
- * seen in production.
+ * single bad value rendered the app as a blank window with nothing in the UI to
+ * explain it. The same failure mode is documented on the tool-part boundary in
+ * components/chat/message-list.tsx, which was added after it was seen in
+ * production.
  *
- * This deliberately renders plain elements and does not call `t()`: locale
- * initialization runs before the tree mounts and has itself been a source of
- * startup failures, so the screen that reports a crash must not depend on it.
+ * It sits above every provider in index.react.tsx, so it must not read any
+ * React context. It deliberately renders plain elements and does not call
+ * `t()`: locale initialization runs before the tree mounts and has itself been
+ * a source of startup failures, so the screen that reports a crash must not
+ * depend on it. No network is needed: the report is copied, never sent.
  */
 export class AppErrorBoundary extends React.Component<
   { children: React.ReactNode },
   AppErrorBoundaryState
 > {
-  state: AppErrorBoundaryState = { error: null };
+  state: AppErrorBoundaryState = { crash: null };
 
-  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
-    return { error };
+  static getDerivedStateFromError(thrown: unknown): AppErrorBoundaryState {
+    return { crash: describeCrash(thrown) };
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
@@ -38,45 +159,8 @@ export class AppErrorBoundary extends React.Component<
   }
 
   render() {
-    const { error } = this.state;
-    if (!error) return this.props.children;
-
-    return (
-      <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
-        <div className="flex w-full max-w-lg flex-col gap-4">
-          <div className="flex flex-col gap-1">
-            <h1 className="text-lg font-semibold text-foreground">
-              OpenWork hit an unexpected error
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              The window recovered instead of going blank. Reloading usually clears it.
-            </p>
-          </div>
-
-          <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs text-muted-foreground">
-            {formatError(error)}
-          </pre>
-
-          <div className="flex gap-2">
-            <button
-              type="button"
-              className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
-              onClick={() => window.location.reload()}
-            >
-              Reload
-            </button>
-            <button
-              type="button"
-              className="rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground"
-              onClick={() => {
-                void navigator.clipboard?.writeText(formatError(error));
-              }}
-            >
-              Copy details
-            </button>
-          </div>
-        </div>
-      </div>
-    );
+    const { crash } = this.state;
+    if (!crash) return this.props.children;
+    return <RecoveryScreen crash={crash} />;
   }
 }

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -1,7 +1,7 @@
 import { ComputerUseControls } from "../domains/session/surface/computer-use-controls";
 /** @jsxImportSource react */
 
-import { useEffect, useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router";
 
 import { captureAnalyticsEvent, initAnalytics } from "../../app/lib/analytics";
@@ -345,6 +345,28 @@ function BrandThemeControlActions() {
     };
   }, []);
   useControlAction(relaunchAction);
+
+  const [renderThrow, setRenderThrow] = useState<string | null>(null);
+  const renderThrowAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+    return {
+      id: "eval.app.render_throw",
+      label: "Throw during render for eval",
+      description: "Dev-only eval hook that throws during React render so the app-level recovery screen can be exercised.",
+      sideEffect: "mutation",
+      requiresArgs: true,
+      args: [{ name: "message", type: "string", required: true, description: "Error message to throw." }],
+      execute: (args) => {
+        if (typeof args !== "object" || args === null || !("message" in args) || typeof args.message !== "string") {
+          return { ok: false, error: "message is required" };
+        }
+        setRenderThrow(args.message);
+        return undefined;
+      },
+    };
+  }, []);
+  useControlAction(renderThrowAction);
+  if (renderThrow) throw new Error(renderThrow);
 
   return null;
 }

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { AppErrorBoundary } from "../src/react-app/shell/app-error-boundary";
+
+// react-dom/server rethrows instead of running error boundaries, so the catch
+// path is exercised by driving the state transition directly:
+// getDerivedStateFromError produces the state, then render() produces the
+// fallback the user actually sees.
+function renderFallback(error: Error): string {
+  const boundary = new AppErrorBoundary({ children: null });
+  boundary.state = AppErrorBoundary.getDerivedStateFromError(error);
+  return renderToStaticMarkup(<>{boundary.render()}</>);
+}
+
+test("getDerivedStateFromError captures the error for the fallback", () => {
+  const error = new Error("boom");
+  expect(AppErrorBoundary.getDerivedStateFromError(error)).toEqual({ error });
+});
+
+test("a captured error renders the recovery screen instead of a blank window", () => {
+  const html = renderFallback(new Error("render exploded"));
+
+  expect(html).toContain("OpenWork hit an unexpected error");
+  expect(html).toContain("render exploded");
+  expect(html).toContain("Reload");
+  expect(html).toContain("Copy details");
+});
+
+test("the recovery screen prefers a stack when one is available", () => {
+  const error = new Error("no stack here");
+  error.stack = "Error: no stack here\n    at sessionRoute (session-route.tsx:1797)";
+
+  expect(renderFallback(error)).toContain("session-route.tsx:1797");
+});
+
+test("children render untouched when nothing throws", () => {
+  const html = renderToStaticMarkup(
+    <AppErrorBoundary>
+      <p>session surface</p>
+    </AppErrorBoundary>,
+  );
+
+  expect(html).toBe("<p>session surface</p>");
+});

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -1,21 +1,29 @@
 import { expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { AppErrorBoundary } from "../src/react-app/shell/app-error-boundary";
+import {
+  AppErrorBoundary,
+  buildCrashReport,
+  describeCrash,
+} from "../src/react-app/shell/app-error-boundary";
 
 // react-dom/server rethrows instead of running error boundaries, so the catch
 // path is exercised by driving the state transition directly:
 // getDerivedStateFromError produces the state, then render() produces the
 // fallback the user actually sees.
-function renderFallback(error: Error): string {
+function renderFallback(thrown: unknown): string {
   const boundary = new AppErrorBoundary({ children: null });
-  boundary.state = AppErrorBoundary.getDerivedStateFromError(error);
+  boundary.state = AppErrorBoundary.getDerivedStateFromError(thrown);
   return renderToStaticMarkup(<>{boundary.render()}</>);
 }
 
-test("getDerivedStateFromError captures the error for the fallback", () => {
+const context = { version: "0.18.44", deployment: "desktop", flavor: "enterprise" };
+
+test("getDerivedStateFromError captures the message and stack for the fallback", () => {
   const error = new Error("boom");
-  expect(AppErrorBoundary.getDerivedStateFromError(error)).toEqual({ error });
+  expect(AppErrorBoundary.getDerivedStateFromError(error)).toEqual({
+    crash: { message: "boom", stack: error.stack ?? "" },
+  });
 });
 
 test("a captured error renders the recovery screen instead of a blank window", () => {
@@ -25,13 +33,39 @@ test("a captured error renders the recovery screen instead of a blank window", (
   expect(html).toContain("render exploded");
   expect(html).toContain("Reload");
   expect(html).toContain("Copy details");
+  // The logs action depends on the desktop bridge, which is absent here.
+  expect(html).not.toContain("Open logs folder");
 });
 
-test("the recovery screen prefers a stack when one is available", () => {
+test("the recovery screen shows the stack when one is available", () => {
   const error = new Error("no stack here");
   error.stack = "Error: no stack here\n    at sessionRoute (session-route.tsx:1797)";
 
   expect(renderFallback(error)).toContain("session-route.tsx:1797");
+});
+
+test("non-Error throws still produce a readable message", () => {
+  expect(describeCrash("Local context is missing")).toEqual({ message: "Local context is missing", stack: "" });
+  expect(renderFallback("Local context is missing")).toContain("Local context is missing");
+});
+
+test("the copy payload carries message, stack, app version and distribution flavor", () => {
+  const error = new Error("Local context is missing");
+  error.stack = "Error: Local context is missing\n    at useLocal (providers.tsx:42)";
+
+  const report = buildCrashReport(describeCrash(error), context);
+
+  expect(report.split("\n\n")).toEqual([
+    "OpenWork 0.18.44 (desktop, enterprise)",
+    "Local context is missing",
+    error.stack,
+  ]);
+});
+
+test("the copy payload omits an empty stack", () => {
+  expect(buildCrashReport({ message: "plain", stack: "" }, context)).toBe(
+    "OpenWork 0.18.44 (desktop, enterprise)\n\nplain",
+  );
 });
 
 test("children render untouched when nothing throws", () => {

--- a/evals/specs/app-render-crash-recovery.e2e.test.ts
+++ b/evals/specs/app-render-crash-recovery.e2e.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { renderCrashWorld } from "../worlds/first-run.ts";
+
+const test = spec.world(renderCrashWorld);
+
+// Thrown by the dev-only eval hook; the recovery screen must show it verbatim.
+const MESSAGE = "Local context is missing (eval render throw)";
+const heading = { text: /OpenWork hit an unexpected error/ };
+
+test("a render throw shows a recovery screen with the error instead of a blank window", async ({ world, user, agent, probe, step }) => {
+  await step("the app is healthy and shows no recovery screen", async () => {
+    expect((await probe.text()).trim().length).toBeGreaterThan(40);
+    await user.notSee(heading);
+  });
+
+  await step("a throw during render lands on the recovery screen, not an empty window", async () => {
+    await agent.run("eval.app.render_throw", { message: MESSAGE });
+    await user.see(heading, { timeoutMs: 15_000 });
+    await user.see({ text: MESSAGE });
+    // The stack names the throwing component, so the failure is reportable.
+    await user.see({ text: /at BrandThemeControlActions/ });
+    await user.see({ role: "button", label: /^reload$/i });
+    await user.see({ role: "button", label: /copy details/i });
+    await user.see({ role: "button", label: /open logs folder/i });
+  });
+
+  await step("copy puts message, stack, app version and flavor on the clipboard", async () => {
+    await user.click({ role: "button", label: /copy details/i });
+    await user.see({ role: "button", label: /^copied$/i });
+    const clipboard = await probe.eventually(() => world.readClipboard(), {
+      within: 5_000,
+      label: "crash report on the clipboard",
+      until: (value) => typeof value === "string" && value.includes(MESSAGE),
+    });
+    const [header, message, stack] = clipboard.split("\n\n");
+    expect(header).toMatch(/^OpenWork \S+ \(desktop, (public|enterprise)\)$/);
+    expect(message).toBe(MESSAGE);
+    expect(stack).toMatch(/at BrandThemeControlActions/);
+  });
+
+  await step("reload brings the app back", async () => {
+    await user.click({ role: "button", label: /^reload$/i });
+    await user.notSee(heading, { timeoutMs: 60_000 });
+    await probe.eventually(() => probe.text(), {
+      within: 120_000,
+      label: "app content after reload",
+      until: (text) => text.trim().length > 40 && !/OpenWork hit an unexpected error/.test(text),
+    });
+  });
+});

--- a/evals/specs/app-render-crash-recovery.e2e.test.ts
+++ b/evals/specs/app-render-crash-recovery.e2e.test.ts
@@ -23,6 +23,7 @@ test("a render throw shows a recovery screen with the error instead of a blank w
     await user.see({ role: "button", label: /^reload$/i });
     await user.see({ role: "button", label: /copy details/i });
     await user.see({ role: "button", label: /open logs folder/i });
+    await user.screenshot();
   });
 
   await step("copy puts message, stack, app version and flavor on the clipboard", async () => {
@@ -41,11 +42,11 @@ test("a render throw shows a recovery screen with the error instead of a blank w
 
   await step("reload brings the app back", async () => {
     await user.click({ role: "button", label: /^reload$/i });
-    await user.notSee(heading, { timeoutMs: 60_000 });
     await probe.eventually(() => probe.text(), {
       within: 120_000,
       label: "app content after reload",
       until: (text) => text.trim().length > 40 && !/OpenWork hit an unexpected error/.test(text),
     });
+    await user.notSee(heading);
   });
 });

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -623,6 +623,19 @@ export async function reliableRecoveryWorld(_seed: Seed, { place }: { place: Pla
   };
 }
 
+/**
+ * A healthy desktop whose render tree is about to throw. The spec triggers the
+ * throw through the dev-only `eval.app.render_throw` control action and reads
+ * back what the recovery screen put on the clipboard.
+ */
+export async function renderCrashWorld(seed: Seed) {
+  const app = await seed.desktop({ name: "render-crash" });
+  return {
+    app,
+    readClipboard: () => seed.evalIn(app, () => (navigator.clipboard.readText()), { awaitPromise: true }),
+  };
+}
+
 async function installUpdaterRaceBridge(app: Awaited<ReturnType<typeof desktop>>, delayStable: boolean) {
   const installed = await evalIn(app, browserScript((delayStable) => {
     const nativeUpdater = window.__OPENWORK_ELECTRON__?.updater;


### PR DESCRIPTION
## Summary
Last-resort React error boundary around the whole desktop/web app. A throw during render — including inside `AppProviders` or the activation gate — now shows a recovery screen instead of an empty `#root`.

Supersedes #3402 by @pranshu26 (rebased onto current `dev`, boundary and test kept; recovery actions and journey proof added). Co-authored-by trailer is on the commit.

## Why
React unmounts the entire tree when a render throws. Until now the only boundaries were `LexicalErrorBoundary` and the tool-part boundary in `components/chat/message-list.tsx`; nothing sat above the routes. A pre-activation crash in an enterprise install is also invisible to telemetry by design (desktop Sentry only sends after a signed-in user/org), so the recovery screen must work with no network and no providers mounted. The provider-composition bug that surfaced this is fixed separately in #4606; this PR changes what any such crash looks like, not the individual cause.

## What changed
- `apps/app/src/react-app/shell/app-error-boundary.tsx` — the boundary and its recovery screen. Sits above every provider in `index.react.tsx`, reads no React context, no `t()` (locale init has itself been a startup failure), no network.
  - Shows the thrown message and stack (non-`Error` throws are stringified).
  - **Copy details** → clipboard: `OpenWork <version> (<deployment>, <flavor>)`, message, stack.
  - **Open logs folder** → reveals the server log via the existing `openworkServerInfo` + `__revealItemInDir` bridge. Hidden on the web and before enterprise activation, where the bridge refuses the call (and no server log exists yet).
  - **Reload**.
- `apps/app/src/index.react.tsx` — wrap the tree inside `StrictMode`, outside `QueryClientProvider`.
- `apps/app/src/react-app/shell/app-root.tsx` — dev-only `eval.app.render_throw` control action (gated on `import.meta.env.DEV`, next to `eval.app.relaunch`) so a journey spec can make the real app throw during render.
- `apps/app/tests/app-error-boundary.test.tsx` — unit coverage for the state transition, fallback markup, non-Error throws, and the exact copy payload.
- `evals/specs/app-render-crash-recovery.e2e.test.ts` + `renderCrashWorld` in `evals/worlds/first-run.ts` — journey spec.

## Proof
Journey spec: `pnpm evals:e2e app-render-crash-recovery` — `placement: daytona (daytona CLI authenticated)`, checkout `9e9ad071dffc`, 1 passed / 0 failed / 0 skipped, verdict `passed`. Steps: app healthy with no recovery screen → `eval.app.render_throw` lands on the recovery screen showing the message, a stack naming the throwing component, Reload / Copy details / Open logs folder → Copy details flips to "Copied" and the clipboard holds `OpenWork <version> (desktop, public|enterprise)`, the message, and the stack → Reload restores the app and the recovery screen is gone.

Also: `pnpm --filter @openwork/app typecheck` exit 0; `bun test --isolate tests/app-error-boundary.test.tsx` 7 pass / 0 fail; boundary and channel ratchets report nothing for the new spec.

Evidence comment follows via `pnpm evals:e2e --publish`.

## Rollback
Revert the commit — remove the wrapper in `index.react.tsx`, the eval hook in `app-root.tsx`, and the new files. Nothing else imports the boundary.
