### PR TITLE
fix(browser): back off policy reads and report incomplete pages

### DIFF
--- a/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
+++ b/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
@@ -161,6 +161,7 @@ function isSameTab(left: PanelTab, right: PanelTab) {
       left.canGoForward === right.canGoForward &&
       left.ownerSessionId === right.ownerSessionId &&
       JSON.stringify(left.browserApproval) === JSON.stringify(right.browserApproval) &&
+      JSON.stringify(left.loadError) === JSON.stringify(right.loadError) &&
       JSON.stringify(left.browserTask) === JSON.stringify(right.browserTask) &&
       left.siteToolCount === right.siteToolCount &&
       JSON.stringify(left.siteTools) === JSON.stringify(right.siteTools) &&

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -465,6 +465,11 @@ function BrowserPanelContent({
           <X />
         </Button>
       </div>
+      {tab.loadError ? (
+        <div role="alert" className="shrink-0 border-b border-border bg-muted px-3 py-2 text-xs">
+          {tab.loadError.message}
+        </div>
+      ) : null}
       <div className="relative min-h-0 flex-1 overflow-hidden">
         {isAvailable ? (
           <div ref={contentRef} className="h-full overflow-hidden">

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -62,6 +62,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
       if (["about:", "data:", "blob:"].some((scheme) => details.url.startsWith(scheme))) { callback({ cancel: false }); return; }
       const tab = [...browserTabs.values()].find((item) => item.view.webContents.id === details.webContentsId);
       const owner = registry.ownerOf(tab?.tabId);
+      const documentGeneration = tab?.documentGeneration;
       const guard = details.resourceType === "mainFrame" ? taskHost.navigationGuard(tab?.tabId) : null;
       const request = { url: details.url, method: details.method, hasUpload: Boolean(details.uploadData?.length) };
       Promise.resolve().then(async () => {
@@ -78,7 +79,20 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
             if (tab && details.resourceType === "mainFrame" && (getBrowserTab(tab.tabId) !== tab || tab.view.webContents.isDestroyed() || registry.ownerOf(tab.tabId) !== owner)) throw new Error("Browser navigation owner changed");
           } catch { callback({ cancel: true }); return; }
           callback({ cancel: false });
-        }, () => callback({ cancel: true }));
+        }, (error) => {
+          if (tab && getBrowserTab(tab.tabId) === tab && !tab.view.webContents.isDestroyed()
+            && registry.ownerOf(tab.tabId) === owner && tab.documentGeneration === documentGeneration
+            && (error?.code === "policy_unavailable" || error?.code === "organization_policy_denied")) {
+            tab.loadError = {
+              code: error.code,
+              message: error.code === "organization_policy_denied"
+                ? "This page may be incomplete. Your organization's policy blocked a browser request."
+                : "This page may be incomplete. Your organization's policy could not be verified.",
+            };
+            sendBrowserState();
+          }
+          callback({ cancel: true });
+        });
     });
   }
   // tabId -> { tabId, view, favicon, background }. Order, ownership, the active
@@ -274,6 +288,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
       canGoForward: webContents.canGoForward(),
       ownerSessionId: registry.ownerOf(tabId),
       browserApproval: tab.browserApproval ?? null,
+      loadError: tab.loadError,
       browserTask: tab.browserTask ?? { status: "idle", operation: null },
       siteToolCount: Number.isInteger(tab.webMcpToolCount) ? tab.webMcpToolCount : 0,
       siteTools: Array.isArray(tab.webMcpTools) ? tab.webMcpTools : [],
@@ -683,6 +698,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
       /** @type {((error: Error | null) => void) | null} */
       finishSuspension: null,
       webMcpRevision: 0,
+      documentGeneration: 0,
+      /** @type {import("@openwork/browser-tabs").BrowserPanelTab["loadError"]} */
+      loadError: null,
       webMcpToolCount: 0,
       webMcpTools: [],
       webMcpActivity: [],
@@ -771,7 +789,13 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
       }
       sendToRenderer("openwork:browser:panel-opened", { ownerSessionId: registry.ownerOf(tabId) });
     });
-    view.webContents.on("did-navigate", () => sendBrowserState());
+    view.webContents.on("did-navigate", () => {
+      // Only a main-frame commit replaces the document. Aborts and downloads
+      // retain its warning; old resource failures cannot affect the new document.
+      tab.documentGeneration += 1;
+      tab.loadError = null;
+      sendBrowserState();
+    });
     view.webContents.on("did-navigate-in-page", () => sendBrowserState());
     view.webContents.on("page-title-updated", () => sendBrowserState());
     view.webContents.on("page-favicon-updated", (_event, favicons) => {

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -110,10 +110,15 @@ export class WebContentsView {
         if ((await this.request(url)).cancel) throw new Error("ERR_BLOCKED_BY_CLIENT");
         await navigation.load(url, this);
         if (this.destroyed) throw new Error("Contents destroyed");
+        this.emit("did-navigate", url);
         this.domReady = true;
         this.emit("dom-ready");
       },
       stop() { this.stops++; },
+      reload() {
+        this.emit("did-start-navigation", this.url, false, true);
+        this.emit("did-navigate", this.url);
+      },
       focus() {},
       close(options) {
         if (options?.waitForBeforeUnload && this.closeMode === "pending") return;
@@ -1538,6 +1543,92 @@ test("managed policy denial precedes loading and is rechecked after navigation a
   assert.deepEqual(contents.destinations, ["http://localhost:4173/"]);
 });
 
+test("managed subresource warnings survive aborted navigation and persist until a document commits", async () => {
+  let failureCode = "policy_unavailable";
+  const { invoke, views, policies } = createPanel(async ({ url }) => {
+    if (url.endsWith("/blocked.css")) throw Object.assign(new Error(url), { code: failureCode });
+  });
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  invoke("openwork:browser:createTab", "about:blank", "A");
+  await flush();
+  const contents = views()[0].webContents;
+  const loadError = () => invoke("openwork:browser:state").tabs[0].loadError;
+  const stylesheet = "https://cdn.example/blocked.css";
+  const loads = [...contents.loads];
+  contents.emit("did-start-navigation", "https://page.example/", false, true);
+  contents.emit("did-navigate", "https://page.example/");
+  assert.deepEqual(await contents.request(stylesheet, { resourceType: "stylesheet" }), { cancel: true });
+  const warning = {
+    code: "policy_unavailable",
+    message: "This page may be incomplete. Your organization's policy could not be verified.",
+  };
+  assert.deepEqual(loadError(), warning);
+  assert.deepEqual(await contents.request("https://cdn.example/ok.js", { resourceType: "script" }), { cancel: false });
+  for (const [event, ...args] of [
+    ["did-start-navigation", "https://frame.example/", false, false],
+    ["did-start-navigation", "https://page.example/#section", true, true],
+    ["did-navigate-in-page", "https://page.example/#section", true],
+    ["did-start-navigation", "https://page.example/aborted", false, true],
+    ["did-fail-provisional-load", -3, "ERR_ABORTED", "https://page.example/aborted", true],
+    ["did-stop-loading"],
+  ]) {
+    contents.emit(event, ...args);
+    assert.deepEqual(loadError(), warning, `${event} must retain the warning`);
+  }
+  await flush();
+  assert.equal(policies.filter(({ url }) => url === stylesheet).length, 1, "no policy retry");
+  assert.deepEqual(contents.loads, loads, "no automatic reload");
+  contents.emit("did-start-navigation", "https://page.example/next", false, true);
+  assert.deepEqual(loadError(), warning, "a pending navigation still displays the old document");
+  contents.emit("did-navigate", "https://page.example/next");
+  assert.equal(loadError(), null);
+  failureCode = "organization_policy_denied";
+  assert.deepEqual(await contents.request(stylesheet, { resourceType: "image" }), { cancel: true });
+  assert.deepEqual(loadError(), {
+    code: "organization_policy_denied",
+    message: "This page may be incomplete. Your organization's policy blocked a browser request.",
+  });
+  invoke("openwork:browser:reload");
+  assert.equal(loadError(), null, "manual reload commits a new document");
+  failureCode = "user_denied";
+  assert.deepEqual(await contents.request(stylesheet, { resourceType: "stylesheet" }), { cancel: true });
+  assert.equal(loadError(), null, "non-policy errors must not become policy warnings");
+});
+
+test("late managed subresource failures belong to the committed document, not a pending navigation", async () => {
+  for (const ending of ["navigate", "reload", "close", "abort"]) {
+    /** @type {() => void} */
+    let fail = () => assert.fail("Policy check has not started");
+    const { invoke, views } = createPanel(async ({ url }) => {
+      if (url.endsWith("/held.css")) await new Promise((_resolve, reject) => {
+        fail = () => reject(Object.assign(new Error("Private response details"), { code: "policy_unavailable" }));
+      });
+    });
+    invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+    const { tabId } = invoke("openwork:browser:createTab", "about:blank", "A");
+    await flush();
+    const contents = views()[0].webContents;
+    const request = contents.request("https://cdn.example/held.css", { resourceType: "stylesheet" });
+    await flush();
+    if (ending === "navigate" || ending === "abort") {
+      contents.emit("did-start-navigation", "https://next.example/", false, true);
+      if (ending === "navigate") contents.emit("did-navigate", "https://next.example/");
+      else contents.emit("did-fail-provisional-load", -3, "ERR_ABORTED", "https://next.example/", true);
+    }
+    if (ending === "reload") invoke("openwork:browser:reload");
+    if (ending === "close") {
+      invoke("openwork:browser:closeTab", tabId);
+      invoke("openwork:browser:createTab", "about:blank", "B");
+    }
+    fail();
+    assert.deepEqual(await request, { cancel: true });
+    const loadError = invoke("openwork:browser:state").tabs[0].loadError;
+    if (ending === "abort") assert.equal(loadError?.code, "policy_unavailable", "the old document's pending resources still warn");
+    else assert.equal(loadError, null, ending);
+    assert.deepEqual(contents.destinations, [], "stale failures remain fail-closed");
+  }
+});
+
 test("takeover cancels pending navigation, permits manual browsing without grants, and requires fresh consent on resume", async () => {
   const { invoke, emit, panel, views, approve, mainContents } = createPanel();
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
@@ -1633,6 +1724,7 @@ test("task popups inherit the navigation gate but no grants, including late popu
   assert.deepEqual(child.destinations, []);
   approve(false);
   assert.deepEqual(await pending, { cancel: true });
+  assert.equal(invoke("openwork:browser:state").tabs.at(-1).loadError, null, "declining consent is not a policy failure");
   invoke("openwork:browser:taskControl", tabId, "pause");
   const lateChild = popup();
   assert.deepEqual(await lateChild.request(url), { cancel: true });

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1082,15 +1082,23 @@ browserPanel = createBrowserPanel({
   getWindow: () => mainWindow,
   onDeepLink: (urls) => queueDeepLinks(urls),
   checkPolicy: async (input) => {
-    const server = await runtimeManager.openworkServerInfo();
-    if (!server.baseUrl || !(server.clientToken ?? server.ownerToken)) throw new Error("OpenWork policy service is unavailable.");
-    // loopback-fetch: the policy service is the locally managed OpenWork server.
-    const response = await fetch(`${server.baseUrl}/managed-policy/evaluate`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${server.clientToken ?? server.ownerToken}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ action: input.external ? "browser_external" : "browser", input }), signal: AbortSignal.timeout(15_000),
-    });
-    if (!response.ok) throw new Error("Your organization's policy blocked this browser request.");
+    let code = "policy_unavailable";
+    try {
+      const server = await runtimeManager.openworkServerInfo();
+      if (!server.baseUrl || !(server.clientToken ?? server.ownerToken)) throw new Error("Policy service unavailable");
+      // loopback-fetch: the policy service is the locally managed OpenWork server.
+      const response = await fetch(`${server.baseUrl}/managed-policy/evaluate`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${server.clientToken ?? server.ownerToken}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ action: input.external ? "browser_external" : "browser", input }), signal: AbortSignal.timeout(15_000),
+      });
+      if (response.ok) return;
+      const payload = await response.json();
+      if (payload?.code === "organization_policy_denied" || payload?.code === "policy_unavailable") code = payload.code;
+    } catch { /* Fail closed without exposing transport or response details. */ }
+    throw Object.assign(new Error(code === "organization_policy_denied"
+      ? "Your organization's policy blocked this browser request."
+      : "Your organization's policy could not be verified."), { code });
   },
 });
 

--- a/apps/server/src/managed-desktop-policy.test.ts
+++ b/apps/server/src/managed-desktop-policy.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import type { ServerConfig } from "./types.js";
+
+// Bun 1.3.4 cannot isolate files; mock.restore() does not undo mock.module().
+// Run these replacements in a child so they cannot contaminate other files.
+if (process.env.OPENWORK_MANAGED_POLICY_TEST_CHILD !== "1") {
+  test("ManagedDesktopPolicy orchestration (isolated module mocks)", () => {
+    const result = spawnSync(process.execPath, ["--conditions=development", "test", import.meta.path, "--timeout=1000"], {
+      env: { ...process.env, OPENWORK_MANAGED_POLICY_TEST_CHILD: "1" },
+      encoding: "utf8", timeout: 8000,
+    });
+    process.stdout.write(result.stdout ?? "");
+    process.stderr.write(result.stderr ?? "");
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+  }, 10000);
+} else {
+  const policy = { allowCustomProviders: false };
+  const session = { baseUrl: "https://den.invalid", token: "old-token", orgId: "old-org" };
+  let waiting = Promise.withResolvers<number>();
+  let release = Promise.withResolvers<void>();
+  const delay = mock((ms: number) => { waiting.resolve(ms); return release.promise; });
+  const externalFetch = mock(async (_url: string, _init?: RequestInit) => Response.json(policy));
+  const parse = mock((_value: unknown) => policy);
+  const write = mock(async (_config: ServerConfig, _policy: unknown) => ({ changed: false }));
+  mock.module("node:timers/promises", () => ({ setTimeout: delay }));
+  mock.module("./server-fetch.js", () => ({ externalFetch }));
+  mock.module("@openwork/types/den/desktop-policies-runtime", () => ({ desktopConfigSchema: { parse } }));
+  mock.module("./runtime-opencode-config-store.js", () => ({
+    readGlobalRuntimeOpencodeConfig: async () => ({}), writeManagedDesktopPolicy: write,
+    runtimeProviderMap: () => ({}),
+  }));
+  mock.module("./workspace-kv-store.js", () => ({
+    isRecord: (value: unknown) => typeof value === "object" && value !== null && !Array.isArray(value),
+  }));
+  mock.module("./managed-policy-rules.js", () => ({ policyDenial: () => null, policyRequestActions: () => [] }));
+  const { managedDesktopPolicy } = await import("./managed-desktop-policy.js");
+  const config: ServerConfig = {
+    host: "127.0.0.1", port: 0, token: "test", hostToken: "test",
+    approval: { mode: "auto", timeoutMs: 30000 }, corsOrigins: [], workspaces: [], authorizedRoots: [],
+    readOnly: false, startedAt: 0, tokenSource: "generated", hostTokenSource: "generated",
+    logFormat: "pretty", logRequests: false,
+  };
+  let service = managedDesktopPolicy({ ...config });
+  const turn = () => new Promise<void>((resolve) => setImmediate(resolve));
+  beforeEach(() => {
+    waiting = Promise.withResolvers<number>();
+    release = Promise.withResolvers<void>();
+    delay.mockClear();
+    externalFetch.mockReset().mockImplementation(async () => Response.json(policy));
+    parse.mockReset().mockImplementation(() => policy);
+    write.mockClear();
+    service = managedDesktopPolicy({ ...config });
+  });
+  afterEach(() => { release.resolve(); });
+
+  test("503 waits for the explicit 200ms release before the second read succeeds", async () => {
+    externalFetch.mockImplementationOnce(async () => new Response(null, { status: 503 }));
+    const installing = service.setSession(session);
+    const current = service.current();
+    expect(service.current()).toBe(current);
+    expect(await waiting.promise).toBe(200);
+    await turn();
+    expect(delay).toHaveBeenCalledTimes(1);
+    expect(externalFetch).toHaveBeenCalledTimes(1);
+    expect(write).not.toHaveBeenCalled();
+    release.resolve();
+    expect(await current).toEqual(policy);
+    await installing;
+    await turn();
+    expect(externalFetch).toHaveBeenCalledTimes(2);
+    expect(parse).toHaveBeenCalledWith(policy);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write.mock.calls[0]?.[1]).toEqual(policy);
+  });
+
+  test("a second 503 fails closed without a third attempt or delay", async () => {
+    externalFetch.mockImplementation(async () => new Response(null, { status: 503 }));
+    const result = service.setSession(session).catch((error: unknown) => error);
+    expect(await waiting.promise).toBe(200);
+    release.resolve();
+    expect(await result).toMatchObject({ code: "policy_unavailable", status: 403 });
+    await turn();
+    expect(externalFetch).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledTimes(1);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  test.each([401, 403, 429])("HTTP %i is not retried", async (status) => {
+    externalFetch.mockImplementation(async () => new Response(null, { status }));
+    await expect(service.setSession(session)).rejects.toMatchObject({ code: "policy_unavailable", status: 403 });
+    expect(externalFetch).toHaveBeenCalledTimes(1);
+    expect(delay).not.toHaveBeenCalled();
+    expect(parse).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  test("schema rejection is not retried", async () => {
+    externalFetch.mockImplementation(async () => Response.json(null));
+    parse.mockImplementationOnce(() => { throw new Error("Invalid desktop config"); });
+    await expect(service.setSession(session)).rejects.toMatchObject({ code: "policy_unavailable", status: 403 });
+    expect(parse).toHaveBeenCalledWith(null);
+    expect(externalFetch).toHaveBeenCalledTimes(1);
+    expect(delay).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  test("identity change during backoff prevents another old-identity fetch or write", async () => {
+    externalFetch.mockImplementationOnce(async () => new Response(null, { status: 503 }));
+    const result = service.setSession(session).catch((error: unknown) => error);
+    expect(await waiting.promise).toBe(200);
+    const next = { ...session, token: "new-token", orgId: "new-org" };
+    const installing = service.setSession(next);
+    expect(await service.current()).toEqual(policy);
+    await installing;
+    release.resolve();
+    expect(await result).toMatchObject({ code: "policy_identity_changed", status: 409 });
+    await turn();
+    expect(externalFetch.mock.calls.map(([url, init]) => [url, init?.headers])).toEqual([
+      [`${session.baseUrl}/v1/me/desktop-config`, { Authorization: "Bearer old-token", "x-openwork-legacy-org-id": "old-org" }],
+      [`${next.baseUrl}/v1/me/desktop-config`, { Authorization: "Bearer new-token", "x-openwork-legacy-org-id": "new-org" }],
+    ]);
+    expect(delay).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+}

--- a/apps/server/src/managed-desktop-policy.ts
+++ b/apps/server/src/managed-desktop-policy.ts
@@ -1,4 +1,5 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import { desktopConfigSchema, type DesktopConfig } from "@openwork/types/den/desktop-policies-runtime";
 import type { CloudProviderDenSession } from "./cloud-provider-sync.js";
 import type { ServerConfig } from "./types.js";
@@ -13,6 +14,7 @@ const services = new WeakMap<ServerConfig, ManagedDesktopPolicy>();
 const DEN_READ_DEADLINE_MS = 6_000;
 const DEN_READ_ATTEMPT_TIMEOUT_MS = 3_500;
 const DEN_READ_MAX_ATTEMPTS = 2;
+const DEN_READ_RETRY_DELAY_MS = 200;
 const RETRYABLE_DEN_STATUSES = new Set([502, 503, 504]);
 const RETRYABLE_TRANSPORT_CODES = new Set([
   "ABORT_ERR",
@@ -97,6 +99,14 @@ class ManagedDesktopPolicy {
     const deadline = performance.now() + DEN_READ_DEADLINE_MS;
     for (let attempt = 1; attempt <= DEN_READ_MAX_ATTEMPTS; attempt += 1) {
       this.identityChanged(generation);
+      if (attempt > 1) {
+        // An immediate retry can hit the same brief outage and leave a page's
+        // stylesheet canceled. Back off inside the existing deadline, without
+        // adding attempts or retrying denials, rate limits, or identity changes.
+        if (deadline - performance.now() <= DEN_READ_RETRY_DELAY_MS) throw new Error("Den read deadline exceeded");
+        await delay(DEN_READ_RETRY_DELAY_MS);
+        this.identityChanged(generation);
+      }
       const remainingMs = Math.floor(deadline - performance.now());
       if (remainingMs <= 0) throw new Error("Den read deadline exceeded");
       try {

--- a/evals/packages/env/src/browser-fixture.ts
+++ b/evals/packages/env/src/browser-fixture.ts
@@ -10,6 +10,10 @@ const page = `<!doctype html><meta charset="utf-8"><title>Browser task fixture</
 <p id="status">Nothing saved</p><input aria-label="Draft title" oninput="fetch('/input',{method:'POST',body:this.value})">
 <button id="save">Save draft</button><button id="popup" onclick="window.open('/popup','_blank','webSecurity=no,nodeIntegration=yes,contextIsolation=no,sandbox=no')">Open details</button>
 <script>
+window.addEventListener('load',()=>{
+  const stylesheet=document.querySelector('#project-stylesheet');
+  if(stylesheet)fetch('/stylesheet-report?'+new URLSearchParams({documentId:stylesheet.dataset.documentId,path:location.pathname,color:getComputedStyle(document.querySelector('h1')).color}));
+},{once:true});
 function authenticated(){document.querySelector('#auth').textContent='Session active';document.querySelector('#signin')?.remove();}
 if(document.cookie.includes('fixture_session=controlled'))authenticated();
 document.querySelector('#signin')?.addEventListener('submit',async(event)=>{
@@ -139,6 +143,8 @@ export interface BrowserFixtureState {
   signInCount: number;
   records: Array<{ method: string; count: number; signedIn: boolean }>;
   pageRequests: Array<{ path: string; signedIn: boolean }>;
+  stylesheetRequests: string[];
+  stylesheetReports: Array<{ documentId: string; path: string; color: string }>;
   signals: string[];
   sessionReads: number;
   popups: boolean[];
@@ -157,7 +163,7 @@ export async function startBrowserFixture(app: Surface, { requireSignIn = true }
   const ready = `/tmp/browser-task-fixture-${randomUUID()}.json`;
   const fixturePage = requireSignIn ? page : page.replace(/<form id="signin">[\s\S]*?<\/form>/, "");
   const source = `import {createServer} from 'node:http';import {writeFileSync} from 'node:fs';
-    const records=[],signals=[],popups=[],privileges=[],pageRequests=[],frameInputs=[],originPolicyReports=[];
+    const records=[],signals=[],popups=[],privileges=[],pageRequests=[],frameInputs=[],originPolicyReports=[],stylesheetRequests=[],stylesheetReports=[];
     let signInCount=0,sessionReads=0,frameClicks=0,uploads=0,inputValue='',originPolicyCallbacks=0;
     let holdDiscovery=false;
     const discovery={waiting:0,released:0,canceled:0,resumed:0,callbacks:0},pendingDiscovery=new Set();
@@ -170,7 +176,14 @@ export async function startBrowserFixture(app: Surface, { requireSignIn = true }
       res.setHeader('Cache-Control','no-store');res.setHeader('Origin-Agent-Cluster',url.pathname==='/origin-policy-opt-out'?'?0':'?1');
       res.setHeader('Permissions-Policy',url.pathname==='/denied'?'tools=()':['/frames','/origin-policy'].includes(url.pathname)?'tools=(self "http://localhost:'+server.address().port+'" "http://127.0.0.2:'+server.address().port+'")':'tools=(self)');
       if(req.method==='GET'&&url.pathname==='/state'){
-        res.setHeader('Content-Type','application/json');res.end(JSON.stringify({records,signals,popups,privileges,pageRequests,signInCount,sessionReads,frameClicks,frameInputs,uploads,inputValue,model,discovery,originPolicyReports,originPolicyCallbacks}));return;
+        res.setHeader('Content-Type','application/json');res.end(JSON.stringify({records,signals,popups,privileges,pageRequests,signInCount,sessionReads,frameClicks,frameInputs,uploads,inputValue,model,discovery,originPolicyReports,originPolicyCallbacks,stylesheetRequests,stylesheetReports}));return;
+      }
+      if(req.method==='GET'&&url.pathname==='/project.css'){
+        stylesheetRequests.push(url.searchParams.get('documentId'));res.setHeader('Content-Type','text/css');res.end('h1{color:rgb(23,87,131)}');return;
+      }
+      // GET keeps this page-side witness available while browser uploads are denied.
+      if(req.method==='GET'&&url.pathname==='/stylesheet-report'){
+        stylesheetReports.push(Object.fromEntries(url.searchParams));res.writeHead(204);res.end();return;
       }
       if(req.method==='GET'&&url.pathname==='/discovery'){
         res.setHeader('Content-Type','application/json');
@@ -213,7 +226,8 @@ export async function startBrowserFixture(app: Surface, { requireSignIn = true }
       if(url.pathname==='/popup')popups.push(signedIn);
       res.setHeader('Content-Type','text/html');
       const title=url.searchParams.get('viewport-probe')||(url.pathname==='/'?'home':url.pathname.slice(1));
-      const document=page.replace('<title>Browser task fixture</title>','<title>Project '+title.replace(/[^a-z-]/g,'')+'</title>');
+      let document=page.replace('<title>Browser task fixture</title>','<title>Project '+title.replace(/[^a-z-]/g,'')+'</title>');
+      if(url.pathname==='/'||url.pathname==='/allowed')document=document.replace('<style>','<link id="project-stylesheet" rel="stylesheet" data-document-id="'+pageRequests.length+'" href="http://localhost:'+server.address().port+'/project.css?documentId='+pageRequests.length+'"><style>');
       res.end(['/frames','/origin-policy'].includes(url.pathname)?framesPage:url.pathname.startsWith('/origin-policy-')?originPolicyPage:url.pathname.startsWith('/frame-')?framePage:document);
     });
     server.listen(0,'0.0.0.0',()=>writeFileSync(${browserScriptValue(ready)},JSON.stringify({pid:process.pid,port:server.address().port})));
@@ -261,6 +275,8 @@ export async function readBrowserFixtureState(app: Surface, origin: string): Pro
     frameInputs: array(state.frameInputs).map((item) => { const row = object(item); return { page: string(row.page), type: string(row.type), x: number(row.x), y: number(row.y), target: string(row.target), trusted: boolean(row.trusted) }; }),
     records: array(state.records).map((item) => { const row = object(item); return { method: string(row.method), count: number(row.count), signedIn: boolean(row.signedIn) }; }),
     pageRequests: array(state.pageRequests).map((item) => { const row = object(item); return { path: string(row.path), signedIn: boolean(row.signedIn) }; }),
+    stylesheetRequests: array(state.stylesheetRequests).map(string),
+    stylesheetReports: array(state.stylesheetReports).map((item) => { const row = object(item); return { documentId: string(row.documentId), path: string(row.path), color: string(row.color) }; }),
     privileges: array(state.privileges).map((item) => { const row = object(item); return { page: string(row.page), require: string(row.require), process: string(row.process), Buffer: string(row.Buffer), ...(row.blocked === undefined ? {} : { blocked: boolean(row.blocked) }) }; }),
     model: { requests: number(model.requests), toolNames: array(model.toolNames).map(string), receivedSaveResult: boolean(model.receivedSaveResult), observedSaved: boolean(model.observedSaved) },
     discovery: { waiting: number(discovery.waiting), released: number(discovery.released), canceled: number(discovery.canceled), resumed: number(discovery.resumed), callbacks: number(discovery.callbacks) },

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -358,9 +358,11 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
     await world.proxy.faults.clear();
     const start = (await world.proxy.requestLog()).length;
     await world.proxy.faults.status(path, statusCode, { times, body });
+    const startedAt = performance.now();
     const result = await world.evaluate(evaluation);
+    const elapsedMs = performance.now() - startedAt;
     const requests = await waitForRequests(start, path, statusCode === 503 ? 2 : 1);
-    return { result, requests };
+    return { result, requests, elapsedMs };
   };
   const latencyEvaluation = async (path: string, evaluation: Record<string, unknown>, times: number) => {
     await world.proxy.faults.clear();
@@ -415,7 +417,7 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
     );
   });
 
-  await step("one transient policy response retries once and applies the live allow", async () => {
+  await step("one transient policy response backs off before retrying once and applies the live allow", async () => {
     const recovered = await faultedEvaluation(policyPath, builtInModel, 503, 1);
     expect(recovered.result.status).toBe(200);
     expect(recovered.requests).toMatchObject([
@@ -423,10 +425,11 @@ test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step,
       { status: 200, faulted: false },
     ]);
     expect(recovered.requests).toHaveLength(2);
+    expect(recovered.elapsedMs).toBeGreaterThanOrEqual(190);
     evidence.recordAssertionEvidence(
-      "A transient Den policy failure retries exactly once and the real OpenWork server applies the live allow",
+      "A transient Den policy failure backs off before retrying exactly once and the real OpenWork server applies the live allow",
       JSON.stringify(recovered),
-      recovered.result.status === 200 && recovered.requests.length === 2
+      recovered.result.status === 200 && recovered.requests.length === 2 && recovered.elapsedMs >= 190
         && recovered.requests[0]?.status === 503 && recovered.requests[1]?.status === 200,
     );
   });

--- a/evals/specs/webmcp-browser-agent.e2e.test.ts
+++ b/evals/specs/webmcp-browser-agent.e2e.test.ts
@@ -64,6 +64,16 @@ test("a conversation signs in, uses site tools and page controls with consent, i
   expect(handle.tabId).toBe(tabId);
   await using site = await attachBuiltinTab(world.app, handle.targetId);
   expect((await witness()).pageRequests).toEqual([{ path: "/", signedIn: false }]);
+  await step("The first document applies its external stylesheet without a reload", async () => {
+    const styled = await probe.eventually(witness, {
+      within: 10_000, until: (value) => value.stylesheetReports.length === 1,
+      label: "the first document reports its computed heading color after load",
+    });
+    expect(styled.stylesheetReports).toEqual([{ documentId: "1", path: "/", color: "rgb(23, 87, 131)" }]);
+    expect(styled.stylesheetRequests).toEqual(["1"]);
+    expect(styled.pageRequests).toEqual([{ path: "/", signedIn: false }]);
+    await user.notSee({ text: "This page may be incomplete." });
+  });
   const save = listed.tools.find((tool) => tool.name === "save_draft");
   if (!save) throw new Error("No concrete save tool.");
 
@@ -491,8 +501,32 @@ test("a conversation signs in, uses site tools and page controls with consent, i
     if (afterRedirect.ok) expect(afterRedirect.url && new URL(afterRedirect.url).origin).toBe(world.origin);
     expect((await witness()).pageRequests).toEqual(before.pageRequests);
     expect(await task("navigate", { tabId, url: `${world.origin}/allowed` })).toMatchObject({ ok: true });
+    const warning = "This page may be incomplete. Your organization's policy blocked a browser request.";
+    await user.see({ text: warning });
+    const incomplete = await probe.eventually(witness, {
+      within: 10_000, until: (value) => value.stylesheetReports.at(-1)?.documentId === String(value.pageRequests.length),
+      label: "the allowed document finishes loading despite its blocked external stylesheet",
+    });
+    expect(incomplete.stylesheetReports.at(-1)).toEqual({ documentId: String(incomplete.pageRequests.length), path: "/allowed", color: "rgb(0, 0, 0)" });
+    expect(incomplete.stylesheetRequests).toEqual(before.stylesheetRequests);
     // Reuse the owned page; isolate upload enforcement from origin enforcement.
     await policy(null, true);
+    await user.see({ text: warning });
+    expect(await witness()).toMatchObject({
+      pageRequests: incomplete.pageRequests, stylesheetRequests: incomplete.stylesheetRequests, stylesheetReports: incomplete.stylesheetReports,
+    });
+    // Restoring policy must not silently retry the failed resource; reload explicitly.
+    await user.click({ role: "button", label: "Reload page" });
+    const recovered = await probe.eventually(witness, {
+      within: 10_000, until: (value) => value.stylesheetReports.at(-1)?.documentId === String(incomplete.pageRequests.length + 1),
+      label: "a new document in the same tab applies the now-allowed stylesheet",
+    });
+    const documentId = String(incomplete.pageRequests.length + 1);
+    expect(recovered.stylesheetReports.at(-1)).toEqual({ documentId, path: "/allowed", color: "rgb(23, 87, 131)" });
+    expect(recovered.stylesheetRequests).toEqual([...incomplete.stylesheetRequests, documentId]);
+    expect(recovered.pageRequests).toEqual([...incomplete.pageRequests, { path: "/allowed", signedIn: true }]);
+    expect(await probe.browserState()).toMatchObject({ activeTabId: tabId, visibleSessionId: sessionId });
+    await user.notSee({ text: "This page may be incomplete." });
     expect(await agent.browserRequest({ url: `${world.origin}/upload`, method: "POST", body: "controlled-upload" })).toMatchObject({ reached: false });
     expect(await witness()).toMatchObject({ uploads: 0, signInCount: 1, records: before.records });
     await policy([]);

--- a/packages/browser-tabs/index.d.ts
+++ b/packages/browser-tabs/index.d.ts
@@ -31,6 +31,7 @@ export type BrowserPanelTab = {
   /** Conversation (session) that opened the tab; null for shared/legacy tabs. */
   ownerSessionId: string | null;
   browserApproval?: { id: string; title: string; message: string; detail: string; approveLabel?: string } | null;
+  loadError?: { code: "policy_unavailable" | "organization_policy_denied"; message: string } | null;
   browserTask?: { status: "idle" | "running" | "paused" | "needs_attention"; operation: string | null };
   siteToolCount: number;
   siteTools: Array<{


### PR DESCRIPTION
## Summary

A policy-verification failure after HTML has loaded can cancel stylesheets and leave an apparently finished, unstyled page. This change mitigates brief verification outages and makes terminal policy failures visible instead of silently presenting an incomplete page.

- Wait 200 ms before the existing second eligible Den verification attempt, within the same six-second deadline and two-attempt limit.
- Preserve safe policy error codes across the desktop boundary and show a persistent incomplete-page warning outside the native browser view.
- Retain warnings through aborted navigation and downloads; clear them only when a new main-frame document commits. Late failures cannot mark a replacement document or closed tab.
- Extend browser and policy journeys with external stylesheet witnesses, first-document computed styling, blocked-resource visibility, and explicit Reload recovery.

Organization denials, authentication failures, rate limits, invalid policy responses, and identity changes remain fail-closed. No policy cache, bypass, additional retry layer, automatic page reload, or automatic replay of a canceled resource is introduced.

## Scope and remaining uncertainty

The policy cancellation path is established in source. The originally reported intermittent first-load occurrence has not been reproduced on its affected website. The backoff is a targeted mitigation, not proof that every first-load CSS failure is resolved. A real browser journey combining a brief Den outage during stylesheet verification with successful first-document computed styling remains missing.

## Verification — Incomplete

Candidate: `75c47b850ef6d057c843a4c491aba62b5a25cf9d`  
Base: `4446e992cffa422739677a25f9d91c6fa47dc8a9`

### Passed

- `node --test apps/desktop/electron/browser-panel.test.mjs` — exit 0; 61 passed, 0 failed, 0 skipped.
- `bun --conditions=development test ./apps/server/src/managed-desktop-policy.test.ts` — exit 0; 7 isolated cases / 41 assertions plus isolation wrapper. Covers held retry backoff, attempt limit, non-retryable responses, and identity replacement during backoff.
- `git diff --check` and syntax checks on changed native modules — exit 0.

These are focused component checks, not end-to-end runtime proof.

### Blocked / deferred

- `corepack pnpm evals:e2e webmcp-browser-agent` — exit 1 before test execution: `Command "vitest" not found` in the separate evals workspace.
- Printed placement: `placement: daytona (daytona CLI authenticated)`. No journey cases ran; counts are unavailable, not passed or skipped. No sandbox was launched by this failed invocation.
- The expanded `desktop-policy-restricted-mode` journey was not rerun after the same missing-runner prerequisite was identified. Full app typecheck and visual verification are deferred.
- No successful exact-head journey evidence is published. After preparing the evals workspace, run `pnpm evals:e2e webmcp-browser-agent` and `pnpm evals:e2e desktop-policy-restricted-mode`, then publish their exact-head results.

### Final local review — Incomplete

`corepack pnpm warden:check` — exit 1, authentication unavailable. Expected and matched: `diff-security-review`, `confidentiality-review`, `spec-provenance-review`, `desktop-den-sync-review`. The security review failed authentication and the remaining scopes were skipped; no complete clearance or finding disposition can be claimed from the empty summary.

Run reference: `23f6e575-2026-09-09T21-44-59-302Z`. HEAD and base remained the refs above before and after the command. Complete this review with configured credentials before claiming review clearance. No private review logs are attached.
