### PR TITLE
fix(updater): re-validate the desktop version policy before installing a downloaded update

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -603,6 +603,35 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
           return;
         }
       }
+      // The download was allowed by the policy in force at check time; the
+      // organization may have revoked that version since, so re-run the policy
+      // allow decision against a fresh desktop config before installing. An
+      // absent allowlist still means unrestricted. Offline, the refresh fails:
+      // fall back to the last known config rather than block an approved
+      // install purely on a network error.
+      const downloadedVersion = updateStatusRef.current?.version;
+      if (downloadedVersion) {
+        const currentDesktopConfig = await refreshDesktopConfig()
+          .catch(() => desktopConfigRef.current);
+        if (!isCurrentReleaseChannel()) return;
+        const stillAllowed = downloadedReleaseChannelRef.current === "alpha"
+          ? await isAlphaUpdateAllowed(downloadedVersion, currentDesktopConfig, appVersion)
+          : isUpdateAllowedByDesktopConfig(downloadedVersion, currentDesktopConfig);
+        if (!isCurrentReleaseChannel()) return;
+        if (!stillAllowed) {
+          downloadedReleaseChannelRef.current = null;
+          availableReleaseChannelRef.current = null;
+          setUpdateStatus({
+            state: "blocked",
+            lastCheckedAt: Date.now(),
+            version: downloadedVersion,
+            message: t("settings.update_blocked_policy", undefined, {
+              version: downloadedVersion,
+            }),
+          });
+          return;
+        }
+      }
       const result = await bridge.installAndRestart();
       if (!isCurrentReleaseChannel()) return;
       if (!result?.ok) {
@@ -632,7 +661,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       });
       setError(message);
     }
-  }, [onReleaseChannelChange, resolvePolicyReleaseChannel, runCheckForUpdates, setError]);
+  }, [appVersion, onReleaseChannelChange, refreshDesktopConfig, resolvePolicyReleaseChannel, runCheckForUpdates, setError]);
 
   const setReleaseChannel = useCallback(
     async (next: ReleaseChannel) => {

--- a/apps/app/tests/electron-updater-install-policy.test.ts
+++ b/apps/app/tests/electron-updater-install-policy.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { DenDesktopConfig } from "../src/app/lib/den";
+import {
+  useElectronUpdaterState,
+  type SettingsUpdateStatus,
+} from "../src/react-app/domains/settings/state/electron-updater-state";
+
+const installedVersion = "0.18.0";
+const downloadedVersion = "0.18.5";
+const metadata = { minAppVersion: "0.1.0", latestAppVersion: downloadedVersion, publishedDesktopVersions: [downloadedVersion] };
+
+type Updater = ReturnType<typeof useElectronUpdaterState>;
+
+describe("install re-validates the organization's desktop version policy", () => {
+  let root: ReturnType<typeof createRoot>;
+  let updater: Updater;
+  let statuses: SettingsUpdateStatus[];
+  let installs: number;
+  let refreshes: number;
+  let refreshResult: () => Promise<DenDesktopConfig>;
+  let downloadedConfig: DenDesktopConfig;
+  const originalDev = process.env.DEV;
+
+  // Stable callbacks, as the provider supplies them; new identities per render
+  // would re-run the hook's mount effects forever.
+  const onReleaseChannelChange = () => {};
+  const setError = () => {};
+  const refreshDesktopConfig = () => {
+    refreshes += 1;
+    return refreshResult();
+  };
+
+  function Harness(props: { desktopConfig: DenDesktopConfig }) {
+    updater = useElectronUpdaterState({
+      releaseChannel: "stable",
+      onReleaseChannelChange,
+      updateAutoCheck: false,
+      updateAutoDownload: true,
+      updatePolicyKnown: true,
+      desktopConfig: props.desktopConfig,
+      refreshDesktopConfig,
+      setError,
+    });
+    statuses.push(updater.updateStatus);
+    return null;
+  }
+
+  beforeEach(async () => {
+    GlobalRegistrator.register({ url: "http://localhost/" });
+    Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+    // Bun aliases import.meta.env to process.env; DEV enables the metadata eval hook.
+    process.env.DEV = "true";
+    window.__openworkReadDesktopVersionMetadataEval = () => metadata;
+    installs = 0;
+    refreshes = 0;
+    statuses = [];
+    downloadedConfig = { allowedDesktopVersions: [downloadedVersion] };
+    refreshResult = async () => downloadedConfig;
+    Reflect.set(window, "__OPENWORK_ELECTRON__", {
+      updater: {
+        getChannel: async () => ({ channel: "stable", currentVersion: installedVersion }),
+        setChannel: async (channel: "stable" | "alpha") => ({ channel, currentVersion: installedVersion }),
+        check: async () => ({ available: true, channel: "stable", currentVersion: installedVersion, latestVersion: downloadedVersion }),
+        download: async () => ({ ok: true }),
+        installAndRestart: async () => {
+          installs += 1;
+          return { ok: true };
+        },
+      },
+    });
+    root = createRoot(document.createElement("div"));
+    await act(async () => { root.render(createElement(Harness, { desktopConfig: downloadedConfig })); });
+    // Check and download while the organization allows the version.
+    await act(async () => { await updater.checkForUpdates(); });
+    expect(updater.updateStatus).toMatchObject({ state: "ready", version: downloadedVersion });
+    refreshes = 0;
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    if (originalDev === undefined) delete process.env.DEV;
+    else process.env.DEV = originalDev;
+    await GlobalRegistrator.unregister();
+  });
+
+  test("installs a downloaded version the organization still allows", async () => {
+    await act(async () => { await updater.installUpdateAndRestart(); });
+
+    expect(refreshes).toBe(1);
+    expect(installs).toBe(1);
+    expect(updater.updateStatus).toMatchObject({ state: "ready", version: downloadedVersion });
+  });
+
+  test("refuses to install a version revoked between download and install", async () => {
+    refreshResult = async () => ({ allowedDesktopVersions: [installedVersion] });
+
+    await act(async () => { await updater.installUpdateAndRestart(); });
+
+    expect(refreshes).toBe(1);
+    expect(installs).toBe(0);
+    expect(updater.updateStatus).toMatchObject({
+      state: "blocked",
+      version: downloadedVersion,
+      message: `OpenWork ${downloadedVersion} is available, but this installation is not eligible for it yet.`,
+    });
+    expect(statuses.some((status) => status?.state === "error")).toBe(false);
+  });
+
+  test("installs when the refreshed policy has no allowlist", async () => {
+    refreshResult = async () => ({});
+
+    await act(async () => { await updater.installUpdateAndRestart(); });
+
+    expect(installs).toBe(1);
+    expect(updater.updateStatus).toMatchObject({ state: "ready" });
+  });
+
+  test("uses the last known policy when the refresh fails", async () => {
+    refreshResult = async () => { throw new Error("offline"); };
+
+    await act(async () => { await updater.installUpdateAndRestart(); });
+
+    expect(refreshes).toBe(1);
+    expect(installs).toBe(1);
+    expect(updater.updateStatus).toMatchObject({ state: "ready", version: downloadedVersion });
+  });
+
+  test("blocks on the last known policy when the refresh fails after a revocation", async () => {
+    await act(async () => {
+      root.render(createElement(Harness, { desktopConfig: { allowedDesktopVersions: [installedVersion] } }));
+    });
+    refreshResult = async () => { throw new Error("offline"); };
+
+    await act(async () => { await updater.installUpdateAndRestart(); });
+
+    expect(installs).toBe(0);
+    expect(updater.updateStatus).toMatchObject({ state: "blocked", version: downloadedVersion });
+  });
+});

--- a/evals/packages/cdp/src/input.ts
+++ b/evals/packages/cdp/src/input.ts
@@ -1,7 +1,7 @@
 import { callFunctionOnSurface, evaluateOnSurface } from "./surface.ts";
 import type { Surface } from "./surface.ts";
 
-export type TargetRole = "button" | "link" | "textbox" | "checkbox" | "menuitem" | "tab" | "option" | "separator";
+export type TargetRole = "button" | "link" | "textbox" | "checkbox" | "switch" | "menuitem" | "tab" | "option" | "separator";
 export type TargetMatcher = string | RegExp;
 
 export type Target = string | {
@@ -216,7 +216,7 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
       ? '[contenteditable="true"][data-lexical-editor="true"]'
       : target.text && !target.role && !target.label && !target.placeholder && !target.testId
         ? 'body *'
-        : 'button, a[href], input, textarea, select, [role="combobox"], [role="listbox"], [contenteditable="true"], [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="menuitem"], [role="tab"], [role="option"], [role="separator"], [data-testid]';
+        : 'button, a[href], input, textarea, select, [role="combobox"], [role="listbox"], [contenteditable="true"], [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="switch"], [role="menuitem"], [role="tab"], [role="option"], [role="separator"], [data-testid]';
     const candidates = [...document.querySelectorAll<HTMLElement>(selector)].filter((element: Element) => {
       if (target.role && implicitRole(element) !== target.role) return false;
       if (target.placeholder !== undefined && (element.getAttribute("placeholder") ?? element.getAttribute("aria-placeholder")) !== target.placeholder) return false;

--- a/evals/packages/cdp/test/input.test.ts
+++ b/evals/packages/cdp/test/input.test.ts
@@ -42,6 +42,7 @@ test("parseTarget normalizes bare, structured, and regular-expression targets", 
     nth: 0,
     composer: false,
   });
+  assert.equal(parseTarget({ role: "switch", label: "Check automatically" }).role, "switch");
 });
 
 test("mapKey produces CDP key fields and modifier bits", () => {

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -101,7 +101,10 @@ test("updates download outside Settings and offer a persistent, optional restart
   await user.see({ text: "Restart OpenWork?" });
   await user.see({ text: /Eligible running tasks resume gradually after restart/ });
   await user.click("Keep working");
-  await user.notSee({ text: "Restart OpenWork?" });
+  await probe.eventually(async () => {
+    await user.notSee({ text: "Restart OpenWork?" }, { timeoutMs: 100 });
+    return true;
+  }, { within: 5_000, label: "Keep working dismisses the restart dialog", until: Boolean });
   expect(await world.snapshot()).toMatchObject({ installs: 0, installAttempts: 0 });
 
   await world.setCustomBranding();
@@ -121,7 +124,10 @@ test("updates download outside Settings and offer a persistent, optional restart
     await user.click({ role: "button", label: /^Notifications/ });
     await user.see({ text: message });
     await user.press("Escape");
-    await user.notSee({ text: "Restart Studio?" });
+    await probe.eventually(async () => {
+      await user.notSee({ text: "Restart Studio?" }, { timeoutMs: 100 });
+      return true;
+    }, { within: 5_000, label: "the failed restart dismisses its dialog", until: Boolean });
     await user.notSee({ text: "Restart to update" });
     expect(await world.snapshot()).toMatchObject({ installAttempts: index + 1, installs: 0 });
     await world.openSettings();

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -110,7 +110,8 @@ test("updates download outside Settings and offer a persistent, optional restart
   // The background behavior above is proven. Isolate the manual install-error
   // retries below from another background check after a fresh policy arrives.
   await world.openSettings();
-  await user.click({ label: "Check automatically" });
+  await user.click({ role: "switch", label: "Check automatically" });
+  expect(await world.snapshot()).toMatchObject({ automaticChecksEnabled: false });
   await world.openWorkspace();
   await world.setCustomBranding();
   await probe.eventually(world.snapshot, {

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -27,7 +27,7 @@ revokedTest("a downloaded update is not installed once the organization revokes 
   await user.notSee({ text: readyText });
   await user.notSee({ text: "Restart to update" });
   await user.notSee({ text: "Install & restart" });
-  expect(await world.snapshot()).toMatchObject({ checks: 1, downloads: 1, installs: 0 });
+  expect(await world.snapshot()).toMatchObject({ downloads: 1, installs: 0 });
   await user.screenshot();
 
   // Positive control: the same version approved again installs from Settings.
@@ -41,7 +41,7 @@ revokedTest("a downloaded update is not installed once the organization revokes 
     within: 10_000, label: "install proceeds while the version stays allowed",
     until: (value) => typeof value === "object" && value !== null && Reflect.get(value, "installs") === 1,
   });
-  expect(await world.snapshot()).toMatchObject({ checks: 2, downloads: 2, installs: 1 });
+  expect(await world.snapshot()).toMatchObject({ downloads: 2, installs: 1 });
 });
 
 test("updates download outside Settings and offer a persistent, optional restart", async ({ world, user, probe }) => {

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -1,9 +1,48 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
-import { backgroundUpdateWorld } from "../worlds/first-run.ts";
+import { backgroundUpdateWorld, revokedUpdateWorld } from "../worlds/first-run.ts";
 import { restartUpdateTaskWorld } from "../worlds/chat.ts";
 
 const test = spec.world(backgroundUpdateWorld);
+const revokedTest = spec.world(revokedUpdateWorld);
+
+revokedTest("a downloaded update is not installed once the organization revokes its version", async ({ world, user, probe }) => {
+  const readyText = "Ready to install: v9.9.9";
+  const blockedText = "OpenWork 9.9.9 is available, but this installation is not eligible for it yet.";
+  const downloaded = (count: number) => (value: unknown) =>
+    typeof value === "object" && value !== null && Reflect.get(value, "downloads") === count;
+
+  await world.openSettings();
+  await user.click({ role: "button", text: "Check now" });
+  await probe.eventually(world.snapshot, { within: 30_000, label: "the allowed version downloads", until: downloaded(1) });
+  await user.see({ text: readyText });
+  await user.see({ text: "Restart to update" });
+
+  // Negative half: the organization drops 9.9.9 after the download completed.
+  await world.allowVersions(["0.18.0"]);
+  await user.click("Restart to update");
+  await user.see({ text: "Restart OpenWork?" });
+  await user.click("Restart & update");
+  await user.see({ text: blockedText }, { timeoutMs: 30_000 });
+  await user.notSee({ text: readyText });
+  await user.notSee({ text: "Restart to update" });
+  await user.notSee({ text: "Install & restart" });
+  expect(await world.snapshot()).toMatchObject({ checks: 1, downloads: 1, installs: 0 });
+  await user.screenshot();
+
+  // Positive control: the same version approved again installs from Settings.
+  await world.allowVersions(["9.9.9"]);
+  await user.click({ role: "button", text: "Check now" });
+  await probe.eventually(world.snapshot, { within: 30_000, label: "the re-approved version downloads again", until: downloaded(2) });
+  await user.see({ text: readyText });
+  await user.notSee({ text: blockedText });
+  await user.click({ role: "button", text: "Install & restart" });
+  await probe.eventually(world.snapshot, {
+    within: 10_000, label: "install proceeds while the version stays allowed",
+    until: (value) => typeof value === "object" && value !== null && Reflect.get(value, "installs") === 1,
+  });
+  expect(await world.snapshot()).toMatchObject({ checks: 2, downloads: 2, installs: 1 });
+});
 
 test("updates download outside Settings and offer a persistent, optional restart", async ({ world, user, probe }) => {
   await probe.eventually(world.snapshot, {

--- a/evals/specs/background-desktop-update.e2e.test.ts
+++ b/evals/specs/background-desktop-update.e2e.test.ts
@@ -107,6 +107,11 @@ test("updates download outside Settings and offer a persistent, optional restart
   }, { within: 5_000, label: "Keep working dismisses the restart dialog", until: Boolean });
   expect(await world.snapshot()).toMatchObject({ installs: 0, installAttempts: 0 });
 
+  // The background behavior above is proven. Isolate the manual install-error
+  // retries below from another background check after a fresh policy arrives.
+  await world.openSettings();
+  await user.click({ label: "Check automatically" });
+  await world.openWorkspace();
   await world.setCustomBranding();
   await probe.eventually(world.snapshot, {
     within: 5_000, label: "custom logo is preserved instead of the default wordmark",

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1267,7 +1267,9 @@ export async function backgroundUpdateWorld(seed: Seed) {
     }),
     setCustomBranding: () => evalIn(app, () => {
       const logo = 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="120" height="32"><rect width="120" height="32" rx="5" fill="#25262b"/><text x="12" y="22" font-family="sans-serif" font-size="18" fill="white">Studio</text></svg>');
-      window.__openworkApplyDesktopConfig({ brandAppName: "Studio", brandLogoUrl: logo });
+      const config = { brandAppName: "Studio", brandLogoUrl: logo };
+      window.__openworkApplyDesktopConfig(config);
+      window.__openworkSetDesktopConfigRefreshResult(config);
     }),
     tickUpdateInterval: () => evalIn(app, () => {
       const state = window.__backgroundUpdateWitness;

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1289,3 +1289,56 @@ export async function backgroundUpdateWorld(seed: Seed) {
     openWorkspace: () => go(app, `/workspace/${workspace.workspaceId}/session`),
   };
 }
+
+/** A desktop signed in to a real Den whose organization pins allowed desktop
+ * versions. The updater feed is faked; the version policy is Den's own. */
+export async function revokedUpdateWorld(seed: Seed) {
+  const den = await seed.den({
+    org: { name: `Update policy ${Date.now()}`, admin: { name: "Update Policy Admin" } },
+  });
+  const allowVersions = async (versions: string[]) => {
+    const result = await seed.api(den.admin, "/v1/org", {
+      method: "PATCH", body: JSON.stringify({ allowedDesktopVersions: versions }),
+    });
+    if (!result.response.ok) throw new Error(`Setting allowed desktop versions failed: HTTP ${result.response.status} ${result.text.slice(0, 300)}`);
+  };
+  await allowVersions(["9.9.9"]);
+  const app = await seed.desktop({ name: "revoked-update", den, as: "admin" });
+  const workspace = await seed.workspace(app, seed.tmpPath("revoked-update"));
+  await evalIn(app, () => {
+    const currentVersion = "0.18.0";
+    const state: Window["__backgroundUpdateWitness"] = { checks: 0, downloads: 0, installs: 0, offset: 0, finishDownload: null, intervalCheck: null };
+    window.__backgroundUpdateWitness = state;
+    window.__openworkReadDesktopVersionMetadataEval = () => ({
+      minAppVersion: "0.1.0", latestAppVersion: "9.9.9", publishedDesktopVersions: ["9.9.9"],
+    });
+    window.__openworkUpdaterEvalBridge = {
+      getChannel: async () => ({ channel: "stable", currentVersion }),
+      setChannel: async (channel) => ({ channel, currentVersion }),
+      check: async () => {
+        state.checks++;
+        return { available: true, channel: "stable", currentVersion, latestVersion: "9.9.9" };
+      },
+      download: async () => {
+        state.downloads++;
+        return { ok: true };
+      },
+      installAndRestart: async () => {
+        state.installs++;
+        return { ok: true };
+      },
+      onDownloadProgress: () => () => {},
+    };
+  });
+  return {
+    app,
+    den,
+    allowVersions,
+    snapshot: () => evalIn(app, () => {
+      const { checks, downloads, installs } = window.__backgroundUpdateWitness;
+      return { checks, downloads, installs };
+    }),
+    openSettings: () => go(app, `/workspace/${workspace.workspaceId}/settings/updates`),
+    openWorkspace: () => go(app, `/workspace/${workspace.workspaceId}/session`),
+  };
+}

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1259,6 +1259,7 @@ export async function backgroundUpdateWorld(seed: Seed) {
       return {
         checks, downloads, installs, route: location.hash,
         installAttempts: window.__backgroundUpdateInstallAttempts,
+        automaticChecksEnabled: localStorage.getItem("openwork.react.settings.update-auto-check") !== "0",
         updateInTitlebar: Boolean(document.querySelector<HTMLElement>('header [data-update-button]')),
         updateInSidebar: Boolean(document.querySelector<HTMLElement>('[data-sidebar="footer"] [data-update-button]')),
         sidebarName: document.querySelector<HTMLElement>('[data-sidebar-brand]')?.textContent?.trim() ?? null,

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1305,8 +1305,10 @@ export async function revokedUpdateWorld(seed: Seed) {
   await allowVersions(["9.9.9"]);
   const app = await seed.desktop({ name: "revoked-update", den, as: "admin" });
   const workspace = await seed.workspace(app, seed.tmpPath("revoked-update"));
-  await evalIn(app, () => {
-    const currentVersion = "0.18.0";
+  await evalIn(app, async () => {
+    // Report the real installed version: a different one would re-key the
+    // background auto-check and start a second check beside the manual one.
+    const { currentVersion } = await window.__OPENWORK_ELECTRON__.updater.getChannel();
     const state: Window["__backgroundUpdateWitness"] = { checks: 0, downloads: 0, installs: 0, offset: 0, finishDownload: null, intervalCheck: null };
     window.__backgroundUpdateWitness = state;
     window.__openworkReadDesktopVersionMetadataEval = () => ({
@@ -1329,14 +1331,14 @@ export async function revokedUpdateWorld(seed: Seed) {
       },
       onDownloadProgress: () => () => {},
     };
-  });
+  }, { awaitPromise: true });
   return {
     app,
     den,
     allowVersions,
     snapshot: () => evalIn(app, () => {
-      const { checks, downloads, installs } = window.__backgroundUpdateWitness;
-      return { checks, downloads, installs };
+      const { downloads, installs } = window.__backgroundUpdateWitness;
+      return { downloads, installs };
     }),
     openSettings: () => go(app, `/workspace/${workspace.workspaceId}/settings/updates`),
     openWorkspace: () => go(app, `/workspace/${workspace.workspaceId}/session`),


### PR DESCRIPTION
## Summary

Narrow follow-up to #4726: revalidate organization permission before **explicit renderer install/restart** of an already-downloaded version. This PR does not close the broader managed-updater finding; the same owner is handling remaining phases in #4767.

## Changes

- Refresh `DesktopConfigProvider.refreshFresh` before the renderer calls `bridge.installAndRestart()`.
- For stable, recheck the recorded downloaded version against `isUpdateAllowedByDesktopConfig`. The Den support decision was made at check time; this pure policy check avoids adding a network dependency for installing an already-approved download. Alpha keeps its existing channel/Den checks and reuses `isAlphaUpdateAllowed` for version eligibility.
- If revoked, do not call the bridge. Set the existing blocked-policy status and clear the renderer's downloaded/available channel refs, removing the restart affordance and allowing a fresh check.
- If desktop-config refresh fails, use the last known config. An absent allowlist retains its existing unrestricted meaning. This does not claim fresh managed-policy authorization while offline.
- Settings and the titlebar restart confirmation share this updater function. The native menu exposes Check for Updates, not an independent renderer install function.

## Validation

- Local app typecheck: `pnpm --filter @openwork/app typecheck`, exit 0.
- Local unit checks: `pnpm --dir apps/app exec bun test --isolate tests/electron-updater-install-policy.test.ts tests/version-gate.test.ts`, exit 0, **26 passed / 0 failed / 0 skipped**.
- The hook tests cover allowed, revoked, absent allowlist, refresh failure with cached permission, and refresh failure with cached revocation.
- Real Den/fake updater feed journey: allow version, download, revoke via `PATCH /v1/org`, confirm titlebar restart, observe blocked UI and zero bridge installs; reapprove and freshly download, then install through Settings as the positive control. All three background-update/revocation/recovery cases passed on final head `d5040026407c9b38d7c20328093cc7a5847d7013` in two complementary Daytona name-filtered runs (exit 0 each; all names covered). [Evidence, commands, prior reds, and final local Warden review](https://github.com/different-ai/openwork/pull/4761#issuecomment-5613608029).
- Test mechanics: await dialog dismissal, preserve branding across the fake refresh, and isolate manual retries from automatic checks using the real settings switch. Add the missing switch role/selector to CDP targeting; its unit file passes 8 tests and the journey asserts the changed preference.
- Private Review upload was unavailable because the available Blob token is for a public store. Evidence is published in text on the PR without uploading records to that public store. The existing recovery witness had one unresolved timeout on an earlier head; it passed on the final head, and this PR does not claim to fix recovery.
- Evals typecheck, spec-layer typecheck, layer lint and both ratchets fail identically on the PR and clean `origin/dev` control `634df629a919db504e27d0f00962dc772344e42a`: respectively 366 errors, 9 errors, 39 violations, 19 and 14 ratchet failures. No added-line diagnostics. Existing `first-run.ts` lines 211/212/219 require an ES2024 Promise library; the configured library is ES2023. No unrelated baseline or `.github` edits.

## Explicitly not fixed here — #4767

The executed current-guard source safety matrix on the product change had **8 passed / 8 failed / 0 skipped** (diagnostic, not journey proof). Post-download revocation now blocks explicit renderer restart. These safety assertions still fail:

- Activated managed signed-out, failed-policy GET, and cached-pending-policy automatic admission.
- Revocation before manual download, during check, and during download.
- Native automatic install-on-quit remains armed even after renderer blocks install; direct native install IPC still only checks activation.

Separate onboarding/branding staging and restart, native staging invalidation, and actual OS installation are not covered by this renderer fix. No native exploit or broader closure is claimed. Public/unmanaged and explicitly unrestricted controls still pass.
