### PR TITLE
fix(evals): preview-world sandbox listing works with the pinned Daytona CLI

### DIFF
--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -39,10 +39,15 @@ interface DaytonaSandboxSummary {
   autoStopInterval: number;
 }
 
+// `daytona sandbox list` paginates by cursor (`-c/--cursor`, `nextCursor` in the JSON body) in every
+// released CLI (v0.191.0 through v0.211.2, including the v0.204.0 CI pin); it has no page flag.
 async function daytonaSandboxes(): Promise<DaytonaSandboxSummary[]> {
   const summaries: DaytonaSandboxSummary[] = [];
-  for (let page = 1; ; page += 1) {
-    const result = await exec("daytona", ["sandbox", "list", "-f", "json", "-l", "200", "-p", String(page)], { timeout: 30000 });
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  for (;;) {
+    const args = ["sandbox", "list", "-f", "json", "-l", "200", ...(cursor === undefined ? [] : ["--cursor", cursor])];
+    const result = await exec("daytona", args, { timeout: 30000 });
     const value: unknown = JSON.parse(result.stdout);
     const entries = Array.isArray(value) ? value : record(value) && Array.isArray(value.items) ? value.items : null;
     if (!entries) throw new Error("Daytona sandbox list did not return items.");
@@ -53,7 +58,10 @@ async function daytonaSandboxes(): Promise<DaytonaSandboxSummary[]> {
         summaries.push({ identities, autoStopInterval: entry.autoStopInterval });
       }
     }
-    if (!record(value) || typeof value.totalPages !== "number" || page >= value.totalPages) break;
+    if (!record(value) || typeof value.nextCursor !== "string" || value.nextCursor.length === 0 || entries.length === 0) break;
+    if (seenCursors.has(value.nextCursor)) throw new Error("Daytona sandbox list repeated a pagination cursor.");
+    seenCursors.add(value.nextCursor);
+    cursor = value.nextCursor;
   }
   return summaries;
 }


### PR DESCRIPTION
## Root cause

Triage `reports/e2e-red-2026-09-09/triage.md` (local folder `/Users/guillaume/OpenWork Chat/reports/e2e-red-2026-09-09/`), **Cluster 3 — Pooled Daytona lane vs. per-spec assumptions**, `preview-world` item, as narrowed by #4730's proof table: test 2 ("preview-desktop retains an exact blank published release…") fails on

```
daytona sandbox list -f json -l 200 -p 1
Error: unknown shorthand flag: 'p' in -p
```

The `-p <page>` / `totalPages` loop in `evals/specs/preview-world.e2e.test.ts#daytonaSandboxes` arrived with #4713 (`1e6e54c16`) and never ran green. The Daytona CLI has **no page flag in any released version**: I checked `daytona sandbox list --help` on v0.191.0, v0.204.0 (the `daytona-e2e.yml` pin), v0.210.0 (local) and v0.211.2 (latest) — all expose only `-c/--cursor`, `-f/--format`, `-l/--limit`, and the JSON body carries `nextCursor` (same convention `scripts/prune-daytona-dev-snapshots.mjs` already follows against the API). Pagination matters here: the org currently has 352 sandboxes, so `-l 200` returns two pages.

## What changed (one spec, evals only)

`daytonaSandboxes()` follows `nextCursor` with `--cursor` instead of `-p`/`totalPages`, stops on a missing/empty cursor or empty page, and throws if the CLI ever repeats a cursor (turns a would-be infinite loop into a clear failure). No assertion changed; no product code touched. Base is `origin/dev` — #4730 (`e2e/pooled-lane-harness`) changes this spec's *placement handling* (strips the pooled slot overrides around `world up/down`), but a single-spec run never prepares a pooled slot (`shouldPrepareSuite` is false for one explicit file), so this fix does not depend on it. The two PRs touch different lines of the same file; whichever lands second rebases trivially.

## Proof — `pnpm evals:e2e preview-world --daytona` at `3c8acd011f1e1e7cd3eb706bc108a63ad568396d`

`OPENWORK_EVAL_REF=3c8acd011f1e1e7cd3eb706bc108a63ad568396d` exported; Daytona CLI pinned to **v0.204.0** (the CI pin, `daytona/clients` release binary) on `PATH` to match the lane exactly; single-spec, no pooled slot, no placeholder slot variables (see above for why they are unnecessary here).

```
selection: engine=legacy surface=legacy case=all; placement: daytona (--daytona)
 ✓ |e2e| specs/preview-world.e2e.test.ts (2 tests) 862185ms
   ✓ preview worlds expose Den and real Electron, preserve progress on frontend update, and tear down only their own stage  575984ms
   ✓ preview-desktop retains an exact blank published release and tears down its two owned sandboxes  286200ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
{"command":"evals:e2e","lane":"e2e","daytona":true,"placement":"daytona",…,"passed":2,"failed":0,"skipped":0,"verdict":"passed"}
```

Verdict: **Passed** (2 passed / 0 failed / 0 skipped). Every world in the log except test 1's intentional "omitted ref defaults to remote dev" step built `ref 3c8acd011…`. All sandboxes the run created were torn down by the spec; a full cursor walk of `daytona sandbox list` afterwards found none of this run's stage names.

Also exercised the new loop standalone against the live org with both the v0.204.0 and v0.210.0 binaries: 2 pages, 352 items, 352 unique ids each. `pnpm --dir evals typecheck` reports no errors in `specs/preview-world.e2e.test.ts` (the tree has pre-existing errors from unbuilt deps, as #4730 noted).

## Noticed, not touched

- `.opencode/skills/preview-my-work/scripts/update-preview.py:83` runs `daytona exec <sandbox> -- python3 -c <shlex.quote(program)>`; #4730 reports this fails with CLI v0.210.0 and passes with v0.204.0 (the quoting assumes the CLI re-joins argv through a shell). I reproduced test 1 green only under the v0.204.0 pin. Worth fixing before CI bumps its pin.
- `pnpm --dir evals test` (`lint:layers`, `spec-channel-ratchet`, `spec-boundary-ratchet`) is red on `dev` before this PR, as #4730 already lists.
- The brief mentions an `API v0.213 vs CLI v0.210` version warning; I did not observe it on `sandbox list -f json` stderr with either v0.204.0 or v0.210.0, so I have not relied on it.
