### PR TITLE
fix(packaging): pin the compose evaluation stack to the 0.18.46 images

### DIFF
--- a/packages/docs/self-host/evaluate-with-docker-compose.mdx
+++ b/packages/docs/self-host/evaluate-with-docker-compose.mdx
@@ -19,9 +19,9 @@ Install Docker Engine or Docker Desktop with Docker Compose v2. The machine must
 
    ```bash
    curl -fsSLo docker-compose.eval.yml \
-     https://raw.githubusercontent.com/different-ai/openwork/50932fa798fb0539bf8c6107b32a29aba83f93c8/packaging/docker/docker-compose.eval.yml
+     https://raw.githubusercontent.com/different-ai/openwork/d10e46e54c40838773355f5aa133d1574a312f3f/packaging/docker/docker-compose.eval.yml
    printf '%s  %s\n' \
-     '2868753a21254902d68b7f1c507012e72137e954102ebe54a2eff970a5029b2d' \
+     '93d02d96f7c03f0f03ca3662068b56eb4a36ca96b8577105a732518408aaae4e' \
      'docker-compose.eval.yml' | shasum -a 256 --check
    ```
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -6,9 +6,9 @@ Run Den API, Den web, and MySQL from published images without cloning or buildin
 
 ```bash
 curl -fsSLo docker-compose.eval.yml \
-  https://raw.githubusercontent.com/different-ai/openwork/50932fa798fb0539bf8c6107b32a29aba83f93c8/packaging/docker/docker-compose.eval.yml
+  https://raw.githubusercontent.com/different-ai/openwork/d10e46e54c40838773355f5aa133d1574a312f3f/packaging/docker/docker-compose.eval.yml
 printf '%s  %s\n' \
-  '2868753a21254902d68b7f1c507012e72137e954102ebe54a2eff970a5029b2d' \
+  '93d02d96f7c03f0f03ca3662068b56eb4a36ca96b8577105a732518408aaae4e' \
   'docker-compose.eval.yml' | shasum -a 256 --check
 umask 077
 printf 'OPENWORK_AUTH_SECRET=%s\nOPENWORK_DB_ENCRYPTION_KEY=%s\n' \

--- a/packaging/docker/docker-compose.eval.yml
+++ b/packaging/docker/docker-compose.eval.yml
@@ -43,7 +43,7 @@ services:
     # intentionally no host port: MySQL stays internal to the compose network
 
   den-migrate:
-    image: ghcr.io/different-ai/openwork-den-api:0.18.45@sha256:973cb75d435ce7d17011d689a23c2becab021b230dc8cffe78c7b4ea15af443d
+    image: ghcr.io/different-ai/openwork-den-api:0.18.46@sha256:e254a3842e7ecb6d0c7128b5f17201e92ac4ee566ad82c70c468938a3faa6407
     depends_on:
       mysql:
         condition: service_healthy
@@ -55,7 +55,7 @@ services:
       DEN_DB_ENCRYPTION_KEY: ${OPENWORK_DB_ENCRYPTION_KEY:?Set OPENWORK_DB_ENCRYPTION_KEY to at least 32 random characters}
 
   den:
-    image: ghcr.io/different-ai/openwork-den-api:0.18.45@sha256:973cb75d435ce7d17011d689a23c2becab021b230dc8cffe78c7b4ea15af443d
+    image: ghcr.io/different-ai/openwork-den-api:0.18.46@sha256:e254a3842e7ecb6d0c7128b5f17201e92ac4ee566ad82c70c468938a3faa6407
     restart: unless-stopped
     depends_on:
       mysql:
@@ -89,7 +89,7 @@ services:
       WORKER_URL_TEMPLATE: https://workers.local/{workerId}
 
   web:
-    image: ghcr.io/different-ai/openwork-den-web:0.18.45@sha256:b145952d15df51d10fdbe7d689f2399cafa81fdfc55da695befc7659d8b67983
+    image: ghcr.io/different-ai/openwork-den-web:0.18.46@sha256:82affe9e09523852dbdb8ffd8c9ac36763a4f7d5d4e4c94d5e2b513e37e04a7b
     restart: unless-stopped
     depends_on:
       den:


### PR DESCRIPTION
## Problem

`v0.18.46` was tagged minutes after #4729 pinned the evaluation stack to 0.18.45, so `packaging/docker/docker-compose.eval.yml` is one release behind again. The automation in #4732 was not on `dev` when that tag was pushed, so this is the manual bump for 0.18.46 (produced with #4732's `scripts/release/pin-compose-images.mjs`, exactly the sequence the bot job runs: `pin` → commit → `docs --commit <sha>` → commit → `check-compose-pins.mjs`).

## Change

- `openwork-den-api:0.18.46@sha256:e254a3842e7ecb6d0c7128b5f17201e92ac4ee566ad82c70c468938a3faa6407` (den-migrate + den)
- `openwork-den-web:0.18.46@sha256:82affe9e09523852dbdb8ffd8c9ac36763a4f7d5d4e4c94d5e2b513e37e04a7b`
- Docs download URL → commit `d10e46e5` (this PR's compose commit), checksum `93d02d96…`; verified `curl` + `shasum -a 256 --check` → `OK`.

Digests are the OCI index digests (`docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`) and equal `containerimage.digest` in `Publish EE Artifacts` run 34431517807 **after its re-run**: the first den-api attempt failed pushing (`error writing layer blob: not_found`), and the rebuilt image has a different digest (`cdb69e1e…` → `e254a384…`). Pinning before the re-run would have pinned the wrong image — the reason #4732 takes the digest from the build artifact and cross-checks the registry.

## Proof

Config change; runtime proof is the documented boot (Docker Desktop, local lane; `OPENWORK_WEB_PORT=3105` / `OPENWORK_API_PORT=8888` documented knobs because the defaults are in use locally):

```
$ docker compose -f docker-compose.eval.yml up -d --wait                 # exit 0
 Container openwork-eval-den-migrate-1 Exited          # Exited (0)
 Container openwork-eval-den-1 Healthy
 Container openwork-eval-web-1 Healthy
$ curl http://127.0.0.1:8888/health
{"ok":true,"service":"den-api","version":"0.18.46"}                     HTTP 200
$ curl http://127.0.0.1:3105/api/ready
{"ok":true,"service":"den-web","checks":{"configuration":"ok","upstream":"ok"}}   HTTP 200
$ curl http://127.0.0.1:3105/api/runtime-config
{"denApiUrl":"http://localhost:8888",...}                                HTTP 200
$ POST http://127.0.0.1:3105/api/auth/sign-up/email                     HTTP 200
$ docker compose ps -a   → den/den-migrate running openwork-den-api@sha256:e254a384…, web running openwork-den-web@sha256:82affe9e…
$ docker compose -f docker-compose.eval.yml down -v                     # exit 0
```

`node scripts/release/check-compose-pins.mjs` on this branch: `{"ok":true,"releasedVersion":"0.18.46","problems":[]}`.

Local Warden `pnpm warden:check` on `be3f365e1` vs `origin/dev b89522735`: 2/2 skills, No findings, exit 0.
