### PR TITLE
docs(self-host): correct install-link filenames, version choice, and Den Web env names

### DIFF
--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -84,13 +84,15 @@ one of these paths:
 | Semi-air-gapped | Stream the matching standard installer from `OPENWORK_INSTALLER_ARTIFACTS_DIR`. There is no ZIP or in-memory whole-file buffer. | Den web/API only. |
 | Fully internal installer delivery | Same mounted-artifact path, with Den web/API and the installer artifact available entirely inside the isolated network. This describes installer bytes only, not full product isolation. | Internal Den web/API only. |
 
-The standard filenames use the release tag without a leading `v`:
+The filenames use the release tag without a leading `v` and a distribution prefix: `openwork-enterprise-` on a single-org (self-hosted) Den, `openwork-cloud-` on the multi-org hosted Den. The public `openwork-<platform>-<version>` names are never served by install links.
 
-- `openwork-mac-arm64-<version>.dmg`
-- `openwork-mac-x64-<version>.dmg`
-- `openwork-win-x64-<version>.exe`
-- `openwork-linux-x86_64-<version>.AppImage`
-- `openwork-linux-arm64-<version>.AppImage`
+- `openwork-enterprise-mac-arm64-<version>.dmg`
+- `openwork-enterprise-mac-x64-<version>.dmg`
+- `openwork-enterprise-win-x64-<version>.exe`
+- `openwork-enterprise-linux-x86_64-<version>.AppImage`
+- `openwork-enterprise-linux-arm64-<version>.AppImage`
+
+The version is `max(allowedDesktopVersions)` when the organization policy is set, else `OPENWORK_INSTALLER_RELEASE_TAG` when set, else the Den's own release version on a single-org Den (latest published stable release on the multi-org hosted Den).
 
 There is no first-request GitHub download inside Den, artifact lookup API call,
 ZIP creation, per-pod cold cache, or different repeated-download path. Every

--- a/packages/docs/start-here/installer-delivery.mdx
+++ b/packages/docs/start-here/installer-delivery.mdx
@@ -9,7 +9,7 @@ Organization install links help members install the standard OpenWork desktop an
 
 | Deployment style | Download behavior | Required client access |
 | --- | --- | --- |
-| Internet-connected | Den validates the organization install token, then redirects the browser to the exact standard GitHub release asset under `OPENWORK_INSTALLER_RELEASE_REPO` and `OPENWORK_INSTALLER_RELEASE_TAG`. The organization token is not forwarded. | Den web/API, `github.com`, `release-assets.githubusercontent.com`, and `objects.githubusercontent.com` for legacy or rollback paths. |
+| Internet-connected | Den validates the organization install token, then redirects the browser to the exact GitHub release asset under `OPENWORK_INSTALLER_RELEASE_REPO` for the resolved version (see [Which version is installed](#which-version-is-installed)). The organization token is not forwarded. | Den web/API, `github.com`, `release-assets.githubusercontent.com`, and `objects.githubusercontent.com` for legacy or rollback paths. |
 | Semi-air-gapped installer delivery | Den streams the matching standard installer from `OPENWORK_INSTALLER_ARTIFACTS_DIR`. | Den web/API only for installer download. Desktop runtime dependencies may still need internet unless mirrored or disabled. |
 | Fully internal installer delivery | Same mounted-artifact path, with Den web/API and installer bytes available entirely inside the isolated network. | Internal Den web/API only for installer download. Full product isolation still requires the broader checklist in [Air-gapped deployment](/start-here/air-gapped-deployment). |
 
@@ -17,15 +17,27 @@ Organization install links help members install the standard OpenWork desktop an
 
 When `OPENWORK_INSTALLER_ARTIFACTS_DIR` points at a mounted directory and the expected file exists, Den streams that file directly. It does not fetch from GitHub, cache on first request, rewrap, ZIP, or hold the whole installer in memory.
 
-`OPENWORK_INSTALLER_RELEASE_TAG` selects the expected release version. The standard filenames use the release tag without a leading `v`:
+The expected filename depends on the deployment. A self-hosted Den (single-org mode, the default) serves the enterprise distribution; the hosted multi-org OpenWork Cloud serves the cloud distribution. Install links never serve the public `openwork-<platform>-<version>` filenames. The version in the filename is the resolved release tag without a leading `v`:
 
-- `openwork-mac-arm64-<version>.dmg`
-- `openwork-mac-x64-<version>.dmg`
-- `openwork-win-x64-<version>.exe`
-- `openwork-linux-x86_64-<version>.AppImage`
-- `openwork-linux-arm64-<version>.AppImage`
+- `openwork-enterprise-mac-arm64-<version>.dmg`
+- `openwork-enterprise-mac-x64-<version>.dmg`
+- `openwork-enterprise-win-x64-<version>.exe`
+- `openwork-enterprise-linux-x86_64-<version>.AppImage`
+- `openwork-enterprise-linux-arm64-<version>.AppImage`
+
+On hosted OpenWork Cloud the prefix is `openwork-cloud-` instead of `openwork-enterprise-`. A mounted file with any other name is ignored and the request falls through to the GitHub redirect.
 
 `OPENWORK_INSTALLER_RELEASE_REPO` controls the GitHub redirect path when Den does not find a mounted artifact. It is not an internal artifact registry setting.
+
+## Which version is installed
+
+Den resolves one release version per download request, in this order:
+
+1. If the organization's `allowedDesktopVersions` desktop policy is set, the highest listed version wins. This is the way to pin a fleet or to opt into a newer desktop than the Den itself.
+2. Otherwise, if `OPENWORK_INSTALLER_RELEASE_TAG` is set on Den API, that tag wins.
+3. Otherwise, a self-hosted Den running a published release image installs its own release version (the `version` reported by `GET /health` on Den API), so a self-hosted control plane never hands out a desktop newer than itself by default. Hosted OpenWork Cloud, and Den builds without a release version, install the latest published stable release instead.
+
+Mounted artifacts must match the resolved version. When you rely on the default in step 3, place the files for the Den release you run; when you set a policy or an override, place the files for that version.
 
 For multi-replica Den API deployments, mount the same read-only PVC at the same path on every replica. Connection grants are stored in MySQL, so preview and acceptance can land on different replicas safely, but installer bytes must be equally visible to each replica.
 

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -104,12 +104,12 @@ OpenWork cloud-style self-hosting is composed of three main pieces:
 - Node.js backend (Hono) with MySQL DB
 - Electron/React desktop app
 
-The desktop app should be pointed at the Den web URL. On startup it reads `${DEN_BASE_URL}/api/runtime-config` from Den Web and uses the returned `denApiUrl` as the source of truth for Den API and MCP traffic. Den Web returns `DEN_API_BASE` when you set it; otherwise it deterministically derives the API origin as `api.${DEN_BASE_URL}`.
+The desktop app should be pointed at the Den web URL. On startup it reads `${DEN_BASE_URL}/api/runtime-config` from Den Web and uses the returned `denApiUrl` as the source of truth for Den API and MCP traffic. Den Web returns `DEN_API_PUBLIC_URL` when you set it; otherwise it deterministically derives the API origin as `api.${DEN_BASE_URL}`. `DEN_BASE_URL` is required on Den Web. `DEN_API_BASE` is the server-only URL Den Web uses to reach Den API internally; it is never returned to desktops.
 
 - API default: `https://api.<den-web-host>/v1/...`
 - MCP default: `https://api.<den-web-host>/mcp/...`
 
-For self-hosted deployments, configure the desktop `baseUrl` to the public Den web origin and make sure `${DEN_BASE_URL}/api/runtime-config` is reachable from member desktops. If the API is not available at `api.${DEN_BASE_URL}`, set `DEN_API_BASE` on Den Web to the externally reachable API origin or proxy path you want desktops to use.
+For self-hosted deployments, configure the desktop `baseUrl` to the public Den web origin and make sure `${DEN_BASE_URL}/api/runtime-config` is reachable from member desktops. If the API is not available at `api.${DEN_BASE_URL}`, set `DEN_API_PUBLIC_URL` on Den Web to the externally reachable API origin you want desktops to use.
 
 These three pieces cover most features, but do not include:
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -272,13 +272,9 @@ Caveats: `grafana/otel-lgtm` is intended for development, demos, and tests, not 
 
 ### Install links (self-host)
 
-Run the install-link migration once against the Den database:
+Install links are enabled for every organization by default; there is no separate migration step or `/admin` toggle. The regular `den-migrate` job creates the tables, and organization owners mint links from the dashboard or with `POST /v1/orgs/{organizationId}/install-links`. A platform admin can disable minting for one organization by setting `metadata.capabilities.installLinks: false` on it.
 
-```bash
-docker compose -f packaging/docker/docker-compose.den-dev.yml exec den sh -lc "node /app/ee/packages/den-db/dist/scripts/bootstrap.js"
-```
-
-Set `DEN_BOOTSTRAP_ADMIN_EMAILS` on the Den API service, restart it, open `/admin`, and toggle `Install links` for each org. Optional installer artifact env vars are `OPENWORK_INSTALLER_RELEASE_TAG`, `OPENWORK_INSTALLER_RELEASE_REPO`, and `OPENWORK_INSTALLER_ARTIFACTS_DIR`; see the [operator guide](../../docs/org-install-links.md).
+With no `allowedDesktopVersions` policy on the organization, a self-hosted (single-org) Den installs its own release version. Set `allowedDesktopVersions` to pin or advance the fleet, or set `OPENWORK_INSTALLER_RELEASE_TAG` to override the default. Optional installer artifact env vars are `OPENWORK_INSTALLER_RELEASE_TAG`, `OPENWORK_INSTALLER_RELEASE_REPO`, and `OPENWORK_INSTALLER_ARTIFACTS_DIR`; see the [operator guide](../../docs/org-install-links.md) and [Installer delivery](../../packages/docs/start-here/installer-delivery.mdx).
 
 ### Faster inner-loop alternative
 


### PR DESCRIPTION
## What

Docs-only follow-up to #4739 from validating the self-hosted 0.18.45 Compose stack.

- `packages/docs/start-here/installer-delivery.mdx`: install links serve `openwork-enterprise-*` on a single-org (self-hosted) Den and `openwork-cloud-*` on hosted Cloud, never the public `openwork-*` names, so mounted `OPENWORK_INSTALLER_ARTIFACTS_DIR` files must use those names. New "Which version is installed" section: `max(allowedDesktopVersions)`, else `OPENWORK_INSTALLER_RELEASE_TAG`, else the Den's own release on a self-hosted Den (hosted Cloud and builds without a release version install latest published).
- `docs/org-install-links.md`: same filename and version-order correction on the repo page that the docs page cites as authoritative.
- `packaging/docker/README.md` "Install links (self-host)": removed the separate install-link migration command and the `/admin` toggle, which no longer exist. Install links are default-on (`install-links-rollout.ts`), the tables come from the normal `den-migrate` job, and a platform admin can disable minting per org with `metadata.capabilities.installLinks: false`.
- `packages/docs/start-here/self-host.mdx`: Den Web's `/api/runtime-config` returns `DEN_API_PUBLIC_URL` (or derives `api.${DEN_BASE_URL}`), not `DEN_API_BASE`, since #4156. `DEN_API_BASE` is still read by Den Web but only server-side (proxy, readiness, SSO probe) and is documented as such. Compose was fixed in #4729; this fixes the prose.

The version-order text describes the behavior introduced in #4739; merge that first.

## Proof

Docs-only change, no runtime path, so runtime proof is skipped as AGENTS.md allows. Ran the CI `validate-docs` commands locally from `packages/docs`:

```
npx -y mint@4.2.868 validate        # success build validation passed
npx -y mint@4.2.868 broken-links    # success no broken links found
```

No em dashes in added prose. Local Warden (`pnpm warden:check` on `8e6932c` vs `origin/dev` `4e63490`): confidentiality-review and diff-security-review completed, no findings, exit 0.
