### PR TITLE
test(desktop): fail packaged first launch on unhandled rejections and cover activated enterprise boot

### DIFF
--- a/apps/app/src/app/theme.ts
+++ b/apps/app/src/app/theme.ts
@@ -58,7 +58,9 @@ const emitThemeChange = () => {
 
 const syncNativeTheme = (mode: ThemeMode) => {
   if (typeof window === "undefined") return;
-  void window.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setNativeTheme", mode);
+  // Fire-and-forget window chrome: the shell refuses this before enterprise
+  // activation, and the window simply keeps its default theme then.
+  void window.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setNativeTheme", mode)?.catch(() => undefined);
 };
 
 const getCurrentMode = () => {

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -322,7 +322,9 @@ export function toggleWorkspaceRightSidebar(state: UiState): UiState {
 }
 
 function syncApplicationMenuVisible(visible: boolean): void {
-  void globalThis.window?.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setApplicationMenuVisible", visible);
+  // Fire-and-forget window chrome: the shell refuses this before enterprise
+  // activation, and the menu simply keeps its default visibility then.
+  void globalThis.window?.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setApplicationMenuVisible", visible)?.catch(() => undefined);
 }
 
 type UiStateStore = UiState & {

--- a/apps/desktop/scripts/packaged-smoke.mjs
+++ b/apps/desktop/scripts/packaged-smoke.mjs
@@ -78,6 +78,8 @@ try {
     accessSync(flavorBinary, constants.X_OK);
     bootPackagedDesktop(`desktop-boot-${flavor}`, "packaged-first-launch", flavorBinary, 150_000);
   }
+  // The same enterprise artifact, booted as an already-activated install (the update path for existing customers).
+  bootPackagedDesktop("desktop-boot-enterprise-activated", "packaged-activated-launch", join(flavorOutput("enterprise"), "linux-unpacked", "openwork-enterprise"), 150_000);
   report.passed = true;
 } finally {
   report.totalMilliseconds = Math.round(performance.now() - started);

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -8,6 +8,7 @@ const definitions = {
   'app-smoke.e2e.test.ts': { name: 'Open a working desktop', critical: true },
   // Boots the packaged cloud and enterprise artifacts; only packaged-smoke provides those binaries.
   'packaged-first-launch.e2e.test.ts': { name: 'Open a fresh cloud or enterprise install', placement: 'local' },
+  'packaged-activated-launch.e2e.test.ts': { name: 'Open an already-activated enterprise install', placement: 'local' },
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
   'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },

--- a/evals/specs/packaged-activated-launch.e2e.test.ts
+++ b/evals/specs/packaged-activated-launch.e2e.test.ts
@@ -16,6 +16,11 @@ const test = spec.world(packagedActivatedLaunchWorld, { timeout: 180_000 });
  * and the routes behind it must mount. The seeded Den is a closed local port,
  * so this holds with no network at all; the sign-in surface it lands on reads
  * its heading from the bootstrap, not from Den.
+ *
+ * This is the activated half of a pair: packaged-first-launch boots the same
+ * enterprise artifact with no bootstrap and requires the activation gate
+ * heading, so a gate that always stepped aside would fail there. packaged-smoke
+ * runs both against one binary.
  */
 const ACTIVATION_GATE_HEADING = "Link this app to your organization";
 const SIGN_IN_HEADING = "Welcome to OpenWork";

--- a/evals/specs/packaged-activated-launch.e2e.test.ts
+++ b/evals/specs/packaged-activated-launch.e2e.test.ts
@@ -1,0 +1,72 @@
+import { expect } from "vitest";
+import { sleep, spec } from "@openwork/testkit";
+import {
+  KNOWN_LAUNCH_REJECTIONS,
+  describeException,
+  isKnownRejection,
+  isRenderCrash,
+  packagedActivatedLaunchWorld,
+} from "../worlds/packaged-first-launch.ts";
+
+const test = spec.world(packagedActivatedLaunchWorld, { timeout: 180_000 });
+
+/**
+ * The path existing enterprise customers take after an update: the bootstrap
+ * already carries an activation stamp, so the activation gate must step aside
+ * and the routes behind it must mount. The seeded Den is a closed local port,
+ * so this holds with no network at all; the sign-in surface it lands on reads
+ * its heading from the bootstrap, not from Den.
+ */
+const ACTIVATION_GATE_HEADING = "Link this app to your organization";
+const SIGN_IN_HEADING = "Welcome to OpenWork";
+
+/** Heading of the root error boundary's recovery screen (app-error-boundary.tsx). */
+const RECOVERY_HEADING = /OpenWork hit an unexpected error/;
+
+/** Late boot work (config refresh, bridge calls) settles well inside this after the routes mount. */
+const REJECTION_SETTLE_MS = 3_000;
+
+test("an activated enterprise install boots past the activation gate without a render crash", async ({ world, user, probe, evidence }) => {
+  const flavor = await probe.eventually(() => world.flavor(), {
+    within: 30_000,
+    label: "packaged distribution flavor",
+    until: (value) => value !== null,
+  });
+  if (flavor !== "enterprise") throw new Error(`Activation only exists in the enterprise flavor; point OPENWORK_EVAL_ELECTRON_BINARY at an enterprise build (got ${flavor})`);
+
+  // Stop on the first of: the sign-in surface, the activation gate, the recovery
+  // screen, or a render crash, so a failure names what went wrong instead of
+  // timing out on a blank window.
+  const rootText = await probe.eventually(() => world.rootText(), {
+    within: 60_000,
+    label: "activated enterprise routes mounted in #root",
+    until: (text) => text.includes(SIGN_IN_HEADING) || text.includes(ACTIVATION_GATE_HEADING) || RECOVERY_HEADING.test(text) || world.exceptions().some(isRenderCrash),
+  });
+  const mounted = world.exceptions();
+  const crashes = mounted.filter(isRenderCrash);
+  expect(crashes.map(describeException), "the renderer threw while booting an activated enterprise install").toEqual([]);
+  expect(rootText, "the root error boundary caught a render crash on an activated enterprise install").not.toMatch(RECOVERY_HEADING);
+  expect(rootText.trim(), "#root stayed empty on an activated enterprise install").not.toBe("");
+
+  // Negative half: the seeded activation must be honoured, so the gate for an
+  // unactivated machine must not appear.
+  expect(rootText, "an already-activated install showed the activation gate").not.toContain(ACTIVATION_GATE_HEADING);
+  expect(rootText).toContain(SIGN_IN_HEADING);
+  await user.see({ text: SIGN_IN_HEADING });
+  await user.notSee({ text: ACTIVATION_GATE_HEADING });
+  await user.notSee({ text: RECOVERY_HEADING });
+  await user.screenshot();
+
+  await sleep(REJECTION_SETTLE_MS);
+  const exceptions = world.exceptions();
+  const knownRejections = exceptions.filter(isKnownRejection);
+  const unexpected = exceptions.filter((exception) => !isRenderCrash(exception) && !isKnownRejection(exception));
+  expect(unexpected.map(describeException), `an unhandled promise rejection outside KNOWN_LAUNCH_REJECTIONS (${KNOWN_LAUNCH_REJECTIONS.length} allowed) while booting an activated enterprise install`).toEqual([]);
+  expect(exceptions.filter(isRenderCrash).map(describeException), "the renderer threw after the activated enterprise routes mounted").toEqual([]);
+
+  evidence.recordAssertionEvidence(
+    `An activated enterprise install with Den at ${world.denBaseUrl} (closed port) mounts "${SIGN_IN_HEADING}" and never shows "${ACTIVATION_GATE_HEADING}"`,
+    `#root text: ${JSON.stringify(rootText.slice(0, 200))}; render crashes: ${crashes.length}; allowlisted rejections: ${knownRejections.length} of ${KNOWN_LAUNCH_REJECTIONS.length} known; unexpected rejections: ${unexpected.length}`,
+    crashes.length === 0 && unexpected.length === 0 && !rootText.includes(ACTIVATION_GATE_HEADING),
+  );
+});

--- a/evals/specs/packaged-first-launch.e2e.test.ts
+++ b/evals/specs/packaged-first-launch.e2e.test.ts
@@ -1,6 +1,12 @@
 import { expect } from "vitest";
-import { spec } from "@openwork/testkit";
-import { isRenderCrash, packagedFirstLaunchWorld } from "../worlds/packaged-first-launch.ts";
+import { sleep, spec } from "@openwork/testkit";
+import {
+  KNOWN_LAUNCH_REJECTIONS,
+  describeException,
+  isKnownRejection,
+  isRenderCrash,
+  packagedFirstLaunchWorld,
+} from "../worlds/packaged-first-launch.ts";
 import type { PackagedFlavor } from "../worlds/packaged-first-launch.ts";
 
 const test = spec.world(packagedFirstLaunchWorld, { timeout: 180_000 });
@@ -19,6 +25,9 @@ const FIRST_LAUNCH_HEADING: Partial<Record<PackagedFlavor, string>> = {
 
 /** Heading of the root error boundary's recovery screen (app-error-boundary.tsx). */
 const RECOVERY_HEADING = /OpenWork hit an unexpected error/;
+
+/** Late boot work (config refresh, bridge calls) settles well inside this after the gate mounts. */
+const REJECTION_SETTLE_MS = 3_000;
 
 test("a packaged flavor renders its first-launch gate without a render crash", async ({ world, user, probe, evidence }) => {
   const flavor = await probe.eventually(() => world.flavor(), {
@@ -39,11 +48,11 @@ test("a packaged flavor renders its first-launch gate without a render crash", a
     label: `${flavor} first-launch gate mounted in #root`,
     until: (text) => text.includes(heading) || RECOVERY_HEADING.test(text) || world.exceptions().some(isRenderCrash),
   });
-  const exceptions = world.exceptions();
-  const crashes = exceptions.filter(isRenderCrash);
-  const contextCrashes = exceptions.filter((exception) => /context is missing|must be used within/i.test(`${exception.text} ${exception.description}`));
+  const mounted = world.exceptions();
+  const crashes = mounted.filter(isRenderCrash);
+  const contextCrashes = mounted.filter((exception) => /context is missing|must be used within/i.test(`${exception.text} ${exception.description}`));
   expect(contextCrashes, "a provider context was missing during first launch").toEqual([]);
-  expect(crashes, "the renderer threw during first launch").toEqual([]);
+  expect(crashes.map(describeException), "the renderer threw during first launch").toEqual([]);
   expect(rootText, "the root error boundary caught a first-launch render crash").not.toMatch(RECOVERY_HEADING);
 
   expect(rootText).toContain(heading);
@@ -51,10 +60,18 @@ test("a packaged flavor renders its first-launch gate without a render crash", a
   await user.notSee({ text: RECOVERY_HEADING });
   await user.screenshot();
 
-  const rejections = exceptions.length - crashes.length;
+  // A rejected bootstrap promise can leave the app unusable without ever
+  // throwing during render, so only exactly-matched known rejections pass.
+  await sleep(REJECTION_SETTLE_MS);
+  const exceptions = world.exceptions();
+  const knownRejections = exceptions.filter(isKnownRejection);
+  const unexpected = exceptions.filter((exception) => !isRenderCrash(exception) && !isKnownRejection(exception));
+  expect(unexpected.map(describeException), `an unhandled promise rejection outside KNOWN_LAUNCH_REJECTIONS (${KNOWN_LAUNCH_REJECTIONS.length} allowed) during ${flavor} first launch`).toEqual([]);
+  expect(exceptions.filter(isRenderCrash).map(describeException), "the renderer threw after the first-launch gate mounted").toEqual([]);
+
   evidence.recordAssertionEvidence(
-    `The ${flavor} desktop mounts "${heading}" on first launch without a render crash`,
-    `#root text: ${JSON.stringify(rootText.slice(0, 200))}; render crashes: ${crashes.length}; unhandled promise rejections (not gating): ${rejections}`,
-    crashes.length === 0,
+    `The ${flavor} desktop mounts "${heading}" on first launch without a render crash or an unexpected unhandled rejection`,
+    `#root text: ${JSON.stringify(rootText.slice(0, 200))}; render crashes: ${crashes.length}; allowlisted rejections: ${knownRejections.length} of ${KNOWN_LAUNCH_REJECTIONS.length} known; unexpected rejections: ${unexpected.length}`,
+    crashes.length === 0 && unexpected.length === 0,
   );
 });

--- a/evals/worlds/packaged-first-launch.ts
+++ b/evals/worlds/packaged-first-launch.ts
@@ -28,12 +28,22 @@ export interface RendererException {
  * matched exactly against `rejectionMessage()`. Tracked debt: every entry
  * names a boot-time caller that should not reject, and the list shrinks back
  * to empty once that caller is fixed; anything not listed fails the launch
- * specs. Until the renderer guarded its fire-and-forget window-chrome IPC
- * (theme.ts, ui-state-store.ts) the one entry was
- * "Error: Error invoking remote method 'openwork:desktop': Error: OpenWork must
- * be activated from your Den portal before this command is available."
+ * specs.
+ *
+ * - The decorative `Dithering` background (`@paper-design/shaders-react`) on
+ *   the activation gate (enterprise-activation-gate.tsx) and the sign-in
+ *   surface (den-signin-surface.tsx) rejects when the GPU offers no WebGL,
+ *   which is every Xvfb CI runner and some VDI desktops. The page itself
+ *   still mounts. Clear when those surfaces skip the shader without WebGL.
+ *
+ * The renderer's fire-and-forget window-chrome IPC (theme.ts,
+ * ui-state-store.ts) used to add "Error: Error invoking remote method
+ * 'openwork:desktop': Error: OpenWork must be activated from your Den portal
+ * before this command is available." until it caught its own rejection.
  */
-export const KNOWN_LAUNCH_REJECTIONS: readonly string[] = [];
+export const KNOWN_LAUNCH_REJECTIONS: readonly string[] = [
+  "Error: Paper Shaders: WebGL is not supported in this browser",
+];
 
 const UNHANDLED_REJECTION_PREFIX = /^Uncaught \(in promise\)\s*/i;
 

--- a/evals/worlds/packaged-first-launch.ts
+++ b/evals/worlds/packaged-first-launch.ts
@@ -1,15 +1,19 @@
-import { attachSurface, evaluateOnSurface } from "@openwork/cdp";
+import { allocateFreePort, attachSurface, evaluateOnSurface } from "@openwork/cdp";
 import type { AttachedSurface } from "@openwork/cdp";
 import { SkipError } from "@openwork/env";
 import type { Seed } from "@openwork/env";
 import { localHost } from "@openwork/hosts";
+import type { ElectronSurfaceOptions } from "@openwork/hosts";
 
 /**
- * First launch of a packaged desktop flavor on a machine that has never run
- * OpenWork: no bootstrap, no activation, no sign-in. The cloud and enterprise
+ * Launch of a packaged desktop flavor on an isolated profile. The fresh world
+ * has no bootstrap, no activation, no sign-in: the cloud and enterprise
  * flavors render a gate above the routes here, which is the one code path
- * dogfooding never exercises. `desktop()` cannot be used because its readiness
- * probe only recognises signed-in surfaces, so this world attaches directly.
+ * dogfooding never exercises. The activated world seeds the bootstrap an
+ * enterprise installation carries after activation, so an update on an
+ * existing customer's machine is covered too. `desktop()` cannot be used
+ * because its readiness probe only recognises signed-in surfaces, so these
+ * worlds attach directly.
  */
 
 export type PackagedFlavor = "public" | "cloud" | "enterprise";
@@ -20,12 +24,47 @@ export interface RendererException {
 }
 
 /**
+ * Unhandled promise rejections a packaged launch is known to produce today,
+ * matched exactly against `rejectionMessage()`. Tracked debt: every entry
+ * names a boot-time caller that should not reject, and the list shrinks back
+ * to empty once that caller is fixed; anything not listed fails the launch
+ * specs. Until the renderer guarded its fire-and-forget window-chrome IPC
+ * (theme.ts, ui-state-store.ts) the one entry was
+ * "Error: Error invoking remote method 'openwork:desktop': Error: OpenWork must
+ * be activated from your Den portal before this command is available."
+ */
+export const KNOWN_LAUNCH_REJECTIONS: readonly string[] = [];
+
+const UNHANDLED_REJECTION_PREFIX = /^Uncaught \(in promise\)\s*/i;
+
+/**
  * A synchronous uncaught exception is what unmounts the React tree and leaves a
  * blank window. Unhandled promise rejections surface as "Uncaught (in promise)"
- * and never take the UI down, so they are reported but do not gate.
+ * and are classified separately by `isKnownRejection`.
  */
 export function isRenderCrash(exception: RendererException): boolean {
-  return !/\(in promise\)/i.test(exception.text);
+  return !UNHANDLED_REJECTION_PREFIX.test(exception.text);
+}
+
+/**
+ * The rejection message as Chromium reports it: the summary text after the
+ * "Uncaught (in promise)" prefix when present, otherwise the first line of the
+ * rejected value's description (an Error rejection keeps its message there).
+ */
+export function rejectionMessage(exception: RendererException): string {
+  const summary = exception.text.replace(UNHANDLED_REJECTION_PREFIX, "").trim();
+  return summary || exception.description.split("\n", 1)[0].trim();
+}
+
+export function isKnownRejection(exception: RendererException): boolean {
+  return !isRenderCrash(exception) && KNOWN_LAUNCH_REJECTIONS.includes(rejectionMessage(exception));
+}
+
+/** Full text of an exception for a failure message: the summary plus the stack-bearing description. */
+export function describeException(exception: RendererException): string {
+  return exception.description && exception.description !== exception.text
+    ? `${exception.text}\n${exception.description}`
+    : exception.text;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -84,13 +123,14 @@ async function observeRendererExceptions(surface: AttachedSurface) {
   };
 }
 
-export async function packagedFirstLaunchWorld(_seed: Seed) {
+async function packagedLaunchWorld(name: string, bootstrap: ElectronSurfaceOptions["bootstrap"]) {
   if (!process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim()) {
     throw new SkipError("OPENWORK_EVAL_ELECTRON_BINARY points at a packaged desktop binary");
   }
   const host = localHost();
-  const handle = await host.spawnElectron("packaged-first-launch", {
+  const handle = await host.spawnElectron(name, {
     profile: "fresh",
+    bootstrap,
     prepareSharedResources: false,
     env: { OPENWORK_DEV_MODE: "0", OPENWORK_ELECTRON_START_URL: "", ELECTRON_START_URL: "" },
   });
@@ -131,4 +171,26 @@ export async function packagedFirstLaunchWorld(_seed: Seed) {
     exceptions: () => [...observed.exceptions],
     [Symbol.asyncDispose]: dispose,
   };
+}
+
+/** A machine that has never run OpenWork: no bootstrap file at all. */
+export function packagedFirstLaunchWorld(_seed: Seed) {
+  return packagedLaunchWorld("packaged-first-launch", undefined);
+}
+
+/**
+ * An enterprise installation that already activated against its Den, as an
+ * existing customer's machine looks after an update. The Den lives on a
+ * closed local port so the launch is deterministic offline: the app has to
+ * get past the activation gate on the seeded bootstrap alone.
+ */
+export async function packagedActivatedLaunchWorld(_seed: Seed) {
+  const denBaseUrl = `http://127.0.0.1:${await allocateFreePort()}`;
+  const world = await packagedLaunchWorld("packaged-activated-launch", {
+    baseUrl: denBaseUrl,
+    apiBaseUrl: denBaseUrl,
+    requireSignin: true,
+    enterpriseActivation: { activatedAt: new Date().toISOString(), denBaseUrl },
+  });
+  return { ...world, denBaseUrl };
 }


### PR DESCRIPTION
## Summary

Tightens the packaged first-launch journey and adds the already-activated enterprise boot path (what existing customers hit after an update).

- **Rejections gate now.** `packaged-first-launch` used to exempt every `Uncaught (in promise)` exception. It now allows only exactly-matched messages from `KNOWN_LAUNCH_REJECTIONS` (documented as tracked debt) and prints any other unhandled rejection in full. Render crashes and the recovery heading (`/OpenWork hit an unexpected error/`) still fail fast; the allowlisted count lands in evidence.
- **Allowlist is empty.** The only known rejection (`Error invoking remote method 'openwork:desktop': ... OpenWork must be activated ...`, 2× on a fresh enterprise launch) came from two boot-time fire-and-forget window-chrome IPCs the enterprise shell refuses before activation: `syncNativeTheme` (`apps/app/src/app/theme.ts`, `__setNativeTheme`, via `bootstrapTheme()` in `index.react.tsx`) and the module-level `syncApplicationMenuVisible` (`apps/app/src/react-app/shell/ui-state-store.ts`, `__setApplicationMenuVisible`). Both are `void`-ed cosmetic calls; each now gets a one-line `.catch(() => undefined)`. The pre-activation command allowlist in `desktop-distribution.mjs` is untouched.
- **New journey `packaged-activated-launch`** (own spec + shared world): boots the enterprise binary with a bootstrap seeded as activated (`baseUrl`/`apiBaseUrl`/`enterpriseActivation.denBaseUrl` on a freshly allocated, closed local port). Asserts `#root` is non-empty, no render crash, no recovery heading, the activation gate heading is **not** shown, and the sign-in surface heading (`Welcome to OpenWork`) **is** shown — deterministic offline, no Den needed.
- `packaged-smoke.mjs`: one additive phase, `desktop-boot-enterprise-activated`, reusing the already-packaged enterprise binary. Catalog entry with `placement: 'local'`.

## Verification (local lane, macOS arm64 packaged builds from this tree)

Daytona was not used: this journey needs the packaged binaries built here (`placement: 'local'` in the catalog).

```
pnpm --filter openwork-server build && node apps/desktop/scripts/electron-build.mjs --server-built
CSC_IDENTITY_AUTO_DISCOVERY=false pnpm --dir apps/desktop exec electron-builder --config electron-builder.enterprise.yml --mac --dir --publish never --config.directories.output=/tmp/ow-gate/fixed
CSC_IDENTITY_AUTO_DISCOVERY=false pnpm --dir apps/desktop exec electron-builder --config electron-builder.cloud.yml --mac --dir --publish never --config.directories.output=/tmp/ow-gate/fixed-cloud
```

With `OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED=1 OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_SURFACES_DIR=/tmp/ow-gate/profiles`:

| Spec | Binary | Command | Result |
| --- | --- | --- | --- |
| `packaged-first-launch` | enterprise (this tree) | `pnpm evals:e2e packaged-first-launch --local` | exit 0, 1 passed / 0 failed / 0 skipped — 0 allowlisted, 0 unexpected rejections |
| `packaged-first-launch` | cloud (this tree) | same | exit 0, 1 passed / 0 failed / 0 skipped |
| `packaged-activated-launch` | enterprise (this tree) | `pnpm evals:e2e packaged-activated-launch --local` | exit 0, 1 passed / 0 failed / 0 skipped |
| `packaged-first-launch` | enterprise, **this tree before the guard** | same | exit 1, fails by name: `an unhandled promise rejection outside KNOWN_LAUNCH_REJECTIONS (0 allowed) during enterprise first launch` listing the 2 `openwork:desktop` activation rejections in full |
| `packaged-first-launch` | **released 0.18.44 enterprise** (negative control) | same | exit 1, fails by name: `a provider context was missing during first launch` (`Local context is missing`) |

Static checks: `node --test evals/scripts/journey-ci.test.mjs` 13/13 pass; `pnpm --filter @openwork/app typecheck` clean; evals `tsc -p .` reports 0 errors in the touched files (pre-existing errors elsewhere on dev unchanged); `lint:layers` 39 violations before and after (none in these files); `spec-channel-ratchet` / `spec-boundary-ratchet` add no violations from these files (pre-existing dev debt unchanged).

Warden (`pnpm warden:check`, bare, on HEAD d4be5567 vs origin/dev c744e2d7, exit 0): diff-security-review, confidentiality-review, spec-provenance-review, desktop-den-sync-review all completed — no findings.
