### PR TITLE
fix(mcp): honor catalog transport lifecycle and streaming responses

### DIFF
--- a/apps/server/src/connect-mcp-transport.ts
+++ b/apps/server/src/connect-mcp-transport.ts
@@ -18,15 +18,54 @@ function parseJsonOrText(raw: string): unknown {
   try { return JSON.parse(raw); } catch { return raw; }
 }
 
-export async function readMcpPayload(response: Response): Promise<unknown> {
-  const raw = await response.text();
-  if (!raw.trim()) return null;
-  if (!response.headers.get("content-type")?.toLowerCase().includes("text/event-stream")) return parseJsonOrText(raw);
-  for (const frame of raw.split(/\r?\n\r?\n/)) {
-    const data = frame.split(/\r?\n/).filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trimStart()).join("\n");
-    if (data) return parseJsonOrText(data);
+export async function readMcpPayload(response: Response, requestId?: string | number): Promise<unknown> {
+  const matches = (payload: unknown) => requestId === undefined || (
+    isRecord(payload) && payload.jsonrpc === "2.0" && payload.id === requestId &&
+    (payload.result !== undefined || payload.error !== undefined)
+  );
+  if (!response.headers.get("content-type")?.toLowerCase().includes("text/event-stream")) {
+    const raw = await response.text();
+    const payload = raw.trim() ? parseJsonOrText(raw) : null;
+    return matches(payload) ? payload : null;
   }
-  return null;
+  if (!response.body) return null;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  let data: string[] = [];
+  let skipLf = false;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) return null;
+      pending += decoder.decode(chunk.value, { stream: true });
+      // Parse lines incrementally: CR, LF and CRLF are legal, including across chunks.
+      while (pending.length) {
+        if (skipLf) {
+          if (pending.startsWith("\n")) pending = pending.slice(1);
+          skipLf = false;
+        }
+        const end = pending.search(/[\r\n]/);
+        if (end === -1) break;
+        const line = pending.slice(0, end);
+        skipLf = pending[end] === "\r";
+        pending = pending.slice(end + 1);
+        if (line === "") {
+          if (data.length) {
+            const payload = parseJsonOrText(data.join("\n"));
+            data = [];
+            if (matches(payload)) return payload;
+          }
+        } else if (line === "data" || line.startsWith("data:")) {
+          data.push(line.slice(5).replace(/^ /, ""));
+        }
+      }
+    }
+  } finally {
+    // A server may keep the stream open after the result. Never wait for EOF.
+    void reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
 }
 
 export function jsonRpcResult(payload: unknown): Record<string, unknown> | null {
@@ -42,7 +81,8 @@ export async function mcpPost(fetcher: McpFetch, url: string, headers: Record<st
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(5_000),
   });
-  return { response, payload: await readMcpPayload(response) };
+  const requestId = isRecord(body) && (typeof body.id === "string" || typeof body.id === "number") ? body.id : undefined;
+  return { response, payload: await readMcpPayload(response, requestId) };
 }
 
 /**
@@ -69,13 +109,19 @@ export async function readMcpResourceText(input: {
       protocolVersion: "2025-06-18",
     },
   });
-  if (!initialized.response.ok || !jsonRpcResult(initialized.payload)) return null;
+  if (!initialized.response.ok) return null;
+  const protocolVersion = jsonRpcResult(initialized.payload)?.protocolVersion;
+  // These are the Streamable HTTP revisions supported by this discovery client.
+  if (protocolVersion !== "2025-06-18" && protocolVersion !== "2025-03-26") return null;
+  const sessionId = initialized.response.headers.get("mcp-session-id");
+  // Normalize header names so configured casing cannot duplicate session headers.
   const sessionHeaders = {
-    ...baseHeaders,
-    ...(initialized.response.headers.get("mcp-session-id") ? { "mcp-session-id": initialized.response.headers.get("mcp-session-id")! } : {}),
-    ...(initialized.response.headers.get("mcp-protocol-version") ? { "mcp-protocol-version": initialized.response.headers.get("mcp-protocol-version")! } : {}),
+    ...Object.fromEntries(new Headers(baseHeaders)),
+    ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+    "mcp-protocol-version": protocolVersion,
   };
-  await mcpPost(input.fetcher, url, sessionHeaders, { jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+  const notification = await mcpPost(input.fetcher, url, sessionHeaders, { jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+  if (notification.response.status !== 202 || notification.payload !== null) return null;
   const resource = await mcpPost(input.fetcher, url, sessionHeaders, {
     id: 2,
     jsonrpc: "2.0",

--- a/apps/server/src/connect-skill-catalog.ts
+++ b/apps/server/src/connect-skill-catalog.ts
@@ -3,10 +3,7 @@ import { z } from "zod";
 
 import {
   escapeXml,
-  isRecord,
-  jsonRpcResult,
-  mcpPost,
-  stringHeaders,
+  readMcpResourceText,
   type McpFetch,
 } from "./connect-mcp-transport.js";
 import { readConnectCloudMcp, writeConnectCloudMcp } from "./connect-state.js";
@@ -43,37 +40,12 @@ const catalogCache = new Map<string, { expiresAt: number; value: Promise<OpenWor
  * so callers can fall back to another candidate config.
  */
 export async function readMcpSkillIndex(config: Record<string, unknown>, fetcher: McpFetch): Promise<OpenWorkConnectSkill[] | null> {
-  const url = typeof config.url === "string" ? config.url : "";
-  if (!/^https?:\/\//.test(url) || config.enabled === false) return null;
-  const baseHeaders = stringHeaders(config.headers);
-  const initialized = await mcpPost(fetcher, url, baseHeaders, {
-    id: 1,
-    jsonrpc: "2.0",
-    method: "initialize",
-    params: {
-      capabilities: {},
-      clientInfo: { name: "openwork-server-skill-catalog", version: "1.0.0" },
-      protocolVersion: "2025-06-18",
-    },
+  const text = await readMcpResourceText({
+    config,
+    fetcher,
+    uri: SKILL_INDEX_URI,
+    clientName: "openwork-server-skill-catalog",
   });
-  if (!initialized.response.ok || !jsonRpcResult(initialized.payload)) return null;
-  const sessionHeaders = {
-    ...baseHeaders,
-    ...(initialized.response.headers.get("mcp-session-id") ? { "mcp-session-id": initialized.response.headers.get("mcp-session-id")! } : {}),
-    ...(initialized.response.headers.get("mcp-protocol-version") ? { "mcp-protocol-version": initialized.response.headers.get("mcp-protocol-version")! } : {}),
-  };
-  await mcpPost(fetcher, url, sessionHeaders, { jsonrpc: "2.0", method: "notifications/initialized", params: {} });
-  const resource = await mcpPost(fetcher, url, sessionHeaders, {
-    id: 2,
-    jsonrpc: "2.0",
-    method: "resources/read",
-    params: { uri: SKILL_INDEX_URI },
-  });
-  if (!resource.response.ok) return null;
-  const result = jsonRpcResult(resource.payload);
-  const contents = result?.contents;
-  if (!Array.isArray(contents)) return null;
-  const text = contents.find((item) => isRecord(item) && item.uri === SKILL_INDEX_URI && typeof item.text === "string")?.text;
   if (typeof text !== "string") return null;
   return skillIndexSchema.parse(JSON.parse(text)).skills;
 }

--- a/evals/packages/labs/src/mock-mcp-catalog-transport.ts
+++ b/evals/packages/labs/src/mock-mcp-catalog-transport.ts
@@ -1,0 +1,96 @@
+import { createServer, type IncomingHttpHeaders } from "node:http";
+
+export type CatalogTransportMode = "json" | "sse-lf" | "sse-cr" | "sse-crlf" | "older-version" |
+  "unsupported-version" | "missing-version" | "initialize-error" | "notification-rejected" |
+  "notification-rpc-error" | "read-error" | "wrong-id" | "wrong-json-id" | "unfinished-stream";
+
+export async function startCatalogTransportWitness(mode: CatalogTransportMode) {
+  const requests: Array<{ method: string; headers: IncomingHttpHeaders; rpc: Record<string, unknown> }> = [];
+  const version = mode === "older-version" ? "2025-03-26" : "2025-06-18";
+  const skill = {
+    name: "transport-witness", type: "skill-md", title: "Transport witness",
+    description: "Synthetic catalog interoperability witness", url: "skill://transport-witness",
+    capability: "skill:transport-witness",
+  };
+  const server = createServer(async (request, response) => {
+    if (request.method !== "POST") {
+      response.writeHead(405).end();
+      return;
+    }
+    let raw = "";
+    for await (const chunk of request) raw += chunk;
+    const rpc: Record<string, unknown> = JSON.parse(raw);
+    requests.push({ method: request.method, headers: request.headers, rpc });
+    const json = (status: number, payload: unknown) => {
+      response.writeHead(status, { "content-type": "application/json" }).end(JSON.stringify(payload));
+    };
+    const error = { jsonrpc: "2.0", id: rpc.id, error: { code: -32603, message: "Synthetic RPC rejection" } };
+    if (request.headers.authorization !== "Bearer synthetic-catalog-token" ||
+      !request.headers.accept?.includes("application/json") || !request.headers.accept.includes("text/event-stream")) {
+      json(400, error);
+      return;
+    }
+    if (rpc.method !== "initialize" &&
+      (request.headers["mcp-protocol-version"] !== version || request.headers["mcp-session-id"] !== "synthetic-session")) {
+      json(400, error);
+      return;
+    }
+    if (rpc.method === "notifications/initialized") {
+      if (mode === "notification-rejected") json(400, error);
+      else if (mode === "notification-rpc-error") json(202, error);
+      else response.writeHead(202).end();
+      return;
+    }
+    const initialize = rpc.method === "initialize";
+    const result = initialize ? {
+      ...(mode === "missing-version" ? {} : { protocolVersion: mode === "unsupported-version" ? "2099-01-01" : version }),
+      capabilities: { resources: {} }, serverInfo: { name: "catalog-witness", version: "1.0.0" },
+    } : {
+      contents: [{ uri: "skill://index.json", mimeType: "application/json", text: JSON.stringify({
+        $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json", skills: [skill],
+      }) }],
+    };
+    const payload = (initialize && mode === "initialize-error") || (!initialize && mode === "read-error")
+      ? error : { jsonrpc: "2.0", id: !initialize && mode === "wrong-json-id" ? "unrelated" : rpc.id, result };
+    if (initialize) {
+      response.setHeader("mcp-session-id", "synthetic-session");
+      // Most servers omit the version header; even a contradictory header must
+      // not override the version negotiated in InitializeResult.
+      if (mode === "older-version") response.setHeader("mcp-protocol-version", "1999-01-01");
+    }
+    const streaming = mode.startsWith("sse-") || mode === "read-error" || mode === "wrong-id" || mode === "unfinished-stream";
+    if (!streaming) {
+      json(200, payload);
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    const newline = mode === "sse-cr" ? "\r" : mode === "sse-crlf" ? "\r\n" : "\n";
+    const frame = (value: unknown) => `data: ${JSON.stringify(value)}${newline}${newline}`;
+    response.write(`: keepalive${newline}${newline}`);
+    response.write(frame({ jsonrpc: "2.0", method: "notifications/message", params: { level: "info", data: "Synthetic progress" } }));
+    response.write(frame({ jsonrpc: "2.0", id: rpc.id, method: "ping" }));
+    response.write(frame({ jsonrpc: "2.0", id: "unrelated", result: {} }));
+    if (!initialize && mode === "wrong-id") { response.end(); return; }
+    if (!initialize && mode === "unfinished-stream") return;
+    // Multiline data and delimiters split across writes, with the stream left open
+    // after the matching response. Waiting for response.text() must time out.
+    const encoded = JSON.stringify(payload);
+    const wire = `data: ${encoded.slice(0, 1)}${newline}data: ${encoded.slice(1)}${newline}${newline}`;
+    response.write(wire.slice(0, -1));
+    const timer = setTimeout(() => response.write(wire.slice(-1)), 10);
+    response.once("close", () => clearTimeout(timer));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Catalog witness did not bind");
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`, requests, skill, version,
+    async stop() {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  };
+}

--- a/evals/specs/mcp-catalog-transport.test.ts
+++ b/evals/specs/mcp-catalog-transport.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { needs, test } from "@openwork/testkit";
+import { startCatalogTransportWitness, type CatalogTransportMode } from "../packages/labs/src/mock-mcp-catalog-transport.ts";
+import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
+
+// New interoperability journey: a real server's catalog API reads a remote MCP
+// resource. No product imports, provider credentials, or test-runner subprocesses.
+// https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+// https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+const modes: CatalogTransportMode[] = [
+  "json", "sse-lf", "sse-cr", "sse-crlf", "older-version", "unsupported-version", "missing-version",
+  "initialize-error", "notification-rejected", "notification-rpc-error", "read-error", "wrong-id", "wrong-json-id", "unfinished-stream",
+];
+for (const mode of modes) {
+  test(`catalog transport: ${mode}`, { timeout: 90_000 }, async ({ evidence }) => {
+    needs({ commands: ["bun"] });
+    const root = await mkdtemp(join(tmpdir(), "openwork-catalog-transport-"));
+    const workspace = join(root, "workspace");
+    await mkdir(workspace);
+    const witness = await startCatalogTransportWitness(mode);
+    const token = "synthetic-catalog-client";
+    const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
+    const server = bootServer({
+      ...inherited, HOME: root, XDG_CONFIG_HOME: join(root, "config"), XDG_DATA_HOME: join(root, "data"),
+      XDG_STATE_HOME: join(root, "state"), XDG_CACHE_HOME: join(root, "cache"),
+      OPENWORK_RUNTIME_DB: join(root, "runtime.sqlite"), OPENWORK_ENCRYPTION_KEY: "synthetic-catalog-vault-key",
+      OPENWORK_ALLOW_PRIVATE_MCP_URLS: "1",
+    }, token, workspace, () => {});
+    try {
+      const base = await server.listening;
+      const request = (path: string, method = "GET", body?: unknown) => fetch(`${base}${path}`, {
+        method, headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }), signal: AbortSignal.timeout(20_000),
+      });
+      const workspaces: unknown = await (await request("/workspaces")).json();
+      if (!isRecord(workspaces) || !Array.isArray(workspaces.items) || !isRecord(workspaces.items[0]) || typeof workspaces.items[0].id !== "string") throw new Error("Workspace missing");
+      const configured = await request(`/workspace/${workspaces.items[0].id}/config`, "PATCH", {
+        opencode: { mcp: { "openwork-cloud": {
+          type: "remote", url: witness.url, enabled: true, oauth: false,
+          headers: { Authorization: "Bearer synthetic-catalog-token", "MCP-Protocol-Version": "invalid-configured-version" },
+        } } },
+      });
+      expect(configured.status, await configured.text()).toBe(200);
+      expect((await fetch(witness.url, { signal: AbortSignal.timeout(5_000) })).status).toBe(405);
+      const started = Date.now();
+      const response = await request("/experimental/connect/skills");
+      const catalog: unknown = await response.json();
+      expect(response.status).toBe(200);
+      const success = ["json", "sse-lf", "sse-cr", "sse-crlf", "older-version"].includes(mode);
+      expect(catalog).toMatchObject({ ok: true, skills: success ? [witness.skill] : [] });
+      expect(Date.now() - started).toBeLessThan(15_000);
+      expect(witness.requests.length).toBeGreaterThan(0);
+      const methods = witness.requests.map((entry) => entry.rpc.method);
+      if (["unsupported-version", "missing-version", "initialize-error"].includes(mode)) {
+        expect(methods.every((method) => method === "initialize")).toBe(true);
+      } else {
+        for (const entry of witness.requests.filter((entry) => entry.rpc.method !== "initialize")) {
+          expect(entry.headers["mcp-protocol-version"]).toBe(witness.version);
+          expect(entry.headers["mcp-session-id"]).toBe("synthetic-session");
+        }
+        expect(methods).toContain("notifications/initialized");
+        if (mode.startsWith("notification-")) expect(methods).not.toContain("resources/read");
+        else expect(methods).toContain("resources/read");
+      }
+      for (const entry of witness.requests) {
+        expect(entry.headers.authorization).toBe("Bearer synthetic-catalog-token");
+        expect(entry.headers.accept).toContain("application/json");
+        expect(entry.headers.accept).toContain("text/event-stream");
+      }
+      evidence.recordAssertionEvidence(`Catalog interoperability: ${mode}`,
+        `${success ? "Witness skill visible" : "No skill leaked from rejected exchange"}; HTTP 200; bounded completion; ${methods.join(", ")}; negotiated version/session and auth headers asserted. GET 405 does not prevent POST discovery.`, true);
+    } finally {
+      await stopChild(server.child);
+      await witness.stop();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Parse incremental SSE responses by JSON-RPC request ID without waiting for EOF; support CR, LF, and CRLF frames.
- Negotiate supported protocol versions, normalize session headers, validate initialization notification acceptance, and share resource discovery with the skill catalog.
- Add a synthetic real-server journey covering 14 success and rejection modes. No catalog diagnostics or app fallback changes.

## Verification
- Committed head: d5e970f46fcd251f5b0eb61e1c6a5713251c887c.
- pnpm --filter openwork-server typecheck: passed (exit 0).
- pnpm evals:pr specs/mcp-catalog-transport.test.ts: 14 passed, 0 failed, 0 skipped (exit 0); cold server per case. PR lane emitted no placement line.
- Consumer review: skill, automation, and MCP-server catalogs retain the shared resource-reader interface; all now require a supported InitializeResult version and an empty HTTP 202 notification response.
- Initial test launch lacked evals dependencies (exit 1); frozen evals install repaired tooling before successful runs.

## Verdict
Functional checks passed; overall Incomplete pending hosted checks and review. Bare pnpm warden:check exited 1 (auth_failed), configured model unchanged. Expected skills: diff-security-review, confidentiality-review, spec-provenance-review; actual complete coverage: none. No native finding IDs were emitted; this is not clearance. Before/after HEAD d5e970f46fcd251f5b0eb61e1c6a5713251c887c and origin/dev 7d5097d4258da3c8568d0735712ea47c6c2fb482 were unchanged. Clear when all expected skills complete on this scope without blockers. No merge requested.