### PR TITLE
test(evals)+fix(app): align desktop-policy-restricted-mode with the simplified Library add flow

### DIFF
--- a/apps/app/src/components/ui/dialog.tsx
+++ b/apps/app/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/30 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/30 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:hidden",
         className
       )}
       {...props}
@@ -48,10 +48,12 @@ function DialogContent({
   return (
     <DialogPortal>
       <DialogOverlay />
+      {/* Dismissal hides the popup in the same frame: an exit animation would keep
+          the dialog (and its fields) on screen until Base UI unmounts it. */}
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed z-50 grid gap-6 overflow-hidden bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 max-lg:inset-x-0 max-lg:bottom-0 max-lg:top-auto max-lg:max-h-[min(92dvh,calc(100dvh-env(safe-area-inset-top)))] max-lg:w-full max-lg:max-w-none max-lg:translate-x-0 max-lg:translate-y-0 max-lg:rounded-t-3xl max-lg:rounded-b-none max-lg:pb-[max(1.5rem,env(safe-area-inset-bottom))] max-lg:data-open:slide-in-from-bottom-4 max-lg:data-closed:slide-out-to-bottom-4 lg:top-1/2 lg:inset-s-1/2 lg:w-[calc(100%-2rem)] lg:max-w-md lg:-translate-x-1/2 rtl:lg:translate-x-1/2 lg:-translate-y-1/2 lg:rounded-4xl lg:data-open:zoom-in-95 lg:data-closed:zoom-out-95",
+          "fixed z-50 grid gap-6 overflow-hidden bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-closed:hidden max-lg:inset-x-0 max-lg:bottom-0 max-lg:top-auto max-lg:max-h-[min(92dvh,calc(100dvh-env(safe-area-inset-top)))] max-lg:w-full max-lg:max-w-none max-lg:translate-x-0 max-lg:translate-y-0 max-lg:rounded-t-3xl max-lg:rounded-b-none max-lg:pb-[max(1.5rem,env(safe-area-inset-bottom))] max-lg:data-open:slide-in-from-bottom-4 lg:top-1/2 lg:inset-s-1/2 lg:w-[calc(100%-2rem)] lg:max-w-md lg:-translate-x-1/2 rtl:lg:translate-x-1/2 lg:-translate-y-1/2 lg:rounded-4xl lg:data-open:zoom-in-95",
           className
         )}
         {...props}

--- a/apps/server/src/managed-desktop-policy.test.ts
+++ b/apps/server/src/managed-desktop-policy.test.ts
@@ -124,4 +124,18 @@ if (process.env.OPENWORK_MANAGED_POLICY_TEST_CHILD !== "1") {
     expect(delay).toHaveBeenCalledTimes(1);
     expect(write).toHaveBeenCalledTimes(1);
   });
+
+  test("re-delivering the same identity during backoff keeps the in-flight verification", async () => {
+    externalFetch.mockImplementationOnce(async () => new Response(null, { status: 503 }));
+    const result = service.setSession(session);
+    expect(await waiting.promise).toBe(200);
+    const redelivered = service.setSession({ ...session });
+    release.resolve();
+    await expect(result).resolves.toBeUndefined();
+    await expect(redelivered).resolves.toBeUndefined();
+    await turn();
+    expect(externalFetch).toHaveBeenCalledTimes(2);
+    expect(externalFetch.mock.calls.every(([, init]) => init?.headers && "Authorization" in init.headers && init.headers.Authorization === "Bearer old-token")).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
 }

--- a/apps/server/src/managed-desktop-policy.ts
+++ b/apps/server/src/managed-desktop-policy.ts
@@ -75,8 +75,13 @@ class ManagedDesktopPolicy {
     return actual.length === expected.length && timingSafeEqual(actual, expected);
   }
   async setSession(session: CloudProviderDenSession): Promise<void> {
+    // The desktop re-delivers the same identity on every launch, reload, and
+    // resume. Only a different account may invalidate in-flight verifications.
+    const current = this.session;
+    if (!current || current.baseUrl !== session.baseUrl || current.token !== session.token || current.orgId !== session.orgId) {
+      this.generation++;
+    }
     this.session = session;
-    this.generation++;
     await this.current();
   }
   async clearSession(): Promise<void> {

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -273,6 +273,13 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     await member.user.notSee(settingsMenuItem);
     const menuText = await member.probe.text();
     await member.user.press("Escape");
+    // The menu has no exit motion, but its unmount is still a React commit
+    // away from the key event. Observe the closed state, then hold it.
+    await member.probe.eventually(() => member.probe.eval(() => document.querySelector('[data-slot="dropdown-menu-content"]') === null), {
+      within: 10_000,
+      label: "account menu finishes closing",
+      until: (closed) => closed,
+    });
     await member.user.notSee(accountMenuItem, { timeoutMs: 10_000 });
     return menuText;
   });


### PR DESCRIPTION
## Root cause

Triage Cluster 6 / Brief G in `reports/e2e-red-2026-09-09/triage.md` ("Library add options changed; restricted-mode spec drifted") reported `desktop-policy-restricted-mode` red at lines 93 (`Add` under the MCPs filter) and 552 (`text=Organization MCP`) after #4645 simplified the Library add flow.

That red was a **runner/ref mismatch, not a spec drift on `dev`**: the "dev baseline" run executed the spec file from the runner's worktree (`feat/api-quality-spectral` @ `ea1e9546e`, which merged `dev` at 10:21 -0400) against a sandbox built from `dev` @ `61b41901c`. `dev` had already re-expressed the spec in `05b9fe2b3` (#4664, 08:47 -0700, commit "test(policy): align Library checks with current add controls"): `Add workspace MCP` single-kind button under the MCPs filter, `Local MCP` absent from the picker and `Connection` retained under restriction, no `Organization MCP`. Line 93/552 with those texts only exist in the spec before #4664. No Library claim needed re-expressing; the product (`libraryAddKindsForFilter`, `LibraryAddControl`) matches the spec.

Running the spec pinned to `origin/dev` @ `c744e2d7b` (runs 1–2, `OPENWORK_EVAL_REF` set, sandbox `source verified c744e2d7b…`) showed the Library claims pass and exposed three *other* failures that block this spec on `dev`:

1. `press("Escape")` → immediate `notSee(...)` on the Library add picker (`library-add-choices`, spec lines 310/839) and the `Add workspace MCP` modal (`App name` textbox, line 102): the plain `Dialog` keeps its 100 ms `data-closed:animate-out fade-out-0` exit motion, so the popup is still visible on `assertAbsent`'s first inspection. Same class as Cluster 7 / #4724, which fixed `alert-dialog.tsx` and `command.tsx` and explicitly left `dialog.tsx` out of scope (its "Noticed, not touched" #3). 3 of 4 dismissals lost the race across two runs.
2. `POST /workspace/:id/opencode-config` by the restricted member returned **409 `policy_identity_changed`** instead of the policy's **403** (line 1082, a policy-enforcement assertion). Since #4718 (`1c455cfab`, merged after #4664's green proof) the desktop pushes the same Den session twice per launch/reload/resume (`PUT /den-session/identity` then `PUT /den-session`); every push bumped `ManagedDesktopPolicy.generation`, so any enforcement check in flight failed with 409 although the account never changed.
3. `press("Escape")` → immediate `notSee(menuitem Account)` on the account dropdown (line 276). The menu already has `animate-none!`; its unmount is still a React commit away from the CDP key event and the first inspection landed 33 ms later.

## What changed

- `apps/app/src/components/ui/dialog.tsx` — dismissal hides the overlay and popup in the same frame (`data-closed:hidden`, exit motion removed, entrance motion unchanged), mirroring #4724.
- `apps/server/src/managed-desktop-policy.ts` — `setSession` bumps the generation only when `baseUrl`, `token`, or `orgId` actually differ, so re-delivering the same identity no longer invalidates in-flight policy checks. Unit witness added to `managed-desktop-policy.test.ts` (fails without the fix: `1 fail`; passes with it: `8 pass`).
- `evals/specs/desktop-policy-restricted-mode.e2e.test.ts` — after `Escape` on the account menu, observe the popup leaving the DOM (`probe.eventually`, bounded) before the unchanged strict `notSee(..., { timeoutMs: 10_000 })`, following `command-palette-search.e2e.test.ts:103-109`. No policy-enforcement assertion was loosened; no sleeps added.

## Proof

`pnpm evals:e2e desktop-policy-restricted-mode --daytona` with `OPENWORK_EVAL_REF=3b896f5a8750c4101d4a4dbca8de4c5773616203` (sandbox log: `HEAD is now at 3b896f5a`, `source verified 3b896f5a8…`):

```
✓ an admin restricts the default policy and the member desktop enforces it  442151ms
✓ managed policy evaluation bounds transient Den retries and never reuses stale access  171868ms
✓ team access overrides overlapping grants and restores only selected desktop capabilities  562986ms
Test Files  1 passed (1) · Tests  3 passed (3)
{"command":"evals:e2e","lane":"e2e","daytona":true,"placement":"daytona","engine":"legacy","surface":"legacy","case":null,"vision":"defer","files":["desktop-policy-restricted-mode"],"passed":3,"failed":0,"skipped":0,"skips":[],"consented":["OPENWORK_EVAL_E2E_TESTS"],"verdict":"passed"}
```

Steps 10/10, 7/7, 8/8; expectations 9 + 7 + 43 passed, 0 failed. Library witnesses observed: "Before the policy change the member can open the local workspace MCP add form", "The Library removes local MCP creation while retaining Connection as a separate picker choice" (×3), "Direct config and extension requests cannot bypass the restricted member's UI" (403/403/200). Vision judgments deferred (default `vision: defer`). All 8 sandboxes deleted by the testkit.

Earlier runs on this branch, same command: `c744e2d7b` (dev) → 2 passed / 1 failed (line 839 race), then 1 passed / 2 failed (lines 102, 839); `3086f1315` (dialog fix only) → 1 passed / 2 failed (line 276 menu race; line 1082 `409 ≠ 403`).

Also: `pnpm --filter openwork-server test src/managed-desktop-policy.test.ts` 8 pass; `pnpm --dir apps/app typecheck` and `pnpm --filter openwork-server typecheck` exit 0.

This branch is based on `c744e2d7b` and merges cleanly onto current `dev` (which added a 4th rollback journey to this spec in #4725, not exercised here).

## Noticed, not touched

1. **Runner/ref mismatch is silent.** The Daytona lane builds `OPENWORK_EVAL_REF` in the sandbox but runs the spec files from the local checkout; nothing warns when the two differ, and `test-run.json` records the runner worktree's `gitSha` (this run: `c744e2d7b` correctly only because the worktree matched). A warning when `OPENWORK_EVAL_REF` ≠ local `HEAD` (and recording the ref) would have made Brief G a non-issue.
2. `assertAbsent` throwing on the first inspection makes every `press → notSee` on any popup a race with one React commit, even without exit motion (item 3 above). #4724 and this PR narrow the window component by component; a harness semantic of "becomes absent within a bound, then stays absent" would remove the class.
3. `press("Escape")` followed directly by `click("Library")` at spec line 821 (team journey) has the same latent race but is not asserted; it passed in all 4 runs.
4. The GitHub `daytona-e2e.yml` nightly at `c744e2d7b` failed in the `Product journeys` job before running any journey, so there is no nightly evidence for this spec on current `dev`.
