### PR TITLE
fix(app): skip the dither shader without WebGL2

### DIFF
--- a/apps/app/src/components/dither-backdrop.tsx
+++ b/apps/app/src/components/dither-backdrop.tsx
@@ -1,0 +1,41 @@
+import { Dithering } from "@paper-design/shaders-react";
+
+let webGl2Available: boolean | null = null;
+
+/**
+ * Paper Shaders mounts on a WebGL2 canvas and throws (as an unhandled
+ * rejection) when the GPU offers none: headless CI, some VDI desktops,
+ * GPU-disabled policies. The check is cached; GPU availability does not
+ * change within a session.
+ */
+function supportsWebGl2(): boolean {
+  if (webGl2Available !== null) return webGl2Available;
+  try {
+    webGl2Available = typeof document !== "undefined"
+      && document.createElement("canvas").getContext("webgl2") !== null;
+  } catch {
+    webGl2Available = false;
+  }
+  return webGl2Available;
+}
+
+/**
+ * Paper first-load spec: subtle pixel-dither mosaic over the page ground.
+ * Renders nothing without WebGL2, leaving the plain page background.
+ */
+export function DitherBackdrop() {
+  if (!supportsWebGl2()) return null;
+  return (
+    <Dithering
+      className="size-full"
+      speed={0.01}
+      shape="warp"
+      type="2x2"
+      size={20.3}
+      scale={1.19}
+      frame={264559.21}
+      colorBack="#00000000"
+      colorFront="#000000"
+    />
+  );
+}

--- a/apps/app/src/components/page.tsx
+++ b/apps/app/src/components/page.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from "react";
 import { Loader2 } from "lucide-react";
-import { Dithering } from "@paper-design/shaders-react";
 
+import { DitherBackdrop } from "@/components/dither-backdrop";
 import { cn } from "@/lib/utils";
 
 function Page({ className, ...props }: ComponentProps<"div">) {
@@ -24,17 +24,7 @@ function PageBackground({ className, ...props }: ComponentProps<"div">) {
       className={cn("pointer-events-none fixed inset-0 z-0 overflow-hidden opacity-[0.1] dark:invert", className)}
       {...props}
     >
-      <Dithering
-        className="size-full"
-        speed={0.01}
-        shape="warp"
-        type="2x2"
-        size={20.3}
-        scale={1.19}
-        frame={264559.21}
-        colorBack="#00000000"
-        colorFront="#000000"
-      />
+      <DitherBackdrop />
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
@@ -5,11 +5,11 @@ import {
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
-import { Dithering } from "@paper-design/shaders-react";
 
 import { t } from "../../../i18n";
 import { resolveExtensionIconSrc } from "../../design-system/extension-icon-src";
 import { DEFAULT_DEN_BASE_URL } from "../../../app/lib/den";
+import { DitherBackdrop } from "@/components/dither-backdrop";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "../../design-system/text-input";
 import { OrganizationServerAffordance } from "../settings/cloud/organization-server-affordance";
@@ -221,17 +221,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
       <div className="relative min-h-dvh bg-background text-foreground">
         {/* Pixel-dither mosaic background (dark:invert keeps it visible in dark mode) */}
         <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden opacity-[0.1] dark:invert">
-          <Dithering
-            className="size-full"
-            speed={0.01}
-            shape="warp"
-            type="2x2"
-            size={20.3}
-            scale={1.19}
-            frame={264559.21}
-            colorBack="#00000000"
-            colorFront="#000000"
-          />
+          <DitherBackdrop />
         </div>
 
         {/* Titlebar drag region */}

--- a/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
+++ b/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource react */
-import { Dithering } from "@paper-design/shaders-react";
 import { useState, useSyncExternalStore, type FormEvent, type ReactNode } from "react";
 
 import {
@@ -14,6 +13,7 @@ import { enterpriseActivationRequired } from "@/app/lib/enterprise-activation";
 import { readDesktopDistributionInfo } from "@/app/lib/desktop";
 import { parseManualAuthInput } from "@/app/lib/manual-auth-input";
 import { normalizeOrganizationServerInput } from "@/app/lib/organization-server-input";
+import { DitherBackdrop } from "@/components/dither-backdrop";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-icon-src";
@@ -161,17 +161,7 @@ function EnterpriseActivationPage() {
         className="pointer-events-none absolute inset-0 z-0 overflow-hidden opacity-[0.1] dark:invert"
         data-testid="enterprise-activation-background"
       >
-        <Dithering
-          className="size-full"
-          speed={0.01}
-          shape="warp"
-          type="2x2"
-          size={20.3}
-          scale={1.19}
-          frame={264559.21}
-          colorBack="#00000000"
-          colorFront="#000000"
-        />
+        <DitherBackdrop />
       </div>
 
       <div className="absolute inset-x-0 top-0 z-20 h-10 mac:titlebar-drag" />

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource react */
 import { useEffect } from "react";
-import { Dithering } from "@paper-design/shaders-react";
 
 import { t } from "../../../i18n";
 import { useBootState } from "../../shell/boot-state";
@@ -9,6 +8,7 @@ import {
   Page,
   PageTitlebarRegion,
 } from "@/components/page";
+import { DitherBackdrop } from "@/components/dither-backdrop";
 import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 import { useShellConfig } from "../../shell/shell-config";
@@ -60,17 +60,7 @@ export function WelcomePage({
                 near-white ground. `dark:invert` flips the pixels to white so
                 the texture survives dark mode. */}
             <div className="pointer-events-none absolute inset-0 overflow-hidden opacity-[0.1] dark:invert">
-              <Dithering
-                className="size-full"
-                speed={0.01}
-                shape="warp"
-                type="2x2"
-                size={20.3}
-                scale={1.19}
-                frame={264559.21}
-                colorBack="#00000000"
-                colorFront="#000000"
-              />
+              <DitherBackdrop />
             </div>
 
             <div className="relative z-10 w-full max-w-[720px] rounded-3xl border border-border bg-background px-8 pb-12 pt-10 sm:px-16 sm:pb-16 sm:pt-14">

--- a/apps/app/tests/enterprise-activation.test.ts
+++ b/apps/app/tests/enterprise-activation.test.ts
@@ -28,6 +28,10 @@ const connectConfirmDialogSource = readFileSync(
   new URL("../src/react-app/domains/cloud/connect-confirm-dialog.tsx", import.meta.url),
   "utf8",
 );
+const ditherBackdropSource = readFileSync(
+  new URL("../src/components/dither-backdrop.tsx", import.meta.url),
+  "utf8",
+);
 
 const publicDistribution = {
   flavor: "public" as const,
@@ -125,14 +129,15 @@ describe("enterprise desktop activation", () => {
 
   test("matches the desktop login gate and offers actionable sign-in", () => {
     for (const marker of [
-      'type="2x2"',
-      "size={20.3}",
-      "scale={1.19}",
-      "frame={264559.21}",
+      "<DitherBackdrop />",
       'className="w-full max-w-[720px] rounded-3xl border border-border bg-background',
     ]) {
       expect(signInSurfaceSource).toContain(marker);
       expect(activationGateSource).toContain(marker);
+    }
+    // The shared backdrop keeps the Paper dither spec and skips the shader without WebGL2.
+    for (const marker of ['type="2x2"', "size={20.3}", "scale={1.19}", "frame={264559.21}", 'getContext("webgl2")']) {
+      expect(ditherBackdropSource).toContain(marker);
     }
     expect(activationGateSource).toContain('id="organization-server-input"');
     expect(activationGateSource).toContain('data-testid="organization-server-input"');

--- a/evals/worlds/packaged-first-launch.ts
+++ b/evals/worlds/packaged-first-launch.ts
@@ -30,20 +30,16 @@ export interface RendererException {
  * to empty once that caller is fixed; anything not listed fails the launch
  * specs.
  *
- * - The decorative `Dithering` background (`@paper-design/shaders-react`) on
- *   the activation gate (enterprise-activation-gate.tsx) and the sign-in
- *   surface (den-signin-surface.tsx) rejects when the GPU offers no WebGL,
- *   which is every Xvfb CI runner and some VDI desktops. The page itself
- *   still mounts. Clear when those surfaces skip the shader without WebGL.
- *
- * The renderer's fire-and-forget window-chrome IPC (theme.ts,
- * ui-state-store.ts) used to add "Error: Error invoking remote method
- * 'openwork:desktop': Error: OpenWork must be activated from your Den portal
- * before this command is available." until it caught its own rejection.
+ * Retired entries, kept so their shape is recognisable if they return:
+ * - "Error: Paper Shaders: WebGL is not supported in this browser" from the
+ *   decorative `Dithering` background on WebGL-less GPUs (Xvfb CI, some VDI),
+ *   until DitherBackdrop started skipping the shader without WebGL2.
+ * - "Error: Error invoking remote method 'openwork:desktop': Error: OpenWork
+ *   must be activated from your Den portal before this command is available."
+ *   from the fire-and-forget window-chrome IPC (theme.ts, ui-state-store.ts),
+ *   until it caught its own rejection.
  */
-export const KNOWN_LAUNCH_REJECTIONS: readonly string[] = [
-  "Error: Paper Shaders: WebGL is not supported in this browser",
-];
+export const KNOWN_LAUNCH_REJECTIONS: readonly string[] = [];
 
 const UNHANDLED_REJECTION_PREFIX = /^Uncaught \(in promise\)\s*/i;
 


### PR DESCRIPTION
## Summary

Follow-up to #4727, which tracked this as the one entry in `KNOWN_LAUNCH_REJECTIONS`.

`@paper-design/shaders-react`'s `Dithering` mounts on a WebGL2 canvas and throws `Paper Shaders: WebGL is not supported in this browser` as an unhandled rejection when the GPU offers none — every Xvfb CI runner, some VDI desktops, GPU-disabled policies. The page still mounted, but the packaged launch specs had to allowlist it.

- New `apps/app/src/components/dither-backdrop.tsx`: `DitherBackdrop` renders the Paper dither spec only when `canvas.getContext("webgl2")` succeeds (cached), otherwise nothing — the plain page background remains.
- The four identical `<Dithering …>` blocks (enterprise activation gate, sign-in surface, welcome page, onboarding `PageBackground`) now use it. Net −40 lines.
- `evals/worlds/packaged-first-launch.ts`: `KNOWN_LAUNCH_REJECTIONS` is empty again; the retired entries stay documented so their shape is recognisable if they return.
- `apps/app/tests/enterprise-activation.test.ts`: the gate/sign-in parity check now asserts the shared `<DitherBackdrop />` and that the shader spec + WebGL2 guard live in the shared component.

## Verification (local lane, macOS arm64 enterprise build from this tree)

```
pnpm --filter openwork-server build && node apps/desktop/scripts/electron-build.mjs --server-built
CSC_IDENTITY_AUTO_DISCOVERY=false pnpm --dir apps/desktop exec electron-builder --config electron-builder.enterprise.yml --mac --dir --publish never --config.directories.output=/tmp/ow-gate/wg
```

With `OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED=1 OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_SURFACES_DIR=/tmp/ow-gate/profiles` and the allowlist **empty**:

| Spec | GPU | Result |
| --- | --- | --- |
| `pnpm evals:e2e packaged-first-launch --local` | `ELECTRON_EXTRA_LAUNCH_ARGS="--disable-gpu --disable-software-rasterizer --disable-gpu-compositing"` (no WebGL) | exit 0, 1 passed — `allowlisted 0 of 0, unexpected 0` (×2; a first attempt timed out on the "Starting OpenWork" screen with `CDP socket is not open` before the gate mounted — CDP attach flake under the synthetic no-GPU flags, not a rejection; two clean reruns followed) |
| `pnpm evals:e2e packaged-activated-launch --local` | same no-GPU flags | exit 0, 1 passed — `0 of 0, unexpected 0` |
| `packaged-first-launch` | default | exit 0, 1 passed — `0 of 0, unexpected 0` |
| `packaged-activated-launch` | default | exit 0, 1 passed — `0 of 0, unexpected 0` |

Control: on #4727's build (before this fix) the same no-GPU flags produced `allowlisted rejections: 1 of 1` (the WebGL message), and CI's Xvfb runner failed the tightened spec by name until the entry was allowlisted. CI's `packaged-smoke` (Xvfb) now runs the same specs with an empty allowlist.

Unit: `bun test --isolate tests/enterprise-activation.test.ts` 10 pass / 0 fail. `pnpm --filter @openwork/app typecheck` clean; evals `tsc` 0 errors in touched files; journey-ci 13/13.

Warden (`pnpm warden:check`, bare, HEAD 5f9800fcd vs origin/dev 3352a5037, exit 0): 4/4 skills completed, no findings.
