### PR TITLE
fix(app)/test: list the injected bench provider model in the composer picker

### DIFF
--- a/evals/specs/bench-openwork-app-v1.e2e.test.ts
+++ b/evals/specs/bench-openwork-app-v1.e2e.test.ts
@@ -757,12 +757,13 @@ async function sendMessage(app: Surface, text: string, witnessNonce: string): Pr
   return measurePreparedSend(app, text, witnessNonce);
 }
 
-async function createNewSession(app: Surface): Promise<{ sessionId: string; ms: number }> {
-  const previousSessionId = await evalIn(
-    app,
-    () => (document.querySelector<HTMLElement>("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""),
-  );
-  const previous = typeof previousSessionId === "string" ? previousSessionId : "";
+/**
+ * The sidebar New task control opens the workspace's empty composer at once and
+ * the session itself is created by the first send, so "ready" is the empty New
+ * task route with no session surface and a prompt-ready composer. The send that
+ * follows reports the new session id.
+ */
+async function createNewSession(app: Surface): Promise<{ ms: number }> {
   await pollExpression(app, () => {
     const button = document.querySelector<HTMLElement>('[data-sidebar-new-chat]');
     return button instanceof HTMLButtonElement && !button.disabled;
@@ -775,24 +776,12 @@ async function createNewSession(app: Surface): Promise<{ sessionId: string; ms: 
     return true;
   });
   expect(clicked).toBe(true);
-  const sessionId = await eventually(async () => {
-    const value = await evalIn(app, () => {
-      const match = /\/session\/(ses_[^/?#]+)/.exec(window.location.hash);
-      return match?.[1] ?? "";
-    });
-    return typeof value === "string" ? value : "";
-  }, {
-    within: 60_000,
-    intervalMs: pollResolutionMs,
-    label: "new session route",
-    until: (value) => value.startsWith("ses_") && value !== previous,
-  });
-  await pollExpression(app, browserScript((sessionId) => {
-    const surface = document.querySelector<HTMLElement>("[data-session-surface-id]");
-    return surface?.getAttribute("data-session-surface-id") === sessionId;
-  }, [sessionId]), `new session surface ${sessionId}`);
-  await waitForComposerReady(app, `new session ${sessionId} composer and Run task`);
-  return { sessionId, ms: Date.now() - startedAt };
+  await pollExpression(app, () => (
+    /^#\/workspace\/[^/?#]+\/session\/?$/.test(window.location.hash)
+      && !document.querySelector<HTMLElement>("[data-session-surface-id]")
+  ), "empty New task route without a session surface");
+  await waitForComposerReady(app, "new task composer and Run task");
+  return { ms: Date.now() - startedAt };
 }
 
 async function createSecondWorkspaceViaUi(app: Surface, firstWorkspaceId: string, workspacePath: string): Promise<string> {
@@ -1042,11 +1031,6 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
             // This benchmark measures engine and UI latency, not plugins. On a fresh isolated HOME, the engine's external-plugin dependency bootstrap
             // (injected by apps/server/src/openwork-runtime-config.ts) can hold its install lock for minutes and block /config + /provider, so the picker
             // reports "No models found" and the run times out. OPENCODE_PURE skips plugin loading for both the v1 and v2 lanes alike.
-        // The completion milestone reads the sidebar's per-session loading
-        // indicator, which only renders at desktop width. A local host's window
-        // manager (tiling, for instance) may shrink the Electron window well
-        // below that, so pin the viewport the benchmark actually measures.
-        await setViewport(app, { width: 1280, height: 900, deviceScaleFactor: 1 });
             OPENCODE_PURE: "true",
             ANTHROPIC_API_KEY: "",
             OPENAI_API_KEY: "",
@@ -1058,6 +1042,11 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
           },
         });
         const appInteractive = Date.now() - coldStartedAt;
+        // The completion milestone reads the sidebar's per-session loading
+        // indicator, which only renders at desktop width. A local host's window
+        // manager (tiling, for instance) may shrink the Electron window well
+        // below that, so pin the viewport the benchmark actually measures.
+        await setViewport(app, { width: 1280, height: 900, deviceScaleFactor: 1 });
         let appReadinessMs: number | undefined;
         for (const span of timeline().slice(timelineStart)) {
           if (span.label === "app.readiness" && span.detail === appName) appReadinessMs = span.ms;
@@ -1127,11 +1116,11 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
           expect(setup.assistantText).toContain(`token 20 ${witnessNonce}`);
           let latestBChat: Chat = { workspaceId: workspaceBId, sessionId: setup.sessionId, title: "workspace B setup" };
           let latestBMarker = setupNonce;
+          const priorSessionIds = new Set([warmup.sessionId, setup.sessionId]);
 
           for (let warmIndex = 0; warmIndex < iterations; warmIndex += 1) {
             const created = await createNewSession(app);
             results.new_session_ready.push(created.ms);
-            newSessionIds.push(created.sessionId);
             if (benchEngine === "v2") {
               if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
             } else if (await ensureBenchModel(app)) {
@@ -1143,9 +1132,13 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
             bNonces.push(messageNonce);
             const messageRun = await sendMessage(app, message, witnessNonce);
             results.message_rtt.push(messageRun.timing);
-            const messageComplete = messageRun.sessionId === created.sessionId
+            // The empty composer creates its session on submit, so the send must
+            // land in a session no earlier turn in this run has used.
+            const messageComplete = !priorSessionIds.has(messageRun.sessionId)
               && messageRun.userLength === message.length
               && messageRun.assistantText.includes(`token 20 ${witnessNonce}`);
+            newSessionIds.push(messageRun.sessionId);
+            priorSessionIds.add(messageRun.sessionId);
             messageCompletions.push(messageComplete);
             expect(messageComplete).toBe(true);
             expect(messageRun.timing.complete, "warm reply finishes without waiting for the reconciliation timer").toBeLessThan(10_000);
@@ -1167,6 +1160,7 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
               witnessNonce,
             );
             results.long_message.push({ insertMs, ...longRun.timing });
+            priorSessionIds.add(longRun.sessionId);
             const longComplete = longRun.userLength === longMessageChars
               && longRun.assistantText.includes(`token 20 ${witnessNonce}`);
             longMessageChecks.push(longComplete);
@@ -1278,8 +1272,8 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
     expect(results.new_session_ready).toHaveLength(iterations);
     expect(new Set(newSessionIds).size).toBe(iterations);
     evidence.recordAssertionEvidence(
-      "Every sidebar New task click reaches a distinct prompt-ready session",
-      `${iterations} New task clicks produced ${new Set(newSessionIds).size} distinct session ids with editable composers and visible Run task controls; ms=${JSON.stringify(results.new_session_ready)}.`,
+      "Every sidebar New task click reaches a prompt-ready empty composer whose first send lands in a distinct new session",
+      `${iterations} New task clicks reached the empty New task route with editable composers and visible Run task controls, and their sends created ${new Set(newSessionIds).size} distinct session ids unused by earlier turns; ms=${JSON.stringify(results.new_session_ready)}.`,
       results.new_session_ready.length === iterations && new Set(newSessionIds).size === iterations,
     );
 

--- a/evals/specs/bench-openwork-app-v1.e2e.test.ts
+++ b/evals/specs/bench-openwork-app-v1.e2e.test.ts
@@ -1056,7 +1056,10 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
         for (const span of timeline().slice(timelineStart)) {
           if (span.label === "app.readiness" && span.detail === appName) appReadinessMs = span.ms;
         }
-        const workspaceA = await createAndSelectWorkspace(app, { path: workspaceAPath });
+        // A fresh desktop boots into its default "OpenWork Chat" workspace, so
+        // the bench folder (which carries the witness provider in opencode.json)
+        // must be created explicitly rather than adopting whatever is active.
+        const workspaceA = await createAndSelectWorkspace(app, { path: workspaceAPath, create: true });
         coldWorkspaceIds.push(workspaceA.workspaceId);
         const workspaceReady = Date.now() - coldStartedAt;
         await waitForComposerReady(app, `cold composer ${coldIndex}`);

--- a/evals/specs/bench-openwork-app-v1.e2e.test.ts
+++ b/evals/specs/bench-openwork-app-v1.e2e.test.ts
@@ -7,6 +7,7 @@ import { arch, cpus, platform, tmpdir, totalmem } from "node:os";
 import { join } from "node:path";
 import { clickButton, createAndSelectWorkspace, evalIn, readComposerState } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
+import { setViewport } from "@openwork/cdp";
 import { desktop } from "@openwork/hosts";
 import type { DesktopHandle } from "@openwork/hosts";
 import { eventually, needs, test } from "@openwork/testkit";
@@ -1041,6 +1042,11 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
             // This benchmark measures engine and UI latency, not plugins. On a fresh isolated HOME, the engine's external-plugin dependency bootstrap
             // (injected by apps/server/src/openwork-runtime-config.ts) can hold its install lock for minutes and block /config + /provider, so the picker
             // reports "No models found" and the run times out. OPENCODE_PURE skips plugin loading for both the v1 and v2 lanes alike.
+        // The completion milestone reads the sidebar's per-session loading
+        // indicator, which only renders at desktop width. A local host's window
+        // manager (tiling, for instance) may shrink the Electron window well
+        // below that, so pin the viewport the benchmark actually measures.
+        await setViewport(app, { width: 1280, height: 900, deviceScaleFactor: 1 });
             OPENCODE_PURE: "true",
             ANTHROPIC_API_KEY: "",
             OPENAI_API_KEY: "",


### PR DESCRIPTION
Triage: `reports/e2e-red-2026-09-09/triage.md` §Cluster 10 — `bench-openwork-app-v1`: "Bench Model listed in picker" never true within 120 s.

## Root cause (harness, not product; the triage hypotheses are refuted)

The composer picker and the engine are fine: with the bench folder active, `GET /provider` lists `bench-witness` (source `config`, 1 model) in <1 s, and neither `fd2868d03` (#4626) nor a model-list cap is involved. The spec was simply looking at the wrong workspace.

1. **First bad commit: `51c0ab92f` (#4608, Sep 8).** A fresh desktop now bootstraps a default **"OpenWork Chat"** workspace (`…/openwork-dev-data/home/OpenWork Chat`) instead of landing on `/welcome`. `createAndSelectWorkspace(app, { path })` only honours `path` on the `/welcome` branch or with `create: true`; otherwise it adopts whatever workspace is active. The bench never set `create`, so its `opencode.json` (which carries the witness provider) sat in a folder the engine never loaded. Confirmed on a live instance: the app's only workspace was "OpenWork Chat", `/provider` `connected: ["opencode"]`, picker = Zen models only. The occasional pass was a race on the persisted active-workspace id.
2. **Runner environment.** Once the picker step passed, the first send never counted as `complete`: that milestone reads the sidebar row's loading indicator, and on this Mac the tiling window manager (Amethyst) squeezed the eval Electron to a **195×1029** viewport, so the sidebar never mounted. Screenshot-verified.
3. **Intentional product change: `b4ed5f47c` (#4577, Sep 6).** Sidebar **New task** opens the empty composer immediately and the session is created on submit, so the spec's wait for a `ses_` id in the route on click can never resolve.

## What changed (spec only, one commit each)

- `e1c4bf325` — `createAndSelectWorkspace(app, { path: workspaceAPath, create: true })`.
- `170dede1c` — `setViewport(app, { width: 1280, height: 900, deviceScaleFactor: 1 })` right after the desktop is interactive (same pattern as `responsive-session-layout`, `sidebar-title-overflow-fade`, the session-shell world).
- `c31785b0d` — `createNewSession` now waits for the empty New task route with no session surface and a prompt-ready composer; the send that follows must land in a session no earlier turn used (tracked in `priorSessionIds`), which preserves the "distinct new session per New task" claim. Evidence prose updated to say so. No assertion loosened, no waits added.

## Proof

`OPENWORK_EVAL_REF=c31785b0d00fc90a8638815a33e01e75640b827c pnpm evals:e2e bench-openwork-app-v1 --daytona` at **`c31785b0d`**:

```
selection: engine=legacy surface=legacy case=all; placement: daytona (--daytona)
 ✓ |e2e| specs/bench-openwork-app-v1.e2e.test.ts (1 test) 41185ms
{"command":"evals:e2e","lane":"e2e","daytona":true,"placement":"daytona",…,"passed":1,"failed":0,"skipped":0,"skips":[],"verdict":"passed"}
```

Same command at the previous commit (`170dede1c` + working tree of `c31785b0d`) also passed (1/0/0). Before the fixes, `origin/dev` @ `c744e2d7b` failed 2 different ways across 5 runs (picker timeout, then `complete` never true).

**Honesty note on the placement line:** this spec imports raw `desktop()` from `@openwork/hosts` (catalog placement `manual`). Single-spec `--daytona` sets `OPENWORK_EVAL_DAYTONA=1` but never `OPENWORK_EVAL_DAYTONA_SANDBOX`, so `resolveHost()` spawns Electron **on the runner** — the printed `placement: daytona` is the runner's selection, not where the app ran. No Daytona sandbox was created by any run here. The triage's red runs were the same arrangement.

## Noticed, not touched

- `createAndSelectWorkspace` silently ignores `path` for every caller that omits `create` since #4608 (`seed.desktop()`, `seed.workspace()`, several specs) — they all run in "OpenWork Chat" now. Harmless for most, but a trap for any spec that writes files into its workspace path. Worth a loud check or a path comparison in `evals/packages/behaviors/src/desktop-boot.ts`.
- `evals/bin/evals.mjs` reports `placement: daytona` for raw-`desktop()` specs that actually run locally; the single-spec `--daytona` lane never provisions a desktop sandbox for them.
- `bench-openwork-app-v1` writes results to `$OPENWORK_BENCH_RESULTS_DIR` / tmp only; it is `manual` placement and never runs in the nightly.
