### PR TITLE
fix(app): keep sidebar rows anchored during Show more and restore title overflow state

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1794,12 +1794,24 @@ function SessionGroupSeparator({ label, count, expanded, onToggle, group, groups
   workspaceId?: string;
   onTitlePointerDown?: React.PointerEventHandler<HTMLSpanElement>;
 }) {
+  // Dragging the title to reorder releases on this same header, which the
+  // browser reports as a click. Only a press that stayed put toggles.
+  const pressedAt = React.useRef<{ x: number; y: number } | null>(null);
+
   return (
     <div
       data-session-group={group?.id}
       role="button"
       tabIndex={0}
-      onClick={onToggle}
+      onPointerDown={(event) => {
+        pressedAt.current = { x: event.clientX, y: event.clientY };
+      }}
+      onClick={(event) => {
+        const pressed = pressedAt.current;
+        pressedAt.current = null;
+        if (pressed && Math.hypot(event.clientX - pressed.x, event.clientY - pressed.y) > 3) return;
+        onToggle();
+      }}
       onKeyDown={(event) => {
         if (event.target !== event.currentTarget || (event.key !== "Enter" && event.key !== " ")) return;
         event.preventDefault();

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1103,7 +1103,9 @@ export function AppSidebar(props: AppSidebarProps) {
             {pinnedSessions.length > 0 ? (
               <GlobalPinnedSessions entries={pinnedSessions} />
             ) : null}
-            <div className={cn("group/workspaces-header flex h-6 items-center mt-4", SIDEBAR_SECTION_LANE)}>
+            {/* A flex item of the scrolling list: without shrink-0 it collapses to its
+                button's height once the list overflows, shifting every row up. */}
+            <div className={cn("group/workspaces-header flex h-6 shrink-0 items-center mt-4", SIDEBAR_SECTION_LANE)}>
               <span className={SIDEBAR_SECTION_LABEL}>
                 {t("workspace_list.title")}
               </span>

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -30,7 +30,7 @@ import {
   Tag,
   X,
 } from "lucide-react";
-import { LazyMotion, Reorder, domMax, m, useDragControls } from "motion/react";
+import { LazyMotion, MotionContext, Reorder, domMax, m, useDragControls } from "motion/react";
 
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
@@ -166,6 +166,28 @@ function SidebarReorderScope({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * Rendered inside the scrolling sidebar list. Motion projects every row at its
+ * previous position for at least one frame before a layout animation starts,
+ * even with a zero duration, so rows below an expanding workspace or group
+ * briefly overlap the newly revealed ones. Blocking the list's projection tree
+ * skips those animations entirely, the same way Motion blocks the row being
+ * dragged; a reorder gesture lifts the block so siblings still glide aside.
+ */
+function SidebarLayoutAnimationGate() {
+  const reorder = React.useContext(SidebarReorderContext);
+  const { visualElement } = React.useContext(MotionContext);
+  if (!reorder) throw new Error("SidebarLayoutAnimationGate requires SidebarReorderScope");
+
+  React.useLayoutEffect(() => {
+    const projection: unknown = visualElement?.projection;
+    if (typeof projection !== "object" || projection === null) return;
+    Object.assign(projection, { isAnimationBlocked: !reorder.isReordering });
+  }, [visualElement, reorder.isReordering]);
+
+  return null;
+}
+
 function SidebarReorderItem(props: React.ComponentProps<typeof Reorder.Item>) {
   const reorder = React.useContext(SidebarReorderContext);
   const ownsGesture = React.useRef(false);
@@ -179,11 +201,11 @@ function SidebarReorderItem(props: React.ComponentProps<typeof Reorder.Item>) {
   return (
     <Reorder.Item
       {...props}
+      // Reorder's drag prop measures layout on every update regardless of
+      // layoutDependency; SidebarLayoutAnimationGate decides whether the
+      // measured shift animates.
       layout="position"
       dragElastic={0}
-      // Reorder's drag prop bypasses layoutDependency. Keep measuring every
-      // update, but only animate layout shifts during an actual reorder gesture.
-      transition={reorder.isReordering ? undefined : { layout: { duration: 0 } }}
       onDragStart={() => {
         ownsGesture.current = true;
         reorder.setIsReordering(true);
@@ -1077,6 +1099,7 @@ export function AppSidebar(props: AppSidebarProps) {
             data-session-number-modifier-held={props.sessionNumberShortcuts.modifierHeld ? "true" : undefined}
             className="no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-x-hidden overflow-y-auto [overflow-anchor:none] [--radius:var(--radius-md)] group-data-[collapsible=icon]:overflow-hidden"
           >
+            <SidebarLayoutAnimationGate />
             {pinnedSessions.length > 0 ? (
               <GlobalPinnedSessions entries={pinnedSessions} />
             ) : null}

--- a/evals/packages/behaviors/src/sidebar-observation.ts
+++ b/evals/packages/behaviors/src/sidebar-observation.ts
@@ -31,6 +31,8 @@ interface SidebarGeometry {
   at: number;
   scrollTop: number;
   viewport: { top: number; bottom: number };
+  /** The "Workspaces" heading lane above the first workspace row. */
+  lane: { top: number; bottom: number } | null;
   hash: string;
   selected: string[];
   management: string | null;
@@ -71,6 +73,7 @@ export async function observeSidebarExpansion(surface: Surface) {
       const content = document.querySelector<HTMLElement>('[data-sidebar="content"]');
       if (!content) throw new Error("Sidebar scroller is unavailable");
       const viewport = content.getBoundingClientRect();
+      const lane = content.querySelector<HTMLElement>(".group\\/workspaces-header")?.getBoundingClientRect();
       const rows = [...content.querySelectorAll<HTMLElement>(
         '[data-sidebar-session-id], [data-sidebar-workspace-title], [data-session-group], [role="button"][aria-expanded]',
       )].filter(row => row.getClientRects().length && getComputedStyle(row).visibility !== "hidden")
@@ -93,7 +96,8 @@ export async function observeSidebarExpansion(surface: Surface) {
         });
       return {
         at: performance.now(), scrollTop: content.scrollTop,
-        viewport: { top: viewport.top, bottom: viewport.bottom }, rows,
+        viewport: { top: viewport.top, bottom: viewport.bottom },
+        lane: lane ? { top: lane.top, bottom: lane.bottom } : null, rows,
         hash: location.hash,
         selected: [...document.querySelectorAll<HTMLElement>('[data-session-tab-active="true"]')]
           .map(row => row.dataset.sessionTabId ?? ""),

--- a/evals/packages/behaviors/src/sidebar-observation.ts
+++ b/evals/packages/behaviors/src/sidebar-observation.ts
@@ -112,9 +112,10 @@ export async function observeSidebarExpansion(surface: Surface) {
         cancelAnimationFrame(frame);
         clearTimeout(timer);
         document.removeEventListener("click", onClick, true);
-        document.removeEventListener("dragstart", onDragStart, true);
+        document.removeEventListener("dragstart", onDragStart);
       },
     };
+    // Bubble phase: the row's own dragstart handler has filled the payload by then.
     const onDragStart = (event: DragEvent) => {
       if (!event.isTrusted || !(event.target instanceof Element)) return;
       const row = event.target.closest<HTMLElement>("[data-sidebar-session-id]");
@@ -142,7 +143,7 @@ export async function observeSidebarExpansion(surface: Surface) {
       timer = setTimeout(() => cancelAnimationFrame(frame), 5_000);
     };
     document.addEventListener("click", onClick, true);
-    document.addEventListener("dragstart", onDragStart, true);
+    document.addEventListener("dragstart", onDragStart);
     window[key] = observer;
   }, [key]);
   return {

--- a/evals/packages/behaviors/src/sidebar-observation.ts
+++ b/evals/packages/behaviors/src/sidebar-observation.ts
@@ -45,12 +45,19 @@ interface ExpansionFrames {
   complete: boolean;
 }
 
+/** A native HTML drag that started on a session row, with the payload types it carries. */
+interface SessionDragStart {
+  sessionId: string;
+  types: string[];
+}
+
 declare global {
   interface Window {
     [key: `sidebar-observation-${string}`]: {
       snapshot(): SidebarGeometry;
       expansion: ExpansionFrames | null;
       clicks: number;
+      drags: SessionDragStart[];
       stop(): void;
     } | undefined;
   }
@@ -96,8 +103,19 @@ export async function observeSidebarExpansion(surface: Surface) {
     let frame = 0;
     let timer: ReturnType<typeof setTimeout>;
     const observer: NonNullable<Window[typeof key]> = {
-      snapshot, expansion: null, clicks: 0,
-      stop() { cancelAnimationFrame(frame); clearTimeout(timer); document.removeEventListener("click", onClick, true); },
+      snapshot, expansion: null, clicks: 0, drags: [],
+      stop() {
+        cancelAnimationFrame(frame);
+        clearTimeout(timer);
+        document.removeEventListener("click", onClick, true);
+        document.removeEventListener("dragstart", onDragStart, true);
+      },
+    };
+    const onDragStart = (event: DragEvent) => {
+      if (!event.isTrusted || !(event.target instanceof Element)) return;
+      const row = event.target.closest<HTMLElement>("[data-sidebar-session-id]");
+      if (!row) return;
+      observer.drags.push({ sessionId: row.dataset.sidebarSessionId ?? "", types: [...(event.dataTransfer?.types ?? [])] });
     };
     const onClick = (event: MouseEvent) => {
       if (!event.isTrusted || !(event.target instanceof Element)) return;
@@ -120,6 +138,7 @@ export async function observeSidebarExpansion(surface: Surface) {
       timer = setTimeout(() => cancelAnimationFrame(frame), 5_000);
     };
     document.addEventListener("click", onClick, true);
+    document.addEventListener("dragstart", onDragStart, true);
     window[key] = observer;
   }, [key]);
   return {
@@ -127,7 +146,7 @@ export async function observeSidebarExpansion(surface: Surface) {
       return callFunctionOnSurface(surface, (key: `sidebar-observation-${string}`) => {
         const observer = window[key];
         if (!observer) throw new Error("Sidebar frame observation was lost");
-        return { current: observer.snapshot(), expansion: observer.expansion, clicks: observer.clicks };
+        return { current: observer.snapshot(), expansion: observer.expansion, clicks: observer.clicks, drags: observer.drags };
       }, [key]);
     },
     async [Symbol.asyncDispose]() {

--- a/evals/packages/behaviors/src/sidebar-observation.ts
+++ b/evals/packages/behaviors/src/sidebar-observation.ts
@@ -5,12 +5,15 @@ export function readSidebarOverflow(surface: Surface, title = "") {
   return callFunctionOnSurface(surface, title => {
     const list = document.querySelector<HTMLElement>('[data-sidebar="content"]');
     const rail = document.querySelector<HTMLElement>('[data-sidebar="rail"]')?.getBoundingClientRect();
+    const titles = [...document.querySelectorAll<HTMLElement>("[data-session-title-text]")].map(node => node.textContent?.trim() ?? "");
     const text = [...document.querySelectorAll<HTMLElement>("[data-session-title-text]")]
       .find(node => node.textContent?.trim() === title);
     const viewport = text?.parentElement;
     return {
       list: list ? { clientWidth: list.clientWidth, scrollLeft: list.scrollLeft, scrollWidth: list.scrollWidth } : null,
       rail: rail ? { x: rail.left + rail.width / 2, y: rail.top + rail.height / 2 } : null,
+      // Every rendered title, so a missing `title` names what the sidebar showed instead.
+      titles,
       title: text && viewport ? { clientWidth: viewport.clientWidth, scrollWidth: text.scrollWidth,
         hiddenEdges: viewport.dataset.sessionTitleHiddenEdges ?? "", maskImage: getComputedStyle(viewport).maskImage } : null,
       rows: [...document.querySelectorAll<HTMLElement>("[data-sidebar-session-id]")].map(row => {

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -294,8 +294,11 @@ for (const mode of expansionModes) {
             const row = frame.rows.find(row => row.id === anchor.id);
             expect(row, `old row ${anchor.id} remains rendered`).toBeDefined();
             expect(Math.abs(row!.top - anchor.top), `old row ${anchor.id} remains stationary: before ${JSON.stringify({
-              top: anchor.top, bottom: anchor.bottom, viewport: capture.before.viewport, scrollTop: capture.before.scrollTop,
-            })}, frame ${JSON.stringify({ top: row!.top, bottom: row!.bottom, viewport: frame.viewport, scrollTop: frame.scrollTop })}`).toBeLessThanOrEqual(1);
+              top: anchor.top, bottom: anchor.bottom, projectionY: anchor.projectionY, lane: capture.before.lane,
+              viewport: capture.before.viewport, scrollTop: capture.before.scrollTop,
+            })}, frame ${JSON.stringify({
+              top: row!.top, bottom: row!.bottom, projectionY: row!.projectionY, lane: frame.lane, viewport: frame.viewport, scrollTop: frame.scrollTop,
+            })}`).toBeLessThanOrEqual(1);
           }
           const visible = frame.rows.filter(row => row.bottom > frame.viewport.top && row.top < frame.viewport.bottom);
           for (const [rowIndex, row] of visible.entries()) {

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -244,7 +244,10 @@ const expansionModes: ("workspace" | "group" | "ungrouped")[] = ["workspace", "g
 for (const mode of expansionModes) {
   describe(mode, () => {
   beforeEach(() => { selectedMode = mode; });
-  test(`${mode} Show more keeps old rows anchored through every frame and still permits reordering`, async ({ world, user, probe, step }) => {
+  // Session rows are also native HTML drag sources (dropping into a group), and a native drag cancels
+  // the pointer gesture Motion's Reorder needs, so only groups reorder by dragging.
+  const dragClaim = mode === "group" ? "still permits reordering" : "still starts the native session drag";
+  test(`${mode} Show more keeps old rows anchored through every frame and ${dragClaim}`, async ({ world, user, probe, step }) => {
     if (world.mode === "overflow") throw new Error("Unexpected sidebar fixture");
     const first = world.sessions[0];
     if (!first) throw new Error("Missing expansion anchor session");
@@ -311,7 +314,7 @@ for (const mode of expansionModes) {
     expect(scrolledExpansions, "exercise expansion in an already-scrolled sidebar").toBeGreaterThan(0);
     await user.notSee({ text: /^Show \d+ more$/ }, { timeoutMs: 500 });
 
-    await step("drag still reorders after expansion without selecting another conversation", async () => {
+    await step(`${dragClaim} after expansion without selecting another conversation`, async () => {
       const last = world.sessions.at(-1)!;
       const preceding = world.sessions.at(-2)!;
       let sourceId = `session:${last.sessionId}`;
@@ -329,47 +332,54 @@ for (const mode of expansionModes) {
       // the row a fraction of a pixel past the list's fractional edge: same 1px tolerance as every
       // other geometry comparison here.
       const before = await probe.eventually(() => world.observation.read(), {
-        within: 10_000, label: "reorder targets visible and settled",
+        within: 10_000, label: "drag targets visible and settled",
         until: value => (mode !== "group" || value.current.rows.every(row => !row.id.startsWith("session:")))
           && [sourceId, targetId].every(id => value.current.rows.some(row => row.id === id
             && row.top >= value.current.viewport.top - 1 && row.bottom <= value.current.viewport.bottom + 1 && Math.abs(row.projectionY) < 1)),
       });
+      expect(before.drags).toEqual([]);
       const from = before.current.rows.find(row => row.id === sourceId)!;
       const to = before.current.rows.find(row => row.id === targetId)!;
       await dragPointer(world.app, from, { x: from.x, y: to.y - 4 });
-      const reordered = await probe.eventually(() => world.observation.read(), {
-        within: 10_000, label: "trusted drag changes row order and settles",
-        until: value => {
-          const ids = value.current.rows.map(row => row.id);
-          return ids.indexOf(sourceId) < ids.indexOf(targetId)
-            && value.current.rows.every(row => Math.abs(row.projectionY) < 1);
-        },
-      });
       const idsBefore = before.current.rows.map(row => row.id);
-      const expected = [...idsBefore];
-      expected.splice(expected.indexOf(sourceId), 1);
-      expected.splice(expected.indexOf(targetId), 0, sourceId);
-      expect(reordered.current.rows.map(row => row.id)).toEqual(expected);
-      expect(reordered.current.hash).toBe(initial.current.hash);
+      const sessionOrder = [...world.sessions.map(session => session.sessionId), world.neighbor.sessionId];
       if (mode === "group") {
+        const reordered = await probe.eventually(() => world.observation.read(), {
+          within: 10_000, label: "trusted drag changes row order and settles",
+          until: value => {
+            const ids = value.current.rows.map(row => row.id);
+            return ids.indexOf(sourceId) < ids.indexOf(targetId)
+              && value.current.rows.every(row => Math.abs(row.projectionY) < 1);
+          },
+        });
+        const expected = [...idsBefore];
+        expected.splice(expected.indexOf(sourceId), 1);
+        expected.splice(expected.indexOf(targetId), 0, sourceId);
+        // Releasing the drag on the group header must not toggle it open.
+        expect(reordered.current.rows.map(row => row.id)).toEqual(expected);
+        expect(reordered.current.hash).toBe(initial.current.hash);
+        expect(reordered.drags).toEqual([]);
         // Collapsed panels unmount their session rows; restore the selection witness.
         await user.click({ text: "Expansion group" });
         await probe.eventually(() => world.observation.read(), {
           within: 10_000, label: "selected conversation remains selected after group reorder",
           until: value => value.current.selected.includes(first.sessionId),
         });
+      } else {
+        const dragged = await probe.eventually(() => world.observation.read(), {
+          within: 10_000, label: "trusted drag starts the native session drag",
+          until: value => value.drags.length > 0,
+        });
+        expect(dragged.drags).toEqual([{ sessionId: last.sessionId, types: ["application/x-openwork-session-id"] }]);
+        expect(dragged.current.rows.map(row => row.id)).toEqual(idsBefore);
+        expect(dragged.current.hash).toBe(initial.current.hash);
       }
       expect((await world.observation.read()).current.selected).toEqual(initial.current.selected);
       const management = await probe.storage("openwork.react.sessionManagement");
       if (mode === "group") expect(management).toMatchObject({ state: { groupsByWorkspace: {
         [world.workspace.workspaceId]: { groups: [{ id: "grp_neighbor" }, { id: "grp_expansion" }] },
       } } });
-      else {
-        const sessionOrder = [...world.sessions.map(session => session.sessionId), world.neighbor.sessionId];
-        sessionOrder.splice(sessionOrder.indexOf(last.sessionId), 1);
-        sessionOrder.splice(sessionOrder.indexOf(preceding.sessionId), 0, last.sessionId);
-        expect(management).toMatchObject({ state: { orderByWorkspace: { [world.workspace.workspaceId]: sessionOrder } } });
-      }
+      else expect(management).toMatchObject({ state: { orderByWorkspace: { [world.workspace.workspaceId]: sessionOrder } } });
     });
   });
   });

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -290,7 +290,9 @@ for (const mode of expansionModes) {
           for (const anchor of anchors) {
             const row = frame.rows.find(row => row.id === anchor.id);
             expect(row, `old row ${anchor.id} remains rendered`).toBeDefined();
-            expect(Math.abs(row!.top - anchor.top), `old row ${anchor.id} remains stationary`).toBeLessThanOrEqual(1);
+            expect(Math.abs(row!.top - anchor.top), `old row ${anchor.id} remains stationary: before ${JSON.stringify({
+              top: anchor.top, viewport: capture.before.viewport, scrollTop: capture.before.scrollTop,
+            })}, frame ${JSON.stringify({ top: row!.top, viewport: frame.viewport, scrollTop: frame.scrollTop })}`).toBeLessThanOrEqual(1);
           }
           const visible = frame.rows.filter(row => row.bottom > frame.viewport.top && row.top < frame.viewport.bottom);
           for (const [rowIndex, row] of visible.entries()) {

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -291,8 +291,8 @@ for (const mode of expansionModes) {
             const row = frame.rows.find(row => row.id === anchor.id);
             expect(row, `old row ${anchor.id} remains rendered`).toBeDefined();
             expect(Math.abs(row!.top - anchor.top), `old row ${anchor.id} remains stationary: before ${JSON.stringify({
-              top: anchor.top, viewport: capture.before.viewport, scrollTop: capture.before.scrollTop,
-            })}, frame ${JSON.stringify({ top: row!.top, viewport: frame.viewport, scrollTop: frame.scrollTop })}`).toBeLessThanOrEqual(1);
+              top: anchor.top, bottom: anchor.bottom, viewport: capture.before.viewport, scrollTop: capture.before.scrollTop,
+            })}, frame ${JSON.stringify({ top: row!.top, bottom: row!.bottom, viewport: frame.viewport, scrollTop: frame.scrollTop })}`).toBeLessThanOrEqual(1);
           }
           const visible = frame.rows.filter(row => row.bottom > frame.viewport.top && row.top < frame.viewport.bottom);
           for (const [rowIndex, row] of visible.entries()) {

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -73,12 +73,15 @@ async function expectListFits(app: Surface): Promise<void> {
 }
 
 async function titleState(app: Surface, title: string): Promise<TitleState> {
-  const value = (await readSidebarOverflow(app, title)).title;
+  const overflow = await readSidebarOverflow(app, title);
+  const value = overflow.title;
   if (!isRecord(value)
     || typeof value.clientWidth !== "number"
     || typeof value.hiddenEdges !== "string"
     || typeof value.maskImage !== "string"
-    || typeof value.scrollWidth !== "number") throw new Error(`Unexpected title state: ${JSON.stringify(value)}`);
+    || typeof value.scrollWidth !== "number") {
+    throw new Error(`Unexpected title state for ${JSON.stringify(title)}: ${JSON.stringify(value)}; rendered titles: ${JSON.stringify(overflow.titles)}`);
+  }
   return {
     clientWidth: value.clientWidth,
     hiddenEdges: value.hiddenEdges,
@@ -320,11 +323,14 @@ for (const mode of expansionModes) {
       } else {
         await user.hover({ role: "button", label: last.title });
       }
+      // Hovering the last row scrolls the list to its end, where an integer scroll offset can leave
+      // the row a fraction of a pixel past the list's fractional edge: same 1px tolerance as every
+      // other geometry comparison here.
       const before = await probe.eventually(() => world.observation.read(), {
         within: 10_000, label: "reorder targets visible and settled",
         until: value => (mode !== "group" || value.current.rows.every(row => !row.id.startsWith("session:")))
           && [sourceId, targetId].every(id => value.current.rows.some(row => row.id === id
-            && row.top >= value.current.viewport.top && row.bottom <= value.current.viewport.bottom && Math.abs(row.projectionY) < 1)),
+            && row.top >= value.current.viewport.top - 1 && row.bottom <= value.current.viewport.bottom + 1 && Math.abs(row.projectionY) < 1)),
       });
       const from = before.current.rows.find(row => row.id === sourceId)!;
       const to = before.current.rows.find(row => row.id === targetId)!;

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -590,7 +590,8 @@ export async function sidebarOverflow(seed: Seed) {
   const longTitle = "Reading Google Drive documents for the quarterly workspace review";
   const app = await seed.desktop({ name: "sidebar-title-overflow-fade" });
   const workspacePath = "/tmp/Yonder";
-  const workspace = await seed.workspace(app, workspacePath);
+  // The desktop already owns its default first-launch workspace; the title under test is this folder's name.
+  const workspace = await seed.workspace(app, workspacePath, { create: true });
   const sessions = await seed.sessions(app, [longTitle]);
   return { app, workspace, workspacePath, sessions, longTitle };
 }


### PR DESCRIPTION
Cluster 8 / brief M of the 2026-09-09 E2E triage (`reports/e2e-red-2026-09-09/triage.md`, "Cluster 8 — Sidebar expansion geometry"): `sidebar-title-overflow-fade` red on Daytona, 4/4 tests.

## Bisect

`pnpm evals:e2e sidebar-title-overflow-fade --daytona` with the current spec against:

| `OPENWORK_EVAL_REF` | title overflow | workspace | group | ungrouped |
| --- | --- | --- | --- | --- |
| `fd2868d03` (= `cb89fd78e^`) | passed | **4 px float** | first frame > 100 ms | "Show 2 more" not found |
| `c744e2d7b` (dev) | `title state null` | **4 px float** | 65 px overlap | reorder never settles |

So `cb89fd78e` (#4628) did not introduce the geometry defects: it wrote a spec claiming stationarity that Motion never delivered on the Daytona renderer, and its own proof never ran there. The title-overflow regression is unrelated to the sidebar code (see 2 below).

## Root causes and what changed

1. **Rows float / overlap during Show more (product).** Motion's projection node starts every layout animation one frame late and, via `setAnimationOrigin → mixTargetDelta(0)`, projects each row at its *previous* position until then — even with `transition.layout.duration: 0`. On the Daytona renderer that frame is observable: siblings below an expanding group sit at their old position under the newly laid-out rows (the 65 px overlap), and the workspace item carries a compensating 4 px translate. Fix: `SidebarLayoutAnimationGate` blocks the list's projection tree (`isAnimationBlocked`, the same flag Motion sets on a dragged node) while no reorder gesture is active, replacing the `duration: 0` toggle. Reorder gestures still animate siblings.
2. **Workspaces heading shrinks 4 px when the list starts to overflow (product).** The heading is a direct flex item of the scrolling `flex-col` list; once Show more makes the list overflow, `flex-shrink: 1` + `min-height: auto` collapse it from `h-6` (24 px) to its 20 px `size-5` button, shifting every row up 4 px. Motion had been masking this with the translate above. Only workspace mode hit it because group/ungrouped lists already overflowed before the click. Fix: `shrink-0`. Reproduced locally by constraining the list height (24 → 20 → 24 with `flex-shrink: 0`).
3. **Dragging a group header toggled it (product).** A completed drag releases on the same header, which the browser reports as a click → `onToggle`. Only a press within Motion's 3 px drag threshold toggles now.
4. **`Unexpected title state: null` (fixture).** Since #4608 the desktop boots with its default `~/OpenWork Chat` workspace, so `seed.workspace(app, "/tmp/Yonder")` selected that existing workspace instead of creating `/tmp/Yonder`; the rendered titles were `["OpenWork Chat", …]`. The fixture now passes `{ create: true }` like `sidebarWorkspaceTitles` already does.
5. **Session-row drag claim re-expressed (spec).** Session rows are native HTML drag sources (`draggable` for group drop zones, since #2039); a native `dragstart` fires `pointercancel`, which cancels the pointer gesture Motion's Reorder needs. So a trusted drag on a session row has never reordered — reproduced on macOS too (`dragstart` → `pointercancel`, no reorder, no click). Not a regression; the spec claimed a behavior the product does not have. Workspace/ungrouped modes now claim the product's gesture: the drag starts the native session drag carrying `application/x-openwork-session-id`, and does not change selection, route, row order, or persisted order. Group mode keeps the Motion reorder claim (groups are not native drag sources) and additionally asserts the release does not toggle the group.
6. Spec diagnostics: a missing title names every rendered title; a moved anchor reports its lane/viewport/scroll/projection; the readiness wait for drag targets tolerates the same 1 px as every other geometry check (hovering the last row scrolls to the list end, where Chrome's integer scroll offset leaves the row 0.125 px past the list's fractional edge on Linux).

## Proof

`OPENWORK_EVAL_REF=74e7da2118b13bd463acf39870bd0ab42b917e68 pnpm evals:e2e sidebar-title-overflow-fade --daytona`

```
✓ specs/sidebar-title-overflow-fade.e2e.test.ts (4 tests) 588037ms
  ✓ the sidebar title fade follows only the edges with hidden text
  ✓ workspace Show more keeps old rows anchored through every frame and still starts the native session drag
  ✓ group Show more keeps old rows anchored through every frame and still permits reordering
  ✓ ungrouped Show more keeps old rows anchored through every frame and still starts the native session drag
Test Files  1 passed (1) · Tests  4 passed (4)
{"command":"evals:e2e","lane":"e2e","daytona":true,"placement":"daytona","engine":"legacy","surface":"legacy","files":["sidebar-title-overflow-fade"],"passed":4,"failed":0,"skipped":0,"skips":[],"verdict":"passed"}
```
All four sandboxes logged `source verified 74e7da2118b13bd463acf39870bd0ab42b917e68`; sandboxes deleted. `pnpm --filter @openwork/app typecheck` clean.

## Noticed, not touched

- **Harness contract drift (affects other clusters):** `createAndSelectWorkspace` only creates a workspace when none is active or `create: true`. Since #4608 every desktop has the default workspace, so `seed.workspace(app, path)` without `create` silently returns "OpenWork Chat" for all ~70 call sites while specs keep using `path`. This is almost certainly the real cause of Cluster 3's `artifact-code-browser` `chmod: cannot access '/tmp/openwork-workspace-spec-…'` (not pooled-lane path reuse). Owner: evals harness — either create when the active workspace's path differs from `input.path`, or make callers explicit.
- **Product design conflict:** Motion `Reorder.Item` on session rows is unreachable while the rows are native `draggable`; session reorder-by-drag has never worked in Chromium. Decide between Motion reorder (drop-to-group via Motion) or native DnD only, then restore the reorder claim in this spec.
- `WorkspaceHeader` has the same click-after-drag exposure as group headers (dragging a workspace title also selects it on release).
- `first expansion frame captured promptly < 100 ms` is a renderer-latency claim; it passed in the proof but failed once at the `fd2868d03` control (155 ms) — a flake risk on slow sandboxes.
- Daytona CLI v0.210.0 vs API v0.213.0 mismatch warning on every exec; one provisioning 502 (`source verification gate`) left a sandbox behind that I deleted by hand.
