### PR TITLE
fix(desktop): restore cloud sessions after runtime replacement

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1595,17 +1595,18 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       const suffix = query.size ? `?${query.toString()}` : "";
       return requestJson<OpenworkConnectState>(baseUrl, `/experimental/connect/state${suffix}`, { token, hostToken, timeoutMs: timeouts.config });
     },
-    putDenSession: async (body: { baseUrl: string; token: string; orgId: string }) => {
-      await requestJson<unknown>(baseUrl, "/den-session", { hostToken, method: "PUT", body, timeoutMs: timeouts.config });
+    putDenSession: async (body: { baseUrl: string; token: string; orgId: string }, signal?: AbortSignal) => {
+      await requestJson<unknown>(baseUrl, "/den-session", { hostToken, method: "PUT", body, signal, timeoutMs: timeouts.config });
     },
     deleteDenSession: async () => {
       await requestJson<unknown>(baseUrl, "/den-session", { hostToken, method: "DELETE", timeoutMs: timeouts.config });
     },
-    runCloudProviderSyncNow: async (reason?: string) =>
+    runCloudProviderSyncNow: async (reason?: string, signal?: AbortSignal) =>
       parseCloudProviderSyncRun(await requestJson<unknown>(baseUrl, "/cloud-provider-sync/run", {
         hostToken,
         method: "POST",
         body: reason ? { reason } : {},
+        signal,
         timeoutMs: timeouts.cloudMcpReconcile,
       })),
     getCloudProviderSyncStatus: async () =>

--- a/apps/app/src/react-app/domains/connections/provider-auth/session-openwork-server.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/session-openwork-server.ts
@@ -31,6 +31,7 @@ export type CreateSessionOpenworkServerInput = {
   endpoint: () => ResolvedWorkspaceEndpoint | null;
   /** Live host token from the desktop runtime (openworkServerInfo). */
   hostToken?: () => string;
+  generation?: () => number | null;
 };
 
 function resolveHostToken(endpoint: ResolvedWorkspaceEndpoint, live: string): string {
@@ -83,6 +84,7 @@ export function createSessionOpenworkServer(
       return {
         openworkServerStatus: "connected",
         openworkServerClient: hostAwareClient(endpoint, hostToken),
+        openworkServerHostInfo: { generation: input.generation?.() ?? null },
         openworkServerAuth: {
           token: endpoint.token || undefined,
           hostToken: hostToken || undefined,

--- a/apps/app/src/react-app/domains/connections/provider-auth/session-openwork-server.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/session-openwork-server.ts
@@ -9,13 +9,13 @@
 // the Den session, and server-side cloud provider sync never started (#3671).
 //
 // This adapter reports the truth for the endpoint it wraps:
-// - local endpoints (the desktop's own OpenWork server) advertise
+// - loopback local endpoints (the desktop's own OpenWork server) advertise
 //   `providerSync: true` — every OpenWork server does
 //   (apps/server/src/types.ts `Capabilities.providerSync: true`) — and carry
 //   the live host token so the store can PUT /den-session and
 //   POST /cloud-provider-sync/run;
-// - remote workspaces keep the previous conservative shape (config only): a
-//   desktop must not push its Den session to a shared remote worker.
+// - remote workspaces and non-loopback local URL overrides stay config-only:
+//   a local workspace label does not authorize forwarding desktop credentials.
 import {
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
@@ -35,11 +35,11 @@ export type CreateSessionOpenworkServerInput = {
 };
 
 function resolveHostToken(endpoint: ResolvedWorkspaceEndpoint, live: string): string {
-  if (live) return live;
   // Fallback mirrors openwork-server-store's getAuth(): persisted settings may
   // hold the host token (ensureDesktopLocalOpenworkConnection writes it), but
-  // only trust it for loopback servers — host tokens never travel off-machine.
+  // both live and stored host tokens must stay on loopback servers.
   if (!isLoopbackOpenworkServerUrl(endpoint.baseUrl)) return "";
+  if (live) return live;
   return readOpenworkServerSettings().hostToken?.trim() ?? "";
 }
 
@@ -73,7 +73,7 @@ export function createSessionOpenworkServer(
           openworkServerCapabilities: null,
         };
       }
-      if (endpoint.isRemote) {
+      if (endpoint.isRemote || !isLoopbackOpenworkServerUrl(endpoint.baseUrl)) {
         return {
           openworkServerStatus: "connected",
           openworkServerClient: endpoint.client,

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -57,6 +57,7 @@ export type ProviderAuthOpenworkServer = {
     "openworkServerStatus" | "openworkServerClient"
   > & {
     openworkServerAuth?: { token?: string; hostToken?: string };
+    openworkServerHostInfo?: { generation: number | null } | null;
     openworkServerCapabilities: { config?: { read?: boolean; write?: boolean }; providerSync?: boolean } | null;
   };
 };
@@ -111,12 +112,18 @@ type CloudProviderSyncReason =
 
 type CloudProviderSyncWorkResult = void | OpenworkCloudProviderSyncRun;
 
+type GlobalCloudProviderSyncOutcome = { contextKey: string } & (
+  | { status: "completed"; result: CloudProviderSyncWorkResult }
+  | { status: "cancelled" }
+  | { status: "failed"; error: unknown }
+);
+
 type GlobalCloudProviderSyncBatch = {
   contextKey: string;
   sync: () => Promise<CloudProviderSyncWorkResult>;
-  promise: Promise<CloudProviderSyncWorkResult>;
-  resolve: (outcome: CloudProviderSyncWorkResult) => void;
-  reject: (error: unknown) => void;
+  isCurrent?: () => boolean;
+  promise: Promise<GlobalCloudProviderSyncOutcome>;
+  resolve: (outcome: GlobalCloudProviderSyncOutcome) => void;
 };
 
 let lastGlobalProviderDisposeRefreshAt = 0;
@@ -124,27 +131,47 @@ let activeGlobalCloudProviderSync: GlobalCloudProviderSyncBatch | null = null;
 let trailingGlobalCloudProviderSync: GlobalCloudProviderSyncBatch | null = null;
 let loggedGatewayCloudProviderSyncSkip = false;
 
-function enqueueGlobalCloudProviderSync(
+async function enqueueGlobalCloudProviderSync(
   contextKey: string,
   sync: () => Promise<CloudProviderSyncWorkResult>,
+  isCurrent?: () => boolean,
 ): Promise<CloudProviderSyncWorkResult> {
-  if (activeGlobalCloudProviderSync?.contextKey === contextKey) {
+  // A trailing batch may be replaced or forwarded to an active batch. Match
+  // the executed context, not the context its waiters originally requested.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (isCurrent?.() === false) return;
+    const outcome = await queueGlobalCloudProviderSync(contextKey, sync, isCurrent);
+    if (isCurrent?.() === false) return;
+    if (outcome.contextKey !== contextKey || outcome.status === "cancelled") continue;
+    if (outcome.status === "failed") throw outcome.error;
+    return outcome.result;
+  }
+  throw new Error("Cloud provider sync context kept changing. Try again.");
+}
+
+function queueGlobalCloudProviderSync(
+  contextKey: string,
+  sync: () => Promise<CloudProviderSyncWorkResult>,
+  isCurrent?: () => boolean,
+): Promise<GlobalCloudProviderSyncOutcome> {
+  if (activeGlobalCloudProviderSync?.contextKey === contextKey && activeGlobalCloudProviderSync.isCurrent?.() !== false) {
     const trailing = trailingGlobalCloudProviderSync;
     if (trailing && trailing.contextKey !== contextKey) {
       trailingGlobalCloudProviderSync = null;
-      void activeGlobalCloudProviderSync.promise.then(trailing.resolve, trailing.reject);
+      void activeGlobalCloudProviderSync.promise.then(trailing.resolve);
     }
     return activeGlobalCloudProviderSync.promise;
   }
   if (trailingGlobalCloudProviderSync) {
-    if (trailingGlobalCloudProviderSync.contextKey !== contextKey) {
+    if (trailingGlobalCloudProviderSync.contextKey !== contextKey || trailingGlobalCloudProviderSync.isCurrent?.() === false) {
       trailingGlobalCloudProviderSync.contextKey = contextKey;
       trailingGlobalCloudProviderSync.sync = sync;
+      trailingGlobalCloudProviderSync.isCurrent = isCurrent;
     }
     return trailingGlobalCloudProviderSync.promise;
   }
 
-  const batch = createGlobalCloudProviderSyncBatch(contextKey, sync);
+  const batch = createGlobalCloudProviderSyncBatch(contextKey, sync, isCurrent);
   if (activeGlobalCloudProviderSync) {
     trailingGlobalCloudProviderSync = batch;
   } else {
@@ -156,25 +183,34 @@ function enqueueGlobalCloudProviderSync(
 function createGlobalCloudProviderSyncBatch(
   contextKey: string,
   sync: () => Promise<CloudProviderSyncWorkResult>,
+  isCurrent?: () => boolean,
 ): GlobalCloudProviderSyncBatch {
-  let resolve: (outcome: CloudProviderSyncWorkResult) => void = () => undefined;
-  let reject: (error: unknown) => void = () => undefined;
-  const promise = new Promise<CloudProviderSyncWorkResult>((resolvePromise, rejectPromise) => {
+  let resolve: (outcome: GlobalCloudProviderSyncOutcome) => void = () => undefined;
+  const promise = new Promise<GlobalCloudProviderSyncOutcome>((resolvePromise) => {
     resolve = resolvePromise;
-    reject = rejectPromise;
   });
-  return { contextKey, sync, promise, resolve, reject };
+  return { contextKey, sync, isCurrent, promise, resolve };
 }
 
 function startGlobalCloudProviderSync(batch: GlobalCloudProviderSyncBatch): void {
   activeGlobalCloudProviderSync = batch;
+  const contextKey = batch.contextKey;
+  if (batch.isCurrent?.() === false) {
+    batch.resolve({ contextKey, status: "cancelled" });
+    finishGlobalCloudProviderSync(batch);
+    return;
+  }
   void batch.sync().then(
-    (outcome) => {
-      batch.resolve(outcome);
+    (result) => {
+      batch.resolve(batch.isCurrent?.() === false
+        ? { contextKey, status: "cancelled" }
+        : { contextKey, status: "completed", result });
       finishGlobalCloudProviderSync(batch);
     },
     (error) => {
-      batch.reject(error);
+      batch.resolve(batch.isCurrent?.() === false
+        ? { contextKey, status: "cancelled" }
+        : { contextKey, status: "failed", error });
       finishGlobalCloudProviderSync(batch);
     },
   );
@@ -346,8 +382,8 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   let cloudOrgProvidersGeneration = 0;
   let cloudProviderSyncContextKey = "";
   let lastDenSessionPushKey = "";
-  let denSessionPushKey = "";
-  let denSessionPushInFlight: Promise<void> | null = null;
+  let denSessionDelivery: { key: string; controller: AbortController } | null = null;
+  let denSessionPushInFlight: Promise<boolean> | null = null;
 
   const emitChange = () => {
     for (const listener of listeners) listener();
@@ -432,29 +468,91 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     );
   };
 
-  const pushDenSession = (force = false): Promise<void> => {
+  const getDenSessionDeliveryKey = () => {
     const openworkSnapshot = options.openworkServer.getSnapshot();
-    const openworkClient = openworkSnapshot.openworkServerClient;
+    const settings = readDenSettings();
+    if (!serverHandlesProviderSync() || !settings.authToken?.trim() || !settings.activeOrgId?.trim()) return "";
+    return JSON.stringify([
+      settings.apiBaseUrl ?? resolveDenBaseUrls(settings).apiBaseUrl,
+      settings.activeOrgId.trim(),
+      settings.authToken.trim(),
+      openworkSnapshot.openworkServerClient?.baseUrl,
+      openworkSnapshot.openworkServerAuth?.token,
+      openworkSnapshot.openworkServerAuth?.hostToken,
+      openworkSnapshot.openworkServerHostInfo?.generation,
+    ]);
+  };
+
+  const invalidateDenSessionDelivery = () => {
+    denSessionDelivery?.controller.abort();
+    denSessionDelivery = null;
+    denSessionPushInFlight = null;
+    lastDenSessionPushKey = "";
+    cloudProviderSyncContextKey = "";
+  };
+
+  const syncDenSessionDelivery = () => {
+    const key = getDenSessionDeliveryKey();
+    if (key !== (denSessionDelivery?.key ?? "")) {
+      invalidateDenSessionDelivery();
+      if (key && !disposed) {
+        denSessionDelivery = { key, controller: new AbortController() };
+      }
+    }
+    return denSessionDelivery;
+  };
+
+  const isCurrentDenSessionDelivery = (delivery: typeof denSessionDelivery) =>
+    !disposed && delivery !== null && delivery === denSessionDelivery && delivery.key === getDenSessionDeliveryKey();
+
+  const pushDenSession = (force = false): Promise<boolean> => {
+    const delivery = syncDenSessionDelivery();
+    const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
+    if (!delivery || !openworkClient || disposed) return Promise.resolve(false);
+    if (!force && delivery.key === lastDenSessionPushKey) return Promise.resolve(true);
+    if (denSessionPushInFlight) return denSessionPushInFlight;
+    lastDenSessionPushKey = "";
     const settings = readDenSettings();
     const apiBaseUrl = settings.apiBaseUrl ?? resolveDenBaseUrls(settings).apiBaseUrl;
     const token = settings.authToken?.trim() ?? "";
     const orgId = settings.activeOrgId?.trim() ?? "";
-    if (!serverHandlesProviderSync() || !openworkClient || !token || !orgId) return Promise.resolve();
-    const key = `${apiBaseUrl}::${orgId}::${token}`;
-    if (!force && key === lastDenSessionPushKey) return Promise.resolve();
-    if (key === denSessionPushKey && denSessionPushInFlight) return denSessionPushInFlight;
-    denSessionPushKey = key;
-    const request = openworkClient.putDenSession({ baseUrl: apiBaseUrl, token, orgId });
+    const request = (async () => {
+      // Retry only delivery, not provider materialization. Policy verification
+      // can fail transiently with 403 policy_unavailable; auth denials and
+      // rate limits remain terminal.
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        if (!isCurrentDenSessionDelivery(delivery)) return false;
+        try {
+          await openworkClient.putDenSession({ baseUrl: apiBaseUrl, token, orgId }, delivery.controller.signal);
+          if (!isCurrentDenSessionDelivery(delivery)) return false;
+          lastDenSessionPushKey = delivery.key;
+          return true;
+        } catch (error) {
+          if (!isCurrentDenSessionDelivery(delivery)) return false;
+          const retryable = error instanceof OpenworkServerError
+            ? (error.status === 403 && error.code === "policy_unavailable") || error.status === 408 || error.status >= 500
+            : error instanceof TypeError || (error instanceof Error && error.message === "Request timed out.");
+          if (!retryable || attempt === 2) throw error;
+          await new Promise<void>((resolve) => {
+            const finish = () => {
+              clearTimeout(timer);
+              delivery.controller.signal.removeEventListener("abort", finish);
+              resolve();
+            };
+            const timer = setTimeout(finish, 250 * 2 ** attempt);
+            delivery.controller.signal.addEventListener("abort", finish, { once: true });
+          });
+        }
+      }
+      return false;
+    })();
     denSessionPushInFlight = request;
-    request.then(
-      () => { lastDenSessionPushKey = key; },
-      () => undefined,
-    ).finally(() => {
+    const clearInFlight = () => {
       if (denSessionPushInFlight === request) {
         denSessionPushInFlight = null;
-        denSessionPushKey = "";
       }
-    });
+    };
+    void request.then(clearInFlight, clearInFlight);
     return request;
   };
 
@@ -592,9 +690,12 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   const refreshImportedCloudProviders = async (refreshOptions?: { strict?: boolean }) => {
     try {
       if (serverHandlesProviderSync()) {
+        const delivery = syncDenSessionDelivery();
+        const contextKey = getCloudProviderSyncContextKey();
         const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
         if (!openworkClient) throw new Error("OpenWork server unavailable.");
         const status = await openworkClient.getCloudProviderSyncStatus();
+        if (!isCurrentDenSessionDelivery(delivery) || contextKey !== getCloudProviderSyncContextKey()) return state.importedCloudProviders;
         const next = Object.fromEntries(status.providers.map((provider) => [provider.cloudProviderId, provider]));
         setStateField("importedCloudProviders", next);
         // Carry the server's truth alongside the records: rows must not show
@@ -1446,9 +1547,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
   }
 
-  async function refreshProviders(optionsArg?: { dispose?: boolean; force?: boolean }) {
+  async function refreshProviders(optionsArg?: { dispose?: boolean; force?: boolean }, isCurrent = () => !disposed) {
     const c = options.client();
-    if (!c) return null;
+    if (!c || !isCurrent()) return null;
 
     if (optionsArg?.dispose) {
       const now = Date.now();
@@ -1511,6 +1612,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     let disabledProviders = options.disabledProviders() ?? [];
     try {
       const config = unwrap(await activeClient.config.get());
+      if (!isCurrent()) return null;
       disabledProviders = Array.isArray(config.disabled_providers)
         ? config.disabled_providers
         : [];
@@ -1521,6 +1623,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       // ignore config read failures and continue with current store state
     }
 
+    if (!isCurrent()) return null;
     try {
       const updated = filterProviderList(
         await ensureProviderListQuery(getReactQueryClient(), {
@@ -1531,6 +1634,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         }),
         disabledProviders,
       );
+      if (!isCurrent()) return null;
       applyProviderListState(updated);
       return updated;
     } catch {
@@ -1877,6 +1981,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       options.selectedWorkspaceRoot().trim(),
       options.runtimeWorkspaceId() ?? "",
       options.client() ? "connected" : "disconnected",
+      getDenSessionDeliveryKey(),
     ].join("::");
   };
 
@@ -1922,8 +2027,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   const refreshProvidersAfterCloudSync = async (optionsArg: {
     dispose?: boolean;
     force?: boolean;
-  }) => {
-    const providerList = await refreshProviders(optionsArg);
+  }, isCurrent = () => !disposed) => {
+    const providerList = await refreshProviders(optionsArg, isCurrent);
+    if (!isCurrent()) return null;
     preselectEntitledOrgDefaultModel(providerList);
     return providerList;
   };
@@ -2076,7 +2182,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
   }
 
-  async function runCloudProviderSync(reason: CloudProviderSyncReason) {
+  async function runCloudProviderSync(reason: CloudProviderSyncReason): Promise<void | { outcome: "handled_server_side" }> {
+    if (disposed) return;
+    const delivery = syncDenSessionDelivery();
     if (!hasCloudProviderSyncPrerequisites()) {
       if (reason === "settings_cloud_opened") {
         setStateField("providerAuthError", null);
@@ -2094,20 +2202,29 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
 
     if (serverHandlesProviderSync()) {
+      const contextKey = getCloudProviderSyncContextKey();
+      const isCurrent = () => isCurrentDenSessionDelivery(delivery) && contextKey === getCloudProviderSyncContextKey();
       try {
         const result = await enqueueGlobalCloudProviderSync(
-          `server:${getCloudProviderSyncContextKey()}`,
+          `server:${contextKey}`,
           async () => {
+            if (!isCurrent()) return;
             const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
             if (!openworkClient) throw new Error("OpenWork server unavailable.");
-            let result = await openworkClient.runCloudProviderSyncNow(reason);
+            // An old server session can still return noop after a failed token
+            // refresh. Delivery must succeed before every run, not just no_session.
+            if (!await pushDenSession() || !isCurrent()) return;
+            let result = await openworkClient.runCloudProviderSyncNow(reason, delivery?.controller.signal);
+            if (!isCurrent()) return;
             if (result.status === "no_session") {
-              await pushDenSession(true);
-              result = await openworkClient.runCloudProviderSyncNow(reason);
+              if (!await pushDenSession(true) || !isCurrent()) return;
+              result = await openworkClient.runCloudProviderSyncNow(reason, delivery?.controller.signal);
             }
             return result;
           },
+          isCurrent,
         );
+        if (!isCurrent()) return;
         if (!result) throw new Error("Cloud provider sync returned no result.");
         // Re-derive the imported records (and reloadPending/skips) from the
         // server's status after EVERY server-handled pass. Without this the
@@ -2115,6 +2232,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         // (usually nothing) and sat on "Syncing" forever even though the
         // server had long since applied the sync (#3671, UI layer).
         await refreshImportedCloudProviders();
+        if (!isCurrent()) return;
         if (result.status === "failed" || result.status === "no_session") {
           const message = logCloudProviderSyncError(
             reason,
@@ -2127,19 +2245,25 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         // a removed managed-model default. Always reread the live catalog and
         // reconcile that preference so Settings diagnostics recover in place,
         // including after a noop server sync.
-        await refreshProvidersAfterCloudSync({ force: true });
+        await refreshProvidersAfterCloudSync({ force: true }, isCurrent);
+        if (!isCurrent()) return;
         return { outcome: "handled_server_side" };
       } catch (error) {
+        if (!isCurrent()) return;
         const message = logCloudProviderSyncError(reason, error);
         publishSettingsCloudProviderSyncError(reason, message);
         return;
       }
     }
 
-    return enqueueGlobalCloudProviderSync(
-      `client:${getCloudProviderSyncContextKey()}`,
+    const contextKey = getCloudProviderSyncContextKey();
+    const isCurrent = () => !disposed && contextKey === getCloudProviderSyncContextKey();
+    await enqueueGlobalCloudProviderSync(
+      `client:${contextKey}`,
       () => performCloudProviderSync(reason),
+      isCurrent,
     ).catch((error) => {
+      if (!isCurrent()) return;
       const message = logCloudProviderSyncError(reason, error);
       publishSettingsCloudProviderSyncError(reason, message);
     });
@@ -2287,6 +2411,8 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     `${options.selectedWorkspaceRoot().trim()}::${options.runtimeWorkspaceId() ?? ""}`;
 
   const syncFromOptions = () => {
+    if (disposed) return;
+    const delivery = syncDenSessionDelivery();
     const workspaceKey = currentWorkspaceKey();
     const workspaceChanged = workspaceKey !== lastWorkspaceKey;
     lastWorkspaceKey = workspaceKey;
@@ -2300,7 +2426,11 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       const nextSyncContextKey = getCloudProviderSyncContextKey();
       if (nextSyncContextKey === cloudProviderSyncContextKey) return;
       cloudProviderSyncContextKey = nextSyncContextKey;
-      void pushDenSession().then(() => runCloudProviderSync("app_launch"));
+      void runCloudProviderSync("app_launch").then((result) => {
+        if (!result && isCurrentDenSessionDelivery(delivery) && cloudProviderSyncContextKey === nextSyncContextKey) {
+          cloudProviderSyncContextKey = "";
+        }
+      });
       return;
     }
     if (!hasCloudProviderSyncPrerequisites()) {
@@ -2343,8 +2473,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             lastSyncError: {},
           }));
           void refreshCloudOrgProviders({ force: true }).catch(() => undefined);
-          void pushDenSession().then(() => runCloudProviderSync("sign_in"));
+          void runCloudProviderSync("sign_in");
         } else {
+          invalidateDenSessionDelivery();
           const logoutProviderIds = [...new Set(options.providerConnectedIds())].filter(
             (providerId) => providerId.trim().toLowerCase() !== DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
           );
@@ -2371,7 +2502,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             lastSyncError: {},
           }));
           if (serverHandlesProviderSync()) {
-            lastDenSessionPushKey = "";
             void (async () => {
               await options.openworkServer.getSnapshot().openworkServerClient?.deleteDenSession().catch(() => undefined);
               // The server removes cloud-owned environment entries from disk,
@@ -2445,6 +2575,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         handleDenSessionUpdate as EventListener,
       );
       const handleDenSettingsChange = () => {
+        syncFromOptions();
         void refreshCloudOrgProviders({ force: true }).catch(() => undefined);
       };
       window.addEventListener(
@@ -2510,6 +2641,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   const dispose = () => {
     if (disposed) return;
     disposed = true;
+    invalidateDenSessionDelivery();
     started = false;
     denSessionCleanup?.();
     denSessionCleanup = null;

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -48,6 +48,7 @@ export type UseSessionProviderAuthInput = {
    * POST /cloud-provider-sync/run are host-token routes.
    */
   localServerHostToken?: string;
+  localServerGeneration?: number | null;
   setProviders: (value: ProviderListItem[]) => void;
   setProviderDefaults: (value: Record<string, string>) => void;
   setProviderConnectedIds: (value: string[]) => void;
@@ -67,6 +68,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
     selectedWorkspaceRoot,
     selectedWorkspaceId,
     localServerHostToken,
+    localServerGeneration,
     setProviders,
     setProviderDefaults,
     setProviderConnectedIds,
@@ -91,6 +93,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
     selectedWorkspaceEndpoint,
     selectedWorkspaceRoot,
     localServerHostToken,
+    localServerGeneration,
   });
   stateRef.current = {
     opencodeClient,
@@ -103,6 +106,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
     selectedWorkspaceEndpoint,
     selectedWorkspaceRoot,
     localServerHostToken,
+    localServerGeneration,
   };
 
   // Depend on the stable callback, not the coordinator object: the context
@@ -135,6 +139,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
         openworkServer: createSessionOpenworkServer({
           endpoint: () => stateRef.current.selectedWorkspaceEndpoint ?? null,
           hostToken: () => stateRef.current.localServerHostToken ?? "",
+          generation: () => stateRef.current.localServerGeneration ?? null,
         }),
         setProviders,
         setProviderDefaults,
@@ -256,8 +261,13 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
     store.syncFromOptions();
   }, [
     opencodeClient,
+    localServerHostToken,
+    localServerGeneration,
     selectedWorkspace?.id,
     selectedWorkspace?.workspaceType,
+    selectedWorkspaceEndpoint?.baseUrl,
+    selectedWorkspaceEndpoint?.token,
+    selectedWorkspaceEndpoint?.isRemote,
     selectedWorkspaceEndpoint?.workspaceId,
     selectedWorkspaceRoot,
     store,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -35,6 +35,7 @@ import { buildOpenworkEnvRuntimeKey } from "@/app/lib/openwork-env-runtime";
 import {
   getDesktopHomeDir,
   joinDesktopPath,
+  openworkServerInfo,
   revealDesktopItemInDir,
   pickDirectory,
   resolveWorkspaceListSelectedId,
@@ -690,6 +691,31 @@ export function SessionRoute() {
     onSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
   });
 
+  useEffect(() => {
+    if (!isDesktopRuntime() || selectedWorkspace?.workspaceType !== "local") return;
+    let cancelled = false;
+    let checking = false;
+    // Ports and credentials can survive a restart. Observe the host's actual
+    // generation even when no settings-change event accompanies it.
+    const interval = window.setInterval(async () => {
+      if (checking || document.visibilityState !== "visible") return;
+      checking = true;
+      try {
+        const info = await openworkServerInfo();
+        if (cancelled || !info.running || info.generation === openworkServerHostInfoState?.generation) return;
+        await refreshRouteState({ supersede: true });
+      } catch {
+        // The next probe can recover a temporarily unavailable desktop bridge.
+      } finally {
+        checking = false;
+      }
+    }, 10_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [openworkServerHostInfoState?.generation, refreshRouteState, selectedWorkspace?.workspaceType]);
+
   const { engineReloadVersion, routeEngineInfo, reloadWorkspaceEngineFromUi } = useEngineReload({
     client,
     workspaceId: selectedWorkspaceId,
@@ -840,6 +866,7 @@ export function SessionRoute() {
     selectedWorkspaceRoot,
     selectedWorkspaceId,
     localServerHostToken: openworkServerHostInfoState?.hostToken?.trim() ?? "",
+    localServerGeneration: openworkServerHostInfoState?.generation ?? null,
     setProviders,
     setProviderDefaults,
     setProviderConnectedIds,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1831,6 +1831,16 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   }, [providerAuthStore, route.tab]);
 
   useEffect(() => {
+    providerAuthStore.syncFromOptions();
+  }, [
+    providerAuthStore,
+    openworkServerSnapshot.openworkServerStatus,
+    openworkServerSnapshot.openworkServerCapabilities?.providerSync,
+    openworkServerSnapshot.openworkServerClient,
+    openworkServerSnapshot.openworkServerHostInfo?.generation,
+  ]);
+
+  useEffect(() => {
     openworkServerStore.syncFromOptions();
     connectionsStore.syncFromOptions();
     providerAuthStore.syncFromOptions();

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -552,8 +552,6 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         setLegacySelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "");
         return;
       }
-      onHostInfo(hostInfo);
-
       // Update the local-server resolver synchronously, BEFORE we kick off any
       // workspace-scoped requests below. `endpointForWorkspace` reads from
       // this resolver synchronously; the render that mirrors `[baseUrl,
@@ -631,6 +629,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       setClient(openworkClient);
       setBaseUrl(normalizedBaseUrl);
       setToken(resolvedToken);
+      // Publish host credentials/generation with their endpoint, never before
+      // the awaited workspace refresh while React still holds the old port.
+      onHostInfo(hostInfo);
       setWorkspaces(nextWorkspaces);
       const nextSessionsByWorkspaceId = Object.fromEntries(cachedEntries.map((entry) => [entry.workspaceId, entry.sessions]));
       sessionsByWorkspaceIdRef.current = nextSessionsByWorkspaceId;

--- a/apps/app/tests/cloud-provider-sync-gateway.test.ts
+++ b/apps/app/tests/cloud-provider-sync-gateway.test.ts
@@ -435,7 +435,9 @@ describe("cloud provider sync in server-capability mode", () => {
 
     releaseFirstRun();
     const outcomes = await Promise.all([first, ...sameContext, ...changedContext]);
-    expect(outcomes).toEqual(Array.from({ length: 5 }, () => ({ outcome: "handled_server_side" })));
+    // The old organization's callers are cancelled rather than publishing
+    // the replacement organization's result into their stale context.
+    expect(outcomes).toEqual([undefined, undefined, undefined, { outcome: "handled_server_side" }, { outcome: "handled_server_side" }]);
     expect(requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run")).toHaveLength(2);
   });
 
@@ -494,7 +496,7 @@ describe("cloud provider sync in server-capability mode", () => {
 
     expect(await store.runCloudProviderSync("settings_cloud_opened")).toEqual({ outcome: "handled_server_side" });
     const sessionRequests = requests.filter((request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session");
-    expect(sessionRequests).toHaveLength(1);
+    expect(sessionRequests).toHaveLength(2);
     expect(sessionRequests[0]?.body).toBe(JSON.stringify({
       baseUrl: "https://den.example/api/den",
       token: "den-token",

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -825,6 +825,40 @@ describe("session-route cloud provider sync wiring", () => {
     });
   }
 
+  for (const origin of [REMOTE_SERVER_ORIGIN, "http://192.0.2.10:7899", "https://localhost.example"]) {
+    test(`a local workspace override at ${origin} stays hostless`, async () => {
+      const storage = installWindow();
+      installCloudSession(storage);
+      storage.setItem("openwork.server.hostToken", "host-token-stored");
+      const requests: RecordedRequest[] = [];
+      installFetchMock(requests);
+      const endpoint = makeEndpoint({ origin, isRemote: false });
+      const adapter = createSessionOpenworkServer({
+        endpoint: () => endpoint,
+        hostToken: () => "host-token-live",
+        generation: () => 2,
+      });
+      expect(adapter.getSnapshot().openworkServerCapabilities?.providerSync).not.toBe(true);
+      expect(adapter.getSnapshot().openworkServerAuth?.hostToken).toBeUndefined();
+      expect(adapter.getSnapshot().openworkServerClient).toBe(endpoint.client);
+      const store = createSessionRouteStore({ endpoint, hostToken: "host-token-live", generation: 2 });
+      try {
+        await store.runCloudProviderSync("sign_in");
+        expect(sessionPuts(requests)).toHaveLength(0);
+        expect(syncRuns(requests)).toHaveLength(0);
+        const overrideRequests = requests.filter((request) => new URL(request.url).origin === origin);
+        expect(overrideRequests.length).toBeGreaterThan(0);
+        expect(overrideRequests.every((request) =>
+          !request.headers["x-openwork-host-token"] && !request.body?.includes("den-token"),
+        )).toBe(true);
+        // Config-only reconciliation still works with the endpoint's own token.
+        expect(overrideRequests.every((request) => request.headers.authorization === "Bearer client-token")).toBe(true);
+      } finally {
+        store.dispose();
+      }
+    });
+  }
+
   test("remote workspaces never receive the desktop's Den session and keep the legacy client path", async () => {
     const storage = installWindow();
     installCloudSession(storage);

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -37,6 +37,7 @@ type RecordedRequest = {
   method: string;
   body: string | null;
   headers: Record<string, string>;
+  signal?: AbortSignal | null;
 };
 
 function memoryStorage(): Storage {
@@ -130,6 +131,28 @@ function jsonResponse(payload: unknown, status = 200) {
   });
 }
 
+async function waitFor(predicate: () => boolean) {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Expected request did not arrive");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function deferredResponse() {
+  let resolve: (response: Response) => void = () => undefined;
+  const promise = new Promise<Response>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+function sessionPuts(requests: RecordedRequest[]) {
+  return requests.filter((request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session");
+}
+
+function syncRuns(requests: RecordedRequest[]) {
+  return requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run");
+}
+
 function cloudProviderPayload() {
   return {
     id: "lpr_test",
@@ -150,9 +173,13 @@ function installFetchMock(
   options: {
     runStatuses?: Array<{ status: "applied" | "noop" | "failed" | "no_session"; message?: string }>;
     providerResponse?: Promise<Response>;
+    sessionResponse?: (attempt: number) => Response | Promise<Response>;
+    runResponse?: Promise<Response> | ((attempt: number) => Response | Promise<Response>);
+    statusResponse?: Promise<Response>;
   } = {},
 ) {
   let runIndex = 0;
+  let sessionIndex = 0;
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
     value: async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -163,6 +190,7 @@ function installFetchMock(
         method,
         body: typeof init?.body === "string" ? init.body : null,
         headers: normalizeHeaders(init),
+        signal: init?.signal,
       });
 
       if (url.origin === "https://den.example" && url.pathname === "/api/den/v1/llm-providers") {
@@ -172,16 +200,18 @@ function installFetchMock(
         return jsonResponse({ llmProvider: cloudProviderPayload() });
       }
       if (url.pathname === "/den-session" && method === "PUT") {
-        return new Response(null, { status: 204 });
+        return options.sessionResponse?.(sessionIndex++) ?? new Response(null, { status: 204 });
       }
       if (url.pathname === "/cloud-provider-sync/run" && method === "POST") {
+        if (typeof options.runResponse === "function") return options.runResponse(runIndex++);
+        if (options.runResponse) return options.runResponse;
         const statuses = options.runStatuses ?? [{ status: "noop" }];
         const result = statuses[Math.min(runIndex, statuses.length - 1)];
         runIndex += 1;
         return jsonResponse(result);
       }
       if (url.pathname === "/cloud-provider-sync/status" && method === "GET") {
-        return jsonResponse({ hasSession: true, lastRun: null, providers: [] });
+        return options.statusResponse ?? jsonResponse({ hasSession: true, lastRun: null, providers: [] });
       }
       if (url.pathname === "/workspace/ws_1/config" && method === "GET") {
         return jsonResponse({ opencode: {}, openwork: {} });
@@ -229,6 +259,7 @@ function makeEndpoint(options: { origin: string; isRemote: boolean }): ResolvedW
 function createSessionRouteStore(options: {
   endpoint: ResolvedWorkspaceEndpoint | null;
   hostToken: string;
+  generation?: number;
   connectedProviderIds?: string[];
 }) {
   const opencodeClient = createClient("https://engine.example", "/tmp/workspace_test", {
@@ -262,6 +293,7 @@ function createSessionRouteStore(options: {
     openworkServer: createSessionOpenworkServer({
       endpoint: () => options.endpoint,
       hostToken: () => options.hostToken,
+      generation: () => options.generation ?? null,
     }),
     setProviders: (value) => {
       providers = value;
@@ -433,7 +465,7 @@ describe("session-route cloud provider sync wiring", () => {
     const sessionPuts = requests.filter(
       (request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session",
     );
-    expect(sessionPuts).toHaveLength(1);
+    expect(sessionPuts).toHaveLength(2);
     expect(new URL(sessionPuts[0]?.url ?? "").origin).toBe(LOCAL_SERVER_ORIGIN);
     expect(sessionPuts[0]?.headers["x-openwork-host-token"]).toBe("host-token-live");
     expect(sessionPuts[0]?.body).toBe(JSON.stringify({
@@ -468,9 +500,330 @@ describe("session-route cloud provider sync wiring", () => {
     const sessionPuts = requests.filter(
       (request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session",
     );
-    expect(sessionPuts).toHaveLength(1);
+    expect(sessionPuts).toHaveLength(2);
     expect(sessionPuts[0]?.headers["x-openwork-host-token"]).toBe("host-token-stored");
   });
+
+  test("the same store redelivers once when only the local runtime generation changes", async () => {
+    installCloudSession(installWindow());
+    const requests: RecordedRequest[] = [];
+    installFetchMock(requests);
+    const options = {
+      endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+      hostToken: "host-token-live",
+      generation: 1,
+    };
+    const store = createSessionRouteStore(options);
+    try {
+      store.syncFromOptions();
+      await store.runCloudProviderSync("manual");
+      expect(sessionPuts(requests)).toHaveLength(1);
+      options.generation = 2;
+      store.syncFromOptions();
+      store.syncFromOptions();
+      await store.runCloudProviderSync("manual");
+      expect(sessionPuts(requests)).toHaveLength(2);
+      expect(syncRuns(requests)).toHaveLength(2);
+      await store.runCloudProviderSync("manual");
+      expect(sessionPuts(requests)).toHaveLength(2);
+      const operations = requests.filter((request) =>
+        ["/den-session", "/cloud-provider-sync/run"].includes(new URL(request.url).pathname),
+      );
+      expect(operations.map((request) => request.method)).toEqual(["PUT", "POST", "PUT", "POST", "POST"]);
+    } finally {
+      store.dispose();
+    }
+  });
+
+  for (const failure of ["network", "policy_unavailable", "server_unavailable"]) {
+    test(`retries transient ${failure} delivery and coalesces concurrent sync requests`, async () => {
+      installCloudSession(installWindow());
+      const requests: RecordedRequest[] = [];
+      installFetchMock(requests, {
+        sessionResponse: (attempt) => {
+          if (attempt > 0) return new Response(null, { status: 204 });
+          if (failure === "network") throw new TypeError("Failed to fetch");
+          return jsonResponse({ code: failure }, failure === "policy_unavailable" ? 403 : 503);
+        },
+      });
+      const store = createSessionRouteStore({
+        endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+        hostToken: "host-token-live",
+      });
+      try {
+        store.syncFromOptions();
+        const results = await Promise.all([
+          store.runCloudProviderSync("manual"),
+          store.runCloudProviderSync("app_resume"),
+        ]);
+        expect(results).toEqual([{ outcome: "handled_server_side" }, { outcome: "handled_server_side" }]);
+        expect(sessionPuts(requests)).toHaveLength(2);
+        expect(syncRuns(requests)).toHaveLength(1);
+        expect(requests.indexOf(syncRuns(requests)[0]!)).toBeGreaterThan(requests.indexOf(sessionPuts(requests)[1]!));
+      } finally {
+        store.dispose();
+      }
+    });
+  }
+
+  test("bounds failed refresh retries and redelivers on the next sync even when the server still has an old session", async () => {
+    const storage = installWindow();
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    installFetchMock(requests, {
+      // Initial delivery succeeds. The next three PUTs fail without clearing
+      // the old server session; its run endpoint would still return noop.
+      sessionResponse: (attempt) => attempt > 0 && attempt < 4
+        ? jsonResponse({ code: "policy_unavailable" }, 403)
+        : new Response(null, { status: 204 }),
+    });
+    const store = createSessionRouteStore({
+      endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+      hostToken: "host-token-live",
+    });
+    try {
+      await store.runCloudProviderSync("manual");
+      storage.setItem("openwork.den.authToken", "refreshed-den-token");
+      store.syncFromOptions();
+      expect(await store.runCloudProviderSync("settings_cloud_opened")).toBeUndefined();
+      expect(sessionPuts(requests)).toHaveLength(4);
+      expect(syncRuns(requests)).toHaveLength(1);
+      expect(await store.runCloudProviderSync("manual")).toEqual({ outcome: "handled_server_side" });
+      expect(sessionPuts(requests)).toHaveLength(5);
+      expect(syncRuns(requests)).toHaveLength(2);
+      expect(JSON.parse(sessionPuts(requests)[4]!.body!).token).toBe("refreshed-den-token");
+    } finally {
+      store.dispose();
+    }
+  });
+
+  for (const { status, code } of [
+    { status: 401, code: "unauthorized" },
+    { status: 403, code: "organization_denied" },
+    { status: 409, code: "policy_identity_changed" },
+    { status: 429, code: "rate_limited" },
+  ]) {
+    test(`does not retry explicit ${code} delivery failure`, async () => {
+      installCloudSession(installWindow());
+      const requests: RecordedRequest[] = [];
+      installFetchMock(requests, { sessionResponse: () => jsonResponse({ code }, status) });
+      const store = createSessionRouteStore({
+        endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+        hostToken: "host-token-live",
+      });
+      try {
+        expect(await store.runCloudProviderSync("manual")).toBeUndefined();
+        expect(sessionPuts(requests)).toHaveLength(1);
+        expect(syncRuns(requests)).toHaveLength(0);
+      } finally {
+        store.dispose();
+      }
+    });
+  }
+
+  for (const cancel of ["signout", "dispose", "remote"]) {
+    test(`${cancel} cancels pending delivery retries without forwarding desktop credentials`, async () => {
+      installCloudSession(installWindow());
+      const requests: RecordedRequest[] = [];
+      installFetchMock(requests, { sessionResponse: () => jsonResponse({ code: "policy_unavailable" }, 403) });
+      const options = {
+        endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+        hostToken: "host-token-live",
+        generation: 1,
+      };
+      const store = createSessionRouteStore(options);
+      store.start();
+      try {
+        const pending = store.runCloudProviderSync("manual");
+        await waitFor(() => sessionPuts(requests).length === 1);
+        if (cancel === "signout") clearDenSession();
+        else if (cancel === "dispose") store.dispose();
+        else {
+          options.endpoint = makeEndpoint({ origin: REMOTE_SERVER_ORIGIN, isRemote: true });
+          options.generation = 2;
+          store.syncFromOptions();
+        }
+        await pending;
+        expect(sessionPuts(requests)).toHaveLength(1);
+        expect(sessionPuts(requests)[0]!.signal?.aborted).toBe(true);
+        expect(syncRuns(requests)).toHaveLength(0);
+        if (cancel === "remote") await store.runCloudProviderSync("manual");
+        expect(requests.filter((request) => new URL(request.url).origin === REMOTE_SERVER_ORIGIN).every((request) =>
+          !request.headers["x-openwork-host-token"] && !request.body?.includes("den-token"),
+        )).toBe(true);
+      } finally {
+        store.dispose();
+      }
+    });
+  }
+
+  test("an obsolete runtime PUT cannot satisfy delivery to the replacement runtime", async () => {
+    installCloudSession(installWindow());
+    const requests: RecordedRequest[] = [];
+    const old = deferredResponse();
+    installFetchMock(requests, { sessionResponse: (attempt) => attempt === 0 ? old.promise : new Response(null, { status: 204 }) });
+    const options = {
+      endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+      hostToken: "host-token-live",
+      generation: 1,
+    };
+    const store = createSessionRouteStore(options);
+    try {
+      const pending = store.runCloudProviderSync("manual");
+      await waitFor(() => sessionPuts(requests).length === 1);
+      options.generation = 2;
+      store.syncFromOptions();
+      old.resolve(new Response(null, { status: 204 }));
+      await pending;
+      await store.runCloudProviderSync("manual");
+      expect(sessionPuts(requests)).toHaveLength(2);
+      expect(syncRuns(requests)).toHaveLength(1);
+      expect(sessionPuts(requests)[0]!.signal?.aborted).toBe(true);
+    } finally {
+      old.resolve(new Response(null, { status: 204 }));
+      store.dispose();
+    }
+  });
+
+  test("a late successful PUT after signout cannot restore or memoize the old session", async () => {
+    const storage = installWindow();
+    installCloudSession(storage);
+    const requests: RecordedRequest[] = [];
+    const old = deferredResponse();
+    installFetchMock(requests, { sessionResponse: (attempt) => attempt === 0 ? old.promise : new Response(null, { status: 204 }) });
+    const store = createSessionRouteStore({
+      endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+      hostToken: "host-token-live",
+    });
+    store.start();
+    try {
+      const pending = store.runCloudProviderSync("manual");
+      await waitFor(() => sessionPuts(requests).length === 1);
+      clearDenSession();
+      expect(syncRuns(requests)).toHaveLength(0);
+      expect(store.getSnapshot().cloudProviderServerSync).toBeNull();
+      // Reusing the same credentials must not revive the old request's lease.
+      installCloudSession(storage);
+      const current = store.runCloudProviderSync("manual");
+      old.resolve(new Response(null, { status: 204 }));
+      await Promise.all([pending, current]);
+      expect(sessionPuts(requests)).toHaveLength(2);
+      expect(syncRuns(requests)).toHaveLength(1);
+    } finally {
+      old.resolve(new Response(null, { status: 204 }));
+      store.dispose();
+    }
+  });
+
+  test("a surviving store takes over a coalesced delivery when its owning store is disposed", async () => {
+    installCloudSession(installWindow());
+    const requests: RecordedRequest[] = [];
+    const old = deferredResponse();
+    installFetchMock(requests, { sessionResponse: (attempt) => attempt === 0 ? old.promise : new Response(null, { status: 204 }) });
+    const options = {
+      endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+      hostToken: "host-token-live",
+    };
+    const owner = createSessionRouteStore(options);
+    const survivor = createSessionRouteStore(options);
+    try {
+      const first = owner.runCloudProviderSync("manual");
+      await waitFor(() => sessionPuts(requests).length === 1);
+      const second = survivor.runCloudProviderSync("manual");
+      expect(sessionPuts(requests)).toHaveLength(1);
+      owner.dispose();
+      old.resolve(new Response(null, { status: 204 }));
+      expect(await first).toBeUndefined();
+      expect(await second).toEqual({ outcome: "handled_server_side" });
+      expect(sessionPuts(requests)).toHaveLength(2);
+      expect(syncRuns(requests)).toHaveLength(1);
+    } finally {
+      old.resolve(new Response(null, { status: 204 }));
+      owner.dispose();
+      survivor.dispose();
+    }
+  });
+
+  for (const action of ["dropped", "replaced"]) {
+    test(`a ${action} trailing batch cannot satisfy another store's runtime generation`, async () => {
+      installCloudSession(installWindow());
+      const requests: RecordedRequest[] = [];
+      const runs = [deferredResponse(), deferredResponse(), deferredResponse()];
+      installFetchMock(requests, {
+        runResponse: (attempt) => runs[attempt]?.promise ?? jsonResponse({ status: "noop" }),
+      });
+      const optionsA = {
+        endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+        hostToken: "host-token-live",
+        generation: 1,
+      };
+      const storeA = createSessionRouteStore(optionsA);
+      const storeB = createSessionRouteStore({ ...optionsA, generation: 2 });
+      const pending: Array<Promise<unknown>> = [];
+      try {
+        pending.push(storeA.runCloudProviderSync("manual"));
+        await waitFor(() => syncRuns(requests).length === 1);
+        let bSettled = false;
+        pending.push(storeB.runCloudProviderSync("manual").then((result) => {
+          bSettled = true;
+          return result;
+        }));
+        // A stale gen1 trigger drops B's gen2 batch; a gen3 trigger replaces
+        // it. Neither executed context may be accepted as B's own sync.
+        if (action === "replaced") optionsA.generation = 3;
+        pending.push(storeA.runCloudProviderSync("app_resume"));
+        expect(syncRuns(requests)).toHaveLength(1);
+        runs[0]!.resolve(jsonResponse({ status: "noop" }));
+        await waitFor(() => syncRuns(requests).length === 2);
+        expect(bSettled).toBe(false);
+        runs[1]!.resolve(jsonResponse({ status: "noop" }));
+        if (action === "replaced") {
+          await waitFor(() => syncRuns(requests).length === 3);
+          expect(bSettled).toBe(false);
+          runs[2]!.resolve(jsonResponse({ status: "noop" }));
+        }
+        const results = await Promise.all(pending);
+        expect(results[1]).toEqual({ outcome: "handled_server_side" });
+        expect(sessionPuts(requests)).toHaveLength(action === "replaced" ? 3 : 2);
+        expect(syncRuns(requests)).toHaveLength(action === "replaced" ? 3 : 2);
+      } finally {
+        storeA.dispose();
+        storeB.dispose();
+        for (const run of runs) run.resolve(jsonResponse({ status: "noop" }));
+        await Promise.allSettled(pending);
+      }
+    });
+  }
+
+  for (const delayed of ["run", "status"]) {
+    test(`discards a late server ${delayed} response after signout`, async () => {
+      installCloudSession(installWindow());
+      const requests: RecordedRequest[] = [];
+      const old = deferredResponse();
+      installFetchMock(requests, delayed === "run" ? { runResponse: old.promise } : { statusResponse: old.promise });
+      const store = createSessionRouteStore({
+        endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+        hostToken: "host-token-live",
+      });
+      store.start();
+      try {
+        const pending = store.runCloudProviderSync("manual");
+        await waitFor(() => delayed === "run"
+          ? syncRuns(requests).length === 1
+          : syncRuns(requests).length === 1 && requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/status").length >= 2);
+        clearDenSession();
+        old.resolve(jsonResponse(delayed === "run"
+          ? { status: "applied" }
+          : { hasSession: true, lastRun: null, providers: [], reloadPending: true }));
+        await pending;
+        expect(store.getSnapshot().cloudProviderServerSync).toBeNull();
+        expect(store.getSnapshot().importedCloudProviders).toEqual({});
+      } finally {
+        old.resolve(jsonResponse({}));
+        store.dispose();
+      }
+    });
+  }
 
   test("remote workspaces never receive the desktop's Den session and keep the legacy client path", async () => {
     const storage = installWindow();

--- a/evals/specs/cloud-provider-sync-contract.e2e.test.ts
+++ b/evals/specs/cloud-provider-sync-contract.e2e.test.ts
@@ -722,4 +722,41 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   expect(await evalIn(desktopApp, () => (window.__modelSelectionProof.loops))).toBe(0);
   evidence.recordAssertionEvidence("selected model survives cloud sync and return to v1", "The exact selected provider/model remained after another Den provider was published, the normal cloud sync completed, and routing returned to v1; no React update loop occurred.", true);
   expect(hotMirrored, `Initial v2 status: ${JSON.stringify(initialV2)}; third v2 status: ${JSON.stringify(thirdV2)}`).toBe(true);
+
+  // Replace only the local runtime: the mounted renderer must redeliver its
+  // identity even when the server reuses the same loopback address. Do not
+  // navigate, focus, manually sync, or reload the renderer to repair it.
+  const beforeRestart = parseSyncStatus(await readSyncStatusPayload(desktopApp));
+  const restart = await evalIn(desktopApp, async () => {
+    const invoke = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!invoke) throw new Error("Desktop runtime bridge unavailable");
+    const before = await invoke("openworkServerInfo");
+    const timeOrigin = performance.timeOrigin;
+    const route = location.hash;
+    const token = localStorage.getItem("openwork.den.authToken");
+    const org = localStorage.getItem("openwork.den.activeOrgId");
+    const after = await invoke("openworkServerRestart");
+    return {
+      generationChanged: after.generation !== before.generation,
+      samePort: after.port === before.port,
+      identityUnchanged: token === localStorage.getItem("openwork.den.authToken")
+        && org === localStorage.getItem("openwork.den.activeOrgId"),
+      timeOrigin,
+      route,
+    };
+  }, { awaitPromise: true, timeoutMs: 120_000 });
+  expect(restart).toMatchObject({ generationChanged: true, samePort: true, identityUnchanged: true });
+  const redelivered = await eventually(async () => parseSyncStatus(await readSyncStatusPayload(desktopApp)), {
+    within: 30_000,
+    intervalMs: 500,
+    label: "automatic session redelivery after same-address runtime replacement",
+    until: (status) => status.hasSession && isTerminal(status) && status.lastRunAt !== beforeRestart.lastRunAt,
+  });
+  expect(await evalIn(desktopApp, () => ({ timeOrigin: performance.timeOrigin, route: location.hash })))
+    .toMatchObject({ timeOrigin: restart.timeOrigin, route: restart.route });
+  evidence.recordAssertionEvidence(
+    "same-address runtime replacement automatically restores the signed-in session",
+    `Runtime generation changed without renderer reload, navigation or account change; the replacement server reached ${redelivered.lastRunStatus} within 30 seconds with both assigned providers restored.`,
+    true,
+  );
 });


### PR DESCRIPTION
## Current readiness — 2026-09-09
Head `b446e7eed33fc40b9ca068bea096451f5982063a`: required build/core checks passed; Warden completed all four reported skills with zero findings and its clearance review approved this head. GitHub reports CLEAN / APPROVED. The local review authentication failure below remains historical, not the current CI review outcome.

Runtime proof is still **Incomplete**. [Product journeys run 34415818735](https://github.com/different-ai/openwork/actions/runs/34415818735) selected the changed cloud-provider-sync-contract journey and the critical journeys, but they are waiting for the protected pr-slow-specs environment. The configured reviewer must approve the test execution; the current account cannot approve it. No bypass, manual approval, or merge was performed.

[Current-head Warden analysis](https://github.com/different-ai/openwork/actions/runs/34415290154). Full delivery clearance still requires current-head runtime evidence; GitHub merge eligibility alone is not that proof.

## Summary
Desktop sessions can outlive the local server process. A same-address restart previously left session delivery memoized against the old process, while a failed delivery could leave synchronization marked as attempted without scheduling recovery.

- Scope successful delivery and in-flight requests to the signed-in identity, local server credentials, and runtime generation.
- Observe runtime generation changes in Session and Settings and ensure session delivery succeeds before provider synchronization.
- Retry transient delivery failures up to three attempts with bounded backoff; keep explicit authorization denials, rate limits, and identity changes terminal.
- Cancel obsolete delivery work on sign-out, disposal, and runtime/identity changes. Match shared synchronization outcomes to the context that actually executed.
- Publish host information together with its endpoint, avoiding mixed old-endpoint/new-credential state.
- Keep remote workspaces and non-loopback local URL overrides hostless. They use endpoint-specific config access, never desktop session delivery.
- Extend existing regression tests and the cloud-provider-sync journey with same-address runtime replacement coverage.

Policy enforcement remains unchanged. This does not add stale-policy authorization or automatic replay of a failed user command.

## Review follow-up
Confirmed high finding `4R2-5S8`; fixed in `b446e7eed33fc40b9ca068bea096451f5982063a` and replied to the review thread. Three non-loopback override regressions failed before the fix and pass afterward. They assert no session PUT, no provider-sync POST, no desktop host header or Den token body, while endpoint-specific config access still works. The thread is resolved; this is not full review clearance.

## Verification — Incomplete
Candidate: `b446e7eed33fc40b9ca068bea096451f5982063a`
Base: `440504bb9010ea7be822f5f9144e2627c84d32d3` (`dev`)

Passed on the updated tree:
- `pnpm --filter @openwork/app exec bun test --isolate ./tests/session-provider-auth-server-sync.test.ts ./tests/cloud-provider-sync-gateway.test.ts` — 42 passed, 0 failed, 163 assertions; exit 0.
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `git diff --check` — exit 0.

Historical only:
- Browser callback check passed on the initial candidate (796 callbacks).
- The existing CI evidence comment names initial head `4429d978c8529a3887f09bc3b284579d4cd053a9`; it does not establish proof for this updated head.

Missing runtime proof:
- The extended `cloud-provider-sync-contract` desktop journey has not been executed or published for this head. Placement discovery selected Daytona; no sandbox was provisioned for the local verification pass.
- Next proof command: `OPENWORK_EVAL_REF=b446e7eed33fc40b9ca068bea096451f5982063a pnpm evals:e2e cloud-provider-sync-contract`.
- The new assertion replaces the local runtime without reloading or navigating the renderer, requires the same port and a changed runtime generation, then requires a fresh successful provider sync within 30 seconds with unchanged sign-in and route.
- Source-level tests are feedback, not desktop runtime proof. Failed-delivery, cancellation, and override-isolation behavior still require runtime validation.

Final local review:
- `pnpm warden:check` — exit 1, authentication failure: no OpenAI API key available to the configured review runtime.
- Expected skills: diff-security-review, confidentiality-review, spec-provenance-review, desktop-den-sync-review. None established completed local review coverage; skipped output is not clearance.
- Review run: `a2c75cf3-2026-09-09T23-04-24-021Z`. The candidate and base above were unchanged before/after review. No new validated finding IDs were produced.
- Clear when: the exact-head journey evidence is published and all applicable review skills complete without blockers.

Open ready for review as requested, with an Incomplete verdict; not a merge-ready claim.