### PR TITLE
ci(security): report missing fork review without exposing credentials

### DIFF
--- a/.github/workflows/external-contributor-checks.yml
+++ b/.github/workflows/external-contributor-checks.yml
@@ -1,0 +1,64 @@
+name: External contributor checks
+
+# Read-only, secret-free validation of the exact pull-request head. This
+# workflow has no credentialed consumer and does not approve external code.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [dev]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: external-contributor-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  secret-free:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout the exact PR head without credentials
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify exact head and whitespace
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git diff --check "$BASE_SHA...$HEAD_SHA"
+          {
+            echo '## Secret-free PR validation'
+            echo
+            echo "PASS: exact-head checkout and \`git diff --check\` completed for \`$HEAD_SHA\`."
+            echo 'This is whitespace validation only; it is not security review or product test evidence.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  fork-review-incomplete:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Report unsupported fork review boundary
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo '## Fork contributor review — INCOMPLETE'
+            echo
+            echo "**INCOMPLETE: exact head \`$HEAD_SHA\` was not reviewed and was not product-tested by this workflow.**"
+            echo
+            echo 'The secret-free whitespace job is not security analysis or product evidence.'
+            echo "Follow \`docs/contributor-security-review.md\` to create a manual exact-head review record and evidence in an isolated environment."
+            echo 'Unsupported credentialed execution of fork code remains blocked; administrators must choose and configure the required-check and approval policy.'
+            echo 'This failing status reports the boundary but does not claim that repository merge rules currently enforce it.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/docs/contributor-security-review.md
+++ b/docs/contributor-security-review.md
@@ -1,0 +1,81 @@
+# Contributor security review
+
+This document defines the review boundary for pull requests from forks. It does
+not change repository settings or authorize credentialed execution of pull
+request code.
+
+## Automated scope
+
+`.github/workflows/external-contributor-checks.yml` checks out the pull request's
+exact event head with persisted checkout credentials disabled, verifies that
+`HEAD` still equals that SHA, and runs `git diff --check` against the event base.
+It does not install dependencies, execute pull request code, receive secrets,
+perform security analysis, or produce product test evidence. Its separate fork
+job therefore reports **INCOMPLETE — not reviewed and not tested** and fails.
+
+Unsupported credentialed execution of fork code remains blocked. There is no
+credentialed consumer behind this workflow. Copying a fork commit or branch to
+an internal branch does not count as review, approval, or evidence and must not
+be used to bypass this boundary.
+
+## Manual exact-head review record
+
+Before treating a fork change as reviewed, a maintainer must record:
+
+- repository and pull request number, base SHA, and the exact 40-character head
+  SHA;
+- reviewer identity, review time, files and generated artifacts reviewed, and
+  the trust boundary used;
+- every finding's stable ID, classification, evidence, `Clear when` condition,
+  and disposition, including an explicit list of unresolved gaps;
+- exact commands, exit codes, placement, artifact directories, and observable
+  assertions for product evidence; skips remain not tested;
+- confirmation that the PR head was re-read after any approval wait and still
+  matched the reviewed SHA. A changed head invalidates the record and requires
+  review and tests to run again.
+
+The review must include introduced risk in:
+
+- dependencies, lockfiles, package-manager configuration, install hooks, and
+  lifecycle or build scripts;
+- test/evaluation harnesses, fixtures, setup actions, runners, caches, and
+  artifact download or publication paths;
+- workflow triggers, event types, permissions, third-party actions, checkout
+  refs, environment gates, and any code that plans or dispatches later jobs;
+- executable, generated, binary, and symlinked files, network destinations,
+  storage boundaries, logging, and credential access; and
+- application and service changes that alter authorization, data access,
+  command execution, or desktop/cloud trust boundaries.
+
+Follow `.warden/README.md` for the repository's final committed-branch review.
+A local review result is supporting evidence, never GitHub approval.
+
+## Isolated credentialed testing prerequisites
+
+Credentialed testing may be designed only after a maintainer approves the exact
+head. It requires all of the following:
+
+1. A fresh disposable runner or sandbox dedicated to that SHA, with no shared
+   home directory, credential cache, mounted volume, host socket, or reusable
+   workspace.
+2. No access to production services or shared development accounts. Network and
+   service access must be limited to disposable test resources.
+3. Narrow, short-lived test credentials held outside pull-request-controlled
+   files and commands. Broad organization, developer, deployment, cloud, or
+   source-control credentials must never be reused.
+4. A fresh server-side comparison of the current PR head to the approved SHA
+   immediately before dispatch, after every approval wait. Mismatch must stop
+   the run.
+5. Recorded negative controls proving that stale-head dispatch, access to
+   shared files or volumes, production endpoints, unapproved outbound traffic,
+   and credential disclosure through logs or artifacts are blocked. These
+   controls must be tested, not assumed.
+6. Destruction of the sandbox and revocation of its credentials after the run,
+   with only reviewed, secret-scanned evidence retained.
+
+This repository does not currently provide that fork credential-execution
+route. Administrators must choose and configure enforcement, such as required
+checks or rulesets for the failing fork status, protected environments and
+reviewers for any future trusted workflow, and the location and required format
+of manual exact-head records. Until then, the workflow status communicates an
+incomplete review; it does not prove that merge policy blocks the pull request.

--- a/evals/scripts/publish-review.mjs
+++ b/evals/scripts/publish-review.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { appendFile, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { publishReviewPr } from "../packages/test-artifacts/src/publish-pr.ts";
@@ -54,9 +54,16 @@ if (current.stdout.trim() !== sha) {
     }
     await visit(directory);
     if (testRunDirs.length === 0) {
-      console.log(
-        "No test records for this PR head were uploaded by the source workflow.",
-      );
+      const message =
+        "INCOMPLETE: no test records for this PR head were uploaded by the source workflow; no passing evidence is claimed.";
+      console.error(message);
+      if (process.env.GITHUB_STEP_SUMMARY) {
+        await appendFile(
+          process.env.GITHUB_STEP_SUMMARY,
+          `## Evidence review — incomplete\n\n${message}\n`,
+        );
+      }
+      process.exitCode = 1;
     } else {
       const result = await publishReviewPr({ pr, testRunDirs, preserveCurrentReport: true });
       console.log(result.posted ? result.urls.report : "A review already covers this commit; preserving the author's selection.");

--- a/evals/specs/evidence-review.test.ts
+++ b/evals/specs/evidence-review.test.ts
@@ -77,6 +77,33 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
     true,
   );
 
+  const missingPublication = await world.runPublisher("missing");
+  expect(missingPublication.code).not.toBe(0);
+  expect(missingPublication.stderr).toContain(
+    "INCOMPLETE: no test records for this PR head",
+  );
+  expect(missingPublication.summary).toContain(
+    "## Evidence review — incomplete",
+  );
+  expect(missingPublication.summary).toContain(
+    "no passing evidence is claimed",
+  );
+  expect(missingPublication.commentWrites).toBe(0);
+  expect(missingPublication.uploadWrites).toBe(0);
+  expect(missingPublication.commandLog).not.toContain('"comment"');
+
+  const currentPublication = await world.runPublisher("current");
+  expect(currentPublication.code).toBe(0);
+  expect(currentPublication.stdout).toContain("http://127.0.0.1:4173/r/");
+  expect(currentPublication.stderr).not.toContain("INCOMPLETE");
+  expect(currentPublication.commentWrites).toBe(1);
+  expect(currentPublication.uploadWrites).toBe(1);
+  evidence.recordAssertionEvidence(
+    "The CI publisher fails closed when exact-head records are missing",
+    "The real publisher CLI exits nonzero and writes an Incomplete summary without upload or comment writes when the controlled download has no current-head record; a valid current-head record follows the supported local-storage and PR-comment path.",
+    true,
+  );
+
   await using production = await reviewWorld("production");
   for (const path of [
     "/",

--- a/evals/specs/evidence-review.test.ts
+++ b/evals/specs/evidence-review.test.ts
@@ -92,6 +92,28 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
   expect(missingPublication.uploadWrites).toBe(0);
   expect(missingPublication.commandLog).not.toContain('"comment"');
 
+  const stalePublication = await world.runPublisher("stale-record");
+  expect(stalePublication.code).not.toBe(0);
+  expect(stalePublication.stderr).toContain(
+    "INCOMPLETE: no test records for this PR head",
+  );
+  expect(stalePublication.summary).toContain(
+    "no passing evidence is claimed",
+  );
+  expect(stalePublication.commentWrites).toBe(0);
+  expect(stalePublication.uploadWrites).toBe(0);
+
+  const supersededPublication = await world.runPublisher("stale-pr-head");
+  expect(supersededPublication.code).toBe(0);
+  expect(supersededPublication.stdout).toContain(
+    "Source run is no longer current; existing evidence is unchanged.",
+  );
+  expect(supersededPublication.commandLog).not.toContain(
+    '["run","download"',
+  );
+  expect(supersededPublication.commentWrites).toBe(0);
+  expect(supersededPublication.uploadWrites).toBe(0);
+
   const currentPublication = await world.runPublisher("current");
   expect(currentPublication.code).toBe(0);
   expect(currentPublication.stdout).toContain("http://127.0.0.1:4173/r/");
@@ -99,8 +121,8 @@ test("A reviewer can inspect two runs and a DocShot with honest results and priv
   expect(currentPublication.commentWrites).toBe(1);
   expect(currentPublication.uploadWrites).toBe(1);
   evidence.recordAssertionEvidence(
-    "The CI publisher fails closed when exact-head records are missing",
-    "The real publisher CLI exits nonzero and writes an Incomplete summary without upload or comment writes when the controlled download has no current-head record; a valid current-head record follows the supported local-storage and PR-comment path.",
+    "The CI publisher distinguishes missing, stale, superseded, and current evidence",
+    "The real publisher CLI exits nonzero with an Incomplete summary and no publication for empty or stale-only downloads; a superseded source run exits successfully before download and preserves existing evidence; a valid current-head record follows the supported local-storage and PR-comment path.",
     true,
   );
 

--- a/evals/worlds/evidence-review.ts
+++ b/evals/worlds/evidence-review.ts
@@ -1,5 +1,13 @@
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,6 +18,7 @@ import { uploadReview } from "@openwork/review/storage";
 import type { TestRunRecord } from "@openwork/test-artifacts";
 
 const root = fileURLToPath(new URL("../../", import.meta.url));
+const publisher = join(root, "evals/scripts/publish-review.mjs");
 
 /** Synthetic report inputs exercise the real publisher and production HTTP app. */
 export async function reviewWorld(
@@ -173,6 +182,96 @@ export async function reviewWorld(
     referenceBundle.assets,
     { localDir: storage },
   );
+  let publisherSequence = 0;
+  async function runPublisher(evidence: "missing" | "current") {
+    publisherSequence += 1;
+    const fixture = join(directory, `publisher-${publisherSequence}`);
+    const bin = join(fixture, "bin");
+    const uploads = join(fixture, "uploads");
+    const summary = join(fixture, "summary.md");
+    const commands = join(fixture, "commands.log");
+    const mutations = join(fixture, "mutations.log");
+    await mkdir(bin, { recursive: true });
+    await mkdir(uploads);
+    await Promise.all([
+      writeFile(summary, ""),
+      writeFile(commands, ""),
+      writeFile(mutations, ""),
+    ]);
+    const gh = join(bin, "gh");
+    await writeFile(
+      gh,
+      `#!${process.execPath}
+const { appendFileSync, cpSync, mkdirSync } = require("node:fs");
+const { join } = require("node:path");
+
+function main() {
+  const args = process.argv.slice(2);
+  const commandLog = process.env.GH_WITNESS_COMMANDS;
+  const mutationLog = process.env.GH_WITNESS_MUTATIONS;
+  const sha = process.env.GH_WITNESS_SHA;
+  if (!commandLog || !mutationLog || !sha) process.exit(90);
+  appendFileSync(commandLog, JSON.stringify(args) + "\\n");
+  if (args[0] === "pr" && args[1] === "view" && args.includes("headRefOid")) {
+    process.stdout.write(args.includes("--jq") ? sha + "\\n" : JSON.stringify({ headRefOid: sha }));
+    return;
+  }
+  if (args[0] === "run" && args[1] === "download") {
+    const output = args[args.indexOf("--dir") + 1];
+    if (!output) process.exit(91);
+    mkdirSync(output, { recursive: true });
+    const source = process.env.GH_WITNESS_SOURCE;
+    if (source) cpSync(source, join(output, "evidence"), { recursive: true });
+    return;
+  }
+  if (args[0] === "pr" && args[1] === "view" && args.includes("comments")) {
+    process.stdout.write(JSON.stringify({ comments: [] }));
+    return;
+  }
+  if ((args[0] === "pr" && args[1] === "comment") || args[0] === "api") {
+    appendFileSync(mutationLog, JSON.stringify(args) + "\\n");
+    return;
+  }
+  process.stderr.write("Unexpected gh command: " + JSON.stringify(args) + "\\n");
+  process.exitCode = 92;
+}
+
+main();
+`,
+    );
+    await chmod(gh, 0o700);
+    const result = spawnSync(process.execPath, [publisher], {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 30_000,
+      env: {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        HOME: fixture,
+        TMPDIR: fixture,
+        LANG: "C.UTF-8",
+        REVIEW_PR: "17",
+        REVIEW_SHA: gitSha,
+        REVIEW_RUN_ID: "123456",
+        GITHUB_STEP_SUMMARY: summary,
+        OPENWORK_REVIEW_LOCAL_DIR: uploads,
+        OPENWORK_REVIEW_URL: "http://127.0.0.1:4173",
+        GH_WITNESS_COMMANDS: commands,
+        GH_WITNESS_MUTATIONS: mutations,
+        GH_WITNESS_SHA: gitSha,
+        ...(evidence === "current" ? { GH_WITNESS_SOURCE: runDirs[0] } : {}),
+      },
+    });
+    const mutationLog = await readFile(mutations, "utf8");
+    return {
+      code: result.status ?? 1,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      summary: await readFile(summary, "utf8"),
+      commandLog: await readFile(commands, "utf8"),
+      commentWrites: mutationLog.split("\n").filter(Boolean).length,
+      uploadWrites: (await readdir(uploads)).length,
+    };
+  }
   const port = await new Promise<number>((resolve, reject) => {
     const server = createServer();
     server.once("error", reject);
@@ -248,6 +347,7 @@ export async function reviewWorld(
     failed,
     reference,
     report: bundle.report,
+    runPublisher,
     directory,
     [Symbol.asyncDispose]: dispose,
   };

--- a/evals/worlds/evidence-review.ts
+++ b/evals/worlds/evidence-review.ts
@@ -183,7 +183,9 @@ export async function reviewWorld(
     { localDir: storage },
   );
   let publisherSequence = 0;
-  async function runPublisher(evidence: "missing" | "current") {
+  async function runPublisher(
+    evidence: "missing" | "current" | "stale-record" | "stale-pr-head",
+  ) {
     publisherSequence += 1;
     const fixture = join(directory, `publisher-${publisherSequence}`);
     const bin = join(fixture, "bin");
@@ -198,6 +200,19 @@ export async function reviewWorld(
       writeFile(commands, ""),
       writeFile(mutations, ""),
     ]);
+    let source: string | undefined;
+    if (evidence === "current") source = runDirs[0];
+    if (evidence === "stale-record") {
+      const record = records[0];
+      if (!record) throw new Error("Missing publisher fixture record.");
+      source = join(fixture, "stale-record");
+      await mkdir(source);
+      await writeFile(
+        join(source, "test-run.json"),
+        JSON.stringify({ ...record, gitSha: "f".repeat(40) }),
+      );
+      await writeFile(join(source, "dialog.png"), png);
+    }
     const gh = join(bin, "gh");
     await writeFile(
       gh,
@@ -257,8 +272,9 @@ main();
         OPENWORK_REVIEW_URL: "http://127.0.0.1:4173",
         GH_WITNESS_COMMANDS: commands,
         GH_WITNESS_MUTATIONS: mutations,
-        GH_WITNESS_SHA: gitSha,
-        ...(evidence === "current" ? { GH_WITNESS_SOURCE: runDirs[0] } : {}),
+        GH_WITNESS_SHA:
+          evidence === "stale-pr-head" ? "e".repeat(40) : gitSha,
+        ...(source ? { GH_WITNESS_SOURCE: source } : {}),
       },
     });
     const mutationLog = await readFile(mutations, "utf8");


### PR DESCRIPTION
## Summary
- Add pinned, read-only exact-head/whitespace checks and an explicit failing INCOMPLETE indicator for fork review. No secrets, PR scripts, dependency installation, or credentialed consumers.
- Keep existing Warden/Daytona fork guards unchanged. The earlier local draft admitting forks to reusable credentialed jobs was rejected and is not included.
- Fail evidence publication visibly when no current-head test records exist; extend the existing production-CLI evidence-review journey.
- Document manual exact-head introduced-risk review and prerequisites for a future isolated, least-privilege, maintainer-approved execution path. Internal branch copies do not authorize execution.

## Scope and limitations
This is an honest missing-evidence indicator, not a complete fork merge gate or an implemented credentialed fork runner. The pull_request workflow is contributor-editable; its status alone is not trusted approval. Requiring its permanently failing fork indicator without a trusted evidence-resolution design would block all forks. Administrator policy decisions remain separate. No settings, licensing, or EE product files changed.

## Verification at 93a1d3d43c177bc5ccac1ba6a7bee04e492b3ef7
- `OPENWORK_EVAL_REVIEW=1 pnpm evals:pr specs/evidence-review.test.ts`: Passed, 1/1, zero skips; local isolated production review app + controlled external CLI witness. Empty and stale-only downloads fail INCOMPLETE without publication; superseded PR runs no-op before download; valid exact-head records publish.
- `actionlint .github/workflows/external-contributor-checks.yml`, `git diff --check`: exit 0.
- `node --test evals/scripts/journey-ci.test.mjs`: 12/12 passed on first commit; unchanged by the test-only follow-up.
- Final bare `pnpm warden:check`: exit 0, all 5 files reviewed. Expected and completed: diff-security-review, confidentiality-review, spec-provenance-review. No findings. Desktop/Den skill not applicable. Run `f4b3253e-2026-09-09T21-41-45-800Z`; private analysis logs not published.
- Review refs before/after unchanged: HEAD `93a1d3d43c177bc5ccac1ba6a7bee04e492b3ef7`, origin/dev `4446e992cffa422739677a25f9d91c6fa47dc8a9`.

## Finding disposition
GitHub Warden BY8-JS3 (medium, spec-provenance-review): accepted and fixed. Clear when stale downloaded records produce a nonzero result without publication. Added that case and superseded-PR-head assertions; exact-head journey rerun passed.

## Merge prerequisites
Independent review is required for these security/workflow changes; local Warden is not GitHub approval. Await required CI and review; no admin bypass. Full real-fork Actions lifecycle and environment isolation are not claimed by the local test. Updated exact-head evidence is published below.