### PR TITLE
Use DCO and EE CLA as the two contribution requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,19 @@
 ## Scope
 -
 
+## Contribution policy
+- [ ] Every commit has a final `Signed-off-by:` trailer matching its author
+      (`git commit -s`), and each `Co-authored-by` has a matching sign-off.
+- [ ] I checked whether any old or new path in this PR is under `ee/`.
+- [ ] I have not pasted a CLA, identity record, or confidential legal evidence
+      into this PR.
+
+Changes under `ee/` require an applicable individual or corporate CLA. Private
+CLA verification is not connected yet, so every such change remains held.
+These declarations are not proof: the gate ignores PR text, checkboxes, labels,
+comments, and collaborator status. Commercial employment or contractor terms
+are handled separately and are not a third contribution-gate requirement.
+
 ## Out of scope
 -
 

--- a/.github/workflows/contribution-policy.yml
+++ b/.github/workflows/contribution-policy.yml
@@ -1,0 +1,55 @@
+name: Contribution Policy
+
+# pull_request_target is deliberate: only the immutable event base revision is
+# checked out and executed. Pull-request code and text are never executed.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review, converted_to_draft]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: contribution-policy-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Publish head-bound contribution status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout verifier from immutable event base
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Evaluate DCO and EE CLA scope
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          EVENT_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SERVER_URL: ${{ github.server_url }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { pathToFileURL } = require("node:url")
+            const verifierUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/scripts/ci/check-contribution-policy.mjs`,
+            ).href
+            const { runContributionPolicy } = await import(verifierUrl)
+            await runContributionPolicy({
+              github,
+              context,
+              core,
+              eventSha: process.env.EVENT_SHA,
+              workflowSha: process.env.WORKFLOW_SHA,
+              runId: process.env.RUN_ID,
+              runAttempt: process.env.RUN_ATTEMPT,
+              serverUrl: process.env.SERVER_URL,
+            })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,21 +14,25 @@ git commit -s -m "your message"
 
 This adds a `Signed-off-by: Your Name <your@email>` trailer asserting that
 you wrote the change (or otherwise have the right to submit it) and that you
-may submit it under this repository's licenses. Pull requests with unsigned
-commits cannot be merged.
+may submit it under this repository's licenses. The final trailer block must
+sign off the commit author's exact name and email and every `Co-authored-by`
+identity. Pull requests with unsigned or mismatched commits cannot be merged.
+The check is syntactic certification, not identity proof or a cryptographic
+signature; checkboxes, labels, comments, and collaborator status do not replace
+a valid trailer.
 
 ## 2. How your contribution is licensed
 
-This repository is open core, and the paperwork depends on where you
-contribute (the same structure GitLab uses for its `ee/` directory):
+This repository is open core, and the applicable terms depend on where you
+contribute:
 
-- Contributions to code **outside `ee/`** are accepted under the
-  [MIT license](./LICENSE) (inbound = outbound), certified by your DCO
-  sign-off.
-- Contributions to code **under `ee/`** additionally require a Contributor
-  License Agreement, because the EE-licensed software is sold under
-  subscriptions and each release later converts to MIT — we need a license
-  from you broad enough to do both:
+- Contributions **outside `ee/`** are accepted under the licenses that already
+  apply under the [root license](./LICENSE), generally MIT, certified by your
+  DCO sign-off. Existing exceptions remain unchanged: third-party components
+  keep their original licenses, and versions released under an earlier license
+  remain under that license.
+- Contributions with an old or new path **under `ee/`** additionally require a
+  privately verified, applicable Contributor License Agreement (CLA):
   - as an individual, the
     [Individual Contributor License Agreement](./legal/individual-contributor-license-agreement.md);
   - on behalf of a company, the
@@ -40,13 +44,21 @@ contribute (the same structure GitLab uses for its `ee/` directory):
 
 By submitting a pull request you agree your contribution is provided under
 the terms above for the directories it modifies. Maintainers will not merge
-`ee/` contributions until the applicable CLA is in place.
+`ee/` contributions until the applicable CLA is privately verified. The
+repository does not currently have an authorized CLA verifier, so the gate
+holds every `ee/` addition, modification, deletion, or rename pending private
+verification. Do not paste agreements or identity records into a pull request.
 
-If you are contributing as part of paid work, a work trial, or on behalf of
-an employer, make sure a signed agreement covering intellectual property
-assignment is in place with Different AI, Inc. **before** your first pull
-request — ask your contact at OpenWork if you are unsure. Maintainers will
-not merge substantive contributions from paid engagements without one.
+Commercial employment, contractor, work-trial, and other service arrangements
+are separate from this repository contribution policy. They add no third gate
+requirement here. The existing CLA terms, including the individual CLA's
+representations about employer rights and authority, remain unchanged.
+
+The `ee/LICENSE` client-side exception and per-version conversion to MIT after
+two years also remain unchanged. CI does not interpret those exceptions to
+bypass path-based CLA review. See
+[the contribution policy](./legal/contribution-policy.md) for the fail-closed
+process and administrator setup still required.
 
 ## Practical notes
 

--- a/legal/contribution-policy.md
+++ b/legal/contribution-policy.md
@@ -1,0 +1,139 @@
+# Contribution licensing process
+
+This document describes a repository merge gate. It is process guidance, not
+a CLA, an employment or contractor agreement, legal advice, or evidence that
+an agreement has been executed.
+
+## The two contribution requirements
+
+1. **DCO for every commit.** A syntactically valid `Signed-off-by:` entry must
+   appear in the commit message's final trailer block and exactly match the Git
+   author name and email. Every final-block `Co-authored-by:` identity needs a
+   corresponding sign-off. There are no bot or known-collaborator exemptions.
+   This certifies the DCO text; it is not identity proof or a cryptographic
+   signature.
+2. **An applicable CLA for `ee/`.** Any addition, modification, deletion, or
+   rename whose old or new path is `ee/` or below requires private verification
+   of the applicable individual or corporate CLA. Mixed pull requests are EE
+   pull requests for this purpose.
+
+Commercial employment, contractor, work-trial, and other service arrangements
+are outside this contribution policy and gate. They do not create a third
+repository contribution requirement. Existing CLA provisions are unchanged,
+including the individual CLA's representations concerning employer rights,
+permission, waiver, or a corporate CLA.
+
+The gate never treats PR text, checkboxes, labels, comments, arbitrary status
+names, email domains, authorship, or known-collaborator status as CLA evidence.
+There is no authorized CLA database, signer service, or approvals map connected
+to this repository. Consequently every `ee/` change fails closed with
+`CLA verification not configured; pending private verification`. There is no
+allow switch. A future trusted verifier requires an explicit administrator and
+counsel decision; this repository does not claim that anyone is verified now.
+Executed agreements, identity records, and other private evidence must not be
+committed or pasted into a pull request.
+
+## Existing license terms are not reinterpreted
+
+The root `LICENSE` continues to preserve its existing allocation: `ee/` uses
+the EE license, prior versions remain under the license under which they were
+released, third-party or upstream components keep their original licenses, and
+the remaining content is MIT-licensed. The EE license's client-side exception
+and its conversion of each version to MIT on that version's second anniversary
+also remain unchanged. CI deliberately does not classify an apparent image,
+font, CSS, or client-side JavaScript path as exempt from CLA review.
+
+Counsel should separately reconcile the EE license's rights language for
+modifications and patches with the CLAs' retained-ownership language and broad
+license grants, and review the individual CLA's employer-authority alternatives
+and the EE client-side exception. These are review flags, not new
+interpretations or changes to any license or CLA.
+
+## Trusted execution and status
+
+The workflow runs on `pull_request_target`, checks out only the immutable event
+base SHA, and executes only the verifier from that base. It never checks out or
+executes pull-request code, installs dependencies, or passes pull-request text
+to a shell. It reads every commit and changed-file page from the GitHub API,
+compares the live base and head before and after collection, and fails closed
+when counts are missing, malformed, inconsistent, or reach GitHub's 250-commit
+or 3,000-file API ceilings. Both sides of every rename are evaluated.
+
+Because a `pull_request_target` job check attaches to the base commit, the
+workflow publishes the stable `contribution-policy-required` commit status to
+the exact event head SHA with the Actions runtime token. It writes pending
+before collection, then success or failure only while its run remains the
+current pending writer. Per-PR serialization, run-ID/run-attempt ordering, and
+a final status recheck prevent an older run from replacing a newer result.
+Collection errors produce failure or leave pending; they never produce green.
+Draft and fork pull requests follow the same evaluation. No label event or
+label value affects the result.
+
+This workflow does not implement `merge_group`. Do not enable a merge queue
+until an equivalent queue-head evaluation exists and is required.
+
+## Administrator-owned safeguards still required
+
+This repository intentionally does not add `CODEOWNERS` with an unapproved
+identity. Administrators must select approved legal/security/repository owners
+and require their review for at least:
+
+- `/ee/`
+- `/legal/`
+- `/LICENSE`
+- `/CONTRIBUTING.md`
+- `/.github/pull_request_template.md`
+- `/.github/workflows/`, especially
+  `/.github/workflows/contribution-policy.yml`
+- `/scripts/ci/check-contribution-policy.mjs`
+- `/scripts/ci/check-contribution-policy.test.mjs`
+- every active CODEOWNERS location, including `/.github/CODEOWNERS`,
+  `/CODEOWNERS`, and `/docs/CODEOWNERS`
+
+Until approved ownership is configured, the evaluator also holds changes to
+these policy, license, and ownership paths. That hold is an administrative
+protection, not another contributor certification or agreement, and has no
+in-repository self-approval path.
+
+For every branch that accepts pull requests, administrators must deploy this
+trusted workflow and separately configure repository rules to:
+
+1. require the head-bound `contribution-policy-required` status;
+2. bind the required status to its expected GitHub App/source where supported,
+   restrict who can write statuses, and use an organization/repository required
+   workflow control so another workflow cannot satisfy the context by name;
+3. protect changes to Actions workflows, this verifier, licenses, contribution
+   docs, and CODEOWNERS with the approved reviewers and audited bypass policy;
+4. require the PR head to be up to date with its exact target before merge, so
+   a head-only status is not reused after the base advances;
+5. prevent force pushes or branch/ruleset changes from bypassing the gate; and
+6. leave merge queues disabled until `merge_group` is implemented.
+
+A status context alone is not origin proof: another authorized integration can
+publish the same name. The workflow cannot declare branch or ruleset enforcement
+from repository files, and none is claimed to be configured here.
+
+## Deployment and live validation
+
+This change must start as a draft pull request because `pull_request_target`
+uses the workflow already on the base branch; the new workflow cannot prove its
+own live behavior before an authorized bootstrap merge. After deployment and
+the safeguards above, administrators must validate on each merge target:
+
+1. a normal non-EE PR with signed commits moves the exact head status from
+   pending to success;
+2. unsigned, author-mismatched, body-only, and missing-coauthor sign-offs each
+   fail, including unsigned bot-authored commits;
+3. EE additions, modifications, deletions, and renames into or out of `ee/`
+   fail even when the path appears client-side and labels or checkboxes claim
+   verification;
+4. a protected policy/license-path change fails and requires the audited
+   administrator path rather than a repository-controlled allow signal;
+5. draft, fork, reopened, edited, and synchronized PRs are re-evaluated;
+6. a head or base change during collection never greens the stale evaluation,
+   and a delayed older run cannot overwrite a newer run's status; and
+7. the required rule recognizes only the expected status producer and blocks
+   merges when the workflow is absent, fails, or remains pending.
+
+Until those GitHub-hosted checks and rule inspections are completed, live
+workflow and merge enforcement remain **Incomplete**.

--- a/scripts/ci/check-contribution-policy.mjs
+++ b/scripts/ci/check-contribution-policy.mjs
@@ -1,0 +1,510 @@
+const STATUS_CONTEXT = "contribution-policy-required"
+const COMMIT_API_CEILING = 250
+const FILE_API_CEILING = 3000
+const SHA_PATTERN = /^[0-9a-f]{40}$/
+const EMAIL_PATTERN = /^[^<>\s@]+@[^<>\s@]+$/
+const FILE_STATUSES = new Set([
+  "added",
+  "removed",
+  "modified",
+  "renamed",
+  "copied",
+  "changed",
+  "unchanged",
+])
+const SUPPORTED_ACTIONS = new Set([
+  "opened",
+  "reopened",
+  "synchronize",
+  "edited",
+  "ready_for_review",
+  "converted_to_draft",
+])
+
+const SENSITIVE_PATHS = new Set([
+  "LICENSE",
+  "CONTRIBUTING.md",
+  "CODEOWNERS",
+  "docs/CODEOWNERS",
+  ".github/CODEOWNERS",
+  ".github/pull_request_template.md",
+  ".github/workflows/contribution-policy.yml",
+  "scripts/ci/check-contribution-policy.mjs",
+  "scripts/ci/check-contribution-policy.test.mjs",
+])
+
+class CollectionError extends Error {}
+
+function failedResult(errors, overrides = {}) {
+  return {
+    ok: false,
+    dcoValid: false,
+    eeChanged: null,
+    sensitivePolicyChanged: null,
+    errors,
+    ...overrides,
+  }
+}
+
+function isSha(value) {
+  return typeof value === "string" && SHA_PATTERN.test(value)
+}
+
+function isRepositoryPath(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    !value.startsWith("/") &&
+    !value.includes("\0")
+  )
+}
+
+function isEePath(path) {
+  return path === "ee" || path.startsWith("ee/")
+}
+
+function isSensitivePolicyPath(path) {
+  return (
+    path === "legal" ||
+    path.startsWith("legal/") ||
+    path === ".github/workflows" ||
+    path.startsWith(".github/workflows/") ||
+    SENSITIVE_PATHS.has(path)
+  )
+}
+
+function parseIdentity(value) {
+  if (typeof value !== "string") return null
+  const match = value.match(/^([^<>\r\n\0]+) <([^<>\s\0]+)>$/)
+  if (!match) return null
+  const [, name, email] = match
+  if (name !== name.trim() || !EMAIL_PATTERN.test(email)) return null
+  return { name, email, key: `${name}\0${email}` }
+}
+
+function parseFinalTrailers(message) {
+  if (typeof message !== "string" || message.length === 0) {
+    return { error: "commit message metadata is missing", trailers: [] }
+  }
+
+  const normalized = message.replaceAll("\r\n", "\n")
+  if (normalized.includes("\r") || normalized.includes("\0")) {
+    return { error: "commit message metadata is malformed", trailers: [] }
+  }
+
+  const lines = normalized.split("\n")
+  while (lines.length > 0 && lines.at(-1).trim() === "") lines.pop()
+
+  let separator = lines.length - 1
+  while (separator >= 0 && lines[separator].trim() !== "") separator -= 1
+  if (separator < 1 || !lines.slice(0, separator).some((line) => line.trim() !== "")) {
+    return { error: "a separate final trailer block is required", trailers: [] }
+  }
+
+  const trailers = []
+  for (const line of lines.slice(separator + 1)) {
+    const match = line.trimEnd().match(/^([A-Za-z0-9][^:\s]*):[ \t]+(\S(?:.*\S)?)$/)
+    if (!match) return { error: "the final trailer block is malformed", trailers: [] }
+    trailers.push({ token: match[1].toLowerCase(), value: match[2] })
+  }
+
+  return { error: null, trailers }
+}
+
+function validateCommit(commit, index) {
+  const prefix = `commit ${index + 1}`
+  if (!commit || typeof commit !== "object") return [`${prefix}: metadata is missing`]
+  if (!isSha(commit.sha)) return [`${prefix}: SHA metadata is malformed`]
+  if (!commit.author || typeof commit.author !== "object") {
+    return [`${prefix}: author metadata is missing`]
+  }
+  if (
+    typeof commit.author.name !== "string" ||
+    typeof commit.author.email !== "string"
+  ) {
+    return [`${prefix}: author metadata is malformed`]
+  }
+
+  const author = parseIdentity(`${commit.author.name} <${commit.author.email}>`)
+  if (
+    !author ||
+    author.name !== commit.author.name ||
+    author.email !== commit.author.email
+  ) {
+    return [`${prefix}: author metadata is malformed`]
+  }
+
+  const parsed = parseFinalTrailers(commit.message)
+  if (parsed.error) return [`${prefix}: ${parsed.error}`]
+
+  const errors = []
+  const signoffs = new Set()
+  const coauthors = []
+  for (const trailer of parsed.trailers) {
+    if (trailer.token !== "signed-off-by" && trailer.token !== "co-authored-by") continue
+    const identity = parseIdentity(trailer.value)
+    if (!identity) {
+      errors.push(`${prefix}: ${trailer.token} identity is malformed`)
+    } else if (trailer.token === "signed-off-by") {
+      signoffs.add(identity.key)
+    } else {
+      coauthors.push(identity.key)
+    }
+  }
+
+  if (!signoffs.has(author.key)) {
+    errors.push(`${prefix}: author name and email lack an exact final-block sign-off`)
+  }
+  if (coauthors.some((coauthor) => !signoffs.has(coauthor))) {
+    errors.push(`${prefix}: a co-author lacks an exact final-block sign-off`)
+  }
+  return errors
+}
+
+export function evaluateContributionPolicy(input) {
+  if (!input || typeof input !== "object") {
+    return failedResult(["pull request metadata is missing"])
+  }
+
+  const metadataErrors = []
+  if (!isSha(input.baseSha) || !isSha(input.headSha)) {
+    metadataErrors.push("pull request revision metadata is malformed")
+  }
+  if (!Number.isSafeInteger(input.commitCount) || input.commitCount < 1) {
+    metadataErrors.push("commit count is missing or malformed")
+  } else if (input.commitCount >= COMMIT_API_CEILING) {
+    metadataErrors.push(`commit count reaches the ${COMMIT_API_CEILING}-commit API ceiling`)
+  }
+  if (!Number.isSafeInteger(input.fileCount) || input.fileCount < 0) {
+    metadataErrors.push("changed-file count is missing or malformed")
+  } else if (input.fileCount >= FILE_API_CEILING) {
+    metadataErrors.push(`changed-file count reaches the ${FILE_API_CEILING}-file API ceiling`)
+  }
+  if (!Array.isArray(input.commits)) {
+    metadataErrors.push("commit metadata is missing")
+  } else if (Number.isSafeInteger(input.commitCount) && input.commits.length !== input.commitCount) {
+    metadataErrors.push("commit metadata is truncated or inconsistent")
+  }
+  if (!Array.isArray(input.files)) {
+    metadataErrors.push("changed-file metadata is missing")
+  } else if (Number.isSafeInteger(input.fileCount) && input.files.length !== input.fileCount) {
+    metadataErrors.push("changed-file metadata is truncated or inconsistent")
+  }
+  if (metadataErrors.length > 0) return failedResult(metadataErrors)
+
+  const commitShas = new Set()
+  const dcoErrors = []
+  input.commits.forEach((commit, index) => {
+    dcoErrors.push(...validateCommit(commit, index))
+    if (commit && typeof commit === "object" && isSha(commit.sha)) {
+      if (commitShas.has(commit.sha)) dcoErrors.push(`commit ${index + 1}: duplicate SHA metadata`)
+      commitShas.add(commit.sha)
+    }
+  })
+  if (input.commits.at(-1)?.sha !== input.headSha) {
+    dcoErrors.push("commit metadata is not bound to the pull request head")
+  }
+
+  const pathErrors = []
+  const currentPaths = new Set()
+  const paths = []
+  input.files.forEach((file, index) => {
+    const prefix = `file ${index + 1}`
+    if (!file || typeof file !== "object" || !isRepositoryPath(file.filename)) {
+      pathErrors.push(`${prefix}: path metadata is missing or malformed`)
+      return
+    }
+    if (!FILE_STATUSES.has(file.status)) {
+      pathErrors.push(`${prefix}: status metadata is missing or malformed`)
+    }
+    if (currentPaths.has(file.filename)) pathErrors.push(`${prefix}: duplicate path metadata`)
+    currentPaths.add(file.filename)
+    paths.push(file.filename)
+
+    if (file.previousFilename !== null && file.previousFilename !== undefined) {
+      if (!isRepositoryPath(file.previousFilename)) {
+        pathErrors.push(`${prefix}: previous path metadata is malformed`)
+      } else {
+        paths.push(file.previousFilename)
+      }
+    } else if (file.status === "renamed") {
+      pathErrors.push(`${prefix}: renamed path lacks its previous path`)
+    }
+  })
+  if (pathErrors.length > 0) {
+    return failedResult([...dcoErrors, ...pathErrors], { dcoValid: dcoErrors.length === 0 })
+  }
+
+  const eeChanged = paths.some(isEePath)
+  const sensitivePolicyChanged = paths.some(isSensitivePolicyPath)
+  const errors = [...dcoErrors]
+  if (eeChanged) {
+    errors.push("CLA verification not configured; pending private verification for ee/ changes")
+  }
+  if (sensitivePolicyChanged) {
+    errors.push("protected contribution-policy or license machinery requires configured ownership review")
+  }
+
+  return {
+    ok: errors.length === 0,
+    dcoValid: dcoErrors.length === 0,
+    eeChanged,
+    sensitivePolicyChanged,
+    errors,
+  }
+}
+
+function countFromPullRequest(pullRequest, field, ceiling, label, allowZero) {
+  const value = pullRequest?.[field]
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1)) {
+    throw new CollectionError(`${label} count is missing or malformed`)
+  }
+  if (value >= ceiling) throw new CollectionError(`${label} count reaches its API ceiling`)
+  return value
+}
+
+function assertLiveRevision(pullRequest, revision) {
+  if (
+    !pullRequest ||
+    pullRequest.number !== revision.pullNumber ||
+    pullRequest.state !== "open" ||
+    pullRequest.base?.sha !== revision.baseSha ||
+    pullRequest.head?.sha !== revision.headSha ||
+    pullRequest.base?.ref !== revision.baseRef ||
+    pullRequest.head?.ref !== revision.headRef ||
+    pullRequest.base?.repo?.full_name !== revision.repository ||
+    pullRequest.head?.repo?.full_name !== revision.headRepository
+  ) {
+    throw new CollectionError("pull request revision changed during policy evaluation")
+  }
+}
+
+export async function collectContributionPolicyInput({ github, revision }) {
+  const request = {
+    owner: revision.owner,
+    repo: revision.repo,
+    pull_number: revision.pullNumber,
+  }
+  const before = (await github.rest.pulls.get(request)).data
+  assertLiveRevision(before, revision)
+  const commitCount = countFromPullRequest(before, "commits", COMMIT_API_CEILING, "commit", false)
+  const fileCount = countFromPullRequest(before, "changed_files", FILE_API_CEILING, "changed-file", true)
+
+  const [commits, files] = await Promise.all([
+    github.paginate(github.rest.pulls.listCommits, { ...request, per_page: 100 }),
+    github.paginate(github.rest.pulls.listFiles, { ...request, per_page: 100 }),
+  ])
+
+  const after = (await github.rest.pulls.get(request)).data
+  assertLiveRevision(after, revision)
+  if (
+    countFromPullRequest(after, "commits", COMMIT_API_CEILING, "commit", false) !== commitCount ||
+    countFromPullRequest(after, "changed_files", FILE_API_CEILING, "changed-file", true) !== fileCount
+  ) {
+    throw new CollectionError("pull request counts changed during policy evaluation")
+  }
+
+  return {
+    baseSha: revision.baseSha,
+    headSha: revision.headSha,
+    commitCount,
+    fileCount,
+    commits: commits.map((commit) => ({
+      sha: commit?.sha,
+      message: commit?.commit?.message,
+      author: {
+        name: commit?.commit?.author?.name,
+        email: commit?.commit?.author?.email,
+      },
+    })),
+    files: files.map((file) => ({
+      filename: file?.filename,
+      previousFilename: file?.previous_filename ?? null,
+      status: file?.status,
+    })),
+  }
+}
+
+function eventRevision(context, eventSha, workflowSha) {
+  const pullRequest = context?.payload?.pull_request
+  const repository = `${context?.repo?.owner}/${context?.repo?.repo}`
+  if (
+    context?.eventName !== "pull_request_target" ||
+    !SUPPORTED_ACTIONS.has(context?.payload?.action) ||
+    !pullRequest ||
+    !Number.isSafeInteger(pullRequest.number) ||
+    context?.payload?.repository?.full_name !== repository ||
+    pullRequest.base?.repo?.full_name !== repository ||
+    typeof pullRequest.base?.ref !== "string" ||
+    typeof pullRequest.head?.ref !== "string" ||
+    typeof pullRequest.head?.repo?.full_name !== "string" ||
+    !isSha(pullRequest.base?.sha) ||
+    !isSha(pullRequest.head?.sha) ||
+    context.sha !== pullRequest.base.sha ||
+    eventSha !== pullRequest.base.sha ||
+    workflowSha !== pullRequest.base.sha
+  ) {
+    throw new CollectionError("event revision is not bound to the trusted base SHA")
+  }
+
+  return {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    repository,
+    pullNumber: pullRequest.number,
+    baseSha: pullRequest.base.sha,
+    headSha: pullRequest.head.sha,
+    baseRef: pullRequest.base.ref,
+    headRef: pullRequest.head.ref,
+    headRepository: pullRequest.head.repo.full_name,
+  }
+}
+
+function runCoordinates(runId, runAttempt, serverUrl, revision) {
+  if (!/^[1-9][0-9]*$/.test(runId) || !/^[1-9][0-9]*$/.test(runAttempt)) {
+    throw new CollectionError("workflow run coordinates are malformed")
+  }
+  let server
+  try {
+    server = new URL(serverUrl)
+  } catch {
+    throw new CollectionError("GitHub server URL is malformed")
+  }
+  if (server.protocol !== "https:" || server.pathname !== "/") {
+    throw new CollectionError("GitHub server URL is not an HTTPS origin")
+  }
+
+  const prefix = `${server.origin}/${revision.repository}/actions/runs/`
+  return {
+    runId,
+    runAttempt,
+    prefix,
+    targetUrl: `${prefix}${runId}/attempts/${runAttempt}`,
+  }
+}
+
+async function policyStatuses(github, revision) {
+  const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+    owner: revision.owner,
+    repo: revision.repo,
+    ref: revision.headSha,
+    per_page: 100,
+  })
+  if (!Array.isArray(statuses)) throw new CollectionError("commit status metadata is malformed")
+  return statuses.filter((status) => status?.context === STATUS_CONTEXT)
+}
+
+function statusRunCoordinates(status, prefix) {
+  if (typeof status?.target_url !== "string" || !status.target_url.startsWith(prefix)) return null
+  const match = status.target_url.slice(prefix.length).match(/^([1-9][0-9]*)\/attempts\/([1-9][0-9]*)$/)
+  return match ? { runId: match[1], runAttempt: match[2] } : null
+}
+
+function isLaterRun(candidate, current) {
+  const candidateRun = BigInt(candidate.runId)
+  const currentRun = BigInt(current.runId)
+  return candidateRun > currentRun || (
+    candidateRun === currentRun && BigInt(candidate.runAttempt) > BigInt(current.runAttempt)
+  )
+}
+
+async function createStatus(github, revision, run, state, description) {
+  await github.rest.repos.createCommitStatus({
+    owner: revision.owner,
+    repo: revision.repo,
+    sha: revision.headSha,
+    state,
+    context: STATUS_CONTEXT,
+    description,
+    target_url: run.targetUrl,
+  })
+}
+
+async function replaceCurrentPendingStatus(github, revision, run, state, description) {
+  const statuses = await policyStatuses(github, revision)
+  const latest = statuses[0]
+  if (latest?.state !== "pending" || latest?.target_url !== run.targetUrl) return false
+  await createStatus(github, revision, run, state, description)
+  return true
+}
+
+export async function runContributionPolicy({
+  github,
+  context,
+  core,
+  eventSha,
+  workflowSha,
+  runId,
+  runAttempt,
+  serverUrl,
+}) {
+  let revision
+  let run
+  try {
+    revision = eventRevision(context, eventSha, workflowSha)
+    run = runCoordinates(runId, runAttempt, serverUrl, revision)
+    const existing = await policyStatuses(github, revision)
+    if (existing.some((status) => {
+      const coordinates = statusRunCoordinates(status, run.prefix)
+      return coordinates && isLaterRun(coordinates, run)
+    })) {
+      core.notice("A newer contribution-policy run already owns this head status; this run is stale.")
+      return { ok: false, stale: true }
+    }
+    await createStatus(
+      github,
+      revision,
+      run,
+      "pending",
+      `run ${runId}/${runAttempt}: evaluating DCO and CLA scope`,
+    )
+  } catch {
+    core.setFailed("Contribution policy could not establish a trusted event and status binding.")
+    return { ok: false, stale: false }
+  }
+
+  let result
+  try {
+    const input = await collectContributionPolicyInput({ github, revision })
+    result = evaluateContributionPolicy(input)
+    core.info(`DCO evaluated for ${input.commitCount} commit(s).`)
+    core.info(`EE path present: ${result.eeChanged === true ? "yes" : "no"}.`)
+  } catch {
+    try {
+      await replaceCurrentPendingStatus(
+        github,
+        revision,
+        run,
+        "failure",
+        "Contribution metadata collection failed closed",
+      )
+    } catch {
+      // Preserve the pending status when a safe final write cannot be established.
+    }
+    core.setFailed("Contribution metadata collection failed closed; no success status was published.")
+    return { ok: false, stale: false }
+  }
+
+  let published
+  try {
+    published = await replaceCurrentPendingStatus(
+      github,
+      revision,
+      run,
+      result.ok ? "success" : "failure",
+      result.ok
+        ? "DCO passed; EE CLA review not applicable"
+        : "Contribution policy failed; see workflow run",
+    )
+  } catch {
+    core.setFailed("The pending head status could not be finalized safely; no success was assumed.")
+    return { ...result, ok: false, stale: false }
+  }
+
+  if (!published) {
+    core.setFailed("A newer or unrelated status replaced this run's pending head status.")
+    return { ...result, ok: false, stale: true }
+  }
+  if (!result.ok) core.setFailed(result.errors.join("; "))
+  return { ...result, stale: false }
+}

--- a/scripts/ci/check-contribution-policy.test.mjs
+++ b/scripts/ci/check-contribution-policy.test.mjs
@@ -1,0 +1,493 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  collectContributionPolicyInput,
+  evaluateContributionPolicy,
+  runContributionPolicy,
+} from "./check-contribution-policy.mjs"
+
+const BASE_SHA = "a".repeat(40)
+const HEAD_SHA = "b".repeat(40)
+
+function commit(overrides = {}) {
+  return {
+    sha: HEAD_SHA,
+    message: "Policy test\n\nSigned-off-by: Example Author <author@example.test>",
+    author: { name: "Example Author", email: "author@example.test" },
+    ...overrides,
+  }
+}
+
+function input(overrides = {}) {
+  return {
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    commitCount: 1,
+    fileCount: 1,
+    commits: [commit()],
+    files: [{ filename: "packages/example.ts", previousFilename: null, status: "modified" }],
+    ...overrides,
+  }
+}
+
+test("signed non-EE commits pass", () => {
+  assert.deepEqual(evaluateContributionPolicy(input()), {
+    ok: true,
+    dcoValid: true,
+    eeChanged: false,
+    sensitivePolicyChanged: false,
+    errors: [],
+  })
+})
+
+test("unsigned and bot-authored commits have no exemptions", () => {
+  const result = evaluateContributionPolicy(input({
+    commits: [commit({
+      message: "Automated update",
+      author: { name: "Example Bot", email: "bot@example.test" },
+    })],
+  }))
+  assert.equal(result.ok, false)
+  assert.match(result.errors.join(" "), /final trailer block/)
+})
+
+test("author sign-off must match exact commit author metadata", () => {
+  const result = evaluateContributionPolicy(input({
+    commits: [commit({ author: { name: "Different Author", email: "author@example.test" } })],
+  }))
+  assert.equal(result.ok, false)
+  assert.match(result.errors.join(" "), /exact final-block sign-off/)
+})
+
+test("a body quotation is not accepted as a trailer block", () => {
+  const result = evaluateContributionPolicy(input({
+    commits: [commit({
+      message: "Policy test\n\nQuoted example:\nSigned-off-by: Example Author <author@example.test>",
+    })],
+  }))
+  assert.equal(result.ok, false)
+  assert.match(result.errors.join(" "), /trailer block is malformed/)
+})
+
+test("every co-author needs a matching final-block sign-off", () => {
+  const missing = evaluateContributionPolicy(input({
+    commits: [commit({
+      message: [
+        "Policy test",
+        "",
+        "Co-authored-by: Example Coauthor <coauthor@example.test>",
+        "Signed-off-by: Example Author <author@example.test>",
+      ].join("\n"),
+    })],
+  }))
+  assert.equal(missing.ok, false)
+  assert.match(missing.errors.join(" "), /co-author lacks/)
+
+  const complete = evaluateContributionPolicy(input({
+    commits: [commit({
+      message: [
+        "Policy test",
+        "",
+        "Co-authored-by: Example Coauthor <coauthor@example.test>",
+        "Signed-off-by: Example Author <author@example.test>",
+        "Signed-off-by: Example Coauthor <coauthor@example.test>",
+      ].join("\n"),
+    })],
+  }))
+  assert.equal(complete.ok, true)
+})
+
+test("missing, inconsistent, and ceiling counts fail closed", () => {
+  for (const candidate of [
+    input({ commitCount: undefined }),
+    input({ commitCount: 2 }),
+    input({ commitCount: 250 }),
+    input({ fileCount: 3000 }),
+  ]) {
+    assert.equal(evaluateContributionPolicy(candidate).ok, false)
+  }
+})
+
+test("every EE path is held even when untrusted signals claim verification", () => {
+  for (const status of ["added", "modified", "removed"]) {
+    const result = evaluateContributionPolicy(input({
+      files: [{ filename: "ee/server.ts", previousFilename: null, status }],
+      labels: ["legal:cla-verified", "legal:ip-verified"],
+      checkboxes: { cla: true, commercialTerms: true },
+    }))
+    assert.equal(result.ok, false)
+    assert.equal(result.eeChanged, true)
+    assert.match(result.errors.join(" "), /CLA verification not configured/)
+  }
+})
+
+test("both sides of renames are checked, including apparent client JavaScript", () => {
+  const intoEe = evaluateContributionPolicy(input({
+    files: [{
+      filename: "ee/client.js",
+      previousFilename: "packages/client.js",
+      status: "renamed",
+    }],
+  }))
+  const outOfEe = evaluateContributionPolicy(input({
+    files: [{
+      filename: "packages/client.js",
+      previousFilename: "ee/client.js",
+      status: "renamed",
+    }],
+  }))
+  assert.equal(intoEe.eeChanged, true)
+  assert.equal(intoEe.ok, false)
+  assert.equal(outOfEe.eeChanged, true)
+  assert.equal(outOfEe.ok, false)
+})
+
+test("policy, license, and CODEOWNERS machinery is held without a named owner", () => {
+  for (const filename of [
+    "LICENSE",
+    "legal/contribution-policy.md",
+    ".github/CODEOWNERS",
+    ".github/workflows/contribution-policy.yml",
+    ".github/workflows/spoof.yml",
+    "scripts/ci/check-contribution-policy.mjs",
+  ]) {
+    const result = evaluateContributionPolicy(input({
+      files: [{ filename, previousFilename: null, status: "modified" }],
+    }))
+    assert.equal(result.sensitivePolicyChanged, true)
+    assert.equal(result.ok, false)
+  }
+})
+
+function livePull(overrides = {}) {
+  return {
+    number: 17,
+    state: "open",
+    commits: 1,
+    changed_files: 1,
+    base: { sha: BASE_SHA, ref: "dev", repo: { full_name: "example/repository" } },
+    head: { sha: HEAD_SHA, ref: "topic", repo: { full_name: "fork/repository" } },
+    ...overrides,
+  }
+}
+
+function revision() {
+  return {
+    owner: "example",
+    repo: "repository",
+    repository: "example/repository",
+    pullNumber: 17,
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    baseRef: "dev",
+    headRef: "topic",
+    headRepository: "fork/repository",
+  }
+}
+
+function githubDouble(pulls) {
+  const listCommits = () => {}
+  const listFiles = () => {}
+  let read = 0
+  return {
+    rest: {
+      pulls: {
+        get: async () => ({ data: pulls[read++] }),
+        listCommits,
+        listFiles,
+      },
+    },
+    paginate: async (method) => {
+      if (method === listCommits) {
+        return [{
+          sha: HEAD_SHA,
+          commit: {
+            message: commit().message,
+            author: commit().author,
+          },
+        }]
+      }
+      if (method === listFiles) {
+        return [{ filename: "packages/example.ts", status: "modified" }]
+      }
+      throw new Error("unexpected endpoint")
+    },
+  }
+}
+
+test("collector returns complete commit and file metadata for a stable fork PR", async () => {
+  const collected = await collectContributionPolicyInput({
+    github: githubDouble([livePull(), livePull()]),
+    revision: revision(),
+  })
+  assert.equal(collected.baseSha, BASE_SHA)
+  assert.equal(collected.headSha, HEAD_SHA)
+  assert.equal(collected.commitCount, 1)
+  assert.equal(collected.commits.length, 1)
+  assert.equal(collected.fileCount, 1)
+  assert.equal(collected.files.length, 1)
+  assert.equal(evaluateContributionPolicy(collected).ok, true)
+})
+
+test("collector rejects a revision that differs before pagination", async () => {
+  const changed = livePull({
+    base: { sha: "c".repeat(40), ref: "dev", repo: { full_name: "example/repository" } },
+  })
+  await assert.rejects(
+    collectContributionPolicyInput({ github: githubDouble([changed]), revision: revision() }),
+    /revision changed/,
+  )
+})
+
+test("collector rejects a head race after full commit and file pagination", async () => {
+  const changed = livePull({ head: { sha: "c".repeat(40), ref: "topic", repo: { full_name: "fork/repository" } } })
+  await assert.rejects(
+    collectContributionPolicyInput({ github: githubDouble([livePull(), changed]), revision: revision() }),
+    /revision changed/,
+  )
+})
+
+test("an older run cannot overwrite a newer head status", async () => {
+  const listCommitStatusesForRef = () => {}
+  let statusWrites = 0
+  let staleNotices = 0
+  const github = {
+    rest: {
+      repos: {
+        listCommitStatusesForRef,
+        createCommitStatus: async () => { statusWrites += 1 },
+      },
+    },
+    paginate: async (method) => {
+      assert.equal(method, listCommitStatusesForRef)
+      return [{
+        context: "contribution-policy-required",
+        state: "success",
+        target_url: "https://github.com/example/repository/actions/runs/11/attempts/1",
+      }]
+    },
+  }
+  const context = {
+    eventName: "pull_request_target",
+    sha: BASE_SHA,
+    repo: { owner: "example", repo: "repository" },
+    payload: {
+      action: "synchronize",
+      repository: { full_name: "example/repository" },
+      pull_request: livePull(),
+    },
+  }
+  const core = {
+    notice: () => { staleNotices += 1 },
+    setFailed: () => assert.fail("a safely stale run should not fail or publish"),
+  }
+
+  const result = await runContributionPolicy({
+    github,
+    context,
+    core,
+    eventSha: BASE_SHA,
+    workflowSha: BASE_SHA,
+    runId: "10",
+    runAttempt: "1",
+    serverUrl: "https://github.com",
+  })
+  assert.equal(result.stale, true)
+  assert.equal(statusWrites, 0)
+  assert.equal(staleNotices, 1)
+})
+
+function runContext() {
+  return {
+    eventName: "pull_request_target",
+    sha: BASE_SHA,
+    repo: { owner: "example", repo: "repository" },
+    payload: {
+      action: "synchronize",
+      repository: { full_name: "example/repository" },
+      pull_request: livePull(),
+    },
+  }
+}
+
+function apiCommit(overrides = {}) {
+  const value = commit(overrides)
+  return {
+    sha: value.sha,
+    commit: { message: value.message, author: value.author },
+  }
+}
+
+function runGithubDouble({
+  pullReads = [livePull(), livePull()],
+  commits = [apiCommit()],
+  files = [{ filename: "packages/example.ts", status: "modified" }],
+  failPullRead = false,
+  replacePending = false,
+} = {}) {
+  const listCommits = () => {}
+  const listFiles = () => {}
+  const listCommitStatusesForRef = () => {}
+  const statusWrites = []
+  const statuses = []
+  let pullRead = 0
+  let statusRead = 0
+  const replacement = {
+    context: "contribution-policy-required",
+    state: "pending",
+    target_url: "https://github.com/example/repository/actions/runs/99/attempts/1",
+  }
+
+  return {
+    statusWrites,
+    github: {
+      rest: {
+        pulls: {
+          get: async () => {
+            if (failPullRead) throw new Error("simulated API failure")
+            return { data: pullReads[pullRead++] }
+          },
+          listCommits,
+          listFiles,
+        },
+        repos: {
+          listCommitStatusesForRef,
+          createCommitStatus: async (status) => {
+            statusWrites.push(status)
+            statuses.unshift({
+              context: status.context,
+              state: status.state,
+              target_url: status.target_url,
+            })
+          },
+        },
+      },
+      paginate: async (method) => {
+        if (method === listCommits) return commits
+        if (method === listFiles) return files
+        if (method === listCommitStatusesForRef) {
+          statusRead += 1
+          if (replacePending && statusRead === 2) return [replacement, ...statuses]
+          return statuses
+        }
+        throw new Error("unexpected endpoint")
+      },
+    },
+  }
+}
+
+function coreDouble() {
+  const failures = []
+  return {
+    failures,
+    core: {
+      info: () => {},
+      notice: () => {},
+      setFailed: (message) => { failures.push(message) },
+    },
+  }
+}
+
+async function runWith(github, core, context = runContext()) {
+  return runContributionPolicy({
+    github,
+    context,
+    core,
+    eventSha: BASE_SHA,
+    workflowSha: BASE_SHA,
+    runId: "20",
+    runAttempt: "2",
+    serverUrl: "https://github.com",
+  })
+}
+
+test("full runner writes pending then success only to a signed non-EE head", async () => {
+  const api = runGithubDouble()
+  const log = coreDouble()
+  const result = await runWith(api.github, log.core)
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(api.statusWrites.map((status) => status.state), ["pending", "success"])
+  assert.ok(api.statusWrites.every((status) => status.sha === HEAD_SHA))
+  assert.ok(api.statusWrites.every((status) => status.sha !== BASE_SHA))
+  assert.ok(api.statusWrites.every((status) => status.context === "contribution-policy-required"))
+  assert.ok(api.statusWrites.every((status) => (
+    status.target_url === "https://github.com/example/repository/actions/runs/20/attempts/2"
+  )))
+  assert.deepEqual(log.failures, [])
+})
+
+test("full runner writes pending then failure for signed EE despite claimed labels", async () => {
+  const api = runGithubDouble({
+    files: [{ filename: "ee/client.js", status: "modified" }],
+  })
+  const log = coreDouble()
+  const context = runContext()
+  context.payload.pull_request.labels = [
+    { name: "legal:cla-verified" },
+    { name: "legal:ip-verified" },
+  ]
+  const result = await runWith(api.github, log.core, context)
+
+  assert.equal(result.ok, false)
+  assert.equal(result.eeChanged, true)
+  assert.deepEqual(api.statusWrites.map((status) => status.state), ["pending", "failure"])
+  assert.ok(api.statusWrites.every((status) => status.sha === HEAD_SHA))
+  assert.match(log.failures.join(" "), /CLA verification not configured/)
+})
+
+test("collector API failure after pending writes failure and never success", async () => {
+  const api = runGithubDouble({ failPullRead: true })
+  const log = coreDouble()
+  const result = await runWith(api.github, log.core)
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(api.statusWrites.map((status) => status.state), ["pending", "failure"])
+  assert.equal(api.statusWrites.some((status) => status.state === "success"), false)
+  assert.ok(api.statusWrites.every((status) => status.sha === HEAD_SHA))
+  assert.match(log.failures.join(" "), /failed closed/)
+})
+
+test("a replaced final pending status prevents success publication", async () => {
+  const api = runGithubDouble({ replacePending: true })
+  const log = coreDouble()
+  const result = await runWith(api.github, log.core)
+
+  assert.equal(result.ok, false)
+  assert.equal(result.stale, true)
+  assert.deepEqual(api.statusWrites.map((status) => status.state), ["pending"])
+  assert.match(log.failures.join(" "), /replaced/)
+})
+
+test("invalid event binding fails before any status write", async () => {
+  const api = runGithubDouble()
+  const log = coreDouble()
+  const context = runContext()
+  context.sha = "c".repeat(40)
+  const result = await runWith(api.github, log.core, context)
+
+  assert.equal(result.ok, false)
+  assert.deepEqual(api.statusWrites, [])
+  assert.match(log.failures.join(" "), /trusted event and status binding/)
+})
+
+test("full runner blocks paginated commit and file count mismatches", async () => {
+  const cases = [
+    runGithubDouble({
+      pullReads: [livePull({ commits: 2 }), livePull({ commits: 2 })],
+    }),
+    runGithubDouble({
+      pullReads: [livePull({ changed_files: 2 }), livePull({ changed_files: 2 })],
+    }),
+  ]
+
+  for (const api of cases) {
+    const log = coreDouble()
+    const result = await runWith(api.github, log.core)
+    assert.equal(result.ok, false)
+    assert.deepEqual(api.statusWrites.map((status) => status.state), ["pending", "failure"])
+    assert.equal(api.statusWrites.some((status) => status.state === "success"), false)
+    assert.match(log.failures.join(" "), /truncated or inconsistent/)
+  }
+})


### PR DESCRIPTION
## Summary
- Require DCO sign-off on every commit and an applicable privately verified individual/corporate CLA for ee/ contributions.
- Remove the blanket paid-work, work-trial, and employer IP-assignment requirement from repository contribution policy; separate commercial agreements and existing CLA authority provisions are unchanged.
- Add a trusted-base, head-bound contribution status gate. EE changes remain held because no authorized private CLA verifier is configured; labels, comments, checkboxes, and collaborator status cannot approve them.
- Check both sides of renames and fail closed on incomplete API data, revision races, unsigned authors/coauthors, and protected policy/license machinery.
- Document administrator-owned review paths without inventing CODEOWNERS identities. Preserve license/CLA terms and flag ownership wording and client-side scope for counsel.

## Scope
Six files only: CONTRIBUTING.md, PR template, dedicated contribution workflow/verifier/colocated tests, and legal/contribution-policy.md. No EE product edits; no existing security, Warden, Daytona, or test workflows changed. No live GitHub rule/setting changes. Developed in an isolated worktree.

## Verification
At 1c9d54b5aa51d29417702f61109cfd3bc3788ca6:
- `node --test scripts/ci/check-contribution-policy.test.mjs`: exit 0, 19 passed, 0 failed/skipped.
- `node --check scripts/ci/check-contribution-policy.mjs`: exit 0.
- `actionlint .github/workflows/contribution-policy.yml`: exit 0.
- `git diff --check`: exit 0.
Coverage decision: colocated pure-function/API-double tests, not journey evidence. No existing GitHub contribution-policy lifecycle journey spec was found. No testkit or GitHub-hosted merge-enforcement verdict is claimed.

## Why draft / remaining proof
Overall verdict: Incomplete. The new pull_request_target workflow uses trusted base code and cannot prove its own live execution until an explicitly authorized bootstrap deployment. The private CLA verification process, approved ownership reviewers, origin-bound required contribution status/workflow, up-to-date branch policy, and GitHub-hosted positive/negative merge-blocking validation remain administrator work. See legal/contribution-policy.md for exact validation cases. Do not treat this PR as deployed enforcement or proof of any executed agreement. Merge queues are not supported.

Read-only live rules audit found openwork-tests-required as the required status on dev, not contribution-policy-required. Code-owner review is enabled by the default-branch ruleset, but this PR does not invent approved owners.

## Local Warden review
`pnpm warden:check` (bare config mode, existing pnpm 11.4.0 launcher on PATH): exit 1, Incomplete due to missing OpenAI credentials. No model or policy override; no fix mode.
- Scope: all six committed changed files; expected skills: diff-security-review and confidentiality-review.
- Actual: diff-security-review auth_failed; confidentiality-review skipped all six files despite a no-findings summary. No clearance claimed and no native finding IDs were returned.
- Clear when: rerun the full review with approved credentials at the final refs; both expected applicable skills must complete without blockers.
- Run reference: ffc33a3d-2026-09-09T21-35-56-807Z (private analysis logs are not attached).
- Before and after HEAD: 1c9d54b5aa51d29417702f61109cfd3bc3788ca6.
- Before and after origin/dev: 4446e992cffa422739677a25f9d91c6fa47dc8a9.

## Risk / rollout
Requiring this status before trusted-verifier and ownership setup deliberately blocks all EE and policy/workflow changes. Bootstrap and audited administrator decisions are required; this implementation provides no label-based bypass. Employment/contractor agreements remain separate from contribution requirements.