### PR TITLE
fix(packaging): pin the compose evaluation stack to the 0.18.45 images

### DIFF
--- a/packages/docs/self-host/evaluate-with-docker-compose.mdx
+++ b/packages/docs/self-host/evaluate-with-docker-compose.mdx
@@ -19,9 +19,9 @@ Install Docker Engine or Docker Desktop with Docker Compose v2. The machine must
 
    ```bash
    curl -fsSLo docker-compose.eval.yml \
-     https://raw.githubusercontent.com/different-ai/openwork/9f8645ebc482c15ab99c0cf155aabaa411e1ca6a/packaging/docker/docker-compose.eval.yml
+     https://raw.githubusercontent.com/different-ai/openwork/50932fa798fb0539bf8c6107b32a29aba83f93c8/packaging/docker/docker-compose.eval.yml
    printf '%s  %s\n' \
-     '69cc7f2666157b7697ebf69b31b0c83887dd99e796c7d956f9ccaab8fa8bf2fc' \
+     '2868753a21254902d68b7f1c507012e72137e954102ebe54a2eff970a5029b2d' \
      'docker-compose.eval.yml' | shasum -a 256 --check
    ```
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -6,9 +6,9 @@ Run Den API, Den web, and MySQL from published images without cloning or buildin
 
 ```bash
 curl -fsSLo docker-compose.eval.yml \
-  https://raw.githubusercontent.com/different-ai/openwork/9f8645ebc482c15ab99c0cf155aabaa411e1ca6a/packaging/docker/docker-compose.eval.yml
+  https://raw.githubusercontent.com/different-ai/openwork/50932fa798fb0539bf8c6107b32a29aba83f93c8/packaging/docker/docker-compose.eval.yml
 printf '%s  %s\n' \
-  '69cc7f2666157b7697ebf69b31b0c83887dd99e796c7d956f9ccaab8fa8bf2fc' \
+  '2868753a21254902d68b7f1c507012e72137e954102ebe54a2eff970a5029b2d' \
   'docker-compose.eval.yml' | shasum -a 256 --check
 umask 077
 printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \

--- a/packaging/docker/docker-compose.eval.yml
+++ b/packaging/docker/docker-compose.eval.yml
@@ -43,7 +43,7 @@ services:
     # intentionally no host port: MySQL stays internal to the compose network
 
   den-migrate:
-    image: ghcr.io/different-ai/openwork-den-api:0.18.37@sha256:5ae1fab94ae2badd49ae74649cfb38ca679a7afc7e9ae8926c927553a34caabd
+    image: ghcr.io/different-ai/openwork-den-api:0.18.45@sha256:973cb75d435ce7d17011d689a23c2becab021b230dc8cffe78c7b4ea15af443d
     depends_on:
       mysql:
         condition: service_healthy
@@ -55,7 +55,7 @@ services:
       DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:?Set OPENWORK_DB_ENCRYPTION_KEY to at least 32 random characters}
 
   den:
-    image: ghcr.io/different-ai/openwork-den-api:0.18.37@sha256:5ae1fab94ae2badd49ae74649cfb38ca679a7afc7e9ae8926c927553a34caabd
+    image: ghcr.io/different-ai/openwork-den-api:0.18.45@sha256:973cb75d435ce7d17011d689a23c2becab021b230dc8cffe78c7b4ea15af443d
     restart: unless-stopped
     depends_on:
       mysql:
@@ -89,7 +89,7 @@ services:
       WORKER_URL_TEMPLATE: https://workers.local/{workerId}
 
   web:
-    image: ghcr.io/different-ai/openwork-den-web:0.18.37@sha256:9ca96fb73bc3512852409f1508876e418cd56f6d5187ff4e0c683f5b69a2dda3
+    image: ghcr.io/different-ai/openwork-den-web:0.18.45@sha256:b145952d15df51d10fdbe7d689f2399cafa81fdfc55da695befc7659d8b67983
     restart: unless-stopped
     depends_on:
       den:
@@ -103,9 +103,12 @@ services:
       retries: 30
       start_period: 60s
     environment:
+      # Den web origin (denUrls source of truth for readiness and derived URLs).
+      DEN_BASE_URL: http://localhost:${OPENWORK_WEB_PORT:-3005}
+      # Container-internal API base for server-side calls (proxy, readiness, SSO probe).
+      DEN_API_BASE: http://den:8788
       # Browser-reachable API origin (what runtime-config hands to clients).
-      DEN_API_BASE: http://localhost:${OPENWORK_API_PORT:-8788}
-      # Container-internal fallback for server-side calls.
+      DEN_API_PUBLIC_URL: http://localhost:${OPENWORK_API_PORT:-8788}
       DEN_AUTH_FALLBACK_BASE: http://den:8788
       DEN_AUTH_ORIGIN: http://localhost:${OPENWORK_WEB_PORT:-3005}
       DEN_WEB_PUBLIC_ORIGIN: http://localhost:${OPENWORK_WEB_PORT:-3005}


### PR DESCRIPTION
## Problem

`packaging/docker/docker-compose.eval.yml` is the documented pull-only evaluation stack for self-hosting (`packages/docs/self-host/evaluate-with-docker-compose.mdx`). It pinned `openwork-den-api` / `openwork-den-web` to `0.18.37@sha256:…` while the current release is v0.18.45 (EE images published by `publish-ee-images.yml`, run `34425154734`, 2026-09-10 01:21 UTC). Nothing in the release pipeline owns this file, so evaluators got an 8-release-old control plane.

## Change

- Pin all three image references (`den-migrate`, `den`, `web`) to the 0.18.45 OCI image-index digests, the same digest kind that was pinned before (verified: `ghcr.io` `docker-content-digest` for `0.18.37` equals the old pins; the new digests equal `containerimage.digest` in the publish run logs):
  - `openwork-den-api:0.18.45@sha256:973cb75d435ce7d17011d689a23c2becab021b230dc8cffe78c7b4ea15af443d`
  - `openwork-den-web:0.18.45@sha256:b145952d15df51d10fdbe7d689f2399cafa81fdfc55da695befc7659d8b67983`
- den-web 0.18.45 changed its env contract in #4156: `DEN_API_BASE` is server-only and `DEN_API_PUBLIC_URL` is what `/api/runtime-config` hands to browsers; `denUrls()` needs `DEN_BASE_URL`. With only the pin bump, `/api/runtime-config` returned **500** (`DEN_BASE_URL must be configured`). The `web` service now sets `DEN_BASE_URL`, `DEN_API_BASE=http://den:8788`, and `DEN_API_PUBLIC_URL`.
- Docs (`evaluate-with-docker-compose.mdx`, `packaging/docker/README.md`) download the compose file by commit SHA + sha256. Both now point at `50932fa7` (this PR's compose commit, same convention as the previous `9f8645eb` PR-head pin) with checksum `2868753a…`. Verified: `curl` of that raw URL + `shasum -a 256 --check` → `OK`.

Other stale refs found: `packaging/docker/Dockerfile` / `docker-compose.yml` carry `OPENWORK_SERVER_VERSION=0.18.4` (the openwork-server npm host image, unrelated to the EE images) — left alone. `packaging/docker/docker-compose.den-dev.yml` (build-from-source) sets neither `DEN_API_PUBLIC_URL` nor `DEN_BASE_URL` on `web`, so it likely has the same runtime-config 500 — out of scope here.

## Proof

Config change; the runtime proof is booting the stack exactly as the doc instructs (Docker Desktop, local lane; no journey spec covers this file and no test parses compose files). `OPENWORK_WEB_PORT=3105` / `OPENWORK_API_PORT=8888` (documented knobs) because 3005/8788 were in use locally.

```
$ umask 077; printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' "$(openssl rand -hex 32)" "$(openssl rand -hex 32)" > .env
$ docker compose -f docker-compose.eval.yml up -d --wait          # exit 0, 37s
 Container openwork-eval-mysql-1 Healthy
 Container openwork-eval-den-migrate-1 Exited          # Exited (0)
 Container openwork-eval-den-1 Healthy
 Container openwork-eval-web-1 Healthy
$ curl http://127.0.0.1:8888/health
{"ok":true,"service":"den-api","version":"0.18.45"}                    HTTP 200
$ curl http://127.0.0.1:3105/api/ready
{"ok":true,"service":"den-web","checks":{"configuration":"ok","upstream":"ok"}}   HTTP 200
$ curl http://127.0.0.1:3105/api/runtime-config
{"denApiUrl":"http://localhost:8888",...,"orgMode":"single_org","singleOrgAllowPublicSignup":true,...}   HTTP 200
$ curl -X POST http://127.0.0.1:3105/api/auth/sign-up/email -d '{...}'   # web -> den proxy via DEN_API_BASE
{"token":"…","user":{"email":"eval-smoke@example.test",...}}            HTTP 200
$ docker compose -f docker-compose.eval.yml down -v                      # exit 0
```

Before the env fix (pins only): `GET /api/runtime-config` → HTTP 500, web log `Error: DEN_BASE_URL must be configured.`

Local Warden: `pnpm warden:check` on `8f4f7b3` vs `origin/dev c744e2d` → 2/2 matched skills (diff-security-review, confidentiality-review), 3 files, No findings, exit 0.

## Follow-up

PR 2 (`fix/compose-pins-release-automation`) automates this: a release-triggered bot PR rewrites the pins + doc checksum, and a CI drift check fails PRs to `dev` when the compose pin lags the released version.
