### PR TITLE
fix(app): list every Advanced section in the developer-mode command palette

### DIFF
--- a/apps/app/src/react-app/shell/command-palette-search.ts
+++ b/apps/app/src/react-app/shell/command-palette-search.ts
@@ -1,5 +1,7 @@
 import fuzzysort from "fuzzysort";
 
+import { ADVANCED_SETTINGS_SECTIONS } from "@/react-app/domains/settings/advanced-sections";
+
 export type PaletteGroup = "recent" | "actions" | "settings" | "sessions";
 
 export type PaletteItem = {
@@ -23,6 +25,9 @@ export type PaletteResultGroup = {
 };
 
 const GROUP_ORDER: PaletteGroup[] = ["recent", "actions", "settings", "sessions"];
+// The empty palette previews only a few settings. Developer mode lists the Advanced
+// sections first, so the preview must be wide enough to show every one of them.
+const SETTINGS_PREVIEW_LIMIT = Math.max(6, ADVANCED_SETTINGS_SECTIONS.length);
 const GROUP_LABELS: Record<PaletteGroup, string> = {
   recent: "Recent",
   actions: "Actions",
@@ -71,7 +76,7 @@ export function rankPaletteItems(
     const groups = [
       resultGroup("recent", recent),
       resultGroup("actions", nonRecentItems.filter((item) => itemGroup(item) === "actions")),
-      resultGroup("settings", nonRecentItems.filter((item) => itemGroup(item) === "settings").slice(0, 6)),
+      resultGroup("settings", nonRecentItems.filter((item) => itemGroup(item) === "settings").slice(0, SETTINGS_PREVIEW_LIMIT)),
       resultGroup("sessions", nonRecentItems.filter((item) => itemGroup(item) === "sessions").slice(0, 5)),
     ];
     return groups.filter((group) => group.items.length > 0);

--- a/apps/app/tests/command-palette-settings.test.ts
+++ b/apps/app/tests/command-palette-settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { ADVANCED_SETTINGS_SECTIONS } from "../src/react-app/domains/settings/advanced-sections";
 import { rankPaletteItems } from "../src/react-app/shell/command-palette-search";
 import { buildCommandPaletteSettingsItems } from "../src/react-app/shell/command-palette-settings";
 
@@ -42,6 +43,15 @@ describe("command palette settings", () => {
       "settings:extensions/agents",
       "settings:extensions/commands",
     ]);
+  });
+
+  test("lists every Advanced section in the empty developer-mode palette", () => {
+    const groups = rankPaletteItems("", build(true, true), []);
+    const settings = groups.find((group) => group.value === "settings");
+
+    expect(settings?.items.map((item) => item.id)).toEqual(expect.arrayContaining(
+      ADVANCED_SETTINGS_SECTIONS.map((section) => `settings:advanced/${section.id}`),
+    ));
   });
 
   test("finds recovery tools under Advanced", () => {

--- a/apps/app/tests/command-palette-settings.test.ts
+++ b/apps/app/tests/command-palette-settings.test.ts
@@ -24,7 +24,7 @@ describe("command palette settings", () => {
     expect(enabledIds).toContain("settings:updates");
   });
 
-  test("uses stable ids for tabs and Library sections", () => {
+  test("uses stable ids for tabs, Advanced sections, and Library sections", () => {
     expect(build(false, true).map((item) => item.id)).toEqual([
       "settings:general",
       "settings:preferences",
@@ -36,6 +36,13 @@ describe("command palette settings", () => {
       "settings:environment",
       "settings:updates",
       "settings:cloud-account",
+      "settings:advanced/organization-server",
+      "settings:advanced/runtime",
+      "settings:advanced/agent-access",
+      "settings:advanced/config-sources",
+      "settings:advanced/experimental-engine",
+      "settings:advanced/workspace-run-mode",
+      "settings:advanced/developer",
       "settings:extensions/skills",
       "settings:extensions/mcps",
       "settings:extensions/connections",
@@ -58,6 +65,9 @@ describe("command palette settings", () => {
     const items = build(false, true);
 
     expect(items.find((item) => item.id === "settings:advanced")?.keywords).toContain("recovery");
-    expect(rankPaletteItems("reset", items, [])[0]?.items[0]?.id).toBe("settings:advanced");
+    expect(rankPaletteItems("reset", items, [])[0]?.items.slice(0, 2).map((item) => item.id)).toEqual([
+      "settings:advanced/organization-server",
+      "settings:advanced",
+    ]);
   });
 });

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -123,6 +123,7 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.see({ role: "option", label: /^Agent access diagnostics/ });
     await user.see({ role: "option", label: /^OpenCode config sources/ });
     await user.see({ role: "option", label: /^Experimental engine/ });
+    await user.see({ role: "option", label: /^Workspace run mode/ });
     await user.see({ role: "option", label: /^Developer/ });
     await user.screenshot();
     await user.type(paletteInput, "Disable Developer Mode", { replace: true });
@@ -137,6 +138,7 @@ test("command palette searches settings by alias, navigates, records recents, an
     { query: "cloud mcp", title: "Agent access diagnostics", id: "agent-access" },
     { query: "config sources", title: "OpenCode config sources", id: "config-sources" },
     { query: "chat engine", title: "Experimental engine", id: "experimental-engine" },
+    { query: "keep going", title: "Workspace run mode", id: "workspace-run-mode" },
     { query: "deep link", title: "Developer", id: "developer" },
   ]) {
     await step(`Command+K jumps directly to ${section.title}`, async () => {


### PR DESCRIPTION
## Root cause

Triage: `/Users/guillaume/OpenWork Chat/reports/e2e-red-2026-09-09/triage.md` → **Cluster 5 — Command palette settings cap** (Brief F).

`rankPaletteItems` caps the no-query **Settings** group at 6 items. #4505 (`ee06ea14d`) put the Advanced sections first in developer mode and relied on there being exactly 6 of them. #4293 (`94649b44a`) added a 7th `ADVANCED_SETTINGS_SECTIONS` entry ("Workspace run mode"), so "Developer" fell off the empty developer-mode palette and `command-palette-search` went red (`Timed out … seeing label=/^Developer/`, first red nightly Sep 6).

## What changed

- `apps/app/src/react-app/shell/command-palette-search.ts` — the settings preview limit is now `Math.max(6, ADVANCED_SETTINGS_SECTIONS.length)`, so every Advanced section is always listed in developer mode; regular mode is unchanged in practice (7 tabs instead of 6 in the preview).
- `apps/app/tests/command-palette-settings.test.ts`
  - new unit test: the empty developer-mode palette lists every `settings:advanced/*` id (verified red without the fix, green with it).
  - re-expressed two claims that were **already red on `origin/dev` @ `c744e2d7b`** (stale since #4505 added per-section Advanced items): the stable-id list now includes the seven Advanced section ids, and `"reset"` is asserted to surface Advanced › Organization server (keyword "reset server") then the Advanced tab. This is re-expressing an intentional product change, not loosening.
- `evals/specs/command-palette-search.e2e.test.ts` — tightening: asserts "Workspace run mode" is listed in developer mode without a search and is reachable via its alias (`keep going`) in the Command+K jump loop.

## Proof

- `bun test --isolate tests/command-palette-search.test.ts tests/command-palette-settings.test.ts` (apps/app): 11 pass, 0 fail. `pnpm --filter @openwork/app typecheck`: exit 0.
- `OPENWORK_EVAL_REF=947150786472aed356b3978f3b8da11d23807ad6 pnpm evals:e2e command-palette-search --daytona` at sha `9471507`:
  - `selection: engine=legacy surface=legacy case=all; placement: daytona (--daytona)`
  - `[openwork/testkit] ==> source verified 947150786472aed356b3978f3b8da11d23807ad6`
  - `{"placement":"daytona","files":["command-palette-search"],"passed":1,"failed":0,"skipped":0,"verdict":"passed"}`

Verdict: **Passed** (Daytona lane, single spec, no skips).

## Noticed, not touched

- `pnpm --dir evals exec tsc -p tsconfig.json` reports ~358 pre-existing errors on `origin/dev` (mostly `packages/email` `--jsx` not set); none in this spec.
- `command-palette-pin-rename` is a separate cluster (macOS `Meta+K` sent to a Linux desktop) and is not addressed here.
