### PR TITLE
fix(app): show the Working treatment for a freshly delegated child task

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1752,6 +1752,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
           : undefined;
         const withFollowup = Boolean(args && typeof args === "object" && Reflect.get(args, "withFollowup") === true);
         setEvalMarkdownMessages(createSubagentActivityEvalMessages(props.sessionId, childSessionId, withFollowup));
+        // A delegating parent is mid-run. Without a streaming thread status the
+        // list reads the parent as stopped and the unobserved child shows
+        // "Waiting for task result" instead of the Working shimmer.
+        setEvalThreadStatus("streaming");
         useSessionActivityStore.getState().setRunStatus(
           props.workspaceId,
           props.sessionId,


### PR DESCRIPTION
## Root cause

Triage: `reports/e2e-red-2026-09-09/triage.md` → **Cluster 2 — Delegated-task activity rows** (Brief C).

`task-activity-shimmer` and `parent-child-permission-approval` ("a parent task surfaces and resolves its child session permission request") both look for `[data-subagent-activity="shimmer"]` on the seeded in-flight child. Since #4635 (`fc8c9852b`) `subagentRunActivity` returns `waiting-result` when the **parent thread is not running** and the child has no observed run (`resultPending = … || (!parentActive && !child?.runActive)`); #4642 (`1396c591f`) then started feeding the in-transcript row the real `parentActive` from `MessageList`'s `runActive` (`status === "submitted" | "streaming" | "retrying"`).

The dev-only `eval.task_activity.seed` hook only marked the **activity store** busy; the `ThreadStatus` that `MessageList` reads comes from the status query and stayed `"ready"`. So the seed rendered "a delegated child under a parent that has stopped", and the product — correctly, and as unit-tested in `message-list-loading.test.tsx` ("does not claim an unobserved child is running after its parent stops") — showed "Waiting for task result" instead of the Working shimmer.

**Decision:** the product state is intentional and right — a live delegating parent is mid-run, so a freshly delegated child with no progress yet *does* get the `shimmer` / "Working" treatment in real use. The seed was misrepresenting the scenario. Neither spec's claim nor prose changes.

## What changed

`apps/app/src/react-app/domains/session/surface/session-surface.tsx` — `eval.task_activity.seed` now also calls `setEvalThreadStatus("streaming")`, exactly like the neighbouring `eval.chat_loading.seed` already does. 4 lines, dev-only eval seam (`import.meta.env.DEV`), no production path touched.

## Proof (Daytona, sandbox `source verified 14ad97df531626c709e85e5cf48080fe0d9f4f24`)

```
OPENWORK_EVAL_REF=14ad97df531626c709e85e5cf48080fe0d9f4f24 pnpm evals:e2e task-activity-shimmer --daytona
selection: engine=legacy surface=legacy case=all; placement: daytona (--daytona)
 ✓ delegated-task activity stays with its original message after a follow-up  110314ms
Tests  1 passed (1)   → {"passed":1,"failed":0,"skipped":0,"verdict":"passed"}
```

```
OPENWORK_EVAL_REF=14ad97df531626c709e85e5cf48080fe0d9f4f24 pnpm evals:e2e parent-child-permission-approval --daytona
selection: engine=legacy surface=legacy case=all; placement: daytona (--daytona)
 ✓ switching and creating threads hydrate permissions without waiting for unrelated roots  121475ms
 ✓ a parent task surfaces and resolves its child session permission request  124752ms   ← this cluster's target, was red
 × retry recovery and stopping a permission leave other requests and fresh work intact   ← Cluster 1 (Brief B), pre-existing
 × a parent answers and stops real child questions, then finishes fresh work …            ← pre-existing, see below
Tests  2 failed | 2 passed (4)
```

The two remaining failures in that file are byte-identical to the `dev` baseline (`e2e-dev-baseline-61b41901c.log`: same messages, same spec lines 138 and 354) and are out of this cluster's scope:
- "Timed out waiting for the unrelated approval is pending … last value []" — the swallowed fresh-session send, **Cluster 1 / Brief B**.
- "Target remained visible: {role: button, label: /^Child checklist/}" at spec:354 after Stop + follow-up — not attributed to a cluster in the triage; noting it for the owner of Brief B/K to check.

Unit control: `apps/app` `pnpm typecheck` clean; `bun test tests/subagent-run-line.test.tsx` 5/5. `tests/message-list-loading.test.tsx` fails 10/16 with "Platform context is missing" both here **and** on a clean `origin/dev` @ `c744e2d7b` control worktree — pre-existing, untouched.

Verdict for this cluster: **Passed** (both target tests green at `14ad97df5`, 0 skips). All Daytona sandboxes from these runs were deleted.

## Noticed, not touched

- The uncommitted `subagent-run-line.tsx` edits in the main worktree (row → details toggle, separate "Open sub-agent chat" arrow button) are orthogonal to this fix; they change layout, not `subagentRunActivity`, so they will not reintroduce this red. They were read, not modified.
- `parent-child-permission-approval` test 4 failure above (not in the triage's clusters).
- `message-list-loading.test.tsx` "Platform context is missing" pre-existing unit red on `dev`.
