### PR TITLE
docs(self-host): pin image.tag with --version, strict sslmode semantics, fix OTel verification curl

### DIFF
--- a/packages/docs/start-here/certificate-trust-and-proxies.mdx
+++ b/packages/docs/start-here/certificate-trust-and-proxies.mdx
@@ -47,8 +47,7 @@ The low-level values and conflict rules are in the Helm README's [Custom CA cert
 For MySQL-compatible databases, encryption and certificate identity verification are separate decisions.
 
 - `sslaccept=accept` keeps TLS enabled but does not verify the certificate chain. Use it only for smoke tests or transitional setup.
-- `sslmode=require` encrypts the connection, but do not describe it as certificate identity verification.
-- `sslmode=verify-ca`, `sslmode=verify-full`, and `sslaccept=strict` are certificate-verifying modes. Pair them with the correct CA bundle, usually through Helm `customCa`.
+- `sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full`, and `sslaccept=strict` are all certificate-verifying modes in OpenWork: Den's MySQL client rejects untrusted chains and checks the hostname for each of them, so `verify-ca` behaves like `verify-full`. The server certificate needs the database hostname in its SAN. Prefer `sslmode=verify-full` and pair it with the correct CA bundle, usually through Helm `customCa`.
 
 ## Proxy guidance
 

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -27,10 +27,11 @@ For Kubernetes installs, use the published Helm chart:
 ```bash
 helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --version <chart-version> \
+  --set image.tag=<chart-version> \
   -f values.prod.yaml
 ```
 
-The chart pulls the matching GHCR images for `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference` unless you mirror them into an internal registry.
+`--version` pins the chart only. The published chart defaults `image.tag` to `latest`, which floats to the newest release on every pull, so set `image.tag` (on the command line or in `values.prod.yaml`) to the same version as the chart. The images are `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference` on GHCR unless you mirror them into an internal registry.
 
 Choose a tested provider path in [Deploy to your cloud](/self-host/deploy-to-your-cloud/overview). The public guides cover AWS, Azure, and Google Cloud, including managed MySQL, ingress, DNS, TLS, migrations, and secure creation of the first administrator.
 
@@ -76,7 +77,7 @@ For containerized services, start from the [Docker packaging](https://github.com
 For production, configure encryption explicitly:
 
 - Enable encryption at rest for the MySQL-compatible database, database backups, object storage, worker volumes, and logs that may contain operational metadata.
-- Require TLS for application-to-database traffic. `sslmode=require` encrypts the connection but is not certificate identity verification. For standard MySQL with certificate verification, use `sslmode=verify-ca`, `sslmode=verify-full`, or a strict equivalent such as `sslaccept=strict`, and provide the CA bundle through the database platform or Helm `customCa`.
+- Require TLS for application-to-database traffic. In OpenWork, `sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full`, and `sslaccept=strict` all verify the server certificate chain and hostname (Den's MySQL client treats `verify-ca` the same as `verify-full`), so the server certificate must chain to a trusted CA and carry the database hostname in its SAN. Use `sslmode=verify-full` and provide a private CA bundle through the database platform or Helm `customCa`. Only `sslaccept=accept` encrypts without certificate verification; keep it for smoke tests.
 - Keep the local Docker MySQL URL (`mysql://root:password@127.0.0.1:3306/openwork_den`) for development only; it is not a production security posture.
 - Set a unique `DEN_DB_ENCRYPTION_KEY` of at least 32 characters. OpenWork uses it to encrypt selected sensitive database columns, but it does not replace infrastructure-level encryption at rest.
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -16,10 +16,14 @@ Published releases are available as an OCI Helm chart:
 ```bash
 helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --version REPLACE_OPENWORK_VERSION \
+  --set image.tag=REPLACE_OPENWORK_VERSION \
   -f values.prod.yaml
 ```
 
-Use the matching image tag in `values.prod.yaml`:
+`--version` pins the chart only. The chart defaults `image.tag` to `latest`,
+which floats to the newest published release on every pull, so always set
+`image.tag` to the same version as `--version`, either with `--set` as above or
+in `values.prod.yaml`.
 
 Create a values file for the target environment:
 
@@ -357,10 +361,13 @@ secret:
     databaseUrl: "mysql://openwork:REPLACE_DB_PASSWORD@mysql.example.internal:3306/openwork_den?sslmode=verify-full"
 ```
 
-`sslmode=verify-ca`, `sslmode=verify-full`, and `sslaccept=strict` enable strict
-certificate verification. `sslaccept=accept` keeps TLS enabled but does not
-verify the certificate chain, so use it only for smoke tests or while preparing
-the CA bundle.
+`sslmode=require`, `sslmode=verify-ca`, `sslmode=verify-full`, and
+`sslaccept=strict` all enable strict certificate verification in Den's MySQL
+client: the chain must be trusted and the certificate must carry the database
+hostname in its SAN (`verify-ca` behaves like `verify-full`). A private-CA
+database therefore needs `customCa` with every one of these modes. Only
+`sslaccept=accept` keeps TLS enabled without verifying the certificate chain, so
+use it only for smoke tests or while preparing the CA bundle.
 
 The custom CA is release-wide for Node.js processes in this chart. Treat it as a
 global trust decision for outbound TLS from those workloads, and include only CA
@@ -528,13 +535,20 @@ In another terminal:
 
 ```bash
 curl --fail --silent --show-error \
-  http://127.0.0.1:3005/api/den/openapi.json >/dev/null
+  http://127.0.0.1:3005/api/auth/get-session >/dev/null
 ```
 
-Your observability backend should show `openwork-den-web` and
-`openwork-den-api`, with one connected trace for the request. Logs from both
+Den Web proxies `/api/auth/*` server-side to Den API, so this single request
+produces a span in `openwork-den-web` and a span in `openwork-den-api`; an
+anonymous session lookup returns `200` with a `null` body. Logs from both
 services carry trace and span IDs. Den API also exports Hono request-duration
 and active-request metrics.
+
+Do not use `/api/den/...` for this check: Den Web answers those paths with a
+`307` redirect to the public API origin instead of proxying them, `curl --fail`
+treats the redirect as success, and Den API never receives the request. Health
+paths (`/api/health`, `/api/ready`, and Den API `/health` and `/ready`) are
+excluded from tracing on purpose.
 
 ### Endpoint and troubleshooting notes
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -538,11 +538,12 @@ curl --fail --silent --show-error \
   http://127.0.0.1:3005/api/auth/get-session >/dev/null
 ```
 
-Den Web proxies `/api/auth/*` server-side to Den API, so this single request
-produces a span in `openwork-den-web` and a span in `openwork-den-api`; an
-anonymous session lookup returns `200` with a `null` body. Logs from both
-services carry trace and span IDs. Den API also exports Hono request-duration
-and active-request metrics.
+Den Web proxies `/api/auth/*` server-side to Den API and forwards the active
+`traceparent`, so your observability backend should show `openwork-den-web` and
+`openwork-den-api` with one connected trace for the request; an anonymous
+session lookup returns `200` with a `null` body. Logs from both services carry
+trace and span IDs. Den API also exports Hono request-duration and
+active-request metrics.
 
 Do not use `/api/den/...` for this check: Den Web answers those paths with a
 `307` redirect to the public API origin instead of proxying them, `curl --fail`


### PR DESCRIPTION
## Summary

Docs-only follow-up to the live Helm validation of the self-hosted chart at v0.18.45. Three findings, three doc fixes:

- **#4752 (doc half)** — `packages/docs/start-here/self-host.mdx` and `packaging/helm/openwork-ee/README.md` now state that the published chart defaults `image.tag` to `latest` (which floats on every pull) and show `--set image.tag=<version>` next to `--version` in the install command. The chart-side change (default `image.tag` to `appVersion`) is in a separate chart PR; that PR closes the issue.
- **#4754** — `self-host.mdx`, `certificate-trust-and-proxies.mdx`, and the chart README now match `ee/packages/den-db/src/mysql-config.ts`: `sslmode=require`, `verify-ca`, `verify-full`, and `sslaccept=strict` all set `rejectUnauthorized: true` (Node verifies chain **and** hostname, so `verify-ca` behaves like `verify-full` and the server cert needs the DB hostname in its SAN). The docs recommend `sslmode=verify-full` + `customCa`, and name `sslaccept=accept` as the only non-verifying mode. No code change; the fail-closed behavior is kept.
- **#4755** — The chart README's OpenTelemetry verification `curl` targeted `/api/den/openapi.json`, which Den Web answers with a `307` to the internal API origin (`app/api/_lib/den-api-redirect.ts`); `curl --fail` accepts the 3xx and Den API never sees the request. Replaced with `GET /api/auth/get-session`, which Den Web proxies server-side to Den API (`app/api/auth/[...path]/route.ts` → `proxyUpstream`) and returns `200` with `null` for an anonymous caller. The text now says a span appears in each service (health paths are intentionally excluded from tracing) and explains why `/api/den/*` must not be used for this check.

Refs #4752
Closes #4754
Closes #4755

## Verification

Docs-only change; runtime proof intentionally skipped (no runtime-observable behavior changed).

Ran the same checks CI's `validate-docs` job runs, from `packages/docs`:

```
npx -y mint@4.2.868 validate      # success build validation passed
npx -y mint@4.2.868 broken-links  # success no broken links found
```

Note: because `packaging/helm/openwork-ee/README.md` is outside `packages/docs/`, CI classifies this PR into the `full` lane rather than `docs`; the mint checks above were run locally for the MDX changes.

Route facts were confirmed by reading `ee/apps/den-web/app/api/den/[...path]/route.ts` (redirect), `ee/apps/den-web/app/api/auth/[...path]/route.ts` (proxy), `ee/apps/den-api/src/observability/runtime.ts` (`/health` and `/ready` excluded from spans), and `ee/packages/den-db/src/mysql-config.ts` (`rejectUnauthorized` set for `require`).
