### PR TITLE
feat(browser): add native page context menus

### DIFF
--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -408,6 +408,56 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     });
   }
 
+  async function showPageContextMenu(tab, params) {
+    if (!browserTabVisible(tab.tabId)) return;
+    const contents = tab.view.webContents;
+    const items = [];
+    const actions = new Map();
+    const add = (id, label, action, enabled = true) => {
+      items.push({ type: "item", id, label, enabled });
+      actions.set(id, action);
+    };
+    const separator = () => { if (items.length) items.push({ type: "separator" }); };
+    if (params.linkURL) {
+      add("open-new-tab", "Open Link in New Tab", null, isHttpUrl(params.linkURL));
+      add("copy-link", "Copy Link Address", () => clipboard.writeText(params.linkURL));
+    }
+    if (params.mediaType === "image") {
+      separator();
+      add("copy-image", "Copy Image", () => contents.copyImageAt(params.x, params.y), params.hasImageContents === true);
+      if (params.srcURL) add("copy-image-address", "Copy Image Address", () => clipboard.writeText(params.srcURL));
+    }
+    if (params.isEditable || params.selectionText) {
+      separator();
+      const edit = (id, label, flag) => add(id, label, () => contents[id](), params.editFlags?.[flag] === true);
+      if (params.isEditable) {
+        edit("undo", "Undo", "canUndo");
+        edit("redo", "Redo", "canRedo");
+        separator();
+        edit("cut", "Cut", "canCut");
+      }
+      edit("copy", "Copy", "canCopy");
+      if (params.isEditable) {
+        edit("paste", "Paste", "canPaste");
+        edit("selectAll", "Select All", "canSelectAll");
+      }
+    }
+    if (!params.isEditable && !params.selectionText && !params.linkURL && params.mediaType !== "image") {
+      add("back", "Back", () => contents.goBack(), contents.canGoBack());
+      add("forward", "Forward", () => contents.goForward(), contents.canGoForward());
+      add("reload", "Reload", () => contents.reload());
+    }
+    // Chromium supplies view-relative coordinates, already in window DIPs.
+    // Convert to app CSS pixels for the shared helper, not through page zoom.
+    const bounds = tab.view.getBounds();
+    const appZoom = window().webContents.getZoomFactor();
+    await showContextMenu({
+      source: "page", tabId: tab.tabId, ownerSessionId: registry.ownerOf(tab.tabId),
+      url: params.linkURL, items, actions,
+      point: { x: (bounds.x + params.x) / appZoom, y: (bounds.y + params.y) / appZoom },
+    });
+  }
+
   async function showContextMenu(request) {
     hideContextMenu();
     const showSerial = ++menuShowSerial;
@@ -416,14 +466,15 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     const tab = request.tabId ? getBrowserTab(request.tabId) : null;
     const isCurrent = () => showSerial === menuShowSerial && window() === mainWindow
       && !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed()
-      && (!tab || (getBrowserTab(tab.tabId) === tab && !tab.view.webContents.isDestroyed() && registry.ownerOf(tab.tabId) === request.ownerSessionId));
+      && (!tab || (getBrowserTab(tab.tabId) === tab && !tab.view.webContents.isDestroyed() && registry.ownerOf(tab.tabId) === request.ownerSessionId))
+      && (request.source !== "page" || browserTabVisible(request.tabId));
     const dismiss = () => { if (menuRequest === request) hideContextMenu(); };
     const invalidate = () => {
       if (showSerial !== menuShowSerial) return;
       dismiss();
       menuShowSerial += 1;
     };
-    const navigated = (_event, _url, _isInPlace, isMainFrame) => { if (isMainFrame) invalidate(); };
+    const navigated = (_event, _url, _isInPlace, isMainFrame) => { if (isMainFrame || request.source === "page") invalidate(); };
     menuRequest = request;
     mainWindow.on("blur", dismiss);
     mainWindow.webContents.on("did-start-navigation", navigated);
@@ -461,9 +512,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
   async function handleMenuChoice(request, itemId, isCurrent) {
     const tab = getBrowserTab(request.tabId);
 
-    if (request.source === "link" && itemId !== "copy-url") {
+    if ((request.source === "link" && itemId !== "copy-url") || (request.source === "page" && itemId === "open-new-tab")) {
       try {
-        const external = itemId !== "open-builtin";
+        const external = request.source === "link" && itemId !== "open-builtin";
         await checkPolicy?.({ url: request.url, external });
         if (!isCurrent()) return;
         if (!external) {
@@ -482,6 +533,11 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
           });
         }
       }
+      return;
+    }
+
+    if (request.source === "page") {
+      request.actions.get(itemId)?.();
       return;
     }
 
@@ -707,6 +763,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     };
     browserTabs.set(tabId, tab);
     if (!restoreTabId) registry.add({ tabId, ownerSessionId });
+    view.webContents.on("context-menu", (_event, params) => {
+      runDetachedTask("show browser page menu", () => showPageContextMenu(tab, params));
+    });
     view.webContents.once("dom-ready", () => {
       tab.domReady = true;
       if (tab.background) emulateBackgroundTab(tab);

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -93,6 +93,9 @@ export class WebContentsView {
       getURL() { return this.url; },
       getOrCreateDevToolsTargetId() { return targetId; },
       getTitle() { return ""; },
+      copyImageAt(x, y) { effects.push({ type: "image", x, y }); },
+      copy() { effects.push({ type: "edit-copy", targetId }); },
+      paste() { effects.push({ type: "edit-paste", targetId }); },
       isLoading() { return this.loading; },
       isCurrentlyAudible() { return this.audible; },
       canGoBack() { return false; },
@@ -256,6 +259,97 @@ function createPanel(checkPolicy = async (_request) => {}, remoteDebugPort = 0) 
 }
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+test("page link menus open a policy-checked tab in the source conversation without replacing the source", async () => {
+  const pending = gate();
+  const { invoke, onScreen, menus, policies, mainContents } = createPanel(async ({ url }) => {
+    if (url === LINK.url) await pending.promise;
+  });
+  invoke("openwork:browser:setVisibleSession", "A");
+  const source = invoke("openwork:browser:createTab", "about:blank", "A");
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  await flush();
+  const contents = onScreen().webContents;
+  contents.getZoomFactor = () => 1.5;
+  mainContents.getZoomFactor = () => 2;
+  contents.emit("context-menu", { x: 20, y: 30, linkURL: LINK.url });
+  await flush();
+  assert.deepEqual(menus.at(-1).request.point, { x: 410, y: 35 });
+  assert.equal(menus.at(-1).request.items[0].label, "Open Link in New Tab");
+  menus.at(-1).choose("open-new-tab");
+  await flush();
+  assert.equal(invoke("openwork:browser:state").tabs.length, 1, "no allocation before policy resolves");
+  pending.finish();
+  await flush();
+  const state = invoke("openwork:browser:state");
+  assert.equal(state.tabs.length, 2);
+  assert.equal(state.tabs.find(tab => tab.id === source.tabId).url, "about:blank");
+  assert.ok(state.tabs.some(tab => tab.id === state.activeTabId && tab.url === LINK.url && tab.ownerSessionId === "A"));
+  assert.ok(policies.some(request => request.url === LINK.url && request.external === false));
+  assert.deepEqual(effects, [], "never launches an external browser");
+  invoke("openwork:browser:destroy");
+});
+
+test("page menu actions reject unsafe links, denied policy, capacity overflow, and stale documents", async () => {
+  for (const mode of ["scheme", "policy", "capacity", "navigation", "frame-navigation", "closed", "conversation"]) {
+    const { invoke, onScreen, menus, views } = createPanel(async ({ url }) => {
+      if (mode === "policy" && url === LINK.url) throw new Error("Destination blocked");
+    });
+    invoke("openwork:browser:setVisibleSession", "A");
+    invoke("openwork:browser:createTab", "about:blank", "A");
+    if (mode === "capacity") for (let index = 1; index < 12; index++) invoke("openwork:browser:createTab", "about:blank", "A");
+    invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+    await flush();
+    const contents = onScreen().webContents;
+    const before = views().length;
+    contents.emit("context-menu", { x: 10, y: 20, linkURL: mode === "scheme" ? "javascript:alert(1)" : LINK.url });
+    await flush();
+    const menu = menus.at(-1);
+    if (mode === "scheme") assert.equal(menu.request.items[0].enabled, false);
+    if (mode === "navigation" || mode === "frame-navigation") contents.emit("did-start-navigation", "https://changed.example", false, mode === "navigation");
+    if (mode === "closed") contents.close();
+    if (mode === "conversation") invoke("openwork:browser:setVisibleSession", "B");
+    menu.choose("open-new-tab");
+    await flush();
+    assert.equal(views().length, before, mode);
+    assert.deepEqual(effects, ["policy", "capacity"].includes(mode) ? [{ type: "dialog" }] : [], mode);
+    invoke("openwork:browser:destroy");
+  }
+});
+
+test("page menus copy linked image pixels and addresses and respect Chromium editing flags", async () => {
+  const { invoke, onScreen, menus } = createPanel();
+  invoke("openwork:browser:setVisibleSession", "A");
+  invoke("openwork:browser:createTab", "about:blank", "A");
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  await flush();
+  const contents = onScreen().webContents;
+  for (const id of ["copy-image", "copy-image-address", "copy-link"]) {
+    contents.emit("context-menu", { x: 10, y: 20, linkURL: LINK.url, mediaType: "image", hasImageContents: true, srcURL: "data:image/png;base64,example" });
+    await flush();
+    assert.deepEqual(menus.at(-1).request.items.filter(item => item.type === "item").map(item => item.id),
+      ["open-new-tab", "copy-link", "copy-image", "copy-image-address"]);
+    menus.at(-1).choose(id);
+    await flush();
+  }
+  assert.deepEqual(effects, [{ type: "image", x: 10, y: 20 }, { type: "copy", url: "data:image/png;base64,example" }, { type: "copy", url: LINK.url }]);
+  effects.length = 0;
+  for (const id of ["paste", "copy"]) {
+    contents.emit("context-menu", { x: 10, y: 20, isEditable: true, editFlags: { canCopy: true, canPaste: false } });
+    await flush();
+    menus.at(-1).choose(id);
+    await flush();
+  }
+  assert.deepEqual(effects, [{ type: "edit-copy", targetId: contents.targetId }]);
+  contents.emit("context-menu", { x: 10, y: 20 });
+  await flush();
+  assert.deepEqual(menus.at(-1).request.items.map(({ id, enabled }) => ({ id, enabled })),
+    [{ id: "back", enabled: false }, { id: "forward", enabled: false }, { id: "reload", enabled: true }]);
+  menus.at(-1).choose("reload");
+  await flush();
+  assert.equal(invoke("openwork:browser:state").tabs.length, 1);
+  invoke("openwork:browser:destroy");
+});
 
 let preloadTestId = 0;
 async function loadPreload(t) {


### PR DESCRIPTION
## Summary
- Right-click links inside the built-in browser to Open Link in New Tab or Copy Link Address.
- Right-click images, including linked images, to Copy Image or Copy Image Address. Pixel copying uses Chromium contents rather than fetching the image URL.
- Selected text and editable fields offer applicable Copy, Undo, Redo, Cut, Paste, and Select All actions using Chromium edit flags. Ordinary page space offers Back, Forward, and Reload.
- Reuse the existing native menu lifecycle, tab ownership, policy checks, sandbox, request policy hook, and global tab limit. Stale choices after page/frame navigation, closure, or conversation switching cannot act on a different page.

## Scope and Limitations
- Main OpenWork desktop only. The page host on current dev is apps/desktop/electron/browser-panel.mjs; the shared browser-tabs package has no electron.mjs.
- New links open in a selected foreground tab in the same conversation, without replacing the source document. Only HTTP(S) links can open; other addresses remain copyable.
- No new download, popup, permission, external-browser, private-window, inspect, or save-page behavior. No opener/referrer emulation or background-tab option is added.
- #4716 was checked for overlap once. Its main-renderer file/image context menus remain separate; this PR does not modify those files or depend on that branch.

## Verification
**Verdict: Incomplete.** Focused host tests pass; native Electron journey evidence and final policy clearance are missing. This PR is intentionally ready for review as requested, not a claim of merge readiness.

Head: `e16cfb5b00d4cc62695a2ccff792bdf16e0d20b8`
Base: `c13e38fa9dcb78a95f09cdaea530d2b0084ee6b4`

| Command | Result |
| --- | --- |
| `pnpm install --offline --ignore-scripts --frozen-lockfile --filter @openwork/desktop` | Exit 0; dependencies installed entirely from cache |
| `node --test apps/desktop/electron/browser-panel.test.mjs` | Exit 0 on final head; 64 passed, 0 failed, 0 skipped |
| `git diff --check origin/dev...HEAD` | Exit 0 |
| `git log --format="%G?" origin/dev..HEAD` | G; signed commit verified |
| `pnpm warden:check` | Exit 1; review authentication unavailable |

The first host-test attempt could not resolve the uninstalled workspace package; the scoped offline install resolved that prerequisite. Final host tests use Electron stubs, not real native menus or clipboard contents.

Runtime proof deferred: `pnpm evals:e2e browser-tabs-owned-by-thread` is the covering journey, but its native page-menu assertions are still missing. No remote provisioning or environment-repair work was undertaken. No placement or runtime pass is claimed. Native popup positioning, iframe editing, image clipboard output, and user-visible navigation remain to be validated in real Electron on this exact head.

Final policy review scope: both changed files, 7 diff chunks. Expected and matched skills: diff-security-review, confidentiality-review, desktop-den-sync-review. Security and confidentiality reviews failed authentication before analysis; sync review skipped both files. No completed applicable review or finding IDs; no clearance claimed. Disposition: Incomplete. Clear when all applicable reviews complete on the exact head without blockers. Run reference: `012d915d-2026-09-09T23-23-38-380Z`. HEAD and origin/dev were unchanged before and after review at the refs above.

## Manual Reproduction (Not Yet Executed)
1. Open a page in the built-in browser, right-click an HTTP(S) link, and select Open Link in New Tab. Verify a second selected tab appears in the same conversation and the source tab remains unchanged.
2. Copy the link address and paste it into a text field; verify the exact destination. Non-HTTP(S) links must not offer an enabled new-tab action.
3. Right-click a linked image. Copy Image should paste pixels into an image-capable application; Copy Image Address and Copy Link Address should copy distinct corresponding addresses without navigation.
4. Select text or right-click an editable field, including inside an iframe. Verify editing commands target that field and unavailable commands are disabled. Right-click empty page space to use history and reload.
5. Check placement at non-default app and page zoom. Navigate, close the source tab, or switch conversations while a menu or policy decision is pending; no stale action should open a tab or copy from another page.
6. Deny the destination through organization policy or fill all 12 native tab slots. The new-tab action must report an error without replacing an existing page or launching an external browser.

No merge or release is included.