### PR TITLE
fix(server): make workspace permission changes reach the engine's effective permissions (composer-run-mode)

### DIFF
--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -117,6 +117,21 @@ export function useDesktopRuntimeBoot() {
         };
 
         const startServerWithoutDesktopWorkspace = async () => {
+          // A renderer reload lands here whenever the selected workspace only
+          // exists in the server registry (workspaces created from the app are
+          // server-owned). The server is already serving it: restarting would
+          // kill the engine and every in-flight run for nothing.
+          const running = await openworkServerInfo().catch(() => null);
+          if (
+            isOpenworkServerInfoLike(running)
+            && isOpenworkServerReady(running)
+            && (running.remoteAccessEnabled === true) === preferredRemoteAccess
+          ) {
+            publishOpenworkServerInfo(running);
+            await window.__OPENWORK_ELECTRON__?.recovery?.recordHealthy?.().catch(() => undefined);
+            markReady();
+            return;
+          }
           setPhase("starting-engine", "Starting OpenWork server");
           const serverInfo = await openworkServerRestart({ remoteAccessEnabled: preferredRemoteAccess }).catch((error) => {
             console.warn("[desktop-boot] openworkServerRestart failed:", error);

--- a/evals/specs/composer-run-mode.e2e.test.ts
+++ b/evals/specs/composer-run-mode.e2e.test.ts
@@ -17,7 +17,7 @@ test("workspace run mode is opt-in, confirms Keep going, and preserves policy wh
 
   const read = async (path: string) => {
     const response = await probe.desktopApi(`${mount}/${path}`);
-    expect(response.status, path).toBe(200);
+    expect(response.status, `${path} ${JSON.stringify(response.body)}`).toBe(200);
     if (!isRecord(response.body)) throw new Error(`Expected an object from ${path}.`);
     return response.body;
   };

--- a/evals/worlds/desktop.ts
+++ b/evals/worlds/desktop.ts
@@ -3,7 +3,12 @@ import type { Seed } from "@openwork/env";
 export async function emptySession(seed: Seed) {
   const workspacePath = seed.tmpPath("empty-session");
   const app = await seed.desktop({ name: "empty-session" });
-  const workspace = await seed.workspace(app, workspacePath);
+  // Create the workspace at the declared tmp path. Without `create`, the seed
+  // adopts the first-launch default workspace, which the dev profile places
+  // inside the repo checkout on Daytona; the engine then merges the repo's
+  // `.opencode/opencode.json` (`"permission": "allow"`) over the workspace's
+  // own permission block, so workspace-level permission claims never hold.
+  const workspace = await seed.workspace(app, workspacePath, { create: true });
   const session = await seed.session(app);
   return { app, workspace, session, workspacePath };
 }


### PR DESCRIPTION
Fixes Cluster 9 of the 2026-09-09 E2E triage (`composer-run-mode`: "workspace `opencode.json` gets `permission:{"*":"ask"}` but `GET permissions/effective` keeps reporting the `mcp` probe as `allow / source:"engine"` for 60 s").

## Root cause

Not a server or engine-reload bug. The engine reload fires, completes, and the rebuilt instance reads the new workspace config; the workspace rule is then **shadowed by an ancestor `.opencode/opencode.json`**.

- `emptySession` (`evals/worlds/desktop.ts`) declares `/tmp/openwork-empty-session-<ts>` but called `seed.workspace()` without `create`, so `createAndSelectWorkspace` adopted the app's existing workspace instead. Since `51c0ab92f` (#4608, Sep 8) first launch auto-creates a default workspace at `<dev profile>/openwork-dev-data/home/OpenWork Chat`; on Daytona the dev profile lives under `/workspace/.openwork-daytona/...`, i.e. **inside the repo checkout**.
- OpenCode's `ConfigPaths.directories` walks from the instance directory up to the git worktree and merges every `.opencode/opencode.json` it finds **after** the workspace's own `opencode.json`. The engine log from a red run shows exactly that order:
  ```
  loading path=".../home/OpenWork Chat/opencode.jsonc"        <- workspace: {"*":"ask"}
  loading path=/workspace/.opencode/opencode.json             <- repo:      "permission": "allow"
  ```
  The repo's `.opencode/opencode.json` (`"permission": "allow"`, since `012bd56ae`) wins, so the governing agent's catch-all stays `* * allow`; OpenWork attributes it to `engine` because it matches none of the three layers it knows about. The `PUT permissions/mode` reload confirmation only checks that a snapshot exists, so it reports `refresh: "reloaded"`.
- This is deterministic since #4608 (5/5 red on `origin/dev` @ `c744e2d7b` in this session; last green nightlies were the two Sep 8 runs before #4608 merged). The Sep 6-7 reds of this spec were a different, still-flaky failure (see below).

## What changed

1. `evals/worlds/desktop.ts` — `emptySession` passes `{ create: true }` so the spec runs against the tmp workspace it declares (same as `session-shell`, `browser-panel`, `models-analytics`). No assertion changed.
2. `evals/specs/composer-run-mode.e2e.test.ts` — the `read` helper includes the server error body in its status assertion message (diagnostic only).
3. `apps/app/src/react-app/shell/desktop-runtime-boot.ts` — exposed by (1): workspaces created from the app exist only in the server registry, so after a renderer reload the boot path hit `startServerWithoutDesktopWorkspace` and **restarted the embedded server and engine** although both were healthy (`Drained engine closed. cause=shutdown`, then ~5 s of `opencode_unconfigured` 400s). Before #4608 this was hidden because an absent desktop workspace-state file triggered recovery from `server.json`. The boot now reuses a ready server whose remote-access mode matches and only restarts when nothing usable is running.

## Proof (`OPENWORK_EVAL_REF` exported, fresh sandbox per run, placement `daytona`)

- Repro on `origin/dev` @ `c744e2d7b`: `pnpm evals:e2e composer-run-mode --daytona` → 0 passed / 1 failed (`engine applies workspace MCP ask` timed out, `allow / source:"engine"`), 5 of 5 runs.
- `a740eb41b` (world fix only): step "Ask before actions … reaches the engine" green; next step failed with `permissions/effective 400 opencode_unconfigured` right after `user.reload()` (server restart described above).
- **`561b5c03a` (this PR head)**: `pnpm evals:e2e composer-run-mode --daytona` → `passed:1 failed:0 skipped:0`, twice in a row (source verified `561b5c03a…`). One earlier run at the same sha failed only in the final step (`run mode flag disabled` after 5 s, last value `true`) — the same pre-existing flake as the Sep 7 nightly, see below.
- `pnpm evals:e2e composer-draft-reload --daytona` at `561b5c03a` (the only other `emptySession` consumer) → `passed:1 failed:0 skipped:0`.
- `pnpm --filter @openwork/app exec tsc --noEmit` clean.

## Noticed, not touched

- **Flag toggle flake** (pre-existing; Sep 7 nightly and 1 of 3 runs here): clicking `workspace-run-mode-flag` a second time in Settings → Advanced sometimes leaves the preference `true`. The harness clicks at coordinates resolved ~250 ms earlier (`waitForLocated` then `clickAt`); Advanced has several async sections above the switch. Belongs with Brief B2 (harness click hardening).
- `permissions/effective` attributes rules from ancestor `.opencode/opencode.json` files to `engine`; a user whose workspace sits inside a repo with such a file sees "Ask before actions" selected while the engine runs everything, and `PUT permissions/mode` still reports `refresh: "reloaded"`. Worth a `project` layer and a real post-reload check.
- Workspaces created from the app never enter the desktop workspace store; on relaunch `bootRuntimeForSelectedWorkspace` skips with `no-local-workspace` and the renderer starts the server instead.
- The repo's own `.opencode/opencode.json` (`"permission": "allow"`) leaks into any Daytona eval whose workspace is the first-launch default folder; other specs relying on the default workspace inherit it.
