### PR TITLE
fix(browser): ask for consent before executing a discovered site tool

### DIFF
--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -1464,7 +1464,12 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     ipcMain.on("openwork:webmcp:tools-changed", (event) => {
       const tab = [...browserTabs.values()].find((candidate) => candidate.view.webContents === event.sender);
       if (!tab) return;
-      invalidateWebMcpTab(tab);
+      // The page relays this after a debounce, so it routinely arrives after a
+      // listing that already saw the same registrations. It is not a new
+      // document: only navigation bumps the revision. Listed handles stay
+      // valid, and execution revalidates each tool's live descriptor digest
+      // before asking for consent, so a changed or removed tool still fails
+      // as stale_tool while an unchanged one reaches the approval prompt.
       scheduleWebMcpToolCountRefresh(tab.tabId);
     });
   }

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -100,6 +100,10 @@ export class WebContentsView {
       isCurrentlyAudible() { return this.audible; },
       canGoBack() { return false; },
       canGoForward() { return false; },
+      // Site tools the document currently registers, as the main-world getTools
+      // reader would report them. The single main frame is origin-keyed.
+      siteTools: [],
+      siteToolCalls: [],
       destinations: [],
       stops: 0,
       async request(url, details = {}) {
@@ -129,6 +133,24 @@ export class WebContentsView {
         this.destroyed = true; this.emit("destroyed");
       },
     };
+    const contents = this.webContents;
+    const frame = {
+      get url() { return contents.url; },
+      get origin() { try { return new URL(contents.url).origin; } catch { return "null"; } },
+      parent: null, frames: [], detached: false,
+      isDestroyed() { return contents.destroyed; },
+      ipc: new EventEmitter(),
+      send(_channel, replyChannel) {
+        frame.ipc.emit(replyChannel, { senderFrame: frame }, { originAgentCluster: true, domainMatchesHost: true, embedding: null });
+      },
+      async executeJavaScript(code) {
+        if (code.includes("OPENWORK_WEBMCP_LIST")) return contents.siteTools.map((tool) => ({ ...tool, origin: frame.origin }));
+        if (code.includes("OPENWORK_WEBMCP_EXECUTE")) { contents.siteToolCalls.push(code); return JSON.stringify({ saved: contents.siteToolCalls.length }); }
+        return true;
+      },
+    };
+    frame.framesInSubtree = [frame];
+    contents.mainFrame = frame;
   }
   setBounds(bounds) { this.bounds = bounds; }
   setVisible(visible) { this.visible = visible; }
@@ -1469,6 +1491,47 @@ test("a first task open stays blank through asynchronous panel mounting and loca
   assert.equal(invoke("openwork:browser:state").tabs[0].browserApproval.title, "Allow website access?", "navigation did not grant reading or action access");
   approve(false);
   assert.equal((await reading).code, "user_denied");
+});
+
+test("a late tool-change relay after discovery still asks for consent before running a listed site tool", async () => {
+  const { invoke, emit, panel, views, approve } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  const opening = panel.browserTask({ sessionId: "A", operation: "open", args: { url: "http://127.0.0.1:4173/" } });
+  await flush();
+  approve();
+  const opened = await opening;
+  assert.equal(opened.ok, true);
+  const contents = views()[0].webContents;
+  // The document registered its tool during load; the preload relays that
+  // registration to the host only after its debounce.
+  contents.siteTools = [{ name: "save_draft", description: "Save the draft in this controlled project." }];
+  const listing = panel.browserTask({ sessionId: "A", operation: "site_tools", args: { tabId: opened.tabId } });
+  await flush();
+  assert.equal(invoke("openwork:browser:state").tabs[0].browserApproval.title, "Allow website access?");
+  approve();
+  const listed = await listing;
+  assert.equal(listed.ok, true);
+  assert.equal(listed.tools.length, 1);
+  emit("openwork:webmcp:tools-changed", { sender: contents });
+  const executing = panel.browserTask({ sessionId: "A", operation: "site_tool", args: { tabId: opened.tabId, toolId: listed.tools[0].toolId, input: {} } });
+  await flush();
+  const review = invoke("openwork:browser:state").tabs[0].browserApproval;
+  assert.equal(review?.title, "Allow website action?", "the relay did not retire the listed handle before the consent prompt");
+  assert.deepEqual(contents.siteToolCalls, [], "nothing runs before approval");
+  approve();
+  await flush();
+  assert.equal(invoke("openwork:browser:state").tabs[0].browserApproval?.title, "Share website result?");
+  approve();
+  const result = await executing;
+  assert.equal(result.ok, true);
+  assert.equal(result.dispatched, true);
+  assert.equal(contents.siteToolCalls.length, 1);
+  // A tool the page changed or removed after listing is still refused as stale.
+  contents.siteTools = [];
+  const removed = await panel.browserTask({ sessionId: "A", operation: "site_tool", args: { tabId: opened.tabId, toolId: listed.tools[0].toolId, input: {} } });
+  assert.equal(removed.code, "stale_tool");
+  assert.equal(contents.siteToolCalls.length, 1);
+  invoke("openwork:browser:closeTab", opened.tabId);
 });
 
 test("denied, canceled, closed and background task opens never load and release their blank tabs", async () => {

--- a/evals/specs/webmcp-browser-agent.e2e.test.ts
+++ b/evals/specs/webmcp-browser-agent.e2e.test.ts
@@ -240,6 +240,9 @@ test("a conversation signs in, uses site tools and page controls with consent, i
     const delayed = tools.tools?.find((tool) => tool.name === "delayed_save");
     if (!delayed) throw new Error("Missing delayed-discovery tool.");
     const pending = task("site_tool", { tabId, toolId: delayed.toolId });
+    // DIAGNOSTIC (temporary): surface an early settlement instead of timing out.
+    const early = await Promise.race([pending, new Promise<null>((resolve) => setTimeout(() => resolve(null), 4_000))]);
+    if (early) throw new Error(`DIAGNOSTIC site_tool settled early: ${JSON.stringify(early)} tools=${JSON.stringify(tools)} state=${JSON.stringify(await probe.browserState())}`);
     await user.see({ role: "button", label: "Allow once" });
     // The host's pre-approval revalidation has finished; delay the next getTools
     // inside actual dispatch, not discovery before the action is approved.

--- a/evals/specs/webmcp-browser-agent.e2e.test.ts
+++ b/evals/specs/webmcp-browser-agent.e2e.test.ts
@@ -240,9 +240,6 @@ test("a conversation signs in, uses site tools and page controls with consent, i
     const delayed = tools.tools?.find((tool) => tool.name === "delayed_save");
     if (!delayed) throw new Error("Missing delayed-discovery tool.");
     const pending = task("site_tool", { tabId, toolId: delayed.toolId });
-    // DIAGNOSTIC (temporary): surface an early settlement instead of timing out.
-    const early = await Promise.race([pending, new Promise<null>((resolve) => setTimeout(() => resolve(null), 4_000))]);
-    if (early) throw new Error(`DIAGNOSTIC site_tool settled early: ${JSON.stringify(early)} tools=${JSON.stringify(tools)} state=${JSON.stringify(await probe.browserState())}`);
     await user.see({ role: "button", label: "Allow once" });
     // The host's pre-approval revalidation has finished; delay the next getTools
     // inside actual dispatch, not discovery before the action is approved.


### PR DESCRIPTION
Fixes the `webmcp-browser-agent` red in the Daytona E2E lane (triage: `reports/e2e-red-2026-09-09/triage.md`, Cluster 6 / Brief I — "Site-tool consent skipped on Daytona").

## Root cause

`ipcMain.on("openwork:webmcp:tools-changed")` in `browser-panel.mjs` called `invalidateWebMcpTab(tab)`, which bumps `webMcpRevision` and deletes **every** WebMCP tool handle for the tab. That IPC is the preload's relay of the page's `registerTool` activity, debounced by 250 ms, so on a freshly navigated page it lands ~250 ms after the document script ran — routinely *after* `webmcp_list_tools` already returned those same tools.

Sequence in the red nightlies (trace `…21-24-36-286Z…/test-run.json` seq 149–152): `navigate /execution-delay` → `site_tools` lists 5 tools (237 ms) → relay lands → `site_tool` returns in 223 ms. The broker's `executeTool` found no handle and threw `stale_tool` before `confirmExecution`, so no "Allow once" prompt ever mounted and the spec timed out 30 s later. Whether the relay lands before `site_tools` or between `site_tools` and `site_tool` is pure timing — deterministic under the loaded nightly lane, green in a quiet single-spec run (my first Daytona run of the *unchanged* product at `cfb7b7bc` passed, which is why this is a race, not a policy).

Ruled out from the brief:
- Workspace run mode (`94649b44a`) / team browser policy (`012586824`): those only add deny paths (`checkPolicy`); nothing auto-allows. Steps 5–8 of the same red runs show "Allow once" working on the same page.
- Engine v1 vs v2: the consent gate lives in the Electron main process (`confirmBrowserAction`), independent of the engine. The red runs were `engine: v1`.

## What changed

- `apps/desktop/electron/browser-panel.mjs`: the `tools-changed` relay no longer treats a registration change like a navigation. It only schedules the tool-count refresh. Only `did-start-navigation` bumps the revision. Safety is unchanged: `executeTool` still re-reads the frame's live tools and compares the descriptor digest before consent, and the in-page dispatcher checks the digest again, so a changed or removed tool is still refused as `stale_tool` (existing broker test "navigation and descriptor changes invalidate opaque handles" covers this without any revision bump).
- `apps/desktop/electron/browser-panel.test.mjs`: the stub `webContents` gains an origin-keyed `mainFrame` so the harness can drive `site_tools`/`site_tool`. New test: list a tool, emit `openwork:webmcp:tools-changed` from the tab, then `site_tool` must mount "Allow website action?" before anything runs; approve execution and result sharing; then a removed tool is still `stale_tool`. Red on the previous handler (`browserApproval` undefined), green with the fix.

No spec changes. The journey's claim ("execution approval is asked after navigate + list") is unchanged; it is now independent of relay timing.

## Proof

```
OPENWORK_EVAL_REF=66e8bdb59f8f5e11e61cd581165edc0f0256231f pnpm evals:e2e webmcp-browser-agent --daytona
```
`{"placement":"daytona","engine":"legacy","surface":"legacy","files":["webmcp-browser-agent"],"passed":1,"failed":0,"skipped":0,"verdict":"passed"}` — sandbox checked out `66e8bdb5`; all 17 steps ok; both sandboxes disposed.

Unit: `node --test apps/desktop/electron/browser-panel.test.mjs apps/desktop/electron/webmcp-host.test.mjs apps/desktop/electron/webmcp-policy.test.mjs` → 85 passed, 0 failed.

Caveat on the journey as proof of *this* race: it exercises the "relay between list and execute" ordering only when timing produces it (as the nightly lane did). The panel test pins that ordering deterministically.

## Noticed, not touched

- `refreshTabToolCount` → `onToolsChanged` replaces `tab.webMcpTools` with entries lacking `toolId` (unlike `listTools`), so the panel's `siteTools` payload shape depends on which path ran last.
- Locally on macOS the spec fails earlier at `agent.run("browser.open_url")` with "no interactive surface" (composer off-screen in the default local window). Not investigated; Daytona is the proof lane.
- The two diagnostic commits (`cfb7b7bc` + its revert `d1ec0c67`) are left in the branch history as the record of the quiet-lane pass on unchanged product; the net diff is only the two files above.
