### PR TITLE
test(evals): fail the first-launch gate fast when the error boundary catches the crash

### DIFF
--- a/evals/specs/packaged-first-launch.e2e.test.ts
+++ b/evals/specs/packaged-first-launch.e2e.test.ts
@@ -17,6 +17,9 @@ const FIRST_LAUNCH_HEADING: Partial<Record<PackagedFlavor, string>> = {
   enterprise: "Link this app to your organization",
 };
 
+/** Heading of the root error boundary's recovery screen (app-error-boundary.tsx). */
+const RECOVERY_HEADING = /OpenWork hit an unexpected error/;
+
 test("a packaged flavor renders its first-launch gate without a render crash", async ({ world, user, probe, evidence }) => {
   const flavor = await probe.eventually(() => world.flavor(), {
     within: 30_000,
@@ -27,23 +30,25 @@ test("a packaged flavor renders its first-launch gate without a render crash", a
   const heading = FIRST_LAUNCH_HEADING[flavor];
   if (!heading) throw new Error(`The ${flavor} flavor has no first-launch gate; point OPENWORK_EVAL_ELECTRON_BINARY at a cloud or enterprise build`);
 
-  // A render throw unmounts the whole tree, so an empty #root and the crash
-  // arrive together. Stop on the first crash so the failure names it instead of
+  // A render throw either unmounts the whole tree (empty #root plus an uncaught
+  // exception) or, with the root error boundary, mounts the recovery screen.
+  // Stop on the first of those so the failure names the crash instead of
   // timing out on a blank window.
   const rootText = await probe.eventually(() => world.rootText(), {
     within: 60_000,
     label: `${flavor} first-launch gate mounted in #root`,
-    until: (text) => text.includes(heading) || world.exceptions().some(isRenderCrash),
+    until: (text) => text.includes(heading) || RECOVERY_HEADING.test(text) || world.exceptions().some(isRenderCrash),
   });
   const exceptions = world.exceptions();
   const crashes = exceptions.filter(isRenderCrash);
   const contextCrashes = exceptions.filter((exception) => /context is missing|must be used within/i.test(`${exception.text} ${exception.description}`));
   expect(contextCrashes, "a provider context was missing during first launch").toEqual([]);
   expect(crashes, "the renderer threw during first launch").toEqual([]);
+  expect(rootText, "the root error boundary caught a first-launch render crash").not.toMatch(RECOVERY_HEADING);
 
   expect(rootText).toContain(heading);
   await user.see({ text: heading });
-  await user.notSee({ text: /Something went wrong/ });
+  await user.notSee({ text: RECOVERY_HEADING });
   await user.screenshot();
 
   const rejections = exceptions.length - crashes.length;


### PR DESCRIPTION
## Problem

#4696 added the `packaged-first-launch` journey that gates `packaged-smoke` on the enterprise and cloud first-launch screens. It stops early on `Runtime.exceptionThrown` so a render crash fails by name.

#4697 then mounted a root error boundary. A first-launch render crash now renders "OpenWork hit an unexpected error" instead of unmounting the tree, and React reports caught errors via `console.error`, not `Runtime.exceptionThrown`. The journey still goes red (the gate heading never appears) but only after the full 60 s wait, with a timeout message that buries the cause inside the last-value dump. It also still checked for a stale "Something went wrong" string that no screen uses.

## Change

`evals/specs/packaged-first-launch.e2e.test.ts` only:
- treat the recovery heading as a terminal state in the `eventually` predicate
- assert by name that `#root` does not match the recovery heading
- replace `/Something went wrong/` with the real heading from `app-error-boundary.tsx`

No product code, no world or CI script changes.

## Proof (local lane, macOS arm64, `electron-builder.enterprise.yml --mac --dir`, `pnpm evals:e2e packaged-first-launch --local`)

| Binary under test | Before this change | After this change |
|---|---|---|
| `dev` (fix + error boundary) | passed | **passed**, 11.2 s |
| `dev` with `providers.tsx` reverted to pre-#4696 (incident state + error boundary) | failed after 65.8 s: `Timed out waiting for enterprise first-launch gate mounted in #root` | **failed in 8.0 s**: `AssertionError: the root error boundary caught a first-launch render crash … Local context is missing` |

Also verified in the authoritative Linux lane: `workflow_dispatch` on `ci/packaged-first-launch-gate-control` (gate without fix, before #4697) failed `desktop-boot-enterprise` in 3.5 s with `Error: Local context is missing` (run 34402512668), and `dev` at `5858b51dc` passes both `desktop-boot-enterprise` and `desktop-boot-cloud` (run 34402429872).

Follow-up to #4696 (Airwallex blank-screen incident, 0.18.43 / 0.18.44).