### PR TITLE
test(evals): released-enterprise-activated release-validation journey

### DIFF
--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -124,6 +124,66 @@ Confirm `npm view openwork-server version` matches.
 
 ---
 
+## Validate a published release
+
+Boot the *released* mac-arm64 desktop binaries (not a source build) through the
+packaged journeys. Both specs are `placement: 'local'` in
+`evals/scripts/journey-catalog.mjs` and skip loudly (verdict `incomplete`,
+exit 2) when `OPENWORK_EVAL_ELECTRON_BINARY` is unset, so a run without a
+binary can never pass by accident.
+
+Download and unpack the enterprise + cloud assets of the tag (`ditto` keeps
+the signature intact; the quarantine flag must go or macOS blocks the spawn):
+
+```bash
+V=X.Y.Z; cd /tmp/ow-release
+gh release download "v$V" -R different-ai/openwork -p "openwork-enterprise-mac-arm64-$V.zip" -p "openwork-cloud-mac-arm64-$V.zip"
+for f in enterprise cloud; do mkdir -p "$f-$V" && ditto -x -k "openwork-$f-mac-arm64-$V.zip" "$f-$V" && xattr -dr com.apple.quarantine "$f-$V"; done
+ENT="/tmp/ow-release/enterprise-$V/OpenWork Enterprise.app/Contents/MacOS/OpenWork Enterprise"
+CLD="/tmp/ow-release/cloud-$V/OpenWork Cloud.app/Contents/MacOS/OpenWork Cloud"
+```
+
+Fresh-machine gate (no bootstrap): the enterprise build must mount
+"Link this app to your organization", the cloud build "Welcome to OpenWork",
+each with zero renderer exceptions:
+
+```bash
+OPENWORK_EVAL_ELECTRON_BINARY="$ENT" pnpm evals:e2e packaged-first-launch --local
+OPENWORK_EVAL_ELECTRON_BINARY="$CLD" pnpm evals:e2e packaged-first-launch --local
+```
+
+Activated enterprise install (what every existing enterprise user boots
+into): the spec cold-boots a local Den, seeds an activated bootstrap and
+asserts the release reports its own version, skips the activation page and
+lands on the interactive `/signin` surface without a render crash.
+`OPENWORK_EVAL_RELEASED_VERSION` pins the version the binary must report:
+
+```bash
+OPENWORK_EVAL_ELECTRON_BINARY="$ENT" OPENWORK_EVAL_RELEASED_VERSION="$V" \
+  pnpm evals:e2e released-enterprise-activated --local
+```
+
+Baseline-upgrade variant: also download the previous release's enterprise zip
+(same steps, e.g. `B=X.Y.W`) and pass it as the baseline. The older release
+signs in and selects a workspace on a fresh profile, quits, then the release
+under test opens that same profile in place and once more after a restart;
+both launches must land in the same signed-in workspace route with zero
+renderer exceptions. Without the baseline variable this second test skips and
+the run is `incomplete`:
+
+```bash
+OPENWORK_EVAL_ELECTRON_BINARY="$ENT" OPENWORK_EVAL_RELEASED_VERSION="$V" \
+OPENWORK_EVAL_RELEASED_BASELINE_BINARY="/tmp/ow-release/enterprise-$B/OpenWork Enterprise.app/Contents/MacOS/OpenWork Enterprise" \
+  pnpm evals:e2e released-enterprise-activated --local
+```
+
+Each command prints a JSON verdict line; only `"verdict":"passed"` with
+`"skipped":0` counts. This covers mac-arm64 only, and the update is simulated
+by launching the new binary on the old profile — the real electron-updater
+download/apply is not exercised.
+
+---
+
 ## Notes
 
 - Desktop installer fixes only reach users through a new release — the org

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -180,7 +180,10 @@ OPENWORK_EVAL_RELEASED_BASELINE_BINARY="/tmp/ow-release/enterprise-$B/OpenWork E
 Each command prints a JSON verdict line; only `"verdict":"passed"` with
 `"skipped":0` counts. This covers mac-arm64 only, and the update is simulated
 by launching the new binary on the old profile — the real electron-updater
-download/apply is not exercised.
+download/apply is not exercised. An activated install does check for updates
+and installs the newest release over its bundle on quit, which is why the
+world launches a private copy of the `.app` each time and why the version pin
+matters: a run that reports a newer version than `$V` booted the wrong binary.
 
 ---
 

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -132,6 +132,12 @@ packaged journeys. Both specs are `placement: 'local'` in
 exit 2) when `OPENWORK_EVAL_ELECTRON_BINARY` is unset, so a run without a
 binary can never pass by accident.
 
+Run them from a checkout of the tag (`git worktree add /tmp/ow-vX.Y.Z vX.Y.Z`,
+then `pnpm install --frozen-lockfile` there) so the specs' expectations match
+the binary. `dev`'s specs move ahead of published binaries: its
+`packaged-first-launch` fails 0.18.45 and 0.18.46 enterprise on the
+pre-activation IPC rejection fixed by #4727, which no release carries yet.
+
 Download and unpack the enterprise + cloud assets of the tag (`ditto` keeps
 the signature intact; the quarantine flag must go or macOS blocks the spawn):
 
@@ -180,10 +186,12 @@ OPENWORK_EVAL_RELEASED_BASELINE_BINARY="/tmp/ow-release/enterprise-$B/OpenWork E
 Each command prints a JSON verdict line; only `"verdict":"passed"` with
 `"skipped":0` counts. This covers mac-arm64 only, and the update is simulated
 by launching the new binary on the old profile — the real electron-updater
-download/apply is not exercised. An activated install does check for updates
-and installs the newest release over its bundle on quit, which is why the
-world launches a private copy of the `.app` each time and why the version pin
-matters: a run that reports a newer version than `$V` booted the wrong binary.
+download/apply is not exercised. An activated install (and, before 0.18.46,
+an unactivated one) checks for updates and installs the newest release over
+its bundle on quit. `released-enterprise-activated` launches a private copy
+of the `.app` each time so the download stays pristine; `packaged-first-launch`
+launches it in place, so re-extract the zip before re-running it. A run that
+reports a newer version than `$V` booted the wrong binary.
 
 ---
 

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -11,6 +11,8 @@ const definitions = {
   // Boots the packaged enterprise artifact twice (fresh and pre-activated); only packaged-smoke provides that binary.
   'packaged-preactivation-updater.e2e.test.ts': { name: 'Keep an unactivated enterprise install from updating itself', placement: 'local' },
   'packaged-activated-launch.e2e.test.ts': { name: 'Open an already-activated enterprise install', placement: 'local' },
+  // Boots a RELEASED enterprise binary (and optionally an older baseline) already activated against a real Den; skips without OPENWORK_EVAL_ELECTRON_BINARY.
+  'released-enterprise-activated.e2e.test.ts': { name: 'Open and update an activated enterprise install against its Den', placement: 'local' },
   'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
   'desktop-policy-restricted-mode.e2e.test.ts': {
     // The rollback case severs local child IPC and faults its loopback transport.

--- a/evals/specs/released-enterprise-activated.e2e.test.ts
+++ b/evals/specs/released-enterprise-activated.e2e.test.ts
@@ -1,0 +1,191 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import type { Probe } from "@openwork/testkit";
+import { isRenderCrash, releasedEnterpriseActivatedWorld } from "../worlds/released-enterprise-activated.ts";
+import type { ReleasedLaunch } from "../worlds/released-enterprise-activated.ts";
+
+/**
+ * What an EXISTING enterprise user sees: an installation already activated
+ * against its private Den boots past the activation gate into the sign-in
+ * surface, and after an in-place update the same profile still boots. The
+ * fresh-machine gate (packaged-first-launch) stops at the activation page, so
+ * the providers mounted only for activated installations are proven here.
+ */
+const test = spec.world(releasedEnterpriseActivatedWorld, {
+  timeout: 300_000,
+  needs: { env: ["OPENWORK_EVAL_ELECTRON_BINARY"] },
+});
+const updateTest = spec.world(releasedEnterpriseActivatedWorld, {
+  timeout: 300_000,
+  needs: { env: ["OPENWORK_EVAL_ELECTRON_BINARY", "OPENWORK_EVAL_RELEASED_BASELINE_BINARY"] },
+});
+
+/** Heading of the enterprise activation page (enterprise-activation-gate.tsx); an activated install must not show it. */
+const ACTIVATION_HEADING = "Link this app to your organization";
+/** Heading of the root error boundary's recovery screen (app-error-boundary.tsx). */
+const RECOVERY_HEADING = /OpenWork hit an unexpected error/;
+/** The forced sign-in surface (den-signin-surface.tsx, fullscreen variant). */
+const SIGN_IN_BUTTON = /^Sign in to /m;
+
+interface Settled {
+  rootText: string;
+  crashes: number;
+  contextCrashes: number;
+  rejections: number;
+}
+
+/**
+ * Wait until the launch either shows a usable surface or fails in one of the
+ * ways a render crash fails: empty tree plus an uncaught exception, or the
+ * recovery screen. Stopping on the first of those names the crash instead of
+ * timing out on a blank window. Returns the facts every claim below is made of.
+ */
+async function settle(launch: ReleasedLaunch, probe: Probe, label: string): Promise<Settled> {
+  const rootText = await probe.eventually(() => launch.rootText(), {
+    within: 90_000,
+    label,
+    until: (text) => SIGN_IN_BUTTON.test(text) || text.includes(ACTIVATION_HEADING) || RECOVERY_HEADING.test(text)
+      || launch.exceptions().some(isRenderCrash),
+  });
+  const exceptions = launch.exceptions();
+  const crashes = exceptions.filter(isRenderCrash);
+  const contextCrashes = exceptions.filter((exception) => /context is missing|must be used within/i.test(`${exception.text} ${exception.description}`));
+  expect(contextCrashes, `a provider context was missing (${label})`).toEqual([]);
+  expect(crashes, `the renderer threw (${label})`).toEqual([]);
+  expect(rootText, `the root error boundary caught a render crash (${label})`).not.toMatch(RECOVERY_HEADING);
+  expect(rootText, `an activated installation showed the activation page again (${label})`).not.toContain(ACTIVATION_HEADING);
+  return { rootText, crashes: crashes.length, contextCrashes: contextCrashes.length, rejections: exceptions.length - crashes.length };
+}
+
+async function expectSignInSurface(launch: ReleasedLaunch, probe: Probe, label: string): Promise<Settled> {
+  const settled = await settle(launch, probe, label);
+  expect(settled.rootText, `the forced sign-in surface did not mount (${label})`).toMatch(SIGN_IN_BUTTON);
+  const state = await probe.eventually(() => launch.state(), {
+    within: 30_000,
+    label: `${label}: interactive sign-in surface`,
+    until: (value) => value.controlReady && value.surface === "welcome",
+  });
+  expect(state.route, `the activated installation is held at the sign-in route (${label})`).toMatch(/^\/signin/);
+  return settled;
+}
+
+async function expectReleaseUnderTest(launch: ReleasedLaunch, expectedVersion: string | null): Promise<string> {
+  const flavor = await launch.flavor();
+  expect(flavor, "the packaged artifact is the enterprise flavor").toBe("enterprise");
+  const build = await launch.buildInfo();
+  if (!build) throw new Error("The running desktop did not report its build info");
+  if (expectedVersion) expect(build.version, "the executable that booted is the release under test").toBe(expectedVersion);
+  return build.version;
+}
+
+test("an activated enterprise installation boots past the gate to its sign-in surface without a render crash", async ({ world, user, probe, evidence, step }) => {
+  const launch = await world.launch({ binary: world.binary, profileDir: world.newProfileDir("fresh-activated"), seedBootstrap: true });
+  const version = await step("the release under test is what booted", () => expectReleaseUnderTest(launch, world.expectedVersion));
+
+  await step("the desktop received the activation stamp through its bootstrap", async () => {
+    const activation = await probe.eventually(() => launch.activation(), { within: 30_000, label: "enterprise activation in the renderer bootstrap", until: (value) => value !== null });
+    expect(activation?.activatedAt).toBe(world.activatedAt);
+    expect(activation?.denBaseUrl).toBe(world.den.ref.webUrl);
+  });
+
+  const settled = await step("the sign-in surface mounts instead of the activation page or a crash", () => expectSignInSurface(launch, probe, "activated first launch"));
+  const screen = user.on(launch.app);
+  await screen.see({ text: SIGN_IN_BUTTON });
+  await screen.notSee({ text: RECOVERY_HEADING });
+  await screen.notSee({ text: ACTIVATION_HEADING });
+  await screen.screenshot();
+
+  evidence.recordAssertionEvidence(
+    `The activated enterprise desktop ${version} boots to its sign-in surface without a render crash`,
+    `binary: ${world.binary}; Den: ${world.den.ref.webUrl}; #root text: ${JSON.stringify(settled.rootText.slice(0, 200))}; render crashes: ${settled.crashes}; missing-context crashes: ${settled.contextCrashes}; unhandled promise rejections (not gating): ${settled.rejections}`,
+    settled.crashes === 0 && settled.contextCrashes === 0,
+  );
+});
+
+updateTest("a profile created by the previous release still boots after updating and after a restart", async ({ world, user, probe, evidence, step }) => {
+  const baseline = world.baselineBinary;
+  if (!baseline) throw new Error("OPENWORK_EVAL_RELEASED_BASELINE_BINARY is required for the update path");
+  const expectedVersion = world.expectedVersion;
+  const profileDir = world.newProfileDir("update-profile");
+
+  const { baselineVersion, baselineRoute } = await step("the previous release signs in and reaches the workspace surface on a fresh profile", async () => {
+    const launch = await world.launch({ binary: baseline, profileDir, seedBootstrap: true });
+    const build = await launch.buildInfo();
+    if (!build) throw new Error("The baseline desktop did not report its build info");
+    if (expectedVersion) expect(build.version, "the baseline is an older release than the one under test").not.toBe(expectedVersion);
+    await expectSignInSurface(launch, probe, `baseline ${build.version} first launch`);
+    const workspace = await world.signInAndSelectWorkspace(launch);
+    const state = await launch.state();
+    expect(state.surface, "the baseline reached the workspace surface").toBe("workspace");
+    expect(state.workspaceId).toBe(workspace.workspaceId);
+    await user.on(launch.app).screenshot();
+    await launch.quit();
+    return { baselineVersion: build.version, baselineRoute: state.route };
+  });
+
+  const updated = await step("the release under test opens that profile in place", async () => {
+    const launch = await world.launch({ binary: world.binary, profileDir, seedBootstrap: false });
+    const version = await expectReleaseUnderTest(launch, expectedVersion);
+    const settledOrState = await settleSignedIn(launch, probe, `updated to ${version}`);
+    // The session and workspace the previous release persisted are what the
+    // update boots into; landing on sign-in again would mean the profile was lost.
+    expect(settledOrState.surface, "the update restored the signed-in workspace").toBe("workspace");
+    expect(settledOrState.route).toBe(baselineRoute);
+    const screen = user.on(launch.app);
+    await screen.notSee({ text: RECOVERY_HEADING });
+    await screen.notSee({ text: ACTIVATION_HEADING });
+    await screen.screenshot();
+    await launch.quit();
+    return { version, ...settledOrState };
+  });
+
+  const restarted = await step("the release under test restarts on the same profile", async () => {
+    const launch = await world.launch({ binary: world.binary, profileDir, seedBootstrap: false });
+    const version = await expectReleaseUnderTest(launch, expectedVersion);
+    const settledOrState = await settleSignedIn(launch, probe, `restart of ${version}`);
+    expect(settledOrState.surface, "the restart restored the signed-in workspace").toBe("workspace");
+    expect(settledOrState.route).toBe(baselineRoute);
+    const screen = user.on(launch.app);
+    await screen.notSee({ text: RECOVERY_HEADING });
+    await screen.notSee({ text: ACTIVATION_HEADING });
+    await screen.screenshot();
+    await launch.quit();
+    return { version, ...settledOrState };
+  });
+
+  evidence.recordAssertionEvidence(
+    `A profile created by ${baselineVersion} boots in ${updated.version} after the update and again after a restart, without a render crash`,
+    `update launch: surface=${updated.surface} route=${updated.route} crashes=${updated.crashes} missing-context=${updated.contextCrashes}; restart launch: surface=${restarted.surface} route=${restarted.route} crashes=${restarted.crashes} missing-context=${restarted.contextCrashes}`,
+    updated.crashes === 0 && restarted.crashes === 0 && updated.contextCrashes === 0 && restarted.contextCrashes === 0,
+  );
+});
+
+/**
+ * Wait for whatever interactive surface the persisted session produces, or for
+ * a crash signature, then hand back the facts the caller asserts on.
+ */
+async function settleSignedIn(launch: ReleasedLaunch, probe: Probe, label: string): Promise<Settled & { surface: string; route: string }> {
+  const state = await probe.eventually(() => launch.state(), {
+    within: 120_000,
+    label: `${label}: interactive surface`,
+    until: (value) => (value.controlReady && value.surface !== null && (value.surface === "welcome" || value.transitional === null))
+      || RECOVERY_HEADING.test(value.text) || launch.exceptions().some(isRenderCrash),
+  });
+  const rootText = await launch.rootText();
+  const exceptions = launch.exceptions();
+  const crashes = exceptions.filter(isRenderCrash);
+  const contextCrashes = exceptions.filter((exception) => /context is missing|must be used within/i.test(`${exception.text} ${exception.description}`));
+  expect(contextCrashes, `a provider context was missing (${label})`).toEqual([]);
+  expect(crashes, `the renderer threw (${label})`).toEqual([]);
+  expect(rootText, `the root error boundary caught a render crash (${label})`).not.toMatch(RECOVERY_HEADING);
+  expect(rootText, `an activated installation showed the activation page again (${label})`).not.toContain(ACTIVATION_HEADING);
+  expect(state.surface, `no interactive surface after ${label}`).not.toBeNull();
+  return {
+    rootText,
+    crashes: crashes.length,
+    contextCrashes: contextCrashes.length,
+    rejections: exceptions.length - crashes.length,
+    surface: state.surface ?? "none",
+    route: state.route,
+  };
+}

--- a/evals/worlds/released-enterprise-activated.ts
+++ b/evals/worlds/released-enterprise-activated.ts
@@ -1,0 +1,297 @@
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createAndSelectWorkspace, quitDesktop, signInDesktopAs } from "@openwork/behaviors";
+import { attachSurface, evaluateOnSurface, probeAppStateOnSurface } from "@openwork/cdp";
+import type { AppStateProbe, AttachedSurface, SurfaceHandle } from "@openwork/cdp";
+import { SkipError } from "@openwork/env";
+import type { Den, Seed } from "@openwork/env";
+import { localHost } from "@openwork/hosts";
+import type { Host } from "@openwork/hosts";
+import type { PackagedFlavor, RendererException } from "./packaged-first-launch.ts";
+
+/**
+ * A packaged enterprise desktop whose installation is ALREADY activated
+ * against a private Den: the bootstrap carries `enterpriseActivation`, so the
+ * activation gate is skipped and the forced sign-in surface renders instead.
+ * The fresh-machine gate (packaged-first-launch) never reaches this code path,
+ * and it is the one every existing enterprise user boots into after an update.
+ *
+ * `OPENWORK_EVAL_ELECTRON_BINARY` names the release under test. The optional
+ * `OPENWORK_EVAL_RELEASED_BASELINE_BINARY` names an older release used to
+ * create the profile that the release under test then opens (an in-place
+ * update), so migrations on a real user's profile are exercised too. The
+ * optional `OPENWORK_EVAL_RELEASED_VERSION` pins the version the binary under
+ * test must report, so a stale download cannot pass as the release.
+ */
+
+export { isRenderCrash } from "./packaged-first-launch.ts";
+
+/** Build facts the main process reports for the running executable. */
+export interface AppBuildInfo {
+  version: string;
+  gitSha: string | null;
+}
+
+export interface ReleasedLaunch extends AsyncDisposable {
+  app: AttachedSurface;
+  binary: string;
+  profileDir: string;
+  /** Flavor baked into the packaged artifact, as the renderer sees it. */
+  flavor(): Promise<PackagedFlavor | null>;
+  /** Version of the executable that is actually running, from its main process. */
+  buildInfo(): Promise<AppBuildInfo | null>;
+  /** Activation stamp the renderer received through the desktop bootstrap. */
+  activation(): Promise<{ activatedAt: string; denBaseUrl: string } | null>;
+  /** Text React actually mounted, as opposed to the body chrome. */
+  rootText(): Promise<string>;
+  state(): Promise<AppStateProbe>;
+  exceptions(): RendererException[];
+  /** Ask Chromium to close the browser the way a quit does, then make sure the process is gone. */
+  quit(): Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function exceptionFrom(params: unknown): RendererException | null {
+  if (!isRecord(params) || !isRecord(params.exceptionDetails)) return null;
+  const details = params.exceptionDetails;
+  const exception = isRecord(details.exception) ? details.exception : {};
+  return {
+    text: readString(details.text),
+    description: readString(exception.description) || readString(exception.value),
+  };
+}
+
+/**
+ * The eval CDP client ignores protocol events, so boot-time exceptions need a
+ * second session on the same page target. Enabling the Runtime domain replays
+ * exceptions recorded before the session attached.
+ */
+async function observeRendererExceptions(surface: AttachedSurface) {
+  const debuggerUrl = surface.client.webSocketDebuggerUrl;
+  if (!debuggerUrl) throw new Error("Renderer exception witness needs a page debugger URL");
+  const socket = new WebSocket(debuggerUrl);
+  const exceptions: RendererException[] = [];
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Renderer exception witness did not attach")), 15_000);
+    socket.addEventListener("open", () => socket.send(JSON.stringify({ id: 1, method: "Runtime.enable", params: {} })));
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout);
+      reject(new Error("Renderer exception witness connection failed"));
+    });
+    socket.addEventListener("message", (event) => {
+      const message: unknown = JSON.parse(String(event.data));
+      if (!isRecord(message)) return;
+      if (message.id === 1) {
+        clearTimeout(timeout);
+        if (message.error) reject(new Error("Runtime.enable failed for the exception witness"));
+        else resolve();
+      }
+      if (message.method !== "Runtime.exceptionThrown") return;
+      const exception = exceptionFrom(message.params);
+      if (exception) exceptions.push(exception);
+    });
+  });
+  return {
+    exceptions,
+    close() {
+      socket.close();
+    },
+  };
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilGone(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidIsAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return !pidIsAlive(pid);
+}
+
+function parseBuildInfo(value: unknown): AppBuildInfo | null {
+  if (!isRecord(value) || typeof value.version !== "string") return null;
+  return { version: value.version, gitSha: typeof value.gitSha === "string" ? value.gitSha : null };
+}
+
+function parseActivation(value: unknown): { activatedAt: string; denBaseUrl: string } | null {
+  if (!isRecord(value)) return null;
+  const activatedAt = readString(value.activatedAt);
+  const denBaseUrl = readString(value.denBaseUrl);
+  return activatedAt && denBaseUrl ? { activatedAt, denBaseUrl } : null;
+}
+
+/**
+ * The local host resolves the executable from the ambient
+ * OPENWORK_EVAL_ELECTRON_BINARY at spawn time; an update scenario needs two
+ * executables in one test, so the override is scoped to one spawn here.
+ */
+async function withElectronBinary<T>(binary: string, run: () => Promise<T>): Promise<T> {
+  const previous = process.env.OPENWORK_EVAL_ELECTRON_BINARY;
+  process.env.OPENWORK_EVAL_ELECTRON_BINARY = binary;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env.OPENWORK_EVAL_ELECTRON_BINARY;
+    else process.env.OPENWORK_EVAL_ELECTRON_BINARY = previous;
+  }
+}
+
+export interface LaunchOptions {
+  binary: string;
+  /** Caller-owned profile root; reuse it across launches to simulate a restart or an update. */
+  profileDir: string;
+  /** Write the activated bootstrap before launching. Omit on relaunches so the file the product persisted is what boots. */
+  seedBootstrap: boolean;
+}
+
+/** The activated bootstrap the product itself writes after a successful enterprise sign-in. */
+export function activatedBootstrap(den: Den, activatedAt: string) {
+  return {
+    baseUrl: den.ref.webUrl,
+    apiBaseUrl: den.ref.apiUrl,
+    requireSignin: true,
+    enterpriseActivation: { activatedAt, denBaseUrl: den.ref.webUrl },
+  };
+}
+
+async function launchReleased(host: Host, name: string, den: Den, activatedAt: string, options: LaunchOptions): Promise<ReleasedLaunch> {
+  const handle: SurfaceHandle = await withElectronBinary(options.binary, () => host.spawnElectron(name, {
+    profile: "fresh",
+    profileDir: options.profileDir,
+    prepareSharedResources: false,
+    ...(options.seedBootstrap ? { bootstrap: activatedBootstrap(den, activatedAt) } : {}),
+    env: { OPENWORK_DEV_MODE: "0", OPENWORK_ELECTRON_START_URL: "", ELECTRON_START_URL: "" },
+  }));
+  let app: AttachedSurface | null = null;
+  let witness: Awaited<ReturnType<typeof observeRendererExceptions>> | null = null;
+  let stopped = false;
+  const dispose = async () => {
+    if (stopped) return;
+    stopped = true;
+    witness?.close();
+    try {
+      await app?.stop();
+    } finally {
+      await host.disposeSurface(handle);
+    }
+  };
+  try {
+    app = await attachSurface(handle, { timeoutMs: 60_000 });
+    witness = await observeRendererExceptions(app);
+  } catch (error) {
+    await dispose().catch(() => undefined);
+    throw error;
+  }
+  const attached = app;
+  const observed = witness;
+  return {
+    app: attached,
+    binary: options.binary,
+    profileDir: options.profileDir,
+    flavor: () => evaluateOnSurface(attached, (): PackagedFlavor | null => {
+      const electron: unknown = Reflect.get(window, "__OPENWORK_ELECTRON__");
+      if (typeof electron !== "object" || electron === null) return null;
+      const meta: unknown = Reflect.get(electron, "meta");
+      if (typeof meta !== "object" || meta === null) return null;
+      const distribution: unknown = Reflect.get(meta, "distribution");
+      if (typeof distribution !== "object" || distribution === null) return null;
+      const flavor: unknown = Reflect.get(distribution, "flavor");
+      return flavor === "public" || flavor === "cloud" || flavor === "enterprise" ? flavor : null;
+    }),
+    buildInfo: async () => parseBuildInfo(await evaluateOnSurface(attached, async (): Promise<unknown> => {
+      const electron: unknown = Reflect.get(window, "__OPENWORK_ELECTRON__");
+      if (typeof electron !== "object" || electron === null) return null;
+      const invoke: unknown = Reflect.get(electron, "invokeDesktop");
+      if (typeof invoke !== "function") return null;
+      return invoke("appBuildInfo");
+    }, { awaitPromise: true, timeoutMs: 15_000 })),
+    activation: async () => parseActivation(await evaluateOnSurface(attached, (): unknown => {
+      const electron: unknown = Reflect.get(window, "__OPENWORK_ELECTRON__");
+      if (typeof electron !== "object" || electron === null) return null;
+      const meta: unknown = Reflect.get(electron, "meta");
+      if (typeof meta !== "object" || meta === null) return null;
+      const bootstrap: unknown = Reflect.get(meta, "desktopBootstrap");
+      if (typeof bootstrap !== "object" || bootstrap === null) return null;
+      return Reflect.get(bootstrap, "enterpriseActivation");
+    })),
+    rootText: () => evaluateOnSurface(attached, () => document.getElementById("root")?.innerText ?? ""),
+    state: () => probeAppStateOnSurface(attached, { timeoutMs: 8_000 }),
+    exceptions: () => [...observed.exceptions],
+    async quit() {
+      if (stopped) return;
+      // Browser.close runs Chromium's normal shutdown, which flushes renderer
+      // storage the way a user quit does; a signal would not.
+      await quitDesktop(attached);
+      if (handle.pid !== undefined) await waitUntilGone(handle.pid, 20_000);
+      await dispose();
+    },
+    [Symbol.asyncDispose]: dispose,
+  };
+}
+
+export async function releasedEnterpriseActivatedWorld(seed: Seed) {
+  const binary = process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim();
+  if (!binary) throw new SkipError("OPENWORK_EVAL_ELECTRON_BINARY points at a packaged enterprise desktop binary");
+  const baselineBinary = process.env.OPENWORK_EVAL_RELEASED_BASELINE_BINARY?.trim() || null;
+  const expectedVersion = process.env.OPENWORK_EVAL_RELEASED_VERSION?.trim() || null;
+  const den = await seed.den();
+  const host = localHost();
+  const activatedAt = new Date().toISOString();
+  const launches: ReleasedLaunch[] = [];
+  const ownedProfiles: string[] = [];
+  let launchIndex = 0;
+
+  return {
+    den,
+    binary,
+    baselineBinary,
+    /** Version the binary under test must report, when the caller pinned one. */
+    expectedVersion,
+    activatedAt,
+    /** A fresh caller-owned profile root that outlives every launch until the world is disposed. */
+    newProfileDir(label: string): string {
+      const root = seed.tmpPath(`released-${label}`);
+      ownedProfiles.push(root);
+      return join(root, "profile");
+    },
+    async launch(options: LaunchOptions): Promise<ReleasedLaunch> {
+      launchIndex += 1;
+      const launch = await launchReleased(host, `released-enterprise-${launchIndex}`, den, activatedAt, options);
+      launches.push(launch);
+      return launch;
+    },
+    /** Sign the Den admin into this launch and select a fresh local workspace folder, as an activated user would. */
+    async signInAndSelectWorkspace(launch: ReleasedLaunch): Promise<{ workspaceId: string; route: string }> {
+      await signInDesktopAs(launch.app, den.ref, den.admin);
+      const workspacePath = seed.tmpPath("released-workspace");
+      ownedProfiles.push(workspacePath);
+      return createAndSelectWorkspace(launch.app, { path: workspacePath });
+    },
+    [Symbol.asyncDispose]: async () => {
+      for (const launch of launches.reverse()) {
+        try {
+          await launch[Symbol.asyncDispose]();
+        } catch {
+          // Every launch is best-effort disposed; the profile removal below still runs.
+        }
+      }
+      for (const profile of ownedProfiles) await rm(profile, { recursive: true, force: true }).catch(() => undefined);
+    },
+  };
+}

--- a/evals/worlds/released-enterprise-activated.ts
+++ b/evals/worlds/released-enterprise-activated.ts
@@ -1,5 +1,5 @@
-import { rm } from "node:fs/promises";
-import { join } from "node:path";
+import { cp, rm } from "node:fs/promises";
+import { basename, dirname, join, relative } from "node:path";
 import { createAndSelectWorkspace, quitDesktop, signInDesktopAs } from "@openwork/behaviors";
 import { attachSurface, evaluateOnSurface, probeAppStateOnSurface } from "@openwork/cdp";
 import type { AppStateProbe, AttachedSurface, SurfaceHandle } from "@openwork/cdp";
@@ -152,6 +152,30 @@ async function withElectronBinary<T>(binary: string, run: () => Promise<T>): Pro
   }
 }
 
+/** The bundle electron-updater replaces in place: the nearest `.app` ancestor of the executable. */
+function appBundleOf(binary: string): string | null {
+  for (let dir = dirname(binary); dir !== dirname(dir); dir = dirname(dir)) {
+    if (dir.endsWith(".app")) return dir;
+  }
+  return null;
+}
+
+/**
+ * An activated installation checks for updates, and on quit electron-updater
+ * installs the newest published release over its own bundle. The release under
+ * test would then silently become a newer one between launches (0.18.45 booted
+ * as 0.18.46 within a single run once 0.18.46 was published), so every launch
+ * boots a private copy of the bundle and the downloaded release stays pristine.
+ * The copy keeps the code signature and notarization ticket intact.
+ */
+async function pristineCopy(binary: string, root: string): Promise<string> {
+  const bundle = appBundleOf(binary);
+  if (!bundle) return binary;
+  const copy = join(root, basename(bundle));
+  await cp(bundle, copy, { recursive: true, verbatimSymlinks: true });
+  return join(copy, relative(bundle, binary));
+}
+
 export interface LaunchOptions {
   binary: string;
   /** Caller-owned profile root; reuse it across launches to simulate a restart or an update. */
@@ -272,7 +296,11 @@ export async function releasedEnterpriseActivatedWorld(seed: Seed) {
     },
     async launch(options: LaunchOptions): Promise<ReleasedLaunch> {
       launchIndex += 1;
-      const launch = await launchReleased(host, `released-enterprise-${launchIndex}`, den, activatedAt, options);
+      const name = `released-enterprise-${launchIndex}`;
+      const bundleRoot = seed.tmpPath(`${name}-bundle`);
+      ownedProfiles.push(bundleRoot);
+      const binary = await pristineCopy(options.binary, bundleRoot);
+      const launch = await launchReleased(host, name, den, activatedAt, { ...options, binary });
       launches.push(launch);
       return launch;
     },


### PR DESCRIPTION
## What

A reusable release-validation journey for the **released** enterprise desktop, plus the runbook to use it.

- `evals/specs/released-enterprise-activated.e2e.test.ts` + `evals/worlds/released-enterprise-activated.ts` — boots the binary named by `OPENWORK_EVAL_ELECTRON_BINARY` with an activated bootstrap against a real Den (cold-booted by the testkit) and proves:
  1. the binary reports the pinned version (`OPENWORK_EVAL_RELEASED_VERSION`) and the enterprise flavor, the renderer received the activation stamp, the activation page does **not** show, the interactive `/signin` surface mounts, zero render crashes and zero missing-context crashes;
  2. with `OPENWORK_EVAL_RELEASED_BASELINE_BINARY` (an older release): the baseline signs in and selects a workspace on a fresh profile and quits; the release under test opens that same profile in place and again after a restart, landing on the same signed-in workspace route with zero renderer exceptions.
- Registered in `evals/scripts/journey-catalog.mjs` as `placement: 'local'`. Without the binary env var both tests skip loudly (`verdict: incomplete`, exit 2) — never a silent pass.
- `.opencode/skills/release/SKILL.md` — new **Validate a published release** section with the exact download/unpack commands and the `packaged-first-launch` + `released-enterprise-activated` (+ baseline-upgrade) commands, limited to what was proven.

Complements #4727's `packaged-activated-launch` (offline, closed-port Den, CI packaged-smoke): this journey targets the *published* asset, a real Den sign-in, and the profile-upgrade path.

### Found while proving it

An activated install checks for updates and electron-updater installs the newest published release over its own bundle on quit. Once v0.18.46 shipped mid-validation, the 0.18.45 binary under test booted as **0.18.46** in a later run — the version pin failed loudly (good), so the world now copies the `.app` bundle per launch (signature/notarization intact, ~1 s) and the downloaded release stays pristine.

### Conventions

Spec imports only `@openwork/testkit` and its world; raw CDP lives in the world. No new `lint:layers` / channel-ratchet / boundary-ratchet findings (39 / 19 / 14 pre-existing on `dev`, identical with and without these files). `node --test evals/scripts/journey-ci.test.mjs` 13/13. No product code, `.github/`, or other sessions' packaged specs touched.

## Verification

Local lane (macOS arm64, released v0.18.45 assets, baseline v0.18.42, local Den via `server()`): see the test-evidence comment below.

```bash
V=0.18.45; B=0.18.42
ENT="/tmp/ow-release/enterprise-$V/OpenWork Enterprise.app/Contents/MacOS/OpenWork Enterprise"
OPENWORK_EVAL_ELECTRON_BINARY="$ENT" OPENWORK_EVAL_RELEASED_VERSION="$V" \
OPENWORK_EVAL_RELEASED_BASELINE_BINARY="/tmp/ow-release/enterprise-$B/OpenWork Enterprise.app/Contents/MacOS/OpenWork Enterprise" \
  pnpm evals:e2e released-enterprise-activated --local
```
