### PR TITLE
ci(evals): consume explicit world plans in product journeys

### DIFF
--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -74,10 +74,21 @@ jobs:
             exit 0
           fi
 
-          guarded="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
-            | grep -E '^(evals/scripts/|\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
+          # Candidate specs are data, but the planner, its imports and install
+          # inputs are executable trust roots. Changes require manual dispatch.
+          # Include old names on renames and fail closed if the file API fails.
+          # GitHub's PR files endpoint is capped at 3,000 files.
+          changed_file_count="$(gh api "repos/$REPO/pulls/$PR" --jq '.changed_files')"
+          if ! [[ "$changed_file_count" =~ ^[0-9]+$ ]] || [ "$changed_file_count" -gt 3000 ]; then
+            echo "::notice::E2E regression withheld: complete changed-file audit unavailable. Explicit manual workflow_dispatch is required."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed_files="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[] | .filename, (.previous_filename // empty)')"
+          trusted_paths='^(evals/(scripts/|bin/test-files\.mjs$|packages/env/src/world-resources\.ts$)|\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)|(^|/)(package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.ya?ml$|package-lock\.json$|npm-shrinkwrap\.json$|yarn\.lock$|\.npmrc$|\.?pnpmfile\.[^/]+$|tsconfig[^/]*\.json$|\.pnp\.[^/]+$|\.yarnrc[^/]*$|\.gitattributes$|\.gitmodules$|patches(/|$)|node_modules(/|$))'
+          guarded="$(printf '%s\n' "$changed_files" | grep -E "$trusted_paths" || test "$?" -eq 1)"
           if [ -n "$guarded" ]; then
-            echo "::notice::E2E regression withheld: PR changes trusted review machinery."
+            echo "::notice::E2E regression withheld: PR changes trusted review/planner machinery or install inputs. Explicit manual workflow_dispatch is required."
             echo "authorized=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -89,6 +100,18 @@ jobs:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        if: github.event_name != 'workflow_run' || steps.authorize.outputs.authorized == 'true'
+        with:
+          node-version: 24.15.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        if: github.event_name != 'workflow_run' || steps.authorize.outputs.authorized == 'true'
+        with:
+          version: 11.4.0
+      - name: Install AST planner dependencies
+        if: github.event_name != 'workflow_run' || steps.authorize.outputs.authorized == 'true'
+        run: pnpm --dir evals install --frozen-lockfile --ignore-scripts
 
       - name: Select user journeys
         id: matrix
@@ -207,7 +230,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: journey-evidence-${{ matrix.journey.spec }}
+          name: journey-evidence-${{ matrix.journey.artifactId }}
           path: |
             evals/results/test-runs/
             /tmp/daytona-e2e.log
@@ -217,7 +240,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: journey-result-${{ matrix.journey.spec }}
+          name: journey-result-${{ matrix.journey.artifactId }}
           path: journey-result.json
           retention-days: 14
           if-no-files-found: warn
@@ -240,11 +263,32 @@ jobs:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-tests
-      - name: Prepare local Den and Electron
+      - name: Resolve local preparation resources
+        id: resources
+        env:
+          JOURNEY: ${{ toJSON(matrix.journey) }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from 'node:fs';
+          const journey = JSON.parse(process.env.JOURNEY);
+          const worlds = journey.worlds;
+          if (!Array.isArray(worlds) || worlds.length === 0) throw new Error('Missing journey world plan');
+          const legacy = worlds.some(world => world.resources === null);
+          const den = legacy || worlds.some(world => world.resources.services.includes('den'));
+          const native = legacy || worlds.some(world => world.resources.surfaces.includes('desktop'));
+          console.log(`Local preparation: den=${den}, native=${native}, legacy=${legacy}`);
+          appendFileSync(process.env.GITHUB_OUTPUT, `den=${den}\nnative=${native}\n`);
+          NODE
+      - name: Prepare local native libraries
+        if: steps.resources.outputs.native == 'true'
         run: |
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y xvfb x11-utils libgtk-3-0 libnss3 libasound2t64 libgbm1
+      - name: Prepare local Den
+        if: steps.resources.outputs.den == 'true'
+        run: |
+          set -euo pipefail
           pnpm --filter @openwork/types build
           pnpm --filter @openwork-ee/den-db build
           pnpm --filter @openwork/email build
@@ -253,11 +297,16 @@ jobs:
         id: run
         env:
           SPEC_SLUG: ${{ matrix.journey.spec }}
+          NEEDS_NATIVE: ${{ steps.resources.outputs.native }}
         run: |
           set -euo pipefail
           # Permission failures must be real; root would bypass the fault.
           test "$(id -u)" -ne 0
-          xvfb-run -a pnpm evals:e2e "$SPEC_SLUG" --local 2>&1 | tee /tmp/local-handoff-e2e.log
+          command=(pnpm evals:e2e "$SPEC_SLUG" --local)
+          if [ "$NEEDS_NATIVE" = "true" ]; then
+            command=(xvfb-run -a "${command[@]}")
+          fi
+          "${command[@]}" 2>&1 | tee /tmp/local-handoff-e2e.log
       - name: Judge deferred vision claims
         id: vision
         if: success() || failure()
@@ -277,7 +326,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: journey-evidence-${{ matrix.journey.spec }}
+          name: journey-evidence-${{ matrix.journey.artifactId }}
           path: |
             evals/results/test-runs/
             /tmp/local-handoff-e2e.log
@@ -287,7 +336,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: journey-result-${{ matrix.journey.spec }}
+          name: journey-result-${{ matrix.journey.artifactId }}
           path: journey-result.json
           retention-days: 14
           if-no-files-found: warn

--- a/evals/runner/stack-suite.test.ts
+++ b/evals/runner/stack-suite.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -19,6 +19,61 @@ function fixtures(t: test.TestContext) {
 
 const app = `const test = spec.world("app", { resources: { surfaces: ["appWeb"], services: ["mock"] } }); test("WEB-01 browser", () => {});`;
 const native = `const native = spec.world("native", { resources: { surfaces: ["desktop"], services: ["den"], nativeReason: "OS integration" } }); native("NATIVE-01 native", () => {});`;
+
+test("CI trust guard blocks planner dependencies and install inputs, and fails closed", t => {
+  const file = fixtures(t);
+  const workflow = readFileSync(new URL("../../.github/workflows/daytona-e2e.yml", import.meta.url), "utf8");
+  const guard = workflow.match(/          changed_file_count=[\s\S]*?echo "authorized=true" >> "\$GITHUB_OUTPUT"/);
+  assert.ok(guard);
+  assert.match(guard[0], /\.previous_filename \/\/ empty/);
+  const run = (paths: string[], count = "1", failure = "0") => {
+    const output = file("guard-output", "");
+    writeFileSync(output, "");
+    const result = spawnSync("bash", ["-c", `set -euo pipefail
+      gh() {
+        if [[ "$*" == *".changed_files"* ]]; then printf '%s\\n' "$GH_COUNT"; return; fi
+        if [ "$GH_FAILURE" = "1" ]; then return 42; fi
+        printf '%s\\n' "$GH_FILES"
+      }
+      ${guard[0]}`], {
+      encoding: "utf8",
+      env: { ...process.env, REPO: "internal/repo", PR: "1", GH_FILES: paths.join("\n"), GH_COUNT: count, GH_FAILURE: failure, GITHUB_OUTPUT: output },
+    });
+    return { ...result, authorization: readFileSync(output, "utf8") };
+  };
+  for (const path of [
+    "evals/scripts/world-plan.ts", "evals/bin/test-files.mjs", "evals/packages/env/src/world-resources.ts",
+    ".github/workflows/daytona-e2e.yml", "warden.toml", ".warden/README.md", ".agents/skills/review/SKILL.md",
+    "package.json", "evals/package.json", "evals/scripts/package.json", "evals/packages/env/src/package.json",
+    "pnpm-lock.yaml", "evals/pnpm-lock.yaml", "pnpm-workspace.yaml", "evals/pnpm-workspace.yaml",
+    ".npmrc", "evals/.npmrc", ".pnpmfile.cjs", "evals/.pnpmfile.cjs", "evals/pnpmfile.cjs",
+    "evals/tsconfig.json", "tsconfig.base.json", "patches/dependency.patch", "evals/node_modules", ".gitattributes",
+  ]) {
+    const result = run([path]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.authorization, "authorized=false\n", path);
+    assert.match(result.stdout, /manual workflow_dispatch/);
+  }
+  const allowed = run(["evals/specs/example.e2e.test.ts", "scenarios/example/e2e.test.ts", "apps/app/src/index.ts"]);
+  assert.equal(allowed.status, 0, allowed.stderr);
+  assert.equal(allowed.authorization, "authorized=true\n");
+  for (const count of ["3001", "null"]) assert.equal(run([], count).authorization, "authorized=false\n");
+  const failed = run([], "1", "1");
+  assert.equal(failed.status, 42);
+  assert.equal(failed.authorization, "");
+});
+
+test("both CI jobs name artifacts with artifactId while retaining spec paths in results", () => {
+  const workflow = readFileSync(new URL("../../.github/workflows/daytona-e2e.yml", import.meta.url), "utf8");
+  for (const job of ["e2e", "local-journey"]) {
+    const body = workflow.split(`\n  ${job}:\n`)[1]?.split(/\n  [a-z-]+:\n/)[0];
+    assert.ok(body, job);
+    assert.match(body, /name: journey-evidence-\$\{\{ matrix\.journey\.artifactId \}\}/);
+    assert.match(body, /name: journey-result-\$\{\{ matrix\.journey\.artifactId \}\}/);
+    assert.match(body, /SPEC_SLUG: \$\{\{ matrix\.journey\.spec \}\}/);
+    assert.doesNotMatch(body, /name: journey-(?:evidence|result)-\$\{\{ matrix\.journey\.spec/);
+  }
+});
 
 test("global setup uses Vitest's project paths, effective name pattern and sequencer shard", t => {
   const file = fixtures(t);
@@ -56,6 +111,27 @@ test("global setup uses Vitest's project paths, effective name pattern and seque
   assert.match(output, /scenarios\/example\/e2e.test.ts/);
   assert.match(output, /surfaces=\[appWeb\]; services=\[mock\]/);
   assert.doesNotMatch(output, /pr.test.ts|other-shard|nativeReason/);
+});
+
+test("CI preparation script separates appWeb, Den, native and legacy resources", t => {
+  const file = fixtures(t);
+  const workflow = readFileSync(new URL("../../.github/workflows/daytona-e2e.yml", import.meta.url), "utf8");
+  const script = workflow.match(/node --input-type=module <<'NODE'\n([\s\S]*?)\n\s+NODE/);
+  assert.ok(script);
+  const cases = [
+    { resources: { surfaces: ["appWeb"], services: ["mock"] }, expected: "den=false\nnative=false\n" },
+    { resources: { surfaces: ["web"], services: ["den"] }, expected: "den=true\nnative=false\n" },
+    { resources: { surfaces: ["desktop"], services: ["mock"] }, expected: "den=false\nnative=true\n" },
+    { resources: null, expected: "den=true\nnative=true\n" },
+  ];
+  for (const [index, entry] of cases.entries()) {
+    const output = file(`output-${index}`, "");
+    writeFileSync(output, "");
+    execFileSync(process.execPath, ["--input-type=module", "-e", script[1]], {
+      env: { ...process.env, JOURNEY: JSON.stringify({ worlds: [{ resources: entry.resources }] }), GITHUB_OUTPUT: output },
+    });
+    assert.equal(readFileSync(output, "utf8"), entry.expected);
+  }
 });
 
 test("selected multi-file appWeb and scenario plans never prepare Den/native", t => {

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -1,4 +1,7 @@
 import { readdir, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { journeyFiles, testName } from '../bin/test-files.mjs';
+import { discoverWorlds } from './world-plan.ts';
 
 // One home for CI grouping, readable names, and execution requirements.
 // Unlisted specs are discovered automatically as full-regression journeys.
@@ -33,21 +36,24 @@ export const registeredCases = Object.freeze(Object.entries(definitions).flatMap
   (definition.cases ?? []).map(value => Object.freeze({ spec, ...value }))
 ));
 
-export async function catalog(root = new URL('../specs/', import.meta.url)) {
-  const files = (await readdir(root)).filter(file => file.endsWith('.e2e.test.ts')).sort();
+export async function catalog(root) {
+  const paths = root ? (await readdir(root)).filter(file => file.endsWith('.e2e.test.ts')).sort().map(file => fileURLToPath(new URL(file, root))) : journeyFiles();
+  const files = paths.map(file => root ? file.split('/').at(-1) : testName(file));
   for (const file of Object.keys(definitions)) {
     if (!files.includes(file)) throw new Error(`Registered journey missing: ${file}`);
   }
-  return Promise.all(files.map(async spec => {
-    const source = await readFile(new URL(spec, root), 'utf8');
+  return Promise.all(files.map(async (spec, index) => {
+    const source = await readFile(paths[index], 'utf8');
     const rawDesktop = /import\s*\{[^}]*\bdesktop\b[^}]*\}\s*from\s*["']@openwork\/hosts["']/s.test(source);
     return {
       spec,
+      artifactId: Buffer.from(spec, 'utf8').toString('base64url'),
       name: spec.replace('.e2e.test.ts', '').replaceAll('-', ' '),
       critical: false,
       model: 'mock',
       placement: rawDesktop ? 'manual' : 'daytona',
       ...definitions[spec],
+      worlds: discoverWorlds(paths[index], source),
     };
   }));
 }

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -77,6 +77,13 @@ test('registered case metadata names exact files, supported execution axes, and 
     assert(entries.some(entry => entry.spec === registered.spec));
     assert.equal('surfaces' in registered, false);
   }
+  assert(entries.some(entry => entry.spec.startsWith('scenarios/')));
+  assert(entries.every(entry => entry.worlds.length > 0));
+  assert.equal(new Set(entries.map(entry => entry.artifactId)).size, entries.length);
+  for (const entry of entries) {
+    assert.match(entry.artifactId, /^[A-Za-z0-9_-]+$/);
+    assert.equal(Buffer.from(entry.artifactId, 'base64url').toString('utf8'), entry.spec);
+  }
 });
 
 test('skips, no tests, missing summaries, setup and judging failures never pass', () => {

--- a/evals/scripts/plan-journeys.mjs
+++ b/evals/scripts/plan-journeys.mjs
@@ -1,11 +1,13 @@
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { catalog, selectJourneys } from './journey-catalog.mjs';
+import { worldContract } from './world-plan.ts';
 
 const changed = process.env.CHANGED_FILES ? JSON.parse(await readFile(process.env.CHANGED_FILES, 'utf8')) : [];
 const critical = process.env.EVENT_NAME === 'workflow_run' || process.env.SUITE === 'critical';
 const all = await catalog();
 const selected = selectJourneys(all, { critical, only: process.env.ONLY_FILTER || '', changed: changed.map(file => file.replace('evals/specs/', '')) });
 const automatic = selected.filter(entry => entry.placement !== 'manual');
+for (const entry of selected) for (const world of entry.worlds) console.log(`contract: ${entry.spec}:${world.line} ${worldContract(world)}`);
 if (automatic.length === 0) throw new Error('No automated journeys matched. Check the filter; this is not a passing run.');
 const plan = { suite: critical ? 'Critical user journeys' : 'Full regression', entries: automatic, manual: selected.filter(entry => entry.placement === 'manual') };
 await mkdir('journey-plan', { recursive: true });


### PR DESCRIPTION
## Stack and dependency
Second PR, stacked on #4762 (`test/explicit-web-desktop-worlds`). Requires its shared world parser and resource declarations. Review this PR against that branch; merge the core first, then retarget this follow-up to dev. No automatic merges.

## Scope
- Move all GitHub Actions changes from #4762 here: planner dependency installation, fail-closed changed-file trust checks (including renames and install inputs), resource-aware local Den/native preparation, and scenario-safe artifact names.
- Add AST world fields and scenario discovery to the CI catalog, and print world contracts in the CI planner. Core CLI/runtime planning remains in #4762; its CI catalog stays plain Node without TypeScript dependencies.
- Preserve the three workflow diagnostics in stack-suite.test.ts and the catalog scenario/artifact/world assertions in this diff. Core runner and registered-case metadata tests remain in the first PR.
- Combined tree is byte-for-byte identical to preserved original head 43b5ba248. POLICY-ROLLBACK metadata correction remains in the core.

## Verification — narrow diagnostics passed
Node 24.15.0 on candidate ab6cddfa2. Each command exited 0, with zero skipped:
- `pnpm exec node --test evals/bin/evals.test.mjs`: 23 passed.
- `pnpm exec node --test evals/scripts/journey-ci.test.mjs`: 13 passed.
- `pnpm exec node --test evals/runner/stack-suite.test.ts`: 9 passed, including all 3 moved workflow tests.
- `pnpm exec node --test evals/packages/hosts/test/provision.test.ts`: 30 passed.
Total: 75 passed, 0 failed, 0 skipped. Frozen evals dependency install succeeded. No heavy runtime journeys rerun, per requester scope.

Historical runtime/ratchet evidence and unresolved typecheck classification remain documented in #4762; these diagnostics do not replace deferred Daytona/v2/native/multi-file runtime proof.

## Review status — incomplete
Live Warden workflow schema accepts only pull_request events targeting dev, with no workflow_dispatch. This stacked base therefore has no supported Warden trigger; no clearance claimed. Keep draft pending independent review / Warden after retargeting. No merge requested or enabled.