### PR TITLE
fix(desktop): wait for native update readiness before restart

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -272,11 +272,13 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       requestedReleaseChannel,
     ).catch((error: unknown) => {
       if (isCurrentReleaseChannel()) {
+        const message = describeError(error);
         setUpdateStatus({
           state: "error",
-          message: describeError(error),
+          message,
           failedAction: "download",
         });
+        setError(message);
       }
       return null;
     });
@@ -317,11 +319,13 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       const result = await bridge.download();
       if (!isCurrentReleaseChannel()) return;
       if (!result?.ok) {
+        const message = result?.reason ?? "Update download failed.";
         setUpdateStatus({
           state: "error",
-          message: result?.reason ?? "Update download failed.",
+          message,
           failedAction: "download",
         });
+        setError(message);
         return;
       }
       if (
@@ -343,11 +347,13 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       }));
     } catch (error) {
       if (!isCurrentReleaseChannel()) return;
+      const message = describeError(error);
       setUpdateStatus({
         state: "error",
-        message: describeError(error),
+        message,
         failedAction: "download",
       });
+      setError(message);
     } finally {
       unsubProgress?.();
     }
@@ -596,6 +602,8 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       const result = await bridge.installAndRestart();
       if (!isCurrentReleaseChannel()) return;
       if (!result?.ok) {
+        const message = result?.reason ?? "Update install failed.";
+        setError(message);
         if (result?.reason === "update-not-downloaded") {
           // The main-side staged download was invalidated; re-check so the UI
           // returns to a working stable-targeted download/install flow.
@@ -606,17 +614,19 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         }
         setUpdateStatus({
           state: "error",
-          message: result?.reason ?? "Update install failed.",
+          message,
           failedAction: "install",
         });
       }
     } catch (error) {
       if (!isCurrentReleaseChannel()) return;
+      const message = describeError(error);
       setUpdateStatus({
         state: "error",
-        message: describeError(error),
+        message,
         failedAction: "install",
       });
+      setError(message);
     }
   }, [onReleaseChannelChange, resolvePolicyReleaseChannel, runCheckForUpdates, setError]);
 

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -258,9 +258,10 @@ const SHIP_IT_DEFAULTS_DOMAIN = "com.differentai.openwork.ShipIt";
 // avoids the ENOENT abort.
 async function enableSquirrelDirectContentsWrite(
   shipItDefaultsDomain = SHIP_IT_DEFAULTS_DOMAIN,
+  writeDefaults = runDefaults,
 ) {
   if (process.platform !== "darwin") return;
-  await runDefaults(["write", shipItDefaultsDomain, "SquirrelMacEnableDirectContentsWrite", "-bool", "YES"]);
+  await writeDefaults(["write", shipItDefaultsDomain, "SquirrelMacEnableDirectContentsWrite", "-bool", "YES"]);
 }
 
 // Path of the ShipIt cache that, when stuck, keeps aborting future installs.
@@ -297,6 +298,8 @@ export function registerUpdaterIpc({
   loadAutoUpdater = () => import("electron-updater"),
   manifestChannel = "latest",
   shipItDefaultsDomain = SHIP_IT_DEFAULTS_DOMAIN,
+  writeDefaults = runDefaults,
+  nativeStagingTimeoutMs = 120_000,
   electronNet = null,
   shell = null,
   distribution = "public",
@@ -310,6 +313,7 @@ export function registerUpdaterIpc({
   let checkedUpdateTargetVersion = null;
   let checkedUpdateChannel = null;
   let updateDownloaded = false;
+  let macStagedVersion = null;
   let recoveryReleases = [];
   const recoveryWitness = { installRequests: [], openedArtifactUrls: [], quitRequested: false };
   let updaterOperationQueue = Promise.resolve();
@@ -349,7 +353,7 @@ export function registerUpdaterIpc({
             autoUpdaterInstance.disableDifferentialDownload = true;
             // Make Squirrel.Mac write contents in place rather than moving whole
             // bundles (see enableSquirrelDirectContentsWrite for why).
-            await enableSquirrelDirectContentsWrite(shipItDefaultsDomain);
+            await enableSquirrelDirectContentsWrite(shipItDefaultsDomain, writeDefaults);
             autoUpdaterInstance.on("error", (err) => {
               // Do not invalidate a staged download on arbitrary updater errors.
               // A later transient check failure does not delete the downloaded
@@ -357,7 +361,7 @@ export function registerUpdaterIpc({
               console.warn("[updater] error", err);
             });
             autoUpdaterInstance.on("update-downloaded", () => {
-              updateDownloaded = true;
+              if (platform !== "darwin") updateDownloaded = true;
             });
             // Forward download progress to the renderer so the UI can show
             // incremental bytes instead of staying stuck at 0.
@@ -380,6 +384,59 @@ export function registerUpdaterIpc({
       })();
     }
     return autoUpdaterLoadPromise;
+  }
+
+  async function downloadAndStageUpdate(updater, version) {
+    if (platform !== "darwin") {
+      updater.autoInstallOnAppQuit = true;
+      await updater.downloadUpdate();
+      return;
+    }
+
+    updateDownloaded = false;
+    macStagedVersion = null;
+    preventPendingUpdaterInstall(updater);
+    // MacUpdater exposes this property at runtime. Never treat ZIP completion
+    // (or its sticky squirrelDownloadedUpdate flag) as native install readiness.
+    const nativeUpdater = updater.nativeUpdater;
+    if (!nativeUpdater) throw new Error("Native macOS updater is unavailable.");
+
+    // With autoInstallOnAppQuit disabled, even a cached ZIP rebuilds the proxy
+    // feed without starting Squirrel. Own that check so errors after ZIP transfer
+    // and a stalled native stage cannot leave downloadUpdate pending forever.
+    await updater.downloadUpdate();
+    const feedUrl = nativeUpdater.getFeedURL();
+    if (!feedUrl) throw new Error("Native macOS update feed is unavailable.");
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        finish(new Error("Timed out preparing the macOS update. Please retry the download."));
+      }, nativeStagingTimeoutMs);
+      function finish(error) {
+        clearTimeout(timer);
+        nativeUpdater.removeListener("update-downloaded", onDownloaded);
+        nativeUpdater.removeListener("error", onError);
+        if (error) reject(error);
+        else resolve();
+      }
+      function onDownloaded(_event, _notes, _name, _date, updateUrl) {
+        // Each MacUpdater download creates a new loopback feed. A cached or
+        // delayed Squirrel event from an older feed must not ready this version.
+        if (typeof updateUrl !== "string" || !updateUrl.startsWith(`${feedUrl}/`)) return;
+        finish();
+      }
+      function onError(error) {
+        finish(error);
+      }
+      nativeUpdater.on("update-downloaded", onDownloaded);
+      nativeUpdater.on("error", onError);
+      try {
+        nativeUpdater.checkForUpdates();
+      } catch (error) {
+        finish(error);
+      }
+    });
+    macStagedVersion = version;
+    updater.autoInstallOnAppQuit = true;
   }
 
   async function resolveRecoveryArtifact(version) {
@@ -553,8 +610,7 @@ export function registerUpdaterIpc({
         if (compareStableVersions(release.version, currentVersion) === null) {
           throw new Error("Installed version could not be validated.");
         }
-        updater.autoInstallOnAppQuit = true;
-        await updater.downloadUpdate();
+        await downloadAndStageUpdate(updater, release.version);
         updater.quitAndInstall(false, true);
         return { ok: true, action: "install" };
       } catch (error) {
@@ -642,6 +698,10 @@ export function registerUpdaterIpc({
         throw new Error(`Target update manifest did not resolve to v${targetVersion}.`);
       }
       const available = Boolean(info?.version && isVersionNewer(info.version, currentVersion));
+      if (platform === "darwin" && info?.version !== macStagedVersion) {
+        updateDownloaded = false;
+        preventPendingUpdaterInstall(updater);
+      }
       checkedUpdateVersion = available ? info.version : null;
       checkedUpdateTargetVersion = available ? targetVersion : null;
       checkedUpdateChannel = available ? channelState.channel : null;
@@ -707,8 +767,7 @@ export function registerUpdaterIpc({
       // Clear any stuck ShipIt state from a prior aborted install so this
       // download applies cleanly on quit.
       await cleanStaleUpdaterState(app, shipItDefaultsDomain);
-      updater.autoInstallOnAppQuit = true;
-      await updater.downloadUpdate();
+      await downloadAndStageUpdate(updater, checkedUpdateVersion);
       updateDownloaded = true;
       return { ok: true };
     } catch (error) {
@@ -724,7 +783,7 @@ export function registerUpdaterIpc({
     try {
       // Re-assert the in-place-write default right before the swap; the ShipIt
       // defaults domain may have been wiped when stale state was cleaned.
-      await enableSquirrelDirectContentsWrite();
+      await enableSquirrelDirectContentsWrite(shipItDefaultsDomain, writeDefaults);
       updater.quitAndInstall(false, true);
       return { ok: true };
     } catch (error) {

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -41,13 +41,14 @@ function fakeUpdaterHarness({ version, platform, manualNativeStaging }) {
   const feeds = [];
   const downloadFeeds = [];
   let nativeFeed = "";
-  const nativeUpdater = new EventEmitter();
-  nativeUpdater.getFeedURL = () => nativeFeed;
-  nativeUpdater.checkForUpdates = () => {
-    calls.push("nativeCheck");
-    nativeUpdater.emit("checking-for-update");
-    if (!manualNativeStaging) finishNativeStage();
-  };
+  const nativeUpdater = Object.assign(new EventEmitter(), {
+    getFeedURL: () => nativeFeed,
+    checkForUpdates: () => {
+      calls.push("nativeCheck");
+      nativeUpdater.emit("checking-for-update");
+      if (!manualNativeStaging) finishNativeStage();
+    },
+  });
   function finishNativeStage(updateUrl = `${nativeFeed}/update.zip`) {
     nativeUpdater.emit("update-downloaded", {}, "", "", new Date(), updateUrl);
   }
@@ -79,6 +80,9 @@ function fakeUpdaterHarness({ version, platform, manualNativeStaging }) {
   return { updater, listeners, calls, feeds, downloadFeeds, nativeUpdater, finishNativeStage };
 }
 
+/**
+ * @param {{ version: string, platform?: string, manualNativeStaging?: boolean, nativeStagingTimeoutMs?: number }} options
+ */
 async function registerFakeUpdaterIpc({ version, platform = "linux", manualNativeStaging = false, nativeStagingTimeoutMs }) {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "openwork-updater-test-"));
   const handlers = new Map();

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { EventEmitter, once } from "node:events";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -34,35 +35,55 @@ const desktopVersion = JSON.parse(
 
 let isolatedUpdaterImportId = 0;
 
-function fakeUpdaterHarness({ version }) {
+function fakeUpdaterHarness({ version, platform, manualNativeStaging }) {
   const listeners = new Map();
   const calls = [];
   const feeds = [];
   const downloadFeeds = [];
+  let nativeFeed = "";
+  const nativeUpdater = new EventEmitter();
+  nativeUpdater.getFeedURL = () => nativeFeed;
+  nativeUpdater.checkForUpdates = () => {
+    calls.push("nativeCheck");
+    nativeUpdater.emit("checking-for-update");
+    if (!manualNativeStaging) finishNativeStage();
+  };
+  function finishNativeStage(updateUrl = `${nativeFeed}/update.zip`) {
+    nativeUpdater.emit("update-downloaded", {}, "", "", new Date(), updateUrl);
+  }
   const updater = {
     autoDownload: true,
     autoInstallOnAppQuit: false,
     disableDifferentialDownload: false,
     allowPrerelease: false,
     allowDowngrade: false,
+    ...(platform === "darwin" ? { nativeUpdater, squirrelDownloadedUpdate: false } : {}),
     on: (name, fn) => listeners.set(name, fn),
     setFeedURL: (feed) => feeds.push(feed),
     checkForUpdates: async () => ({ updateInfo: { version } }),
     downloadUpdate: async () => {
       calls.push("download");
       downloadFeeds.push(feeds.at(-1));
+      nativeFeed = `http://127.0.0.1:${10000 + downloadFeeds.length}`;
+      listeners.get("update-downloaded")?.({ version });
+      // Match MacUpdater: ZIP completion builds the native feed, and only
+      // autoInstallOnAppQuit starts Squirrel automatically.
+      if (platform === "darwin" && updater.autoInstallOnAppQuit) nativeUpdater.checkForUpdates();
     },
     quitAndInstall: () => {
       calls.push("quitAndInstall");
     },
   };
-  return { updater, listeners, calls, feeds, downloadFeeds };
+  nativeUpdater.on("error", (error) => listeners.get("error")?.(error));
+  nativeUpdater.on("update-downloaded", () => { updater.squirrelDownloadedUpdate = true; });
+  return { updater, listeners, calls, feeds, downloadFeeds, nativeUpdater, finishNativeStage };
 }
 
-async function registerFakeUpdaterIpc({ version }) {
+async function registerFakeUpdaterIpc({ version, platform = "linux", manualNativeStaging = false, nativeStagingTimeoutMs }) {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "openwork-updater-test-"));
   const handlers = new Map();
-  const harness = fakeUpdaterHarness({ version });
+  const harness = fakeUpdaterHarness({ version, platform, manualNativeStaging });
+  const defaultsWrites = [];
   isolatedUpdaterImportId += 1;
   const updaterModuleUrl = new URL(
     `./updater.mjs?updater-lifecycle=${isolatedUpdaterImportId}`,
@@ -80,8 +101,12 @@ async function registerFakeUpdaterIpc({ version }) {
     ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
     getMainWindow: () => null,
     loadAutoUpdater: async () => ({ autoUpdater: harness.updater }),
+    platform,
+    nativeStagingTimeoutMs,
+    shipItDefaultsDomain: "test.openwork.ShipIt",
+    writeDefaults: async (args) => { defaultsWrites.push(args); },
   });
-  return { tempDir, handlers, ...harness };
+  return { tempDir, handlers, defaultsWrites, ...harness };
 }
 
 describe("staleUpdaterStatePaths", () => {
@@ -580,6 +605,165 @@ describe("downloaded update lifecycle", () => {
       assert.deepEqual(await install(), {
         ok: false,
         reason: "update-not-downloaded",
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("macOS native staging", () => {
+  it("waits beyond ZIP completion and the wrapper event before allowing install", async () => {
+    const { tempDir, handlers, updater, nativeUpdater, finishNativeStage, calls, defaultsWrites } = await registerFakeUpdaterIpc({
+      version: "0.17.1", platform: "darwin", manualNativeStaging: true,
+    });
+    try {
+      const started = once(nativeUpdater, "checking-for-update");
+      let downloaded = false;
+      const download = handlers.get("openwork:updater:download")().then((result) => {
+        downloaded = true;
+        return result;
+      });
+      await started;
+      assert.equal(downloaded, false);
+      assert.equal(updater.autoInstallOnAppQuit, false);
+      assert.deepEqual(calls, ["download", "nativeCheck"]);
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 2);
+      const install = handlers.get("openwork:updater:installAndRestart")();
+      finishNativeStage();
+      assert.deepEqual(await download, { ok: true });
+      assert.equal(updater.autoInstallOnAppQuit, true);
+      assert.deepEqual(await install, { ok: true });
+      assert.deepEqual(calls, ["download", "nativeCheck", "quitAndInstall"]);
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 1);
+      assert.equal(nativeUpdater.listenerCount("error"), 1);
+      if (process.platform === "darwin") {
+        assert.equal(defaultsWrites.length, 2);
+        assert.ok(defaultsWrites.every((args) => args[1] === "test.openwork.ShipIt"));
+      }
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a late native error, blocks install, and stages the cached ZIP on retry", async () => {
+    const { tempDir, handlers, updater, nativeUpdater, finishNativeStage, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1", platform: "darwin", manualNativeStaging: true,
+    });
+    try {
+      const started = once(nativeUpdater, "checking-for-update");
+      const download = handlers.get("openwork:updater:download")();
+      await started;
+      nativeUpdater.emit("error", new Error("native signature validation failed"));
+      assert.deepEqual(await download, { ok: false, reason: "native signature validation failed" });
+      assert.equal(updater.autoInstallOnAppQuit, false);
+      assert.deepEqual(await handlers.get("openwork:updater:installAndRestart")(), {
+        ok: false, reason: "update-not-downloaded",
+      });
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 1);
+      assert.equal(nativeUpdater.listenerCount("error"), 1);
+
+      const retryStarted = once(nativeUpdater, "checking-for-update");
+      const retry = handlers.get("openwork:updater:download")();
+      await retryStarted;
+      finishNativeStage();
+      assert.deepEqual(await retry, { ok: true });
+      assert.deepEqual(await handlers.get("openwork:updater:installAndRestart")(), { ok: true });
+      assert.deepEqual(calls, ["download", "nativeCheck", "download", "nativeCheck", "quitAndInstall"]);
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 1);
+      assert.equal(nativeUpdater.listenerCount("error"), 1);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("times out native staging, removes listeners, and ignores a delayed prior-version event on retry", async () => {
+    const { tempDir, handlers, updater, nativeUpdater, finishNativeStage, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1", platform: "darwin", manualNativeStaging: true, nativeStagingTimeoutMs: 25,
+    });
+    try {
+      const download = handlers.get("openwork:updater:download");
+      const started = once(nativeUpdater, "checking-for-update");
+      const pending = download();
+      await started;
+      const oldFeed = nativeUpdater.getFeedURL();
+      const result = await pending;
+      assert.equal(result.ok, false);
+      assert.match(result.reason, /Timed out preparing the macOS update/);
+      assert.equal(updater.autoInstallOnAppQuit, false);
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 1);
+      assert.equal(nativeUpdater.listenerCount("error"), 1);
+      finishNativeStage();
+      assert.deepEqual(await handlers.get("openwork:updater:installAndRestart")(), {
+        ok: false, reason: "update-not-downloaded",
+      });
+
+      updater.checkForUpdates = async () => ({ updateInfo: { version: "0.17.2" } });
+      await handlers.get("openwork:updater:check")(null, "stable");
+      const retryStarted = once(nativeUpdater, "checking-for-update");
+      let downloaded = false;
+      const retry = download().then((value) => { downloaded = true; return value; });
+      await retryStarted;
+      assert.equal(updater.squirrelDownloadedUpdate, true, "MacUpdater retains its old ready flag");
+      finishNativeStage(`${oldFeed}/update.zip`);
+      await Promise.resolve();
+      assert.equal(downloaded, false);
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 2);
+      finishNativeStage();
+      assert.deepEqual(await retry, { ok: true });
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 1);
+      assert.equal(nativeUpdater.listenerCount("error"), 1);
+      assert.equal(calls.includes("quitAndInstall"), false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("invalidates a staged version only when a successful check selects a different version", async () => {
+    const { tempDir, handlers, updater, nativeUpdater, listeners, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1", platform: "darwin",
+    });
+    try {
+      const check = handlers.get("openwork:updater:check");
+      const install = handlers.get("openwork:updater:installAndRestart");
+      assert.deepEqual(await handlers.get("openwork:updater:download")(), { ok: true });
+      updater.checkForUpdates = async () => { throw new Error("network flake"); };
+      assert.equal((await check(null, "stable")).available, false);
+      // Wrapper errors from checks remain informational, not native-stage failures.
+      listeners.get("error")(new Error("network flake"));
+      assert.deepEqual(await install(), { ok: true });
+      updater.checkForUpdates = async () => ({ updateInfo: { version: "0.17.1" } });
+      await check(null, "stable");
+      assert.deepEqual(await install(), { ok: true });
+      updater.checkForUpdates = async () => ({ updateInfo: { version: "0.17.2" } });
+      await check(null, "stable");
+      assert.equal(updater.autoInstallOnAppQuit, false);
+      assert.deepEqual(await install(), { ok: false, reason: "update-not-downloaded" });
+      assert.equal(calls.filter((call) => call === "quitAndInstall").length, 2);
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 1);
+      assert.equal(nativeUpdater.listenerCount("error"), 1);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed without the native updater and cleans up a synchronous native check failure", async () => {
+    const { tempDir, handlers, updater, nativeUpdater, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1", platform: "darwin",
+    });
+    try {
+      delete updater.nativeUpdater;
+      const download = handlers.get("openwork:updater:download");
+      assert.deepEqual(await download(), { ok: false, reason: "Native macOS updater is unavailable." });
+      assert.deepEqual(calls, []);
+      updater.nativeUpdater = nativeUpdater;
+      nativeUpdater.checkForUpdates = () => { throw new Error("native check failed"); };
+      assert.deepEqual(await download(), { ok: false, reason: "native check failed" });
+      assert.equal(updater.autoInstallOnAppQuit, false);
+      assert.equal(nativeUpdater.listenerCount("update-downloaded"), 1);
+      assert.equal(nativeUpdater.listenerCount("error"), 1);
+      assert.deepEqual(await handlers.get("openwork:updater:installAndRestart")(), {
+        ok: false, reason: "update-not-downloaded",
       });
     } finally {
       await rm(tempDir, { recursive: true, force: true });

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -25,6 +25,25 @@ test("updates download outside Settings and offer a persistent, optional restart
   await user.notSee({ text: "Restart to update" });
   await world.returnToApp();
   expect(await world.snapshot()).toMatchObject({ checks: 4, downloads: 1, installs: 0 });
+  for (const [index, message] of [
+    "Update native preparation failed.",
+    "Update download connection failed.",
+  ].entries()) {
+    await world.finishDownload();
+    await user.click({ role: "button", label: /^Notifications/ });
+    await user.see({ text: message });
+    await user.press("Escape");
+    await user.notSee({ text: "Restart to update" });
+    expect(await world.snapshot()).toMatchObject({ downloads: index + 1, installs: 0, installAttempts: 0 });
+    await world.openSettings();
+    await user.click({ role: "button", text: "Check now" });
+    await probe.eventually(world.snapshot, {
+      within: 5_000, label: "the user retries the failed download through Settings",
+      until: (value) => typeof value === "object" && value !== null && Reflect.get(value, "downloads") === index + 2,
+    });
+    await world.openWorkspace();
+    await user.notSee({ text: "Restart to update" });
+  }
   await world.finishDownload();
   await user.see({ text: "Restart to update" });
   await user.notSee({ text: "Ready when you are." });
@@ -33,7 +52,7 @@ test("updates download outside Settings and offer a persistent, optional restart
   await world.openWorkspace();
   await world.returnToApp();
   await user.see({ text: "Restart to update" });
-  expect(await world.snapshot()).toMatchObject({ checks: 4, downloads: 1, installs: 0, updateInTitlebar: true, updateInSidebar: false });
+  expect(await world.snapshot()).toMatchObject({ checks: 6, downloads: 3, installs: 0, installAttempts: 0, updateInTitlebar: true, updateInSidebar: false });
   await user.looks([
     "A compact neutral Restart to update button sits in the titlebar with the app's other controls",
     "The OpenWork name remains above the sidebar navigation and no update card or banner covers the workspace",
@@ -44,7 +63,7 @@ test("updates download outside Settings and offer a persistent, optional restart
   await user.see({ text: /Eligible running tasks resume gradually after restart/ });
   await user.click("Keep working");
   await user.notSee({ text: "Restart OpenWork?" });
-  expect(await world.snapshot()).toMatchObject({ installs: 0 });
+  expect(await world.snapshot()).toMatchObject({ installs: 0, installAttempts: 0 });
 
   await world.setCustomBranding();
   await probe.eventually(world.snapshot, {
@@ -52,13 +71,41 @@ test("updates download outside Settings and offer a persistent, optional restart
     until: (value) => typeof value === "object" && value !== null && Reflect.get(value, "customLogoLoaded") === true,
   });
   expect(await world.snapshot()).toMatchObject({ sidebarName: null, customLogoLoaded: true });
+  for (const [index, message] of [
+    "Update installer could not start.",
+    "Update installer connection failed.",
+  ].entries()) {
+    await user.click("Restart to update");
+    await user.see({ text: "Restart Studio?" });
+    expect(await world.snapshot()).toMatchObject({ installAttempts: index, installs: 0 });
+    await user.click("Restart & update");
+    await user.click({ role: "button", label: /^Notifications/ });
+    await user.see({ text: message });
+    await user.press("Escape");
+    await user.notSee({ text: "Restart Studio?" });
+    await user.notSee({ text: "Restart to update" });
+    expect(await world.snapshot()).toMatchObject({ installAttempts: index + 1, installs: 0 });
+    await world.openSettings();
+    await user.click({ role: "button", text: "Check now" });
+    await probe.eventually(world.snapshot, {
+      within: 5_000, label: "the user re-downloads after the failed install through Settings",
+      until: (value) => typeof value === "object" && value !== null && Reflect.get(value, "downloads") === index + 4,
+    });
+    await user.notSee({ text: "Restart to update" });
+    await world.finishDownload();
+    await world.openWorkspace();
+    await user.see({ text: "Restart to update" });
+    expect(await world.snapshot()).toMatchObject({ installAttempts: index + 1, installs: 0 });
+  }
   await user.click("Restart to update");
   await user.see({ text: "Restart Studio?" });
+  expect(await world.snapshot()).toMatchObject({ installAttempts: 2, installs: 0 });
   await user.click("Restart & update");
   await probe.eventually(world.snapshot, {
     within: 5_000, label: "restart only after confirmation",
     until: (value) => typeof value === "object" && value !== null && Reflect.get(value, "installs") === 1,
   });
+  expect(await world.snapshot()).toMatchObject({ installAttempts: 3, installs: 1 });
 });
 
 const recoveryTest = spec.world(restartUpdateTaskWorld, { timeout: 600_000 });

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1192,6 +1192,12 @@ export async function managedVaultWorld(_seed: Seed, { place }: { place: Place }
   };
 }
 
+declare global {
+  interface Window {
+    __backgroundUpdateInstallAttempts: number;
+  }
+}
+
 export async function backgroundUpdateWorld(seed: Seed) {
   const app = await seed.desktop({ name: "background-update", signIn: false });
   const workspace = await seed.workspace(app, seed.tmpPath("background-update"));
@@ -1200,6 +1206,7 @@ export async function backgroundUpdateWorld(seed: Seed) {
     const now = Date.now.bind(Date);
     const state: Window["__backgroundUpdateWitness"] = { checks: 0, downloads: 0, installs: 0, offset: 0, finishDownload: null, intervalCheck: null };
     window.__backgroundUpdateWitness = state;
+    window.__backgroundUpdateInstallAttempts = 0;
     const schedule = window.setInterval.bind(window);
     // The browser timer returns a numeric handle; Node's merged ambient overload does not apply here.
     const browserWindow: Window = window;
@@ -1222,9 +1229,24 @@ export async function backgroundUpdateWorld(seed: Seed) {
       },
       download: async () => {
         state.downloads++;
-        return new Promise(resolve => { state.finishDownload = () => resolve({ ok: true }); });
+        const attempt = state.downloads;
+        return new Promise((resolve, reject) => {
+          state.finishDownload = () => {
+            state.finishDownload = null;
+            if (attempt === 1) resolve({ ok: false, reason: "Update native preparation failed." });
+            else if (attempt === 2) reject(new Error("Update download connection failed."));
+            else resolve({ ok: true });
+          };
+        });
       },
-      installAndRestart: async () => { state.installs++; return { ok: true }; },
+      // Witness renderer handling of bridge outcomes, not native installer behavior.
+      installAndRestart: async () => {
+        const attempt = ++window.__backgroundUpdateInstallAttempts;
+        if (attempt === 1) return { ok: false, reason: "Update installer could not start." };
+        if (attempt === 2) throw new Error("Update installer connection failed.");
+        state.installs++;
+        return { ok: true };
+      },
       onDownloadProgress: () => () => {},
     };
     state.offset += 16 * 60 * 1000;
@@ -1236,6 +1258,7 @@ export async function backgroundUpdateWorld(seed: Seed) {
       const { checks, downloads, installs } = window.__backgroundUpdateWitness;
       return {
         checks, downloads, installs, route: location.hash,
+        installAttempts: window.__backgroundUpdateInstallAttempts,
         updateInTitlebar: Boolean(document.querySelector<HTMLElement>('header [data-update-button]')),
         updateInSidebar: Boolean(document.querySelector<HTMLElement>('[data-sidebar="footer"] [data-update-button]')),
         sidebarName: document.querySelector<HTMLElement>('[data-sidebar-brand]')?.textContent?.trim() ?? null,
@@ -1252,7 +1275,11 @@ export async function backgroundUpdateWorld(seed: Seed) {
       state.offset += 15 * 60 * 1000;
       state.intervalCheck();
     }),
-    finishDownload: () => evalIn(app, () => (window.__backgroundUpdateWitness.finishDownload?.())),
+    finishDownload: () => evalIn(app, () => {
+      const finish = window.__backgroundUpdateWitness.finishDownload;
+      if (!finish) throw new Error("No update download is pending");
+      finish();
+    }),
     returnToApp: () => evalIn(app, () => {
       window.__backgroundUpdateWitness.offset += 16 * 60 * 1000;
       window.dispatchEvent(new Event("focus"));


### PR DESCRIPTION
## Problem

On macOS, electron-updater emits its download event before Squirrel finishes preparing the update. A later native staging error only reaches the log, leaving OpenWork showing **Ready to install**. Confirming restart can then return success while waiting for a native event that will never arrive.

Download and installation failures also disappear from the titlebar without notifying someone working outside Settings.

## Changes

- Keep macOS updates in the download/preparation state until the native installer reports readiness for the current feed.
- Bound native staging to two minutes, propagate errors, clean up attempt listeners, and allow a fresh staging attempt for a cached download.
- Reject stale native readiness when the selected version changes; preserve staged downloads across unrelated transient check errors.
- Show existing update notifications for failed download/preparation and restart requests.
- Extend the existing background-update journey with failure visibility, retry, and confirmation assertions. Keep policy checks, opt-out, and **Keep working** behavior intact.

## Verification — Incomplete

Head: `863e07fe861b976a8ee9abcb56a429500aa0e715`
Base: `440504bb9010ea7be822f5f9144e2627c84d32d3`

### Passed

- `node --test apps/desktop/electron/updater.test.mjs` — exit 0; 33 passed, 0 failed, 1 existing platform-specific skip. Includes delayed native preparation, staging error, timeout, retry, old-feed events, and transient-check preservation.
- `node apps/app/node_modules/typescript/bin/tsc -p apps/app/tsconfig.json --noEmit` — exit 0.
- `git diff --check` — exit 0.

### Skipped / blocked

- The unit test for non-macOS cache paths is skipped on macOS.
- `pnpm evals:e2e background-desktop-update` — exit 1 before placement or test execution. pnpm attempted dependency installation and stopped with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. No journey evidence was produced.
- `pnpm warden:check` — exit 1 at the same dependency preflight. Expected: `diff-security-review`, `confidentiality-review`, `spec-provenance-review`, and `desktop-den-sync-review`; actually reviewed: none. No findings or clearance were produced. Head and base were unchanged before/after the command.

### Remaining proof

Restore the worktree's pinned dependency installation, then run the two blocked commands above. The renderer journey uses a deterministic update bridge and does not prove Squirrel itself; a signed macOS packaged update must separately verify preparation, replacement, and relaunch. No installed application was restarted during this work.

## Review notes

The native boundary uses electron-updater 6.8.3's runtime `nativeUpdater` property; it is not public in that package's TypeScript declaration. Missing native access fails closed. This fixes a source-confirmed failure sequence, not a log-confirmed diagnosis of a particular installation attempt. General shutdown hardening is intentionally out of scope.
