### PR TITLE
Lead the landing page with sovereign AI positioning

### DIFF
--- a/ee/apps/landing/components/landing-app-demo-panel.tsx
+++ b/ee/apps/landing/components/landing-app-demo-panel.tsx
@@ -1,38 +1,35 @@
 import { ChevronRight } from "lucide-react";
 
 import type { DemoFlow } from "./landing-demo-flows";
-import { landingDemoFlowTimes } from "./landing-demo-flows";
 
 type Props = {
   flows: DemoFlow[];
   activeFlowId: string;
   onSelectFlow: (id: string) => void;
-  timesById?: Record<string, string>;
   className?: string;
 };
 
 export function LandingAppDemoPanel(props: Props) {
   const activeFlow = props.flows.find((flow) => flow.id === props.activeFlowId) ?? props.flows[0];
-  const timesById = props.timesById ?? landingDemoFlowTimes;
 
   return (
     <div
       className={[
-        "relative z-10 flex flex-col gap-4 md:flex-row md:items-start",
+        "relative z-10 flex min-w-0 flex-col gap-3 sm:flex-row sm:items-stretch",
         props.className
       ]
         .filter(Boolean)
         .join(" ")}
     >
-      <div className="flex w-full flex-col gap-1 rounded-xl border border-[#F1F5F9] bg-[var(--lp-tonal)] p-2 md:w-1/3">
+      <div className="hidden min-w-0 flex-col gap-1 rounded-xl border border-[#F1F5F9] bg-[var(--lp-tonal)] p-2 sm:flex sm:w-[30%]">
         {activeFlow.agents.map((agent) => (
           <div
             key={agent.name}
-            className="flex cursor-pointer items-center justify-between rounded-xl p-3 transition-colors hover:bg-[var(--lp-tonal)]"
+            className="flex flex-wrap items-center gap-2 rounded-xl p-2 transition-colors hover:bg-[var(--lp-tonal)]"
           >
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
               <div className={`h-6 w-6 rounded-full ${agent.color}`}></div>
-              <span className="text-sm font-medium">{agent.name}</span>
+              <span className="text-xs font-medium">{agent.name}</span>
             </div>
             {agent.desc ? <span className="text-xs text-[var(--lp-muted)]">{agent.desc}</span> : null}
           </div>
@@ -48,19 +45,17 @@ export function LandingAppDemoPanel(props: Props) {
                   key={flow.id}
                   type="button"
                   onClick={() => props.onSelectFlow(flow.id)}
-                  className={`flex items-center justify-between rounded-xl px-3 py-2.5 text-left text-[13px] transition-colors ${
+                  aria-pressed={isActive}
+                  className={`flex min-w-0 items-center justify-between rounded-xl px-2 py-2.5 text-left text-xs transition-colors ${
                       isActive ? "bg-[var(--lp-tonal)]" : "hover:bg-[var(--lp-tonal)]"
                   }`}
                 >
                   <span
-                    className={`mr-2 truncate ${
+                    className={`min-w-0 ${
                       isActive ? "font-medium text-[var(--lp-ink)]" : "text-[var(--lp-body)]"
                     }`}
                   >
-                    {flow.tabLabel}
-                  </span>
-                  <span className="whitespace-nowrap text-[var(--lp-muted)]">
-                    {timesById[flow.id] ?? "Now"}
+                    {flow.categoryLabel}
                   </span>
                 </button>
               );
@@ -75,14 +70,14 @@ export function LandingAppDemoPanel(props: Props) {
         </button>
       </div>
 
-      <div className="flex w-full flex-col overflow-hidden rounded-xl border border-[var(--lp-border)] bg-white shadow-sm md:w-2/3">
-        <div className="flex flex-col gap-4 px-5 pb-2 pt-5 text-[13px]">
+      <div className="flex min-w-0 w-full flex-col overflow-hidden rounded-xl border border-[var(--lp-border)] bg-white shadow-sm sm:w-[70%]">
+        <div className="flex flex-col gap-4 px-4 pb-4 pt-4 text-[13px]">
           {activeFlow.chatHistory.map((message, index) => {
             if (message.role === "user") {
               return (
                 <div
                   key={`${message.role}-${index}`}
-                  className="mt-2 max-w-[85%] self-center rounded-3xl bg-[var(--lp-tonal)] px-5 py-3 text-center text-[var(--lp-ink)]"
+                  className="max-w-full self-end rounded-2xl bg-[var(--lp-tonal)] px-4 py-3 text-left text-[var(--lp-ink)]"
                 >
                   {message.content}
                 </div>
@@ -116,12 +111,10 @@ export function LandingAppDemoPanel(props: Props) {
           })}
         </div>
 
-        <div className="border-t border-white/50 bg-white/50 p-4">
+        <div className="mt-auto border-t border-[var(--lp-border)] bg-white/50 p-3">
           <div className="mb-2 px-1 text-xs text-[var(--lp-muted)]">Describe your task</div>
-          <div className="rounded-xl border border-[#F1F5F9] bg-white p-3.5 text-sm leading-relaxed text-[#011627] shadow-sm">
-            {activeFlow.task} <span className="text-[var(--lp-muted)]">[task]</span> {activeFlow.context}{" "}
-            <span className="text-[var(--lp-muted)]">[context]</span> {activeFlow.output}{" "}
-            <span className="text-[var(--lp-muted)]">[result]</span>
+          <div className="rounded-xl border border-[#F1F5F9] bg-white p-3 text-xs leading-relaxed text-[#011627] shadow-sm">
+            {activeFlow.task}
           </div>
           <div className="mt-3 flex items-center justify-end px-1">
             <button

--- a/ee/apps/landing/components/landing-demo-flows.ts
+++ b/ee/apps/landing/components/landing-demo-flows.ts
@@ -164,4 +164,4 @@ export const landingDemoFlowTimes: Record<string, string> = {
   "outreach-creation": "22h ago"
 };
 
-export const defaultLandingDemoFlowId = landingDemoFlows[0]?.id ?? "";
+export const defaultLandingDemoFlowId = "data-analysis";

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { ArrowRight, Globe, Monitor, SquareTerminal } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -8,8 +8,7 @@ import { BrandLogo } from "./lp-brand-logos";
 import { LandingAppDemoPanel } from "./landing-app-demo-panel";
 import {
   defaultLandingDemoFlowId,
-  landingDemoFlows,
-  landingDemoFlowTimes
+  landingDemoFlows
 } from "./landing-demo-flows";
 import { LandingFaq } from "./landing-faq";
 import { LandingHeroPrompt } from "./landing-hero-prompt";
@@ -81,23 +80,39 @@ export function LandingHome(props: Props) {
         />
 
         <main className="mx-auto w-full max-w-[1176px] px-6 pb-8">
-          <section className="max-w-4xl pt-8 md:pt-12">
-            <h1 className="mb-5 text-4xl font-medium leading-[1.1] tracking-tight md:text-5xl lg:text-6xl">
-              The open source
-              <br />
-              Claude Cowork
-              <br />
-              <span className="font-pixel inline-block align-middle text-[1.05em] font-normal">
-                alternative.
-              </span>
-            </h1>
-            <p className="mb-6 max-w-4xl text-lg leading-relaxed text-gray-700 md:mb-7 md:text-xl">
-              OpenWork is the desktop app that lets you use 50+ LLMs, bring your
-              own keys, and share your setups seamlessly with your team.
-            </p>
+          <div
+            aria-hidden="true"
+            className="font-pixel flex justify-between pb-10 pt-6 text-[clamp(3rem,16vw,12rem)] leading-none tracking-[-0.06em] sm:pb-12 sm:pt-8 lg:pb-16"
+          >
+            {Array.from("OpenWork").map((letter, index) => (
+              <span key={index}>{letter}</span>
+            ))}
+          </div>
 
-            <div className="mt-6 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
-              <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+          <section
+            aria-labelledby="sovereign-hero-heading"
+            className="grid items-start gap-10 lg:grid-cols-[minmax(0,1.08fr)_minmax(0,1fr)] lg:gap-12"
+          >
+            <div className="min-w-0 lg:order-2 lg:pt-2">
+              <p className="mono mb-5 text-[11px] leading-relaxed tracking-[0.1em] text-[var(--lp-body)] sm:text-xs">
+                SOVEREIGN AI FOR KNOWLEDGE WORKERS
+              </p>
+              <h1
+                id="sovereign-hero-heading"
+                className="text-[clamp(2.5rem,4.4vw,3.25rem)] font-medium leading-[1.08] tracking-[-0.045em]"
+              >
+                Your AI workspace.
+                <br />
+                Without
+                <br />
+                <span className="whitespace-nowrap">vendor lock-in.</span>
+              </h1>
+              <p className="mt-6 max-w-xl text-[17px] leading-[1.6] text-[var(--lp-body)] lg:text-lg">
+                An open-source alternative to Claude Cowork, built for knowledge
+                workers who want the freedom to choose their AI.
+              </p>
+
+              <div className="mt-8 flex flex-wrap items-center gap-3">
                 {props.isMobileVisitor ? (
                   <a
                     href={CLOUD_SIGNUP_URL}
@@ -108,105 +123,71 @@ export function LandingHome(props: Props) {
                     Get Started for Free <ArrowRight size={18} />
                   </a>
                 ) : (
-                  <DownloadLink
-                    className="doc-button inline-flex items-center gap-2"
-                  >
+                  <DownloadLink className="doc-button inline-flex items-center gap-2">
                     Download for free <ArrowRight size={18} />
                   </DownloadLink>
                 )}
-                <a
-                  href={props.callHref}
-                  className="secondary-button"
-                  target={callExternal ? "_blank" : undefined}
-                  rel={callExternal ? "noreferrer" : undefined}
-                >
-                  Contact sales
+                <a href="/enterprise" className="secondary-button">
+                  Explore enterprise
                 </a>
               </div>
 
-              <div className="flex items-center gap-2 opacity-80 sm:ml-4">
-                <span className="text-[13px] font-medium text-gray-500">
-                  Backed by
-                </span>
-                <div className="flex items-center gap-1.5">
-                  <div className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] bg-[#ff6600] text-[11px] font-bold leading-none text-white">
-                    Y
+              <div className="mt-4 flex flex-wrap items-center gap-x-1.5 gap-y-2 text-xs text-[var(--lp-muted)]">
+                <span>Free desktop app</span>
+                <span aria-hidden="true">·</span>
+                <a href="/download" className="underline-offset-4 hover:underline">macOS</a>
+                <span aria-hidden="true">·</span>
+                <a href={props.windowsDownloadHref} className="underline-offset-4 hover:underline">Windows</a>
+                <span aria-hidden="true">·</span>
+                <a href={props.linuxDownloadHref} className="underline-offset-4 hover:underline">Linux</a>
+              </div>
+
+              {props.isMobileVisitor ? null : (
+                <div className="mt-7 flex flex-wrap items-center gap-3 border-t border-[var(--lp-border)] pt-5">
+                  <p className="text-xs text-[var(--lp-muted)]">Already use an AI agent? Let it set up OpenWork.</p>
+                  <LandingHeroPrompt compact />
+                </div>
+              )}
+
+              <div className="mt-7 flex items-center gap-2 text-xs text-[var(--lp-muted)]">
+                <span>Backed by</span>
+                <span className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] bg-[#ff6600] text-[11px] text-white">Y</span>
+                <span className="font-medium">Combinator</span>
+              </div>
+            </div>
+
+            <div id="product" className="min-w-0 scroll-mt-24 lg:order-1" aria-label="OpenWork product demo">
+              <div className="landing-shell overflow-hidden rounded-2xl">
+                <div className="relative flex h-10 items-center border-b border-white/50 bg-gradient-to-b from-white/90 to-white/60 px-4">
+                  <div className="flex gap-1.5" aria-hidden="true">
+                    <div className="h-2.5 w-2.5 rounded-full border border-[#e0443e]/20 bg-[#ff5f56]/90" />
+                    <div className="h-2.5 w-2.5 rounded-full border border-[#dea123]/20 bg-[#ffbd2e]/90" />
+                    <div className="h-2.5 w-2.5 rounded-full border border-[#1aab29]/20 bg-[#27c93f]/90" />
                   </div>
-                  <span className="text-[13px] font-semibold tracking-tight text-gray-600">
-                    Combinator
-                  </span>
+                  <span className="absolute left-1/2 -translate-x-1/2 text-xs font-medium text-[var(--lp-muted)]">OpenWork</span>
                 </div>
-              </div>
-            </div>
-
-            <div className="mt-4 flex flex-wrap items-center gap-x-1.5 gap-y-2 text-[13px] text-gray-500">
-              <span>Also available:</span>
-              <a
-                href={props.windowsDownloadHref}
-                className="text-[var(--lp-ink)] underline decoration-transparent underline-offset-4 transition-colors hover:decoration-current"
-              >
-                Windows
-              </a>
-              <span>·</span>
-              <a
-                href={props.linuxDownloadHref}
-                className="text-[var(--lp-ink)] underline decoration-transparent underline-offset-4 transition-colors hover:decoration-current"
-              >
-                Linux
-              </a>
-            </div>
-
-            {props.isMobileVisitor ? null : (
-              <LandingHeroPrompt className="mt-10 hidden md:block" />
-            )}
-          </section>
-
-          <section
-            className="relative mt-16 flex flex-col gap-6 overflow-hidden md:mt-20 md:gap-8"
-            aria-label="OpenWork product demo"
-          >
-            <div className="landing-shell relative flex flex-col overflow-hidden rounded-2xl">
-              <div className="relative z-20 flex h-10 w-full shrink-0 items-center border-b border-white/50 bg-gradient-to-b from-white/90 to-white/60 px-4">
-                <div className="flex gap-1.5">
-                  <div className="h-3 w-3 rounded-full border border-[#e0443e]/20 bg-[#ff5f56]/90 shadow-sm"></div>
-                  <div className="h-3 w-3 rounded-full border border-[#dea123]/20 bg-[#ffbd2e]/90 shadow-sm"></div>
-                  <div className="h-3 w-3 rounded-full border border-[#1aab29]/20 bg-[#27c93f]/90 shadow-sm"></div>
+                <div className="p-3">
+                  <LandingAppDemoPanel
+                    flows={landingDemoFlows}
+                    activeFlowId={activeDemo.id}
+                    onSelectFlow={setActiveDemoId}
+                  />
                 </div>
-                <div className="absolute left-1/2 -translate-x-1/2 text-[12px] font-medium tracking-wide text-gray-500">
-                  OpenWork
-                </div>
-              </div>
-
-              <div className="bg-white p-4 md:p-6">
-                <LandingAppDemoPanel
-                  flows={landingDemoFlows}
-                  activeFlowId={activeDemo.id}
-                  onSelectFlow={setActiveDemoId}
-                  timesById={landingDemoFlowTimes}
-                />
-              </div>
-
-              <div className="relative z-10 mb-4 flex w-full flex-col items-start justify-between gap-4 px-2 md:flex-row md:items-center">
-                <div className="landing-chip flex w-full flex-wrap gap-2 overflow-x-auto rounded-full p-1.5 md:w-[600px]">
+                <div className="flex flex-wrap gap-1 border-t border-[var(--lp-border)] px-3 py-3" aria-label="Example tasks">
                   {landingDemoFlows.map((flow) => {
                     const isActive = flow.id === activeDemo.id;
-
                     return (
                       <button
                         key={flow.id}
                         type="button"
                         onClick={() => setActiveDemoId(flow.id)}
                         aria-pressed={isActive}
-                        className={`relative cursor-pointer whitespace-nowrap rounded-full px-5 py-2 text-sm font-medium transition-colors ${
-                          isActive
-                            ? "text-[#011627]"
-                            : "text-gray-600 hover:text-gray-900"
-                        }`}
+                        className={`relative cursor-pointer rounded-full px-3 py-2 text-xs transition-colors ${isActive ? "text-[var(--lp-ink)]" : "text-[var(--lp-muted)] hover:text-[var(--lp-ink)]"}`}
                       >
                         {isActive ? (
                           <motion.div
                             layoutId="active-pill"
-                            className="absolute inset-0 rounded-full border border-gray-100 bg-white shadow-sm"
+                            className="absolute inset-0 rounded-full border border-[var(--lp-border)] bg-white shadow-sm"
                             transition={{ type: "spring", stiffness: 400, damping: 30 }}
                           />
                         ) : null}
@@ -215,30 +196,26 @@ export function LandingHome(props: Props) {
                     );
                   })}
                 </div>
-
-                <div className="min-h-[44px] text-left md:text-right">
-                  <AnimatePresence mode="wait">
-                    <motion.div
-                      key={activeDemo.id}
-                      initial={{ opacity: 0, y: 5 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -5 }}
-                      transition={{ duration: 0.2 }}
-                    >
-                      <div className="text-lg font-medium text-[#011627]">
-                        {activeDemo.title}
-                      </div>
-                      <div className="ml-auto mt-1 max-w-md text-sm text-gray-500">
-                        {activeDemo.description}
-                      </div>
-                    </motion.div>
-                  </AnimatePresence>
-                </div>
               </div>
+              <p className="mt-4 text-[13px] leading-relaxed text-[var(--lp-muted)]" aria-live="polite">
+                {activeDemo.description}
+              </p>
             </div>
           </section>
 
-          <section className="mt-[120px]">
+          <div className="mt-12 grid gap-4 border-y border-[var(--lp-border)] py-6 text-[13px] text-[var(--lp-body)] sm:grid-cols-3 sm:gap-0 lg:mt-16">
+            <a href="#models" className="flex items-center justify-between gap-3 transition-colors hover:text-[var(--lp-ink)] sm:pr-6">
+              Choose your models <ArrowRight size={15} aria-hidden="true" />
+            </a>
+            <a href="/enterprise" className="flex items-center justify-between gap-3 transition-colors hover:text-[var(--lp-ink)] sm:border-x sm:border-[var(--lp-border)] sm:px-6">
+              Control your deployment <ArrowRight size={15} aria-hidden="true" />
+            </a>
+            <a href="#comparison" className="flex items-center justify-between gap-3 transition-colors hover:text-[var(--lp-ink)] sm:pl-6">
+              Own your setup <ArrowRight size={15} aria-hidden="true" />
+            </a>
+          </div>
+
+          <section className="mt-20 scroll-mt-24 lg:mt-[120px]" id="models">
             <div className="mb-8">
               <h2 className="max-w-[680px] text-[16px] font-normal text-[var(--lp-ink)]">
                 Bring any model — or provision centrally for your whole org

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -350,14 +350,20 @@ test("visitors can explore the sovereign AI homepage without losing comparison o
     evidence.recordAssertionEvidence(`Homepage copy, links, and responsive layout at ${width}px`, JSON.stringify(facts), true);
   }
 
-  await clickAt(browser, (await waitForLocated(browser, { role: "button", label: /^Outreach Creation$/, nth: 1 }, { mustHitTest: true })).center);
-  const outreach = await eventually(() => evaluateOnSurface(browser, () => document.getElementById("product")?.innerText), {
+  const outreach = await eventually(async () => {
+    await freezeMotion(browser);
+    await clickAt(browser, (await waitForLocated(browser, { role: "button", label: /^Outreach Creation$/, nth: 1 }, { mustHitTest: true, timeoutMs: 5_000 })).center);
+    return evaluateOnSurface(browser, () => document.getElementById("product")?.innerText);
+  }, {
     within: 10_000, until: (text) => typeof text === "string" && text.includes("I've drafted the follow-up email"),
   });
   expect(outreach).not.toContain("I analyzed the spreadsheet");
   evidence.recordAssertionEvidence("Visitors can change the app demo to outreach", outreach, true);
-  await clickAt(browser, (await waitForLocated(browser, { role: "button", label: /^Data Analysis$/, nth: 1 }, { mustHitTest: true })).center);
-  const analysis = await eventually(() => evaluateOnSurface(browser, () => document.getElementById("product")?.innerText), {
+  const analysis = await eventually(async () => {
+    await freezeMotion(browser);
+    await clickAt(browser, (await waitForLocated(browser, { role: "button", label: /^Data Analysis$/, nth: 1 }, { mustHitTest: true, timeoutMs: 5_000 })).center);
+    return evaluateOnSurface(browser, () => document.getElementById("product")?.innerText);
+  }, {
     within: 10_000, until: (text) => typeof text === "string" && text.includes("I analyzed the spreadsheet"),
   });
   expect(analysis).not.toContain("I've drafted the follow-up email");

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { chrome } from "@openwork/hosts";
-import { clickAt, evaluateOnSurface, locate, navigate, reload, setViewport } from "@openwork/cdp";
+import { clickAt, evaluateOnSurface, freezeMotion, locate, navigate, reload, setViewport, waitForLocated } from "@openwork/cdp";
 import { eventually, needs, test } from "@openwork/testkit";
 
 test("visitors see consistent monthly Team and Enterprise pricing", async ({ evidence }) => {
@@ -240,9 +240,10 @@ test("download CTAs request the detected installer once and retain the alternati
 
       // Carry a campaign through the actual homepage CTA (not a crafted intent URL).
       await navigate(browser.client, `${origin}/${attribution}`);
-      await eventually(() => evaluateOnSurface(browser, () => document.body.innerText.includes("Contact sales")), { within: 30_000, until: Boolean });
+      await eventually(() => evaluateOnSurface(browser, () => location.pathname === "/" && Boolean(document.querySelector("main h1")?.textContent?.includes("Your AI workspace."))), { within: 30_000, until: Boolean });
+      await freezeMotion(browser);
       expect(requests).toHaveLength(before);
-      await clickAt(browser, (await locate(browser, { role: "link", text: device.platform === "Android" ? /^Download$/ : /^Download for free/ })).center);
+      await clickAt(browser, (await waitForLocated(browser, { role: "link", text: device.platform === "Android" ? /^Download$/ : /^Download for free/ }, { mustHitTest: true })).center);
       await eventually(() => evaluateOnSurface(browser, () => location.pathname + location.search), {
         within: 30_000, until: (path) => path === `/download${attribution}`
       });
@@ -285,4 +286,80 @@ test("download CTAs request the detected installer once and retain the alternati
   } finally {
     socket.close();
   }
+});
+
+
+test("visitors can explore the sovereign AI homepage without losing comparison or download paths", async ({ evidence }) => {
+  needs({ env: ["OPENWORK_EVAL_LANDING_URL"] });
+  const origin = process.env.OPENWORK_EVAL_LANDING_URL;
+  await using browser = await chrome({ startUrl: `${origin}/`, headless: true });
+  await eventually(() => evaluateOnSurface(browser, () => document.querySelector("h1")?.textContent), {
+    within: 30_000, until: (value) => typeof value === "string" && value.includes("vendor lock-in"),
+  });
+
+  await freezeMotion(browser);
+  for (const width of [320, 390, 768, 1024, 1440]) {
+    await setViewport(browser, { width, height: 1000, deviceScaleFactor: 1 });
+    const facts = await evaluateOnSurface(browser, async () => {
+      await document.fonts.ready;
+      const hero = document.querySelector<HTMLElement>('section[aria-labelledby="sovereign-hero-heading"]');
+      const heading = hero?.querySelector("h1");
+      const demo = document.getElementById("product");
+      if (!hero || !heading || !demo) throw new Error("Homepage hero or interactive demo is missing");
+      const headingBounds = heading.getBoundingClientRect();
+      const demoBounds = demo.getBoundingClientRect();
+      const buttons = [...demo.querySelectorAll<HTMLButtonElement>('button[aria-pressed]')]
+        .filter((button) => button.getBoundingClientRect().width > 0);
+      const links = [...hero.querySelectorAll<HTMLAnchorElement>("a")];
+      return {
+        heading: heading.innerText.replace(/\s+/g, " ").trim(),
+        headings: document.querySelectorAll("h1").length,
+        title: document.title,
+        canonical: document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href,
+        comparison: hero.innerText.includes("open-source alternative to Claude Cowork"),
+        migration: Boolean(document.querySelector('a[href="/docs/start-here/migrate-from-claude-cowork"]')),
+        modelSection: Boolean(document.getElementById("models")),
+        pageFits: document.documentElement.scrollWidth <= window.innerWidth,
+        headingFits: headingBounds.left >= 0 && headingBounds.right <= window.innerWidth && heading.scrollWidth <= heading.clientWidth,
+        demoFits: demoBounds.left >= 0 && demoBounds.right <= window.innerWidth && demo.scrollWidth <= demo.clientWidth,
+        linksFit: links.every((link) => {
+          const bounds = link.getBoundingClientRect();
+          return bounds.width > 0 && bounds.left >= 0 && bounds.right <= window.innerWidth;
+        }),
+        actions: links.map((link) => ({ text: link.textContent?.trim(), path: new URL(link.href).pathname })),
+        examples: buttons.map((button) => button.textContent?.trim()),
+        desktopSplit: demoBounds.right <= headingBounds.left,
+        mobileReadingOrder: headingBounds.bottom <= demoBounds.top,
+      };
+    });
+    expect(facts).toMatchObject({
+      headings: 1,
+      title: "OpenWork — Open source Claude Cowork alternative for teams",
+      canonical: "https://openworklabs.com/",
+      comparison: true, migration: true, modelSection: true,
+      pageFits: true, headingFits: true, demoFits: true, linksFit: true,
+    });
+    expect(facts.heading).toContain("Your AI workspace.");
+    expect(facts.heading).toContain("vendor lock-in.");
+    expect(facts.heading).not.toContain("Cowork");
+    expect(facts.actions).toContainEqual({ text: "Download for free", path: "/download" });
+    expect(facts.actions).toContainEqual({ text: "Explore enterprise", path: "/enterprise" });
+    expect(facts.examples).toEqual(expect.arrayContaining(["Browser Automation", "Data Analysis", "Outreach Creation"]));
+    if (width >= 1024) expect(facts.desktopSplit).toBe(true);
+    else expect(facts.mobileReadingOrder).toBe(true);
+    evidence.recordAssertionEvidence(`Homepage copy, links, and responsive layout at ${width}px`, JSON.stringify(facts), true);
+  }
+
+  await clickAt(browser, (await waitForLocated(browser, { role: "button", label: /^Outreach Creation$/, nth: 1 }, { mustHitTest: true })).center);
+  const outreach = await eventually(() => evaluateOnSurface(browser, () => document.getElementById("product")?.innerText), {
+    within: 10_000, until: (text) => typeof text === "string" && text.includes("I've drafted the follow-up email"),
+  });
+  expect(outreach).not.toContain("I analyzed the spreadsheet");
+  evidence.recordAssertionEvidence("Visitors can change the app demo to outreach", outreach, true);
+  await clickAt(browser, (await waitForLocated(browser, { role: "button", label: /^Data Analysis$/, nth: 1 }, { mustHitTest: true })).center);
+  const analysis = await eventually(() => evaluateOnSurface(browser, () => document.getElementById("product")?.innerText), {
+    within: 10_000, until: (text) => typeof text === "string" && text.includes("I analyzed the spreadsheet"),
+  });
+  expect(analysis).not.toContain("I've drafted the follow-up email");
+  evidence.recordAssertionEvidence("Visitors can return to the spreadsheet example", analysis, true);
 });


### PR DESCRIPTION
## Summary
Lead the homepage with sovereign AI for knowledge workers and “Your AI workspace. Without vendor lock-in.” The split hero pairs that message with the existing interactive app demo under an oversized OpenWork wordmark.

## Why
Make freedom from vendor lock-in the primary promise while retaining the visible Claude Cowork comparison and the existing search title, canonical, FAQ, structured data, and migration links.

## Issue
User-requested landing-page design; no linked issue.

## Scope
Reuse the existing Inter, FK Raster, and monospace fonts, Paper grain background, navigation, buttons, and demo shell. Start the demo on spreadsheet analysis, adapt it to the narrower column, and stack the copy before the demo on mobile. Add links to models, deployment, and the comparison. Extend the existing landing journey spec.

## Out of scope
Provider/runtime behavior, pricing, search-title changes, and deployment.

## Testing
The landing unit suite passed: 7 tests, 0 failures. Final PR-lane browser journeys passed on `355b624f`: 4 passed, 0 failed, 0 skipped, exit 0. Coverage includes five responsive widths, demo selection, pricing/footer journeys, and platform download behavior. Warden is incomplete: automatic approval review blocked execution because it may send the private diff to an external model service.

The production bundle compiles, but production type validation fails in `packages/email/src/render-email.ts:8` with incompatible React element/node types. The same build command fails at the same line on a clean control at base `8f6d4649d1391773b625d68de12a6b24e06a62d0`:

```sh
LANDING_DIST_DIR=.next/production pnpm --filter @openwork-ee/landing build
```

Standalone `pnpm --filter @openwork-ee/landing exec tsc --noEmit` also reports the same shared email/UI React type conflicts on both trees. Build and typecheck exit 1 through pnpm. No shared-package changes are included to mask these failures.

## CI status
Pending PR checks. Draft pending a passing production build and Warden approval/review.

## Manual verification
1. Open the homepage at desktop and mobile widths; check the wordmark, headline, Cowork supporting copy, and CTAs.
2. Change the demo between spreadsheet analysis and outreach.
3. Follow the models, enterprise, and comparison links; check that download choices remain available.

## Evidence
Desktop/mobile screenshots and original assertions are attached in the sticky test-evidence comment.

## Risk
The homepage H1 and visual hierarchy change; unchanged title and comparison copy do not guarantee unchanged search rankings. Production-build verification is blocked by the confirmed base-branch type issue.

## Rollback
Revert this PR’s commits.
