### PR TITLE
fix(desktop): unregister managed policy engine plugins

### DIFF
--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import { randomUUID } from "node:crypto";
-import { managedDesktopPolicy } from "./managed-desktop-policy.js";
 import { mkdir } from "node:fs/promises";
 
 import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
@@ -83,7 +82,6 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
       ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
       OPENWORK_SERVER_URL: serverUrl,
       OPENWORK_SERVER_TOKEN: config.token,
-      OPENWORK_POLICY_TOKEN: managedDesktopPolicy(config).evaluationToken,
       OPENCODE_CONFIG: runtimeConfigPath,
       OPENCODE_MODELS_URL: opencodeModelsUrl,
     };

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -7,7 +7,6 @@
  */
 import { randomUUID } from "node:crypto";
 import { stopTaskRecovery } from "./task-recovery.js";
-import { managedDesktopPolicy } from "./managed-desktop-policy.js";
 import { mkdir } from "node:fs/promises";
 import { resolveServerConfig, type CliArgs } from "./config.js";
 import {
@@ -217,7 +216,6 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
         ...(process.env.OPENWORK_UI_CONTROL_DISCOVERY ? { OPENWORK_UI_CONTROL_DISCOVERY: process.env.OPENWORK_UI_CONTROL_DISCOVERY } : {}),
         OPENWORK_SERVER_URL: serverUrl,
         OPENWORK_SERVER_TOKEN: config.token,
-        OPENWORK_POLICY_TOKEN: managedDesktopPolicy(config).evaluationToken,
         OPENCODE_CONFIG: runtimeConfigPath,
         OPENCODE_MODELS_URL: opencodeModelsUrl,
       };

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -494,7 +494,6 @@ export function createEngineV2Preview(options: { config: ServerConfig; env?: Pic
       bin: resolved.bin,
       rootDir,
       env: { OPENCODE_MODELS_URL: opencodeModelsUrl },
-      checkPolicy: (action, input) => managedDesktopPolicy(config).assert(action, input),
       permissions: async () => executionRules((await readGlobalRuntimeOpencodeConfig(config)).managedPolicy?.execution),
     });
     sidecar = managed;

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -1,13 +1,10 @@
-import { managedPolicyPluginPath } from "./managed-policy-plugin.js";
 import type { EnginePermissionRule } from "./managed-policy-rules.js";
-import { serveManagedPolicyIpc, type ManagedPolicyCheck } from "./managed-policy-ipc.js";
 // Parallel v2 lane prototype: provider injection is a watched-config write. This module
 // deliberately has no reload/dispose call, unlike managed-opencode.ts and server.ts reloadOpencodeEngine.
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
 import { appendEngineOutputTail, createEngineStartupLineReader } from "./engine-output.js";
 
 export { installOpencodeV2Binary } from "./opencode-v2-binary.js";
@@ -39,7 +36,6 @@ export interface ManagedOpencodeV2ServerOptions {
   env?: Record<string, string>;
   bootTimeoutMs?: number;
   permissions?: () => Promise<EnginePermissionRule[]>;
-  checkPolicy?: ManagedPolicyCheck;
 }
 
 export interface OpencodeV2Health {
@@ -85,7 +81,6 @@ export async function createManagedOpencodeV2Server(
   const port = options.port ?? 0;
   const bootTimeoutMs = options.bootTimeoutMs ?? 60_000;
   const configDir = join(options.rootDir, "config");
-  const policyPluginDir = join(options.rootDir, "managed-policy");
   const password = randomBytes(24).toString("base64url");
   const username = "opencode";
   let url = "";
@@ -112,16 +107,9 @@ export async function createManagedOpencodeV2Server(
   await chmod(options.rootDir, 0o700);
   await mkdir(configDir, { recursive: true, mode: 0o700 });
   await chmod(configDir, 0o700);
-  if (options.checkPolicy) {
-    // The pinned v2 loader accepts configured plugin directories, not files.
-    // Keep its entrypoint inside that directory for the loader's path check.
-    await mkdir(policyPluginDir, { recursive: true, mode: 0o700 });
-    await chmod(policyPluginDir, 0o700);
-    await writeFile(join(policyPluginDir, "server.js"),
-      `export { default } from ${JSON.stringify(pathToFileURL(managedPolicyPluginPath(true)).href)};\n`,
-      { mode: 0o600 });
-  }
-  // Load enforcement on the first boot, before any session can run.
+  // Replace the generated config before boot, removing stale managed-policy
+  // registrations while retaining independent engine permissions. Leave the
+  // old entrypoint on disk: another configuration may still reference it.
   await writeProviders();
   const child = spawn(options.bin, ["serve", "--hostname", hostname, "--port", String(port)], {
     env: {
@@ -131,10 +119,8 @@ export async function createManagedOpencodeV2Server(
       OPENCODE_CONFIG_DIR: configDir,
       ...(opencodeModelsUrl === undefined ? {} : { OPENCODE_MODELS_URL: opencodeModelsUrl }),
     },
-    stdio: ["ignore", "pipe", "pipe", options.checkPolicy ? "ipc" : "ignore"],
-    serialization: "json",
+    stdio: ["ignore", "pipe", "pipe"],
   });
-  if (options.checkPolicy) serveManagedPolicyIpc(child, options.checkPolicy);
 
   let stdout = "";
   let stderr = "";
@@ -150,14 +136,12 @@ export async function createManagedOpencodeV2Server(
     closed = true;
     lines.stop();
   });
-  // The extra IPC entry selects spawn's nullable-stream overload, but both
-  // diagnostic streams are explicitly piped above.
-  child.stdout!.on("data", (chunk) => {
+  child.stdout.on("data", (chunk) => {
     const text = String(chunk);
     stdout = appendEngineOutputTail(stdout, text);
     lines.write(text);
   });
-  child.stderr!.on("data", (chunk) => {
+  child.stderr.on("data", (chunk) => {
     stderr = appendEngineOutputTail(stderr, String(chunk));
   });
   child.on("error", (error) => {
@@ -248,7 +232,6 @@ export async function createManagedOpencodeV2Server(
       $schema: "https://opencode.ai/config.json",
       providers: providerConfig,
       ...(options.permissions ? { permissions: await options.permissions() } : {}),
-      ...(options.checkPolicy ? { plugins: [policyPluginDir] } : {}),
     }, null, 2)}\n`, { mode: 0o600 });
     await rename(temporary, target);
   }

--- a/apps/server/src/managed-opencode.test.ts
+++ b/apps/server/src/managed-opencode.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -117,29 +117,22 @@ describe("managed OpenCode startup", () => {
     });
   }
 
-  test("checks next-engine policy over private IPC without giving shell children a credential or channel", async () => {
+  test("starts next-engine without managed policy credentials or IPC", async () => {
     const root = await createRoot();
-    const clientPath = new URL("./opencode-plugins/managed-policy-next.ts", import.meta.url).href;
+    const policyDir = join(root, "managed-policy");
+    await mkdir(policyDir);
+    await mkdir(join(root, "config"));
+    const oldEntrypoint = "export default {}; // retained for explicit references\n";
+    await writeFile(join(policyDir, "server.js"), oldEntrypoint);
+    await writeFile(join(root, "config", "opencode.json"), JSON.stringify({ plugins: [policyDir] }));
     const shellPath = join(root, "shell-child.mjs");
     await writeFile(shellPath, "console.log(JSON.stringify({ policy: process.env.OPENWORK_POLICY_TOKEN ?? null, client: process.env.OPENWORK_SERVER_TOKEN ?? null, ipc: typeof process.send === 'function' }));");
-    const checked: Array<{ action: string; input: Record<string, unknown> }> = [];
-    const checking = Promise.withResolvers<void>();
-    const unblock = Promise.withResolvers<void>();
     const bin = await writeExecutable(root, "policy-env.mjs", [
-      `import plugin from ${JSON.stringify(clientPath)};`,
       "import { execFileSync } from 'node:child_process';",
-      "const hooks = {};",
-      "await plugin.setup(Object.fromEntries(['tool', 'shell', 'session'].map(kind => [kind, { hook: async (name, callback) => { hooks[kind] = callback; } }])));",
       "const server = Bun.serve({ hostname: '127.0.0.1', port: 0, async fetch(request) {",
       "  const path = new URL(request.url).pathname;",
-      "  if (path === '/env') return Response.json({ policy: process.env.OPENWORK_POLICY_TOKEN ?? null, client: process.env.OPENWORK_SERVER_TOKEN ?? null });",
+      "  if (path === '/env') return Response.json({ policy: process.env.OPENWORK_POLICY_TOKEN ?? null, client: process.env.OPENWORK_SERVER_TOKEN ?? null, ipc: typeof process.send === 'function' });",
       `  if (path === '/shell-env') return Response.json(JSON.parse(execFileSync(process.execPath, [${JSON.stringify(shellPath)}], { encoding: 'utf8' })));`,
-      "  if (path === '/disconnect') { process.disconnect(); return Response.json({ ok: true }); }",
-      "  if (path === '/check') {",
-      "    const { kind, event } = await request.json();",
-      "    try { await hooks[kind](event); return Response.json({ allowed: true }); }",
-      "    catch (error) { return Response.json({ allowed: false, message: error.message }); }",
-      "  }",
       "  return Response.json({ healthy: true, version: 'test', pid: process.pid });",
       "} });",
       "console.log(`opencode server listening on http://127.0.0.1:${server.port}`);",
@@ -148,33 +141,16 @@ describe("managed OpenCode startup", () => {
     const managed = await createManagedOpencodeV2Server({
       bin, rootDir: root,
       env: { OPENWORK_SERVER_TOKEN: "must-stay-private", OPENWORK_POLICY_TOKEN: "policy-only-test-token" },
-      checkPolicy: async (action, input) => {
-        checked.push({ action, input });
-        if (input.command === "blocked") throw new Error("Command blocked by team policy.");
-        if (input.command === "waiting") { checking.resolve(); await unblock.promise; }
-      },
+      permissions: async () => [{ action: "shell", resource: "*", effect: "deny" }],
     });
     try {
-      expect(await managed.fetchJson("/env")).toEqual({ status: 200, json: { policy: null, client: null } });
+      const config = JSON.parse(await readFile(join(root, "config", "opencode.json"), "utf8"));
+      expect(config.plugins).toBeUndefined();
+      expect(config.permissions).toEqual([{ action: "shell", resource: "*", effect: "deny" }]);
+      expect(await readFile(join(policyDir, "server.js"), "utf8")).toBe(oldEntrypoint);
+      expect(await managed.fetchJson("/env")).toEqual({ status: 200, json: { policy: null, client: null, ipc: false } });
       expect(await managed.fetchJson("/shell-env")).toEqual({ status: 200, json: { policy: null, client: null, ipc: false } });
-      const check = (kind: string, event: Record<string, unknown>) => managed.fetchJson("/check", { method: "POST", body: { kind, event }, timeoutMs: 2000 });
-      expect(await check("shell", { command: "allowed" })).toEqual({ status: 200, json: { allowed: true } });
-      expect(await check("shell", { command: "blocked" })).toEqual({ status: 200, json: { allowed: false, message: "Command blocked by team policy." } });
-      expect(await check("tool", { tool: "read", input: {} })).toEqual({ status: 200, json: { allowed: true } });
-      expect(await check("session", { model: { providerID: "fixture", id: "model" } })).toEqual({ status: 200, json: { allowed: true } });
-      expect(checked).toEqual([
-        { action: "shell", input: { command: "allowed" } },
-        { action: "shell", input: { command: "blocked" } },
-        { action: "sync", input: {} },
-        { action: "model", input: { providerID: "fixture", id: "model" } },
-      ]);
-      const waiting = check("shell", { command: "waiting" });
-      await checking.promise;
-      await managed.fetchJson("/disconnect");
-      expect(await waiting).toEqual({ status: 200, json: { allowed: false, message: "OpenWork policy service is unavailable." } });
-      expect(await check("shell", { command: "allowed" })).toEqual({ status: 200, json: { allowed: false, message: "OpenWork policy service is unavailable." } });
-      expect(checked).toHaveLength(5);
-    } finally { unblock.resolve(); await managed.close(); }
+    } finally { await managed.close(); }
   });
 
   test("spawns the engine with npm audit disabled so first-run installs never wait on the advisories endpoint", async () => {

--- a/apps/server/src/managed-policy-plugin.ts
+++ b/apps/server/src/managed-policy-plugin.ts
@@ -1,4 +1,15 @@
 import { openworkPluginPath } from "./openwork-extensions-plugin-path.js";
+import { fileURLToPath } from "node:url";
 export function managedPolicyPluginPath(next = false): string {
   return openworkPluginPath(next ? "managed-policy-next" : "managed-policy");
+}
+
+// Remove only our own registrations, including file-URL copies persisted by
+// older runtime configs. A third-party plugin with the same basename is valid.
+export function isManagedPolicyPlugin(value: string): boolean {
+  let path = value;
+  if (value.startsWith("file:")) {
+    try { path = fileURLToPath(value); } catch { return false; }
+  }
+  return path === managedPolicyPluginPath() || path === managedPolicyPluginPath(true);
 }

--- a/apps/server/src/managed-policy-rules.ts
+++ b/apps/server/src/managed-policy-rules.ts
@@ -17,9 +17,9 @@ export const desktopPolicyTargets = {
 } satisfies Record<DesktopPolicyKey, string>;
 
 export const executionPolicyTargets = {
-  commands: ["engine.shell", "tool.before", "shell.before", "engine.proxy"],
-  blockedCommands: ["engine.shell", "tool.before", "shell.before", "engine.proxy"],
-  browserOrigins: ["engine.webfetch", "tool.before", "browser.request"],
+  commands: ["engine.shell", "engine.proxy"],
+  blockedCommands: ["engine.shell", "engine.proxy"],
+  browserOrigins: ["engine.webfetch", "browser.request"],
   blockBrowserUploads: ["browser.request"],
 } satisfies Record<keyof DesktopExecutionPolicy, readonly string[]>;
 

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { managedPolicyPluginPath } from "./managed-policy-plugin.js";
 
 import {
   buildOpenworkRuntimeConfig,
@@ -58,6 +60,8 @@ async function readConfigFile(config: ServerConfig): Promise<Record<string, unkn
 describe("openwork runtime config file", () => {
   test("managed browser restrictions use scalar actions in global and agent permissions", () => {
     const parsed = buildOpenworkRuntimeConfigObjectFromSnapshot({
+      plugin: [managedPolicyPluginPath(), pathToFileURL(managedPolicyPluginPath(true)).href,
+        "ordinary-plugin", "/user/plugins/managed-policy.ts"],
       managedPolicy: {
         execution: {
           commands: "deny", blockedCommands: ["curl *"],
@@ -69,6 +73,10 @@ describe("openwork runtime config file", () => {
     expect(parsed.permission).toEqual(permission);
     expect(parsed.agent).toMatchObject({ openwork: { permission } });
     expect(parsed.managedPolicy).toBeUndefined();
+    expect(parsed.plugin).not.toContain(managedPolicyPluginPath());
+    expect(parsed.plugin).not.toContain(pathToFileURL(managedPolicyPluginPath(true)).href);
+    expect(parsed.plugin).toContain("ordinary-plugin");
+    expect(parsed.plugin).toContain("/user/plugins/managed-policy.ts");
     expect(buildOpenworkRuntimeConfigObjectFromSnapshot({}).permission).toEqual({});
   });
 

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -1,5 +1,5 @@
 import { legacyExecutionPermissions } from "./managed-policy-rules.js";
-import { managedPolicyPluginPath } from "./managed-policy-plugin.js";
+import { isManagedPolicyPlugin } from "./managed-policy-plugin.js";
 /**
  * Runtime OpenCode configuration injected via a server-managed config file
  * passed to the engine as OPENCODE_CONFIG.
@@ -91,7 +91,6 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
       },
     },
     plugin: [
-      managedPolicyPluginPath(),
       openworkChromeDevtoolsPluginPath(),
       // Registration order is prompt order: the knowledge plugin appends the
       // operating rules first, then the extensions plugin adds app-control
@@ -105,7 +104,7 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
       openworkAnthropicAdaptiveThinkingPluginPath(),
       openworkAnthropicToolSchemaPluginPath(),
       openworkTitleRecoveryPluginPath(),
-      ...runtimePluginList(runtimeConfig),
+      ...runtimePluginList(runtimeConfig).filter((plugin) => !isManagedPolicyPlugin(plugin)),
     ],
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),
     mcp: Object.fromEntries(Object.entries(runtimeMcpMap(runtimeConfig))

--- a/docs/desktop-policy-engine-rollback.md
+++ b/docs/desktop-policy-engine-rollback.md
@@ -1,0 +1,50 @@
+# Desktop managed-policy engine rollback
+
+OpenWork no longer automatically registers `managed-policy` in OpenCode v1 or
+`managed-policy-next` in OpenCode v2. Agent tools no longer wait for these
+plugins' per-tool HTTP or IPC policy checks. The v2 engine is started without
+the policy IPC channel; v1 no longer receives a policy-evaluation credential.
+
+Restart OpenWork and its managed engines after upgrading. Rewriting generated
+configuration does not unload hooks already installed in a running engine.
+
+## Configuration cleanup
+
+The v1 generated runtime configuration omits the managed plugin, including
+copies of either current managed plugin path persisted in the runtime plugin
+list (plain paths or file URLs). The v2 generated configuration is replaced
+before startup without its old `managed-policy` directory registration.
+Old plugin files are retained because another configuration may reference them.
+Ordinary user plugins remain supported. Explicit registrations in user-owned
+configuration are not deleted automatically.
+
+## Enforcement that remains
+
+- Server request admission, configuration-management gates, terminal and saved
+  command gates, and model checks at the server request boundary.
+- Independent generated engine command permissions in both generations;
+  built-in web fetching/search restrictions when approved sites are configured.
+- Native built-in browser request, origin, and upload gates.
+- Local engine approvals, Den authorization and model assignment, and desktop
+  capability and branding controls.
+
+Command and browser controls remain visible because their enforcement does not
+depend solely on the removed plugin.
+
+## Enforcement removed
+
+- Engine-local protected-configuration checks before file writes, edits, and
+  patches. Server configuration endpoints still have their own gates, but an
+  engine file tool no longer calls the policy service to protect these paths.
+- Policy synchronization before read-only and otherwise unclassified tools.
+  An already-running turn no longer revalidates policy at every tool boundary.
+- Hook-time model checks in engine session/chat hooks. Server admission and Den
+  inference authorization remain separate checks; they do not recreate those
+  in-engine hooks.
+- Live per-tool command/browser/extension classification by the managed plugin.
+  Generated permissions and native/server gates continue independently, without
+  making a fresh policy request from every engine tool.
+
+These remaining controls are not a replacement for the removed engine-local
+checks or an OS sandbox. This rollback does not deploy an upgrade or restart any
+existing desktop automatically.

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -9,7 +9,11 @@ const definitions = {
   // Boots the packaged cloud and enterprise artifacts; only packaged-smoke provides those binaries.
   'packaged-first-launch.e2e.test.ts': { name: 'Open a fresh cloud or enterprise install', placement: 'local' },
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
-  'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
+  'desktop-policy-restricted-mode.e2e.test.ts': {
+    // The rollback case severs local child IPC and faults its loopback transport.
+    name: 'Apply organization and team permissions', critical: true, placement: 'local',
+    cases: [{ id: 'POLICY-ROLLBACK', engines: ['v1', 'v2'], surfaces: ['web'], defaultSurface: 'web', optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v1', surface: 'web' } }],
+  },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },
   'workspace-new-task-hit-target.e2e.test.ts': { name: 'Keep new tasks and sends instantly responsive', placement: 'local' },
   'streamed-markdown-answer.e2e.test.ts': {

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -58,6 +58,13 @@ test('registered case metadata names exact files, supported execution axes, and 
   const entries = await catalog();
   assert.deepEqual(registeredCases.map(({ spec, id, engines, surfaces, defaultSurface }) => ({ spec, id, engines, surfaces, defaultSurface })), [
     {
+      spec: 'desktop-policy-restricted-mode.e2e.test.ts',
+      id: 'POLICY-ROLLBACK',
+      engines: ['v1', 'v2'],
+      surfaces: ['web'],
+      defaultSurface: 'web',
+    },
+    {
       spec: 'streamed-markdown-answer.e2e.test.ts',
       id: 'CONT-01',
       engines: ['v1', 'v2'],

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 import { selectModel } from "@openwork/behaviors";
 import { spec, type Agent, type User } from "@openwork/testkit";
-import { defaultPolicyEditorAndMemberDesktop, managedPolicyRecovery, readDefaultDesktopPolicy, teamAccess } from "../worlds/desktop-policies.ts";
+import { defaultPolicyEditorAndMemberDesktop, managedPolicyRecovery, policyTransportRollback, readDefaultDesktopPolicy, teamAccess } from "../worlds/desktop-policies.ts";
 
 // An organization that wants a vanilla OpenWork picks one decision, Restricted,
 // in the Den policy editor. This spec drives the real editor as the admin and a
@@ -11,11 +11,17 @@ import { defaultPolicyEditorAndMemberDesktop, managedPolicyRecovery, readDefault
 const defaultJourney = "an admin restricts the default policy and the member desktop enforces it";
 const teamJourney = "team access overrides overlapping grants and restores only selected desktop capabilities";
 const recoveryJourney = "managed policy evaluation bounds transient Den retries and never reuses stale access";
+const rollbackJourney = "POLICY-ROLLBACK tools complete when policy HTTP fails and IPC is disconnected";
 // Register one fixture extension: Vitest 3 accumulates fixtures when the same
 // base is extended twice. Choose the setup at the test boundary, keeping the
 // worlds framework-free and each sequential journey isolated.
 const test = spec.world(async (seed) => {
   const name = expect.getState().currentTestName;
+  if (name?.endsWith(rollbackJourney)) {
+    const rollback = await policyTransportRollback(seed);
+    return { app: rollback.app, rollback, defaultPolicy: null, team: null, recovery: null,
+      [Symbol.asyncDispose]: () => rollback[Symbol.asyncDispose]() };
+  }
   if (name?.endsWith(defaultJourney)) {
     return { defaultPolicy: await defaultPolicyEditorAndMemberDesktop(seed), team: null, recovery: null };
   }
@@ -322,6 +328,37 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Connection") && !restrictedMcpText.includes("Local MCP") && !restrictedMcpText.includes("Add workspace MCP"),
   );
 
+});
+
+test(rollbackJourney, { timeout: 300_000 }, async ({ world, user, agent, probe, step, evidence }) => {
+  if (!("rollback" in world) || !world.rollback) throw new Error("Expected the rollback world");
+  const rollback = world.rollback;
+  await step("the isolated engine starts with a failing policy transport", async () => {
+    expect(await rollback.faultReceipt()).toBe("HTTP fault configured; IPC fd closed");
+    expect(await rollback.checkFault()).toMatchObject({ status: 503 });
+    expect(rollback.policyRequests()).toHaveLength(1);
+  });
+  await user.type("composer", `Copy the supplied local file using the requested tools. ${rollback.marker}`);
+  await agent.run("composer.send");
+  const snapshot = await step("real read and command tools complete despite the fault", async () => {
+    return probe.eventually(async () => {
+      await rollback.approve();
+      return rollback.native();
+    }, {
+      within: 120_000, label: "read and shell completed in native engine history",
+      until: (snapshot) => snapshot.ok && snapshot.data.messages.flatMap((message) => message.parts)
+        .filter((part) => ["read", "bash", "shell"].includes(part.tool) && part.status === "completed").length === 2,
+    });
+  });
+  expect(snapshot.ok).toBe(true);
+  expect(await rollback.output()).toBe(rollback.content);
+  expect(rollback.policyRequests()).toHaveLength(1);
+  await user.see({ text: "The requested file was copied successfully." }, { timeoutMs: 30_000 });
+  evidence.recordAssertionEvidence(
+    `${rollback.engine} executes read and shell with policy HTTP 503 and disconnected IPC`,
+    JSON.stringify({ engine: rollback.engine, snapshot, output: await rollback.output(), policyRequests: rollback.policyRequests() }),
+    true,
+  );
 });
 
 test(recoveryJourney, { timeout: 300_000 }, async ({ world: selectedWorld, step, evidence }) => {

--- a/evals/specs/opencode-v2-provider-hot-inject.test.ts
+++ b/evals/specs/opencode-v2-provider-hot-inject.test.ts
@@ -52,8 +52,6 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
   const binary = await resolveOpencodeV2Bin();
   const nonce = `WITNESS-OK-${randomBytes(12).toString("hex")}`;
   const requests: WitnessRequest[] = [];
-  const policyChecks: Array<{ action: string; input: Record<string, unknown> }> = [];
-  let blockProviderB = true;
   let impersonatorRequests = 0;
   const witness = createServer(async (request, response) => {
     if (request.url === "/api/health") {
@@ -137,12 +135,6 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
         OPENAI_API_KEY: "fixture-server-only", ANTHROPIC_API_KEY: "fixture-server-only",
         AWS_SECRET_ACCESS_KEY: "fixture-server-only", GITHUB_TOKEN: "fixture-server-only",
         DATABASE_URL: "fixture-server-only", CUSTOM_SERVICE_SECRET: "fixture-server-only",
-      },
-      checkPolicy: async (action, input) => {
-        policyChecks.push({ action, input });
-        if (blockProviderB && action === "model" && input.providerID === "openwork-witness-b") {
-          throw new Error("Witness B is blocked by team policy.");
-        }
       },
     });
     const initialHealth = await server.health();
@@ -247,10 +239,9 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
       throw new Error("The policy boundary shell probe did not return output");
     }
     expect(JSON.parse(shellMessage.output.output.trim())).toEqual({ policy: false, client: false, ipc: false });
-    expect(policyChecks).toContainEqual({ action: "shell", input: { command } });
     evidence.recordAssertionEvidence(
       "shell execution cannot inherit the host policy credential or IPC channel",
-      "The real v2 shell completed a presence-only probe: neither policy nor client credentials nor a process IPC capability were inherited, while its shell policy hook reached the host.",
+      "The real v2 shell completed a presence-only probe: neither policy nor client credentials nor a process IPC capability were inherited.",
       true,
     );
     const promptA = await server.fetchJson(`/api/session/${idA}/prompt`, {
@@ -265,7 +256,6 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
     );
     expect(requests.some((entry) => entry.auth === "Bearer witness-key-a" && entry.model === "witness-model-a")).toBe(true);
     expect(requests.some((entry) => entry.model === "witness-model-b")).toBe(false);
-    expect(policyChecks).toContainEqual({ action: "model", input: expect.objectContaining({ providerID: "openwork-witness-a", id: "witness-model-a" }) });
     evidence.recordAssertionEvidence(
       "C3 positive provider A execution and negative wrong-credential routing",
       "The A session received the witness nonce, and the witness observed model A paired with only the expected Bearer key A assertion.",
@@ -314,29 +304,8 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
       body: { text: "reply with anything" },
     });
     expect(promptB.status).toBe(200);
-    await eventually(async () => {
-      const result = await server?.fetchJson(`/api/session/${idB}`, { directory });
-      return isRecord(result?.json) && isRecord(result.json.data) ? result.json.data.outcome : undefined;
-    }, { within: 15_000, intervalMs: 100, label: "blocked model execution to fail", until: (outcome) => outcome === "failed" });
-    await eventually(async () => {
-      const result = await server?.fetchJson("/api/session/active", { directory });
-      return isRecord(result?.json) && isRecord(result.json.data) && result.json.data[idB] === undefined;
-    }, { within: 15_000, intervalMs: 100, label: "blocked model execution to settle", until: (idle) => idle });
-    expect(policyChecks.some((entry) => entry.action === "model" && entry.input.providerID === "openwork-witness-b")).toBe(true);
-    expect(requests.some((entry) => entry.model === "witness-model-b")).toBe(false);
-    evidence.recordAssertionEvidence(
-      "policy checks stay in the host without a policy credential in the engine",
-      "The v2 model hook reached the host over private IPC: A was permitted, B reached a failed idle outcome after the host denied it, and the provider witness received no B request.",
-      true,
-    );
-    // Removing the restriction uses the same host callback and same engine.
-    blockProviderB = false;
-    const allowedPromptB = await server.fetchJson(`/api/session/${idB}/prompt`, {
-      method: "POST",
-      directory,
-      body: { text: "reply with anything" },
-    });
-    expect(allowedPromptB.status).toBe(200);
+    // Direct engine prompts no longer run the removed managed model hook.
+    // Server request admission and Den model authorization are separate journeys.
     await eventually(
       async () => JSON.stringify((await server?.fetchJson(`/api/session/${idB}/message`, { directory }))?.json),
       { within: 60_000, intervalMs: 250, label: "provider B witness response", until: (text) => text.includes(nonce) },

--- a/evals/specs/opencode-v2-provider-hot-inject.test.ts
+++ b/evals/specs/opencode-v2-provider-hot-inject.test.ts
@@ -225,7 +225,9 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
     if (idA === undefined) throw new Error("Provider A session response did not contain data.id");
     const shellProbe = join(directory, "policy-boundary.cjs");
     await writeFile(shellProbe, `console.log(JSON.stringify({ policy: Object.hasOwn(process.env, "OPENWORK_POLICY_TOKEN"), client: Object.hasOwn(process.env, "OPENWORK_SERVER_TOKEN"), ipc: typeof process.send === "function" }));\n`);
-    const command = `node "${shellProbe}"`;
+    // The engine's login shell can replace PATH. Use the test runner's Node,
+    // rather than an unrelated system install, for this presence-only probe.
+    const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(shellProbe)}`;
     const shell = await server.fetchJson(`/api/session/${idA}/shell`, {
       method: "POST", directory, body: { command }, timeoutMs: 15_000,
     });
@@ -234,7 +236,7 @@ test("opencode v2 injects providers at runtime without an engine reload", { time
     const shellMessage: unknown = isRecord(shellMessages.json) && Array.isArray(shellMessages.json.data)
       ? shellMessages.json.data.find((message: unknown) => isRecord(message) && message.type === "shell" && message.command === command)
       : undefined;
-    expect(shellMessage).toMatchObject({ status: "exited", exit: 0 });
+    expect(shellMessage, JSON.stringify(shellMessage)).toMatchObject({ status: "exited", exit: 0 });
     if (!isRecord(shellMessage) || !isRecord(shellMessage.output) || typeof shellMessage.output.output !== "string") {
       throw new Error("The policy boundary shell probe did not return output");
     }

--- a/evals/worlds/desktop-policies.ts
+++ b/evals/worlds/desktop-policies.ts
@@ -1,9 +1,129 @@
-import { faultProxy, mcpMock } from "@openwork/env";
+import { faultProxy, mcpMock, resolveEvalEngine } from "@openwork/env";
+import { execFileSync } from "node:child_process";
+import { createServer } from "node:http";
+import { engineSessionProbe } from "@openwork/behaviors";
+import { configureProvider } from "./chat.ts";
 import type { Seed } from "@openwork/env";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { isRecord, records } from "./library.ts";
 import { bootServer, stopChild } from "./openwork-server-cli.ts";
+
+/** Real app-web tools with the old policy HTTP service faulted and IPC severed.
+ * Wrappers affect only this fixture's captured PATH, never a personal engine. */
+export async function policyTransportRollback(seed: Seed) {
+  await using setup = new AsyncDisposableStack();
+  const engine = resolveEvalEngine();
+  const root = seed.tmpPath("policy-transport-rollback");
+  const bin = join(root, "bin");
+  const workspacePath = join(root, "workspace");
+  await mkdir(bin, { recursive: true });
+  await mkdir(workspacePath, { recursive: true });
+  const input = "policy-transport-input.txt";
+  const content = `tool-read-witness-${Date.now()}`;
+  await writeFile(join(workspacePath, input), content);
+  const requests: string[] = [];
+  const upstreamPath = join(root, "upstream.txt");
+  const fault = createServer(async (request, response) => {
+    if (request.url === "/managed-policy/evaluate") {
+      requests.push(request.url);
+      response.writeHead(503, { "content-type": "application/json" });
+      response.end(JSON.stringify({ message: "Fixture policy transport unavailable" }));
+      return;
+    }
+    try {
+      const upstream = await readFile(upstreamPath, "utf8");
+      const body = [];
+      for await (const chunk of request) body.push(Buffer.from(chunk));
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(request.headers)) {
+        if (value !== undefined && !["host", "connection", "content-length"].includes(key)) headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+      }
+      const result = await fetch(`${upstream}${request.url}`, {
+        method: request.method, headers,
+        ...(body.length ? { body: Buffer.concat(body) } : {}),
+        signal: AbortSignal.timeout(30_000),
+      });
+      response.writeHead(result.status, { "content-type": result.headers.get("content-type") ?? "application/json" });
+      response.end(Buffer.from(await result.arrayBuffer()));
+    } catch {
+      response.writeHead(502);
+      response.end("Fixture forwarding failed");
+    }
+  });
+  setup.defer(async () => {
+    fault.closeAllConnections();
+    await new Promise<void>((resolve) => fault.close(() => resolve()));
+  });
+  await new Promise<void>((resolve) => fault.listen(0, "127.0.0.1", resolve));
+  const address = fault.address();
+  if (!address || typeof address === "string") throw new Error("Policy fault did not bind");
+  const faultUrl = `http://127.0.0.1:${address.port}`;
+  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  for (const name of ["opencode", "opencode2"]) {
+    const real = execFileSync("which", [name], { encoding: "utf8" }).trim();
+    await writeFile(join(bin, name), `#!/bin/sh
+if [ "$1" = "serve" ]; then
+  printf '%s' "$OPENWORK_SERVER_URL" > ${quote(upstreamPath)}
+  export OPENWORK_SERVER_URL=${quote(faultUrl)}
+  export OPENWORK_POLICY_TOKEN=fixture-policy-transport
+  unset NODE_CHANNEL_FD NODE_CHANNEL_SERIALIZATION_MODE
+  exec 3<&- 3>&-
+  printf '%s' 'HTTP fault configured; IPC fd closed' > ${quote(join(root, `${name}-fault.txt`))}
+fi
+exec ${quote(real)} "$@"
+`, { mode: 0o700 });
+  }
+  const marker = "POLICY_TRANSPORT_ROLLBACK";
+  const output = "policy-tool-output.txt";
+  const command = `printf '%s' '${content}' > '${output}'`;
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${bin}:${previousPath}`;
+  let app;
+  try {
+    app = await seed.appWeb({
+      name: "policy-transport-rollback", workspacePath, headless: true,
+      mocks: { witness: seed.mock({ isolatedProcessEnv: true, agentWorkloads: [{
+        promptMarker: marker, finalReply: "The requested file was copied successfully.", steps: [
+          { tool: "read", arguments: { filePath: join(workspacePath, input), path: join(workspacePath, input) } },
+          { tool: engine === "v2" ? "shell" : "bash", arguments: { command, description: "Copy the read witness" } },
+        ],
+      }] }) },
+    });
+  } finally {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+  }
+  const workspace = await seed.workspace(app, workspacePath);
+  const providerId = "policy-rollback-witness";
+  const modelId = "policy-rollback-model";
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    permission: { bash: "allow", read: "allow" },
+    provider: { [providerId]: {
+      npm: "@ai-sdk/openai-compatible", name: "Policy rollback witness",
+      options: { baseURL: `${app.mocks.witness!.url}/v1`, apiKey: "fixture-only" },
+      models: { [modelId]: { name: "Policy rollback model", tool_call: true } },
+    } },
+  }, engine);
+  const session = await seed.session(app, { title: "Copy a local file during policy outage" });
+  const token = await seed.evalIn(app, () => localStorage.getItem("openwork.server.token"));
+  if (typeof token !== "string" || !token) throw new Error("Missing isolated app-web token");
+  const native = engineSessionProbe({ engine, serverUrl: app.openworkUrl, token, workspaceId: workspace.workspaceId });
+  const owned = setup.move();
+  return {
+    app, engine, marker, session, content, command,
+    native: () => native.snapshot(session.sessionId),
+    approve: () => native.approvePendingPermissions(session.sessionId),
+    output: () => readFile(join(workspacePath, output), "utf8"),
+    faultReceipt: () => readFile(join(root, `${engine === "v2" ? "opencode2" : "opencode"}-fault.txt`), "utf8"),
+    checkFault: async () => {
+      const response = await fetch(`${faultUrl}/managed-policy/evaluate`, { method: "POST" });
+      return { status: response.status, message: await response.text() };
+    },
+    policyRequests: () => [...requests],
+    [Symbol.asyncDispose]: () => owned.disposeAsync(),
+  };
+}
 
 /**
  * The organization's default desktop policy as Den returns it, with the shape


### PR DESCRIPTION
## Authorized rollback
Unregister the automatically injected desktop managed-policy engine plugins in v1 and v2 so per-tool HTTP/IPC policy communication cannot block agent tools. Based on c744e2d7b; no opt-in lease changes.

- Remove v1 registration and policy-token injection. Exclude copies of the current managed plugin paths/file URLs from generated runtime config.
- Remove v2 registration, generated entrypoint writes, and IPC callback wiring. Replace generated config before boot while retaining old files that another configuration may reference.
- Preserve ordinary plugins, generated command/web permissions, local approvals, server request gates, native browser gates, Den authorization/model assignment, and capability/branding controls. No UI controls were hidden because command/browser controls have independent enforcement.
- Document lost protected-config file checks, read-only policy synchronization, and hook-time model checks in docs/desktop-policy-engine-rollback.md. Restart is needed to unload hooks from already-running engines.

## Verification at bc62ca9636ebdd4c353525c608033f44d467c4cb
[Complete assertion evidence and original records](https://github.com/different-ai/openwork/pull/4725#issuecomment-5611692896).

Node 24.15.0 and DISABLE_V8_COMPILE_CACHE=1:

1. `pnpm evals:e2e desktop-policy-restricted-mode --local --engine v1 --surface web --case POLICY-ROLLBACK` — exit 0; 1 selected pass, 0 selected skips. Printed placement: local (--local).
2. Same command with `--engine v2` — exit 0; 1 selected pass, 0 selected skips. Printed placement: local (--local).
3. `OPENWORK_WORLD_PLACE=local pnpm evals:pr specs/opencode-v2-provider-hot-inject.test.ts` — exit 0; 1 passed, 0 skipped. Direct local engine; this PR-lane command does not print a placement line.

The headless cases assert real completed read/shell tool records, exact shell-written output, rendered final answer, a configured HTTP 503 policy fault, disconnected IPC, and zero workload policy HTTP calls. They do not prove reasoning or data dependency from the read result to shell output. Each selected case leaves three existing native policy journeys not run; no native browser or Den UI regression pass is claimed.

Supplementary checks: targeted server startup/config tests 17 passed / 335 assertions; browser check 823 callbacks passed; catalog/reporting checks 18 passed. CI core, build, and required-test aggregation pass on this head. The initial CI catalog expectation failure was reproduced locally and fixed.

Full `pnpm evals:typecheck` exits 2 on branch and a fresh clean c744e2d7b control with matching first diagnostics (agent-context-cloud-probe.ts:216 TS1294 erasableSyntaxOnly, followed by broader baseline diagnostics). The provider shell probe initially exited 134 on both branch and control because the login shell selected a broken system Node; the updated test pins the runner Node 24 and passes.

The private review-app publisher failed because the available Blob token is for a public store. Complete parsed original records and assertions are published in GitHub comments instead; private Warden analysis logs are not published.

## Final local Warden — accepted intentional regression
Bare `pnpm warden:check`, using Infisical OpenAI credentials with unchanged config/model, exit **1**. Run **5634e10a-d40f-4ea3-b0aa-40e432f7ae27**, 2026-09-10T02:24:02Z, scope origin/dev...HEAD, clean committed branch, 15 files / 36 chunks.

Expected and completed: diff-security-review (15 files), confidentiality-review (15), spec-provenance-review (3). desktop-den-sync-review: not applicable to changed paths. Confidentiality returned no findings.

| Finding | Classification and evidence | Clear when / disposition |
| --- | --- | --- |
| **4PD-XK6**, high/high confidence (same root cause as prior **RGS-SPX** and GitHub **EAM-TQ6**) | Intentional authorized removal of engine-local file-write/extension checks. Native executionRules are not equivalent to all removed hooks; documentation states the loss. | Warden asks for restored hooks or equivalent authorization. That conflicts with this approved rollback scope. The requester explicitly accepted this intentional enforcement reduction after disclosure and authorized finalization. Disposition: accepted regression, not fixed and not Warden-cleared. The technical Clear when condition remains unmet; normal GitHub approval and merge requirements still apply. |
| **SB8-N33**, medium/high confidence | Scope mismatch: it asks tools to reach the failed policy transport. Zero workload policy calls is the intended rollback postcondition. The fixture confirms the endpoint returns 503 and the engine tools complete without contacting it. | Clear when assessed as removal/no-contact coverage rather than fault tolerance of a retained hook. Nonblocking advisory; no claim that hooks remain. |
| **555-UR6**, medium/high confidence | Valid coverage limitation: the deterministic shell command writes seeded content independently of the preceding read result. | Clear when a read-result/data-dependency assertion is added if file-copy reasoning is claimed. Current proof is explicitly scoped to actual tool completion and shell side effect. Nonblocking advisory retained. |

Before and after final review: HEAD=bc62ca9636ebdd4c353525c608033f44d467c4cb; origin/dev=c744e2d7bf1882b3e3455eb4d58376ca922faae7, unchanged. The initial auth-failed run and earlier-head reviews are superseded. GitHub workflow exit 0 is not security clearance: its native security check is neutral and reports EAM-TQ6, the same accepted regression. No local review or runtime checks were repeated because the committed code, base, review configuration, and model are unchanged.

No personal desktop or live organization was mutated. No product release or existing-engine restart was performed.
