### PR TITLE
fix(preview): default omitted source refs to remote dev

### DIFF
--- a/.opencode/skills/preview-my-work/SKILL.md
+++ b/.opencode/skills/preview-my-work/SKILL.md
@@ -38,8 +38,11 @@ recorded scenario and ref before adopting it. A stage is not a git ref.
 
 Use reviewed repository code: previews execute that ref’s build scripts. Do not
 load production credentials or attach shared secrets volumes. Push the intended
-commit and use its full 40-character SHA so Daytona can fetch it. Both launch
-and update reject mutable branch names. Then:
+commit and use its full 40-character SHA so Daytona can fetch it. When
+`OPENWORK_EVAL_REF` is omitted, launch resolves remote `origin/dev` once to a
+full SHA, prints it, and records it in the world outputs. This assumes `dev`
+is the reviewed baseline. Explicit launch refs and update refs still reject
+mutable branch names. To preview a specific commit:
 
 ```sh
 OPENWORK_EVAL_REF=<pushed-sha> infisical run --silent --env dev -- pnpm world up preview-den --stage pr-1234 --place daytona --detach --timeout 600000 -- --scenario fresh --lifetime 120
@@ -52,10 +55,11 @@ ready world is quick. Never promise seconds for an unmeasured cold boot.
 For an immutable published desktop preview, run:
 
 ```sh
-OPENWORK_EVAL_REF=<pushed-den-sha> pnpm world up preview-desktop --stage pr-1234 --place daytona --detach --timeout 600000 -- --release 0.18.44 --distribution enterprise --scenario blank
+pnpm world up preview-desktop --stage pr-1234 --place daytona --detach --timeout 600000 -- --release 0.18.44 --distribution enterprise --scenario blank
 ```
 
-`OPENWORK_EVAL_REF` pins only the independently provisioned Den source.
+`OPENWORK_EVAL_REF` pins only the independently provisioned Den source; omit
+it to use the current remote `dev` commit, independently of the desktop version.
 The world driver and release installer run from the local checkout's HEAD, and
 the desktop sandbox uses the snapshot's inherited display/browser helpers.
 `--release` selects desktop bytes; none of these identities falls back to

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -94,8 +94,19 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
     }
     await assert.rejects(exec("python3", [join(root, ".opencode/skills/preview-my-work/scripts/update-preview.py"), "preview-den", "--stage", stage, "--ref", "dev"], { cwd: root, timeout: 10000 }), (error: unknown) => record(error) && error.code === 2 && typeof error.stderr === "string" && error.stderr.includes("full 40-character commit SHA"));
     evidence.recordAssertionEvidence("Mutable refs are rejected before preview execution", "Launch with a branch name fails without a live receipt; the updater rejects a branch name before reading a receipt or invoking Daytona.", true);
-    assert.equal(await up("preview-den", "fresh"), 0);
+    const { stdout: remoteDev } = await exec("git", ["ls-remote", "--exit-code", "origin", "refs/heads/dev"], { cwd: root, timeout: 30000 });
+    const expectedDefaultRef = remoteDev.trim().split(/\s+/)[0];
+    assert.match(expectedDefaultRef ?? "", /^[0-9a-f]{40}$/);
+    try {
+      delete process.env.OPENWORK_EVAL_REF;
+      assert.equal(await up("preview-den", "fresh"), 0);
+    } finally {
+      process.env.OPENWORK_EVAL_REF = pinnedRef;
+    }
     const den = await snapshot("preview-den");
+    assert.equal(den.outputs.ref, expectedDefaultRef);
+    assert.equal(den.outputs.denRef, expectedDefaultRef);
+    evidence.recordAssertionEvidence("Omitting the preview ref pins remote dev", "Fresh Den launches without OPENWORK_EVAL_REF and records the remote dev commit SHA in both ref outputs.", true);
     assert.equal(den.outputs.scenario, "fresh");
     assert.equal(den.outputs.password, undefined);
     assert.equal((await fetch(den.outputs.preview)).status, 200);
@@ -107,6 +118,8 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
 
     assert.equal(await up("preview-desktop", "restricted"), 0);
     const desktop = await snapshot("preview-desktop");
+    assert.equal(desktop.outputs.ref, pinnedRef);
+    assert.equal(desktop.outputs.denRef, pinnedRef);
     assert.notEqual(desktop.outputs.denSandbox, den.outputs.denSandbox);
     assert.ok(desktop.outputs.desktopSandbox);
     assert.equal((await fetch(desktop.outputs.preview)).status, 200);

--- a/worlds/lib/preview.ts
+++ b/worlds/lib/preview.ts
@@ -1,5 +1,8 @@
+import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { denFetch } from "../../evals/packages/behaviors/src/den.ts";
 import { app, blankReleaseApp } from "../../evals/packages/env/src/desktop-app.ts";
 import { server } from "../../evals/packages/env/src/den.ts";
@@ -207,6 +210,20 @@ export async function bootPreview(stack: AsyncDisposableStack, place: Place, sur
 
 export async function runPreview(surface: PreviewSurface, argv = process.argv.slice(2)): Promise<void> {
   const { scenario, lifetimeMinutes, release } = parsePreviewOptions(argv);
+  if (resolvePlace().kind === "daytona" && !process.env.OPENWORK_EVAL_REF?.trim()) {
+    try {
+      const { stdout } = await promisify(execFile)("git", ["ls-remote", "--exit-code", "origin", "refs/heads/dev"], {
+        cwd: fileURLToPath(new URL("../..", import.meta.url)),
+        timeout: 30_000,
+      });
+      const ref = stdout.trim().split(/\s+/)[0];
+      if (!ref || !/^[0-9a-f]{40}$/.test(ref)) throw new Error("Remote dev did not return a full commit SHA.");
+      process.env.OPENWORK_EVAL_REF = ref;
+      console.error(`preview  defaulting to origin/dev at ${ref}`);
+    } catch (cause) {
+      throw new Error("Could not resolve remote dev for this preview. Check access to origin or set OPENWORK_EVAL_REF to a reviewed, pushed full 40-character commit SHA.", { cause });
+    }
+  }
   process.env.OPENWORK_WORLD_PREVIEW_DAYTONA = "1";
   await using stack = new AsyncDisposableStack();
   const { outputs } = await bootPreview(stack, resolvePlace(), surface, scenario, release);


### PR DESCRIPTION
## Summary
- Resolve remote origin/dev once to a full SHA when OPENWORK_EVAL_REF is omitted for Daytona previews.
- Log the selected SHA and preserve existing ref/denRef receipt outputs; explicit refs remain SHA-only.
- Extend the existing preview journey and update preview instructions.

## Verification
Passed on final head d97628a747f4a54d7171b3e0e964b6340ddad727:
```sh
OPENWORK_EVAL_REF=$(git rev-parse HEAD) pnpm evals:e2e preview-world
```
Placement: daytona (daytona CLI authenticated). Exit 0; 2 passed, 0 failed, 0 skipped. The journey removes the variable for its default-ref launch, then restores it for explicit-ref coverage. Also covers the published 0.18.44 enterprise blank preview.
Run: cli-run-1789012497776.json. Detailed assertion evidence follows in the evidence comment.
An initial invocation without the test-suite prerequisite ref exited 1 at its setup assertions; the correctly configured final-head run above passed.

## Local Warden — Incomplete
`pnpm warden:check` exited 1: authentication required. Expected skills: diff-security-review, confidentiality-review, spec-provenance-review. First two failed with auth_failed; provenance reported no findings but skipped its file. No completed review clearance or finding IDs.
Scope: all three committed changed files against origin/dev; unrelated untracked nested worktree excluded.
Before/after refs unchanged: HEAD d97628a747f4a54d7171b3e0e964b6340ddad727; origin/dev 4e634905e75a6dc44ffca66d1124c76ee5e19120.
Run reference: 3f9c5d09-2026-09-10T04-12-22-927Z. Private analysis logs are not attached.
Classification: environment/authentication blocker. Clear when approved Warden credentials are available and the full bare review completes with all applicable skills and no blockers. Disposition: unresolved; draft pending review completion.
