### PR TITLE
fix(app): close the restart prompt and command palette synchronously on dismiss

### DIFF
--- a/apps/app/src/components/ui/alert-dialog.tsx
+++ b/apps/app/src/components/ui/alert-dialog.tsx
@@ -30,7 +30,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Backdrop
       data-slot="alert-dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/30 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/30 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:hidden",
         className
       )}
       {...props}
@@ -48,11 +48,13 @@ function AlertDialogContent({
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
+      {/* Dismissal hides the popup in the same frame: an exit animation would keep
+          the dialog on screen (and its text visible) until Base UI unmounts it. */}
       <AlertDialogPrimitive.Popup
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl bg-popover p-6 text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl bg-popover p-6 text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:hidden",
           className
         )}
         {...props}

--- a/apps/app/src/components/ui/command.tsx
+++ b/apps/app/src/components/ui/command.tsx
@@ -43,7 +43,7 @@ export function CommandDialogBackdrop({
   return (
     <CommandDialogPrimitive.Backdrop
       className={cn(
-        "fixed inset-0 z-50 bg-black/32 transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "fixed inset-0 z-50 bg-black/32 transition-all duration-200 data-starting-style:opacity-0 data-closed:hidden",
         className,
       )}
       data-slot="command-dialog-backdrop"
@@ -80,9 +80,11 @@ export function CommandDialogPopup({
     <CommandDialogPortal {...portalProps}>
       <CommandDialogBackdrop />
       <CommandDialogViewport>
+        {/* Closing hides the palette in the same frame: an exit transition would keep
+            its search input on screen until Base UI unmounts the popup. */}
         <CommandDialogPrimitive.Popup
           className={cn(
-            "relative row-start-2 flex max-h-105 min-h-0 w-full min-w-0 max-w-xl -translate-y-[calc(1.25rem*var(--nested-dialogs))] scale-[calc(1-0.1*var(--nested-dialogs))] flex-col rounded-2xl border bg-popover not-dark:bg-clip-padding text-popover-foreground opacity-[calc(1-0.1*var(--nested-dialogs))] shadow-lg/5 outline-none transition-[scale,opacity,translate] duration-200 ease-in-out will-change-transform before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-2xl)-1px)] before:bg-muted/20 before:shadow-[0_1px_--theme(--color-black/4%)] data-nested:data-ending-style:translate-y-8 data-nested:data-starting-style:translate-y-8 data-nested-dialog-open:origin-top data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 **:data-[slot=scroll-area-viewport]:data-has-overflow-y:pe-0.5 dark:before:shadow-[0_-1px_--theme(--color-white/6%)] backdrop-blur-xl",
+            "relative row-start-2 flex max-h-105 min-h-0 w-full min-w-0 max-w-xl -translate-y-[calc(1.25rem*var(--nested-dialogs))] scale-[calc(1-0.1*var(--nested-dialogs))] flex-col rounded-2xl border bg-popover not-dark:bg-clip-padding text-popover-foreground opacity-[calc(1-0.1*var(--nested-dialogs))] shadow-lg/5 outline-none transition-[scale,opacity,translate] duration-200 ease-in-out will-change-transform before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-2xl)-1px)] before:bg-muted/20 before:shadow-[0_1px_--theme(--color-black/4%)] data-nested:data-starting-style:translate-y-8 data-nested-dialog-open:origin-top data-starting-style:scale-98 data-starting-style:opacity-0 data-closed:hidden **:data-[slot=scroll-area-viewport]:data-has-overflow-y:pe-0.5 dark:before:shadow-[0_-1px_--theme(--color-white/6%)] backdrop-blur-xl",
             className,
           )}
           data-slot="command-dialog-popup"


### PR DESCRIPTION
## Root cause

Triage cluster 7/K in `reports/e2e-red-2026-09-09/triage.md` ("Dismiss-then-`notSee` races"): `assertAbsent` (`evals/packages/cdp/src/input.ts`) requires the target to be gone on its **first** inspection, ~44 ms after the dismissing input. Both dialogs are Base UI popups that stay mounted until their exit motion finishes (`useAnimationsFinished` on the popup element):

- `AlertDialogContent` (restart prompt, `desktop-updater-provider.tsx`): `data-closed:animate-out fade-out-0 zoom-out-95 duration-100` → still opaque enough to count as visible at 44 ms → `Target remained visible: "Restart OpenWork?"`. Test 2 of the same spec ("control rail not ready … Keep completed after update") was the follow-on of that dialog still being open.
- `CommandDialogPopup` (command palette): `transition-[scale,opacity,translate] duration-200 data-ending-style:opacity-0` → the palette input with placeholder `Search actions, settings, and sessions…` is still visible right after `Escape` (`streamed-markdown-answer` test 3).

## What changed

Dismissal now hides the popup in the same frame: `data-closed:hidden` on the AlertDialog popup/overlay and the command palette popup/backdrop, replacing their exit animation/transition (entrance motion is unchanged). `display:none` is used rather than `visibility:hidden` because the AlertDialog's `duration-100` leaves `transition-property` at its `all` default, which would animate `visibility` as a discrete step and keep the element visible for the whole duration. With no running animation Base UI unmounts the popup on the next frame. No spec was changed; no waits were added.

## Proof (Daytona, sha `a42676ec1b6f51f831359e6b4f47320233b19565`, `OPENWORK_EVAL_REF` pinned — sandbox log: `HEAD is now at a42676ec`)

Placement line for both runs: `{"lane":"e2e","daytona":true,"placement":"daytona","engine":"legacy","surface":"legacy","vision":"defer",…}`

`pnpm evals:e2e background-desktop-update --daytona` → passed 1 / failed 1 / skipped 0
- ✓ `a confirmed update relaunch resumes only the unfinished task on its original engine` (the cluster's follow-on test; red on dev)
- × `updates download outside Settings and offer a persistent, optional restart` — the cluster claims now pass in the trace: `click(Keep working)` → `notSee(text=Restart OpenWork?)` ok (absent for the full 3000 ms window), and `press(Escape)` → `notSee(text=Restart Studio?)` ok. The test then fails **later**, at spec line 89 (`click({role:"button", text:"Check now"})` in the install-failure loop): `Located element was visible=true, hitTestOk=false. Covered by div text="Check now"` for 30 s, i.e. the Settings `Check now` button is disabled (`busy || checking || downloading`) after a failed install. That loop was added by #4714, which merged as "Verification — Incomplete" with this spec never executed; the triage lane predates it. Not touched here.

`pnpm evals:e2e streamed-markdown-answer --daytona` → passed 1 / failed 3 / skipped 0
- Tests 1–2 are triage Cluster 1 (fresh-session `Run task` click swallowed; `draftText` is `"\n"`), unchanged and out of scope.
- × test 3 `v1 keeps long tool-rich history…` — the cluster claims pass: `press(Escape)` → `notSee(placeholder=Search servers and artifacts...)` ok and `press(Escape)` → `notSee(placeholder=Search actions, settings, and sessions…)` ok, each observed twice for the full 3 s window. It then fails **later** in `browseHistory` (added by #4683, never reached on the lane before): `keyboard browsing settles above the latest turn … expected 561 to be greater than or equal to 657` (`rows.at(-1).rect.top >= viewport.bottom` after `PageUp`). Not touched here.
- ✓ `CONT-01 restores the exact cumulative prefix…`

Verdict for this PR's claim: dismissal is synchronous for both dialogs (observable in both traces). Spec-level verdict for the two files remains **Incomplete** because of the two unrelated downstream failures above. Both runs' sandboxes were deleted by the testkit.

Also: `pnpm --dir apps/app typecheck` exit 0.

## Noticed, not touched

1. #4714 follow-up: after a failed `Restart & update`, Settings › Updates `Check now` stays disabled (button `pointer-events:none`, hit lands on its wrapper) so the new install-failure loop in `background-desktop-update` cannot proceed. Hypothesis: an automatic check → auto-download leaves the status in `downloading` with the mock's `finishDownload` unresolved; needs a probe of `updateStatus` at that point.
2. #4683 follow-up: `browseHistory` in `streamed-markdown-answer` test 3 — after `PageUp` the last user row's top (561) never gets ≥ the viewport bottom (657) on Daytona.
3. `components/ui/dialog.tsx` still uses the same `data-closed:animate-out … duration-100` exit pattern; any spec that `notSee`s right after closing a plain Dialog will hit the same race. Left alone to stay in scope.
4. `command-palette-search` / `command-palette-pin-rename` already work around this race with `probe.eventually(… footer disappears)` before `notSee`; those waits are now unnecessary.
