### PR TITLE
fix(app): keep crash details behind a Technical details toggle

### DIFF
--- a/apps/app/src/react-app/shell/app-error-boundary.tsx
+++ b/apps/app/src/react-app/shell/app-error-boundary.tsx
@@ -57,6 +57,7 @@ async function resolveLogFilePath(): Promise<string | null> {
 }
 
 function RecoveryScreen({ crash }: { crash: CrashDetails }) {
+  const [open, setOpen] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
   const [logFilePath, setLogFilePath] = React.useState<string | null>(null);
   const [logsError, setLogsError] = React.useState<string | null>(null);
@@ -91,14 +92,7 @@ function RecoveryScreen({ crash }: { crash: CrashDetails }) {
           </p>
         </div>
 
-        <p className="break-words font-medium text-foreground">{crash.message}</p>
-        {crash.stack ? (
-          <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs text-muted-foreground">
-            {crash.stack}
-          </pre>
-        ) : null}
-
-        <div className="flex flex-wrap gap-2">
+        <div>
           <button
             type="button"
             className="rounded-md bg-primary px-3 py-2 font-medium text-primary-foreground"
@@ -106,24 +100,48 @@ function RecoveryScreen({ crash }: { crash: CrashDetails }) {
           >
             Reload
           </button>
+        </div>
+
+        {/* Same disclosure shape as the session error card: the raw payload
+            and its actions are for whoever reports the crash, on demand. */}
+        <div className="flex flex-col gap-2">
           <button
             type="button"
-            className="rounded-md border border-border px-3 py-2 font-medium text-foreground"
-            onClick={copy}
+            aria-expanded={open}
+            onClick={() => setOpen(!open)}
+            className="flex w-fit items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
           >
-            {copied ? "Copied" : "Copy details"}
+            <span aria-hidden="true" className={open ? "inline-block rotate-90" : "inline-block"}>›</span>
+            Technical details
           </button>
-          {logFilePath ? (
-            <button
-              type="button"
-              className="rounded-md border border-border px-3 py-2 font-medium text-foreground"
-              onClick={() => openLogs(logFilePath)}
-            >
-              Open logs folder
-            </button>
+          {open ? (
+            <div className="flex flex-col gap-2 rounded-lg bg-muted p-3 text-xs">
+              <p className="break-words font-medium text-foreground">{crash.message}</p>
+              {crash.stack ? (
+                <pre className="max-h-64 overflow-auto whitespace-pre-wrap text-muted-foreground">{crash.stack}</pre>
+              ) : null}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  className="rounded-md border border-border px-3 py-1.5 font-medium text-foreground"
+                  onClick={copy}
+                >
+                  {copied ? "Copied" : "Copy details"}
+                </button>
+                {logFilePath ? (
+                  <button
+                    type="button"
+                    className="rounded-md border border-border px-3 py-1.5 font-medium text-foreground"
+                    onClick={() => openLogs(logFilePath)}
+                  >
+                    Open logs folder
+                  </button>
+                ) : null}
+              </div>
+              {logsError ? <p className="text-muted-foreground">{logsError}</p> : null}
+            </div>
           ) : null}
         </div>
-        {logsError ? <p className="text-muted-foreground">{logsError}</p> : null}
       </div>
     </div>
   );

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -26,27 +26,24 @@ test("getDerivedStateFromError captures the message and stack for the fallback",
   });
 });
 
-test("a captured error renders the recovery screen instead of a blank window", () => {
-  const html = renderFallback(new Error("render exploded"));
+test("a captured error renders the recovery screen with the details collapsed", () => {
+  const error = new Error("render exploded");
+  error.stack = "Error: render exploded\n    at sessionRoute (session-route.tsx:1797)";
+  const html = renderFallback(error);
 
   expect(html).toContain("OpenWork hit an unexpected error");
-  expect(html).toContain("render exploded");
   expect(html).toContain("Reload");
-  expect(html).toContain("Copy details");
-  // The logs action depends on the desktop bridge, which is absent here.
+  expect(html).toContain('aria-expanded="false"');
+  expect(html).toContain("Technical details");
+  // Progressive disclosure: the raw payload and its actions wait behind the toggle.
+  expect(html).not.toContain("render exploded");
+  expect(html).not.toContain("session-route.tsx:1797");
+  expect(html).not.toContain("Copy details");
   expect(html).not.toContain("Open logs folder");
-});
-
-test("the recovery screen shows the stack when one is available", () => {
-  const error = new Error("no stack here");
-  error.stack = "Error: no stack here\n    at sessionRoute (session-route.tsx:1797)";
-
-  expect(renderFallback(error)).toContain("session-route.tsx:1797");
 });
 
 test("non-Error throws still produce a readable message", () => {
   expect(describeCrash("Local context is missing")).toEqual({ message: "Local context is missing", stack: "" });
-  expect(renderFallback("Local context is missing")).toContain("Local context is missing");
 });
 
 test("the copy payload carries message, stack, app version and distribution flavor", () => {

--- a/evals/specs/app-render-crash-recovery.e2e.test.ts
+++ b/evals/specs/app-render-crash-recovery.e2e.test.ts
@@ -17,10 +17,20 @@ test("a render throw shows a recovery screen with the error instead of a blank w
   await step("a throw during render lands on the recovery screen, not an empty window", async () => {
     await agent.run("eval.app.render_throw", { message: MESSAGE });
     await user.see(heading, { timeoutMs: 15_000 });
+    await user.see({ role: "button", label: /^reload$/i });
+    await user.see({ role: "button", label: /technical details/i });
+    // Progressive disclosure: the raw payload waits behind the toggle.
+    await user.notSee({ text: MESSAGE });
+    await user.notSee({ text: /at BrandThemeControlActions/ });
+    await user.notSee({ role: "button", label: /copy details/i });
+    await user.screenshot();
+  });
+
+  await step("technical details reveal the message, stack and reporting actions on demand", async () => {
+    await user.click({ role: "button", label: /technical details/i });
     await user.see({ text: MESSAGE });
     // The stack names the throwing component, so the failure is reportable.
     await user.see({ text: /at BrandThemeControlActions/ });
-    await user.see({ role: "button", label: /^reload$/i });
     await user.see({ role: "button", label: /copy details/i });
     await user.see({ role: "button", label: /open logs folder/i });
     await user.screenshot();


### PR DESCRIPTION
## Summary
Follow-up to #4697. The recovery screen now follows the progressive-disclosure shape the rest of the app uses for errors (session error cards in `components/chat/message-list.tsx`, the boot-failure screen in `shell/loading-overlay.tsx`, and recent #4623 / #4666 / #4678): headline, plain guidance and **Reload** first; the raw message, stack, **Copy details** and **Open logs folder** open on demand behind a **Technical details** toggle (`aria-expanded`).

Not gated on Developer mode on purpose: this screen exists so an unsigned-in user can report a crash, so the details stay one click away rather than behind a setting.

## What changed
- `apps/app/src/react-app/shell/app-error-boundary.tsx` — collapsed disclosure; no other behavior change (copy payload, logs bridge, reload unchanged).
- `apps/app/tests/app-error-boundary.test.tsx` — initial markup has the toggle collapsed and does not contain the message, stack, or Copy/Logs actions.
- `evals/specs/app-render-crash-recovery.e2e.test.ts` — negative half before the toggle (message, stack and Copy details not visible), then a new step that opens Technical details and asserts them; copy and reload steps unchanged.

## Proof
`pnpm evals:e2e app-render-crash-recovery` — `placement: daytona (daytona CLI authenticated)`, checkout `6bda7271443e`, 1 passed / 0 failed / 0 skipped, verdict `passed`, 5/5 steps.
`pnpm --filter @openwork/app typecheck` exit 0; `bun test --isolate tests/app-error-boundary.test.tsx` 6 pass / 0 fail. Boundary and channel ratchets report nothing for the spec.

## Rollback
Revert the commit.
