### PR TITLE
fix(app): harden the root error boundary's crash report and web monitoring

### DIFF
--- a/apps/app/src/app/lib/error-monitoring.ts
+++ b/apps/app/src/app/lib/error-monitoring.ts
@@ -118,7 +118,8 @@ export function buildSentryEnvelope(event: WebErrorEvent): string {
   return `${header}\n${itemHeader}\n${JSON.stringify(event)}`;
 }
 
-let started = false;
+/** Set once the gate opens; null keeps every reporting path inert (desktop). */
+let monitor: { target: SentryDsnTarget; release: string } | null = null;
 let sentCount = 0;
 const seenErrors = new Set<string>();
 
@@ -154,7 +155,7 @@ function resourceUrl(target: EventTarget | null): string | null {
  * load failures are reported for web deployments.
  */
 export function startWebErrorMonitoring() {
-  if (started || typeof window === "undefined") return;
+  if (monitor || typeof window === "undefined") return;
   const dsn = String(import.meta.env.VITE_OPENWORK_SENTRY_DSN ?? "").trim();
   const gate: WebErrorMonitoringGate = {
     dsn,
@@ -165,11 +166,11 @@ export function startWebErrorMonitoring() {
   const target = parseSentryDsn(dsn);
   if (!target) return;
 
-  started = true;
   // Hand off from the pre-boot beacon in index.html.
   window.__openworkWebErrorMonitorActive = true;
   const release = String(import.meta.env.VITE_OPENWORK_BUILD_SHA ?? "").trim()
     || String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
+  monitor = { target, release };
 
   window.addEventListener(
     "error",
@@ -208,5 +209,23 @@ export function startWebErrorMonitoring() {
       release,
       phase: "runtime",
     });
+  });
+}
+
+/**
+ * Report an error a React error boundary caught. React swallows render throws
+ * before they reach the window "error" listener above, so the boundary hands
+ * them over explicitly. Same gate, dedupe and cap as every other event; a no-op
+ * until startWebErrorMonitoring() has opened the gate.
+ */
+export function reportCaughtWebError(error: Error) {
+  if (!monitor) return;
+  deliver(monitor.target, {
+    type: error.name,
+    message: error.message,
+    stack: error.stack,
+    url: sanitizePageUrl(window.location.href),
+    release: monitor.release,
+    phase: "runtime",
   });
 }

--- a/apps/app/src/app/lib/error-monitoring.ts
+++ b/apps/app/src/app/lib/error-monitoring.ts
@@ -215,10 +215,10 @@ export function startWebErrorMonitoring() {
 /**
  * Report an error a React error boundary caught. React swallows render throws
  * before they reach the window "error" listener above, so the boundary hands
- * them over explicitly. Same gate, dedupe and cap as every other event; a no-op
- * until startWebErrorMonitoring() has opened the gate.
+ * them over explicitly, already redacted. Same gate, dedupe and cap as every
+ * other event; a no-op until startWebErrorMonitoring() has opened the gate.
  */
-export function reportCaughtWebError(error: Error) {
+export function reportCaughtWebError(error: Pick<Error, "name" | "message" | "stack">) {
   if (!monitor) return;
   deliver(monitor.target, {
     type: error.name,

--- a/apps/app/src/react-app/shell/app-error-boundary.tsx
+++ b/apps/app/src/react-app/shell/app-error-boundary.tsx
@@ -196,8 +196,9 @@ export class AppErrorBoundary extends React.Component<
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     console.error("[app] render failed", error, info.componentStack);
     // A caught render throw never reaches the window "error" listener, so the
-    // web deployment's monitor is told directly. Inert on desktop.
-    reportCaughtWebError(error);
+    // web deployment's monitor is told directly, with the same redacted text
+    // the screen shows. Inert on desktop.
+    reportCaughtWebError({ name: error.name, ...describeCrash(error) });
   }
 
   render() {

--- a/apps/app/src/react-app/shell/app-error-boundary.tsx
+++ b/apps/app/src/react-app/shell/app-error-boundary.tsx
@@ -27,18 +27,21 @@ const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=[^&\s]+/gi;
 
 /**
  * Messages and stacks can quote URLs whose query strings carry sign-in grants
- * or deep-link tokens. Same rule as the web error beacon (origin + path only),
- * plus a mask for bare `token=…` pairs. file:// asset paths stay intact.
+ * or deep-link tokens. Same rule as the web error beacon (origin + path only:
+ * no userinfo, query or fragment), plus a mask for bare `token=…` pairs.
+ * file:// asset paths stay intact.
  */
 export function redactCrashText(text: string): string {
   return text
     .replace(SECRET_PAIR_PATTERN, "$1=[redacted]")
     .replace(URL_PATTERN, (url) => {
-      const cut = url.search(/[?#]/);
-      if (cut === -1 || /^file:/i.test(url)) return url;
+      if (/^file:/i.test(url)) return url;
+      const withoutUserinfo = url.replace(/^([^/]*\/\/)[^/@]*@/, "$1");
+      const cut = withoutUserinfo.search(/[?#]/);
+      if (cut === -1) return withoutUserinfo;
       // Keep the `:line:col` a stack frame appends after a dev-server URL.
-      const position = /(:\d+){1,2}$/.exec(url)?.[0] ?? "";
-      return url.slice(0, cut) + position;
+      const position = /(:\d+){1,2}$/.exec(withoutUserinfo)?.[0] ?? "";
+      return withoutUserinfo.slice(0, cut) + position;
     });
 }
 

--- a/apps/app/src/react-app/shell/app-error-boundary.tsx
+++ b/apps/app/src/react-app/shell/app-error-boundary.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { openworkServerInfo, readDesktopDistributionInfo, revealDesktopItemInDir } from "@/app/lib/desktop";
+import { reportCaughtWebError } from "@/app/lib/error-monitoring";
 import { getOpenWorkDeployment } from "@/app/lib/openwork-deployment";
 
 const APP_VERSION = String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
@@ -21,12 +22,32 @@ interface AppErrorBoundaryState {
   crash: CrashDetails | null;
 }
 
+const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>()]+/gi;
+const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=[^&\s]+/gi;
+
+/**
+ * Messages and stacks can quote URLs whose query strings carry sign-in grants
+ * or deep-link tokens. Same rule as the web error beacon (origin + path only),
+ * plus a mask for bare `token=…` pairs. file:// asset paths stay intact.
+ */
+export function redactCrashText(text: string): string {
+  return text
+    .replace(SECRET_PAIR_PATTERN, "$1=[redacted]")
+    .replace(URL_PATTERN, (url) => {
+      const cut = url.search(/[?#]/);
+      if (cut === -1 || /^file:/i.test(url)) return url;
+      // Keep the `:line:col` a stack frame appends after a dev-server URL.
+      const position = /(:\d+){1,2}$/.exec(url)?.[0] ?? "";
+      return url.slice(0, cut) + position;
+    });
+}
+
 /** React hands the boundary whatever was thrown; only Error carries a stack. */
 export function describeCrash(thrown: unknown): CrashDetails {
   if (thrown instanceof Error) {
-    return { message: thrown.message, stack: thrown.stack ?? "" };
+    return { message: redactCrashText(thrown.message), stack: redactCrashText(thrown.stack ?? "") };
   }
-  return { message: String(thrown), stack: "" };
+  return { message: redactCrashText(String(thrown)), stack: "" };
 }
 
 /** Clipboard payload: message, stack, app version and distribution flavor. */
@@ -174,6 +195,9 @@ export class AppErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     console.error("[app] render failed", error, info.componentStack);
+    // A caught render throw never reaches the window "error" listener, so the
+    // web deployment's monitor is told directly. Inert on desktop.
+    reportCaughtWebError(error);
   }
 
   render() {

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -90,6 +90,15 @@ test("redaction drops query strings and fragments from URLs in the message and s
   expect(report).toContain("https://app.openworklabs.com/signin");
 });
 
+test("redaction drops credentials embedded in a URL authority", () => {
+  expect(redactCrashText("fetch failed for https://svc:eval-secret-pass@example.test/path")).toBe(
+    "fetch failed for https://example.test/path",
+  );
+  expect(redactCrashText("fetch failed for https://svc:eval-secret-pass@example.test/path?code=c#f")).toBe(
+    "fetch failed for https://example.test/path",
+  );
+});
+
 test("redaction masks bare token-like pairs outside URLs", () => {
   expect(redactCrashText("Handoff rejected: token=eyJhbGci.payload grant=g-123 state=ok")).toBe(
     "Handoff rejected: token=[redacted] grant=[redacted] state=ok",

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -8,6 +8,7 @@ import {
   AppErrorBoundary,
   buildCrashReport,
   describeCrash,
+  redactCrashText,
 } from "../src/react-app/shell/app-error-boundary";
 import { StartupApp, StartupScreen } from "../src/react-app/shell/startup-screen";
 import { ArchitectureMismatchGate } from "../src/react-app/shell/architecture-mismatch-gate";
@@ -69,6 +70,68 @@ test("the copy payload omits an empty stack", () => {
   expect(buildCrashReport({ message: "plain", stack: "" }, context)).toBe(
     "OpenWork 0.18.44 (desktop, enterprise)\n\nplain",
   );
+});
+
+test("redaction drops query strings and fragments from URLs in the message and stack", () => {
+  const error = new Error(
+    "Sign-in failed for https://app.openworklabs.com/signin?code=eval-secret-code&state=xyz#accessToken=at",
+  );
+  error.stack = `Error: ${error.message}\n    at finishSignIn (https://app.openworklabs.com/assets/index-abc.js:1:2345)`;
+
+  const crash = describeCrash(error);
+  const report = buildCrashReport(crash, context);
+
+  expect(crash.message).toBe("Sign-in failed for https://app.openworklabs.com/signin");
+  expect(crash.stack).toBe(
+    "Error: Sign-in failed for https://app.openworklabs.com/signin\n    at finishSignIn (https://app.openworklabs.com/assets/index-abc.js:1:2345)",
+  );
+  expect(report).not.toContain("eval-secret-code");
+  expect(report).not.toContain("accessToken");
+  expect(report).toContain("https://app.openworklabs.com/signin");
+});
+
+test("redaction masks bare token-like pairs outside URLs", () => {
+  expect(redactCrashText("Handoff rejected: token=eyJhbGci.payload grant=g-123 state=ok")).toBe(
+    "Handoff rejected: token=[redacted] grant=[redacted] state=ok",
+  );
+  expect(redactCrashText("openworkToken=tok&accessToken=at")).toBe("openworkToken=[redacted]&accessToken=[redacted]");
+});
+
+test("redaction keeps file:// stack frames and dev-server line:col positions intact", () => {
+  const packaged = "    at render (file:///Applications/OpenWork.app/Contents/Resources/app/dist/assets/index-abc.js:1:2345)";
+  expect(redactCrashText(packaged)).toBe(packaged);
+  expect(redactCrashText("    at AppRoot (http://localhost:5173/src/react-app/shell/app-root.tsx?t=1725000000:371:23)")).toBe(
+    "    at AppRoot (http://localhost:5173/src/react-app/shell/app-root.tsx:371:23)",
+  );
+});
+
+test("the revealed technical details show the redacted message, never the query value", async () => {
+  const ownedDom = typeof window === "undefined";
+  if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const logError = spyOn(console, "error").mockImplementation(() => {});
+  function Throws(): ReactNode {
+    throw new Error("Deep link rejected: openwork://open?token=eval-secret-token");
+  }
+  try {
+    await act(async () => {
+      root.render(<AppErrorBoundary><Throws /></AppErrorBoundary>);
+    });
+    const toggle = Array.from(container.querySelectorAll("button")).find((button) => /technical details/i.test(button.textContent ?? ""));
+    await act(async () => { toggle?.click(); });
+    expect(container.textContent).toContain("Deep link rejected: openwork://open");
+    expect(container.textContent).not.toContain("eval-secret-token");
+  } finally {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    logError.mockRestore();
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+    if (ownedDom) await GlobalRegistrator.unregister();
+  }
 });
 
 test("children render untouched when nothing throws", () => {

--- a/apps/app/tests/error-monitoring.test.ts
+++ b/apps/app/tests/error-monitoring.test.ts
@@ -5,11 +5,11 @@ import {
   buildSentryEnvelope,
   buildWebErrorEvent,
   parseSentryDsn,
-  reportCaughtWebError,
   sanitizePageUrl,
   shouldMonitorWebErrors,
   startWebErrorMonitoring,
 } from "../src/app/lib/error-monitoring";
+import { AppErrorBoundary } from "../src/react-app/shell/app-error-boundary";
 
 const DSN = "https://publickey123@o123456.ingest.us.sentry.io/4500000000000000";
 
@@ -133,6 +133,8 @@ describe("buildSentryEnvelope", () => {
 describe("reportCaughtWebError", () => {
   // Bun aliases import.meta.env to process.env, so the build-time gate can be
   // driven at runtime. Module state only opens once, so desktop runs first.
+  // The boundary's componentDidCatch is the real caller, so the hand-off and
+  // its redaction are exercised through it.
   test("a boundary-caught error produces exactly one envelope on web and none on desktop", async () => {
     GlobalRegistrator.register({ url: "https://app.openworklabs.com/signin?grant=secret-grant" });
     const bodies: string[] = [];
@@ -140,30 +142,38 @@ describe("reportCaughtWebError", () => {
       bodies.push(String(init?.body));
       return Promise.resolve(new Response());
     });
+    const logError = spyOn(console, "error").mockImplementation(() => {});
     const previous = {
       deployment: process.env.VITE_OPENWORK_DEPLOYMENT,
       dsn: process.env.VITE_OPENWORK_SENTRY_DSN,
     };
+    const boundary = new AppErrorBoundary({ children: null });
+    const info = { componentStack: "\n    at AppRoot" };
+    const thrown = new Error("Deep link rejected: openwork://open?token=eval-secret-token");
     try {
       process.env.VITE_OPENWORK_DEPLOYMENT = "desktop";
       process.env.VITE_OPENWORK_SENTRY_DSN = DSN;
       startWebErrorMonitoring();
-      reportCaughtWebError(new Error("render exploded"));
+      boundary.componentDidCatch(thrown, info);
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(window.__openworkWebErrorMonitorActive).toBeUndefined();
 
       process.env.VITE_OPENWORK_DEPLOYMENT = "web";
       startWebErrorMonitoring();
-      reportCaughtWebError(new Error("render exploded"));
-      reportCaughtWebError(new Error("render exploded"));
+      boundary.componentDidCatch(thrown, info);
+      boundary.componentDidCatch(thrown, info);
       expect(bodies).toHaveLength(1);
       const event = JSON.parse(bodies[0].split("\n")[2]);
-      expect(event.exception.values).toEqual([{ type: "Error", value: "render exploded" }]);
+      expect(event.exception.values).toEqual([{ type: "Error", value: "Deep link rejected: openwork://open" }]);
       expect(event.tags).toEqual({ boot_phase: "runtime" });
       expect(event.request).toEqual({ url: "https://app.openworklabs.com/signin" });
-      expect(JSON.stringify(event)).not.toContain("secret-grant");
+      expect(event.extra.stack).toContain("Deep link rejected: openwork://open");
+      // Neither the page URL's grant nor the thrown URL's token leaves the page.
+      expect(bodies[0]).not.toContain("secret-grant");
+      expect(bodies[0]).not.toContain("eval-secret-token");
     } finally {
       fetchSpy.mockRestore();
+      logError.mockRestore();
       if (previous.deployment === undefined) delete process.env.VITE_OPENWORK_DEPLOYMENT;
       else process.env.VITE_OPENWORK_DEPLOYMENT = previous.deployment;
       if (previous.dsn === undefined) delete process.env.VITE_OPENWORK_SENTRY_DSN;

--- a/apps/app/tests/error-monitoring.test.ts
+++ b/apps/app/tests/error-monitoring.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 import {
   buildSentryEnvelope,
   buildWebErrorEvent,
   parseSentryDsn,
+  reportCaughtWebError,
   sanitizePageUrl,
   shouldMonitorWebErrors,
+  startWebErrorMonitoring,
 } from "../src/app/lib/error-monitoring";
 
 const DSN = "https://publickey123@o123456.ingest.us.sentry.io/4500000000000000";
@@ -124,5 +127,48 @@ describe("buildSentryEnvelope", () => {
     expect(JSON.parse(lines[0]).event_id).toBe(event.event_id);
     expect(JSON.parse(lines[1])).toEqual({ type: "event" });
     expect(JSON.parse(lines[2]).exception.values[0].value).toBe("boom");
+  });
+});
+
+describe("reportCaughtWebError", () => {
+  // Bun aliases import.meta.env to process.env, so the build-time gate can be
+  // driven at runtime. Module state only opens once, so desktop runs first.
+  test("a boundary-caught error produces exactly one envelope on web and none on desktop", async () => {
+    GlobalRegistrator.register({ url: "https://app.openworklabs.com/signin?grant=secret-grant" });
+    const bodies: string[] = [];
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      bodies.push(String(init?.body));
+      return Promise.resolve(new Response());
+    });
+    const previous = {
+      deployment: process.env.VITE_OPENWORK_DEPLOYMENT,
+      dsn: process.env.VITE_OPENWORK_SENTRY_DSN,
+    };
+    try {
+      process.env.VITE_OPENWORK_DEPLOYMENT = "desktop";
+      process.env.VITE_OPENWORK_SENTRY_DSN = DSN;
+      startWebErrorMonitoring();
+      reportCaughtWebError(new Error("render exploded"));
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(window.__openworkWebErrorMonitorActive).toBeUndefined();
+
+      process.env.VITE_OPENWORK_DEPLOYMENT = "web";
+      startWebErrorMonitoring();
+      reportCaughtWebError(new Error("render exploded"));
+      reportCaughtWebError(new Error("render exploded"));
+      expect(bodies).toHaveLength(1);
+      const event = JSON.parse(bodies[0].split("\n")[2]);
+      expect(event.exception.values).toEqual([{ type: "Error", value: "render exploded" }]);
+      expect(event.tags).toEqual({ boot_phase: "runtime" });
+      expect(event.request).toEqual({ url: "https://app.openworklabs.com/signin" });
+      expect(JSON.stringify(event)).not.toContain("secret-grant");
+    } finally {
+      fetchSpy.mockRestore();
+      if (previous.deployment === undefined) delete process.env.VITE_OPENWORK_DEPLOYMENT;
+      else process.env.VITE_OPENWORK_DEPLOYMENT = previous.deployment;
+      if (previous.dsn === undefined) delete process.env.VITE_OPENWORK_SENTRY_DSN;
+      else process.env.VITE_OPENWORK_SENTRY_DSN = previous.dsn;
+      await GlobalRegistrator.unregister();
+    }
   });
 });

--- a/evals/specs/app-render-crash-recovery.e2e.test.ts
+++ b/evals/specs/app-render-crash-recovery.e2e.test.ts
@@ -34,8 +34,10 @@ test("a render throw shows a recovery screen with the error instead of a blank w
   await step("technical details reveal the redacted message, stack and reporting actions on demand", async () => {
     await user.click({ role: "button", label: /technical details/i });
     await user.see({ text: MESSAGE });
-    // The URL keeps its path for diagnosis; the grant in its query never shows.
-    await user.notSee({ text: SECRET });
+    // The URL keeps its path for diagnosis; the grant in its query never shows
+    // anywhere on the page, message or stack.
+    expect(await probe.has("https://app.openworklabs.com/signin")).toBe(true);
+    expect(await probe.has(SECRET)).toBe(false);
     // The stack names the throwing component, so the failure is reportable.
     await user.see({ text: /at BrandThemeControlActions/ });
     await user.see({ role: "button", label: /copy details/i });

--- a/evals/specs/app-render-crash-recovery.e2e.test.ts
+++ b/evals/specs/app-render-crash-recovery.e2e.test.ts
@@ -4,8 +4,12 @@ import { renderCrashWorld } from "../worlds/first-run.ts";
 
 const test = spec.world(renderCrashWorld);
 
-// Thrown by the dev-only eval hook; the recovery screen must show it verbatim.
-const MESSAGE = "Local context is missing (eval render throw)";
+// Thrown by the dev-only eval hook. The message quotes a sign-in URL whose
+// query string carries a grant: the recovery screen and the copied report must
+// keep the path but never the query value.
+const SECRET = "eval-secret-grant-4242";
+const THROWN = `Local context is missing (eval render throw) after https://app.openworklabs.com/signin?code=${SECRET}`;
+const MESSAGE = "Local context is missing (eval render throw) after https://app.openworklabs.com/signin";
 const heading = { text: /OpenWork hit an unexpected error/ };
 
 test("a render throw shows a recovery screen with the error instead of a blank window", async ({ world, user, agent, probe, step }) => {
@@ -16,7 +20,7 @@ test("a render throw shows a recovery screen with the error instead of a blank w
   });
 
   await step("a throw during render lands on the recovery screen, not an empty window", async () => {
-    await agent.run("eval.app.render_throw", { message: MESSAGE });
+    await agent.run("eval.app.render_throw", { message: THROWN });
     await user.see(heading, { timeoutMs: 15_000 });
     await user.see({ role: "button", label: /^reload$/i });
     await user.see({ role: "button", label: /technical details/i });
@@ -27,9 +31,11 @@ test("a render throw shows a recovery screen with the error instead of a blank w
     await user.screenshot();
   });
 
-  await step("technical details reveal the message, stack and reporting actions on demand", async () => {
+  await step("technical details reveal the redacted message, stack and reporting actions on demand", async () => {
     await user.click({ role: "button", label: /technical details/i });
     await user.see({ text: MESSAGE });
+    // The URL keeps its path for diagnosis; the grant in its query never shows.
+    await user.notSee({ text: SECRET });
     // The stack names the throwing component, so the failure is reportable.
     await user.see({ text: /at BrandThemeControlActions/ });
     await user.see({ role: "button", label: /copy details/i });
@@ -37,7 +43,7 @@ test("a render throw shows a recovery screen with the error instead of a blank w
     await user.screenshot();
   });
 
-  await step("copy puts message, stack, app version and flavor on the clipboard", async () => {
+  await step("copy puts the redacted message, stack, app version and flavor on the clipboard", async () => {
     await user.click({ role: "button", label: /copy details/i });
     await user.see({ role: "button", label: /^copied$/i });
     const clipboard = await probe.eventually(() => world.readClipboard(), {
@@ -49,6 +55,8 @@ test("a render throw shows a recovery screen with the error instead of a blank w
     expect(header).toMatch(/^OpenWork \S+ \(desktop, (public|enterprise)\)$/);
     expect(message).toBe(MESSAGE);
     expect(stack).toMatch(/at BrandThemeControlActions/);
+    expect(clipboard).toContain("https://app.openworklabs.com/signin");
+    expect(clipboard).not.toContain(SECRET);
   });
 
   await step("reload brings the app back", async () => {


### PR DESCRIPTION
## Summary

Follow-up hardening for the root React error boundary (`apps/app/src/react-app/shell/app-error-boundary.tsx`, #4697/#4698). Neither gap is a vulnerability.

1. **Redact secrets in the crash report and Technical details.** Error messages can quote URLs whose query strings carry grants or tokens (deep links, sign-in handoff). `describeCrash` now runs message and stack through `redactCrashText`: query strings and fragments are dropped from every URL (the same origin+path rule `index.html`'s pre-boot beacon and `sanitizePageUrl` already apply), and bare `token|grant|code|secret|key=…` pairs become `=[redacted]`. `file://` asset paths stay intact, and a dev-server frame keeps its `:line:col`. Both the on-screen details and the clipboard payload read from the redacted state.
2. **Keep web Sentry monitoring aware of boundary-caught crashes.** A caught render throw never reaches the `window` `error` listener. `error-monitoring.ts` now keeps the gated target/release at module level and exports `reportCaughtWebError`, which `componentDidCatch` calls. It goes through the existing `deliver` (web-only gate, DSN, analytics preference, dedupe, per-session cap). On desktop the gate never opens, so the call is a no-op: no new network from the boundary in Electron.

## Tests

- `apps/app/tests/app-error-boundary.test.tsx`: URL `?code=…` redaction in message/stack and copy payload, bare `token=`/`grant=` masking, `file://` frame and dev-server `:line:col` untouched, revealed Technical details never show the query value.
- `apps/app/tests/error-monitoring.test.ts`: a boundary-caught error yields exactly one envelope on web (dedupe on repeat, page URL sanitized) and none on desktop.
- `evals/specs/app-render-crash-recovery.e2e.test.ts`: the thrown message now quotes a sign-in URL with a `?code=` grant; the visible details and the copied report keep the path and never contain the query value.

Test evidence is published in the sticky comment below.