### PR TITLE
fix(den-api): install links default to the Den's own release when self-hosted

### DIFF
--- a/ee/apps/den-api/src/desktop-releases.ts
+++ b/ee/apps/den-api/src/desktop-releases.ts
@@ -98,6 +98,17 @@ function releasesUrl() {
   return `${baseUrl}/repos/${repositoryPath}/releases?per_page=100`
 }
 
+// A self-hosted (single-org) Den must never hand out a desktop newer than
+// itself by default, so it installs its own release instead of GitHub latest.
+// Dev and commit builds have no stable release tag and keep runtime discovery.
+function singleOrgDenReleaseTag() {
+  if (env.orgMode === "multi_org") {
+    return null
+  }
+  const releaseTag = `v${env.serviceVersion}`
+  return DESKTOP_RELEASE_TAG_PATTERN.test(releaseTag) ? releaseTag : null
+}
+
 export function createDesktopReleaseSource() {
   let lastSuccessfulMetadata: DesktopReleaseMetadata | null = null
   let refreshAfter = 0
@@ -157,6 +168,10 @@ export function createDesktopReleaseSource() {
     }
     if (env.desktopReleasesMode === "static") {
       return env.installerReleaseTag
+    }
+    const denReleaseTag = singleOrgDenReleaseTag()
+    if (denReleaseTag) {
+      return denReleaseTag
     }
 
     const metadata = await getDesktopReleaseMetadata()

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -247,7 +247,7 @@ function maxAllowedDesktopVersion(versions: string[]) {
   return maxVersion
 }
 
-async function installerReleaseTagForMetadata(metadataInput: unknown) {
+export async function installerReleaseTagForMetadata(metadataInput: unknown) {
   const metadata = normalizeOrganizationMetadata(organizationMetadataInput(metadataInput)).metadata
   const allowedVersions = metadata.allowedDesktopVersions
   if (!allowedVersions?.length) {

--- a/ee/apps/den-api/test/desktop-releases.test.ts
+++ b/ee/apps/den-api/test/desktop-releases.test.ts
@@ -57,6 +57,8 @@ beforeEach(() => {
   envModule.env.installerReleaseRepo = "different-ai/openwork"
   envModule.env.installerReleaseTag = `v${PUBLISHED_DESKTOP_VERSIONS[0]}`
   envModule.env.installerReleaseTagExplicit = false
+  envModule.env.orgMode = "multi_org"
+  envModule.env.serviceVersion = "dev"
 })
 
 afterAll(() => {
@@ -111,5 +113,39 @@ describe("desktop release discovery", () => {
 
     await expect(desktopReleases.createDesktopReleaseSource().resolveInstallerReleaseTag()).resolves.toBe("v7.6.5")
     expect(failureRequests).toBe(0)
+  })
+
+  test("multi-org installs the latest published release", async () => {
+    envModule.env.serviceVersion = "0.18.45"
+
+    await expect(desktopReleases.createDesktopReleaseSource().resolveInstallerReleaseTag()).resolves.toBe("v1.0.0")
+    expect(successRequestUrl).not.toBeNull()
+  })
+
+  test("single-org installs the Den's own release without runtime discovery", async () => {
+    envModule.env.orgMode = "single_org"
+    envModule.env.serviceVersion = "0.18.45"
+    envModule.env.desktopReleasesBaseUrl = `${server.url.origin}/failure`
+
+    await expect(desktopReleases.createDesktopReleaseSource().resolveInstallerReleaseTag()).resolves.toBe("v0.18.45")
+    expect(failureRequests).toBe(0)
+  })
+
+  test("single-org dev and commit builds keep runtime discovery", async () => {
+    envModule.env.orgMode = "single_org"
+
+    for (const serviceVersion of ["dev", "commit a0d6bd1", "0.18.45-rc.1"]) {
+      envModule.env.serviceVersion = serviceVersion
+      await expect(desktopReleases.createDesktopReleaseSource().resolveInstallerReleaseTag()).resolves.toBe("v1.0.0")
+    }
+  })
+
+  test("single-org honors the explicit installer release tag over the Den's own release", async () => {
+    envModule.env.orgMode = "single_org"
+    envModule.env.serviceVersion = "0.18.45"
+    envModule.env.installerReleaseTag = "v7.6.5"
+    envModule.env.installerReleaseTagExplicit = true
+
+    await expect(desktopReleases.createDesktopReleaseSource().resolveInstallerReleaseTag()).resolves.toBe("v7.6.5")
   })
 })

--- a/ee/apps/den-api/test/install-link-release-tag.test.ts
+++ b/ee/apps/den-api/test/install-link-release-tag.test.ts
@@ -1,0 +1,65 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+
+type EnvModule = typeof import("../src/env.js")
+type InstallLinksModule = typeof import("../src/routes/org/install-links.js")
+
+let envModule: EnvModule
+let installLinks: InstallLinksModule
+
+mock.module("../src/db.js", () => ({ db: {} }))
+mock.module("../src/auth.js", () => ({
+  auth: {},
+  DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX: "ow_mcp_at_",
+  DEN_MCP_FIRST_PARTY_CLIENT_ID: "openwork-desktop",
+  DEN_MCP_FIRST_PARTY_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+  DEN_MCP_GRANT_ID_CLAIM: "https://openworklabs.com/grant_id",
+  DEN_MCP_ORG_ID_CLAIM: "https://openworklabs.com/org_id",
+  DEN_MCP_OAUTH_RESOURCE: "http://127.0.0.1:8790/mcp",
+  DEN_MCP_RESOURCE: "http://127.0.0.1:8790/mcp",
+  DEN_MCP_RESOURCE_CLAIM: "https://openworklabs.com/resource",
+  DEN_MCP_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+  DEN_MCP_TOKEN_USE_CLAIM: "https://openworklabs.com/token_use",
+}))
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
+  process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790"
+
+  envModule = await import("../src/env.js")
+  installLinks = await import("../src/routes/org/install-links.js")
+})
+
+beforeEach(() => {
+  // Self-hosted release image: single-org, DEN_API_VERSION baked at build,
+  // GitHub discovery pointed at an unreachable host so any fallthrough fails loudly.
+  envModule.env.orgMode = "single_org"
+  envModule.env.serviceVersion = "0.18.45"
+  envModule.env.desktopReleasesMode = "github"
+  envModule.env.desktopReleasesBaseUrl = "http://127.0.0.1:9"
+  envModule.env.installerReleaseTag = "v0.18.23"
+  envModule.env.installerReleaseTagExplicit = false
+})
+
+describe("install link release tag for a self-hosted Den", () => {
+  test("installs the Den's own release when allowedDesktopVersions is unset", async () => {
+    for (const metadata of [null, {}, JSON.stringify({ limits: { members: 5 } }), { allowedDesktopVersions: [] }]) {
+      await expect(installLinks.installerReleaseTagForMetadata(metadata)).resolves.toBe("v0.18.45")
+    }
+  })
+
+  test("installs max(allowedDesktopVersions) when the policy is set, above or below the Den's release", async () => {
+    await expect(installLinks.installerReleaseTagForMetadata({ allowedDesktopVersions: ["0.18.42", "0.18.45"] })).resolves.toBe("v0.18.45")
+    await expect(installLinks.installerReleaseTagForMetadata({ allowedDesktopVersions: ["0.18.42"] })).resolves.toBe("v0.18.42")
+    await expect(installLinks.installerReleaseTagForMetadata({ allowedDesktopVersions: ["0.18.42", "0.18.99"] })).resolves.toBe("v0.18.99")
+  })
+
+  test("OPENWORK_INSTALLER_RELEASE_TAG overrides the Den's own release", async () => {
+    envModule.env.installerReleaseTag = "v0.18.44"
+    envModule.env.installerReleaseTagExplicit = true
+
+    await expect(installLinks.installerReleaseTagForMetadata({})).resolves.toBe("v0.18.44")
+    await expect(installLinks.installerReleaseTagForMetadata({ allowedDesktopVersions: ["0.18.42"] })).resolves.toBe("v0.18.42")
+  })
+})


### PR DESCRIPTION
## What

A self-hosted Den now installs its own release by default. When an organization has no `allowedDesktopVersions` policy and the deployment is single-org (`DEN_ORG_MODE` is not `multi_org`), `resolveInstallerReleaseTag()` returns `v<DEN_API_VERSION>` (the version `/health` reports, baked into the image at build) instead of asking GitHub for the newest stable release at request time.

## Resolution order (explicit, so it can be approved or adjusted)

1. `allowedDesktopVersions` set on the org: `max(allowed)` (unchanged).
2. `OPENWORK_INSTALLER_RELEASE_TAG` set: that tag (unchanged, operator override).
3. `DEN_DESKTOP_RELEASES_MODE=static`: the committed release snapshot (unchanged).
4. **New:** single-org Den whose `DEN_API_VERSION` is a stable `x.y.z`: `v<that version>`.
5. Otherwise (multi-org hosted Cloud, or dev / commit builds without a release tag): GitHub latest stable, with the snapshot as offline fallback (unchanged).

Hosted Cloud is multi-org and therefore unchanged. Local dev (`DEN_API_VERSION=dev`) is unchanged.

## Why

Validation of the self-hosted 0.18.45 Compose stack showed that with the policy unset, the install link hands out whatever OpenWork most recently published (0.18.45 today only because that is the newest tag), and 0.18.23 when GitHub is unreachable. A customer running a self-hosted Den at 0.18.43 with no policy therefore handed new hires the 0.18.44 blank-window desktop build the moment it was published. A control plane should never hand out a desktop newer than itself by default; the org policy remains the way to opt into newer (or pin older) versions, and this PR keeps `max(allowed)` winning.

Only `ee/apps/den-api` changes. `installerReleaseTagForMetadata` is exported so the policy path can be unit tested; no route behavior changes.

## Proof

Lane: local (bun 1.3.10, Node 24). Daytona was not needed for pure unit tests.

```
pnpm --filter @openwork-ee/den-api test                      # CI script: 24 pass / 0 fail, 4 files
bun test --conditions development test/install-link-release-tag.test.ts test/desktop-releases.test.ts test/installer-artifacts.test.ts
                                                             # 27 pass / 0 fail, 44 expects
pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit   # exit 0
```

New assertions (`test/desktop-releases.test.ts`, `test/install-link-release-tag.test.ts`):
- single-org, policy unset (`null`, `{}`, unrelated metadata, `[]`) -> `v0.18.45` with GitHub pointed at an unreachable host and zero requests made
- single-org, policy `[0.18.42, 0.18.45]` -> `v0.18.45`; `[0.18.42]` -> `v0.18.42`; `[0.18.42, 0.18.99]` -> `v0.18.99` (policy beats the Den version in both directions)
- multi-org, policy unset -> GitHub latest (`v1.0.0` from the fake releases server), unchanged
- `OPENWORK_INSTALLER_RELEASE_TAG` wins over the Den version; policy still wins over the override
- single-org with `dev`, `commit a0d6bd1`, or `0.18.45-rc.1` service versions keeps GitHub discovery

Negative control: reverting `src/desktop-releases.ts` to `origin/dev` turns exactly the two "Den's own release" tests red (10 pass / 2 fail); with the fix all pass.

`evals/specs/first-run-cloud-share.e2e.test.ts` is the only spec mentioning install-config; it stubs Den's `/v1/install-config` from the desktop side and does not exercise tag resolution, so it was not run. `test/install-link-access.test.ts` (not in the CI script) fails to import on `origin/dev` (`DEN_MCP_GRANT_ID_CLAIM` not exported from `src/auth.ts`); pre-existing, left alone.

Local Warden (`pnpm warden:check` on `b729176` vs `origin/dev` `a0d6bd1`): diff-security-review, confidentiality-review, desktop-den-sync-review all completed, no findings, exit 0.

Docs follow in a separate docs-only PR (installer-delivery, Docker README, self-host env names).
