### PR TITLE
feat(preview): launch blank published desktop releases

### DIFF
--- a/.devcontainer/test-server-on-daytona.sh
+++ b/.devcontainer/test-server-on-daytona.sh
@@ -20,6 +20,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SANDBOX="openwork-server-$(date +%Y%m%d-%H%M%S)-$$-$(od -An -N2 -tx2 /dev/urandom | tr -d ' ')"
 DAYTONA_SERVER_SNAPSHOT="${DAYTONA_SERVER_SNAPSHOT:-openwork-server}"
 DAYTONA_TARGET="${DAYTONA_TARGET:-us}"
+DAYTONA_AUTO_STOP_MINUTES="${DAYTONA_AUTO_STOP_MINUTES:-60}"
 DEN_API_PORT="${DEN_API_PORT:-8788}"
 DEN_WEB_PORT="${DEN_WEB_PORT:-3005}"
 MAX_WAIT="${DAYTONA_SERVER_MAX_WAIT:-240}"
@@ -51,6 +52,10 @@ while [ "$#" -gt 0 ]; do
     --name)
       shift
       SANDBOX="${1:?missing sandbox name}"
+      ;;
+    --auto-stop)
+      shift
+      DAYTONA_AUTO_STOP_MINUTES="${1:?missing auto-stop minutes}"
       ;;
     --help|-h)
       sed -n '1,13p' "$0"
@@ -85,12 +90,20 @@ case "$REF" in
     ;;
 esac
 
+case "$DAYTONA_AUTO_STOP_MINUTES" in
+  ""|*[!0-9]*) echo "ERROR: auto-stop minutes must be a whole number from 0 through 1440" >&2; exit 1 ;;
+esac
+if [ "$DAYTONA_AUTO_STOP_MINUTES" -gt 1440 ]; then
+  echo "ERROR: auto-stop minutes must be a whole number from 0 through 1440" >&2
+  exit 1
+fi
+
 snapshot_id() {
   daytona snapshot list -f json | node -e 'const name = process.argv[1]; let input = ""; process.stdin.on("data", (chunk) => input += chunk); process.stdin.on("end", () => { const snapshot = JSON.parse(input).find((item) => item.name === name); if (snapshot) process.stdout.write(snapshot.id || snapshot.name); });' "$1"
 }
 
 SNAPSHOT_ID="$(snapshot_id "$DAYTONA_SERVER_SNAPSHOT")"
-CREATE_ARGS=(--name "$SANDBOX" --auto-stop 60 --public --target "$DAYTONA_TARGET")
+CREATE_ARGS=(--name "$SANDBOX" --auto-stop "$DAYTONA_AUTO_STOP_MINUTES" --public --target "$DAYTONA_TARGET")
 if [ -n "$SNAPSHOT_ID" ]; then
   echo "==> Using Daytona server snapshot: $DAYTONA_SERVER_SNAPSHOT"
   CREATE_ARGS+=(--snapshot "$SNAPSHOT_ID")
@@ -101,7 +114,17 @@ fi
 
 echo "==> Creating server sandbox: $SANDBOX"
 echo "    Ref: $REF"
+created=0
+cleanup_failed_provision() {
+  status=$?
+  if [ "$status" -ne 0 ] && [ "$created" -eq 1 ]; then
+    printf 'y\n' | daytona delete "$SANDBOX" >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap cleanup_failed_provision EXIT
 daytona create "${CREATE_ARGS[@]}"
+created=1
 
 echo "==> Waiting for sandbox exec readiness..."
 exec_ready=0
@@ -183,3 +206,4 @@ echo ""
 echo "  Cleanup:"
 echo "    daytona delete $SANDBOX"
 echo "============================================"
+created=0

--- a/.opencode/skills/preview-my-work/SKILL.md
+++ b/.opencode/skills/preview-my-work/SKILL.md
@@ -22,6 +22,13 @@ for a signed-in desktop workspace without pre-added tools. Fresh desktop creates
 its local workspace but does not sign into Den. No model credentials are seeded.
 Do not describe these fixtures as capable of live model/provider requests.
 
+Use `--scenario blank --release <x.y.z> --distribution <name>` to preview exact
+published Linux x64 tarball bytes with a completely isolated, unseeded profile.
+Supported distributions are `public`, `cloud`, and `enterprise`; other
+platforms, architectures, package formats, prereleases, and mutable/latest
+versions are not supported. The installer resolves the exact `v<x.y.z>` GitHub
+release asset and verifies its API-published SHA-256 digest before extraction.
+
 ## Start and open
 
 Use a unique stage such as `pr-1234` to keep previews separate. First inspect
@@ -41,6 +48,23 @@ OPENWORK_EVAL_REF=<pushed-sha> infisical run --silent --env dev -- pnpm world up
 Substitute `preview-desktop` and the desired scenario as needed. The existing
 Daytona snapshots handle dependencies. A cold build takes minutes; reopening a
 ready world is quick. Never promise seconds for an unmeasured cold boot.
+
+For an immutable published desktop preview, run:
+
+```sh
+OPENWORK_EVAL_REF=<pushed-den-sha> pnpm world up preview-desktop --stage pr-1234 --place daytona --detach --timeout 600000 -- --release 0.18.44 --distribution enterprise --scenario blank
+```
+
+`OPENWORK_EVAL_REF` pins only the independently provisioned Den source.
+The world driver and release installer run from the local checkout's HEAD, and
+the desktop sandbox uses the snapshot's inherited display/browser helpers.
+`--release` selects desktop bytes; none of these identities falls back to
+another. Release sandboxes do not mount shared secrets and do not run a source
+checkout, `pnpm install`, Electron source launch, or Vite. Their viewer,
+startup observation, release digest, Den URLs, log/profile paths, relaunch
+shortcut, browser shortcut, and protocol handler are reported as outputs. A
+crashed or unresponsive app is retained for inspection and is not reported as
+healthy; CDP is output only when it actually responded.
 
 Read the resulting world outputs. Open `preview` with Codex's `open_in_codex`
 browser target when available; do not launch the operating system browser.
@@ -75,6 +99,10 @@ It preserves the Den database, accounts, Electron process and profile. Desktop
 renderer updates use the existing Vite hot reload; reload the viewer/app if
 needed. Verify the changed screen before claiming the update is visible.
 
+The update helper rejects published release previews. Stop that exact stage and
+launch a new stage/version instead; changing source cannot change published
+desktop bytes.
+
 The helper deliberately does not restart Den API, migrate data, or restart
 Electron main/preload. For those changes, create a new stage on the new ref and
 explain that it is a fresh preview. Do not silently reset a working preview.
@@ -91,9 +119,16 @@ pnpm world down preview-den --stage pr-1234
 The default lifetime is two hours from readiness, **not an idle timer**. Use
 `--lifetime 0` only when the user asks to keep it until explicitly stopped;
 otherwise accept 1–1440 minutes. The world process owns orderly teardown on
-expiry or `down`. An abruptly killed driver cannot run its cleanup; inspect the
-stage's resource ledger and use the existing world reaper for orphan recovery.
-Do not delete sandboxes by broad name patterns.
+expiry or `down`; preview provisioning disables Daytona's separate idle timer
+for both the Den and desktop sandboxes. An abruptly killed driver cannot run
+that cleanup. Use only the exact `denSandbox` and `desktopSandbox` IDs recorded
+in the owner-only outputs to inspect or remove leftovers; never delete by broad
+name patterns.
+
+`world up` adopts an already-running stage before it evaluates new script
+arguments. Inspect its recorded scenario, Den ref, release version,
+distribution, and digest first. If any requested value differs, use a new stage
+or explicitly stop/reset the existing one; never treat adoption as an update.
 
 Report the preview link, tested ref/scenario, expiry, and any actual limitation.
 Keep infrastructure IDs and startup logs out of the user-facing walkthrough.

--- a/.opencode/skills/preview-my-work/scripts/update-preview.py
+++ b/.opencode/skills/preview-my-work/scripts/update-preview.py
@@ -25,6 +25,8 @@ if state.get("kind") != "script" or state.get("place") != "daytona" or Path(stat
     parser.error("Receipt is not an owned Daytona preview in this worktree.")
 os.kill(state["pid"], 0)
 outputs = state["outputs"]
+if outputs.get("releaseVersion"):
+    parser.error("Published release previews are immutable and cannot use the source frontend updater; stop this stage and launch a new one.")
 # All commands are argv-based locally, and one shell-quoted Python program remotely.
 # Reuse the running web process's environment without printing or serializing it.
 remote = r'''

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -57,6 +57,8 @@ export interface ServerOptions {
   reuseMembers?: Record<string, PersonShape>;
   ports?: { api: number; web: number };
   seedProfile?: "demo-org";
+  /** Daytona idle shutdown in minutes. Preview worlds pass 0 so their lifetime owns teardown. */
+  daytonaAutoStopMinutes?: number;
   /**
    * Extra origins Den should trust, on top of its own API and web hosts. A
    * loopback identity provider needs this: Den refuses to register an SSO
@@ -685,6 +687,7 @@ export async function server(options: ServerOptions): Promise<Den> {
       reuse: preparedSandbox,
       bootstrapAdminEmail: bootstrapAdmin.email,
       env: denEnv,
+      ...(options.daytonaAutoStopMinutes === undefined ? {} : { autoStopMinutes: options.daytonaAutoStopMinutes }),
       log: (line) => console.error(`[openwork/testkit] ${line}`),
     });
     let bootedMocks: { handles: Record<string, MockHandle>; env: Record<string, string> } = { handles: {}, env: {} };

--- a/evals/packages/env/src/desktop-app.ts
+++ b/evals/packages/env/src/desktop-app.ts
@@ -2,10 +2,10 @@ import { browserScript } from "@openwork/cdp";
 import { createAndSelectWorkspace, signInDesktopAs } from "@openwork/behaviors";
 import { attachSurface, evaluateOnSurface, isInteractive, probeAppStateOnSurface } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
-import { desktop } from "@openwork/hosts";
+import { desktop, retainedDesktop } from "@openwork/hosts";
 import { liveSharedProductionStateEnv } from "@openwork/hosts";
 import { progress, trackResource } from "@openwork/world";
-import type { AppReadiness, DesktopHandle, Host, InstalledProductionDesktopState } from "@openwork/hosts";
+import type { AppReadiness, DesktopHandle, DesktopRelease, Host, InstalledProductionDesktopState, RetainedDesktopHandle } from "@openwork/hosts";
 import type { Den } from "./den.ts";
 import type { Place } from "./place.ts";
 
@@ -46,6 +46,33 @@ export interface App extends DesktopHandle {
   workspaceId: string;
   /** Live-state launches may have no selected workspace; snapshots preserve that as null. */
   snapshotWorkspaceId?: string | null;
+}
+
+/** A published desktop with an isolated empty profile; no bootstrap, workspace, activation, or sign-in is seeded. */
+export async function blankReleaseApp(options: {
+  place: Place;
+  release: DesktopRelease;
+  startupTimeoutMs?: number;
+}): Promise<RetainedDesktopHandle> {
+  const host = options.place.host();
+  if (!host) throw new Error("Published desktop previews require a host.");
+  const electronStep = steps.step("electron-release-blank", "Electron (published blank release)");
+  try {
+    const stage = process.env.OPENWORK_WORLD_STAGE?.trim();
+    const surface = await retainedDesktop({
+      name: `release-${options.release.distribution}-${options.release.version}${stage ? `-${stage}` : ""}`,
+      host,
+      release: options.release,
+      ...(options.startupTimeoutMs === undefined ? {} : { startupTimeoutMs: options.startupTimeoutMs }),
+    });
+    await electronStep.note(`startup ${surface.startup.state}`);
+    await electronStep.note(`log ${surface.handle.meta?.log}`);
+    await electronStep.ok(surface.startup.state);
+    return surface;
+  } catch (error) {
+    await electronStep.fail(error instanceof Error ? error.message : String(error));
+    throw error;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/evals/packages/env/src/place.ts
+++ b/evals/packages/env/src/place.ts
@@ -7,6 +7,7 @@ import type {
   ChromeSurfaceOptions,
   ElectronSurfaceOptions,
   Host,
+  RetainedElectronSurface,
   SurfaceHandle,
 } from "@openwork/hosts";
 
@@ -158,6 +159,7 @@ interface PlacedSurface {
   host: Host;
   sandbox: string;
   created: boolean;
+  release?: Awaited<ReturnType<typeof provisionDesktopSandbox>>["release"];
 }
 
 /** Provisions one isolated sandbox for each app surface, only when it is used. */
@@ -175,8 +177,9 @@ class DaytonaPlacementHost implements Host {
     this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox) : undefined;
   }
 
-  async #provision(name: string): Promise<PlacedSurface> {
+  async #provision(name: string, options?: ElectronSurfaceOptions): Promise<PlacedSurface> {
     if (this.#preparedSandbox && this.#preparedHost) {
+      if (options?.release) throw new Error("Published release previews require a newly owned Daytona sandbox.");
       return {
         host: this.#preparedHost,
         sandbox: this.#preparedSandbox,
@@ -186,21 +189,73 @@ class DaytonaPlacementHost implements Host {
     const provisioned = await provisionDesktopSandbox({
       ref: this.#ref,
       name,
+      ...(options?.release ? { release: options.release } : {}),
+      ...(process.env.OPENWORK_WORLD_PREVIEW_DAYTONA === "1" ? { autoStopMinutes: 0 } : {}),
       log: (line) => console.error(`[openwork/testkit] ${line}`),
     });
     return {
       host: daytonaSandbox(provisioned.sandbox),
       sandbox: provisioned.sandbox,
       created: provisioned.created,
+      ...(provisioned.release ? { release: provisioned.release } : {}),
     };
   }
 
   async spawnElectron(name: string, options?: ElectronSurfaceOptions): Promise<SurfaceHandle> {
-    const placed = await this.#provision(name);
+    const placed = await this.#provision(name, options);
     try {
-      const handle = await placed.host.spawnElectron(name, options);
+      const handle = await placed.host.spawnElectron(name, {
+        ...options,
+        ...(placed.release ? { binaryPath: placed.release.binaryPath } : {}),
+      });
+      if (placed.release) {
+        handle.meta = {
+          ...handle.meta,
+          releaseArchive: placed.release.archivePath,
+          releaseAsset: placed.release.assetName,
+          releaseBinary: placed.release.binaryPath,
+          releaseDigest: placed.release.digest,
+          releaseDistribution: placed.release.distribution,
+          releaseInstallRoot: placed.release.installRoot,
+          releaseManifest: placed.release.manifestPath,
+          releaseVersion: placed.release.version,
+        };
+      }
       this.#surfaces.set(handle, placed);
       return handle;
+    } catch (error) {
+      if (placed.created) {
+        await deleteSandboxes([placed.sandbox]).catch((cleanupError: unknown) => {
+          console.error(`[openwork/testkit] Daytona cleanup failed: ${messageText(cleanupError)}`);
+        });
+      }
+      throw error;
+    }
+  }
+
+  async spawnElectronRetained(name: string, options?: ElectronSurfaceOptions): Promise<RetainedElectronSurface> {
+    const placed = await this.#provision(name, options);
+    try {
+      if (!placed.host.spawnElectronRetained) throw new Error("The selected host cannot retain a failed Electron launch.");
+      const surface = await placed.host.spawnElectronRetained(name, {
+        ...options,
+        ...(placed.release ? { binaryPath: placed.release.binaryPath } : {}),
+      });
+      if (placed.release) {
+        surface.handle.meta = {
+          ...surface.handle.meta,
+          releaseArchive: placed.release.archivePath,
+          releaseAsset: placed.release.assetName,
+          releaseBinary: placed.release.binaryPath,
+          releaseDigest: placed.release.digest,
+          releaseDistribution: placed.release.distribution,
+          releaseInstallRoot: placed.release.installRoot,
+          releaseManifest: placed.release.manifestPath,
+          releaseVersion: placed.release.version,
+        };
+      }
+      this.#surfaces.set(surface.handle, placed);
+      return surface;
     } catch (error) {
       if (placed.created) {
         await deleteSandboxes([placed.sandbox]).catch((cleanupError: unknown) => {

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { setTimeout } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { resolveEvalEngineValue } from "./eval-engine.ts";
-import type { ChromeSurfaceOptions, DenServiceHandle, DenServiceOptions, ElectronSurfaceOptions, Host, ShareLinks, SurfaceHandle } from "./types.ts";
+import type { ChromeSurfaceOptions, DenServiceHandle, DenServiceOptions, ElectronSurfaceOptions, Host, RetainedElectronSurface, ShareLinks, SurfaceHandle } from "./types.ts";
 
 export interface DaytonaExecResult {
   stdout: string;
@@ -30,6 +30,7 @@ export interface DaytonaHostOptions {
 
 export interface DaytonaHost extends Host, AsyncDisposable {
   previewUrl(port: number): Promise<string>;
+  spawnElectronRetained(name: string, opts?: ElectronSurfaceOptions): Promise<RetainedElectronSurface>;
   startDen(opts?: DenServiceOptions): Promise<DenServiceHandle>;
   share(): Promise<ShareLinks>;
   stop(): Promise<void>;
@@ -545,6 +546,33 @@ function appendExtraEnv(assignments: Map<string, string>, env: Record<string, st
   }
 }
 
+function appendBlankProfileEnv(assignments: Map<string, string>, profileRoot: string, userDataDir: string): void {
+  const home = `${profileRoot}/home`;
+  const config = `${profileRoot}/openwork/config`;
+  assignments.set("HOME", home);
+  assignments.set("USERPROFILE", home);
+  assignments.set("XDG_CONFIG_HOME", `${profileRoot}/xdg/config`);
+  assignments.set("XDG_DATA_HOME", `${profileRoot}/xdg/data`);
+  assignments.set("XDG_CACHE_HOME", `${profileRoot}/xdg/cache`);
+  assignments.set("XDG_STATE_HOME", `${profileRoot}/xdg/state`);
+  assignments.set("APPDATA", `${profileRoot}/windows/app-data/roaming`);
+  assignments.set("LOCALAPPDATA", `${profileRoot}/windows/app-data/local`);
+  assignments.set("OPENWORK_ELECTRON_USERDATA", userDataDir);
+  assignments.set("OPENWORK_DESKTOP_BOOTSTRAP_PATH", `${config}/desktop-bootstrap.json`);
+  assignments.set("OPENWORK_SERVER_CONFIG", `${config}/server.json`);
+  assignments.set("OPENWORK_ENV_STORE", `${config}/env.json`);
+  assignments.set("OPENWORK_TOKEN_STORE", `${config}/tokens.json`);
+  assignments.set("OPENWORK_RUNTIME_DB", `${config}/runtime.sqlite`);
+  assignments.set("OPENWORK_DATA_DIR", `${profileRoot}/openwork/data`);
+  assignments.set("OPENCODE_CONFIG_DIR", `${profileRoot}/opencode/config`);
+  assignments.set("OPENCODE_DB", `${profileRoot}/opencode/data/opencode.db`);
+  assignments.set("OPENWORK_ELECTRON_DISABLE_PROTOCOL_REGISTRATION", "1");
+}
+
+function encodedFile(content: string): string {
+  return Buffer.from(content, "utf8").toString("base64");
+}
+
 export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
   const exec = options.exec ?? defaultDaytonaExec;
   const previewCache = new Map<number, string>();
@@ -575,7 +603,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
     return url;
   }
 
-  async function spawnElectron(name: string, opts: ElectronSurfaceOptions = {}): Promise<SurfaceHandle> {
+  async function launchElectron(name: string, opts: ElectronSurfaceOptions, retainStartupFailure: boolean): Promise<RetainedElectronSurface> {
     const sandbox = requireSandbox();
     const safeName = sanitizeName(name);
     const spawnStamp = timestamp();
@@ -590,6 +618,29 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
     // Per-spawn log so the integrity check below can never read a previous
     // run's lines.
     const logPath = `/tmp/electron-${safeName}-${spawnStamp}.log`;
+    const binaryPath = opts.devCommand ? undefined : opts.binaryPath?.trim();
+    if (opts.profile === "blank" && !binaryPath) {
+      releasePort(electronPorts, port);
+      throw new Error("A blank Daytona Electron profile requires an explicit binaryPath.");
+    }
+    if (binaryPath && (!binaryPath.startsWith("/") || binaryPath.includes("\0") || binaryPath.includes("\n"))) {
+      releasePort(electronPorts, port);
+      throw new Error("Daytona Electron binaryPath must be an absolute single-line path.");
+    }
+    if (opts.profile === "blank" && opts.bootstrap) {
+      releasePort(electronPorts, port);
+      throw new Error("A blank Daytona Electron profile cannot be seeded with bootstrap state.");
+    }
+
+    const handle: SurfaceHandle = {
+      name,
+      kind: "electron",
+      hostKind: "daytona",
+      cdpUrl: "",
+      sandboxId: sandbox,
+      profileDir: profileRoot,
+      meta: { cdpPort: String(port), log: logPath, profileOwner: callerOwnedProfile ? "caller" : "host" },
+    };
 
     try {
       await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(userDataDir)], `mkdir Daytona Electron profile ${userDataDir}`, { timeoutMs: 30_000 });
@@ -605,30 +656,141 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
       }
 
       const env = new Map<string, string>();
-      if (resolveEvalEngineValue(process.env.OPENWORK_EVAL_ENGINE) === "v2") env.set("OPENWORK_ENGINE_V2_PREVIEW", "1");
-      appendExtraEnv(env, opts.env);
+      if (opts.profile !== "blank") {
+        if (resolveEvalEngineValue(process.env.OPENWORK_EVAL_ENGINE) === "v2") env.set("OPENWORK_ENGINE_V2_PREVIEW", "1");
+        appendExtraEnv(env, opts.env);
+      }
       env.set("DAYTONA_ELECTRON_LOG", logPath);
       env.set("OPENWORK_ELECTRON_REMOTE_DEBUG_PORT", String(port));
       env.set("OPENWORK_ELECTRON_USERDATA", userDataDir);
-      env.set("OPENWORK_WORKSPACE_DIR", "/workspace");
-      env.set("OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT", "1");
-      const packagedBinary = process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim();
-      if (packagedBinary) env.set("OPENWORK_EVAL_ELECTRON_BINARY", packagedBinary);
       if (opts.bootstrap) env.set("OPENWORK_DESKTOP_BOOTSTRAP_PATH", bootstrapPath);
+      let remotePid = "";
+      if (binaryPath) {
+        env.set("DISPLAY", ":99");
+        env.set("ELECTRON_DISABLE_SANDBOX", "1");
+        env.set("ELECTRON_EXTRA_LAUNCH_ARGS", "--disable-gpu --disable-dev-shm-usage --enable-unsafe-swiftshader");
+        env.set("OPENWORK_REACT_DEVTOOLS", "0");
+        if (opts.profile === "blank") {
+          appendBlankProfileEnv(env, profileRoot, userDataDir);
+          env.set("OPENWORK_DEV_MODE", "0");
+        }
+        const vmHomeResult = await checkedExec(
+          exec,
+          ["exec", sandbox, "--", `bash -lc ${shellQuote('printf %s "$HOME"')}`],
+          `resolve Daytona VM home for ${name}`,
+          { timeoutMs: 30_000 },
+        );
+        const vmHome = vmHomeResult.stdout.trim();
+        if (!vmHome.startsWith("/") || vmHome.includes("\n")) throw new Error(`Daytona VM returned an invalid home path for ${name}.`);
+        const launcherPath = `${profileRoot}/launch-openwork`;
+        const browserLauncherPath = `${profileRoot}/launch-browser`;
+        const protocolHandlerPath = `${profileRoot}/xdg/data/applications/openwork-release-preview.desktop`;
+        const relaunchShortcutPath = `${vmHome}/Desktop/OpenWork Release ${safeName}.desktop`;
+        const browserShortcutPath = `${vmHome}/Desktop/Browser ${safeName}.desktop`;
+        const binaryArgs = [
+          "--no-sandbox",
+          "--disable-gpu",
+          "--disable-dev-shm-usage",
+          "--enable-unsafe-swiftshader",
+          ...(opts.launchArgs ?? []),
+        ];
+        const isolatedShell = `openwork_dbus="\${DBUS_SESSION_BUS_ADDRESS-}"
+openwork_xauthority="\${XAUTHORITY-}"
+for openwork_env_name in $(compgen -e); do unset "$openwork_env_name" 2>/dev/null || true; done
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export LANG=C.UTF-8
+if [ -n "$openwork_dbus" ]; then export DBUS_SESSION_BUS_ADDRESS="$openwork_dbus"; fi
+if [ -n "$openwork_xauthority" ]; then export XAUTHORITY="$openwork_xauthority"; fi
+${shellExport(env)}
+cd "$HOME"`;
+        const launcher = `#!/usr/bin/env bash\nset -euo pipefail\n${isolatedShell}\nexec ${shellQuote(binaryPath)} ${binaryArgs.map(shellQuote).join(" ")} "$@"\n`;
+        const browserLauncher = `#!/usr/bin/env bash\nset -euo pipefail\n${isolatedShell}\nBROWSER="$(command -v chromium || command -v google-chrome || command -v google-chrome-stable || true)"\nif [ -z "$BROWSER" ]; then exit 127; fi\nexec "$BROWSER" --user-data-dir=${shellQuote(`${profileRoot}/browser`)} --no-sandbox --disable-dev-shm-usage "$@"\n`;
+        const desktopEntry = `[Desktop Entry]\nType=Application\nVersion=1.0\nName=OpenWork Release\nExec=${launcherPath} %U\nTryExec=${launcherPath}\nTerminal=false\nCategories=Development;Utility;\nMimeType=x-scheme-handler/openwork;\n`;
+        const browserEntry = `[Desktop Entry]\nType=Application\nVersion=1.0\nName=Browser\nExec=${browserLauncherPath}\nTryExec=${browserLauncherPath}\nTerminal=false\nCategories=Network;WebBrowser;\n`;
+        const profileDirectories = [
+          userDataDir,
+          `${profileRoot}/home`,
+          `${vmHome}/Desktop`,
+          `${profileRoot}/xdg/config`,
+          `${profileRoot}/xdg/data/applications`,
+          `${profileRoot}/xdg/cache`,
+          `${profileRoot}/xdg/state`,
+          `${profileRoot}/windows/app-data/roaming`,
+          `${profileRoot}/windows/app-data/local`,
+          `${profileRoot}/openwork/config`,
+          `${profileRoot}/openwork/data`,
+          `${profileRoot}/opencode/config`,
+          `${profileRoot}/opencode/data`,
+          `${profileRoot}/browser`,
+        ];
+        const setupCommand = [
+          "set -euo pipefail",
+          `test -x ${shellQuote(binaryPath)}`,
+          `mkdir -p ${profileDirectories.map(shellQuote).join(" ")}`,
+          `printf %s ${encodedFile(launcher)} | base64 -d > ${shellQuote(launcherPath)}`,
+          `printf %s ${encodedFile(browserLauncher)} | base64 -d > ${shellQuote(browserLauncherPath)}`,
+          `printf %s ${encodedFile(desktopEntry)} | base64 -d > ${shellQuote(protocolHandlerPath)}`,
+          `printf %s ${encodedFile(desktopEntry)} | base64 -d > ${shellQuote(relaunchShortcutPath)}`,
+          `printf %s ${encodedFile(browserEntry)} | base64 -d > ${shellQuote(browserShortcutPath)}`,
+          `chmod +x ${[launcherPath, browserLauncherPath, protocolHandlerPath, relaunchShortcutPath, browserShortcutPath].map(shellQuote).join(" ")}`,
+          `${shellExport(env)} xdg-mime default openwork-release-preview.desktop x-scheme-handler/openwork`,
+          `${shellExport(env)} test "$(xdg-mime query default x-scheme-handler/openwork)" = openwork-release-preview.desktop`,
+          `gio set ${shellQuote(relaunchShortcutPath)} metadata::trusted true >/dev/null 2>&1 || true`,
+          `gio set ${shellQuote(browserShortcutPath)} metadata::trusted true >/dev/null 2>&1 || true`,
+        ].join("; ");
+        await checkedExec(exec, ["exec", sandbox, "--", `bash -lc ${shellQuote(setupCommand)}`], `prepare Daytona packaged Electron surface ${name}`, { timeoutMs: 60_000 });
+        handle.meta = {
+          ...handle.meta,
+          binary: binaryPath,
+          browserShortcut: browserShortcutPath,
+          protocolHandler: protocolHandlerPath,
+          relaunchShortcut: relaunchShortcutPath,
+        };
+        spawnedSurfaces.add(handle);
+        const startCommand = `python3 - <<PYEOF
+import subprocess
+log = open(${JSON.stringify(logPath)}, "ab", buffering=0)
+process = subprocess.Popen([${JSON.stringify(launcherPath)}], cwd=${JSON.stringify(`${profileRoot}/home`)}, stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT, start_new_session=True, close_fds=True)
+print("OPENWORK_REMOTE_PID=" + str(process.pid))
+PYEOF`;
+        const started = await checkedExec(exec, ["exec", sandbox, "--", `bash -lc ${shellQuote(startCommand)}`], `start Daytona packaged Electron surface ${name}`, { timeoutMs: 60_000 });
+        remotePid = started.stdout.split(/\r?\n/).find((line) => line.startsWith("OPENWORK_REMOTE_PID="))?.slice("OPENWORK_REMOTE_PID=".length).trim() ?? "";
+        if (!/^\d+$/.test(remotePid)) throw new Error(`Daytona packaged Electron surface ${name} did not report its remote pid.`);
+        handle.meta.remotePid = remotePid;
+      } else {
+        env.set("OPENWORK_WORKSPACE_DIR", "/workspace");
+        env.set("OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT", "1");
+        const packagedBinary = process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim();
+        if (packagedBinary) env.set("OPENWORK_EVAL_ELECTRON_BINARY", packagedBinary);
+        const startCommand = `set -euo pipefail; cd /workspace; ${shellExport(env)} bash /workspace/.devcontainer/start-daytona-electron.sh --detach`;
+        spawnedSurfaces.add(handle);
+        await checkedExec(
+          exec,
+          ["exec", sandbox, "--", `bash -lc ${shellQuote(startCommand)}`],
+          `start Daytona Electron surface ${name}`,
+          { timeoutMs: 60_000 },
+        );
+      }
 
-      const startCommand = `set -euo pipefail; cd /workspace; ${shellExport(env)} bash /workspace/.devcontainer/start-daytona-electron.sh --detach`;
-      await checkedExec(
-        exec,
-        ["exec", sandbox, "--", `bash -lc ${shellQuote(startCommand)}`],
-        `start Daytona Electron surface ${name}`,
-        { timeoutMs: 60_000 },
-      );
-
-      const cdpUrl = await previewUrl(port);
+      handle.cdpUrl = await previewUrl(port);
       // SurfaceRegistry also waits 30s before attaching, but Daytona preview URLs
       // can route before cold Electron CDP is actually responsive; give remote
       // sandboxes a longer preflight here so attach remains a normal fast probe.
-      await waitForCdp(`${cleanBaseUrl(cdpUrl)}/json/list`, ELECTRON_CDP_WAIT_MS, `Electron CDP ${name}`);
+      try {
+        await waitForCdp(`${cleanBaseUrl(handle.cdpUrl)}/json/list`, opts.startupTimeoutMs ?? ELECTRON_CDP_WAIT_MS, `Electron CDP ${name}`);
+      } catch (startupError) {
+        if (!retainStartupFailure) throw startupError;
+        const local = await checkedExec(
+          exec,
+          ["exec", sandbox, "--", `bash -lc ${shellQuote(`if curl -sf --max-time 3 http://127.0.0.1:${port}/json/list >/dev/null; then echo CDP_LOCAL; else echo CDP_DOWN; fi; if kill -0 ${remotePid} 2>/dev/null; then echo PROCESS_ALIVE; else echo PROCESS_EXITED; fi`)}`],
+          `observe Daytona packaged Electron startup ${name}`,
+          { timeoutMs: 15_000 },
+        );
+        if (local.stdout.includes("CDP_LOCAL")) throw startupError;
+        const state = local.stdout.includes("PROCESS_ALIVE") ? "unresponsive" : "crashed";
+        surfacePorts.set(port, `electron:${name} CDP (${state})`);
+        return { handle, startup: { state, detail: `${state === "crashed" ? "Process exited" : "Process remained alive"} before CDP responded; inspect ${logPath}.` } };
+      }
       // Spawn integrity: the port serving CDP must belong to THIS spawn, not a
       // pre-existing instance. electron-dev.mjs logs the resolved CDP port; if
       // it differs from the one we exported, the bind failed (port collision)
@@ -651,22 +813,25 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
         );
       }
       surfacePorts.set(port, `electron:${name} CDP`);
-      const handle: SurfaceHandle = {
-        name,
-        kind: "electron",
-        hostKind: "daytona",
-        cdpUrl,
-        sandboxId: sandbox,
-        profileDir: profileRoot,
-        meta: { cdpPort: String(port), log: logPath, profileOwner: callerOwnedProfile ? "caller" : "host" },
-      };
-      spawnedSurfaces.add(handle);
-      return handle;
+      return { handle, startup: { state: "cdp-responsive", detail: `CDP responded on sandbox port ${port}.` } };
     } catch (error) {
-      releasePort(electronPorts, port);
-      surfacePorts.delete(port);
+      if (spawnedSurfaces.has(handle)) {
+        await disposeSurface(handle).catch((cleanupError: unknown) => options.log(`Daytona surface ${name} cleanup failed: ${messageText(cleanupError)}`));
+      } else {
+        releasePort(electronPorts, port);
+        surfacePorts.delete(port);
+      }
       throw error;
     }
+  }
+
+  async function spawnElectron(name: string, opts: ElectronSurfaceOptions = {}): Promise<SurfaceHandle> {
+    return (await launchElectron(name, opts, false)).handle;
+  }
+
+  async function spawnElectronRetained(name: string, opts: ElectronSurfaceOptions = {}): Promise<RetainedElectronSurface> {
+    if (!opts.binaryPath) throw new Error("Retained Daytona Electron launch requires an explicit binaryPath.");
+    return launchElectron(name, opts, true);
   }
 
   async function spawnChrome(name: string, opts: ChromeSurfaceOptions = {}): Promise<SurfaceHandle> {
@@ -760,12 +925,21 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
       const profilePattern = handle.profileDir
         ? electronProfilePattern(`${electronProfileRoot(handle.profileDir)}/electron-userdata`)
         : "";
+      const remotePid = handle.meta?.remotePid;
+      const binary = handle.meta?.binary;
+      const exactProcess = remotePid && /^\d+$/.test(remotePid) && binary
+        ? `if [ "$(readlink -f /proc/${remotePid}/exe 2>/dev/null || true)" = ${shellQuote(binary)} ]; then pgid=$(ps -o pgid= -p ${remotePid} | tr -d " "); if [ -n "$pgid" ]; then kill -TERM -"$pgid" 2>/dev/null || true; fi; fi`
+        : "true";
+      const shortcuts = [handle.meta?.relaunchShortcut, handle.meta?.browserShortcut]
+        .filter((path): path is string => typeof path === "string" && path.startsWith("/"));
       const stopCommand = [
+        exactProcess,
         profilePattern ? killGroupsForPatternCommand(profilePattern, "TERM") : "true",
         `pkill -f ${shellQuote(pattern)} || true`,
         "sleep 1",
         profilePattern ? killGroupsForPatternCommand(profilePattern, "KILL") : "true",
         `pkill -f ${shellQuote(pattern)} || true`,
+        shortcuts.length > 0 ? `rm -f ${shortcuts.map(shellQuote).join(" ")}` : "true",
       ].join("; ");
       await checkedExec(
         exec,
@@ -841,6 +1015,7 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
     workspaceRoot: "/workspace",
     previewUrl,
     spawnElectron,
+    spawnElectronRetained,
     spawnChrome,
     startDen,
     share,

--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -3,7 +3,7 @@ import { timed } from "@openwork/timeline";
 import { attachSurface, describeAppState, dumpScreenState, isInteractive, probeAppStateOnSurface } from "@openwork/cdp";
 import { resolveHost } from "./resolve.ts";
 import type { AppStateProbe, AppSurfaceState, AttachedSurface, Surface, SurfaceHandle } from "@openwork/cdp";
-import type { Host } from "./types.ts";
+import type { DesktopRelease, ElectronStartupObservation, Host } from "./types.ts";
 
 const DEFAULT_TIMEOUT_MS = 180_000;
 const POLL_INTERVAL_MS = 250;
@@ -76,6 +76,53 @@ export interface DesktopHandle extends AttachedSurface {
    */
   workspaceRoot: string | null;
   stop(): Promise<void>;
+}
+
+export interface RetainedDesktopHandle extends AsyncDisposable {
+  handle: SurfaceHandle;
+  startup: ElectronStartupObservation;
+  workspaceRoot: string;
+  stop(): Promise<void>;
+}
+
+export interface RetainedDesktopOptions {
+  name?: string;
+  host: Host;
+  binaryPath?: string;
+  release?: DesktopRelease;
+  profileDir?: string;
+  env?: Record<string, string>;
+  launchArgs?: readonly string[];
+  startupTimeoutMs?: number;
+}
+
+/** Retain the host and viewer when product startup crashes or never exposes CDP. */
+export async function retainedDesktop(opts: RetainedDesktopOptions): Promise<RetainedDesktopHandle> {
+  if (!opts.host.spawnElectronRetained) {
+    throw new Error("The selected desktop host does not support retained Electron launches.");
+  }
+  const launched = await opts.host.spawnElectronRetained(opts.name ?? "retained", {
+    profile: "blank",
+    ...(opts.binaryPath === undefined ? {} : { binaryPath: opts.binaryPath }),
+    ...(opts.release === undefined ? {} : { release: opts.release }),
+    ...(opts.profileDir === undefined ? {} : { profileDir: opts.profileDir }),
+    ...(opts.env === undefined ? {} : { env: opts.env }),
+    ...(opts.launchArgs === undefined ? {} : { launchArgs: opts.launchArgs }),
+    ...(opts.startupTimeoutMs === undefined ? {} : { startupTimeoutMs: opts.startupTimeoutMs }),
+  });
+  let stopped = false;
+  const stop = async (): Promise<void> => {
+    if (stopped) return;
+    stopped = true;
+    await opts.host.disposeSurface(launched.handle);
+  };
+  return {
+    handle: launched.handle,
+    startup: launched.startup,
+    workspaceRoot: opts.host.workspaceRoot,
+    stop,
+    [Symbol.asyncDispose]: () => stop().catch((error: unknown) => logCleanupError(launched.handle.name, error)),
+  };
 }
 
 async function waitForReadiness(app: Surface, timeoutMs: number): Promise<AppReadiness> {

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { checkedExec, defaultDaytonaExec } from "./daytona.ts";
 import { FAULT_PROXY_SCRIPT } from "./fault-proxy-script.ts";
 import type { DaytonaExec, DaytonaExecResult } from "./daytona.ts";
+import type { DesktopRelease, DesktopReleaseDistribution } from "./types.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const DESKTOP_READY_TIMEOUT_MS = 300_000;
@@ -19,6 +20,83 @@ const READINESS_POLL_INTERVAL_MS = 5_000;
 const HTTPS_URL = /https:\/\/[^\s"'<>)]+/;
 const DEN_WEB_PORT = 3005;
 const DEN_API_PORT = 8788;
+const RELEASE_REPOSITORY = "different-ai/openwork";
+const MAX_DESKTOP_RELEASE_ARCHIVE_BYTES = 1024 * 1024 * 1024;
+
+const RELEASE_ARTIFACTS: Record<DesktopReleaseDistribution, { prefix: string; binary: string }> = {
+  public: { prefix: "openwork", binary: "openwork" },
+  cloud: { prefix: "openwork-cloud", binary: "openwork-cloud" },
+  enterprise: { prefix: "openwork-enterprise", binary: "openwork-enterprise" },
+};
+
+export const DESKTOP_RELEASE_ARCHIVE_INSTALLER = `
+import hashlib
+import pathlib
+import stat
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+root = pathlib.Path(sys.argv[2]).resolve()
+binary_name = sys.argv[3]
+expected_digest = sys.argv[4]
+expected_size = int(sys.argv[5])
+actual_size = archive.stat().st_size
+if actual_size != expected_size:
+    raise RuntimeError("Published release size mismatch: expected " + str(expected_size) + ", received " + str(actual_size))
+digest = hashlib.sha256()
+with archive.open("rb") as source:
+    for chunk in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(chunk)
+if digest.hexdigest() != expected_digest:
+    raise RuntimeError("Published release SHA-256 mismatch")
+
+root.mkdir(parents=True, exist_ok=True)
+seen = set()
+member_limit = 10000
+member_size_limit = 2 * 1024 * 1024 * 1024
+unpacked_size_limit = 4 * 1024 * 1024 * 1024
+
+with tarfile.open(archive, "r:gz") as bundle:
+    members = bundle.getmembers()
+    if len(members) > member_limit:
+        raise RuntimeError("Archive contains too many members: " + str(len(members)))
+    unpacked_size = 0
+    for member in members:
+        if member.size < 0 or member.size > member_size_limit:
+            raise RuntimeError("Archive member exceeds size limit: " + member.name)
+        unpacked_size += member.size
+        if unpacked_size > unpacked_size_limit:
+            raise RuntimeError("Archive exceeds unpacked size limit")
+        pure = pathlib.PurePosixPath(member.name)
+        if pure.is_absolute() or ".." in pure.parts:
+            raise RuntimeError("Archive member escapes extraction root: " + member.name)
+        normalized = str(pure)
+        if normalized in seen:
+            raise RuntimeError("Archive contains a duplicate member: " + member.name)
+        seen.add(normalized)
+        target = (root.joinpath(*pure.parts)).resolve()
+        if target != root and root not in target.parents:
+            raise RuntimeError("Archive member escapes extraction root: " + member.name)
+        if member.issym():
+            link = (target.parent / member.linkname).resolve()
+            if link != root and root not in link.parents:
+                raise RuntimeError("Archive symlink escapes extraction root: " + member.name)
+        elif member.islnk():
+            link = (root / member.linkname).resolve()
+            if link != root and root not in link.parents:
+                raise RuntimeError("Archive hard link escapes extraction root: " + member.name)
+        elif member.isdev() or member.isfifo():
+            raise RuntimeError("Archive contains a device or FIFO: " + member.name)
+    bundle.extractall(root, filter="data")
+
+candidates = [candidate for candidate in root.rglob(binary_name) if candidate.is_file() and not candidate.is_symlink()]
+if len(candidates) != 1:
+    raise RuntimeError("Archive must contain exactly one " + binary_name + " executable; found " + str(len(candidates)))
+binary = candidates[0].resolve()
+binary.chmod(binary.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+print("OPENWORK_RELEASE_BINARY=" + str(binary))
+`.trim();
 
 export interface ProvisionExecOptions {
   exec?: DaytonaExec;
@@ -37,12 +115,36 @@ export interface DesktopSandboxOptions {
    * so nothing in the connector room needs this.
    */
   secrets?: boolean;
+  /** Install exact published desktop bytes instead of checking out/building source. */
+  release?: DesktopRelease;
+  /** Test seam for GitHub release metadata retrieval. */
+  releaseFetch?: typeof fetch;
+  /** Daytona idle shutdown in minutes; preview worlds pass 0 so their owner process controls expiry. */
+  autoStopMinutes?: number;
+  /** Test-only override for the sandbox exec-readiness budget. */
+  sandboxReadyTimeoutMs?: number;
   log?: (line: string) => void;
+}
+
+export interface PublishedDesktopRelease extends DesktopRelease {
+  assetName: string;
+  binaryName: string;
+  browserDownloadUrl: string;
+  digest: string;
+  size: number;
+}
+
+export interface InstalledDesktopRelease extends PublishedDesktopRelease {
+  archivePath: string;
+  binaryPath: string;
+  installRoot: string;
+  manifestPath: string;
 }
 
 export interface DesktopSandbox {
   sandbox: string;
   created: boolean;
+  release?: InstalledDesktopRelease;
 }
 
 export interface DenSandboxOptions {
@@ -52,6 +154,8 @@ export interface DenSandboxOptions {
   bootstrapAdminEmail?: string;
   /** Extra Den environment for a freshly provisioned sandbox; a reused Den is already running and cannot take it. */
   env?: Record<string, string>;
+  /** Daytona idle shutdown in minutes; preview worlds pass 0 so their owner process controls expiry. */
+  autoStopMinutes?: number;
   log?: (line: string) => void;
 }
 
@@ -122,6 +226,59 @@ function firstHttpsUrl(text: string): string | null {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function desktopReleaseArtifact(release: DesktopRelease): { assetName: string; binaryName: string } {
+  if (!/^\d+\.\d+\.\d+$/.test(release.version)) {
+    throw new Error(`Desktop release version must be an exact x.y.z version without a tag prefix; received ${JSON.stringify(release.version)}.`);
+  }
+  const artifact = RELEASE_ARTIFACTS[release.distribution];
+  if (!artifact) {
+    throw new Error(`Unsupported desktop release distribution ${JSON.stringify(release.distribution)}. Use public, cloud, or enterprise.`);
+  }
+  return {
+    assetName: `${artifact.prefix}-linux-x64-${release.version}.tar.gz`,
+    binaryName: artifact.binary,
+  };
+}
+
+export async function resolvePublishedDesktopRelease(
+  release: DesktopRelease,
+  fetchImpl: typeof fetch = fetch,
+): Promise<PublishedDesktopRelease> {
+  const { assetName, binaryName } = desktopReleaseArtifact(release);
+  const tag = `v${release.version}`;
+  const response = await fetchImpl(`https://api.github.com/repos/${RELEASE_REPOSITORY}/releases/tags/${tag}`, {
+    headers: { accept: "application/vnd.github+json", "user-agent": "openwork-release-preview" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Could not resolve published desktop release ${tag}: GitHub API returned HTTP ${response.status}.`);
+  }
+  const body: unknown = await response.json();
+  if (!isRecord(body) || body.tag_name !== tag || body.draft === true || body.prerelease === true || !Array.isArray(body.assets)) {
+    throw new Error(`GitHub returned invalid or unpublished metadata for desktop release ${tag}.`);
+  }
+  const matches = body.assets.filter((entry: unknown) => isRecord(entry) && entry.name === assetName && entry.state === "uploaded");
+  if (matches.length !== 1) {
+    throw new Error(`Published desktop release ${tag} must contain exactly one ${assetName} asset; found ${matches.length}.`);
+  }
+  const asset = matches[0];
+  if (!isRecord(asset)) throw new Error(`GitHub returned invalid metadata for ${assetName}.`);
+  const digest = asset.digest;
+  const browserDownloadUrl = asset.browser_download_url;
+  const size = asset.size;
+  if (typeof digest !== "string" || !/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    throw new Error(`Published asset ${assetName} has no authoritative SHA-256 digest.`);
+  }
+  const expectedUrl = `https://github.com/${RELEASE_REPOSITORY}/releases/download/${tag}/${assetName}`;
+  if (browserDownloadUrl !== expectedUrl) {
+    throw new Error(`Published asset ${assetName} has an unexpected download URL.`);
+  }
+  if (typeof size !== "number" || !Number.isSafeInteger(size) || size <= 0 || size > MAX_DESKTOP_RELEASE_ARCHIVE_BYTES) {
+    throw new Error(`Published asset ${assetName} has an invalid size.`);
+  }
+  return { ...release, assetName, binaryName, browserDownloadUrl, digest, size };
 }
 
 async function timedStep<T>(log: (line: string) => void, name: string, action: () => Promise<T>): Promise<T> {
@@ -199,8 +356,8 @@ export function serverSandboxName(): string {
   return `openwork-server-${sandboxTimestamp()}-${process.pid}-${randomBytes(4).toString("hex")}`;
 }
 
-async function waitForExecReady(exec: DaytonaExec, sandbox: string): Promise<void> {
-  const deadline = Date.now() + DESKTOP_READY_TIMEOUT_MS;
+async function waitForExecReady(exec: DaytonaExec, sandbox: string, timeoutMs = DESKTOP_READY_TIMEOUT_MS): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   let lastError = "not attempted";
   while (Date.now() < deadline) {
     try {
@@ -209,53 +366,135 @@ async function waitForExecReady(exec: DaytonaExec, sandbox: string): Promise<voi
     } catch (error) {
       lastError = messageText(error);
     }
-    await delay(5_000);
+    await delay(Math.min(5_000, Math.max(0, deadline - Date.now())));
   }
-  throw new Error(`Sandbox exec-ready gate failed for ${sandbox} after 300s. Last output: ${lastError}`);
+  throw new Error(`Sandbox exec-ready gate failed for ${sandbox} after ${timeoutMs}ms. Last output: ${lastError}`);
 }
 
 function lastNonemptyLine(text: string): string {
   return text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).at(-1) ?? "";
 }
 
+export interface PublishedDesktopReleaseInstallCommand {
+  command: string;
+  archivePath: string;
+  appRoot: string;
+  installRoot: string;
+  manifestPath: string;
+}
+
+function safeInstallRoot(value: string): string {
+  if (!/^\/[A-Za-z0-9._/-]+$/.test(value) || value.split("/").includes("..")) {
+    throw new Error(`Published desktop release install root must be a safe absolute path; received ${JSON.stringify(value)}.`);
+  }
+  return value.replace(/\/+$/, "");
+}
+
+/** Complete fail-closed download, verification, and extraction command. */
+export function publishedDesktopReleaseInstallCommand(
+  release: PublishedDesktopRelease,
+  requestedInstallRoot = `/workspace/.openwork-daytona/releases/${release.distribution}-${release.version}`,
+): PublishedDesktopReleaseInstallCommand {
+  const installRoot = safeInstallRoot(requestedInstallRoot);
+  const archivePath = `${installRoot}/${release.assetName}`;
+  const appRoot = `${installRoot}/app`;
+  const manifestPath = `${installRoot}/release.json`;
+  const installerPath = `${installRoot}/install.py`;
+  const installer = Buffer.from(`${DESKTOP_RELEASE_ARCHIVE_INSTALLER}\n`, "utf8").toString("base64");
+  const manifest = Buffer.from(`${JSON.stringify(release, null, 2)}\n`, "utf8").toString("base64");
+  const digest = release.digest.slice("sha256:".length);
+  const command = [
+    "set -euo pipefail",
+    "umask 077",
+    `rm -rf ${installRoot}`,
+    `mkdir -p ${installRoot}`,
+    `curl --fail --location --retry 3 --retry-all-errors --connect-timeout 30 --max-time 900 --max-filesize ${release.size} --proto =https --tlsv1.2 --output ${archivePath} ${release.browserDownloadUrl}`,
+    `printf %s ${installer} | base64 -d > ${installerPath}`,
+    `printf %s ${manifest} | base64 -d > ${manifestPath}`,
+    `python3 ${installerPath} ${archivePath} ${appRoot} ${release.binaryName} ${digest} ${release.size}`,
+    `rm -f ${installerPath}`,
+  ].join("; ");
+  return { command, archivePath, appRoot, installRoot, manifestPath };
+}
+
+async function installPublishedDesktopRelease(
+  exec: DaytonaExec,
+  sandbox: string,
+  release: PublishedDesktopRelease,
+): Promise<InstalledDesktopRelease> {
+  const install = publishedDesktopReleaseInstallCommand(release);
+  const installed = await execInSandbox(exec, sandbox, install.command, {
+    timeoutMs: INSTALL_TIMEOUT_MS,
+    context: `published desktop release install for ${sandbox}`,
+  });
+  const binaryLine = installed.stdout.split(/\r?\n/).find((line) => line.startsWith("OPENWORK_RELEASE_BINARY="));
+  const binaryPath = binaryLine?.slice("OPENWORK_RELEASE_BINARY=".length).trim();
+  if (!binaryPath || !binaryPath.startsWith(`${install.appRoot}/`)) {
+    throw new Error(`Published desktop release installer did not return a binary below ${install.appRoot}. Output tail: ${outputTail(installed)}`);
+  }
+  return { ...release, archivePath: install.archivePath, binaryPath, installRoot: install.installRoot, manifestPath: install.manifestPath };
+}
+
+function autoStopMinutes(value: number | undefined): string {
+  const minutes = value ?? 60;
+  if (!Number.isInteger(minutes) || minutes < 0 || minutes > 1440) {
+    throw new Error(`Daytona auto-stop must be a whole number from 0 through 1440; received ${JSON.stringify(value)}.`);
+  }
+  return String(minutes);
+}
+
 export async function provisionDesktopSandbox(options: DesktopSandboxOptions & ProvisionExecOptions): Promise<DesktopSandbox> {
   const exec = options.exec ?? defaultDaytonaExec;
   const log = options.log ?? console.error;
-  const ref = assertSafeRef(options.ref);
+  if (options.release && options.secrets === true) {
+    throw new Error("Published desktop release sandboxes cannot mount the shared eval secrets volume.");
+  }
+  const release = options.release
+    ? await resolvePublishedDesktopRelease(options.release, options.releaseFetch)
+    : undefined;
+  const ref = release ? "" : assertSafeRef(options.ref);
   const reused = options.reuse?.trim() || "";
   let sandbox = reused;
-
-  await timedStep(log, "sandbox gate", async () => {
-    if (reused) {
-      await exec(["sandbox", "start", reused], { timeoutMs: 60_000 });
-    } else {
-      const snapshot = options.snapshot ?? "openwork-eval-vnc";
-      const listed = await checkedExec(exec, ["snapshot", "list", "-f", "json"], "snapshot gate", { timeoutMs: 60_000 });
-      const id = snapshotId(listed.stdout, snapshot);
-      if (!id) {
-        throw new Error(`Snapshot gate failed: snapshot ${snapshot} is missing. Output tail: ${outputTail(listed)}`);
+  let created = false;
+  let ownedReleaseSandbox = "";
+  let installedRelease: InstalledDesktopRelease | undefined;
+  try {
+    await timedStep(log, "sandbox gate", async () => {
+      if (reused) {
+        await exec(["sandbox", "start", reused], { timeoutMs: 60_000 });
+      } else {
+        const snapshot = options.snapshot ?? "openwork-eval-vnc";
+        const listed = await checkedExec(exec, ["snapshot", "list", "-f", "json"], "snapshot gate", { timeoutMs: 60_000 });
+        const id = snapshotId(listed.stdout, snapshot);
+        if (!id) {
+          throw new Error(`Snapshot gate failed: snapshot ${snapshot} is missing. Output tail: ${outputTail(listed)}`);
+        }
+        sandbox = desktopSandboxName(options.name);
+        if (release) ownedReleaseSandbox = sandbox;
+        await checkedExec(
+          exec,
+          [
+            "create",
+            "--name", sandbox,
+            "--snapshot", id,
+            ...(options.secrets === true ? ["--volume", "openwork-eval-secrets:/daytona-secrets"] : []),
+            "--auto-stop", autoStopMinutes(options.autoStopMinutes),
+            "--public",
+            "--target", "us",
+          ],
+          `sandbox creation gate for ${sandbox}`,
+          { timeoutMs: 300_000 },
+        );
+        created = true;
+        log(`==> desktop sandbox created: ${sandbox}`);
       }
-      sandbox = desktopSandboxName(options.name);
-      await checkedExec(
-        exec,
-        [
-          "create",
-          "--name", sandbox,
-          "--snapshot", id,
-          ...(options.secrets === true ? ["--volume", "openwork-eval-secrets:/daytona-secrets"] : []),
-          "--auto-stop", "60",
-          "--public",
-          "--target", "us",
-        ],
-        `sandbox creation gate for ${sandbox}`,
-        { timeoutMs: 300_000 },
-      );
-      log(`==> desktop sandbox created: ${sandbox}`);
-    }
-    await waitForExecReady(exec, sandbox);
-  });
+      await waitForExecReady(exec, sandbox, options.sandboxReadyTimeoutMs);
+    });
 
-  await timedStep(log, "checkout gate", async () => {
+    if (release) {
+      installedRelease = await timedStep(log, "published release gate", () => installPublishedDesktopRelease(exec, sandbox, release));
+    } else {
+      await timedStep(log, "checkout gate", async () => {
     const result = await execInSandbox(
       exec,
       sandbox,
@@ -273,54 +512,54 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
       throw new Error(`Checkout gate failed for ${sandbox}: asked for ${ref} but HEAD is ${sha}.`);
     }
     log(`==> checkout resolved ${sha}`);
-  });
+      });
 
-  await timedStep(log, "install gate", async () => {
-    await execInSandbox(
-      exec,
-      sandbox,
-      "cd /workspace; pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store",
-      { timeoutMs: INSTALL_TIMEOUT_MS, context: `install gate for ${sandbox}` },
-    );
-  });
+      await timedStep(log, "install gate", async () => {
+        await execInSandbox(
+          exec,
+          sandbox,
+          "cd /workspace; pnpm install --store-dir /workspace/.openwork-daytona/pnpm-store",
+          { timeoutMs: INSTALL_TIMEOUT_MS, context: `install gate for ${sandbox}` },
+        );
+      });
 
-  await timedStep(log, "cleanup and disk gate", async () => {
-    const result = await execInSandbox(
-      exec,
-      sandbox,
-      "rm -rf /workspace/.openwork-daytona/profiles /tmp/openwork-* 2>/dev/null; df -P /workspace | tail -1",
-      { timeoutMs: 60_000, context: `cleanup and disk gate for ${sandbox}` },
-    );
-    const dfLine = lastNonemptyLine(result.stdout);
-    const useField = dfLine.split(/\s+/).find((field) => /^\d+%$/.test(field));
-    if (!useField) {
-      throw new Error(`Cleanup and disk gate failed for ${sandbox}: could not parse Use% from ${JSON.stringify(dfLine)}.`);
+      await timedStep(log, "cleanup and disk gate", async () => {
+        const result = await execInSandbox(
+          exec,
+          sandbox,
+          "rm -rf /workspace/.openwork-daytona/profiles /tmp/openwork-* 2>/dev/null; df -P /workspace | tail -1",
+          { timeoutMs: 60_000, context: `cleanup and disk gate for ${sandbox}` },
+        );
+        const dfLine = lastNonemptyLine(result.stdout);
+        const useField = dfLine.split(/\s+/).find((field) => /^\d+%$/.test(field));
+        if (!useField) {
+          throw new Error(`Cleanup and disk gate failed for ${sandbox}: could not parse Use% from ${JSON.stringify(dfLine)}.`);
+        }
+        const used = Number.parseInt(useField, 10);
+        if (used <= 85) return;
+        const sizes = await execInSandbox(
+          exec,
+          sandbox,
+          "du -sh /workspace/node_modules /workspace/.openwork-daytona/pnpm-store 2>&1 || true",
+          { timeoutMs: 60_000, context: `disk usage detail for ${sandbox}` },
+        );
+        throw new Error(`Cleanup and disk gate failed for ${sandbox}: workspace is ${useField} used. df: ${dfLine}\n${outputTail(sizes)}`);
+      });
     }
-    const used = Number.parseInt(useField, 10);
-    if (used > 85) {
-      const sizes = await execInSandbox(
+
+    await timedStep(log, "display gate", async () => {
+      const result = await execInSandbox(
         exec,
         sandbox,
-        "du -sh /workspace/node_modules /workspace/.openwork-daytona/pnpm-store 2>&1 || true",
-        { timeoutMs: 60_000, context: `disk usage detail for ${sandbox}` },
+        "bash /workspace/.devcontainer/start-daytona-vnc.sh >/tmp/vnc.log 2>&1; sleep 2; pgrep -f Xvfb >/dev/null && echo XVFB_OK || echo XVFB_FAIL",
+        { timeoutMs: 60_000, context: `display gate for ${sandbox}` },
       );
-      throw new Error(`Cleanup and disk gate failed for ${sandbox}: workspace is ${useField} used. df: ${dfLine}\n${outputTail(sizes)}`);
-    }
-  });
+      if (!result.stdout.includes("XVFB_OK")) {
+        throw new Error(`Display gate failed for ${sandbox}: expected XVFB_OK. Output tail: ${outputTail(result)}`);
+      }
+    });
 
-  await timedStep(log, "display gate", async () => {
-    const result = await execInSandbox(
-      exec,
-      sandbox,
-      "bash /workspace/.devcontainer/start-daytona-vnc.sh >/tmp/vnc.log 2>&1; sleep 2; pgrep -f Xvfb >/dev/null && echo XVFB_OK || echo XVFB_FAIL",
-      { timeoutMs: 60_000, context: `display gate for ${sandbox}` },
-    );
-    if (!result.stdout.includes("XVFB_OK")) {
-      throw new Error(`Display gate failed for ${sandbox}: expected XVFB_OK. Output tail: ${outputTail(result)}`);
-    }
-  });
-
-  await timedStep(log, "browser hop gate", async () => {
+    await timedStep(log, "browser hop gate", async () => {
     // Chromium launched inside a pipe-stdin exec session TERMs the whole
     // session as it starts (exit 143 at ~2.5s; the same script survives under
     // a TTY). So nothing may run as a child of the session: both halves are
@@ -359,9 +598,13 @@ echo detached`;
     if (!seen) {
       throw new Error(`Browser hop gate failed for ${sandbox}: xdg-open never delivered a request (no browser reachable from the OAuth connect flow).`);
     }
-  });
+    });
 
-  await timedStep(log, "first boot gate", async () => {
+    if (installedRelease) {
+      return { sandbox, created, release: installedRelease };
+    }
+
+    await timedStep(log, "first boot gate", async () => {
     // A sandbox's first Electron boot pays sidecar prepare, the
     // openwork-server tsc build, and the engine cold start. Paid INSIDE a
     // spec, that bill starved the tool-call phase past its window while every
@@ -406,9 +649,9 @@ echo detached`;
       ).catch(() => null);
       throw new Error(`First boot gate failed for ${sandbox}: CDP never answered on 9825. Last probe: ${last}. Log tail:\n${bootLog ? outputTail(bootLog) : "unavailable"}`);
     }
-  });
+    });
 
-  await timedStep(log, "Vite prewarm gate", async () => {
+    await timedStep(log, "Vite prewarm gate", async () => {
     const detachScript = `cd /workspace; python3 - <<PYEOF
 import subprocess
 log = open("/tmp/vite-prewarm.log", "ab", buffering=0)
@@ -455,9 +698,17 @@ echo detached`;
     );
     const phase = detached ? "Vite to answer on port 5173" : "the Daytona exec tunnel to accept the detach command";
     throw new Error(`Vite prewarm gate timed out after ${VITE_PREWARM_TIMEOUT_MS}ms waiting for ${phase} in ${sandbox}. Last readiness error: ${last}. Log tail:\n${outputTail(viteLog)}`);
-  });
+    });
 
-  return { sandbox, created: !reused };
+    return { sandbox, created };
+  } catch (error) {
+    if (ownedReleaseSandbox) {
+      await deleteSandboxes([ownedReleaseSandbox], { exec, log }).catch((cleanupError: unknown) => {
+        log(`==> desktop sandbox cleanup failed: ${messageText(cleanupError)}`);
+      });
+    }
+    throw error;
+  }
 }
 
 interface LocalProcessResult {
@@ -500,12 +751,16 @@ export function encodeDenExtraEnv(env: Record<string, string>): string {
   return Buffer.from(lines.join("\n"), "utf8").toString("base64");
 }
 
-function runDenProvisionScript(ref: string, repoRoot: string, bootstrapAdminEmail: string | undefined, extraEnv: Record<string, string> | undefined, log: (line: string) => void, urlsFile: string): Promise<LocalProcessResult> {
+export function denProvisionScriptArgs(ref: string, name: string, requestedAutoStopMinutes?: number): string[] {
+  return [".devcontainer/test-server-on-daytona.sh", ref, "--seed", "--name", name, "--auto-stop", autoStopMinutes(requestedAutoStopMinutes)];
+}
+
+function runDenProvisionScript(ref: string, repoRoot: string, bootstrapAdminEmail: string | undefined, extraEnv: Record<string, string> | undefined, log: (line: string) => void, urlsFile: string, requestedAutoStopMinutes?: number): Promise<LocalProcessResult> {
   return new Promise((resolve, reject) => {
     const env: NodeJS.ProcessEnv = { ...process.env, OPENWORK_DEN_URLS_FILE: urlsFile };
     if (bootstrapAdminEmail) env.DEN_BOOTSTRAP_ADMIN_EMAILS = bootstrapAdminEmail;
     if (extraEnv && Object.keys(extraEnv).length > 0) env.OPENWORK_DEN_EXTRA_ENV_B64 = encodeDenExtraEnv(extraEnv);
-    const child = spawn("bash", [".devcontainer/test-server-on-daytona.sh", ref, "--seed", "--name", serverSandboxName()], {
+    const child = spawn("bash", denProvisionScriptArgs(ref, serverSandboxName(), requestedAutoStopMinutes), {
       cwd: repoRoot,
       env,
       stdio: ["ignore", "pipe", "pipe"],
@@ -677,6 +932,7 @@ export async function provisionDenSandbox(options: DenSandboxOptions & Provision
         options.env,
         log,
         urlsFile,
+        options.autoStopMinutes,
       ));
       if (result.code !== 0) {
         throw new Error(`Den provisioning script gate failed with exit ${result.code}. Output tail:\n${textTail(result.output)}`);

--- a/evals/packages/hosts/src/types.ts
+++ b/evals/packages/hosts/src/types.ts
@@ -2,8 +2,24 @@ import type { SurfaceHandle, SurfaceKind } from "@openwork/cdp";
 
 export type { SurfaceHandle, SurfaceKind } from "@openwork/cdp";
 
+export type DesktopReleaseDistribution = "public" | "cloud" | "enterprise";
+
+export interface DesktopRelease {
+  version: string;
+  distribution: DesktopReleaseDistribution;
+}
+
+export type ElectronStartupObservation =
+  | { state: "cdp-responsive"; detail: string }
+  | { state: "crashed" | "unresponsive"; detail: string };
+
+export interface RetainedElectronSurface {
+  handle: SurfaceHandle;
+  startup: ElectronStartupObservation;
+}
+
 export interface ElectronSurfaceOptions {
-  profile?: "fresh" | "shared";
+  profile?: "fresh" | "shared" | "blank";
   /** Exact caller-owned profile root. Hosts preserve it on surface disposal. */
   profileDir?: string;
   bootstrap?: {
@@ -14,7 +30,15 @@ export interface ElectronSurfaceOptions {
     enterpriseActivation?: { activatedAt: string; denBaseUrl: string };
   };
   env?: Record<string, string>;
-  /** Root package script used for a source Electron launch. Setting this bypasses OPENWORK_EVAL_ELECTRON_BINARY. */
+  /** Exact executable on the target host. Unlike the ambient eval override, this is scoped to one launch. */
+  binaryPath?: string;
+  /** Published release to install before launching. Placement resolves this to binaryPath. */
+  release?: DesktopRelease;
+  /** Additional arguments passed to an explicit binary. */
+  launchArgs?: readonly string[];
+  /** Retained launch startup observation budget. */
+  startupTimeoutMs?: number;
+  /** Root package script used for a source Electron launch. Setting this bypasses explicit and ambient binaries. */
   devCommand?: "dev" | "dev:electron";
   /** Skip host-side sidecar/helper preparation when the caller intentionally uses existing resources. */
   prepareSharedResources?: boolean;
@@ -53,6 +77,8 @@ export interface Host {
   workspaceRoot: string;
   previewUrl?(port: number): Promise<string>;
   spawnElectron(name: string, opts?: ElectronSurfaceOptions): Promise<SurfaceHandle>;
+  /** Launch without requiring product readiness; app crashes remain inspectable through the host viewer. */
+  spawnElectronRetained?(name: string, opts?: ElectronSurfaceOptions): Promise<RetainedElectronSurface>;
   spawnChrome(name: string, opts?: ChromeSurfaceOptions): Promise<SurfaceHandle>;
   startDen?(opts?: DenServiceOptions): Promise<DenServiceHandle>;
   share?(): Promise<ShareLinks>;

--- a/evals/packages/hosts/test/daytona-host.test.ts
+++ b/evals/packages/hosts/test/daytona-host.test.ts
@@ -78,6 +78,16 @@ function createFakeExec(previewUrlForPort: (port: string) => string): { exec: Da
       const port = portFlag >= 0 ? args[portFlag + 1] ?? "" : "";
       return { stdout: `time=ignored\nPreview URL: ${previewUrlForPort(port)}\n`, stderr: "", code: 0 };
     }
+    const text = args.join(" ");
+    if (text.includes('printf %s "$HOME"')) {
+      return { stdout: "/home/daytona", stderr: "", code: 0 };
+    }
+    if (text.includes("OPENWORK_REMOTE_PID=") && text.includes("subprocess.Popen")) {
+      return { stdout: "OPENWORK_REMOTE_PID=4242\n", stderr: "", code: 0 };
+    }
+    if (text.includes("kill -0 4242")) {
+      return { stdout: "CDP_DOWN\nPROCESS_EXITED\n", stderr: "", code: 0 };
+    }
     return { stdout: "", stderr: "", code: 0 };
   };
   return { exec, calls };
@@ -242,6 +252,86 @@ test("spawnElectron maps the v2 eval lane before Daytona caller overrides", asyn
   const starts = calls.filter((call) => argsText(call).includes("/workspace/.devcontainer/start-daytona-electron.sh"));
   assert.match(argsText(starts[0] ?? { args: [] }), /OPENWORK_ENGINE_V2_PREVIEW=.*1/);
   assert.match(argsText(starts[1] ?? { args: [] }), /OPENWORK_ENGINE_V2_PREVIEW=.*sidecar/);
+});
+
+test("retained packaged Electron uses an explicit binary, complete blank profile, and same-profile VM shortcuts", async () => {
+  const { exec, calls } = createFakeExec((port) => `https://cdp-${port}.example.test`);
+  const host = createDaytonaHost({
+    sandboxId: "openwork-test-packaged",
+    log: () => undefined,
+    exec,
+    repoRoot: "/repo",
+    waitForCdp: successfulPolls(),
+  });
+
+  const launched = await host.spawnElectronRetained("published", {
+    binaryPath: "/workspace/releases/openwork-enterprise",
+    profile: "blank",
+    env: {
+      OPENWORK_DEV_MODE: "1",
+      OPENWORK_EVAL_ELECTRON_BINARY: "/workspace/source-electron",
+      OPENAI_API_KEY: "must-not-propagate",
+    },
+  });
+
+  assert.equal(launched.startup.state, "cdp-responsive");
+  assert.equal(launched.handle.meta?.binary, "/workspace/releases/openwork-enterprise");
+  assert.equal(launched.handle.meta?.remotePid, "4242");
+  const commands = calls.map(argsText).join("\n");
+  assert(!commands.includes("start-daytona-electron.sh"));
+  assert(!commands.includes("pnpm"));
+  const setup = findCall(calls, "openwork-release-preview.desktop");
+  const setupText = argsText(setup);
+  assert(setupText.includes("set -euo pipefail"));
+  assert(setupText.includes("x-scheme-handler/openwork"));
+  assert(setupText.includes("xdg-mime default openwork-release-preview.desktop"));
+  assert(setupText.includes("xdg-mime query default x-scheme-handler/openwork"));
+  assert(setupText.includes('= openwork-release-preview.desktop'));
+  assert(setupText.indexOf("set -euo pipefail") < setupText.indexOf("xdg-mime query default"));
+  assert(!setupText.includes('test "$(xdg-mime query default x-scheme-handler/openwork)" = openwork-release-preview.desktop || true'));
+  assert(setupText.includes("OpenWork Release published.desktop"));
+  assert(setupText.includes("Browser published.desktop"));
+  const launchWrite = calls.find((call) => argsText(call).includes("launch-openwork"));
+  assert(launchWrite);
+  const allEncoded = launchWrite.args.join(" ").match(/[A-Za-z0-9+/=]{100,}/g) ?? [];
+  const decoded = allEncoded.map((value) => Buffer.from(value, "base64").toString("utf8")).join("\n");
+  for (const key of ["HOME", "USERPROFILE", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME", "APPDATA", "LOCALAPPDATA", "OPENWORK_ELECTRON_USERDATA", "OPENWORK_DESKTOP_BOOTSTRAP_PATH", "OPENWORK_SERVER_CONFIG", "OPENWORK_ENV_STORE", "OPENWORK_TOKEN_STORE", "OPENWORK_RUNTIME_DB", "OPENWORK_DATA_DIR", "OPENCODE_CONFIG_DIR", "OPENCODE_DB"]) {
+    assert(decoded.includes(`${key}=`), `blank launcher must isolate ${key}`);
+  }
+  assert.equal(decoded.match(/cd "\$HOME"/g)?.length, 2, "app and browser launchers must enter the isolated HOME");
+  assert.equal(decoded.match(/OPENWORK_DEV_MODE='0'/g)?.length, 2, "app and browser launchers must explicitly disable dev mode");
+  assert.equal(decoded.match(/compgen -e/g)?.length, 2, "app and browser launchers must clear inherited environment");
+  assert(!decoded.includes("/workspace/source-electron"));
+  assert(!decoded.includes("must-not-propagate"));
+  assert(decoded.includes("/workspace/releases/openwork-enterprise"));
+  assert(decoded.includes('"$@"'));
+
+  await host.disposeSurface(launched.handle);
+});
+
+test("retained packaged Electron reports an app crash without disposing its inspectable host surface", async () => {
+  const { exec, calls } = createFakeExec((port) => `https://cdp-${port}.example.test`);
+  const host = createDaytonaHost({
+    sandboxId: "openwork-test-crashed",
+    log: () => undefined,
+    exec,
+    repoRoot: "/repo",
+    waitForCdp: async () => { throw new Error("CDP stayed down"); },
+  });
+
+  const launched = await host.spawnElectronRetained("broken", {
+    binaryPath: "/bin/false",
+    profile: "blank",
+    startupTimeoutMs: 1,
+  });
+
+  assert.equal(launched.startup.state, "crashed");
+  assert.match(launched.startup.detail, /Process exited.*electron-broken/);
+  const stopCallsBeforeDispose = calls.filter((call) => argsText(call).includes("pkill -f") && argsText(call).includes("remote-debugging-port")).length;
+  assert.equal(stopCallsBeforeDispose, 0);
+  assert.equal((await host.share()).some((link) => link.label.includes("crashed")), true);
+  await host.disposeSurface(launched.handle);
+  assert.equal(calls.some((call) => argsText(call).includes("remote-debugging-port")), true);
 });
 
 test("spawnElectron preserves a caller-owned Daytona profile while generated profiles are removed", async () => {

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -1,12 +1,21 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 
 import {
+  DESKTOP_RELEASE_ARCHIVE_INSTALLER,
   deleteSandboxes,
   desktopSandboxName,
   encodeDenExtraEnv,
   parseConnectorE2eTestEnv,
   provisionDesktopSandbox,
+  publishedDesktopReleaseInstallCommand,
+  resolvePublishedDesktopRelease,
   renderConnectorE2eTestEnv,
   serverSandboxName,
   startFaultProxyOnSandbox,
@@ -14,6 +23,8 @@ import {
 } from "../src/provision.ts";
 import type { ConnectorE2eTestEnv } from "../src/provision.ts";
 import type { DaytonaExec } from "../src/daytona.ts";
+
+const execFileAsync = promisify(execFile);
 
 interface ExecCall {
   args: string[];
@@ -43,6 +54,9 @@ function desktopFake(diskUse = "40%"):
     if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
     if (script.includes("json/version")) return { stdout: '{"Browser":"Chrome/144"}', stderr: "", code: 0 };
     if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
+    if (script.includes("install.py")) {
+      return { stdout: "OPENWORK_RELEASE_BINARY=/workspace/.openwork-daytona/releases/enterprise-0.18.44/app/openwork-enterprise\n", stderr: "", code: 0 };
+    }
     return { stdout: "", stderr: "", code: 0 };
   };
   return { exec, calls };
@@ -128,10 +142,291 @@ test("provisionDesktopSandbox resolves the snapshot id and creates with connecto
   assert(create);
   assert(create.args.includes("snapshot-123"));
   assert(!create.args.includes("--volume"), "eval secrets must not be mounted next to an untrusted ref by default");
-  assert(create.args.includes("--auto-stop"));
+  assert.equal(create.args[create.args.indexOf("--auto-stop") + 1], "60");
   assert(create.args.includes("--public"));
   assert.equal(calls.filter((call) => call.args[0] === "sandbox" && call.args[1] === "start").length, 0);
   assertRemoteCommandsAreSingleArgument(calls);
+});
+
+test("published desktop provisioning resolves exact GitHub metadata and skips every source build gate", async () => {
+  const digest = `sha256:${"a".repeat(64)}`;
+  const assetName = "openwork-enterprise-linux-x64-0.18.44.tar.gz";
+  const metadata = {
+    tag_name: "v0.18.44",
+    draft: false,
+    assets: [{
+      name: assetName,
+      state: "uploaded",
+      size: 123,
+      digest,
+      browser_download_url: `https://github.com/different-ai/openwork/releases/download/v0.18.44/${assetName}`,
+    }],
+  };
+  const releaseFetch: typeof fetch = async () => new Response(JSON.stringify(metadata), { status: 200 });
+  const resolved = await resolvePublishedDesktopRelease({ version: "0.18.44", distribution: "enterprise" }, releaseFetch);
+  assert.equal(resolved.assetName, assetName);
+  assert.equal(resolved.digest, digest);
+
+  const { exec, calls } = desktopFake();
+  const result = await provisionDesktopSandbox({
+    ref: "this-ref-must-not-be-used",
+    name: "release",
+    release: { version: "0.18.44", distribution: "enterprise" },
+    releaseFetch,
+    autoStopMinutes: 0,
+    exec,
+    log: () => undefined,
+  });
+
+  assert.equal(result.release?.digest, digest);
+  assert.equal(result.release?.binaryPath, "/workspace/.openwork-daytona/releases/enterprise-0.18.44/app/openwork-enterprise");
+  const create = calls.find((call) => call.args[0] === "create");
+  assert(create);
+  assert.equal(create.args[create.args.indexOf("--auto-stop") + 1], "0");
+  const remote = calls.map((call) => call.args[3] ?? "").join("\n");
+  assert.match(remote, /install\.py/);
+  assert.match(remote, /openwork-enterprise-linux-x64-0\.18\.44\.tar\.gz/);
+  for (const forbidden of ["git fetch", "pnpm install", "warmup-electron", "vite-prewarm", "dev:electron"]) {
+    assert(!remote.includes(forbidden), `release provisioning must not run ${forbidden}`);
+  }
+  assert(!calls.some((call) => call.args.includes("--volume")));
+});
+
+test("published desktop install rejects an invalid digest before extracting or returning an executable", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-release-digest-"));
+  const archive = join(root, "source.tar.gz");
+  const fakeBin = join(root, "bin");
+  const fakeCurl = join(fakeBin, "curl");
+  const createArchive = `
+import io
+import tarfile
+import sys
+payload = b"#!/bin/sh\\nexit 0\\n"
+with tarfile.open(sys.argv[1], "w:gz") as bundle:
+    binary = tarfile.TarInfo("openwork-enterprise")
+    binary.size = len(payload)
+    bundle.addfile(binary, io.BytesIO(payload))
+`;
+  try {
+    await mkdir(fakeBin);
+    await execFileAsync("python3", ["-c", createArchive, archive]);
+    await writeFile(fakeCurl, `#!/bin/sh
+set -eu
+output=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    output=$2
+    shift 2
+  else
+    shift
+  fi
+done
+test -n "$output"
+cp "$FAKE_RELEASE_ARCHIVE" "$output"
+`);
+    await chmod(fakeCurl, 0o755);
+    const archiveStat = await stat(archive);
+    const install = publishedDesktopReleaseInstallCommand({
+      version: "0.18.44",
+      distribution: "enterprise",
+      assetName: "openwork-enterprise-linux-x64-0.18.44.tar.gz",
+      binaryName: "openwork-enterprise",
+      browserDownloadUrl: "https://example.test/openwork-enterprise-linux-x64-0.18.44.tar.gz",
+      digest: `sha256:${"0".repeat(64)}`,
+      size: archiveStat.size,
+    }, join(root, "install"));
+
+    await assert.rejects(
+      execFileAsync("bash", ["-c", install.command], {
+        env: {
+          ...process.env,
+          FAKE_RELEASE_ARCHIVE: archive,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      }),
+      (error: unknown) => {
+        assert(error instanceof Error);
+        assert.match(error.message, /Published release SHA-256 mismatch/);
+        if ("stdout" in error) assert.doesNotMatch(String(error.stdout), /OPENWORK_RELEASE_BINARY=/);
+        return true;
+      },
+    );
+    await assert.rejects(access(install.appRoot));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("published desktop metadata and shared secrets are rejected before sandbox allocation", async () => {
+  const { exec, calls } = desktopFake();
+  await assert.rejects(
+    provisionDesktopSandbox({
+      ref: "unused",
+      name: "release",
+      release: { version: "0.18.44", distribution: "enterprise" },
+      secrets: true,
+      exec,
+      log: () => undefined,
+    }),
+    /cannot mount the shared eval secrets volume/,
+  );
+  assert.equal(calls.length, 0);
+  const missingFetch: typeof fetch = async () => new Response(JSON.stringify({ tag_name: "v0.18.44", draft: false, assets: [] }), { status: 200 });
+  await assert.rejects(
+    provisionDesktopSandbox({
+      ref: "unused",
+      name: "release",
+      release: { version: "0.18.44", distribution: "enterprise" },
+      releaseFetch: missingFetch,
+      exec,
+      log: () => undefined,
+    }),
+    /must contain exactly one/,
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("a failed published release install deletes its partially allocated sandbox", async () => {
+  const assetName = "openwork-enterprise-linux-x64-0.18.44.tar.gz";
+  const releaseFetch: typeof fetch = async () => new Response(JSON.stringify({
+    tag_name: "v0.18.44",
+    draft: false,
+    assets: [{
+      name: assetName,
+      state: "uploaded",
+      size: 123,
+      digest: `sha256:${"a".repeat(64)}`,
+      browser_download_url: `https://github.com/different-ai/openwork/releases/download/v0.18.44/${assetName}`,
+    }],
+  }), { status: 200 });
+  const base = desktopFake();
+  const exec: DaytonaExec = async (args, options) => {
+    if ((args[3] ?? "").includes("install.py")) {
+      base.calls.push({ args: [...args], opts: options });
+      return { stdout: "", stderr: "checksum mismatch", code: 1 };
+    }
+    return base.exec(args, options);
+  };
+
+  await assert.rejects(
+    provisionDesktopSandbox({
+      ref: "unused",
+      name: "release-failure",
+      release: { version: "0.18.44", distribution: "enterprise" },
+      releaseFetch,
+      exec,
+      log: () => undefined,
+    }),
+    /checksum mismatch/,
+  );
+  const create = base.calls.find((call) => call.args[0] === "create");
+  const remove = base.calls.find((call) => call.args[0] === "delete");
+  assert.ok(create);
+  assert.deepEqual(remove?.args, ["delete", create.args[2]]);
+});
+
+test("published release allocation and readiness failures clean up only newly owned sandboxes", async () => {
+  const assetName = "openwork-enterprise-linux-x64-0.18.44.tar.gz";
+  const releaseFetch: typeof fetch = async () => new Response(JSON.stringify({
+    tag_name: "v0.18.44",
+    draft: false,
+    assets: [{
+      name: assetName,
+      state: "uploaded",
+      size: 123,
+      digest: `sha256:${"a".repeat(64)}`,
+      browser_download_url: `https://github.com/different-ai/openwork/releases/download/v0.18.44/${assetName}`,
+    }],
+  }), { status: 200 });
+
+  for (const failure of ["create", "ready"]) {
+    const calls: ExecCall[] = [];
+    const exec: DaytonaExec = async (args, opts) => {
+      calls.push({ args: [...args], opts });
+      if (args[0] === "snapshot") {
+        return { stdout: JSON.stringify([{ name: "openwork-eval-vnc", id: "snapshot-123" }]), stderr: "", code: 0 };
+      }
+      if (args[0] === "create") {
+        return failure === "create"
+          ? { stdout: "", stderr: "creation failed", code: 1 }
+          : { stdout: "", stderr: "", code: 0 };
+      }
+      if (args[0] === "exec") return { stdout: "", stderr: "not ready", code: 1 };
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await assert.rejects(
+      provisionDesktopSandbox({
+        ref: "unused",
+        name: `release-${failure}`,
+        release: { version: "0.18.44", distribution: "enterprise" },
+        releaseFetch,
+        sandboxReadyTimeoutMs: 0,
+        exec,
+        log: () => undefined,
+      }),
+      failure === "create" ? /creation failed/ : /exec-ready gate failed/,
+    );
+    const create = calls.find((call) => call.args[0] === "create");
+    assert(create);
+    assert.deepEqual(calls.find((call) => call.args[0] === "delete")?.args, ["delete", create.args[2]]);
+  }
+
+  const reusedCalls: ExecCall[] = [];
+  const reusedExec: DaytonaExec = async (args, opts) => {
+    reusedCalls.push({ args: [...args], opts });
+    if (args[0] === "exec") return { stdout: "", stderr: "not ready", code: 1 };
+    return { stdout: "", stderr: "", code: 0 };
+  };
+  await assert.rejects(
+    provisionDesktopSandbox({
+      ref: "unused",
+      name: "release-reused",
+      reuse: "caller-owned",
+      release: { version: "0.18.44", distribution: "enterprise" },
+      releaseFetch,
+      sandboxReadyTimeoutMs: 0,
+      exec: reusedExec,
+      log: () => undefined,
+    }),
+    /exec-ready gate failed/,
+  );
+  assert(!reusedCalls.some((call) => call.args[0] === "delete"));
+});
+
+test("published desktop archive installer rejects traversal and escaping links", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-release-archive-"));
+  const archive = join(root, "malicious.tar.gz");
+  const extract = join(root, "extract");
+  const createArchive = `
+import io
+import tarfile
+import sys
+with tarfile.open(sys.argv[1], "w:gz") as bundle:
+    traversal = tarfile.TarInfo("../escaped")
+    traversal.size = 1
+    bundle.addfile(traversal, io.BytesIO(b"x"))
+    link = tarfile.TarInfo("openwork-enterprise")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "../../outside"
+    bundle.addfile(link)
+`;
+  try {
+    await execFileAsync("python3", ["-c", createArchive, archive]);
+    const archiveBytes = await readFile(archive);
+    const digest = createHash("sha256").update(archiveBytes).digest("hex");
+    await assert.rejects(
+      execFileAsync("python3", ["-c", DESKTOP_RELEASE_ARCHIVE_INSTALLER, archive, extract, "openwork-enterprise", digest, String(archiveBytes.byteLength)]),
+      (error: unknown) => {
+        assert(error instanceof Error);
+        assert("stderr" in error);
+        assert.match(String(error.stderr), /Archive member escapes extraction root/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("rendered values are shell-quoted, because the env file is meant to be sourced", () => {

--- a/evals/packages/testkit/src/daytona-witness.ts
+++ b/evals/packages/testkit/src/daytona-witness.ts
@@ -1,0 +1,219 @@
+import {
+  daytonaSandbox,
+  defaultDaytonaExec,
+  execInSandbox,
+  retainedDesktop,
+} from "@openwork/hosts";
+import type { ElectronStartupObservation } from "@openwork/hosts";
+
+export interface PublishedDesktopSandboxWitnessOptions {
+  sandboxId: string;
+  pid: string;
+  archivePath: string;
+  bootstrapPath: string;
+  protocolHandlerPath: string;
+  shortcutPaths: readonly string[];
+  environmentKeys: readonly string[];
+  dispatchDeepLink?: boolean;
+}
+
+export interface PublishedDesktopSandboxWitness {
+  archiveSha256: string;
+  executablePath: string;
+  workingDirectory: string;
+  bootstrapExists: boolean;
+  environment: Record<string, string>;
+  unexpectedSensitiveEnvironmentKeys: string[];
+  protocolHandler: string;
+  defaultProtocolHandler: string;
+  shortcutsExecutable: boolean[];
+  handoffExitCode: number | null;
+  primaryProcessAlive: boolean;
+}
+
+export interface RetainedCrashedDesktopWitness extends AsyncDisposable {
+  startup: ElectronStartupObservation;
+  stop(): Promise<void>;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: Record<string, unknown>, key: string): string {
+  const field = value[key];
+  if (typeof field !== "string") throw new Error(`Published desktop witness returned invalid ${key}.`);
+  return field;
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!record(value)) throw new Error("Published desktop witness returned an invalid environment.");
+  const result: Record<string, string> = {};
+  for (const [key, field] of Object.entries(value)) {
+    if (typeof field !== "string") throw new Error(`Published desktop witness returned an invalid ${key} environment value.`);
+    result[key] = field;
+  }
+  return result;
+}
+
+/** Read only release-integrity fields and explicitly named process environment values from a Daytona sandbox. */
+export async function readPublishedDesktopSandboxWitness(
+  options: PublishedDesktopSandboxWitnessOptions,
+): Promise<PublishedDesktopSandboxWitness> {
+  const payload = Buffer.from(JSON.stringify(options), "utf8").toString("base64");
+  const source = `
+import base64
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import time
+
+request = json.loads(base64.b64decode("${payload}"))
+pid = str(int(request["pid"]))
+process_root = pathlib.Path("/proc") / pid
+allowed = set(request["environmentKeys"])
+environment = {}
+environment_names = []
+for entry in (process_root / "environ").read_bytes().split(b"\\0"):
+    key_bytes, separator, value_bytes = entry.partition(b"=")
+    if not separator:
+        continue
+    key = key_bytes.decode("utf-8", errors="replace")
+    environment_names.append(key)
+    if key in allowed:
+        environment[key] = value_bytes.decode("utf-8", errors="replace")
+
+sensitive_markers = ("API_KEY", "ACCESS_KEY", "CREDENTIAL", "PASSWORD", "PRIVATE_KEY", "SECRET", "TOKEN")
+source_overrides = {"OPENWORK_ELECTRON_BINARY", "OPENWORK_EVAL_ELECTRON_BINARY", "OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT", "OPENWORK_WORKSPACE_DIR", "VITE_DEV_SERVER_URL"}
+unexpected_sensitive = sorted({
+    key for key in environment_names
+    if key in source_overrides or (key not in allowed and any(marker in key for marker in sensitive_markers))
+})
+
+digest = hashlib.sha256()
+with pathlib.Path(request["archivePath"]).open("rb") as archive:
+    for chunk in iter(lambda: archive.read(1024 * 1024), b""):
+        digest.update(chunk)
+
+xdg_environment = {
+    key: value for key, value in environment.items()
+    if key in {"DISPLAY", "HOME", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"}
+}
+xdg_environment["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+xdg_environment["LANG"] = "C.UTF-8"
+xdg_environment["XDG_CURRENT_DESKTOP"] = "XFCE"
+xdg_environment["DESKTOP_SESSION"] = "xfce"
+handler = subprocess.run(
+    ["xdg-mime", "query", "default", "x-scheme-handler/openwork"],
+    check=False,
+    capture_output=True,
+    text=True,
+    timeout=30,
+    env=xdg_environment,
+)
+handoff_exit_code = None
+if request.get("dispatchDeepLink", False):
+    handoff = subprocess.run(
+        ["xdg-open", "openwork://open"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=30,
+        env=xdg_environment,
+    )
+    handoff_exit_code = handoff.returncode
+    time.sleep(2)
+
+result = {
+    "archiveSha256": digest.hexdigest(),
+    "executablePath": os.readlink(process_root / "exe"),
+    "workingDirectory": os.readlink(process_root / "cwd"),
+    "bootstrapExists": pathlib.Path(request["bootstrapPath"]).exists(),
+    "environment": environment,
+    "unexpectedSensitiveEnvironmentKeys": unexpected_sensitive,
+    "protocolHandler": pathlib.Path(request["protocolHandlerPath"]).read_text(encoding="utf-8"),
+    "defaultProtocolHandler": handler.stdout.strip() if handler.returncode == 0 else "",
+    "shortcutsExecutable": [pathlib.Path(path).is_file() and os.access(path, os.X_OK) for path in request["shortcutPaths"]],
+    "handoffExitCode": handoff_exit_code,
+    "primaryProcessAlive": process_root.exists(),
+}
+print(json.dumps(result))
+`.trim();
+  const encodedSource = Buffer.from(source, "utf8").toString("base64");
+  const result = await execInSandbox(
+    defaultDaytonaExec,
+    options.sandboxId,
+    `printf %s ${encodedSource} | base64 -d | python3`,
+    { timeoutMs: 90_000, context: "published desktop sandbox witness" },
+  );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`Published desktop witness returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!record(parsed)) throw new Error("Published desktop witness returned a non-object result.");
+  const sensitive = parsed.unexpectedSensitiveEnvironmentKeys;
+  const shortcuts = parsed.shortcutsExecutable;
+  const handoffExitCode = parsed.handoffExitCode;
+  if (!Array.isArray(sensitive) || !sensitive.every((key) => typeof key === "string")) {
+    throw new Error("Published desktop witness returned invalid sensitive environment keys.");
+  }
+  if (!Array.isArray(shortcuts) || !shortcuts.every((ready) => typeof ready === "boolean")) {
+    throw new Error("Published desktop witness returned invalid shortcut readiness.");
+  }
+  if (handoffExitCode !== null && typeof handoffExitCode !== "number") {
+    throw new Error("Published desktop witness returned an invalid deep-link exit code.");
+  }
+  if (typeof parsed.bootstrapExists !== "boolean" || typeof parsed.primaryProcessAlive !== "boolean") {
+    throw new Error("Published desktop witness returned invalid process state.");
+  }
+  return {
+    archiveSha256: stringField(parsed, "archiveSha256"),
+    executablePath: stringField(parsed, "executablePath"),
+    workingDirectory: stringField(parsed, "workingDirectory"),
+    bootstrapExists: parsed.bootstrapExists,
+    environment: stringRecord(parsed.environment),
+    unexpectedSensitiveEnvironmentKeys: sensitive,
+    protocolHandler: stringField(parsed, "protocolHandler"),
+    defaultProtocolHandler: stringField(parsed, "defaultProtocolHandler"),
+    shortcutsExecutable: shortcuts,
+    handoffExitCode,
+    primaryProcessAlive: parsed.primaryProcessAlive,
+  };
+}
+
+/** Launch a known-negative binary without exposing host construction to journey specs. */
+export async function retainedCrashedDesktopWitness(sandboxId: string): Promise<RetainedCrashedDesktopWitness> {
+  const host = daytonaSandbox(sandboxId);
+  try {
+    const desktop = await retainedDesktop({
+      host,
+      name: "release-crash-proof",
+      binaryPath: "/bin/false",
+      startupTimeoutMs: 3_000,
+    });
+    let stopped = false;
+    const stop = async (): Promise<void> => {
+      if (stopped) return;
+      stopped = true;
+      try {
+        await desktop.stop();
+      } finally {
+        await host[Symbol.asyncDispose]();
+      }
+    };
+    return {
+      startup: desktop.startup,
+      stop,
+      [Symbol.asyncDispose]: () => stop(),
+    };
+  } catch (error) {
+    try {
+      await host[Symbol.asyncDispose]();
+    } catch {}
+    throw error;
+  }
+}

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -14,6 +14,7 @@ export type { StepRecord, TestOutcome, TraceEntry } from "@openwork/test-evidenc
 export { test } from "./fixture.ts";
 export * from "@openwork/env";
 export * from "./brief.ts";
+export * from "./daytona-witness.ts";
 export * from "./eventually.ts";
 export * from "./link.ts";
 export * from "./self-host.ts";

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -9,7 +9,14 @@ import { main, isProcessAlive, readScriptWorldSnapshot } from "@openwork/world";
 import { denFetch, signIn } from "@openwork/behaviors";
 import { attachSurface, evaluateOnSurface } from "@openwork/cdp";
 import { screenshot } from "@openwork/test-evidence";
-import { eventually, needs, test } from "@openwork/testkit";
+import {
+  eventually,
+  needs,
+  readDenClientState,
+  readPublishedDesktopSandboxWitness,
+  retainedCrashedDesktopWitness,
+  test,
+} from "@openwork/testkit";
 
 const exec = promisify(execFile);
 const root = fileURLToPath(new URL("../..", import.meta.url));
@@ -25,6 +32,40 @@ async function rfbHandshake(url: string): Promise<string> {
     socket.onmessage = (event) => { clearTimeout(timer); socket.close(); resolve(new TextDecoder().decode(event.data)); };
     socket.onerror = () => { clearTimeout(timer); socket.close(); reject(new Error("noVNC WebSocket failed")); };
   });
+}
+
+interface DaytonaSandboxSummary {
+  identities: string[];
+  autoStopInterval: number;
+}
+
+async function daytonaSandboxes(): Promise<DaytonaSandboxSummary[]> {
+  const summaries: DaytonaSandboxSummary[] = [];
+  for (let page = 1; ; page += 1) {
+    const result = await exec("daytona", ["sandbox", "list", "-f", "json", "-l", "200", "-p", String(page)], { timeout: 30000 });
+    const value: unknown = JSON.parse(result.stdout);
+    const entries = Array.isArray(value) ? value : record(value) && Array.isArray(value.items) ? value.items : null;
+    if (!entries) throw new Error("Daytona sandbox list did not return items.");
+    for (const entry of entries) {
+      if (!record(entry)) continue;
+      const identities = [entry.id, entry.name].filter((identity): identity is string => typeof identity === "string");
+      if (identities.length > 0 && typeof entry.autoStopInterval === "number") {
+        summaries.push({ identities, autoStopInterval: entry.autoStopInterval });
+      }
+    }
+    if (!record(value) || typeof value.totalPages !== "number" || page >= value.totalPages) break;
+  }
+  return summaries;
+}
+
+async function daytonaSandboxIdentities(): Promise<string[]> {
+  return [...new Set((await daytonaSandboxes()).flatMap((sandbox) => sandbox.identities))].sort();
+}
+
+async function daytonaSandboxAutoStopInterval(identity: string): Promise<number> {
+  const sandbox = (await daytonaSandboxes()).find((entry) => entry.identities.includes(identity));
+  if (!sandbox) throw new Error(`Daytona sandbox ${identity} was not listed.`);
+  return sandbox.autoStopInterval;
 }
 
 test("preview worlds expose Den and real Electron, preserve progress on frontend update, and tear down only their own stage", { timeout: 1_500_000 }, async ({ evidence }) => {
@@ -129,6 +170,150 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
   } finally {
     for (const name of ["preview-desktop", "preview-den"]) {
       if (await readScriptWorldSnapshot(join(snapshots, `${name}--${stage}.json`))) await down(name);
+    }
+    if (previous === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previous;
+    await rm(snapshots, { recursive: true, force: true });
+  }
+});
+
+test("preview-desktop retains an exact blank published release and tears down its two owned sandboxes", { timeout: 1_500_000 }, async ({ evidence }) => {
+  needs({ placement: "daytona" });
+  const snapshots = await mkdtemp(join(tmpdir(), "openwork-release-preview-proof-"));
+  const previous = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  process.env.OPENWORK_WORLD_SNAPSHOT_DIR = snapshots;
+  const suffix = Date.now();
+  const stage = `release-${suffix}`;
+  const invalidStage = `invalid-${suffix}`;
+  const controlStage = `control-${suffix}`;
+  const options = { cwd: root, worldsDirectory: join(root, "worlds"), print: (line: string) => console.error(line) };
+  const up = (name: string, selectedStage: string, args: string[]) => main(["up", name, "--stage", selectedStage, "--place", "daytona", "--detach", "--timeout", "600000", "--", ...args], options);
+  const down = (name: string, selectedStage: string) => main(["down", name, "--stage", selectedStage], options);
+  const snapshot = async (name: string, selectedStage: string) => {
+    const value = await readScriptWorldSnapshot(join(snapshots, `${name}--${selectedStage}.json`));
+    assert.ok(value);
+    return value;
+  };
+  try {
+    assert.match(process.env.OPENWORK_EVAL_REF ?? "", /^[0-9a-f]{40}$/);
+    assert.equal(await up("preview-desktop", invalidStage, ["--release", "latest", "--distribution", "enterprise", "--scenario", "blank"]), 1);
+    assert.equal(await readScriptWorldSnapshot(join(snapshots, `preview-desktop--${invalidStage}.json`)), undefined);
+    assert.equal((await daytonaSandboxIdentities()).some((identity) => identity.includes(invalidStage)), false);
+    evidence.recordAssertionEvidence("Invalid release arguments allocate nothing", "A mutable release value exits without a world receipt or any stage-labeled Daytona sandbox.", true);
+
+    assert.equal(await up("preview-den", controlStage, ["--scenario", "fresh", "--lifetime", "30"]), 0);
+    const control = await snapshot("preview-den", controlStage);
+    assert.equal(await up("preview-desktop", stage, ["--release", "0.18.44", "--distribution", "enterprise", "--scenario", "blank", "--lifetime", "30"]), 0);
+    const release = await snapshot("preview-desktop", stage);
+    assert.equal(release.outputs.releaseVersion, "0.18.44");
+    assert.equal(release.outputs.distribution, "enterprise");
+    assert.equal(release.outputs.platform, "linux");
+    assert.equal(release.outputs.architecture, "x64");
+    assert.equal(release.outputs.denRef, process.env.OPENWORK_EVAL_REF);
+    assert.equal(release.outputs.startup, "cdp-responsive");
+    assert.ok(release.outputs.cdp);
+    assert.notEqual(release.outputs.denSandbox, release.outputs.desktopSandbox);
+    assert.notEqual(release.outputs.denSandbox, control.outputs.denSandbox);
+    assert.notEqual(release.outputs.desktopSandbox, control.outputs.denSandbox);
+    for (const sandbox of [control.outputs.denSandbox, release.outputs.denSandbox, release.outputs.desktopSandbox]) {
+      assert.equal(await daytonaSandboxAutoStopInterval(sandbox), 0);
+    }
+    evidence.recordAssertionEvidence("Preview lifetime owns both sandbox lifecycles", "Daytona reports autoStopInterval 0 for the control Den and for the release world's Den and desktop; expiry/down remains the only configured stop timer.", true);
+    assert.equal((await fetch(release.outputs.preview)).status, 200);
+    assert.match(await rfbHandshake(release.outputs.preview), /^RFB 003\./);
+    await assert.rejects(
+      exec("python3", [join(root, ".opencode/skills/preview-my-work/scripts/update-preview.py"), "preview-desktop", "--stage", stage, "--ref", process.env.OPENWORK_EVAL_REF ?? ""], { cwd: root, timeout: 10000 }),
+      (error: unknown) => record(error) && error.code === 2 && typeof error.stderr === "string" && error.stderr.includes("Published release previews are immutable"),
+    );
+
+    const metadataResponse = await fetch("https://api.github.com/repos/different-ai/openwork/releases/tags/v0.18.44", {
+      headers: { accept: "application/vnd.github+json", "user-agent": "openwork-release-preview-evidence" },
+    });
+    assert.equal(metadataResponse.status, 200);
+    const metadata: unknown = await metadataResponse.json();
+    assert.ok(record(metadata) && Array.isArray(metadata.assets));
+    const asset = metadata.assets.find((entry: unknown) => record(entry) && entry.name === release.outputs.releaseAsset);
+    assert.ok(record(asset) && typeof asset.digest === "string");
+    assert.equal(release.outputs.releaseDigest, asset.digest);
+    await using surface = await attachSurface({ name: "release-preview-proof", kind: "electron", hostKind: "daytona", cdpUrl: release.outputs.cdp });
+    const rendererState = await evaluateOnSurface(surface, () => ({
+      hash: location.hash,
+      seededKeys: Object.keys(localStorage).filter((key) => key.includes("workspace") || key.includes("activation")),
+    }));
+    assert.ok(record(rendererState) && rendererState.hash === "" && Array.isArray(rendererState.seededKeys) && rendererState.seededKeys.length === 0);
+    assert.deepEqual(await readDenClientState(surface), { authTokenPresent: false, activeOrgId: null, activeOrgSlug: null, activeOrgName: null });
+    const bootstrap = `${release.outputs.profilePath}/openwork/config/desktop-bootstrap.json`;
+    const expectedPaths: Record<string, string> = {
+      HOME: `${release.outputs.profilePath}/home`,
+      USERPROFILE: `${release.outputs.profilePath}/home`,
+      XDG_CONFIG_HOME: `${release.outputs.profilePath}/xdg/config`,
+      XDG_DATA_HOME: `${release.outputs.profilePath}/xdg/data`,
+      XDG_CACHE_HOME: `${release.outputs.profilePath}/xdg/cache`,
+      XDG_STATE_HOME: `${release.outputs.profilePath}/xdg/state`,
+      APPDATA: `${release.outputs.profilePath}/windows/app-data/roaming`,
+      LOCALAPPDATA: `${release.outputs.profilePath}/windows/app-data/local`,
+      OPENWORK_ELECTRON_USERDATA: `${release.outputs.profilePath}/electron-userdata`,
+      OPENWORK_DESKTOP_BOOTSTRAP_PATH: bootstrap,
+      OPENWORK_SERVER_CONFIG: `${release.outputs.profilePath}/openwork/config/server.json`,
+      OPENWORK_ENV_STORE: `${release.outputs.profilePath}/openwork/config/env.json`,
+      OPENWORK_TOKEN_STORE: `${release.outputs.profilePath}/openwork/config/tokens.json`,
+      OPENWORK_RUNTIME_DB: `${release.outputs.profilePath}/openwork/config/runtime.sqlite`,
+      OPENWORK_DATA_DIR: `${release.outputs.profilePath}/openwork/data`,
+      OPENCODE_CONFIG_DIR: `${release.outputs.profilePath}/opencode/config`,
+      OPENCODE_DB: `${release.outputs.profilePath}/opencode/data/opencode.db`,
+    };
+    const environment = { ...expectedPaths, DISPLAY: ":99", OPENWORK_DEV_MODE: "0" };
+    const witnessOptions = {
+      sandboxId: release.outputs.desktopSandbox,
+      pid: release.outputs.desktopPid,
+      archivePath: release.outputs.releaseArchive,
+      bootstrapPath: bootstrap,
+      protocolHandlerPath: release.outputs.protocolHandler,
+      shortcutPaths: [release.outputs.relaunchShortcut, release.outputs.browserShortcut],
+      environmentKeys: Object.keys(environment),
+    };
+    const witness = await readPublishedDesktopSandboxWitness({ ...witnessOptions, dispatchDeepLink: true });
+    assert.equal(`sha256:${witness.archiveSha256}`, asset.digest);
+    assert.equal(witness.executablePath, release.outputs.releaseBinary);
+    assert.equal(witness.workingDirectory, `${release.outputs.profilePath}/home`);
+    assert.equal(witness.primaryProcessAlive, true);
+    evidence.recordAssertionEvidence("The preview runs exact published enterprise bytes without source fallback", "The requested Linux x64 asset and receipt digest equal live GitHub release metadata, the retained archive hashes to that digest, and the running process executable is the extracted release binary.", true);
+
+    assert.equal(witness.bootstrapExists, false);
+    assert.deepEqual(witness.environment, environment);
+    assert.deepEqual(witness.unexpectedSensitiveEnvironmentKeys, []);
+    assert.ok(witness.protocolHandler.includes(`Exec=${release.outputs.profilePath}/launch-openwork %U`));
+    assert.ok(witness.protocolHandler.includes("MimeType=x-scheme-handler/openwork;"));
+    assert.equal(witness.defaultProtocolHandler, "openwork-release-preview.desktop");
+    assert.deepEqual(witness.shortcutsExecutable, [true, true]);
+    assert.equal(witness.handoffExitCode, 0);
+    evidence.recordAssertionEvidence("Blank means no seeded identity, activation, or workspace", "The renderer has no workspace or Den identity, no bootstrap file exists, every expected HOME/XDG/OpenWork/OpenCode path is rooted in one launch profile, credential-like and source override environment keys are absent, and xdg-open completes a benign handoff through the discoverable same-profile handler.", true);
+
+    {
+      await using broken = await retainedCrashedDesktopWitness(release.outputs.desktopSandbox);
+      assert.equal(broken.startup.state, "crashed");
+      assert.match(broken.startup.detail, /Process exited/);
+      assert.equal((await fetch(release.outputs.preview)).status, 200);
+      assert.match(await rfbHandshake(release.outputs.preview), /^RFB 003\./);
+    }
+    const afterCrash = await readPublishedDesktopSandboxWitness(witnessOptions);
+    assert.equal(afterCrash.defaultProtocolHandler, "openwork-release-preview.desktop");
+    assert.equal(afterCrash.primaryProcessAlive, true);
+    evidence.recordAssertionEvidence("An app crash retains a real viewer without a healthy label", "A real /bin/false launch is observed as crashed while the same HTTP/noVNC endpoint continues to answer and complete an RFB handshake.", true);
+
+    const owned = [release.outputs.denSandbox, release.outputs.desktopSandbox];
+    assert.equal(await down("preview-desktop", stage), 0);
+    await eventually(async () => {
+      const identities = await daytonaSandboxIdentities();
+      return owned.every((sandbox) => !identities.includes(sandbox));
+    }, { within: 120000, intervalMs: 2000, label: "release preview owned sandboxes deleted" });
+    assert.equal((await fetch(control.outputs.preview)).status, 200);
+    assert.ok((await daytonaSandboxIdentities()).includes(control.outputs.denSandbox));
+    evidence.recordAssertionEvidence("Down deletes exactly the release world's Den and desktop", "Both recorded owned sandbox identities disappear while the separately staged control Den remains listed and HTTP-reachable.", true);
+    assert.equal(await down("preview-den", controlStage), 0);
+  } finally {
+    for (const [name, selectedStage] of [["preview-desktop", stage], ["preview-desktop", invalidStage], ["preview-den", controlStage]]) {
+      if (await readScriptWorldSnapshot(join(snapshots, `${name}--${selectedStage}.json`))) await down(name, selectedStage);
     }
     if (previous === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
     else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previous;

--- a/worlds/lib/preview.ts
+++ b/worlds/lib/preview.ts
@@ -1,36 +1,103 @@
 import { randomBytes } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import { denFetch } from "../../evals/packages/behaviors/src/den.ts";
-import { app } from "../../evals/packages/env/src/desktop-app.ts";
+import { app, blankReleaseApp } from "../../evals/packages/env/src/desktop-app.ts";
 import { server } from "../../evals/packages/env/src/den.ts";
 import type { Den } from "../../evals/packages/env/src/den.ts";
 import { resolvePlace } from "../../evals/packages/env/src/place.ts";
 import type { Place } from "../../evals/packages/env/src/place.ts";
 import { daytonaSandbox } from "../../evals/packages/hosts/src/resolve.ts";
+import type { DesktopRelease, DesktopReleaseDistribution } from "../../evals/packages/hosts/src/types.ts";
 import { hold } from "../../packages/world/src/hold.ts";
 import { output, secret } from "../../packages/world/src/outputs.ts";
 import type { WorldOutput } from "../../packages/world/src/outputs.ts";
 
-export type PreviewScenario = "fresh" | "team" | "restricted" | "workspace";
+export type PreviewScenario = "blank" | "fresh" | "team" | "restricted" | "workspace";
 export type PreviewSurface = "den" | "desktop";
 
 export function parsePreviewOptions(argv: readonly string[]) {
   let scenario: PreviewScenario = "fresh";
   let lifetimeMinutes = 120;
+  let releaseVersion: string | undefined;
+  let distribution: DesktopReleaseDistribution | undefined;
   for (let i = 0; i < argv.length; i += 2) {
     const value = argv[i + 1];
-    if (argv[i] === "--scenario" && (value === "fresh" || value === "team" || value === "restricted" || value === "workspace")) {
+    if (argv[i] === "--scenario" && (value === "blank" || value === "fresh" || value === "team" || value === "restricted" || value === "workspace")) {
       scenario = value;
     } else if (argv[i] === "--lifetime" && value !== undefined && /^\d+$/.test(value) && Number(value) <= 1440) {
       lifetimeMinutes = Number(value);
+    } else if (argv[i] === "--release" && value !== undefined && /^\d+\.\d+\.\d+$/.test(value)) {
+      releaseVersion = value;
+    } else if (argv[i] === "--distribution" && (value === "public" || value === "cloud" || value === "enterprise")) {
+      distribution = value;
     } else {
-      throw new Error("Use --scenario fresh|team|restricted|workspace and --lifetime <minutes, 0 keeps running, maximum 1440>.");
+      throw new Error("Use --scenario blank|fresh|team|restricted|workspace, --release <x.y.z>, --distribution public|cloud|enterprise, and --lifetime <minutes, 0 keeps running, maximum 1440>.");
     }
   }
-  return { scenario, lifetimeMinutes };
+  if ((releaseVersion === undefined) !== (distribution === undefined)) {
+    throw new Error("Published previews require both --release <x.y.z> and --distribution public|cloud|enterprise.");
+  }
+  if (scenario === "blank" && releaseVersion === undefined) {
+    throw new Error("The blank scenario requires an exact published --release and --distribution.");
+  }
+  if (releaseVersion !== undefined && scenario !== "blank") {
+    throw new Error("Published release previews support only --scenario blank.");
+  }
+  const release: DesktopRelease | undefined = releaseVersion && distribution
+    ? { version: releaseVersion, distribution }
+    : undefined;
+  return { scenario, lifetimeMinutes, release };
 }
 
 function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(values: Record<string, string>, key: string): string {
+  const value = values[key];
+  if (!value) throw new Error(`Published desktop preview is missing ${key} metadata.`);
+  return value;
+}
+
+async function noVncRfbBanner(viewerUrl: string): Promise<string> {
+  const endpoint = new URL("/websockify", viewerUrl);
+  endpoint.protocol = "wss:";
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(endpoint, ["binary"]);
+    socket.binaryType = "arraybuffer";
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error("noVNC did not reach the desktop RFB server"));
+    }, 10_000);
+    socket.onmessage = (event) => {
+      clearTimeout(timer);
+      socket.close();
+      resolve(typeof event.data === "string" ? event.data : new TextDecoder().decode(event.data));
+    };
+    socket.onerror = () => {
+      clearTimeout(timer);
+      socket.close();
+      reject(new Error("noVNC WebSocket failed"));
+    };
+  });
+}
+
+async function waitForNoVnc(viewerUrl: string): Promise<void> {
+  const deadline = Date.now() + 45_000;
+  let last = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(viewerUrl, { signal: AbortSignal.timeout(5_000) });
+      if (!response.ok) throw new Error(`viewer returned HTTP ${response.status}`);
+      const banner = await noVncRfbBanner(viewerUrl);
+      if (!banner.startsWith("RFB 003.")) throw new Error(`unexpected RFB banner ${JSON.stringify(banner)}`);
+      return;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+      await delay(1_000);
+    }
+  }
+  throw new Error(`Desktop preview transport did not become ready: ${last}`);
 }
 
 async function setupTeam(den: Den, restricted: boolean): Promise<void> {
@@ -64,8 +131,9 @@ async function setupTeam(den: Den, restricted: boolean): Promise<void> {
 }
 
 /** Owned, disposable infrastructure only. Never attach a preview to an existing test or production sandbox. */
-export async function bootPreview(stack: AsyncDisposableStack, place: Place, surface: PreviewSurface, scenario: PreviewScenario) {
+export async function bootPreview(stack: AsyncDisposableStack, place: Place, surface: PreviewSurface, scenario: PreviewScenario, release?: DesktopRelease) {
   if (place.kind !== "daytona") throw new Error("Interactive previews require --place daytona.");
+  if (release && surface !== "desktop") throw new Error("Published releases are supported only by preview-desktop.");
   const base = place.denBase();
   if (base.kind !== "daytona" || !/^[0-9a-f]{40}$/.test(base.ref)) {
     throw new Error("Set OPENWORK_EVAL_REF to the reviewed, pushed full 40-character commit SHA before booting a preview.");
@@ -73,9 +141,10 @@ export async function bootPreview(stack: AsyncDisposableStack, place: Place, sur
   if (["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DAYTONA_DEN_SANDBOX", "OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX", "OPENWORK_EVAL_DAYTONA_SANDBOX"].some((key) => process.env[key]?.trim())) {
     throw new Error("Preview worlds require isolated infrastructure. Remove existing sandbox/reuse overrides before starting.");
   }
-  const fresh = scenario === "fresh";
+  const fresh = scenario === "fresh" || scenario === "blank";
   const den = stack.use(await server({
     place, provision: !fresh, web: true,
+    daytonaAutoStopMinutes: 0,
     ...(!fresh ? { org: { name: "Preview team", admin: { name: "Preview owner", email: `preview-${randomBytes(6).toString("hex")}@example.test` } } } : {}),
     env: { OPENWORK_DEV_MODE: "1", DEN_REQUIRE_EMAIL_VERIFICATION: "false", RESEND_API_KEY: "", SMTP_HOST: "" },
   }));
@@ -93,25 +162,54 @@ export async function bootPreview(stack: AsyncDisposableStack, place: Place, sur
     outputs.email = output(den.admin.email, { group: "Test account" });
     outputs.password = secret(den.admin.password, { group: "Test account" });
   }
-  const desktop = surface === "desktop" ? stack.use(await app({ den, place, ...(fresh ? { signIn: false } : { as: "admin" }) })) : undefined;
-  if (desktop) {
-    const sandbox = desktop.handle.sandboxId;
+  const releaseDesktop = release ? stack.use(await blankReleaseApp({ place, release })) : undefined;
+  const desktop = surface === "desktop" && !release ? stack.use(await app({ den, place, ...(fresh ? { signIn: false } : { as: "admin" }) })) : undefined;
+  const desktopHandle = releaseDesktop?.handle ?? desktop?.handle;
+  if (desktopHandle) {
+    const sandbox = desktopHandle.sandboxId;
     if (!sandbox) throw new Error("Desktop preview did not return its owned Daytona sandbox.");
     const host = daytonaSandbox(sandbox);
     if (!host.previewUrl) throw new Error("Daytona host cannot expose its viewer.");
     const url = new URL(await host.previewUrl(6080));
     url.search = "autoconnect=1&resize=scale&reconnect=1&reconnect_delay=2000";
+    await waitForNoVnc(url.href);
     outputs.preview = output(url.href, { group: "Preview", note: "Real Linux Electron app · noVNC · clipboard in the side toolbar" });
     outputs.desktopSandbox = output(sandbox, { group: "World" });
-    outputs.cdp = secret(desktop.handle.cdpUrl, { group: "Services" });
+    if (!releaseDesktop || releaseDesktop.startup.state === "cdp-responsive") {
+      outputs.cdp = secret(desktopHandle.cdpUrl, { group: "Services" });
+    }
   }
-  return { den, desktop, outputs };
+  if (releaseDesktop) {
+    const meta = releaseDesktop.handle.meta ?? {};
+    const profilePath = releaseDesktop.handle.profileDir;
+    if (!profilePath) throw new Error("Published desktop preview is missing its profile path.");
+    outputs.releaseVersion = output(requiredString(meta, "releaseVersion"), { group: "Release" });
+    outputs.distribution = output(requiredString(meta, "releaseDistribution"), { group: "Release" });
+    outputs.platform = output("linux", { group: "Release" });
+    outputs.architecture = output("x64", { group: "Release" });
+    outputs.releaseAsset = output(requiredString(meta, "releaseAsset"), { group: "Release" });
+    outputs.releaseDigest = output(requiredString(meta, "releaseDigest"), { group: "Release" });
+    outputs.releaseArchive = output(requiredString(meta, "releaseArchive"), { group: "Release" });
+    outputs.releaseBinary = output(requiredString(meta, "releaseBinary"), { group: "Release" });
+    outputs.releaseInstall = output(requiredString(meta, "releaseInstallRoot"), { group: "Release" });
+    outputs.releaseManifest = output(requiredString(meta, "releaseManifest"), { group: "Release" });
+    outputs.startup = output(releaseDesktop.startup.state, { group: "Desktop", note: releaseDesktop.startup.detail });
+    outputs.desktopLog = output(requiredString(meta, "log"), { group: "Desktop" });
+    outputs.profilePath = output(profilePath, { group: "Desktop" });
+    outputs.desktopPid = output(requiredString(meta, "remotePid"), { group: "Desktop" });
+    outputs.protocolHandler = output(requiredString(meta, "protocolHandler"), { group: "Desktop" });
+    outputs.relaunchShortcut = output(requiredString(meta, "relaunchShortcut"), { group: "Desktop" });
+    outputs.browserShortcut = output(requiredString(meta, "browserShortcut"), { group: "Desktop" });
+  }
+  outputs.denRef = output(base.ref, { group: "World", ...(release ? { note: "Pinned Den/tooling source; independent from published desktop bytes" } : {}) });
+  return { den, desktop: releaseDesktop ?? desktop, outputs };
 }
 
 export async function runPreview(surface: PreviewSurface, argv = process.argv.slice(2)): Promise<void> {
-  const { scenario, lifetimeMinutes } = parsePreviewOptions(argv);
+  const { scenario, lifetimeMinutes, release } = parsePreviewOptions(argv);
+  process.env.OPENWORK_WORLD_PREVIEW_DAYTONA = "1";
   await using stack = new AsyncDisposableStack();
-  const { outputs } = await bootPreview(stack, resolvePlace(), surface, scenario);
+  const { outputs } = await bootPreview(stack, resolvePlace(), surface, scenario, release);
   const expires = lifetimeMinutes === 0 ? undefined : new Date(Date.now() + lifetimeMinutes * 60_000);
   outputs.expires = output(expires?.toISOString() ?? "Until stopped", { group: "World", note: "Session lifetime, not an idle timer" });
   const timer = expires ? setTimeout(() => process.kill(process.pid, "SIGTERM"), lifetimeMinutes * 60_000) : undefined;


### PR DESCRIPTION
## Summary
- Extend `preview-desktop` with `--release <x.y.z> --distribution public|cloud|enterprise --scenario blank` for published Linux x64 tarballs.
- Verify GitHub-published SHA-256 and size before safe extraction; never fall back to source Electron or latest.
- Isolate the blank profile, retain noVNC when app startup fails, and provide same-profile browser/deep-link/relaunch shortcuts.
- Keep Den source independently pinned, expose release identity/startup/log outputs, and use world lifetime/down for both sandboxes.

## Usage
```sh
OPENWORK_EVAL_REF=<pushed-den-sha> pnpm world up preview-desktop --stage release-test --place daytona --detach --timeout 600000 -- --release 0.18.44 --distribution enterprise --scenario blank
```
Use a new stage or explicitly stop the old stage to change versions; an already-running stage is adopted, not updated. Linux x64 stable releases with published SHA-256 metadata only. Windows/macOS and installer parity are not claimed. Abrupt driver termination can require exact-ID manual cleanup; generalized orphan reaping is outside this change.

## Verification
Head: `d6e6891bdd8451d5e2000b711d357b4afba9eb20`.
- Canonical `OPENWORK_EVAL_REF=d6e6891bdd8451d5e2000b711d357b4afba9eb20 pnpm evals:e2e preview-world --daytona`: exit 0, placement `daytona (--daytona)`, 2 passed / 0 failed / 0 skipped. Both source and release journeys record six passing assertion groups; all seven owned sandboxes were confirmed deleted.
- Host suites: 38 passed / 0 failed / 0 skipped, including executable checksum rejection.
- Typecheck (exit 2, 355 diagnostics), boundary ratchet (exit 1, 14 violations), and channel ratchet (exit 1, 20 violations / 13 warnings) reproduce on clean `origin/dev` control `eb77060da70618a63098b998a5fc362b487d3f8c`; no preview-specific static regression found.

## Why draft / missing clearance
Runtime assertions passed, but overall review is **Incomplete**: bare `pnpm warden:check` exited 1 because no OpenAI API key was available. Expected skills were diff-security-review, confidentiality-review, and spec-provenance-review; auth failure/skipped files means none is claimed fully reviewed. A source-preview reference screenshot is unvalidated; no visual claim is made. Evidence publication is recorded in the follow-up verification comment.

Warden scope: committed `origin/dev..HEAD`, 16 files / 61 chunks. Before/after HEAD stayed `d6e6891bdd8451d5e2000b711d357b4afba9eb20`; before/after origin/dev stayed `eb77060da70618a63098b998a5fc362b487d3f8c`. Run reference `b72f10aa-2026-09-09T22-56-28-509Z`. No substantive finding IDs were produced (authentication failed); disposition: blocked, not cleared. Clear when approved Warden OpenAI credentials are available and all expected skills complete without blockers on this head. No private Warden logs are attached.