### PR TITLE
fix(den-web): navigate to Workflow Runs from the Analytics tabs after an Enterprise upgrade

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_features/analytics/analytics-layout.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_features/analytics/analytics-layout.tsx
@@ -26,7 +26,8 @@ export function AnalyticsPageHeader({ orgSlug, active, title, description, actio
     <div className="flex flex-wrap items-start justify-between gap-4">
       <div className="max-w-2xl">
         <h1 className="text-[28px] font-semibold tracking-[-0.04em] text-[#07192C]">{title}</h1>
-        <p className="mt-1.5 text-sm leading-6 text-[#637291]">{description}</p>
+        {/* Two reserved lines keep the shared tab strip below at the same position on every Analytics page. */}
+        <p className="mt-1.5 min-h-12 text-sm leading-6 text-[#637291]">{description}</p>
         {caption ? <div className="mt-2 text-xs text-[#637291]">{caption}</div> : null}
       </div>
       {action}


### PR DESCRIPTION
## Root cause

Triage: `reports/e2e-red-2026-09-09/triage.md` → Cluster 6 / Brief J (`workflow-run-previews`, red in nightlies since Sep 8 18:12Z, introduced by #4591).

The Analytics tab strip (`AnalyticsPageHeader` in `ee/apps/den-web/app/(den)/dashboard/_features/analytics/analytics-layout.tsx`) is rendered **below** the page title and description. The Workflow Runs description wraps to two lines at 1440px while the "Usage & adoption" and "Models & usage" descriptions fit on one, so the strip sits 24px lower on the Workflow Runs page than on the others.

In the failing trace (`2026-09-09T21-14-45-972Z`, `dev` @ `61b41901c`):

- `click(Usage & adoption)` at 04.922 → starts a client transition from `/dashboard/analytics/workflow-runs` to `/dashboard/analytics`.
- `target(Workflow Runs)` at 04.953 (31 ms later) is located on the **still-displayed old page** at `y=252`.
- `click(Workflow Runs)` at 05.030 lands at `y≈269` — by then the Usage & adoption page has rendered with its strip at `y≈228–262`, so the click hits nothing below the strip.
- Route stays `/dashboard/analytics` for the rest of the 30 s wait; spec fails on the Workflow Runs description.

Not an entitlement/capability refresh, `(admin)` guard, or stale `orgContext` problem: the "Workflow Runs" link is rendered after the upgrade; it simply moves between pages.

## What changed

- `analytics-layout.tsx`: reserve two lines for the description (`min-h-12` with `leading-6`) so the shared tab strip is at the same position on every Analytics page. One line + comment; no spec changes.

## Proof

- `OPENWORK_EVAL_REF=2096bb4bf8c44abbed518b3dbd9b256ba55a06da pnpm evals:e2e workflow-run-previews --daytona`
- Sandbox checked out `2096bb4bf` (`Ref:` and `HEAD is now at 2096bb4b` in provisioning log).
- Verdict line: `{"command":"evals:e2e","lane":"e2e","daytona":true,"placement":"daytona","engine":"legacy","surface":"legacy",...,"passed":1,"failed":0,"skipped":0,"skips":[],"verdict":"passed"}`
- Exit 0; `1 passed / 0 failed / 0 skipped`, test 267.6 s.
- In the green trace the same click sequence happens with the same timing (target located 35 ms after the previous click, at `y=252`) and the Workflow Runs page renders (`Workflows are repeatable tasks…` seen in 44 ms).

Red control: `dev` @ `61b41901c` baseline run in the triage folder (`e2e-dev-baseline-61b41901c.log`) fails with `Timed out after 30000ms seeing text=Workflows are repeatable tasks… route: "/dashboard/analytics"`.

## Noticed, not touched

- The testkit locates a target and dispatches the CDP click ~75 ms later without re-checking geometry, so any page whose layout shifts during a client transition can absorb a click the same way. A re-locate/hit-test immediately before `Input.dispatchMouseEvent` (or a settle after link clicks) would make `user.click` robust to this class of shift; left for the testkit owners (Brief B2 touches `user.click`).
- At content widths under `max-w-2xl` the Workflow Runs description can wrap to three lines, at which point the strip would move again; the spec runs at 1440×1000.