### PR TITLE
fix(packaging): pin the compose evaluation stack to the 0.18.46 images

### DIFF
--- a/packaging/docker/docker-compose.eval.yml
+++ b/packaging/docker/docker-compose.eval.yml
@@ -43,7 +43,7 @@ services:
     # intentionally no host port: MySQL stays internal to the compose network
 
   den-migrate:
-    image: ghcr.io/different-ai/openwork-den-api:0.18.45@sha256:973cb75d435ce7d17011d689a23c2becab021b230dc8cffe78c7b4ea15af443d
+    image: ghcr.io/different-ai/openwork-den-api:0.18.46@sha256:cdb69e1e5a1d577e4e367fee95bca4d39fe68494cb85766368848dbbb72aa4ee
     depends_on:
       mysql:
         condition: service_healthy
@@ -55,7 +55,7 @@ services:
       DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:?Set OPENWORK_DB_ENCRYPTION_KEY to at least 32 random characters}
 
   den:
-    image: ghcr.io/different-ai/openwork-den-api:0.18.45@sha256:973cb75d435ce7d17011d689a23c2becab021b230dc8cffe78c7b4ea15af443d
+    image: ghcr.io/different-ai/openwork-den-api:0.18.46@sha256:cdb69e1e5a1d577e4e367fee95bca4d39fe68494cb85766368848dbbb72aa4ee
     restart: unless-stopped
     depends_on:
       mysql:
@@ -89,7 +89,7 @@ services:
       WORKER_URL_TEMPLATE: https://workers.local/{workerId}
 
   web:
-    image: ghcr.io/different-ai/openwork-den-web:0.18.45@sha256:b145952d15df51d10fdbe7d689f2399cafa81fdfc55da695befc7659d8b67983
+    image: ghcr.io/different-ai/openwork-den-web:0.18.46@sha256:82affe9e09523852dbdb8ffd8c9ac36763a4f7d5d4e4c94d5e2b513e37e04a7b
     restart: unless-stopped
     depends_on:
       den:


### PR DESCRIPTION
## Problem

v0.18.46 was released 2026-09-10 03:05 UTC, 96 minutes after #4729 pinned the documented evaluation stack to 0.18.45. The drift check in #4732 already flags `dev` for exactly this. Until that automation lands, the pins are bumped by hand.

## Change

`packaging/docker/docker-compose.eval.yml`: den-api and den-web (all three image references) → `0.18.46` with the manifest-list digests resolved by `docker buildx imagetools inspect`:

- `openwork-den-api:0.18.46@sha256:cdb69e1e5a1d577e4e367fee95bca4d39fe68494cb85766368848dbbb72aa4ee`
- `openwork-den-web:0.18.46@sha256:82affe9e09523852dbdb8ffd8c9ac36763a4f7d5d4e4c94d5e2b513e37e04a7b`

No other file references 0.18.45 (README and evaluate-with-docker-compose.mdx are version-neutral since #4729).

## Proof (config change; runtime proof is the documented boot)

```
OPENWORK_AUTH_SECRET=… OPENWORK_DB_ENCRYPTION_KEY=… OPENWORK_WEB_PORT=13005 OPENWORK_API_PORT=18788 OPENWORK_ALLOW_SIGNUP=false \
docker compose -p verify46 -f packaging/docker/docker-compose.eval.yml up -d --wait
```
- `den-migrate` exited 0: `recording 94 committed migrations as baseline`, `running committed migrations` (no new migrations 0.18.45 → 0.18.46)
- `GET :18788/health` → `{"ok":true,"service":"den-api","version":"0.18.46"}` (200)
- `GET :13005/api/runtime-config` → 200, `denApiUrl` = the API origin, `orgMode: "single_org"`, `singleOrgAllowPublicSignup: false`
- `down -v` clean

With this merged, #4732's "Compare compose pins with the released version" check goes green.