### PR TITLE
fix(desktop): keep the updater inert until enterprise activation

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/desktop-updater-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/state/desktop-updater-provider.tsx
@@ -7,6 +7,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { t } from "../../../../i18n";
 import { useLocal } from "../../../kernel/local-provider";
 import { useDesktopConfig } from "../../cloud/desktop-config-provider";
+import { useEnterpriseActivationRequired } from "../../cloud/enterprise-activation-gate";
 import { useBrandAppName } from "../../cloud/brand-theme";
 import { notifyAlert } from "../../../shell/notifications";
 import { useElectronUpdaterState } from "./electron-updater-state";
@@ -28,6 +29,11 @@ function useUpdatePreference(key: string) {
 function useUpdater() {
   const local = useLocal();
   const desktopConfig = useDesktopConfig();
+  // This provider mounts above the enterprise activation gate. Before activation
+  // no Den is known, and until the desktop config has resolved once the
+  // organization's allowed-versions policy cannot be honoured, so no update
+  // check (and therefore no download) may run yet.
+  const updatePolicyKnown = !useEnterpriseActivationRequired() && !desktopConfig.loading;
   const [updateAutoCheck, setUpdateAutoCheck] = useUpdatePreference("openwork.react.settings.update-auto-check");
   // Older Settings wrote "0" even when the user never touched the old opt-in.
   // Start the automatic-download default once, then retain future opt-outs.
@@ -45,6 +51,7 @@ function useUpdater() {
     onReleaseChannelChange,
     updateAutoCheck,
     updateAutoDownload,
+    updatePolicyKnown,
     desktopConfig: desktopConfig.config,
     refreshDesktopConfig: desktopConfig.refreshFresh,
     setError,

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -43,6 +43,8 @@ type UseElectronUpdaterStateOptions = {
   onReleaseChannelChange: (next: ReleaseChannel) => void;
   updateAutoCheck: boolean;
   updateAutoDownload: boolean;
+  /** False until the organization's update policy can be honoured (activation done, desktop config resolved). */
+  updatePolicyKnown: boolean;
   desktopConfig: DenDesktopConfig | null | undefined;
   refreshDesktopConfig: () => Promise<DenDesktopConfig>;
   setError: (message: string | null) => void;
@@ -148,6 +150,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     onReleaseChannelChange,
     updateAutoCheck,
     updateAutoDownload,
+    updatePolicyKnown,
     desktopConfig,
     refreshDesktopConfig,
     setError,
@@ -539,7 +542,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   );
 
   useEffect(() => {
-    if (!updateAutoCheck || updateEnv?.supported === false || !appVersion) return;
+    if (!updatePolicyKnown || !updateAutoCheck || updateEnv?.supported === false || !appVersion) return;
     const key = `${policyReleaseChannel}:${appVersion}`;
     const interval = 15 * 60 * 1000;
     const check = () => {
@@ -565,15 +568,16 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       window.removeEventListener("online", check);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [appVersion, policyReleaseChannel, runCheckForUpdates, updateAutoCheck, updateEnv?.supported]);
+  }, [appVersion, policyReleaseChannel, runCheckForUpdates, updateAutoCheck, updateEnv?.supported, updatePolicyKnown]);
 
   // Run a check when the native "Check for Updates..." menu item was used.
+  // A request made before the policy is known stays queued until it is.
   const updateCheckRequestedAt = useUpdateCheckRequestStore((state) => state.requestedAt);
   useEffect(() => {
-    if (updateCheckRequestedAt == null || updateEnv?.supported === false) return;
+    if (!updatePolicyKnown || updateCheckRequestedAt == null || updateEnv?.supported === false) return;
     useUpdateCheckRequestStore.getState().clearUpdateCheckRequest();
     void checkForUpdates();
-  }, [checkForUpdates, updateCheckRequestedAt, updateEnv?.supported]);
+  }, [checkForUpdates, updateCheckRequestedAt, updateEnv?.supported, updatePolicyKnown]);
 
   const installUpdateAndRestart = useCallback(async () => {
     const releaseChannelRequestId = releaseChannelRequestRef.current;

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2793,6 +2793,7 @@ const { ensureAutoUpdater } = registerUpdaterIpc({
   distribution: DESKTOP_DISTRIBUTION.flavor,
   platform: process.platform,
   arch: process.arch,
+  assertActivation: assertDesktopActivation,
 });
 
 if (!app.requestSingleInstanceLock()) {

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -306,6 +306,10 @@ export function registerUpdaterIpc({
   platform = process.platform,
   arch = process.arch,
   env = process.env,
+  // Throws while the installation still has to be activated. Until then no Den
+  // is known, so the organization's allowed-versions policy cannot be honoured
+  // and the renderer must not be able to check for, stage, or install updates.
+  assertActivation = () => {},
 }) {
   let autoUpdaterInstance = null;
   let autoUpdaterLoadPromise = null;
@@ -673,6 +677,7 @@ export function registerUpdaterIpc({
   }));
 
   ipcMain.handle("openwork:updater:check", async (_event, rawChannel, rawTargetVersion) => queueUpdaterOperation(async () => {
+    assertActivation();
     // A check selects a feed for this operation only. The persisted preference
     // belongs exclusively to setChannel so a stale check cannot undo a choice.
     const channel = rawChannel === undefined
@@ -733,6 +738,7 @@ export function registerUpdaterIpc({
   }));
 
   ipcMain.handle("openwork:updater:download", async () => queueUpdaterOperation(async () => {
+    assertActivation();
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
@@ -777,6 +783,7 @@ export function registerUpdaterIpc({
   }));
 
   ipcMain.handle("openwork:updater:installAndRestart", async () => queueUpdaterOperation(async () => {
+    assertActivation();
     if (!updateDownloaded) return { ok: false, reason: "update-not-downloaded" };
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -81,9 +81,9 @@ function fakeUpdaterHarness({ version, platform, manualNativeStaging }) {
 }
 
 /**
- * @param {{ version: string, platform?: string, manualNativeStaging?: boolean, nativeStagingTimeoutMs?: number }} options
+ * @param {{ version: string, platform?: string, manualNativeStaging?: boolean, nativeStagingTimeoutMs?: number, assertActivation?: () => void }} options
  */
-async function registerFakeUpdaterIpc({ version, platform = "linux", manualNativeStaging = false, nativeStagingTimeoutMs }) {
+async function registerFakeUpdaterIpc({ version, platform = "linux", manualNativeStaging = false, nativeStagingTimeoutMs, assertActivation }) {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "openwork-updater-test-"));
   const handlers = new Map();
   const harness = fakeUpdaterHarness({ version, platform, manualNativeStaging });
@@ -109,6 +109,7 @@ async function registerFakeUpdaterIpc({ version, platform = "linux", manualNativ
     nativeStagingTimeoutMs,
     shipItDefaultsDomain: "test.openwork.ShipIt",
     writeDefaults: async (args) => { defaultsWrites.push(args); },
+    ...(assertActivation ? { assertActivation } : {}),
   });
   return { tempDir, handlers, defaultsWrites, ...harness };
 }
@@ -530,6 +531,38 @@ describe("installAndRestart", () => {
       ok: false,
       reason: "update-not-downloaded",
     });
+  });
+});
+
+describe("pre-activation guard", () => {
+  it("rejects check, download, and install without touching the updater while activation is required", async () => {
+    let activationRequired = true;
+    const { tempDir, handlers, calls, feeds } = await registerFakeUpdaterIpc({
+      version: "9.9.9",
+      assertActivation: () => {
+        if (activationRequired) throw new Error("OpenWork must be activated from your Den portal before this command is available.");
+      },
+    });
+    try {
+      const check = handlers.get("openwork:updater:check");
+      const download = handlers.get("openwork:updater:download");
+      const install = handlers.get("openwork:updater:installAndRestart");
+      await assert.rejects(() => check(null, "stable"), /must be activated/, "check must reject before activation");
+      await assert.rejects(() => download(), /must be activated/, "download must reject before activation");
+      await assert.rejects(() => install(), /must be activated/, "installAndRestart must reject before activation");
+      // ensureAutoUpdater selects a feed as soon as electron-updater loads, so an
+      // empty feed list proves the updater was never even configured.
+      assert.deepEqual(feeds, [], "no update feed may be selected before activation");
+      assert.deepEqual(calls, [], "no download may start before activation");
+
+      // The same handlers work normally once the installation is activated.
+      activationRequired = false;
+      assert.equal((await check(null, "stable")).available, true);
+      assert.deepEqual(await download(), { ok: true });
+      assert.deepEqual(calls, ["download"]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/desktop/scripts/packaged-smoke.mjs
+++ b/apps/desktop/scripts/packaged-smoke.mjs
@@ -77,6 +77,10 @@ try {
     const flavorBinary = join(flavorOutput(flavor), "linux-unpacked", executable);
     accessSync(flavorBinary, constants.X_OK);
     bootPackagedDesktop(`desktop-boot-${flavor}`, "packaged-first-launch", flavorBinary, 150_000);
+    // Only the enterprise flavor has an activation gate that must hold the updater back.
+    if (flavor === "enterprise") {
+      bootPackagedDesktop("desktop-updater-gate-enterprise", "packaged-preactivation-updater", flavorBinary, 300_000);
+    }
   }
   report.passed = true;
 } finally {

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -8,6 +8,8 @@ const definitions = {
   'app-smoke.e2e.test.ts': { name: 'Open a working desktop', critical: true },
   // Boots the packaged cloud and enterprise artifacts; only packaged-smoke provides those binaries.
   'packaged-first-launch.e2e.test.ts': { name: 'Open a fresh cloud or enterprise install', placement: 'local' },
+  // Boots the packaged enterprise artifact twice (fresh and pre-activated); only packaged-smoke provides that binary.
+  'packaged-preactivation-updater.e2e.test.ts': { name: 'Keep an unactivated enterprise install from updating itself', placement: 'local' },
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
   'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },

--- a/evals/specs/packaged-preactivation-updater.e2e.test.ts
+++ b/evals/specs/packaged-preactivation-updater.e2e.test.ts
@@ -1,0 +1,95 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import type { Probe } from "@openwork/testkit";
+import {
+  packagedActivatedUpdaterWorld,
+  packagedPreactivationUpdaterWorld,
+} from "../worlds/packaged-preactivation-updater.ts";
+
+/**
+ * An enterprise install must not check for or stage an update before it is
+ * activated. Until activation no Den is known, so the organization's
+ * allowed-versions policy cannot be honoured; an early check would stage the
+ * newest enterprise release and defeat that containment. 0.18.43 moved the
+ * updater above the activation gate, which is exactly when this started.
+ *
+ * Both halves boot the same packaged enterprise binary on a fresh profile. The
+ * negative half has no bootstrap, so the activation gate is on screen; the
+ * positive control seeds an activation stamp for an unreachable Den, proving the
+ * same watch does see a check as soon as activation is complete.
+ */
+const ACTIVATION_HEADING = "Link this app to your organization";
+
+/** The unfixed build checked and started a download within ~2 s of the renderer booting. */
+const QUIET_WINDOW_MS = 20_000;
+
+const preactivation = spec.world(packagedPreactivationUpdaterWorld, { timeout: 180_000 });
+const activated = spec.world(packagedActivatedUpdaterWorld, { timeout: 180_000 });
+
+async function requireEnterpriseFlavor(world: { flavor: () => Promise<string | null> }, probe: Probe) {
+  const flavor = await probe.eventually(() => world.flavor(), {
+    within: 30_000,
+    label: "packaged distribution flavor",
+    until: (value) => value !== null,
+  });
+  if (flavor !== "enterprise") {
+    throw new Error(`Activation gates only the enterprise flavor; OPENWORK_EVAL_ELECTRON_BINARY points at a ${flavor ?? "unknown"} build`);
+  }
+}
+
+preactivation("an unactivated enterprise install does not check for or download updates", async ({ world, user, probe, evidence }) => {
+  await requireEnterpriseFlavor(world, probe);
+  await probe.eventually(() => world.rootText(), {
+    within: 60_000,
+    label: "enterprise activation gate mounted in #root",
+    until: (text) => text.includes(ACTIVATION_HEADING),
+  });
+  await user.see({ text: ACTIVATION_HEADING });
+
+  // The renderer (and its updater provider) is up. Watch the main process for
+  // the whole quiet window, stopping early only if a check does appear.
+  const quietUntil = Date.now() + QUIET_WINDOW_MS;
+  const activity = await probe.eventually(() => world.updaterActivity(), {
+    within: QUIET_WINDOW_MS + 10_000,
+    intervalMs: 1_000,
+    label: "updater activity before activation",
+    until: (value) => value.checks > 0 || Date.now() >= quietUntil,
+  });
+  // The install is still unactivated at the end of the window, so any activity
+  // above happened before the organization's policy could be known.
+  await user.see({ text: ACTIVATION_HEADING });
+  await user.screenshot();
+
+  expect(activity.checks, `update checks started before activation: ${activity.lines.join(" | ")}`).toBe(0);
+  expect(activity.downloads, `update downloads started before activation: ${activity.lines.join(" | ")}`).toBe(0);
+  evidence.recordAssertionEvidence(
+    `An unactivated enterprise install starts no update check or download within ${QUIET_WINDOW_MS / 1000}s of showing "${ACTIVATION_HEADING}"`,
+    `main-process updater lines: ${JSON.stringify(activity.lines)}`,
+    activity.checks === 0 && activity.downloads === 0,
+  );
+});
+
+activated("an activated enterprise install still checks for updates", async ({ world, user, probe, evidence }) => {
+  await requireEnterpriseFlavor(world, probe);
+
+  // Same binary, same watch: once activated the check must appear. Its Den is
+  // unreachable and the network may refuse the manifest, so only the attempt
+  // is asserted, never its result.
+  const activity = await probe.eventually(() => world.updaterActivity(), {
+    within: 90_000,
+    intervalMs: 1_000,
+    label: "update check after activation",
+    until: (value) => value.checks > 0,
+  });
+  const rootText = await world.rootText();
+  await user.notSee({ text: ACTIVATION_HEADING }, { timeoutMs: 1_000 });
+  await user.screenshot();
+
+  expect(rootText, "the activation gate must not be on screen for an activated install").not.toContain(ACTIVATION_HEADING);
+  expect(activity.checks).toBeGreaterThan(0);
+  evidence.recordAssertionEvidence(
+    "An activated enterprise install starts an update check without any user action",
+    `main-process updater lines: ${JSON.stringify(activity.lines)}`,
+    activity.checks > 0,
+  );
+});

--- a/evals/specs/packaged-preactivation-updater.e2e.test.ts
+++ b/evals/specs/packaged-preactivation-updater.e2e.test.ts
@@ -73,8 +73,9 @@ activated("an activated enterprise install still checks for updates", async ({ w
   await requireEnterpriseFlavor(world, probe);
 
   // Same binary, same watch: once activated the check must appear. Its Den is
-  // unreachable and the network may refuse the manifest, so only the attempt
-  // is asserted, never its result.
+  // unreachable, the network may refuse the manifest, and an unpacked Linux
+  // directory cannot self-update at all, so only the attempt is asserted, never
+  // its result.
   const activity = await probe.eventually(() => world.updaterActivity(), {
     within: 90_000,
     intervalMs: 1_000,

--- a/evals/worlds/packaged-preactivation-updater.ts
+++ b/evals/worlds/packaged-preactivation-updater.ts
@@ -1,0 +1,109 @@
+import { readFile } from "node:fs/promises";
+import { attachSurface, evaluateOnSurface } from "@openwork/cdp";
+import type { AttachedSurface, SurfaceHandle } from "@openwork/cdp";
+import { SkipError } from "@openwork/env";
+import type { Seed } from "@openwork/env";
+import { localHost } from "@openwork/hosts";
+import type { ElectronSurfaceOptions } from "@openwork/hosts";
+
+/**
+ * A packaged enterprise desktop before and after activation, watched for update
+ * traffic. The updater provider mounts above the activation gate (since #4482),
+ * so an unactivated install could check and stage the newest enterprise release
+ * before the organization's allowed-versions policy is known. `desktop()` cannot
+ * be used because its readiness probe only recognises signed-in surfaces.
+ *
+ * The witness is the Electron main-process log: electron-updater logs
+ * "Checking for update" when it fetches the release manifest and "Downloading
+ * update from" when it starts staging one. Both happen in the main process, so
+ * neither the renderer's Network domain nor its DOM can see them.
+ */
+
+export interface UpdaterActivity {
+  /** Release-manifest fetches electron-updater started. */
+  checks: number;
+  /** Update downloads electron-updater started. */
+  downloads: number;
+  /** The matching log lines, for evidence. */
+  lines: string[];
+}
+
+const UPDATER_LOG_LINE = /^(?:Checking for update|Found version |Downloading update from |Update for version )/;
+
+export function updaterActivityFromLog(log: string): UpdaterActivity {
+  const lines = log.split(/\r?\n/).filter((line) => UPDATER_LOG_LINE.test(line));
+  return {
+    checks: lines.filter((line) => line.startsWith("Checking for update")).length,
+    downloads: lines.filter((line) => line.startsWith("Downloading update from")).length,
+    lines,
+  };
+}
+
+/** Activation stamp of an install already linked to a private Den that is not reachable here. */
+export const ACTIVATED_ENTERPRISE_BOOTSTRAP: NonNullable<ElectronSurfaceOptions["bootstrap"]> = {
+  baseUrl: "http://127.0.0.1:9",
+  requireSignin: true,
+  enterpriseActivation: { activatedAt: "2026-01-01T00:00:00.000Z", denBaseUrl: "http://127.0.0.1:9" },
+};
+
+async function launchPackagedEnterprise(name: string, bootstrap?: ElectronSurfaceOptions["bootstrap"]) {
+  if (!process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim()) {
+    throw new SkipError("OPENWORK_EVAL_ELECTRON_BINARY points at a packaged enterprise desktop binary");
+  }
+  const host = localHost();
+  const handle: SurfaceHandle = await host.spawnElectron(name, {
+    profile: "fresh",
+    prepareSharedResources: false,
+    env: { OPENWORK_DEV_MODE: "0", OPENWORK_ELECTRON_START_URL: "", ELECTRON_START_URL: "" },
+    ...(bootstrap ? { bootstrap } : {}),
+  });
+  const logPath = handle.meta?.log;
+  if (!logPath) {
+    await host.disposeSurface(handle);
+    throw new Error("The packaged desktop surface did not expose its main-process log");
+  }
+  let app: AttachedSurface | null = null;
+  const dispose = async () => {
+    try {
+      await app?.stop();
+    } finally {
+      await host.disposeSurface(handle);
+    }
+  };
+  try {
+    app = await attachSurface(handle, { timeoutMs: 60_000 });
+  } catch (error) {
+    await dispose().catch(() => undefined);
+    throw error;
+  }
+  const attached = app;
+  return {
+    app: attached,
+    /** Flavor baked into the packaged artifact, as the renderer sees it. */
+    flavor: () => evaluateOnSurface(attached, (): string | null => {
+      const electron: unknown = Reflect.get(window, "__OPENWORK_ELECTRON__");
+      if (typeof electron !== "object" || electron === null) return null;
+      const meta: unknown = Reflect.get(electron, "meta");
+      if (typeof meta !== "object" || meta === null) return null;
+      const distribution: unknown = Reflect.get(meta, "distribution");
+      if (typeof distribution !== "object" || distribution === null) return null;
+      const flavor: unknown = Reflect.get(distribution, "flavor");
+      return typeof flavor === "string" ? flavor : null;
+    }),
+    /** Text React actually mounted, as opposed to the body chrome. */
+    rootText: () => evaluateOnSurface(attached, () => document.getElementById("root")?.innerText ?? ""),
+    /** Update checks and downloads the main process has started so far. */
+    updaterActivity: async () => updaterActivityFromLog(await readFile(logPath, "utf8")),
+    [Symbol.asyncDispose]: dispose,
+  };
+}
+
+/** First launch on a machine that has never run OpenWork: no bootstrap, so activation is required. */
+export async function packagedPreactivationUpdaterWorld(_seed: Seed) {
+  return launchPackagedEnterprise("packaged-preactivation-updater");
+}
+
+/** Positive control: the same binary already activated, so the updater may run. */
+export async function packagedActivatedUpdaterWorld(_seed: Seed) {
+  return launchPackagedEnterprise("packaged-activated-updater", ACTIVATED_ENTERPRISE_BOOTSTRAP);
+}

--- a/evals/worlds/packaged-preactivation-updater.ts
+++ b/evals/worlds/packaged-preactivation-updater.ts
@@ -13,14 +13,17 @@ import type { ElectronSurfaceOptions } from "@openwork/hosts";
  * before the organization's allowed-versions policy is known. `desktop()` cannot
  * be used because its readiness probe only recognises signed-in surfaces.
  *
- * The witness is the Electron main-process log: electron-updater logs
- * "Checking for update" when it fetches the release manifest and "Downloading
- * update from" when it starts staging one. Both happen in the main process, so
- * neither the renderer's Network domain nor its DOM can see them.
+ * The witness is the Electron main-process log: every `checkForUpdates()` call
+ * makes electron-updater log either "Checking for update" (it fetches the
+ * release manifest) or, for a package form that cannot self-update such as the
+ * unpacked Linux directory the smoke gate boots, the "APPIMAGE env is not
+ * defined" refusal. "Downloading update from" marks a download starting. All of
+ * these happen in the main process, so neither the renderer's Network domain
+ * nor its DOM can see them.
  */
 
 export interface UpdaterActivity {
-  /** Release-manifest fetches electron-updater started. */
+  /** Times the app asked electron-updater to check for an update. */
   checks: number;
   /** Update downloads electron-updater started. */
   downloads: number;
@@ -28,12 +31,13 @@ export interface UpdaterActivity {
   lines: string[];
 }
 
-const UPDATER_LOG_LINE = /^(?:Checking for update|Found version |Downloading update from |Update for version )/;
+const CHECK_ATTEMPT = /^(?:Checking for update|APPIMAGE env is not defined|SNAP env is defined, updater is disabled)/;
+const UPDATER_LOG_LINE = /^(?:Checking for update|APPIMAGE env is not defined|SNAP env is defined|Found version |Downloading update from |Update for version |\[updater\] )/;
 
 export function updaterActivityFromLog(log: string): UpdaterActivity {
   const lines = log.split(/\r?\n/).filter((line) => UPDATER_LOG_LINE.test(line));
   return {
-    checks: lines.filter((line) => line.startsWith("Checking for update")).length,
+    checks: lines.filter((line) => CHECK_ATTEMPT.test(line)).length,
     downloads: lines.filter((line) => line.startsWith("Downloading update from")).length,
     lines,
   };


### PR DESCRIPTION
## Problem

Since #4482 `DesktopUpdaterProvider` mounts at `AppRoot`, above `EnterpriseActivationGate`, and #4606/#4696 made the contexts it needs (`DesktopConfigProvider`, `LocalProvider`) available in the pre-activation branch. The updater therefore runs **before** enterprise activation:

- `useElectronUpdaterState` auto-checks on mount (`updateAutoCheck` defaults on) and auto-downloads (`updateAutoDownload` defaults on).
- `isUpdateAllowedByDesktopConfig` returns `true` when `allowedDesktopVersions` is absent — always the case before activation, because no Den is known.
- `openwork:updater:check/download/installAndRestart` had no `assertDesktopActivation` guard (only the `openwork:desktop` channel did).

In 0.18.42 the updater lived inside Settings, which never mounts pre-activation, so this is new in 0.18.43+. An unactivated enterprise install could check and stage the newest enterprise-channel release before the organization's allowed-versions policy was known, defeating the containment that organizations get by pinning versions in Den.

**Confirmed dynamically** on a packaged enterprise `--dir` build of `origin/dev` (c744e2d7b), fresh profile, no user action. Within 2 s of the renderer mounting `Link this app to your organization`, the Electron main log contained:

```
Checking for update
Found version 0.18.45 (url: openwork-enterprise-mac-arm64-0.18.45.zip, …)
Downloading update from openwork-enterprise-mac-arm64-0.18.45.zip, …
```

(The download then failed only because the unsigned `--dir` build has no `app-update.yml`; a signed release install would have staged it.)

## Fix (smallest diff, providers stay mounted)

**Renderer** — `desktop-updater-provider.tsx` derives `updatePolicyKnown = !useEnterpriseActivationRequired() && !desktopConfig.loading` and passes it to `useElectronUpdaterState`, which now skips both the automatic check effect and the native-menu "Check for Updates…" effect until it is true. The `!desktopConfig.loading` half means the first post-activation check already sees `allowedDesktopVersions` (cached or freshly fetched) instead of the empty default. A menu request made too early stays queued and runs once the policy is known. Defaults for activated installs are unchanged.

**Main process** — `registerUpdaterIpc` takes `assertActivation` (default no-op); `main.mjs` passes the existing `assertDesktopActivation`. `openwork:updater:check`, `download`, and `installAndRestart` reject while `desktopActivationRequired(DESKTOP_DISTRIBUTION, bootstrap)` is true, before electron-updater is loaded or a feed selected, so no renderer path (including the menu) can reach the network early.

## Proof

| Check | Command | Lane | Result |
| --- | --- | --- | --- |
| Main-process guard unit test (`pre-activation guard`) | `node --test apps/desktop/electron/updater.test.mjs` | local | 34 pass / 0 fail (33 baseline + 1 new; new test red without the guard) |
| Desktop core tests | `pnpm --filter @openwork/desktop test:core` | local | 136 pass / 0 fail |
| Journey `packaged-preactivation-updater` on **unfixed** enterprise build (`origin/dev`) | `OPENWORK_EVAL_ELECTRON_BINARY=… pnpm evals:e2e packaged-preactivation-updater --local` | local | **Failed** as expected: `update checks started before activation: Checking for update: expected 1 to be +0`; positive control passed |
| Journey `packaged-preactivation-updater` on **fixed** enterprise build (this branch) | same | local | **Passed** 2/2: no check/download for 20 s while the gate is on screen; activated bootstrap checks within ~4 s |
| Journey `packaged-first-launch` on fixed enterprise build (no regression) | `pnpm evals:e2e packaged-first-launch --local` | local | Passed 1/1 |
| App typecheck | `pnpm --filter @openwork/app typecheck` | local | clean |
| Electron IPC-contract typecheck | `pnpm --filter @openwork/desktop typecheck:electron` | local | clean |
| App unit tests touched | `bun test src/react-app/shell/providers.test.tsx`, `…/electron-updater-state.test.ts`, `tests/enterprise-activation.test.ts` | local | 1/4/10 pass |
| Journey catalog | `node --test evals/scripts/journey-ci.test.mjs` | local | 13 pass |
| evals typecheck (my files) | `pnpm --dir evals typecheck` | local | 0 errors in `specs/packaged-preactivation-updater.e2e.test.ts` / `worlds/packaged-preactivation-updater.ts`; the 368 remaining errors are pre-existing on `dev` (`packages/email` jsx, `worlds/session-shell.ts` withResolvers, …) |
| Warden | `pnpm warden:check` on 1f3f29b (bare mode vs `dev`) | local | exit 0; diff-security-review, confidentiality-review, spec-provenance-review, desktop-den-sync-review all completed, no findings |

Lane: local for everything (Daytona not attempted: this journey needs the packaged enterprise binary produced by `packaged-smoke`, which is a `placement: 'local'` journey).

New journey `evals/specs/packaged-preactivation-updater.e2e.test.ts` + `evals/worlds/packaged-preactivation-updater.ts`: boots the packaged enterprise binary on a fresh profile, waits for the activation heading, then watches the main-process log (electron-updater's `Checking for update` / `Downloading update from`) for a 20 s quiet window. Positive control boots the same binary with an `enterpriseActivation` bootstrap (unreachable Den) and asserts the check *attempt* appears. Registered in `journey-catalog.mjs` (`placement: 'local'`) and added as the `desktop-updater-gate-enterprise` phase in `packaged-smoke.mjs`, reusing the enterprise binary that script already packages.

## Not covered

- The journey witnesses electron-updater's main-process log lines, not the IPC call itself; the unit test covers the IPC rejection directly.
- The positive control asserts only that a check is attempted (network may refuse the manifest); it does not assert the staged version.
- macOS/Windows packaged runs of the journey only happened locally (macOS); CI runs it on Linux through `packaged-smoke`.
- Adds roughly 40–50 s to the packaged smoke gate (fresh boot + 20 s quiet window + activated boot).
