### PR TITLE
ci: enforce DCO sign-off on every pull request and gate ee/ changes on CLA

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -177,7 +177,7 @@ jobs:
           git config --local user.signingkey "$signing_key"
           git switch -c "$BRANCH_NAME"
           git add packages/docs/changelog.mdx changelog/
-          git commit -S -m "docs(changelog): release notes for $TAG"
+          git commit -S -s -m "docs(changelog): release notes for $TAG"
 
       - name: Open pull request
         if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'

--- a/.github/workflows/contribution-guard.yml
+++ b/.github/workflows/contribution-guard.yml
@@ -1,12 +1,16 @@
-# Contribution guard for fork pull requests.
+# Contribution guard for every pull request.
 #
-# Enforces CONTRIBUTING.md §1 and §2 on pull requests from forks:
-#   1. DCO: every commit carries a `Signed-off-by:` trailer whose email matches
-#      the commit author email or the PR author's GitHub noreply address.
-#   2. ee/: any change under ee/ requires the `cla-signed` label (a maintainer
-#      applies it once the CLA under legal/ is on file).
-# Same-repository pull requests exit green without checking anything —
-# employees are covered by their employment terms and must not be blocked.
+# Enforces CONTRIBUTING.md §1 and §2:
+#   1. DCO (all pull requests, forks and same-repository alike): every non-merge
+#      commit carries a `Signed-off-by:` trailer whose email matches the commit
+#      author email or the PR author's GitHub noreply address. Commits by the
+#      allow-listed bots that cannot sign (sentry[bot], dependabot[bot]) on
+#      their own PRs are exempt. Same-repository commits authored before
+#      DCO_ENFORCED_FROM (scripts/ci/contribution-guard.mjs) are grandfathered
+#      so in-flight internal branches are not blocked by the rollout.
+#   2. ee/ (fork pull requests only): any change under ee/ requires the
+#      `cla-signed` label (a maintainer applies it once the CLA under legal/ is
+#      on file). Same-repository authors are covered by their agreements.
 #
 # Security model (same as revert-fastlane.yml): this runs on
 # pull_request_target, so the workflow definition AND

--- a/.github/workflows/contribution-guard.yml
+++ b/.github/workflows/contribution-guard.yml
@@ -1,0 +1,67 @@
+# Contribution guard for fork pull requests.
+#
+# Enforces CONTRIBUTING.md §1 and §2 on pull requests from forks:
+#   1. DCO: every commit carries a `Signed-off-by:` trailer whose email matches
+#      the commit author email or the PR author's GitHub noreply address.
+#   2. ee/: any change under ee/ requires the `cla-signed` label (a maintainer
+#      applies it once the CLA under legal/ is on file).
+# Same-repository pull requests exit green without checking anything —
+# employees are covered by their employment terms and must not be blocked.
+#
+# Security model (same as revert-fastlane.yml): this runs on
+# pull_request_target, so the workflow definition AND
+# scripts/ci/contribution-guard.mjs execute from the trusted base branch
+# (github.sha), never from the PR. The job never checks out, fetches, or runs
+# PR code; it only reads PR metadata (commits, files, labels) through the REST
+# API with a read-only token. actions/checkout and actions/setup-node are pinned
+# to immutable commits. PR-controlled strings never reach a `run:` script via
+# expression interpolation; only the numeric PR number is passed, via env.
+#
+# Status name `contribution-guard` is meant to be added to the dev ruleset's
+# required status checks (repository settings step, not done by this file).
+
+name: Contribution Guard
+
+on:
+  pull_request_target:
+    # labeled/unlabeled re-run the ee/ check when a maintainer adds `cla-signed`.
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: contribution-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  contribution-guard:
+    name: contribution-guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      # github.sha is the base-branch revision this workflow file was read from,
+      # so the script below is the trusted copy that ships with this workflow.
+      - name: Checkout trusted guard script (base branch, not the PR)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: scripts/ci
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Unit-test the guard logic
+        run: node --test scripts/ci/contribution-guard.test.mjs
+
+      - name: Check DCO sign-off and ee/ CLA label
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/ci/contribution-guard.mjs

--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -179,7 +179,7 @@ jobs:
           git config --local user.signingkey "$signing_key"
           git switch -c "$BRANCH_NAME"
           git add "$MODELS_PATH"
-          git commit -S -m "chore: update models snapshot"
+          git commit -S -s -m "chore: update models snapshot"
 
       - name: Open pull request
         if: steps.changes.outputs.changed == 'true'

--- a/scripts/ci/contribution-guard.mjs
+++ b/scripts/ci/contribution-guard.mjs
@@ -37,9 +37,10 @@ export function checkSignoffs(commits, prAuthorLogin) {
     const author = (commit.commit.author?.email ?? "").toLowerCase();
     const emails = signoffEmails(commit.commit.message);
     if (emails.some((email) => email === author || isNoreplyFor(email, prAuthorLogin))) continue;
+    // Never echo emails or logins: this report lands in public logs and the step summary.
     const subject = commit.commit.message.split(/\r?\n/, 1)[0];
     const reason = emails.length
-      ? `Signed-off-by <${emails.join(">, <")}> does not match the author email <${author}> or @${prAuthorLogin}'s GitHub noreply address`
+      ? "Signed-off-by email does not match the commit author email or the PR author's GitHub noreply address"
       : "missing Signed-off-by trailer";
     problems.push(`${commit.sha.slice(0, 7)} "${subject}": ${reason}`);
   }

--- a/scripts/ci/contribution-guard.mjs
+++ b/scripts/ci/contribution-guard.mjs
@@ -1,4 +1,11 @@
-// Contribution guard for fork pull requests (CONTRIBUTING.md §1 and §2).
+// Contribution guard (CONTRIBUTING.md §1 and §2).
+//
+//   §1 DCO: every pull request, from a fork or from this repository, must carry
+//      a matching `Signed-off-by:` trailer on every non-merge commit. On
+//      same-repository pull requests, commits authored before
+//      DCO_ENFORCED_FROM are grandfathered (see below); fork commits never are.
+//   §2 ee/ CLA label: fork pull requests only. Same-repository authors have
+//      write access and are covered by their agreements with Different AI.
 //
 // Pure decision logic is exported for `node --test`; `main` only reads PR
 // metadata through the GitHub REST API. It never fetches or executes PR code.
@@ -8,6 +15,26 @@ import { pathToFileURL } from "node:url";
 
 export const CLA_LABEL = "cla-signed";
 export const EE_PREFIX = "ee/";
+
+// Rollout grace for same-repository pull requests only: a commit whose *author*
+// date is older than this was written before sign-off was enforced internally
+// (~140 open same-repository PRs, including the merge train, predate it).
+// Author date survives `git rebase`, so in-flight branches stay green as they
+// rebase onto dev; anything authored from this instant on must be signed off.
+// Fork commits get no grace: CONTRIBUTING.md has required their sign-off all
+// along. Remove this constant once the last pre-cutoff branch has merged.
+export const DCO_ENFORCED_FROM = "2026-09-12T00:00:00Z";
+
+// Bots that open pull requests here and cannot sign off:
+//   sentry[bot]     — Seer autofix; generated commits carry no trailer.
+//   dependabot[bot] — signs as `support@github.com`, which never matches its
+//                     `49699333+dependabot[bot]@users.noreply.github.com`
+//                     author email and is not configurable.
+// A commit is exempt only when GitHub attributes it to that Bot account AND the
+// same bot opened the pull request, so a human commit pushed onto a bot branch
+// (or a human PR spoofing a bot email) is still checked. github-actions[bot]
+// PRs are not exempt: our workflows commit as a person and pass `-s`.
+export const BOT_ALLOWLIST = new Set(["sentry[bot]", "dependabot[bot]"]);
 
 const CLA_DOCUMENTS = [
   "legal/individual-contributor-license-agreement.md",
@@ -29,11 +56,23 @@ export function isNoreplyFor(email, login) {
   return new RegExp(`^(\\d+\\+)?${escaped}@users\\.noreply\\.github\\.com$`, "i").test(email);
 }
 
-export function checkSignoffs(commits, prAuthorLogin) {
+export function isExemptBotCommit(commit, prAuthorLogin) {
+  const login = commit.author?.login;
+  return commit.author?.type === "Bot" && BOT_ALLOWLIST.has(login) && login === prAuthorLogin;
+}
+
+// `enforcedFrom` is the grace cutoff for same-repository PRs; pass null for no grace (forks).
+export function checkSignoffs(commits, prAuthorLogin, enforcedFrom) {
   const problems = [];
+  const exempt = { merge: 0, bot: 0, legacy: 0 };
+  const cutoff = enforcedFrom ? Date.parse(enforcedFrom) : Number.NEGATIVE_INFINITY;
   for (const commit of commits) {
     // Merge commits carry no authorship of their own; the DCO app skips them too.
-    if ((commit.parents?.length ?? 0) > 1) continue;
+    if ((commit.parents?.length ?? 0) > 1) { exempt.merge++; continue; }
+    if (isExemptBotCommit(commit, prAuthorLogin)) { exempt.bot++; continue; }
+    // Missing or unparsable author dates are treated as new: fail closed.
+    const authored = Date.parse(commit.commit.author?.date ?? "");
+    if (!Number.isNaN(authored) && authored < cutoff) { exempt.legacy++; continue; }
     const author = (commit.commit.author?.email ?? "").toLowerCase();
     const emails = signoffEmails(commit.commit.message);
     if (emails.some((email) => email === author || isNoreplyFor(email, prAuthorLogin))) continue;
@@ -44,7 +83,7 @@ export function checkSignoffs(commits, prAuthorLogin) {
       : "missing Signed-off-by trailer";
     problems.push(`${commit.sha.slice(0, 7)} "${subject}": ${reason}`);
   }
-  return problems;
+  return { problems, exempt };
 }
 
 export function eePaths(files) {
@@ -53,24 +92,32 @@ export function eePaths(files) {
     .filter((path) => typeof path === "string" && path.startsWith(EE_PREFIX));
 }
 
-export function evaluate({ repository, headRepository, prAuthorLogin, labels, commits, files }) {
-  if (headRepository === repository) {
-    return { verdict: "skipped", dco: [], ee: [], reason: "same-repository pull request; employees are covered by their employment terms" };
-  }
-  const dco = checkSignoffs(commits, prAuthorLogin);
-  const ee = labels.includes(CLA_LABEL) ? [] : eePaths(files);
-  return { verdict: dco.length || ee.length ? "fail" : "pass", dco, ee };
+export function evaluate({ repository, headRepository, prAuthorLogin, labels, commits, files, enforcedFrom = DCO_ENFORCED_FROM }) {
+  const fork = headRepository !== repository;
+  const { problems: dco, exempt } = checkSignoffs(commits, prAuthorLogin, fork ? null : enforcedFrom);
+  // The CLA-label rule is fork-only: same-repository authors have write access
+  // and are covered by their agreements with Different AI (CONTRIBUTING.md §2).
+  const ee = fork && !labels.includes(CLA_LABEL) ? eePaths(files) : [];
+  return { verdict: dco.length || ee.length ? "fail" : "pass", fork, dco, ee, exempt };
 }
 
 export function report(result) {
   const lines = ["# Contribution guard", ""];
-  if (result.verdict === "skipped") {
-    lines.push(`Skipped: ${result.reason}.`);
-  } else if (result.verdict === "pass") {
-    lines.push("PASS: every commit carries a matching `Signed-off-by:` trailer and no `ee/` path is touched without the CLA label.");
+  if (result.verdict === "pass") {
+    lines.push(
+      result.fork
+        ? "PASS: every checked commit carries a matching `Signed-off-by:` trailer and no `ee/` path is touched without the CLA label."
+        : "PASS: every checked commit carries a matching `Signed-off-by:` trailer (same-repository pull request; the `ee/` CLA-label rule applies to forks only).",
+    );
+  }
+  const exempted = Object.entries(result.exempt).filter(([, count]) => count > 0);
+  if (exempted.length) {
+    const labels = { merge: "merge", bot: "allow-listed bot", legacy: "grandfathered (authored before enforcement)" };
+    lines.push("", `Not checked for sign-off: ${exempted.map(([kind, count]) => `${count} ${labels[kind]}`).join(", ")} commit(s).`);
   }
   if (result.dco.length) {
     lines.push(
+      "",
       "## DCO sign-off missing",
       "",
       "CONTRIBUTING.md §1: \"Every commit must be signed off, certifying the Developer Certificate of Origin v1.1. Pull requests with unsigned commits cannot be merged.\"",
@@ -126,13 +173,14 @@ async function main() {
   const prefix = `/repos/${repository}/pulls/${number}`;
   const pull = await api(prefix, token);
   const headRepository = pull.head.repo?.full_name ?? "";
-  let commits = [];
-  let files = [];
-  if (headRepository !== repository) {
-    [commits, files] = await Promise.all([api(`${prefix}/commits`, token, true), api(`${prefix}/files`, token, true)]);
-    if (commits.length !== pull.commits) {
-      throw new Error(`Listed ${commits.length} of ${pull.commits} commits; refusing to verify a partial commit list.`);
-    }
+  // Commits are checked on every pull request; changed files only matter for
+  // the fork-only ee/ rule, so same-repository runs skip that request.
+  const [commits, files] = await Promise.all([
+    api(`${prefix}/commits`, token, true),
+    headRepository !== repository ? api(`${prefix}/files`, token, true) : [],
+  ]);
+  if (commits.length !== pull.commits) {
+    throw new Error(`Listed ${commits.length} of ${pull.commits} commits; refusing to verify a partial commit list.`);
   }
   const result = evaluate({
     repository,
@@ -141,6 +189,8 @@ async function main() {
     labels: pull.labels.map((label) => label.name),
     commits,
     files,
+    // Local dry runs may move the grace cutoff; the workflow never sets this.
+    enforcedFrom: process.env.DCO_ENFORCED_FROM || DCO_ENFORCED_FROM,
   });
   const text = report(result);
   console.log(text);

--- a/scripts/ci/contribution-guard.mjs
+++ b/scripts/ci/contribution-guard.mjs
@@ -1,0 +1,152 @@
+// Contribution guard for fork pull requests (CONTRIBUTING.md §1 and §2).
+//
+// Pure decision logic is exported for `node --test`; `main` only reads PR
+// metadata through the GitHub REST API. It never fetches or executes PR code.
+
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const CLA_LABEL = "cla-signed";
+export const EE_PREFIX = "ee/";
+
+const CLA_DOCUMENTS = [
+  "legal/individual-contributor-license-agreement.md",
+  "legal/corporate-contributor-license-agreement.md",
+];
+
+export function signoffEmails(message) {
+  const emails = [];
+  for (const line of message.split(/\r?\n/)) {
+    const match = /^Signed-off-by:\s*.*<([^>]+)>\s*$/i.exec(line.trim());
+    if (match) emails.push(match[1].trim().toLowerCase());
+  }
+  return emails;
+}
+
+// GitHub noreply addresses: `login@users.noreply.github.com` or `ID+login@users.noreply.github.com`.
+export function isNoreplyFor(email, login) {
+  const escaped = login.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^(\\d+\\+)?${escaped}@users\\.noreply\\.github\\.com$`, "i").test(email);
+}
+
+export function checkSignoffs(commits, prAuthorLogin) {
+  const problems = [];
+  for (const commit of commits) {
+    // Merge commits carry no authorship of their own; the DCO app skips them too.
+    if ((commit.parents?.length ?? 0) > 1) continue;
+    const author = (commit.commit.author?.email ?? "").toLowerCase();
+    const emails = signoffEmails(commit.commit.message);
+    if (emails.some((email) => email === author || isNoreplyFor(email, prAuthorLogin))) continue;
+    const subject = commit.commit.message.split(/\r?\n/, 1)[0];
+    const reason = emails.length
+      ? `Signed-off-by <${emails.join(">, <")}> does not match the author email <${author}> or @${prAuthorLogin}'s GitHub noreply address`
+      : "missing Signed-off-by trailer";
+    problems.push(`${commit.sha.slice(0, 7)} "${subject}": ${reason}`);
+  }
+  return problems;
+}
+
+export function eePaths(files) {
+  return files
+    .flatMap((file) => [file.filename, file.previous_filename])
+    .filter((path) => typeof path === "string" && path.startsWith(EE_PREFIX));
+}
+
+export function evaluate({ repository, headRepository, prAuthorLogin, labels, commits, files }) {
+  if (headRepository === repository) {
+    return { verdict: "skipped", dco: [], ee: [], reason: "same-repository pull request; employees are covered by their employment terms" };
+  }
+  const dco = checkSignoffs(commits, prAuthorLogin);
+  const ee = labels.includes(CLA_LABEL) ? [] : eePaths(files);
+  return { verdict: dco.length || ee.length ? "fail" : "pass", dco, ee };
+}
+
+export function report(result) {
+  const lines = ["# Contribution guard", ""];
+  if (result.verdict === "skipped") {
+    lines.push(`Skipped: ${result.reason}.`);
+  } else if (result.verdict === "pass") {
+    lines.push("PASS: every commit carries a matching `Signed-off-by:` trailer and no `ee/` path is touched without the CLA label.");
+  }
+  if (result.dco.length) {
+    lines.push(
+      "## DCO sign-off missing",
+      "",
+      "CONTRIBUTING.md §1: \"Every commit must be signed off, certifying the Developer Certificate of Origin v1.1. Pull requests with unsigned commits cannot be merged.\"",
+      "",
+      ...result.dco.map((problem) => `- ${problem}`),
+      "",
+      "Remedy: sign new commits with `git commit -s`, or add the trailer to existing commits with `git rebase --signoff origin/dev` and force-push. The trailer email must match the commit author email (or your GitHub noreply address).",
+      "",
+    );
+  }
+  if (result.ee.length) {
+    lines.push(
+      "## Contributor License Agreement required for `ee/`",
+      "",
+      "CONTRIBUTING.md §2: \"Contributions to code under ee/ additionally require a Contributor License Agreement.\" This pull request changes:",
+      "",
+      ...result.ee.map((path) => `- \`${path}\``),
+      "",
+      `Remedy: sign the applicable CLA (${CLA_DOCUMENTS.map((path) => `\`${path}\``).join(" or ")}) and send it to your OpenWork contact. A maintainer adds the \`${CLA_LABEL}\` label once it is on file; the check re-runs on labeling.`,
+      "",
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function api(path, token, paginate = false) {
+  const base = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const headers = {
+    accept: "application/vnd.github+json",
+    authorization: `Bearer ${token}`,
+    "x-github-api-version": "2022-11-28",
+  };
+  if (!paginate) {
+    const response = await fetch(`${base}${path}`, { headers });
+    if (!response.ok) throw new Error(`GET ${path} failed: ${response.status}`);
+    return response.json();
+  }
+  const items = [];
+  for (let page = 1; ; page++) {
+    const response = await fetch(`${base}${path}?per_page=100&page=${page}`, { headers });
+    if (!response.ok) throw new Error(`GET ${path} failed: ${response.status}`);
+    const batch = await response.json();
+    items.push(...batch);
+    if (batch.length < 100) return items;
+  }
+}
+
+async function main() {
+  const { GITHUB_TOKEN: token, GITHUB_REPOSITORY: repository, PR_NUMBER: number } = process.env;
+  if (!token || !repository || !/^\d+$/.test(number ?? "")) {
+    throw new Error("GITHUB_TOKEN, GITHUB_REPOSITORY, and a numeric PR_NUMBER are required.");
+  }
+  const prefix = `/repos/${repository}/pulls/${number}`;
+  const pull = await api(prefix, token);
+  const headRepository = pull.head.repo?.full_name ?? "";
+  let commits = [];
+  let files = [];
+  if (headRepository !== repository) {
+    [commits, files] = await Promise.all([api(`${prefix}/commits`, token, true), api(`${prefix}/files`, token, true)]);
+    if (commits.length !== pull.commits) {
+      throw new Error(`Listed ${commits.length} of ${pull.commits} commits; refusing to verify a partial commit list.`);
+    }
+  }
+  const result = evaluate({
+    repository,
+    headRepository,
+    prAuthorLogin: pull.user.login,
+    labels: pull.labels.map((label) => label.name),
+    commits,
+    files,
+  });
+  const text = report(result);
+  console.log(text);
+  if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, text);
+  process.exitCode = result.verdict === "fail" ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => { console.error(error.message); process.exitCode = 1; });
+}

--- a/scripts/ci/contribution-guard.test.mjs
+++ b/scripts/ci/contribution-guard.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { CLA_LABEL, evaluate, isNoreplyFor, report } from "./contribution-guard.mjs";
+
+const REPO = "different-ai/openwork";
+const FORK = "contributor/openwork";
+const LOGIN = "contributor";
+
+const commit = (sha, subject, { email = "dev@example.com", signoff = `Dev <${email}>`, parents = 1 } = {}) => ({
+  sha,
+  parents: Array.from({ length: parents }, (_, index) => ({ sha: `parent${index}` })),
+  commit: {
+    author: { name: "Dev", email },
+    message: signoff ? `${subject}\n\nSigned-off-by: ${signoff}\n` : `${subject}\n`,
+  },
+});
+
+const forkPull = (overrides = {}) => ({
+  repository: REPO,
+  headRepository: FORK,
+  prAuthorLogin: LOGIN,
+  labels: [],
+  commits: [commit("a".repeat(40), "feat: one"), commit("b".repeat(40), "fix: two")],
+  files: [{ filename: "apps/desktop/src/main.ts" }],
+  ...overrides,
+});
+
+test("all commits signed off with a matching email pass", () => {
+  const result = evaluate(forkPull());
+  assert.equal(result.verdict, "pass");
+  assert.deepEqual(result.dco, []);
+  assert.deepEqual(result.ee, []);
+});
+
+test("one unsigned commit fails and names the commit", () => {
+  const result = evaluate(forkPull({
+    commits: [commit("a".repeat(40), "feat: one"), commit("b".repeat(40), "fix: two", { signoff: null })],
+  }));
+  assert.equal(result.verdict, "fail");
+  assert.equal(result.dco.length, 1);
+  assert.match(result.dco[0], /^bbbbbbb "fix: two": missing Signed-off-by trailer$/);
+  assert.match(report(result), /git commit -s/);
+  assert.match(report(result), /git rebase --signoff/);
+  assert.match(report(result), /CONTRIBUTING\.md §1/);
+});
+
+test("a sign-off from someone else fails; the GitHub noreply address of the PR author passes", () => {
+  const mismatch = evaluate(forkPull({
+    commits: [commit("c".repeat(40), "chore: three", { signoff: "Other <other@example.com>" })],
+  }));
+  assert.equal(mismatch.verdict, "fail");
+  assert.match(mismatch.dco[0], /does not match the author email <dev@example.com>/);
+
+  const noreply = evaluate(forkPull({
+    commits: [commit("d".repeat(40), "chore: four", { signoff: `Dev <12345+${LOGIN}@users.noreply.github.com>` })],
+  }));
+  assert.equal(noreply.verdict, "pass");
+  assert.equal(isNoreplyFor(`${LOGIN}@users.noreply.github.com`, LOGIN), true);
+  assert.equal(isNoreplyFor(`${LOGIN}@users.noreply.github.com`, "someone-else"), false);
+});
+
+test("merge commits are not required to carry a sign-off", () => {
+  const result = evaluate(forkPull({
+    commits: [commit("e".repeat(40), "Merge branch 'dev'", { signoff: null, parents: 2 })],
+  }));
+  assert.equal(result.verdict, "pass");
+});
+
+test("an ee/ file without the CLA label fails and points at the CLA documents", () => {
+  const result = evaluate(forkPull({
+    files: [{ filename: "ee/apps/den-api/src/index.ts" }, { filename: "README.md" }],
+  }));
+  assert.equal(result.verdict, "fail");
+  assert.deepEqual(result.ee, ["ee/apps/den-api/src/index.ts"]);
+  assert.deepEqual(result.dco, []);
+  const text = report(result);
+  assert.match(text, /legal\/individual-contributor-license-agreement\.md/);
+  assert.match(text, /legal\/corporate-contributor-license-agreement\.md/);
+  assert.match(text, /CONTRIBUTING\.md §2/);
+});
+
+test("a file renamed out of ee/ still counts as touching ee/", () => {
+  const result = evaluate(forkPull({
+    files: [{ filename: "packages/moved.ts", previous_filename: "ee/packages/moved.ts" }],
+  }));
+  assert.deepEqual(result.ee, ["ee/packages/moved.ts"]);
+});
+
+test("an ee/ file with the cla-signed label passes", () => {
+  const result = evaluate(forkPull({
+    labels: [CLA_LABEL],
+    files: [{ filename: "ee/apps/den-api/src/index.ts" }],
+  }));
+  assert.equal(result.verdict, "pass");
+  assert.deepEqual(result.ee, []);
+});
+
+test("same-repository pull requests are skipped even when unsigned and touching ee/", () => {
+  const result = evaluate(forkPull({
+    headRepository: REPO,
+    commits: [commit("f".repeat(40), "wip", { signoff: null })],
+    files: [{ filename: "ee/LICENSE" }],
+  }));
+  assert.equal(result.verdict, "skipped");
+  assert.deepEqual(result.dco, []);
+  assert.deepEqual(result.ee, []);
+  assert.match(report(result), /Skipped: same-repository pull request/);
+});

--- a/scripts/ci/contribution-guard.test.mjs
+++ b/scripts/ci/contribution-guard.test.mjs
@@ -49,7 +49,9 @@ test("a sign-off from someone else fails; the GitHub noreply address of the PR a
     commits: [commit("c".repeat(40), "chore: three", { signoff: "Other <other@example.com>" })],
   }));
   assert.equal(mismatch.verdict, "fail");
-  assert.match(mismatch.dco[0], /does not match the author email <dev@example.com>/);
+  assert.match(mismatch.dco[0], /^ccccccc "chore: three": Signed-off-by email does not match/);
+  // Public logs must never carry contributor identifiers (Warden EQE-3T4).
+  assert.doesNotMatch(report(mismatch), /@example\.com|@contributor|contributor'/);
 
   const noreply = evaluate(forkPull({
     commits: [commit("d".repeat(40), "chore: four", { signoff: `Dev <12345+${LOGIN}@users.noreply.github.com>` })],

--- a/scripts/ci/contribution-guard.test.mjs
+++ b/scripts/ci/contribution-guard.test.mjs
@@ -1,16 +1,24 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { CLA_LABEL, evaluate, isNoreplyFor, report } from "./contribution-guard.mjs";
+import { BOT_ALLOWLIST, CLA_LABEL, DCO_ENFORCED_FROM, evaluate, isNoreplyFor, report } from "./contribution-guard.mjs";
 
 const REPO = "different-ai/openwork";
 const FORK = "contributor/openwork";
 const LOGIN = "contributor";
+// Author dates on either side of the same-repository grace cutoff.
+const AFTER_CUTOFF = new Date(Date.parse(DCO_ENFORCED_FROM) + 60_000).toISOString();
+const BEFORE_CUTOFF = new Date(Date.parse(DCO_ENFORCED_FROM) - 60_000).toISOString();
 
-const commit = (sha, subject, { email = "dev@example.com", signoff = `Dev <${email}>`, parents = 1 } = {}) => ({
+const commit = (
+  sha,
+  subject,
+  { email = "dev@example.com", signoff = `Dev <${email}>`, parents = 1, date = AFTER_CUTOFF, githubAuthor = { login: LOGIN, type: "User" } } = {},
+) => ({
   sha,
   parents: Array.from({ length: parents }, (_, index) => ({ sha: `parent${index}` })),
+  author: githubAuthor,
   commit: {
-    author: { name: "Dev", email },
+    author: { name: "Dev", email, date },
     message: signoff ? `${subject}\n\nSigned-off-by: ${signoff}\n` : `${subject}\n`,
   },
 });
@@ -97,14 +105,111 @@ test("an ee/ file with the cla-signed label passes", () => {
   assert.deepEqual(result.ee, []);
 });
 
-test("same-repository pull requests are skipped even when unsigned and touching ee/", () => {
+test("fork commits get no grace: an old unsigned fork commit still fails", () => {
   const result = evaluate(forkPull({
-    headRepository: REPO,
-    commits: [commit("f".repeat(40), "wip", { signoff: null })],
-    files: [{ filename: "ee/LICENSE" }],
+    commits: [commit("f".repeat(40), "old fork work", { signoff: null, date: BEFORE_CUTOFF })],
   }));
-  assert.equal(result.verdict, "skipped");
-  assert.deepEqual(result.dco, []);
+  assert.equal(result.verdict, "fail");
+  assert.equal(result.exempt.legacy, 0);
+});
+
+// Same-repository pull requests: DCO applies to everyone, the ee/ label rule does not.
+
+const samePull = (overrides = {}) => forkPull({ headRepository: REPO, prAuthorLogin: "employee", ...overrides });
+
+test("same-repository: every commit signed off passes and the ee/ label is not required", () => {
+  const result = evaluate(samePull({ files: [{ filename: "ee/apps/den-api/src/index.ts" }] }));
+  assert.equal(result.verdict, "pass");
   assert.deepEqual(result.ee, []);
-  assert.match(report(result), /Skipped: same-repository pull request/);
+  assert.match(report(result), /same-repository pull request; the `ee\/` CLA-label rule applies to forks only/);
+});
+
+test("same-repository: a missing trailer fails and names the commit", () => {
+  const result = evaluate(samePull({
+    commits: [commit("a".repeat(40), "feat: one"), commit("b".repeat(40), "wip", { signoff: null })],
+  }));
+  assert.equal(result.verdict, "fail");
+  assert.deepEqual(result.dco, ['bbbbbbb "wip": missing Signed-off-by trailer']);
+});
+
+test("same-repository: a mismatched sign-off email fails", () => {
+  const result = evaluate(samePull({
+    commits: [commit("c".repeat(40), "chore: three", { signoff: "Other <other@example.com>" })],
+  }));
+  assert.equal(result.verdict, "fail");
+  assert.match(result.dco[0], /Signed-off-by email does not match/);
+});
+
+test("same-repository: the PR author's GitHub noreply address passes", () => {
+  const result = evaluate(samePull({
+    commits: [commit("d".repeat(40), "chore: four", { signoff: "Employee <686630+employee@users.noreply.github.com>" })],
+  }));
+  assert.equal(result.verdict, "pass");
+});
+
+test("same-repository: merge commits are skipped", () => {
+  const result = evaluate(samePull({
+    commits: [commit("e".repeat(40), "Merge branch 'dev'", { signoff: null, parents: 2 })],
+  }));
+  assert.equal(result.verdict, "pass");
+  assert.equal(result.exempt.merge, 1);
+});
+
+test("same-repository: commits authored before the cutoff are grandfathered; the cutoff itself is not", () => {
+  const legacy = evaluate(samePull({
+    commits: [commit("1".repeat(40), "pre-enforcement work", { signoff: null, date: BEFORE_CUTOFF })],
+  }));
+  assert.equal(legacy.verdict, "pass");
+  assert.equal(legacy.exempt.legacy, 1);
+  assert.match(report(legacy), /1 grandfathered/);
+
+  const boundary = evaluate(samePull({
+    commits: [commit("2".repeat(40), "at cutoff", { signoff: null, date: DCO_ENFORCED_FROM })],
+  }));
+  assert.equal(boundary.verdict, "fail");
+
+  // A missing author date fails closed.
+  const undated = evaluate(samePull({
+    commits: [commit("3".repeat(40), "no date", { signoff: null, date: undefined })],
+  }));
+  assert.equal(undated.verdict, "fail");
+});
+
+test("bot allow-list: sentry and dependabot commits on their own PRs are exempt", () => {
+  for (const login of BOT_ALLOWLIST) {
+    const result = evaluate(samePull({
+      prAuthorLogin: login,
+      commits: [commit("4".repeat(40), "fix: generated", {
+        signoff: null,
+        email: `123+${login}@users.noreply.github.com`,
+        githubAuthor: { login, type: "Bot" },
+      })],
+    }));
+    assert.equal(result.verdict, "pass", login);
+    assert.equal(result.exempt.bot, 1);
+  }
+  assert.deepEqual([...BOT_ALLOWLIST].sort(), ["dependabot[bot]", "sentry[bot]"]);
+});
+
+test("bot allow-list: a human commit on a bot PR, an unlisted bot, and a bot commit on a human PR are all checked", () => {
+  const humanOnBotBranch = evaluate(samePull({
+    prAuthorLogin: "dependabot[bot]",
+    commits: [
+      commit("5".repeat(40), "chore(deps): bump x", { signoff: null, githubAuthor: { login: "dependabot[bot]", type: "Bot" } }),
+      commit("6".repeat(40), "fix: allow transitive deps", { signoff: null, email: "maintainer@example.com" }),
+    ],
+  }));
+  assert.equal(humanOnBotBranch.verdict, "fail");
+  assert.deepEqual(humanOnBotBranch.dco, ['6666666 "fix: allow transitive deps": missing Signed-off-by trailer']);
+
+  const unlistedBot = evaluate(samePull({
+    prAuthorLogin: "github-actions[bot]",
+    commits: [commit("7".repeat(40), "docs(changelog): release notes", { signoff: null, githubAuthor: { login: "github-actions[bot]", type: "Bot" } })],
+  }));
+  assert.equal(unlistedBot.verdict, "fail");
+
+  const spoofedOnHumanPull = evaluate(samePull({
+    commits: [commit("8".repeat(40), "fix: looks generated", { signoff: null, githubAuthor: { login: "sentry[bot]", type: "Bot" } })],
+  }));
+  assert.equal(spoofedOnHumanPull.verdict, "fail");
 });


### PR DESCRIPTION
## What this enforces

A `contribution-guard` status on **every pull request**, per CONTRIBUTING.md §1 and §2:

1. **DCO — all PRs, forks and same-repository alike.** Every non-merge commit must carry a `Signed-off-by:` trailer whose email matches the commit author email or the PR author's GitHub noreply address (`login@users.noreply.github.com` / `ID+login@users.noreply.github.com`). Failure names each offending commit (7-char SHA + subject, never emails/logins) and quotes CONTRIBUTING.md with the `git commit -s` / `git rebase --signoff origin/dev` remedy.
2. **`ee/` paths — fork PRs only.** If any changed file (including a rename *out of* `ee/`) starts with `ee/`, the PR must carry the `cla-signed` label. CONTRIBUTING.md §2 covers same-repository authors through their agreements with Different AI, so the label is not required internally.

Background: #4606 and #3402 were external contributions that landed without sign-off; run read-only against them this script still fails both on the exact commit (`4144db4`, `3ce2b8b`). The same-repository scope was added because the requirement is meant to apply to everyone, not only forks.

### Exemptions (explicit, each documented in the script)

| Commit | Handling | Why |
|---|---|---|
| Merge commits (`parents > 1`) | skipped | no authorship of their own; the DCO GitHub App skips them too |
| `sentry[bot]` commits on a `sentry[bot]` PR | skipped (allow-list) | Seer autofix cannot sign |
| `dependabot[bot]` commits on a `dependabot[bot]` PR | skipped (allow-list) | signs as `support@github.com`, never matches its author email, not configurable |
| A human commit pushed onto a bot branch, or a bot-attributed commit on a human PR | **checked** | exemption requires GitHub author `type: Bot` **and** the same bot opened the PR |
| `github-actions[bot]` PRs (changelog, models snapshot) | **checked** | our own workflows; `changelog.yml` and `update-models.yml` now commit with `-S -s` |
| Same-repository commits **authored before `2026-09-12T00:00:00Z`** | grandfathered | rollout grace, see below. Fork commits get no grace. Missing author date fails closed |

## Rollout impact (measured 2026-09-11 against all 257 open PRs, read-only)

Without grace the new rule would fail **232/257** open PRs: same-repo 140/148 (616/621 commits unsigned), forks 92/109; yomgui 27/28, benjaminshafii 81/84, reachjalil 36/36. dev itself is squash-merged and only 3 of the last 200 commits carry a trailer. That would stall the merge train, so:

**Grace: `DCO_ENFORCED_FROM = 2026-09-12T00:00:00Z`** in `scripts/ci/contribution-guard.mjs`. Same-repository commits whose *author* date predates it are not checked. Author date survives `git rebase`, so in-flight branches (the merge train included) stay green as they rebase onto dev; any commit authored after the cutoff must be signed off. With grace, every open same-repo PR passes today; forks keep the original behaviour (17/109 pass).

**Merge-train recommendation:** this PR is informational until `contribution-guard` is made required, and with the grace cutoff it does not block existing commits even then. It can merge while the train is running. If it merges after 2026-09-12, bump the constant to the merge date in a follow-up so nothing authored in between is caught by surprise. Remove the constant once the last pre-cutoff branch has merged.

## Relationship to #4709 (@benjaminshafii)

#4709 holds every `ee/` change closed (no CLA verifier), requires exact name+email sign-off on merge commits and co-authors, and has no noreply or bot handling — as its own body says, it is Incomplete until an authorized verifier exists. This PR is the smaller step that gets "every commit on every PR must be signed off" enforceable now. What remains valuable in #4709 and can be rebased onto this guard rather than compete with it: `legal/contribution-policy.md`, the CONTRIBUTING.md policy rewording (paid-work paragraph), the PR template, and the private CLA verifier, which can replace the `cla-signed` label in `evaluate()` when it exists.

Why not the probot DCO GitHub App: org-admin install plus `.github/dco.yml`, an external service in the merge path, a separate `DCO` status name, it silently exempts *every* Bot author, and it has no `ee/` rule, so this workflow would still be needed alongside it.

## Why it is safe under `pull_request_target` (unchanged)

Same model as `revert-fastlane.yml` / `warden-clearance.yml`:

- Workflow **and** `scripts/ci/contribution-guard.mjs` execute from the trusted base revision (`ref: ${{ github.sha }}`, sparse-checkout of `scripts/ci` only, `persist-credentials: false`). PR code is never checked out, fetched, or executed.
- Token is `contents: read` + `pull-requests: read` at both workflow and job level. The script only does `GET /pulls/{n}`, `/commits`, and (forks only) `/files` via `fetch` — zero dependencies. Fails closed if the API returns a partial commit list.
- No PR-controlled string is interpolated into a `run:` block; only the numeric PR number is passed, via `env`. Actions are pinned to immutable commit SHAs.

## Verification (head `7ca5b7cd6`, local lane — this is a CI script with no Daytona surface)

- `node --test scripts/ci/contribution-guard.test.mjs` → **16 pass / 0 fail / 0 skipped** (fork: all signed pass, unsigned fails naming the commit, mismatched email fails, noreply passes, merge exempt, `ee/` without label fails with `legal/` pointers, rename out of `ee/`, `ee/` with label passes, old unsigned fork commit still fails; same-repo: signed passes and `ee/` label not required, missing trailer fails, mismatched email fails, noreply passes, merge exempt, grandfathered before cutoff / not at cutoff / undated fails closed; bots: sentry+dependabot exempt on own PRs, human commit on bot branch fails, unlisted bot fails, spoofed bot author on human PR fails). The workflow re-runs this file on every PR.
- `pnpm dlx @action-validator/cli` on `contribution-guard.yml`, `changelog.yml`, `update-models.yml` → exit 0 each.
- Live read-only runs (`GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=different-ai/openwork PR_NUMBER=<n> node scripts/ci/contribution-guard.mjs`), production cutoff:
  - #4606 fork → exit 1, `4144db4 … missing Signed-off-by trailer`
  - #3402 fork → exit 1, `3ce2b8b … missing Signed-off-by trailer`
  - #4733 (this PR, same-repo, all signed) → exit 0 PASS
  - #4874, #4850 (same-repo, unsigned, pre-cutoff) → exit 0, `1 grandfathered`
  - #4712 sentry[bot] → exit 0, `2 allow-listed bot commit(s)`
  - #3400 dependabot[bot] + one human commit → exit 0, `1 allow-listed bot, 1 grandfathered`
  - #4735 github-actions[bot] changelog → exit 0, `1 grandfathered`
- Same runs with grace disabled (`DCO_ENFORCED_FROM=2020-01-01T00:00:00Z`, dry-run override the workflow never sets): #4733 → exit 0 PASS; #4850 → exit 1 `e31e58b … missing Signed-off-by trailer`; #3400 → exit 1 naming only the human commit `b541988`; #4735 → exit 1 `f941137 … missing Signed-off-by trailer`.
- No product code or evals touched. CONTRIBUTING.md already says "Every commit must be signed off" with no fork-only wording, so it is unchanged.

## ⚠️ Manual approval required

This PR touches `.github/`, so `warden-clearance.yml` refuses to self-clear it. A human review/approval is needed to merge.

## Admin step: make `contribution-guard` required on `dev`

Adding a required status is a repository-settings action (not done by this PR):

1. GitHub → **different-ai/openwork → Settings → Rules → Rulesets**.
2. Open **“Require OpenWork Tests on dev”** (ruleset `20914107`, target `refs/heads/dev`, currently requires only `openwork-tests-required`).
3. Under **Require status checks to pass → Add checks**, search `contribution-guard` and add it (it appears once the workflow has run at least once on `dev`, i.e. after this PR merges and any PR triggers it). Leave “Require branches to be up to date” as it is.
4. **Save changes.** From then on every PR into `dev` needs a green `contribution-guard`; existing same-repo commits stay green through the grace cutoff.

Alternatively via API: `gh api -X PUT repos/different-ai/openwork/rulesets/20914107 --input ruleset.json` with `openwork-tests-required` and `contribution-guard` both listed under `required_status_checks`.
