### PR TITLE
fix(desktop): recover credentials before engine readiness

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -103,7 +103,16 @@
     </script>
   </head>
   <body class="bg-dls-surface text-dls-text mac:bg-transparent">
-    <div id="root"></div>
+    <div id="root">
+      <!-- Visible even when the entry bundle cannot load. React replaces this on mount. -->
+      <div style="min-height: 100dvh; display: flex; align-items: center; justify-content: center; font: 14px system-ui; text-align: center; padding: 24px; box-sizing: border-box">
+        <div>
+          <p role="status">Starting OpenWork</p>
+          <p>If startup does not finish, reload to try again.</p>
+          <button type="button" onclick="window.location.reload()" style="font: inherit; padding: 8px 16px; cursor: pointer">Reload</button>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/index.react.tsx"></script>
   </body>
 </html>

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1595,6 +1595,9 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       const suffix = query.size ? `?${query.toString()}` : "";
       return requestJson<OpenworkConnectState>(baseUrl, `/experimental/connect/state${suffix}`, { token, hostToken, timeoutMs: timeouts.config });
     },
+    putDenIdentity: async (body: { baseUrl: string; token: string; orgId: string }, signal?: AbortSignal) => {
+      await requestJson<unknown>(baseUrl, "/den-session/identity", { hostToken, method: "PUT", body, signal, timeoutMs: timeouts.config });
+    },
     putDenSession: async (body: { baseUrl: string; token: string; orgId: string }, signal?: AbortSignal) => {
       await requestJson<unknown>(baseUrl, "/den-session", { hostToken, method: "PUT", body, signal, timeoutMs: timeouts.config });
     },

--- a/apps/app/src/index.react.tsx
+++ b/apps/app/src/index.react.tsx
@@ -21,13 +21,8 @@ import { AppErrorBoundary } from "./react-app/shell/app-error-boundary";
 import { AppRoot } from "./react-app/shell/app-root";
 import { setWebNotificationHandler } from "./react-app/shell/desktop-notifications";
 import { startDeepLinkBridge } from "./react-app/shell/startup-deep-links";
+import { StartupApp, StartupScreen } from "./react-app/shell/startup-screen";
 import "./app/index.css";
-
-startWebErrorMonitoring();
-bootstrapTheme();
-initLocale();
-startDeepLinkBridge();
-await initializeDenBootstrapConfig();
 
 const root = document.getElementById("root");
 
@@ -35,27 +30,42 @@ if (!root) {
   throw new Error("Root element not found");
 }
 
-root.dataset.openworkDeployment = getOpenWorkDeployment();
+// Keep one startup promise across StrictMode renders. Rejections now reach the
+// error boundary, and pending bootstrap IPC no longer leaves an empty root.
+const startup = Promise.resolve().then(async () => {
+  startWebErrorMonitoring();
+  bootstrapTheme();
+  initLocale();
+  startDeepLinkBridge();
+  await initializeDenBootstrapConfig();
 
-const platform = createDefaultPlatform();
-setWebNotificationHandler(platform.notify);
-const queryClient = getReactQueryClient();
-const Router = isDesktopRuntime() ? HashRouter : BrowserRouter;
+  root.dataset.openworkDeployment = getOpenWorkDeployment();
+  const platform = createDefaultPlatform();
+  setWebNotificationHandler(platform.notify);
+  const queryClient = getReactQueryClient();
+  const Router = isDesktopRuntime() ? HashRouter : BrowserRouter;
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <PlatformProvider value={platform}>
+          <AppProviders>
+            <Router>
+              <AppRoot />
+            </Router>
+          </AppProviders>
+        </PlatformProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+});
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
     <AppErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
-          <PlatformProvider value={platform}>
-            <AppProviders>
-              <Router>
-                <AppRoot />
-              </Router>
-            </AppProviders>
-          </PlatformProvider>
-        </TooltipProvider>
-      </QueryClientProvider>
+      <React.Suspense fallback={<StartupScreen />}>
+        <StartupApp startup={startup} />
+      </React.Suspense>
     </AppErrorBoundary>
   </React.StrictMode>,
 );

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -382,8 +382,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   let cloudOrgProvidersGeneration = 0;
   let cloudProviderSyncContextKey = "";
   let lastDenSessionPushKey = "";
+  let lastDenIdentityPushKey = "";
   let denSessionDelivery: { key: string; controller: AbortController } | null = null;
-  let denSessionPushInFlight: Promise<boolean> | null = null;
+  let denSessionPushInFlight: { mode: "identity" | "sync"; promise: Promise<boolean> } | null = null;
 
   const emitChange = () => {
     for (const listener of listeners) listener();
@@ -488,6 +489,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     denSessionDelivery = null;
     denSessionPushInFlight = null;
     lastDenSessionPushKey = "";
+    lastDenIdentityPushKey = "";
     cloudProviderSyncContextKey = "";
   };
 
@@ -505,27 +507,35 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   const isCurrentDenSessionDelivery = (delivery: typeof denSessionDelivery) =>
     !disposed && delivery !== null && delivery === denSessionDelivery && delivery.key === getDenSessionDeliveryKey();
 
-  const pushDenSession = (force = false): Promise<boolean> => {
+  const pushDenSession = (mode: "identity" | "sync" = "sync", force = false): Promise<boolean> => {
     const delivery = syncDenSessionDelivery();
     const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
     if (!delivery || !openworkClient || disposed) return Promise.resolve(false);
-    if (!force && delivery.key === lastDenSessionPushKey) return Promise.resolve(true);
-    if (denSessionPushInFlight) return denSessionPushInFlight;
-    lastDenSessionPushKey = "";
+    if (!force && delivery.key === (mode === "identity" ? lastDenIdentityPushKey : lastDenSessionPushKey)) return Promise.resolve(true);
+    if (denSessionPushInFlight) {
+      if (denSessionPushInFlight.mode === mode) return denSessionPushInFlight.promise;
+      // Readiness can recover during early verification, including an older
+      // server's 404. Serialize the full PUT, but never dedupe it against identity.
+      return denSessionPushInFlight.promise.catch(() => false).then(() =>
+        isCurrentDenSessionDelivery(delivery) ? pushDenSession(mode, force) : false);
+    }
+    if (mode === "sync" && !hasCloudProviderSyncPrerequisites()) return Promise.resolve(false);
+    if (mode === "sync") lastDenSessionPushKey = "";
     const settings = readDenSettings();
     const apiBaseUrl = settings.apiBaseUrl ?? resolveDenBaseUrls(settings).apiBaseUrl;
     const token = settings.authToken?.trim() ?? "";
     const orgId = settings.activeOrgId?.trim() ?? "";
     const request = (async () => {
-      // Retry only delivery, not provider materialization. Policy verification
-      // can fail transiently with 403 policy_unavailable; auth denials and
-      // rate limits remain terminal.
+      // Policy verification can fail transiently with 403 policy_unavailable;
+      // auth denials and rate limits remain terminal.
       for (let attempt = 0; attempt < 3; attempt += 1) {
         if (!isCurrentDenSessionDelivery(delivery)) return false;
         try {
-          await openworkClient.putDenSession({ baseUrl: apiBaseUrl, token, orgId }, delivery.controller.signal);
+          const put = mode === "identity" ? openworkClient.putDenIdentity : openworkClient.putDenSession;
+          await put({ baseUrl: apiBaseUrl, token, orgId }, delivery.controller.signal);
           if (!isCurrentDenSessionDelivery(delivery)) return false;
-          lastDenSessionPushKey = delivery.key;
+          lastDenIdentityPushKey = delivery.key;
+          lastDenSessionPushKey = mode === "sync" ? delivery.key : "";
           return true;
         } catch (error) {
           if (!isCurrentDenSessionDelivery(delivery)) return false;
@@ -546,9 +556,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       }
       return false;
     })();
-    denSessionPushInFlight = request;
+    denSessionPushInFlight = { mode, promise: request };
     const clearInFlight = () => {
-      if (denSessionPushInFlight === request) {
+      if (denSessionPushInFlight?.promise === request) {
         denSessionPushInFlight = null;
       }
     };
@@ -2189,6 +2199,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       if (reason === "settings_cloud_opened") {
         setStateField("providerAuthError", null);
       }
+      // The trusted local server needs the session before the engine or
+      // workspace is ready. Provider materialization still waits for both.
+      if (delivery && !getOpenworkGatewayOrigin()) {
+        try {
+          await pushDenSession("identity");
+        } catch (error) {
+          if (isCurrentDenSessionDelivery(delivery)) logCloudProviderSyncError(reason, error);
+        }
+      }
       return;
     }
     if (getOpenworkGatewayOrigin()) {
@@ -2217,7 +2236,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             let result = await openworkClient.runCloudProviderSyncNow(reason, delivery?.controller.signal);
             if (!isCurrent()) return;
             if (result.status === "no_session") {
-              if (!await pushDenSession(true) || !isCurrent()) return;
+              if (!await pushDenSession("sync", true) || !isCurrent()) return;
               result = await openworkClient.runCloudProviderSyncNow(reason, delivery?.controller.signal);
             }
             return result;

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -51,6 +51,7 @@ import { ShellConfigProvider } from "./shell-config";
 import { WelcomeRoute } from "./welcome-route";
 import { readOrgSelectionPending } from "../../app/lib/den-sign-in-intent";
 import { signedInRoute } from "./den-signin-routing";
+import { StartupScreen } from "./startup-screen";
 
 
 type DenSigninGateProps = {
@@ -76,7 +77,7 @@ const subscribeToDenBootstrap = (onStoreChange: () => void) => {
  * never let users land on `/signin` — redirect them to `/session` instead.
  *
  * While we're still checking the Den session AND sign-in is required, we
- * render nothing so the transcript/settings never flash behind the gate.
+ * show startup progress without mounting transcript/settings behind the gate.
  */
 function DenSigninGate({ children }: DenSigninGateProps) {
   const denAuth = useDenAuth();
@@ -186,7 +187,7 @@ function DenSigninGate({ children }: DenSigninGateProps) {
   }, [navigate]);
 
   if (requireSignin && denAuth.status === "checking") {
-    return null;
+    return <StartupScreen message="Checking your sign-in" />;
   }
 
   if (redirectingPreparedWorkspace) return <Navigate to="/onboarding" replace />;

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useReducer, type ReactNode } from "react";
 
 import { isDesktopRuntime } from "../../app/utils";
 import { useBootState } from "./boot-state";
+import { StartupScreen } from "./startup-screen";
 
 type ArchitectureInfo = {
   appArch: string;
@@ -94,7 +95,7 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
     void window.__OPENWORK_ELECTRON__?.shell?.openExternal?.(info.releaseUrl);
   }, [info?.releaseUrl]);
 
-  if (!checked) return null;
+  if (!checked) return <StartupScreen message="Checking this OpenWork installation" />;
   if (!info?.mismatch) return <>{children}</>;
 
   return (

--- a/apps/app/src/react-app/shell/loading-overlay.tsx
+++ b/apps/app/src/react-app/shell/loading-overlay.tsx
@@ -104,14 +104,21 @@ export function LoadingOverlay() {
         fading ? "opacity-0" : "opacity-100"
       }`}
       aria-live="polite"
-      aria-busy={!fading}
+      aria-busy={!fading && !error}
       role="status"
     >
       <div className="flex w-full max-w-[320px] flex-col items-center gap-4 px-6 text-center">
         {error ? (
           <div className="flex w-full flex-col gap-3 text-[12px] leading-5">
             <div className="text-base font-medium text-dls-primary">OpenWork couldn't start</div>
-            <div className="text-dls-secondary">Return to a version that works on this computer.</div>
+            <div className="text-dls-secondary">Reload to try again, or return to a version that works on this computer.</div>
+            <button
+              type="button"
+              className="rounded-md border border-dls-border px-3 py-2 font-medium text-dls-primary"
+              onClick={() => window.location.reload()}
+            >
+              Reload
+            </button>
             <button
               type="button"
               disabled={!releases.some((release) => release.marking === "previous")}
@@ -165,6 +172,13 @@ export function LoadingOverlay() {
             <div className="text-[12px] leading-5 text-dls-secondary">
               {message || "Preparing workspace"}
             </div>
+            <button
+              type="button"
+              className="rounded-md border border-dls-border px-3 py-2 text-sm font-medium text-dls-primary"
+              onClick={() => window.location.reload()}
+            >
+              Reload
+            </button>
           </>
         )}
       </div>

--- a/apps/app/src/react-app/shell/startup-screen.tsx
+++ b/apps/app/src/react-app/shell/startup-screen.tsx
@@ -1,0 +1,25 @@
+/** @jsxImportSource react */
+import { use, type ReactNode } from "react";
+
+// Startup gates cannot depend on the providers they are still waiting to mount.
+export function StartupScreen({ message = "Starting OpenWork" }: { message?: string }) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-dls-surface p-6 text-dls-primary">
+      <div className="flex max-w-sm flex-col items-center gap-4 text-center text-sm">
+        <p role="status" aria-live="polite">{message}</p>
+        <p className="text-dls-secondary">If startup does not finish, reload to try again.</p>
+        <button
+          type="button"
+          className="rounded-md border border-dls-border px-3 py-2 font-medium"
+          onClick={() => window.location.reload()}
+        >
+          Reload
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function StartupApp({ startup }: { startup: Promise<ReactNode> }) {
+  return use(startup);
+}

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -1,4 +1,7 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, StrictMode, Suspense, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
@@ -6,6 +9,9 @@ import {
   buildCrashReport,
   describeCrash,
 } from "../src/react-app/shell/app-error-boundary";
+import { StartupApp, StartupScreen } from "../src/react-app/shell/startup-screen";
+import { ArchitectureMismatchGate } from "../src/react-app/shell/architecture-mismatch-gate";
+import { BootStateProvider } from "../src/react-app/shell/boot-state";
 
 // react-dom/server rethrows instead of running error boundaries, so the catch
 // path is exercised by driving the state transition directly:
@@ -73,4 +79,91 @@ test("children render untouched when nothing throws", () => {
   );
 
   expect(html).toBe("<p>session surface</p>");
+});
+
+test("the architecture check shows progress without mounting the gated application", async () => {
+  const ownedDom = typeof window === "undefined";
+  if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  const bridge = window.__OPENWORK_ELECTRON__;
+  Reflect.set(window, "__OPENWORK_ELECTRON__", { system: {} });
+  try {
+    const html = renderToStaticMarkup(
+      <BootStateProvider>
+        <ArchitectureMismatchGate><p>private workspace</p></ArchitectureMismatchGate>
+      </BootStateProvider>,
+    );
+    expect(html).toContain("Checking this OpenWork installation");
+    expect(html).toContain("Reload");
+    expect(html).not.toContain("private workspace");
+  } finally {
+    if (bridge === undefined) Reflect.deleteProperty(window, "__OPENWORK_ELECTRON__");
+    else Reflect.set(window, "__OPENWORK_ELECTRON__", bridge);
+    if (ownedDom) await GlobalRegistrator.unregister();
+  }
+});
+
+test.each(["ready", "error"])("pending startup remains actionable and settles to %s without clearing continuity", async (outcome) => {
+  const ownedDom = typeof window === "undefined";
+  if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/#/workspace/ws/session/thread" });
+  const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const reload = spyOn(window.location, "reload").mockImplementation(() => {});
+  const logError = spyOn(console, "error").mockImplementation(() => {});
+  const startup = Promise.withResolvers<ReactNode>();
+  const hash = window.location.hash;
+  const stored = window.localStorage.getItem("openwork.server.active");
+  window.localStorage.setItem("openwork.server.active", "https://self-hosted.example.test/opencode");
+  let mounted = 0;
+  function Session() {
+    mounted += 1;
+    return <p>restored thread</p>;
+  }
+  try {
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <AppErrorBoundary>
+            <Suspense fallback={<StartupScreen />}>
+              <StartupApp startup={startup.promise} />
+            </Suspense>
+          </AppErrorBoundary>
+        </StrictMode>,
+      );
+    });
+    expect(container.textContent).toContain("Starting OpenWork");
+    expect(mounted).toBe(0);
+    const retry = container.querySelector("button");
+    expect(retry?.textContent).toBe("Reload");
+    await act(async () => { retry?.click(); });
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      if (outcome === "ready") startup.resolve(<Session />);
+      else startup.reject(new Error("bootstrap IPC failed"));
+    });
+    expect(container.textContent).not.toContain("Starting OpenWork");
+    if (outcome === "ready") {
+      expect(container.textContent).toBe("restored thread");
+      expect(mounted).toBeGreaterThan(0);
+    } else {
+      expect(container.textContent).toContain("OpenWork hit an unexpected error");
+      expect(container.textContent).toContain("Reload");
+      expect(container.textContent).not.toContain("bootstrap IPC failed");
+      expect(mounted).toBe(0);
+    }
+    expect(window.location.hash).toBe(hash);
+    expect(window.localStorage.getItem("openwork.server.active")).toBe("https://self-hosted.example.test/opencode");
+  } finally {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    reload.mockRestore();
+    logError.mockRestore();
+    if (stored === null) window.localStorage.removeItem("openwork.server.active");
+    else window.localStorage.setItem("openwork.server.active", stored);
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+    if (ownedDom) await GlobalRegistrator.unregister();
+  }
 });

--- a/apps/app/tests/session-provider-auth-server-sync.test.ts
+++ b/apps/app/tests/session-provider-auth-server-sync.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { clearDenSession } from "../src/app/lib/den";
+import { denSessionUpdatedEvent } from "../src/app/lib/den-session-events";
 import { createOpenworkServerClient } from "../src/app/lib/openwork-server";
 import { createClient } from "../src/app/lib/opencode";
 import type { ResolvedWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
@@ -149,6 +150,10 @@ function sessionPuts(requests: RecordedRequest[]) {
   return requests.filter((request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session");
 }
 
+function identityPuts(requests: RecordedRequest[]) {
+  return requests.filter((request) => request.method === "PUT" && new URL(request.url).pathname === "/den-session/identity");
+}
+
 function syncRuns(requests: RecordedRequest[]) {
   return requests.filter((request) => new URL(request.url).pathname === "/cloud-provider-sync/run");
 }
@@ -174,12 +179,14 @@ function installFetchMock(
     runStatuses?: Array<{ status: "applied" | "noop" | "failed" | "no_session"; message?: string }>;
     providerResponse?: Promise<Response>;
     sessionResponse?: (attempt: number) => Response | Promise<Response>;
+    identityResponse?: (attempt: number) => Response | Promise<Response>;
     runResponse?: Promise<Response> | ((attempt: number) => Response | Promise<Response>);
     statusResponse?: Promise<Response>;
   } = {},
 ) {
   let runIndex = 0;
   let sessionIndex = 0;
+  let identityIndex = 0;
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
     value: async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -201,6 +208,9 @@ function installFetchMock(
       }
       if (url.pathname === "/den-session" && method === "PUT") {
         return options.sessionResponse?.(sessionIndex++) ?? new Response(null, { status: 204 });
+      }
+      if (url.pathname === "/den-session/identity" && method === "PUT") {
+        return options.identityResponse?.(identityIndex++) ?? new Response(null, { status: 204 });
       }
       if (url.pathname === "/cloud-provider-sync/run" && method === "POST") {
         if (typeof options.runResponse === "function") return options.runResponse(runIndex++);
@@ -261,6 +271,9 @@ function createSessionRouteStore(options: {
   hostToken: string;
   generation?: number;
   connectedProviderIds?: string[];
+  engineReady?: boolean;
+  workspaceReady?: boolean;
+  onProviderStateWrite?: () => void;
 }) {
   const opencodeClient = createClient("https://engine.example", "/tmp/workspace_test", {
     token: "engine-token",
@@ -279,7 +292,7 @@ function createSessionRouteStore(options: {
   let disabledProviders: string[] = [];
 
   return createProviderAuthStore({
-    client: () => opencodeClient,
+    client: () => options.engineReady === false ? null : opencodeClient,
     providers: () => providers,
     providerDefaults: () => providerDefaults,
     providerConnectedIds: () => providerConnectedIds,
@@ -287,8 +300,8 @@ function createSessionRouteStore(options: {
     checkDesktopAppRestriction: () => false,
     selectedWorkspaceDisplay: () => workspace,
     providerBaseUrl: () => "https://engine.example",
-    selectedWorkspaceRoot: () => "/tmp/workspace_test",
-    runtimeWorkspaceId: () => "ws_1",
+    selectedWorkspaceRoot: () => options.workspaceReady === false ? "" : "/tmp/workspace_test",
+    runtimeWorkspaceId: () => options.workspaceReady === false ? null : "ws_1",
     // The exact snapshot builder the session route mounts.
     openworkServer: createSessionOpenworkServer({
       endpoint: () => options.endpoint,
@@ -296,18 +309,22 @@ function createSessionRouteStore(options: {
       generation: () => options.generation ?? null,
     }),
     setProviders: (value) => {
+      options.onProviderStateWrite?.();
       providers = value;
     },
     setProviderDefaults: (value) => {
+      options.onProviderStateWrite?.();
       providerDefaults = value;
     },
     setProviderConnectedIds: (value) => {
+      options.onProviderStateWrite?.();
       providerConnectedIds = value;
     },
     setDisabledProviders: (value) => {
+      options.onProviderStateWrite?.();
       disabledProviders = value;
     },
-    markOpencodeConfigReloadRequired: () => undefined,
+    markOpencodeConfigReloadRequired: () => options.onProviderStateWrite?.(),
   });
 }
 
@@ -449,6 +466,206 @@ describe("session-route cloud provider sync wiring", () => {
     expect(store.getSnapshot().importedCloudProviders).toEqual({});
     store.dispose();
   });
+
+  for (const trigger of ["startup/options", "sign_in"]) {
+    for (const missing of ["engine", "workspace", "engine and workspace"]) {
+      test(`${trigger} delivers the local Den session without ${missing} readiness and syncs only after recovery`, async () => {
+        const storage = installWindow();
+        const requests: RecordedRequest[] = [];
+        installFetchMock(requests);
+        let providerStateWrites = 0;
+        const options = {
+          endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+          hostToken: "host-token-live",
+          engineReady: missing === "workspace",
+          workspaceReady: missing === "engine",
+          onProviderStateWrite: () => { providerStateWrites += 1; },
+        };
+        const store = createSessionRouteStore(options);
+        try {
+          if (trigger === "startup/options") {
+            installCloudSession(storage);
+            store.start();
+            store.syncFromOptions();
+          } else {
+            store.start();
+            installCloudSession(storage);
+            window.dispatchEvent(new CustomEvent(denSessionUpdatedEvent, { detail: { status: "success" } }));
+          }
+          await waitFor(() => identityPuts(requests).length === 1);
+          await store.runCloudProviderSync("sign_in");
+          expect(identityPuts(requests)).toHaveLength(1);
+          expect(sessionPuts(requests)).toHaveLength(0);
+          expect(identityPuts(requests)[0]).toMatchObject({
+            url: `${LOCAL_SERVER_ORIGIN}/den-session/identity`,
+            headers: { "x-openwork-host-token": "host-token-live" },
+            body: JSON.stringify({ baseUrl: "https://den.example/api/den", token: "den-token", orgId: "org_test" }),
+          });
+          expect(syncRuns(requests)).toHaveLength(0);
+          expect(requests.filter((request) => request.method !== "GET")).toEqual(identityPuts(requests));
+          expect(providerStateWrites).toBe(0);
+
+          options.engineReady = true;
+          options.workspaceReady = true;
+          store.syncFromOptions();
+          await waitFor(() => providerStateWrites > 0);
+          expect(syncRuns(requests)).toHaveLength(1);
+          expect(sessionPuts(requests)).toHaveLength(1);
+          expect(identityPuts(requests)).toHaveLength(1);
+          expect(requests.indexOf(identityPuts(requests)[0]!)).toBeLessThan(requests.indexOf(sessionPuts(requests)[0]!));
+          expect(requests.indexOf(sessionPuts(requests)[0]!)).toBeLessThan(requests.indexOf(syncRuns(requests)[0]!));
+        } finally {
+          store.dispose();
+        }
+      });
+    }
+
+    for (const target of ["remote", "hostless", "non-loopback", "gateway"]) {
+      test(`${trigger} never delivers desktop credentials to ${target} with a null engine client`, async () => {
+        const storage = installWindow();
+        if (target === "gateway") window.__OPENWORK_GATEWAY__ = { version: 1 };
+        const requests: RecordedRequest[] = [];
+        installFetchMock(requests);
+        let providerStateWrites = 0;
+        const store = createSessionRouteStore({
+          endpoint: makeEndpoint({
+            origin: target === "remote" || target === "non-loopback" ? REMOTE_SERVER_ORIGIN : LOCAL_SERVER_ORIGIN,
+            isRemote: target === "remote",
+          }),
+          hostToken: target === "hostless" ? "" : "host-token-live",
+          engineReady: false,
+          onProviderStateWrite: () => { providerStateWrites += 1; },
+        });
+        try {
+          if (trigger === "startup/options") {
+            installCloudSession(storage);
+            store.start();
+            store.syncFromOptions();
+          } else {
+            store.start();
+            installCloudSession(storage);
+            window.dispatchEvent(new CustomEvent(denSessionUpdatedEvent, { detail: { status: "success" } }));
+          }
+          await store.runCloudProviderSync("sign_in");
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(sessionPuts(requests)).toHaveLength(0);
+          expect(identityPuts(requests)).toHaveLength(0);
+          expect(syncRuns(requests)).toHaveLength(0);
+          expect(requests.filter((request) => request.method !== "GET")).toHaveLength(0);
+          expect(providerStateWrites).toBe(0);
+          if (target !== "gateway") {
+            expect(requests.every((request) => !request.headers["x-openwork-host-token"])).toBe(true);
+          }
+        } finally {
+          store.dispose();
+        }
+      });
+    }
+  }
+
+  for (const earlyStatus of [204, 404]) {
+    test(`readiness during early delivery (${earlyStatus}) waits then sends a full session`, async () => {
+      installCloudSession(installWindow());
+      const requests: RecordedRequest[] = [];
+      const early = deferredResponse();
+      installFetchMock(requests, { identityResponse: () => early.promise });
+      const options = {
+        endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+        hostToken: "host-token-live",
+        engineReady: false,
+      };
+      const store = createSessionRouteStore(options);
+      try {
+        const initial = store.runCloudProviderSync("sign_in");
+        await waitFor(() => identityPuts(requests).length === 1);
+        expect(sessionPuts(requests)).toHaveLength(0);
+        expect(syncRuns(requests)).toHaveLength(0);
+        options.engineReady = true;
+        const ready = store.runCloudProviderSync("app_launch");
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(sessionPuts(requests)).toHaveLength(0);
+        early.resolve(new Response(null, { status: earlyStatus }));
+        await initial;
+        expect(await ready).toEqual({ outcome: "handled_server_side" });
+        expect(identityPuts(requests)).toHaveLength(1);
+        expect(sessionPuts(requests)).toHaveLength(1);
+        expect(syncRuns(requests)).toHaveLength(1);
+      } finally {
+        early.resolve(new Response(null, { status: earlyStatus }));
+        store.dispose();
+      }
+    });
+  }
+
+  test("an older server never gets the auto-sync PUT before readiness", async () => {
+    installCloudSession(installWindow());
+    const requests: RecordedRequest[] = [];
+    installFetchMock(requests, { identityResponse: () => jsonResponse({ code: "not_found" }, 404) });
+    const options = {
+      endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+      hostToken: "host-token-live",
+      engineReady: false,
+    };
+    const store = createSessionRouteStore(options);
+    try {
+      await store.runCloudProviderSync("sign_in");
+      expect(identityPuts(requests)).toHaveLength(1);
+      expect(sessionPuts(requests)).toHaveLength(0);
+      expect(syncRuns(requests)).toHaveLength(0);
+      options.engineReady = true;
+      expect(await store.runCloudProviderSync("app_launch")).toEqual({ outcome: "handled_server_side" });
+      expect(sessionPuts(requests)).toHaveLength(1);
+    } finally {
+      store.dispose();
+    }
+  });
+
+  for (const cancel of ["dispose", "org", "runtime"]) {
+    test(`early delivery and queued readiness are cancelled on ${cancel}`, async () => {
+      const storage = installWindow();
+      installCloudSession(storage);
+      const requests: RecordedRequest[] = [];
+      const early = deferredResponse();
+      installFetchMock(requests, { identityResponse: (attempt) => attempt === 0 ? early.promise : new Response(null, { status: 204 }) });
+      const options = {
+        endpoint: makeEndpoint({ origin: LOCAL_SERVER_ORIGIN, isRemote: false }),
+        hostToken: "host-token-live",
+        engineReady: false,
+        generation: 1,
+      };
+      const store = createSessionRouteStore(options);
+      try {
+        const initial = store.runCloudProviderSync("sign_in");
+        await waitFor(() => identityPuts(requests).length === 1);
+        options.engineReady = true;
+        const ready = store.runCloudProviderSync("app_launch");
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        options.engineReady = false;
+        if (cancel === "dispose") store.dispose();
+        else {
+          if (cancel === "org") storage.setItem("openwork.den.activeOrgId", "org_replacement");
+          else options.generation = 2;
+          store.syncFromOptions();
+        }
+        early.resolve(new Response(null, { status: 204 }));
+        await Promise.all([initial, ready]);
+        expect(identityPuts(requests)[0]!.signal?.aborted).toBe(true);
+        expect(sessionPuts(requests)).toHaveLength(0);
+        expect(syncRuns(requests)).toHaveLength(0);
+        if (cancel !== "dispose") {
+          await store.runCloudProviderSync("sign_in");
+          expect(identityPuts(requests)).toHaveLength(2);
+          options.engineReady = true;
+          expect(await store.runCloudProviderSync("app_launch")).toEqual({ outcome: "handled_server_side" });
+          expect(sessionPuts(requests)).toHaveLength(1);
+          expect(JSON.parse(sessionPuts(requests)[0]!.body!).orgId).toBe(cancel === "org" ? "org_replacement" : "org_test");
+        }
+      } finally {
+        early.resolve(new Response(null, { status: 204 }));
+        store.dispose();
+      }
+    });
+  }
 
   test("a local endpoint with a host token pushes the Den session and syncs server-side after sign-in", async () => {
     const storage = installWindow();

--- a/apps/server/src/cloud-provider-sync-reload-guard.test.ts
+++ b/apps/server/src/cloud-provider-sync-reload-guard.test.ts
@@ -159,6 +159,7 @@ function startFakeDen(options?: { providers?: Record<string, unknown>[] }): { ur
     fetch(request) {
       const url = new URL(request.url);
       requests.push(`${request.method} ${url.pathname}`);
+      if (request.method === "GET" && url.pathname === "/v1/me/desktop-config") return Response.json({});
       if (request.method === "GET" && url.pathname === "/v1/llm-providers") {
         return new Response(JSON.stringify({ llmProviders: providers }), { headers: { "content-type": "application/json" } });
       }

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { EnvService } from "./env-file.js";
 import { CloudProviderSync } from "./cloud-provider-sync.js";
+import { openworkRuntimeConfigFilePath } from "./openwork-runtime-config.js";
 import { clearEnginePoolForConfig, setEnginePoolForConfig, type EnginePool } from "./engine-pool.js";
 import { readOpenworkWorkspaceConfig, writeOpenworkWorkspaceConfig } from "./openwork-workspace-config-store.js";
 import {
@@ -180,6 +181,191 @@ afterEach(async () => {
 });
 
 describe("cloud provider sync gateway", () => {
+  test("same-identity full delivery preserves providers on a busy engine; a new identity still cleans up", async () => {
+    const root = await createRoot();
+    const provider = buildProvider([{ id: "model-a", name: "Model A", config: {} }]);
+    let busy = false;
+    const engineRequests: string[] = [];
+    const engine = Bun.serve({ port: 0, fetch(request) {
+      const path = new URL(request.url).pathname;
+      engineRequests.push(`${request.method} ${path}`);
+      if (path === "/session/status") return Response.json(busy ? { ses_live: { type: "busy" } } : {});
+      return Response.json(true);
+    } });
+    stops.push(() => engine.stop(true));
+    let denyPolicyB = true;
+    const den = Bun.serve({ port: 0, fetch(request) {
+      const path = new URL(request.url).pathname;
+      const org = request.headers.get("x-openwork-legacy-org-id");
+      if (path === "/v1/me/desktop-config") return org === "org_b" && denyPolicyB
+        ? Response.json({ error: "denied" }, { status: 401 }) : Response.json({});
+      if (org === "org_b") return Response.json({ error: "not_found" }, { status: 404 });
+      return Response.json(path === "/v1/llm-providers" ? { llmProviders: [provider] } : { llmProvider: provider });
+    } });
+    stops.push(() => den.stop(true));
+    const config = serverConfig(root, `http://127.0.0.1:${engine.port}`);
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+    const put = (path: string, orgId: string) => fetch(`${base}${path}`, {
+      method: "PUT", headers: hostHeaders(),
+      body: JSON.stringify({ baseUrl: `http://127.0.0.1:${den.port}`, token: "den-token", orgId }),
+    });
+    expect((await put("/den-session", "org_a")).status).toBe(204);
+    await waitForLastRun(base, "applied");
+    const readEnv = () => new EnvService({ path: process.env.OPENWORK_ENV_STORE }).list();
+    const envBefore = await readEnv();
+    const configBefore = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeDefined();
+    expect(envBefore.some((entry) => entry.key === "TEST_PROVIDER_API_KEY")).toBe(true);
+    busy = true;
+    engineRequests.length = 0;
+
+    // Repeated early A delivery and a rejected B identity must both retain A's
+    // actual ownership. Resuming A is reconciliation, never forced cleanup.
+    for (const org of ["org_a", "org_a", "org_b"]) {
+      expect((await put("/den-session/identity", org)).status).toBe(org === "org_b" ? 403 : 204);
+      expect(await runSync(base, "suspended")).toEqual({ status: "no_session" });
+    }
+    expect((await put("/den-session", "org_a")).status).toBe(204);
+    expect(await runSync(base, "resumed")).toEqual({ status: "noop" });
+    expect(await readEnv()).toEqual(envBefore);
+    expect(await readFile(openworkRuntimeConfigFilePath(config), "utf8")).toBe(configBefore);
+    expect(engineRequests.filter((request) => !request.startsWith("GET "))).toEqual([]);
+
+    denyPolicyB = false;
+    expect((await put("/den-session/identity", "org_b")).status).toBe(204);
+    expect((await put("/den-session", "org_b")).status).toBe(204);
+    await waitForLastRun(base, "failed");
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeUndefined();
+    expect(await readEnv()).toEqual([]);
+    expect(engineRequests).toContain("DELETE /auth/lpr_test");
+    expect(engineRequests).toContain("POST /instance/dispose");
+
+    expect((await put("/den-session", "org_a")).status).toBe(204);
+    await waitForLastRun(base, "applied");
+    expect((await put("/den-session/identity", "org_a")).status).toBe(204);
+    expect((await fetch(`${base}/den-session`, { method: "DELETE", headers: hostHeaders() })).status).toBe(204);
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeUndefined();
+    expect(await readEnv()).toEqual([]);
+  });
+
+  for (const resumeOrg of ["org_a", "org_b"]) {
+    test(`suspension during apply retains the actual owner, not the pending session, before resuming ${resumeOrg}`, async () => {
+      const root = await createRoot();
+      const config = serverConfig(root, "https://engine.example.test");
+      const provider = buildProvider([{ id: "model-a", name: "Model A", config: {} }]);
+      const reached = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      let reloads = 0;
+      let holdAuth = true;
+      const fetchImpl = Object.assign(async (
+        input: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1],
+      ) => {
+        const url = new URL(String(input));
+        if (url.hostname === "den.example.test") return Response.json(url.pathname === "/v1/llm-providers"
+          ? { llmProviders: [provider] } : { llmProvider: provider });
+        if (init?.method === "PUT" && holdAuth) {
+          reached.resolve();
+          await release.promise;
+        }
+        return Response.json(true);
+      }, { preconnect: globalThis.fetch.preconnect });
+      const env = new EnvService({ path: process.env.OPENWORK_ENV_STORE });
+      const sync = new CloudProviderSync({ config, env, fetchImpl, engineBusy: async () => true,
+        reloadEngine: async () => { reloads += 1; }, intervalMs: 3_600_000 });
+      stops.push(() => sync.stop());
+      const session = { baseUrl: "https://den.example.test", token: "token-a", orgId: "org_a" };
+      try {
+        await sync.setSession(session);
+        await Promise.race([reached.promise, Bun.sleep(1_000).then(() => { throw new Error("Apply did not reach auth delivery"); })]);
+        const pendingB = sync.setSession({ ...session, orgId: "org_b" });
+        const suspended = sync.suspend();
+        holdAuth = false;
+        release.resolve();
+        await Promise.all([pendingB, suspended]);
+        await sync.suspend();
+        expect(reloads).toBe(0);
+        expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeDefined();
+        const before = await env.list();
+        await sync.setSession({ ...session, orgId: resumeOrg });
+        expect((await sync.run("resumed")).status).toBe("applied");
+        if (resumeOrg === "org_a") expect(await env.list()).toEqual(before);
+        else expect((await env.list()).map(({ key, value }) => ({ key, value })))
+          .toEqual(before.map(({ key, value }) => ({ key, value })));
+        expect(reloads).toBe(resumeOrg === "org_a" ? 0 : 1);
+      } finally {
+        holdAuth = false;
+        release.resolve();
+      }
+    });
+  }
+
+  test("early identity cancels a previous provider fetch and stays dormant across timer ticks", async () => {
+    const root = await createRoot();
+    process.env.OPENWORK_CLOUD_PROVIDER_SYNC_INTERVAL_MS = "20";
+    process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS = "20";
+    const reached = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const provider = buildProvider([{ id: "model-a", name: "Model A", config: {} }]);
+    const denRequests: string[] = [];
+    const den = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const path = new URL(request.url).pathname;
+        const org = request.headers.get("x-openwork-legacy-org-id");
+        denRequests.push(`${org} ${path}`);
+        if (path === "/v1/me/desktop-config") return Response.json({ allowCustomProviders: false });
+        if (path === "/v1/llm-providers") {
+          if (org === "org_old") {
+            reached.resolve();
+            await release.promise;
+          }
+          return Response.json({ llmProviders: [provider] });
+        }
+        return Response.json({ llmProvider: provider });
+      },
+    });
+    stops.push(() => den.stop(true));
+    const engineRequests: string[] = [];
+    const engine = Bun.serve({ port: 0, fetch(request) {
+      engineRequests.push(`${request.method} ${new URL(request.url).pathname}`);
+      return Response.json({});
+    } });
+    stops.push(() => engine.stop(true));
+    const config = serverConfig(root, `http://127.0.0.1:${engine.port}`);
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+    const put = (path: string, orgId: string) => fetch(`${base}${path}`, {
+      method: "PUT", headers: hostHeaders(),
+      body: JSON.stringify({ baseUrl: `http://127.0.0.1:${den.port}`, token: "den-token", orgId }),
+    });
+    try {
+      expect((await put("/den-session", "org_old")).status).toBe(204);
+      await Promise.race([reached.promise, Bun.sleep(1_000).then(() => { throw new Error("Old provider fetch did not start"); })]);
+      expect((await put("/den-session/identity", "org_new")).status).toBe(204);
+      // This succeeds while the old Den response is still held: delivery does
+      // not depend on the obsolete provider service or the engine recovering.
+      release.resolve();
+      const baseline = [...engineRequests];
+      await Bun.sleep(80);
+      expect(await runSync(base, "not-ready")).toEqual({ status: "no_session" });
+      expect(denRequests.filter((path) => path.includes("llm-providers"))).toEqual(["org_old /v1/llm-providers"]);
+      expect(engineRequests).toEqual(baseline);
+      expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))).toEqual({});
+      expect(await new EnvService({ path: process.env.OPENWORK_ENV_STORE }).list()).toEqual([]);
+      expect((await responseRecord(await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() }), "status")))
+        .toMatchObject({ hasSession: false, providers: [], lastRun: null });
+      expect((await put("/den-session", "org_new")).status).toBe(204);
+      await waitForLastRun(base, "applied");
+      expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeDefined();
+      expect(denRequests).toContain("org_new /v1/llm-providers/lpr_test/connect");
+    } finally {
+      release.resolve();
+    }
+  });
+
   test("joins concurrent runs, keeps identical sessions inert, and runs one latest-session trailing pass", async () => {
     const root = await createRoot();
     let markFirstListReached: () => void = () => undefined;
@@ -464,6 +650,24 @@ describe("cloud provider sync gateway", () => {
     expect(sync.status().reloadPending).toBe(false);
     await Bun.sleep(100);
     expect(reloads).toBe(1);
+
+    // A new early identity must also cancel a reload owed by the old one,
+    // without sweeping credentials into an engine that is not ready yet.
+    draining = true;
+    provider.apiKey = "sk-rotated-before-identity";
+    expect((await sync.run("rotation")).status).toBe("applied");
+    expect(sync.status().reloadPending).toBe(true);
+    const env = new EnvService({ path: process.env.OPENWORK_ENV_STORE });
+    const before = await env.list();
+    await sync.suspend();
+    draining = false;
+    await Bun.sleep(100);
+    expect(reloads).toBe(1);
+    expect(await env.list()).toEqual(before);
+    expect(await sync.run("not-ready")).toEqual({ status: "no_session" });
+    await sync.setSession({ baseUrl: "https://den.example.test", token: "token-b", orgId: "org_b" });
+    expect((await sync.run("ready")).status).toBe("applied");
+    expect(reloads).toBeGreaterThan(1);
   });
 
   test("materializes providers before the first workspace exists and finishes setup later", async () => {
@@ -747,6 +951,7 @@ describe("cloud provider sync gateway", () => {
 
   test("materializes Den providers globally, reconciles changes, and sweeps the session", async () => {
     const root = await createRoot();
+    process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS = "20";
     const engineRequests: string[] = [];
     const engine = Bun.serve({
       port: 0,
@@ -765,6 +970,7 @@ describe("cloud provider sync gateway", () => {
     stops.push(() => engine.stop(true));
 
     let denFailure = false;
+    let policyFailure = false;
     let denProviders = [
       buildProvider([
         { id: "model-z", name: "Model Z", config: { reasoning: true } },
@@ -784,7 +990,8 @@ describe("cloud provider sync gateway", () => {
         });
         // This fixture isolates provider-catalog outages; policy verification
         // remains available when the provider service fails.
-        if (url.pathname === "/v1/me/desktop-config") return Response.json({});
+        if (url.pathname === "/v1/me/desktop-config") return policyFailure
+          ? Response.json({ error: "denied" }, { status: 401 }) : Response.json({});
         if (denFailure) return Response.json({ error: "unavailable" }, { status: 503 });
         if (url.pathname === "/v1/llm-providers") return Response.json({ llmProviders: denProviders });
         const match = url.pathname.match(/^\/v1\/llm-providers\/([^/]+)\/connect$/);
@@ -825,6 +1032,43 @@ describe("cloud provider sync gateway", () => {
     expect((await responseRecord(capabilitiesResponse, "capabilities")).providerSync).toBe(true);
 
     expect(await runSync(base, "before-session")).toEqual({ status: "no_session" });
+
+    const identity = {
+      baseUrl: `http://127.0.0.1:${den.port}`,
+      token: "den-token",
+      orgId: "org_test",
+    };
+    const deliverIdentity = (body = identity, headers: Record<string, string> = hostHeaders()) => fetch(`${base}/den-session/identity`, {
+      method: "PUT", headers, body: JSON.stringify(body),
+    });
+    for (const headers of [{}, clientHeaders(), { ...hostHeaders(), "x-openwork-host-token": "wrong" }]) {
+      expect((await deliverIdentity(identity, headers)).status).toBe(401);
+    }
+    for (const body of [{ ...identity, baseUrl: "file:///tmp/den" }, { ...identity, token: "" }]) {
+      expect((await deliverIdentity(body)).status).toBe(400);
+    }
+    expect(denRequests).toEqual([]);
+    config.readOnly = true;
+    expect((await deliverIdentity()).status).toBe(403);
+    config.readOnly = false;
+    policyFailure = true;
+    expect((await deliverIdentity()).status).toBe(403);
+    expect(await runSync(base, "unverified-identity")).toEqual({ status: "no_session" });
+    policyFailure = false;
+    const env = new EnvService({ path: process.env.OPENWORK_ENV_STORE });
+    const envBefore = await env.list();
+    const providersBefore = runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config));
+    const fileBefore = await readFile(openworkRuntimeConfigFilePath(config), "utf8").catch(() => null);
+    const engineBefore = [...engineRequests];
+    expect((await deliverIdentity()).status).toBe(204);
+    await Bun.sleep(80);
+    expect(await runSync(base, "identity-is-not-ready")).toEqual({ status: "no_session" });
+    expect(denRequests.every((request) => request.path === "/v1/me/desktop-config")).toBe(true);
+    expect((await readGlobalRuntimeOpencodeConfig(config)).managedPolicy).toBeDefined();
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))).toEqual(providersBefore);
+    expect(await env.list()).toEqual(envBefore);
+    expect(await readFile(openworkRuntimeConfigFilePath(config), "utf8").catch(() => null)).toBe(fileBefore);
+    expect(engineRequests).toEqual(engineBefore);
 
     const sessionResponse = await fetch(`${base}/den-session`, {
       method: "PUT",

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -345,6 +345,7 @@ async function requestJson(
   fetchImpl: typeof globalThis.fetch,
   session: CloudProviderDenSession,
   path: string,
+  signal: AbortSignal,
 ): Promise<unknown> {
   let response: Response;
   try {
@@ -354,7 +355,7 @@ async function requestJson(
         Authorization: `Bearer ${session.token}`,
         "x-openwork-legacy-org-id": session.orgId,
       },
-      signal: AbortSignal.timeout(requestTimeoutMs),
+      signal: AbortSignal.any([signal, AbortSignal.timeout(requestTimeoutMs)]),
     });
   } catch (error) {
     throw new Error(error instanceof Error ? `den_request_failed: ${error.message}` : "den_request_failed");
@@ -371,12 +372,13 @@ async function requestJson(
 async function fetchProviders(
   fetchImpl: typeof globalThis.fetch,
   session: CloudProviderDenSession,
+  signal: AbortSignal,
 ): Promise<DenProviderConnection[]> {
-  const providers = parseProviderList(await requestJson(fetchImpl, session, "/v1/llm-providers"));
+  const providers = parseProviderList(await requestJson(fetchImpl, session, "/v1/llm-providers", signal));
   return Promise.all(
     providers.map(async (provider) =>
       parseProviderConnection(
-        await requestJson(fetchImpl, session, `/v1/llm-providers/${encodeURIComponent(provider.id)}/connect`),
+        await requestJson(fetchImpl, session, `/v1/llm-providers/${encodeURIComponent(provider.id)}/connect`, signal),
         provider,
       )),
   );
@@ -623,6 +625,7 @@ export class CloudProviderSync {
   private providers: CloudProviderSyncStatusProvider[] = [];
   private skippedProviders: CloudProviderSyncSkippedProvider[] = [];
   private fingerprint: string | null = null;
+  private materializationContextKey: string | null = null;
   private ownedEnvKeys = new Set<string>();
   private managedProviderIds = new Set<string>();
   private importedAtByCloudProviderId = new Map<string, number>();
@@ -634,6 +637,8 @@ export class CloudProviderSync {
   private trailingRun: CloudProviderSyncTrailingRun | null = null;
   private interval: ReturnType<typeof setInterval> | null = null;
   private pendingReloadRetry: ReturnType<typeof setTimeout> | null = null;
+  private suspended = false;
+  private providerFetchController = new AbortController();
   private readonly reloadRetryMs: number;
 
   constructor(options: CloudProviderSyncOptions) {
@@ -653,11 +658,13 @@ export class CloudProviderSync {
     if (this.pendingSession?.contextKey === contextKey) return this.pendingSession.promise;
 
     const hasMaterializedContext = this.session !== null
+      || this.activeRun !== null
       || this.managedProviderIds.size > 0
       || this.ownedEnvKeys.size > 0;
     this.contextGeneration += 1;
+    this.stopReloadRetry();
 
-    if (!hasMaterializedContext) {
+    if (!hasMaterializedContext && !this.suspended) {
       this.session = session;
       this.startInterval();
       void this.run("den_session_updated");
@@ -667,7 +674,6 @@ export class CloudProviderSync {
     const generation = this.contextGeneration;
     this.session = null;
     this.stopInterval();
-    this.stopReloadRetry();
     const trailing = this.trailingRun;
     this.trailingRun = null;
     trailing?.resolve({ status: "no_session" });
@@ -677,10 +683,13 @@ export class CloudProviderSync {
 
     const promise = this.enqueue(async () => {
       if (generation !== this.contextGeneration) return;
-      await this.sweep({ forceReload: true });
-      this.resetMaterializationState();
+      if (this.materializationContextKey !== null && this.materializationContextKey !== contextKey) {
+        await this.sweep({ forceReload: true });
+        this.resetMaterializationState();
+      }
       if (generation !== this.contextGeneration) return;
       this.session = session;
+      this.suspended = false;
       this.startInterval();
       void this.run("den_session_updated");
     });
@@ -697,7 +706,30 @@ export class CloudProviderSync {
     return promise;
   }
 
+  async suspend(): Promise<void> {
+    // Identity delivery must not materialize providers or reload an unready
+    // engine. Keep cleanup ownership for the next full session (or sign-out).
+    this.suspended = true;
+    this.providerFetchController.abort();
+    this.providerFetchController = new AbortController();
+    this.contextGeneration += 1;
+    this.pendingSession = null;
+    this.session = null;
+    this.stopInterval();
+    this.stopReloadRetry();
+    const trailing = this.trailingRun;
+    this.trailingRun = null;
+    trailing?.resolve({ status: "no_session" });
+    this.lastRun = null;
+    this.providers = [];
+    this.skippedProviders = [];
+    // Let already-started writes finish before acknowledging the identity;
+    // queued/fetching runs are invalidated by contextGeneration.
+    await this.enqueue(async () => undefined);
+  }
+
   async clearSession(): Promise<void> {
+    this.suspended = false;
     this.contextGeneration += 1;
     this.pendingSession = null;
     this.session = null;
@@ -781,6 +813,7 @@ export class CloudProviderSync {
   }
 
   private resetMaterializationState(): void {
+    this.materializationContextKey = null;
     this.lastRun = null;
     this.providers = [];
     this.skippedProviders = [];
@@ -849,13 +882,16 @@ export class CloudProviderSync {
    * session idles. Serialized on the same queue as sync passes.
    */
   private scheduleReloadRetry(): void {
-    if (this.pendingReloadRetry) return;
+    if (this.suspended || this.pendingReloadRetry) return;
+    const generation = this.contextGeneration;
     const timer = setTimeout(() => {
       this.pendingReloadRetry = null;
       if (!this.reloadPending) return;
       void this.enqueue(async () => {
-        if (!this.reloadPending) return;
-        if (await this.reloadDeferredByActivity()) {
+        if (this.suspended || generation !== this.contextGeneration || !this.reloadPending) return;
+        const busy = await this.reloadDeferredByActivity();
+        if (this.suspended || generation !== this.contextGeneration) return;
+        if (busy) {
           this.scheduleReloadRetry();
           return;
         }
@@ -910,9 +946,10 @@ export class CloudProviderSync {
 
   private async runPass(request: CloudProviderSyncRequest): Promise<CloudProviderSyncRunResult> {
     const { reason, session } = request;
+    if (request.generation !== this.contextGeneration) return { status: "no_session" };
     try {
       const [providers, storedEnv] = await Promise.all([
-        fetchProviders(this.fetchImpl, session),
+        fetchProviders(this.fetchImpl, session, this.providerFetchController.signal),
         this.env.list(),
       ]);
       // Local credentials only satisfy materialization eligibility. Never add
@@ -922,7 +959,11 @@ export class CloudProviderSync {
         .map((entry) => entry.key);
       const prepared = prepareMaterialization(providers, localEnvNames);
       if (request.generation !== this.contextGeneration) return { status: "no_session" };
+      // Ownership follows the apply that can write, not a pending session.
+      // Retain it through suspension, including a partially completed apply.
+      this.materializationContextKey = request.contextKey;
       const { changed, detail, reloadError } = await this.apply(prepared);
+      if (request.generation !== this.contextGeneration) return { status: "no_session" };
       // The materialization itself succeeded (config + env writes landed), so
       // record it even when the engine reload failed: hiding the providers
       // made a reload-only failure indistinguishable from "nothing synced".

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2886,6 +2886,19 @@ function createRoutes(
     return jsonResponse({ provider: runtimeProviderMap(runtime) });
   });
 
+  addRoute(routes, "PUT", "/den-session/identity", "host-token", async (ctx) => {
+    ensureWritable(config);
+    const session = parseCloudProviderDenSession(await readJsonBody(ctx.request));
+    if (!session) throw new ApiError(400, "invalid_payload", "baseUrl, token, and orgId are required");
+    const suspended = cloudProviderSync.suspend();
+    try {
+      await managedDesktopPolicy(config).setSession(session);
+    } finally {
+      await suspended;
+    }
+    return new Response(null, { status: 204 });
+  });
+
   addRoute(routes, "PUT", "/den-session", "host-token", async (ctx) => {
     ensureWritable(config);
     const session = parseCloudProviderDenSession(await readJsonBody(ctx.request));

--- a/evals/specs/app-render-crash-recovery.e2e.test.ts
+++ b/evals/specs/app-render-crash-recovery.e2e.test.ts
@@ -10,6 +10,7 @@ const heading = { text: /OpenWork hit an unexpected error/ };
 
 test("a render throw shows a recovery screen with the error instead of a blank window", async ({ world, user, agent, probe, step }) => {
   await step("the app is healthy and shows no recovery screen", async () => {
+    await user.see("composer", { editable: true, timeoutMs: 120_000 });
     expect((await probe.text()).trim().length).toBeGreaterThan(40);
     await user.notSee(heading);
   });
@@ -51,12 +52,15 @@ test("a render throw shows a recovery screen with the error instead of a blank w
   });
 
   await step("reload brings the app back", async () => {
+    const route = await probe.hash();
     await user.click({ role: "button", label: /^reload$/i });
     await probe.eventually(() => probe.text(), {
       within: 120_000,
       label: "app content after reload",
       until: (text) => text.trim().length > 40 && !/OpenWork hit an unexpected error/.test(text),
     });
+    await user.see("composer", { editable: true, timeoutMs: 120_000 });
+    expect(await probe.hash()).toBe(route);
     await user.notSee(heading);
   });
 });

--- a/evals/specs/managed-provider-env-delivery-reload.test.ts
+++ b/evals/specs/managed-provider-env-delivery-reload.test.ts
@@ -31,10 +31,15 @@ async function handleEngineRequest(
   response: ServerResponse,
   config: ServerConfig,
   requests: string[],
+  busy: boolean,
 ): Promise<void> {
   const method = request.method ?? "GET";
   const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
   requests.push(`${method} ${path}`);
+  if (method === "GET" && path === "/session/status") {
+    sendJson(response, 200, busy ? { ses_live: { type: "busy" } } : {});
+    return;
+  }
   if (method === "GET" && path === "/config") {
     const content = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
     response.writeHead(200, { "content-type": "application/json" });
@@ -53,8 +58,9 @@ async function handleEngineRequest(
 }
 
 async function startFakeEngine(config: ServerConfig, requests: string[]) {
+  let busy = false;
   const engine = createServer((request, response) => {
-    void handleEngineRequest(request, response, config, requests).catch((error) => {
+    void handleEngineRequest(request, response, config, requests, busy).catch((error) => {
       sendJson(response, 500, { error: error instanceof Error ? error.message : String(error) });
     });
   });
@@ -66,6 +72,7 @@ async function startFakeEngine(config: ServerConfig, requests: string[]) {
   if (!address || typeof address === "string") throw new Error("Fake engine did not bind a TCP port");
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
+    setBusy: (value: boolean) => { busy = value; },
     stop: () => new Promise<void>((resolve, reject) => {
       engine.close((error) => error ? reject(error) : resolve());
       engine.closeAllConnections();
@@ -73,7 +80,7 @@ async function startFakeEngine(config: ServerConfig, requests: string[]) {
   };
 }
 
-test("stored managed provider credentials reload the engine after auth delivery", async () => {
+test("stored managed provider credentials reload only after full session or auth delivery", async () => {
   const root = await mkdtemp(join(tmpdir(), "openwork-provider-env-reload-"));
   const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
   const previousEnvStore = process.env.OPENWORK_ENV_STORE;
@@ -113,6 +120,7 @@ test("stored managed provider credentials reload the engine after auth delivery"
   };
   let engine: Awaited<ReturnType<typeof startFakeEngine>> | undefined;
   let server: Awaited<ReturnType<typeof startServer>> | undefined;
+  let den: ReturnType<typeof createServer> | undefined;
 
   try {
     engine = await startFakeEngine(config, engineRequests);
@@ -199,8 +207,76 @@ test("stored managed provider credentials reload the engine after auth delivery"
       label: "rotated managed auth delivery followed by engine reload",
     })).toEqual(["PUT /auth/lpr_test", "POST /instance/dispose"]);
     expect(engineRequests).toEqual(["PUT /auth/lpr_test", "GET /session/status", "POST /instance/dispose"]);
+    engineRequests.length = 0;
+
+    const denRequests: string[] = [];
+    const cloudProvider = {
+      id: "lpr_ready", providerId: "openai-compatible", name: "Ready provider", source: "custom",
+      providerConfig: { env: ["READY_PROVIDER_KEY"], npm: "@ai-sdk/openai-compatible" },
+      apiKey: "sk-ready-only", models: [{ id: "ready-model", name: "Ready model", config: {} }],
+    };
+    const denWitness = createServer((request, response) => {
+      const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+      denRequests.push(path);
+      if (path === "/v1/me/desktop-config") sendJson(response, 200, {});
+      else if (path === "/v1/llm-providers") sendJson(response, 200, { llmProviders: [cloudProvider] });
+      else if (path === "/v1/llm-providers/lpr_ready/connect") sendJson(response, 200, { llmProvider: cloudProvider });
+      else sendJson(response, 404, { error: "not_found" });
+    });
+    den = denWitness;
+    await new Promise<void>((resolve, reject) => {
+      denWitness.once("error", reject);
+      denWitness.listen(0, "127.0.0.1", resolve);
+    });
+    const address = denWitness.address();
+    if (!address || typeof address === "string") throw new Error("Den witness did not bind a port");
+    const identity = JSON.stringify({ baseUrl: `http://127.0.0.1:${address.port}`, token: "test-den-token", orgId: "org_ready" });
+    const providersBefore = await (await fetch(`${base}/runtime-config/providers`, { headers: hostHeaders() })).json();
+    const envBefore = await readFile(process.env.OPENWORK_ENV_STORE, "utf8");
+    const configBefore = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
+    const early = await fetch(`${base}/den-session/identity`, { method: "PUT", headers: hostHeaders(), body: identity });
+    expect(early.status).toBe(204);
+    expect(await (await fetch(`${base}/managed-policy`, { headers: { authorization: `Bearer ${CLIENT_TOKEN}` } })).json())
+      .toMatchObject({ policy: {} });
+    const premature = await fetch(`${base}/cloud-provider-sync/run`, { method: "POST", headers: hostHeaders(), body: "{}" });
+    expect(await premature.json()).toEqual({ status: "no_session" });
+    expect(denRequests.every((path) => path === "/v1/me/desktop-config")).toBe(true);
+    expect(await (await fetch(`${base}/runtime-config/providers`, { headers: hostHeaders() })).json()).toEqual(providersBefore);
+    expect(await readFile(process.env.OPENWORK_ENV_STORE, "utf8")).toBe(envBefore);
+    expect(await readFile(openworkRuntimeConfigFilePath(config), "utf8")).toBe(configBefore);
+    expect(engineRequests).toEqual([]);
+
+    const ready = await fetch(`${base}/den-session`, { method: "PUT", headers: hostHeaders(), body: identity });
+    expect(ready.status).toBe(204);
+    await eventually(async () => {
+      const response = await fetch(`${base}/cloud-provider-sync/status`, { headers: { authorization: `Bearer ${CLIENT_TOKEN}` } });
+      return response.json();
+    }, { within: 5_000, intervalMs: 25, until: (status) => status.lastRun?.status === "applied", label: "automatic sync after full session delivery" });
+    expect(denRequests).toContain("/v1/llm-providers/lpr_ready/connect");
+    expect(await (await fetch(`${base}/env/READY_PROVIDER_KEY`, { headers: hostHeaders() })).json())
+      .toMatchObject({ item: { value: "sk-ready-only" } });
+    expect(managedProviderChanges(engineRequests)).toContain("PUT /auth/lpr_ready");
+    expect(engineRequests.indexOf("PUT /auth/lpr_ready")).toBeLessThan(engineRequests.indexOf("POST /instance/dispose"));
+
+    const materializedEnv = await readFile(process.env.OPENWORK_ENV_STORE, "utf8");
+    const materializedConfig = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
+    engine.setBusy(true);
+    engineRequests.length = 0;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect((await fetch(`${base}/den-session/identity`, { method: "PUT", headers: hostHeaders(), body: identity })).status).toBe(204);
+    }
+    expect((await fetch(`${base}/den-session`, { method: "PUT", headers: hostHeaders(), body: identity })).status).toBe(204);
+    const resumed = await fetch(`${base}/cloud-provider-sync/run`, { method: "POST", headers: hostHeaders(), body: "{}" });
+    expect(await resumed.json()).toEqual({ status: "noop" });
+    expect(await readFile(process.env.OPENWORK_ENV_STORE, "utf8")).toBe(materializedEnv);
+    expect(await readFile(openworkRuntimeConfigFilePath(config), "utf8")).toBe(materializedConfig);
+    expect(engineRequests.filter((entry) => !entry.startsWith("GET "))).toEqual([]);
   } finally {
     await server?.stop();
+    if (den) {
+      const witness = den;
+      await new Promise<void>((resolve) => { witness.close(() => resolve()); witness.closeAllConnections(); });
+    }
     await engine?.stop();
     resetManagedProviderAuthCache();
     if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;

--- a/evals/specs/reliable-app-recovery.e2e.test.ts
+++ b/evals/specs/reliable-app-recovery.e2e.test.ts
@@ -8,6 +8,7 @@ const verifiedArtifact = "https://releases.openwork.test/v1.8.2/OpenWork-darwin-
 test("a fatal desktop bootstrap failure offers one-click verified recovery without losing the profile", async ({ world, user, seed, probe }) => {
   await user.see({ text: /OpenWork (couldn't|could not) start/i });
   await user.see("Restore previous version");
+  await user.see({ role: "button", label: /^reload$/i });
   await user.notSee({ text: /EVAL_FATAL_DESKTOP_BOOTSTRAP_FAILURE|invalid code signature/ });
   await user.notSee({ text: /GitHub|open an issue|download.*manually/i });
 


### PR DESCRIPTION
## Summary

Recover trusted desktop credentials before engine readiness without starting provider materialization, and keep startup failures actionable instead of leaving an empty window. Follow-up to #4711.

- Add a host-only identity-delivery endpoint that verifies managed policy while suspending provider synchronization. Full session delivery and provider synchronization remain readiness-gated.
- Keep identity delivery separate from successful full-session delivery. Preserve endpoint/identity/runtime isolation, cancel obsolete work, and avoid premature fallback on older servers that do not support the new endpoint.
- Preserve existing credentials and configuration on same-identity resume; do not force disposal of a busy engine. Actual identity changes and sign-out retain cleanup.
- Render startup content before the entry bundle mounts, show progress while bootstrap/architecture/sign-in checks are pending, and expose Reload on loading/error screens. Bootstrap rejection reaches the existing error boundary without bypassing sign-in or policy gates.
- Extend existing component, server, and journey coverage; no new journey files or dependency changes.

## Compatibility and containment

- Remote, hostless, non-loopback, and gateway exclusions remain enforced.
- Legacy full-session delivery continues to start synchronization. An older server's identity-endpoint 404 does not trigger the full-session endpoint before readiness.
- The server-boundary test asserts no early provider config/environment/engine writes, later materialization, and unchanged config/environment with zero non-GET engine requests during same-identity resume while busy.
- Reload preserves the current route and retained profile; the desktop journey requires an editable composer after recovery.
- This does not change upstream authorization/rate-limit error classification or interrupted-sign-out inventory cleanup. Those remain separate concerns.

## Verification — Incomplete

Candidate: `c8cfcdd7def1b8a1d9c054387483a1d1a9b4a2ec`
Base and merge base: `00b0a1613bba00c785ae74934c0b6ed6cb5b2d8d` (`dev`)

Passed on the committed, rebased candidate (all exit 0; no failures or skips):

| Check | Result |
| --- | --- |
| `pnpm --filter @openwork/app exec bun test --isolate ./tests/session-provider-auth-server-sync.test.ts ./tests/cloud-provider-sync-gateway.test.ts ./tests/app-error-boundary.test.tsx ./tests/boot-state.test.ts` | 72 passed |
| `pnpm --filter openwork-server exec bun --conditions=development test src/cloud-provider-sync.e2e.test.ts src/cloud-provider-sync-reload-guard.test.ts` | 21 passed |
| `pnpm evals:pr specs/managed-provider-env-delivery-reload.test.ts` | 1 passed; isolated local HTTP boundary |
| `pnpm evals:e2e app-render-crash-recovery --local` | 1 passed |
| `pnpm evals:e2e reliable-app-recovery --local` | 1 passed |
| `pnpm --filter @openwork/app typecheck` | Passed |
| `pnpm --filter openwork-server typecheck` | Passed |
| `git diff --check origin/dev...HEAD` | Passed |

Both desktop runs reported: `selection: engine=legacy surface=legacy case=all; placement: local (--local)`.

### Remaining clearance

- Final-head evidence publication was attempted with the three saved journey runs, but the publisher exited 1 because `OPENWORK_REVIEW_URL` is not configured. Test results above passed locally; their full evidence reports are not published. Configure the review endpoint and publish the existing runs without rerunning them.
- `pnpm warden:check` failed with exit 1 because the configured review authentication was unavailable. The scope was 17 changed files/60 chunks. Expected: diff-security-review, confidentiality-review, spec-provenance-review, desktop-den-sync-review. No applicable skill established completed coverage; skipped output is not clearance. No validated finding IDs were produced. Head/base were unchanged before and after the attempt.
- Review run: `a2cec4f1-2026-09-10T00-13-35-547Z`.
- Pending/rejected startup promises are covered at component level. The desktop journeys verify actual render-crash reload and fatal-startup recovery, not every entry-bundle/bootstrap-IPC stall or every operating-system failure.
- A full cross-platform/enterprise deployment matrix was not run. Passing focused checks are not a zero-regression guarantee.
- Clear when the applicable final policy review completes without blockers and final-head journey evidence is inspectable on this PR. This PR is ready for review, not a merge or deployment authorization.
