### PR TITLE
test(evals): validate-a-release runbook; clone released bundles and let ShipIt finish

### DIFF
--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -126,72 +126,13 @@ Confirm `npm view openwork-server version` matches.
 
 ## Validate a published release
 
-Boot the *released* mac-arm64 desktop binaries (not a source build) through the
-packaged journeys. Both specs are `placement: 'local'` in
-`evals/scripts/journey-catalog.mjs` and skip loudly (verdict `incomplete`,
-exit 2) when `OPENWORK_EVAL_ELECTRON_BINARY` is unset, so a run without a
-binary can never pass by accident.
-
-Run them from a checkout of the tag (`git worktree add /tmp/ow-vX.Y.Z vX.Y.Z`,
-then `pnpm install --frozen-lockfile` there) so the specs' expectations match
-the binary. `dev`'s specs move ahead of published binaries: its
-`packaged-first-launch` fails 0.18.45 and 0.18.46 enterprise on the
-pre-activation IPC rejection fixed by #4727, which no release carries yet.
-
-Download and unpack the enterprise + cloud assets of the tag (`ditto` keeps
-the signature intact; the quarantine flag must go or macOS blocks the spawn):
-
-```bash
-V=X.Y.Z; cd /tmp/ow-release
-gh release download "v$V" -R different-ai/openwork -p "openwork-enterprise-mac-arm64-$V.zip" -p "openwork-cloud-mac-arm64-$V.zip"
-for f in enterprise cloud; do mkdir -p "$f-$V" && ditto -x -k "openwork-$f-mac-arm64-$V.zip" "$f-$V" && xattr -dr com.apple.quarantine "$f-$V"; done
-ENT="/tmp/ow-release/enterprise-$V/OpenWork Enterprise.app/Contents/MacOS/OpenWork Enterprise"
-CLD="/tmp/ow-release/cloud-$V/OpenWork Cloud.app/Contents/MacOS/OpenWork Cloud"
-```
-
-Fresh-machine gate (no bootstrap): the enterprise build must mount
-"Link this app to your organization", the cloud build "Welcome to OpenWork",
-each with zero renderer exceptions:
-
-```bash
-OPENWORK_EVAL_ELECTRON_BINARY="$ENT" pnpm evals:e2e packaged-first-launch --local
-OPENWORK_EVAL_ELECTRON_BINARY="$CLD" pnpm evals:e2e packaged-first-launch --local
-```
-
-Activated enterprise install (what every existing enterprise user boots
-into): the spec cold-boots a local Den, seeds an activated bootstrap and
-asserts the release reports its own version, skips the activation page and
-lands on the interactive `/signin` surface without a render crash.
-`OPENWORK_EVAL_RELEASED_VERSION` pins the version the binary must report:
-
-```bash
-OPENWORK_EVAL_ELECTRON_BINARY="$ENT" OPENWORK_EVAL_RELEASED_VERSION="$V" \
-  pnpm evals:e2e released-enterprise-activated --local
-```
-
-Baseline-upgrade variant: also download the previous release's enterprise zip
-(same steps, e.g. `B=X.Y.W`) and pass it as the baseline. The older release
-signs in and selects a workspace on a fresh profile, quits, then the release
-under test opens that same profile in place and once more after a restart;
-both launches must land in the same signed-in workspace route with zero
-renderer exceptions. Without the baseline variable this second test skips and
-the run is `incomplete`:
-
-```bash
-OPENWORK_EVAL_ELECTRON_BINARY="$ENT" OPENWORK_EVAL_RELEASED_VERSION="$V" \
-OPENWORK_EVAL_RELEASED_BASELINE_BINARY="/tmp/ow-release/enterprise-$B/OpenWork Enterprise.app/Contents/MacOS/OpenWork Enterprise" \
-  pnpm evals:e2e released-enterprise-activated --local
-```
-
-Each command prints a JSON verdict line; only `"verdict":"passed"` with
-`"skipped":0` counts. This covers mac-arm64 only, and the update is simulated
-by launching the new binary on the old profile — the real electron-updater
-download/apply is not exercised. An activated install (and, before 0.18.46,
-an unactivated one) checks for updates and installs the newest release over
-its bundle on quit. `released-enterprise-activated` launches a private copy
-of the `.app` each time so the download stays pristine; `packaged-first-launch`
-launches it in place, so re-extract the zip before re-running it. A run that
-reports a newer version than `$V` booted the wrong binary.
+Once the assets are published, run the `validate-a-release` skill
+(`.opencode/skills/validate-a-release/SKILL.md`) against the released
+mac-arm64 zips before telling anyone the version is safe to roll out: it
+boots the released enterprise and cloud binaries through
+`packaged-first-launch` and `released-enterprise-activated` (fresh install,
+activated install, and a previous-release profile opened by the new build),
+checks the updater manifests' sha512, and verifies signing/notarization.
 
 ---
 

--- a/.opencode/skills/validate-a-release/SKILL.md
+++ b/.opencode/skills/validate-a-release/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: validate-a-release
+description: Validate the release, check the released binaries, is 0.18.x safe to roll out, prove a published desktop release. Boots the RELEASED mac-arm64 enterprise and cloud binaries through the packaged journeys, checks updater manifests and notarization, and publishes evidence.
+---
+
+# Skill: validate-a-release
+
+Run after `release` reports the GitHub release published. Every check runs on
+the artifacts users download, never on a local build. macOS arm64 host, MySQL
+on `127.0.0.1:3306` (`pnpm dev:den:mysql`), `gh` authenticated. Work from a
+clean checkout (evidence is bound to its `git HEAD`): `origin/dev` today; from
+the first release that ships these specs, the tag's own checkout
+(`git worktree add /tmp/ow-vX.Y.Z vX.Y.Z`) so the gate matches the binary.
+
+## 1. Download and unpack
+
+`V` is the release under test, `B` the previous release existing users update from.
+
+```bash
+export V=0.18.45 B=0.18.42
+export R=/tmp/ow-release-$V; mkdir -p $R && cd $R
+gh release download v$V -R different-ai/openwork -p "openwork-enterprise-mac-arm64-$V.zip" -p "openwork-cloud-mac-arm64-$V.zip" -p '*.yml' --clobber
+gh release download v$B -R different-ai/openwork -p "openwork-enterprise-mac-arm64-$B.zip" --clobber
+for s in enterprise:$V cloud:$V enterprise:$B; do f=${s%%:*}; v=${s##*:}; rm -rf $f-$v; mkdir $f-$v
+  ditto -x -k openwork-$f-mac-arm64-$v.zip $f-$v && xattr -dr com.apple.quarantine $f-$v; done
+export ENT="$R/enterprise-$V/OpenWork Enterprise.app" CLOUD="$R/cloud-$V/OpenWork Cloud.app" BASE="$R/enterprise-$B/OpenWork Enterprise.app"
+```
+
+## 2. Signing and notarization
+
+```bash
+for app in "$ENT" "$CLOUD"; do codesign --verify --deep --strict "$app" && spctl -a -t exec -vv "$app"; done
+```
+
+Expect `accepted`, `source=Notarized Developer ID`, `origin=Developer ID Application: Different AI inc. (F5DJWB4CCV)`.
+
+## 3. Updater manifests
+
+```bash
+grep -H '^version:' enterprise*.yml cloud*.yml            # every line must be: version: $V
+gh release view v$V -R different-ai/openwork --json assets --jq '.assets[].name' > assets.txt
+grep -h 'url: ' enterprise*.yml cloud*.yml | awk '{print $NF}' | sort -u | while read u; do grep -qx "$u" assets.txt && echo "ok $u" || echo "MISSING $u"; done
+for f in enterprise cloud; do zip=openwork-$f-mac-arm64-$V.zip
+  want=$(awk -v z="$zip" '$0 ~ "url: "z {f=1} f && /sha512:/ {print $2; exit}' $f-mac.yml)
+  have=$(openssl dgst -sha512 -binary $zip | base64); [ "$want" = "$have" ] && echo "$zip sha512 OK" || echo "$zip sha512 MISMATCH"; done
+```
+
+Any `MISSING`, `MISMATCH`, or wrong version means the updater will fail or refuse the download: stop and report.
+
+## 4. Journeys (from the repo root)
+
+The app installs any newer public release over itself when it quits (ShipIt
+swaps the `.app` in place; builds before #4726 do it even before activation),
+so never launch an extracted bundle directly: `clone` gives each journey a
+throwaway APFS copy, and journey 3+4 clones internally.
+
+```bash
+export OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED=1 OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_SURFACES_DIR=/tmp/ow-profiles-$V
+clone() { rm -rf "$R/clone"; mkdir "$R/clone"; cp -Rc "$1" "$R/clone/"; }
+```
+
+| # | Journey | Command |
+|---|---------|---------|
+| 1 | Fresh enterprise install shows the activation gate, 0 render crashes | `clone "$ENT"; OPENWORK_EVAL_ELECTRON_BINARY="$R/clone/OpenWork Enterprise.app/Contents/MacOS/OpenWork Enterprise" pnpm evals:e2e packaged-first-launch --local` |
+| 2 | Fresh cloud install shows the welcome page, 0 render crashes | `clone "$CLOUD"; OPENWORK_EVAL_ELECTRON_BINARY="$R/clone/OpenWork Cloud.app/Contents/MacOS/OpenWork Cloud" pnpm evals:e2e packaged-first-launch --local` |
+| 3+4 | Activated enterprise install boots to `/signin`; a `$B` signed-in profile opens in `$V` and again after restart | `OPENWORK_EVAL_ELECTRON_BINARY="$ENT/Contents/MacOS/OpenWork Enterprise" OPENWORK_EVAL_RELEASED_BASELINE_BINARY="$BASE/Contents/MacOS/OpenWork Enterprise" OPENWORK_EVAL_RELEASED_VERSION=$V pnpm evals:e2e released-enterprise-activated --local` |
+
+Each command must end with `"verdict":"passed"` and `"skipped":0`. Journey 3+4
+without `OPENWORK_EVAL_RELEASED_BASELINE_BINARY` skips the update test and the
+verdict is `incomplete`, never passed. Before each journey confirm the
+extracted bundle is still the release:
+`/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' "$ENT/Contents/Info.plist"` must print `$V` (re-extract if not).
+
+Second lane for 3+4 against a Den built from the release tag (covers the Den
+the release ships with, not just the local one):
+
+```bash
+bash .devcontainer/test-server-on-daytona.sh v$V --seed --name release-$V-den --auto-stop 90   # prints DEN_WEB_URL / DEN_API_URL
+OPENWORK_EVAL_DEN_WEB_URL=<DEN_WEB_URL> <same variables as journey 3+4> pnpm evals:e2e released-enterprise-activated --den <DEN_API_URL>
+daytona delete release-$V-den
+```
+
+Journeys 1 and 2 also fail on any unhandled rejection outside
+`KNOWN_LAUNCH_REJECTIONS` (evals/worlds/packaged-first-launch.ts). A release
+that predates a fix already on `dev` fails there with `Uncaught (in promise)`
+entries (0.18.45 and 0.18.46: two `OpenWork must be activated…` IPC rejections,
+fixed by #4727). Report those messages verbatim as `Failed`; a render crash
+(no `(in promise)` prefix) or the recovery screen is a rollout blocker.
+
+Negative control when a regression is suspected: run journey 1 with the last
+known-bad release; it must fail (for 0.18.44 it fails with `Local context is missing`).
+
+## 5. Publish evidence
+
+Test runs land in `evals/results/test-runs/<timestamp>-<test>` with the
+checkout's `gitSha`. Publish each run to the PR or issue that tracks the
+release; without a PR, keep the run directories and quote the JSON verdict lines:
+
+```bash
+infisical run --silent -- pnpm evals:e2e --publish --pr <n> --test-run <dir>
+```
+
+## What this proves and does not prove
+
+Proves, on the released mac-arm64 binaries: Developer ID signature and
+notarization; fresh-profile first launch of both flavors mounts its gate with
+zero renderer exceptions and no recovery screen; an already-activated
+enterprise install pointed at a real Den boots past the gate to the interactive
+sign-in surface and reports version `$V`; a profile created and signed in by
+`$B` opens in `$V` straight into the same workspace route, and again after a
+restart, with zero renderer exceptions; all updater manifests name `$V`, point
+at existing assets, and the mac-arm64 sha512s match.
+
+Does not prove: mac-x64, Windows, or Linux binaries boot (only their manifest
+entries are checked); the real electron-updater download/apply path (the update
+is simulated by opening the `$B` profile with `$V`); a customer's self-hosted Den
+version, branding, or policies; SSO/browser sign-in (sign-in uses the handoff
+grant); or any chat/model work after boot.

--- a/evals/worlds/released-enterprise-activated.ts
+++ b/evals/worlds/released-enterprise-activated.ts
@@ -1,5 +1,7 @@
-import { cp, rm } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
 import { basename, dirname, join, relative } from "node:path";
+import { promisify } from "node:util";
 import { createAndSelectWorkspace, quitDesktop, signInDesktopAs } from "@openwork/behaviors";
 import { attachSurface, evaluateOnSurface, probeAppStateOnSurface } from "@openwork/cdp";
 import type { AppStateProbe, AttachedSurface, SurfaceHandle } from "@openwork/cdp";
@@ -166,14 +168,42 @@ function appBundleOf(binary: string): string | null {
  * test would then silently become a newer one between launches (0.18.45 booted
  * as 0.18.46 within a single run once 0.18.46 was published), so every launch
  * boots a private copy of the bundle and the downloaded release stays pristine.
- * The copy keeps the code signature and notarization ticket intact.
+ * The copy keeps the code signature and notarization ticket intact. `cp -c`
+ * clones through APFS clonefile(2), so a 250 MB bundle costs neither time nor
+ * disk; on other volumes cp falls back to a regular copy.
  */
 async function pristineCopy(binary: string, root: string): Promise<string> {
   const bundle = appBundleOf(binary);
   if (!bundle) return binary;
+  await mkdir(root, { recursive: true });
   const copy = join(root, basename(bundle));
-  await cp(bundle, copy, { recursive: true, verbatimSymlinks: true });
+  await execFileAsync("cp", ["-Rc", bundle, copy]);
   return join(copy, relative(bundle, binary));
+}
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Squirrel's ShipIt helper applies a staged update after the app exits, into
+ * the bundle the app ran from. Removing that copy while ShipIt is still moving
+ * files leaves a half-applied install and a resumable ShipIt state behind, so
+ * disposal waits for ShipIt to finish first.
+ */
+async function shipItIsRunning(): Promise<boolean> {
+  if (process.platform !== "darwin") return false;
+  try {
+    await execFileAsync("pgrep", ["-f", "com.differentai.openwork.ShipIt"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForShipItIdle(timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && await shipItIsRunning()) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
 }
 
 export interface LaunchOptions {
@@ -319,6 +349,7 @@ export async function releasedEnterpriseActivatedWorld(seed: Seed) {
           // Every launch is best-effort disposed; the profile removal below still runs.
         }
       }
+      await waitForShipItIdle(60_000);
       for (const profile of ownedProfiles) await rm(profile, { recursive: true, force: true }).catch(() => undefined);
     },
   };


### PR DESCRIPTION
Supersedes #4760 (same tree, re-signed: the dev ruleset requires signed commits and that commit was unsigned).

Follow-up to #4743, which landed the `released-enterprise-activated` journey. This PR adds only what dev did not have:

## Changes

- **`.opencode/skills/validate-a-release/SKILL.md`** (new, 118 lines): the per-release runbook with the checks the release-skill section lacked — updater-manifest `version`/asset-presence/mac-arm64 sha512 check, `codesign --verify --deep --strict` + `spctl -a` notarization check, a Daytona-Den lane for `released-enterprise-activated` (`--den`), a `clone` helper so `packaged-first-launch` never launches the extracted bundle (pre-#4726 builds self-update before activation and ShipIt swaps the `.app` in place), how to read a rejection failure on a release older than dev's `KNOWN_LAUNCH_REJECTIONS`, the publish step, and what is / is not proven.
- **`.opencode/skills/release/SKILL.md`**: the 71-line "Validate a published release" section becomes a pointer paragraph to the new skill.
- **`evals/worlds/released-enterprise-activated.ts`**: `pristineCopy` uses APFS clonefile (`cp -Rc`, ~0.8 s) instead of a 250 MB `fs.cp`; disposal waits for Squirrel's ShipIt to finish before removing clones so a quit-time install never leaves a half-applied bundle or a resumable ShipIt state (observed: a lingering ShipIt with a deleted target).

No spec changes; catalog unchanged.

## Verification (head d4d42bd51, released 0.18.45 mac-arm64 binaries, baseline 0.18.42)

| Journey | Lane | Command | Result |
|---|---|---|---|
| released-enterprise-activated (2 tests) | local Electron + **Daytona Den** built from `v0.18.45` (`--den`) | `OPENWORK_EVAL_ELECTRON_BINARY=<ent 0.18.45> OPENWORK_EVAL_RELEASED_BASELINE_BINARY=<ent 0.18.42> OPENWORK_EVAL_RELEASED_VERSION=0.18.45 OPENWORK_EVAL_DEN_WEB_URL=… pnpm evals:e2e released-enterprise-activated --den …` | **passed 2/0/0** |
| released-enterprise-activated (2 tests) | local, Den cold-booted by `server()` | same, `--local` | **passed 2/0/0** |
| packaged-first-launch, cloud 0.18.45 | local | `clone "$CLOUD"; OPENWORK_EVAL_ELECTRON_BINARY=… pnpm evals:e2e packaged-first-launch --local` | **passed 1/0/0** |
| packaged-first-launch, enterprise 0.18.45 | local | `clone "$ENT"; … pnpm evals:e2e packaged-first-launch --local` | **failed 0/1/0** — pre-existing: identical failure on a clean `origin/dev` (07bdea2f1) control. dev's gate (#4727) rejects two non-crashing `Uncaught (in promise) … OpenWork must be activated from your Den portal` IPC rejections that 0.18.45 **and 0.18.46** emit; the product fix is #4727 itself, which no release carries yet. No render crash; activation page mounted. |

Source bundles verified `0.18.45 / 0.18.45 / 0.18.42` via `PlistBuddy` before and after every run (the clones took every quit-time install).

Manual checks on the same artifacts: `codesign --verify --deep --strict` OK and `spctl -a -t exec` → `accepted, source=Notarized Developer ID` for both flavors; all 8 `enterprise*.yml`/`cloud*.yml` say `version: 0.18.45`, all 16 referenced assets exist, and both mac-arm64 zip sha512s match their manifest.

Static: `tsc -p .` (evals), `lint:layers`, both ratchets add 0 violations from these files (counts identical to origin/dev); `node --test evals/scripts/journey-ci.test.mjs` 13/13.

Warden (`pnpm warden:check`, bare, clean tree, HEAD d4d42bd51, origin/dev 3352a5037 before and after): diff-security-review, confidentiality-review, spec-provenance-review all completed — **No findings**. Exit 0.

Test evidence is published in the sticky comment below.
