### PR TITLE
fix(app): restore startup recovery button contrast

### DIFF
--- a/apps/app/src/react-app/shell/loading-overlay.tsx
+++ b/apps/app/src/react-app/shell/loading-overlay.tsx
@@ -115,7 +115,7 @@ export function LoadingOverlay() {
             <button
               type="button"
               disabled={!releases.some((release) => release.marking === "previous")}
-              className="rounded-md bg-dls-accent px-3 py-2 font-medium text-dls-accent-foreground disabled:opacity-50"
+              className="rounded-md bg-dls-accent px-3 py-2 font-medium text-[var(--dls-accent-fg)] disabled:opacity-50"
               onClick={() => void runRecovery(window.__OPENWORK_ELECTRON__?.recovery?.restorePrevious)}
             >
               Restore previous version


### PR DESCRIPTION
## Summary
Replace the undefined `text-dls-accent-foreground` utility on Restore previous version with `text-[var(--dls-accent-fg)]`, matching existing accent buttons. The paired foreground token follows light/dark and organization accent settings. Recovery behavior, disabled state, layout, and copy are unchanged.

## Validation
Verdict: **Incomplete**.

- Passed: `git diff --check origin/dev...HEAD` (exit 0).
- Passed: Node assertion calculating WCAG contrast for the default token values `#ffffff` / `#011627`: 18.33:1, above 4.5:1 (exit 0). This is a token-value calculation, not rendered UI proof.
- Inspected: foreground token exists in both themes and is updated by brand theming; the old utility has no theme mapping.
- Not run: `pnpm evals:e2e reliable-app-recovery`. This clean worktree has no app/eval dependencies installed; no cloud provisioning or new spend was authorized. No runtime tests passed, failed, or skipped; no head-matching evidence is available.
- Deferred: rendered contrast assertion in the existing recovery journey, which currently covers visibility and verified recovery behavior only. No new test files added.
- Not run: `pnpm warden:check`; model-backed review spend was not authorized. Expected applicable skills: diff-security-review, confidentiality-review, desktop-den-sync-review. Actually reviewed: none; no Warden run, findings, or clearance.

Head: `9f51b1dd110bf38805ad19e5c95d6d7c2256b0d8`.
Fetched base and merge base: `00b0a1613bba00c785ae74934c0b6ed6cb5b2d8d`. Rebase was a no-op; commit signature verified locally (`G`).

Opened ready as explicitly requested despite incomplete proof. This is not a merge-readiness claim; required CI and review remain outstanding.