### PR TITLE
test(den-api): fix stale SCIM rotation fixture and add test:db for provider-rotation tests

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -12,6 +12,7 @@
     "openapi:snapshot": "tsx scripts/generate-openapi-snapshot.ts",
     "smoke:config-object-payload-boundary": "tsx scripts/smoke-config-object-payload-boundary.ts",
     "test": "bun test --conditions development test/api-keys.test.ts test/bearer-session.test.ts test/cloud-provider-materialization-read-retry.test.ts test/remote-session-capability-wire.test.ts",
+    "test:db": "bun test --conditions development test/scim-provider-rotation.test.ts test/sso-provider-rotation.test.ts",
     "backfill:desktop-policies": "pnpm run build:den-db && tsx scripts/backfill-desktop-policies.ts",
     "migrate:skills-to-plugins": "pnpm run build:den-db && tsx scripts/migrate-skills-to-plugins.ts",
     "test:admin-scale": "bun test test/admin-scale-performance.test.ts",

--- a/ee/apps/den-api/test/database-test-env.ts
+++ b/ee/apps/den-api/test/database-test-env.ts
@@ -1,0 +1,19 @@
+// Shared by tests that write to a real MySQL database (run via `pnpm test:db`).
+// Fails fast with a clear message instead of defaulting to a database that
+// does not exist and surfacing as a connection error later.
+export function seedDatabaseTestEnv(): string {
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+  if (!databaseUrl) {
+    throw new Error(
+      [
+        "DATABASE_URL is required: this test writes to a real MySQL database.",
+        "Bootstrap one with: DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_test_den_api pnpm --dir ee/packages/den-db db:bootstrap",
+        "then run: DATABASE_URL=<same url> pnpm --filter @openwork-ee/den-api test:db",
+      ].join("\n"),
+    )
+  }
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  return databaseUrl
+}

--- a/ee/apps/den-api/test/scim-provider-rotation.test.ts
+++ b/ee/apps/den-api/test/scim-provider-rotation.test.ts
@@ -1,12 +1,6 @@
 import { afterAll, beforeAll, expect, mock, test } from "bun:test"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-
-function seedRequiredEnv() {
-  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_scim_provider_rotation"
-  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
-  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
-  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
-}
+import { seedDatabaseTestEnv } from "./database-test-env"
 
 const organizationId = createDenTypeId("organization")
 const scimOnlyUserId = createDenTypeId("user")
@@ -34,11 +28,11 @@ async function cleanup() {
 }
 
 beforeAll(async () => {
-  seedRequiredEnv()
+  const databaseUrl = seedDatabaseTestEnv()
   mock.restore()
 
   const realDb = (await import("@openwork-ee/den-db")).createDenDb({
-    databaseUrl: process.env.DATABASE_URL,
+    databaseUrl,
     mode: "mysql",
   }).db
   mock.module("../src/db.js", () => ({ db: realDb }))
@@ -48,7 +42,7 @@ beforeAll(async () => {
         generateSCIMToken: async (input: {
           body: {
             providerId: string
-            organizationId: string
+            organizationId: typeof organizationId
           }
         }) => {
           await realDb.insert(schema.ScimProviderTable).values({
@@ -138,6 +132,7 @@ beforeAll(async () => {
     id: groupId,
     organizationId,
     providerId: legacyProviderId,
+    scimGroupId: groupId,
     externalId: "legacy-group",
     displayName: "Legacy SCIM group",
   })

--- a/ee/apps/den-api/test/sso-provider-rotation.test.ts
+++ b/ee/apps/den-api/test/sso-provider-rotation.test.ts
@@ -1,12 +1,6 @@
 import { afterAll, beforeAll, expect, mock, test } from "bun:test"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-
-function seedRequiredEnv() {
-  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_sso_provider_rotation"
-  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
-  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
-  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
-}
+import { seedDatabaseTestEnv } from "./database-test-env"
 
 const ownerUserId = createDenTypeId("user")
 const ssoOnlyUserId = createDenTypeId("user")
@@ -38,11 +32,11 @@ async function cleanup() {
 }
 
 beforeAll(async () => {
-  seedRequiredEnv()
+  const databaseUrl = seedDatabaseTestEnv()
   mock.restore()
 
   const realDb = (await import("@openwork-ee/den-db")).createDenDb({
-    databaseUrl: process.env.DATABASE_URL,
+    databaseUrl,
     mode: "mysql",
   }).db
   mock.module("../src/db.js", () => ({ db: realDb }))


### PR DESCRIPTION
## Summary

Small test-debt fix found while validating self-hosted v0.18.45 SSO/SCIM.

`ee/apps/den-api/test/scim-provider-rotation.test.ts` fails with `Field 'scim_group_id' doesn't have a default value`: it inserts a `scim_group` row without `scimGroupId`, a NOT NULL column added by #3809 (2026-08-17; the test was last touched 2026-07-29 in #3278). Identical failure on v0.18.43 and v0.18.45, so pre-existing. It went unnoticed because neither `scim-provider-rotation.test.ts` nor `sso-provider-rotation.test.ts` is in any den-api package script, so CI has never run them.

### Changes

- **Fix the fixture**: set `scimGroupId: groupId` on the seeded `scim_group` row. This matches production (`createScimGroup` in `src/scim-groups.ts` uses the row id) and the #3809 migration backfill (`UPDATE scim_group SET scim_group_id = id`). Test intent is unchanged: rotating a legacy SCIM provider must clean provider-scoped groups, members, tombstones, and accounts, and re-key `external_identity` rows correctly (scim-only → inactive/detached; scim+sso → sso-only).
- **New `test:db` script** listing both provider-rotation tests, so there is a single command CI can call once MySQL is available to the job.
- **Fail-fast guard**: both tests now share `test/database-test-env.ts` (`seedDatabaseTestEnv()`), which throws a clear, actionable error when `DATABASE_URL` is missing instead of defaulting to a phantom per-test database (`openwork_test_scim_provider_rotation`) that nobody has and surfacing later as a connection error.
- Typed the mocked `generateSCIMToken` `organizationId` as the branded id (`typeof organizationId`) so the test file typechecks; same pattern the SSO test already used. Test files are not in any tsconfig, so this error was also invisible.

No `.github/` changes.

### CI wiring: what I did and what still needs a human

`pnpm --filter @openwork-ee/den-api test` runs on PRs via `pnpm test:core` (`ci-tests.yml`) and in the scheduled `openwork-tests-extended` job. Neither job has a MySQL service. The only workflow with MySQL is `den-db-check.yml`, and it runs `@openwork-ee/den-db test` only. So I could not add the rotation tests to `test` without turning every PR red; I stopped at the package.json level as instructed.

To make CI actually run `test:db`, a workflow change (human-owned) would need, in `ci-tests.yml` (or a new den-api job):

1. A MySQL 8 service, same shape as `den-db-check.yml` (`image: mysql:8`, root password, health check).
2. A bootstrap step: `DATABASE_URL=mysql://root:<pw>@127.0.0.1:<port>/openwork_test_den_api pnpm --dir ee/packages/den-db db:bootstrap`.
3. `DATABASE_URL=<same> pnpm --filter @openwork-ee/den-api test:db`.

Until then, `test:db` is the documented local path, and the guard makes "ran without a DB" a loud failure rather than a silent no-op.

### Other den-api tests not in any package script (inventory only; not fixed here)

`ee/apps/den-api/test/` has **247** `*.test.ts` files; **7** are referenced by a script (`test`: 4, `test:db`: 2, `test:admin-scale`: 1). The remaining **240** are orphaned. No other runner (turbo, evals, `den-stack.ts`) picks them up either.

**29 need MySQL** (`createDenDb({ mode: "mysql" })`), candidates for `test:db` once CI has a database:

<details><summary>DB-backed orphans (29)</summary>

```
bootstrap-claim-lifecycle-hardening.test.ts
codemode-runs.test.ts
dashboards.test.ts
external-capabilities-search-divergence.test.ts
google-workspace-capabilities.test.ts
grant-native-capabilities.test.ts
invitation-lifecycle-hardening.test.ts
llm-provider-access-parity.test.ts
llm-provider-member-credentials.test.ts
llm-provider-team-inheritance.test.ts
marketplace-capabilities.test.ts
marketplace-cloud-readiness.test.ts
marketplace-codemode-scripts.test.ts
mcp-connections-connect-start.test.ts
mcp-connections-edit.test.ts
mcp-connections-required-by.test.ts
mcp-connections-tools.test.ts
mcp-oauth-cursor-desktop.test.ts
mcp-oauth-refresh-flow.test.ts
mcp-oauth-refresh-lifecycle.test.ts
plugin-mcp-connector-parity.test.ts
plugin-system-access-list-freshness.test.ts
plugin-system-me-access.test.ts
plugin-system-me-library.test.ts
plugin-system-member-create.test.ts
plugin-system-team-access.test.ts
role-invitation-lifecycle.test.ts
team-lifecycle-hardening.test.ts
workflow-automation-run-access.test.ts
```
</details>

**211 appear to be unit tests** (no MySQL), candidates for `test` after checking each is green:

<details><summary>Unit-level orphans (211)</summary>

```
admin-capabilities.test.ts
admin-delete-user-id-validation.test.ts
admin-management-inference-usage.test.ts
admin-mcp-routes.test.ts
admin-mcp.test.ts
admin-organization-capabilities.test.ts
agent-codemode-script.test.ts
agent-mcp-routes.test.ts
agent-plugin-import-policy.test.ts
agent-plugin-v1.test.ts
audit-events.test.ts
auth-login-options.test.ts
auth-mcp-resource-normalization.test.ts
auth-oauth-redirect.test.ts
auth-protection.test.ts
automation-index.test.ts
automation-model-attention-rollout.test.ts
automation-rollout.test.ts
automation-runner-auth.test.ts
automation-runner-protocol.test.ts
automation-web-access.test.ts
automations-model-authority.test.ts
better-auth-bypass-denial.test.ts
better-auth-member-connected-account-removal.test.ts
brand-asset-routes.test.ts
brand-assets.test.ts
brand-icon-validation.test.ts
cache.test.ts
capability-parity.test.ts
cloud-agent-signed-preview-routing.test.ts
cloud-automation-artifact-state.test.ts
cloud-failure.test.ts
cloud-hosting.test.ts
cloud-instance-route.test.ts
cloud-lifecycle.test.ts
cloud-provider-materialization.test.ts
cloud-provisioning-image-version.test.ts
cloud-provisioning-state-machine.test.ts
cloud-runtime-access.test.ts
codemode-native-binding.test.ts
codemode-tools.test.ts
config-object-projection-clamp.test.ts
connect-link-mode-env.test.ts
connector-cleanup.test.ts
cors-handled-by-edge.test.ts
credential-revocation.test.ts
dashboard-rollout.test.ts
daytona-checkpoint-command.test.ts
daytona-provisioning.test.ts
delete-organization.test.ts
den-base-url-env.test.ts
den-web-org-access.test.ts
deprecated-memory-routes.test.ts
deprecated-skill-hubs.test.ts
desktop-connect-grants-db.test.ts
desktop-handoff-public-url.test.ts
desktop-policy-json-column-strings.test.ts
desktop-policy-role-assignments.test.ts
desktop-releases.test.ts
egress-diagnostics.test.ts
enterprise-mcp-adapter-budget.test.ts
enterprise-mcp-oauth-persistence.test.ts
entitlements.test.ts
external-capability-errors.test.ts
external-connection-proxy.test.ts
external-mcp-diagnostics.test.ts
external-mcp-oauth-state-identity.test.ts
external-mcp-preset-oauth-defaults.test.ts
external-mcp-readiness.test.ts
external-mcp-resolve.test.ts
external-mcp-rollout.test.ts
external-mcp-tool-arguments.test.ts
external-mcp-tool-inspection.test.ts
external-mcp-tool-policy.test.ts
external-tools-search-cache.test.ts
generated-artifact-view-builder.test.ts
generated-artifact-view-rollout.test.ts
generic-oauth-state.test.ts
generic-oauth-token-response.test.ts
github-connector-app.test.ts
github-discovery.test.ts
github-import-projection.test.ts
github-plugin-import-schema.test.ts
github-plugin-mcp-auth.test.ts
github-sync-request-budget.test.ts
github-sync-worker-retry-classification.test.ts
github-sync-worker.test.ts
github-webhook-tenant-scope.test.ts
github-webhook.test.ts
gmail-draft.test.ts
gmail-file-input.test.ts
gmail-management.test.ts
google-productivity-management.test.ts
google-workspace-api.test.ts
handoff-exchange-cors.test.ts
initial-admin-bootstrap.test.ts
install-link-access.test.ts
install-link-release-tag.test.ts
install-links-rollout.test.ts
installer-artifacts.test.ts
internal-mcp-principal.test.ts
invite-duplicate-members.test.ts
llm-custom-provider-guided.test.ts
llm-endpoint-probe.test.ts
llm-provider-normalization.test.ts
login-rate-limit-keys.test.ts
marketplace-codemode-readiness.test.ts
mcp-access-token-contract.test.ts
mcp-admin-capabilities.test.ts
mcp-agent-config-policy.test.ts
mcp-agent-standalone-get.test.ts
mcp-agent-stateless.test.ts
mcp-agent-timeouts.test.ts
mcp-auth.test.ts
mcp-catalog-parameter-refs.test.ts
mcp-connection-action.test.ts
mcp-connection-apps.test.ts
mcp-dynamic-artifact-app.test.ts
mcp-generated-artifact-views.test.ts
mcp-grant-cache.test.ts
mcp-grant-deletion-tombstones.test.ts
mcp-grant-request-liveness.test.ts
mcp-grant-revocation.test.ts
mcp-invoke-body.test.ts
mcp-json-rpc-preflight.test.ts
mcp-membership-revocation.test.ts
mcp-oauth-client-policy.test.ts
mcp-oauth-grant-policy.test.ts
mcp-plugin-flow-app.test.ts
mcp-protocol-version.test.ts
mcp-resource-url.test.ts
mcp-resource.test.ts
mcp-scopes.test.ts
mcp-skill-created-app.test.ts
mcp-token-lifetime.test.ts
mcp-tool-content.test.ts
mcp-tool-name-length.test.ts
mcp-url-guard.test.ts
me-desktop-config.test.ts
member-connected-account-revocation-contract.test.ts
member-removal-rejoin.test.ts
microsoft-365-provider-scopes.test.ts
microsoft-365-routes.test.ts
microsoft-graph.test.ts
native-capabilities.test.ts
native-provider-connections.test.ts
native-provider-scopes.test.ts
oauth-client-rotation.test.ts
oauth-credential-json-normalization.test.ts
oauth-response-realm.test.ts
oauth-tenant.test.ts
oauth-token-rate-limit-observability.test.ts
oauth-token-rate-limit.test.ts
observability.test.ts
openwork-web-access.test.ts
openwork-web-rollout.test.ts
operational-errors.test.ts
org-identity-access.test.ts
org-invitations.test.ts
org-member-guards.test.ts
org-role-permissions.test.ts
organization-capabilities.test.ts
organization-context.test.ts
organization-invite-email.test.ts
organization-join-verification.test.ts
organization-role-credential-revocation.test.ts
organization-role-hierarchy.test.ts
organization-role-session-revocation.test.ts
organization-settings-permissions.test.ts
plugin-system-access.test.ts
plugin-system-config-object-ownership.test.ts
plugin-system-create-bundle.test.ts
plugin-system-cross-org-idor.test.ts
plugin-system-marketplace-defaults.test.ts
plugin-system-marketplace-seeding-db.test.ts
preview-fetch.test.ts
provider-credentials.test.ts
public-api-url.test.ts
public-response-headers.test.ts
rate-limit.test.ts
remote-mcp-apps.test.ts
remote-session-capabilities.test.ts
remote-session-desktop-commands.test.ts
request-log-redaction.test.ts
route-access-policy.test.ts
route-guard-policy.test.ts
saved-script-artifacts.test.ts
scim-auth-sync.test.ts
scim-groups.test.ts
scim-token-storage.test.ts
security-headers.test.ts
sentry-sourcemaps-build.test.ts
service-version.test.ts
session-lifetime.test.ts
single-org-mode.test.ts
single-org-route-guards.test.ts
slack-mcp-diagnostic-compat.test.ts
sso-account-linking-policy.test.ts
sso-entra-domain.test.ts
sso-jit.test.ts
sso-readiness.test.ts
sso-resolve-helpers.test.ts
sso-resolve-route.test.ts
sso-saml-policy.test.ts
sso-saml-response-policy.test.ts
stripe-billing-seats.test.ts
stripe-billing.test.ts
telemetry-dimensions.test.ts
version.test.ts
worker-provisioning-reconciler.test.ts
worker-runtime-signed-preview.test.ts
```
</details>

Note `codemode-runs.test.ts` uses the opposite pattern (`console.warn` + skip assertions when MySQL is down); that is the silent-skip behavior this PR's guard avoids for the rotation tests.

## Verification

Local lane (macOS, MySQL 8.4 in Docker Desktop, bun 1.3.10, pnpm 11.4.0). Daytona not used; this is a DB-backed package test, not a journey spec.

Scratch DB: `docker exec ... mysql -e "CREATE DATABASE openwork_test_provider_rotation"` then `DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_test_provider_rotation pnpm --dir ee/packages/den-db db:bootstrap` (94 migrations recorded as baseline).

Before fix, reproduced on this branch's base:
```
error: Field 'scim_group_id' doesn't have a default value   (ER_NO_DEFAULT_FOR_FIELD)
 0 pass / 1 fail
```

After fix:
```
$ DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_test_provider_rotation pnpm --filter @openwork-ee/den-api test:db
bun test v1.3.10
 2 pass
 0 fail
 23 expect() calls
Ran 2 tests across 2 files.                       # exit 0

$ env -u DATABASE_URL pnpm --filter @openwork-ee/den-api test:db
error: DATABASE_URL is required: this test writes to a real MySQL database.
Bootstrap one with: DATABASE_URL=... pnpm --dir ee/packages/den-db db:bootstrap
then run: DATABASE_URL=<same url> pnpm --filter @openwork-ee/den-api test:db
(fail) [4ms]                                      # exit 1, fails fast before connecting

$ pnpm --filter @openwork-ee/den-api test
 24 pass
 0 fail
Ran 24 tests across 4 files.                      # exit 0

$ tsc -p ee/apps/den-api/tsconfig.json --noEmit  # exit 0 (after build:workspace-dependencies)
$ tsc --noEmit --strict ... --types bun-types test/database-test-env.ts test/scim-provider-rotation.test.ts test/sso-provider-rotation.test.ts
                                                  # exit 0 (base had 2 errors in scim-provider-rotation.test.ts: the missing scimGroupId and the string organizationId)
```

Warden (local final review, bare `pnpm warden:check`, committed branch vs `origin/dev`): exit 0. Skills expected 3 (diff-security-review, confidentiality-review, desktop-den-sync-review), all 3 completed, 4/4 changed files reviewed, no findings. HEAD `309d6152` and origin/dev `634df629` unchanged before/after.
