### PR TITLE
fix(mcp): retain private catalog discovery diagnostics

### DIFF
--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -2,6 +2,7 @@ import { createHash, webcrypto } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import type { createOpencodeClient, McpStatus, ToolIds, ToolList } from "@opencode-ai/sdk/v2/client";
 import { ApiError } from "./errors.js";
+import type { ConnectMcpCatalogDiagnostic } from "./connect-mcp-server-catalog.js";
 import { diagnoseMcpToolDenies, type McpToolDeny } from "./mcp.js";
 import { openworkPluginPath } from "./openwork-extensions-plugin-path.js";
 import { sanitizeDiagnosticString, sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
@@ -216,6 +217,8 @@ export type CloudMcpHealth = {
   usable: boolean;
   usableByCurrentModel: boolean | null;
   connectCatalogEnabled: boolean;
+  /** Result of this reconciliation's private catalog discovery; absent when not attempted. */
+  connectCatalogDiagnostic?: ConnectMcpCatalogDiagnostic;
   workspace: {
     id: string;
     type: WorkspaceInfo["workspaceType"];
@@ -2436,16 +2439,20 @@ export async function reconcileOpenworkCloudMcp(input: {
   refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
   fanoutGlobalDesired?: boolean;
 }): Promise<CloudMcpHealth> {
-  const readHealth = (directProbeReuse?: DirectProbeReuse) => readOpenworkCloudMcpHealthInternal({
-    config: input.config,
-    workspace: input.workspace,
-    directory: input.directory,
-    providerModel: input.providerModel,
-    serverMetadata: input.serverMetadata,
-    createWorkspaceOpencodeClient: input.createWorkspaceOpencodeClient,
-    probe: true,
-    directProbeReuse,
-    refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
+  let connectCatalogDiagnostic: ConnectMcpCatalogDiagnostic | undefined;
+  const readHealth = async (directProbeReuse?: DirectProbeReuse): Promise<CloudMcpHealth> => ({
+    ...await readOpenworkCloudMcpHealthInternal({
+      config: input.config,
+      workspace: input.workspace,
+      directory: input.directory,
+      providerModel: input.providerModel,
+      serverMetadata: input.serverMetadata,
+      createWorkspaceOpencodeClient: input.createWorkspaceOpencodeClient,
+      probe: true,
+      directProbeReuse,
+      refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
+    }),
+    ...(connectCatalogDiagnostic === undefined ? {} : { connectCatalogDiagnostic }),
   });
   const configBody = input.body.config ?? input.body;
   const desiredConfig = canonicalizeCloudMcpConfig(normalizeCloudMcpConfig(configBody));
@@ -2510,7 +2517,10 @@ export async function reconcileOpenworkCloudMcp(input: {
     workspace: input.workspace,
     cloudMcp: desiredConfig,
     appHostAuthorization: readString(input.body.appHostAuthorization) ?? undefined,
-  }).catch(() => ({ status: "unavailable" as const, appHostNames: [], directNames: [], removedNames: [] }));
+  }).catch((): { diagnostic: ConnectMcpCatalogDiagnostic; directNames: string[]; removedNames: string[] } => ({
+    diagnostic: "discovery_unavailable", directNames: [], removedNames: [],
+  }));
+  connectCatalogDiagnostic = connectServers.diagnostic;
 
   const opencode = input.createWorkspaceOpencodeClient(input.config, input.workspace);
   for (const name of connectServers.removedNames) {

--- a/apps/server/src/connect-mcp-server-catalog.test.ts
+++ b/apps/server/src/connect-mcp-server-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   type OpenWorkConnectMcpServerIndex,
   readOpenWorkConnectMcpAppHostCatalog,
   readOpenWorkConnectMcpServerIndex,
+  readOpenWorkConnectMcpServerIndexWithDiagnostics,
   reconcileOpenWorkConnectMcpServers,
   refreshOpenWorkConnectMcpAppHostCatalog,
   writeOpenWorkConnectMcpAppHostAuthorization,
@@ -141,6 +142,7 @@ describe("OpenWork Connect MCP server catalog", () => {
     const runtime = await readRuntimeOpencodeConfig(config, "ws_1");
     expect(result).toEqual({
       status: "synced",
+      diagnostic: "ready",
       appHostNames: [connectMcpAppHostName(connectionId)],
       directNames: [],
       removedNames: ["openwork-connect-stale"],
@@ -194,6 +196,7 @@ describe("OpenWork Connect MCP server catalog", () => {
 
     expect(result).toEqual({
       status: "synced",
+      diagnostic: "ready",
       appHostNames: [connectMcpAppHostName(boundedId), connectMcpAppHostName(directId)].sort(),
       directNames: [directName],
       removedNames: ["openwork-direct-revoked-abc123"],
@@ -256,6 +259,7 @@ describe("OpenWork Connect MCP server catalog", () => {
     });
     expect(result).toEqual({
       status: "unavailable",
+      diagnostic: "missing_app_host_auth",
       appHostNames: [],
       directNames: [],
       removedNames: ["openwork-direct-linear-abc123"],
@@ -281,7 +285,7 @@ describe("OpenWork Connect MCP server catalog", () => {
 
     const result = await refreshOpenWorkConnectMcpAppHostCatalog(config, "ws_1", indexFetcher(requests));
 
-    expect(result).toEqual({ status: "synced", appHostNames: [connectMcpAppHostName(connectionId)] });
+    expect(result).toEqual({ status: "synced", diagnostic: "ready", appHostNames: [connectMcpAppHostName(connectionId)] });
     expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers[0]?.connectionId).toBe(connectionId);
     expect(requests.every((request) => request.headers.get("authorization") === "Bearer private-app-host-token")).toBe(true);
   });
@@ -317,7 +321,7 @@ describe("OpenWork Connect MCP server catalog", () => {
       async () => new Response(null, { status: 503 }),
     );
 
-    expect(result).toEqual({ status: "unavailable", appHostNames: [] });
+    expect(result).toEqual({ status: "unavailable", diagnostic: "discovery_unavailable", appHostNames: [] });
     expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers[0]?.connectionId).toBe(connectionId);
   });
 
@@ -334,6 +338,7 @@ describe("OpenWork Connect MCP server catalog", () => {
     });
     expect(result).toEqual({
       status: "unavailable",
+      diagnostic: "missing_app_host_auth",
       appHostNames: [],
       directNames: [],
       removedNames: ["openwork-connect-existing"],
@@ -360,6 +365,7 @@ describe("OpenWork Connect MCP server catalog", () => {
 
     expect(result).toEqual({
       status: "synced",
+      diagnostic: "empty",
       appHostNames: [],
       directNames: [],
       removedNames: ["openwork-connect-existing"],
@@ -394,6 +400,7 @@ describe("OpenWork Connect MCP server catalog", () => {
 
     expect(untrustedRequests).toBe(0);
     expect(result.status).toBe("unavailable");
+    expect(result.diagnostic).toBe("untrusted_origin");
     expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers).toEqual([]);
   });
 
@@ -412,7 +419,7 @@ describe("OpenWork Connect MCP server catalog", () => {
       }]),
     });
 
-    expect(result).toEqual({ status: "unavailable", appHostNames: [], directNames: [], removedNames: [] });
+    expect(result).toEqual({ status: "unavailable", diagnostic: "invalid_proxy_descriptor", appHostNames: [], directNames: [], removedNames: [] });
     expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers).toEqual([]);
   });
 
@@ -431,7 +438,32 @@ describe("OpenWork Connect MCP server catalog", () => {
       }]),
     });
 
-    expect(result).toEqual({ status: "unavailable", appHostNames: [], directNames: [], removedNames: [] });
+    expect(result).toEqual({ status: "unavailable", diagnostic: "invalid_proxy_descriptor", appHostNames: [], directNames: [], removedNames: [] });
     expect((await readOpenWorkConnectMcpAppHostCatalog(config, "ws_1")).servers).toEqual([]);
+  });
+  test("attributes malformed JSON and invalid index schemas without returning provider data", async () => {
+    for (const text of ["not-json", JSON.stringify({ schemaVersion: "unsupported", servers: [] })]) {
+      const result = await readOpenWorkConnectMcpServerIndexWithDiagnostics(
+        { type: "remote", url: "https://api.openworklabs.com/mcp/agent" },
+        "Bearer private-app-host-token",
+        async (url, init) => {
+          const response = await indexFetcher([])(url, init);
+          if (JSON.parse(String(init?.body)).method !== "resources/read") return response;
+          return Response.json({ jsonrpc: "2.0", id: 2, result: { contents: [{ uri: CONNECT_MCP_SERVER_INDEX_URI, text }] } });
+        },
+      );
+      expect(result).toEqual({ index: null, diagnostic: "invalid_catalog" });
+    }
+  });
+
+  test("does not mislabel HTTP failures as missing auth or a successful empty catalog", async () => {
+    for (const status of [401, 403, 404, 503]) {
+      const result = await readOpenWorkConnectMcpServerIndexWithDiagnostics(
+        { type: "remote", url: "https://api.openworklabs.com/mcp/agent" },
+        "Bearer private-app-host-token",
+        async () => new Response(null, { status }),
+      );
+      expect(result).toEqual({ index: null, diagnostic: "discovery_unavailable" });
+    }
   });
 });

--- a/apps/server/src/connect-mcp-server-catalog.ts
+++ b/apps/server/src/connect-mcp-server-catalog.ts
@@ -58,6 +58,27 @@ export type OpenWorkConnectMcpServerIndex = z.output<typeof indexSchema>;
 /** Index shape as Den publishes it; `exposeDirectly` is absent from older Den releases and defaults to false. */
 export type OpenWorkConnectMcpServerIndexInput = z.input<typeof indexSchema>;
 
+/**
+ * Safe to surface: no credentials or provider data. Missing auth requires a
+ * fresh private App-host credential; untrusted origins require enterprise Den
+ * activation (never bypass trust). Invalid catalogs/proxies require a Den
+ * descriptor fix. Unavailable discovery can be retried, but does not prove an
+ * auth failure. Only `empty` proves successful discovery with no servers.
+ */
+export type ConnectMcpCatalogDiagnostic =
+  | "ready"
+  | "empty"
+  | "missing_app_host_auth"
+  | "untrusted_origin"
+  | "invalid_catalog"
+  | "invalid_proxy_descriptor"
+  | "discovery_unavailable";
+
+export type ConnectMcpCatalogReadResult = {
+  index: OpenWorkConnectMcpServerIndex | null;
+  diagnostic: ConnectMcpCatalogDiagnostic;
+};
+
 const emptyIndex = (): OpenWorkConnectMcpServerIndex => ({
   schemaVersion: CONNECT_MCP_SERVER_INDEX_SCHEMA_VERSION,
   servers: [],
@@ -271,29 +292,47 @@ export async function readOpenWorkConnectMcpServerIndex(
   appHostAuthorization: string,
   fetcher: McpFetch = externalFetch,
 ): Promise<OpenWorkConnectMcpServerIndex | null> {
-  if (!await trustedAppHostCloudEndpoint(cloudMcp)) return null;
+  return (await readOpenWorkConnectMcpServerIndexWithDiagnostics(cloudMcp, appHostAuthorization, fetcher)).index;
+}
+
+export async function readOpenWorkConnectMcpServerIndexWithDiagnostics(
+  cloudMcp: Record<string, unknown>,
+  appHostAuthorization: string | null,
+  fetcher: McpFetch = externalFetch,
+): Promise<ConnectMcpCatalogReadResult> {
+  if (!await trustedAppHostCloudEndpoint(cloudMcp)) return { index: null, diagnostic: "untrusted_origin" };
+  const authorization = privateAppHostAuthorization(appHostAuthorization);
+  if (!authorization) return { index: null, diagnostic: "missing_app_host_auth" };
   const text = await readMcpResourceText({
     config: {
       ...cloudMcp,
       headers: {
-        Authorization: appHostAuthorization,
+        Authorization: authorization,
         [CONNECT_MCP_APP_HOST_CAPABILITY_HEADER]: CONNECT_MCP_APP_HOST_CAPABILITY,
       },
     },
     uri: CONNECT_MCP_SERVER_INDEX_URI,
     fetcher,
     clientName: "openwork-server-connect-mcp-catalog",
-  });
-  if (text === null) return null;
-  const parsed = indexSchema.safeParse(JSON.parse(text));
-  if (!parsed.success) return null;
+  }).catch(() => null);
+  // Transport currently collapses HTTP and protocol failures. Do not guess
+  // that an unavailable discovery response means expired auth or no apps.
+  if (text === null) return { index: null, diagnostic: "discovery_unavailable" };
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return { index: null, diagnostic: "invalid_catalog" };
+  }
+  const parsed = indexSchema.safeParse(value);
+  if (!parsed.success) return { index: null, diagnostic: "invalid_catalog" };
   const servers: OpenWorkConnectMcpServerIndex["servers"] = [];
   for (const server of parsed.data.servers) {
     const url = normalizeAppHostProxyUrl(cloudMcp.url, server);
-    if (!url) return null;
+    if (!url) return { index: null, diagnostic: "invalid_proxy_descriptor" };
     servers.push({ ...server, url });
   }
-  return { ...parsed.data, servers };
+  return { index: { ...parsed.data, servers }, diagnostic: servers.length === 0 ? "empty" : "ready" };
 }
 
 /**
@@ -305,25 +344,24 @@ export async function refreshOpenWorkConnectMcpAppHostCatalog(
   config: ServerConfig,
   workspaceId: string,
   fetcher?: McpFetch,
-): Promise<{ status: "synced" | "unavailable"; appHostNames: string[] }> {
+): Promise<{ status: "synced" | "unavailable"; appHostNames: string[]; diagnostic: ConnectMcpCatalogDiagnostic }> {
   const cloudMcp = await readGlobalRuntimeMcpConfig(config, "openwork-cloud")
     ?? await readRuntimeMcpConfig(config, workspaceId, "openwork-cloud");
-  if (!cloudMcp || !await trustedAppHostCloudEndpoint(cloudMcp)) {
-    return { status: "unavailable", appHostNames: [] };
+  if (!cloudMcp) {
+    return { status: "unavailable", appHostNames: [], diagnostic: "discovery_unavailable" };
   }
   const appHostAuthorization = await readOpenWorkConnectMcpAppHostAuthorization(
     config,
     workspaceId,
     String(cloudMcp.url),
   );
-  if (!appHostAuthorization) return { status: "unavailable", appHostNames: [] };
-
-  const index = await readOpenWorkConnectMcpServerIndex(cloudMcp, appHostAuthorization, fetcher).catch(() => null);
-  if (!index) return { status: "unavailable", appHostNames: [] };
+  const { index, diagnostic } = await readOpenWorkConnectMcpServerIndexWithDiagnostics(cloudMcp, appHostAuthorization, fetcher);
+  if (!index) return { status: "unavailable", appHostNames: [], diagnostic };
 
   await writeOpenWorkConnectMcpAppHostCatalog(config, workspaceId, index);
   return {
     status: "synced",
+    diagnostic,
     appHostNames: index.servers.map((server) => connectMcpAppHostName(server.connectionId)).sort(),
   };
 }
@@ -340,7 +378,7 @@ export async function reconcileOpenWorkConnectMcpServers(input: {
   cloudMcp: Record<string, unknown>;
   appHostAuthorization?: string;
   fetcher?: McpFetch;
-}): Promise<{ status: "synced" | "unavailable"; appHostNames: string[]; directNames: string[]; removedNames: string[] }> {
+}): Promise<{ status: "synced" | "unavailable"; appHostNames: string[]; directNames: string[]; removedNames: string[]; diagnostic: ConnectMcpCatalogDiagnostic }> {
   const trustedCloudEndpoint = await trustedAppHostCloudEndpoint(input.cloudMcp);
   if (trustedCloudEndpoint && input.appHostAuthorization !== undefined) {
     await writeOpenWorkConnectMcpAppHostAuthorization(
@@ -357,9 +395,7 @@ export async function reconcileOpenWorkConnectMcpServers(input: {
       String(input.cloudMcp.url),
     )
     : null;
-  const index = trustedCloudEndpoint && appHostAuthorization
-    ? await readOpenWorkConnectMcpServerIndex(input.cloudMcp, appHostAuthorization, input.fetcher).catch(() => null)
-    : null;
+  const { index, diagnostic } = await readOpenWorkConnectMcpServerIndexWithDiagnostics(input.cloudMcp, appHostAuthorization, input.fetcher);
   const privateCatalog = index ?? emptyIndex();
   await writeOpenWorkConnectMcpAppHostCatalog(input.config, input.workspace.id, privateCatalog);
 
@@ -385,6 +421,7 @@ export async function reconcileOpenWorkConnectMcpServers(input: {
   });
   return {
     status: index ? "synced" : "unavailable",
+    diagnostic,
     appHostNames: privateCatalog.servers.map((server) => connectMcpAppHostName(server.connectionId)).sort(),
     directNames: Object.keys(directEntries).sort(),
     removedNames,

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -521,7 +521,7 @@ describe("MCP Apps host transport", () => {
         toolName: "render_fixture",
         resourceUri: RESOURCE_URI,
       },
-    })).rejects.toMatchObject({ code: "server_unavailable" });
+    })).rejects.toMatchObject({ code: "connect_catalog_missing_app_host_auth" });
   });
 
   test("resolves a same-server MCP App through its capability gateway", async () => {

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -5,11 +5,13 @@ import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
   CONNECT_MCP_APP_HOST_CAPABILITY,
   CONNECT_MCP_APP_HOST_CAPABILITY_HEADER,
+  CONNECT_MCP_APP_HOST_NAME_PREFIX,
   connectMcpAppHostName,
   findOpenWorkConnectMcpAppHostServer,
   readOpenWorkConnectMcpAppHostAuthorization,
   readOpenWorkConnectMcpAppHostCatalog,
   refreshOpenWorkConnectMcpAppHostCatalog,
+  type ConnectMcpCatalogDiagnostic,
 } from "./connect-mcp-server-catalog.js";
 import type { ServerConfig } from "./types.js";
 import {
@@ -281,12 +283,25 @@ function decodeResourceHtml(content: { text?: string; blob?: string }): { html: 
   throw new McpAppHostError("invalid_resource", "The MCP App resource must contain exactly one of text or blob HTML.");
 }
 
+function connectCatalogError(diagnostic: Exclude<ConnectMcpCatalogDiagnostic, "ready" | "empty">): McpAppHostError {
+  const messages = {
+    missing_app_host_auth: "The Connect MCP App host needs a fresh private authorization. Sync OpenWork Connect and try again.",
+    untrusted_origin: "The Connect MCP catalog origin is not trusted. Activate the enterprise Den origin before loading Apps.",
+    invalid_catalog: "The Connect MCP catalog is invalid. Ask your administrator to check the Den catalog.",
+    invalid_proxy_descriptor: "The Connect MCP catalog contains an invalid provider proxy descriptor. Ask your administrator to correct it in Den.",
+    discovery_unavailable: "The Connect MCP catalog could not be discovered. Try again; this does not establish that the connection is missing.",
+  };
+  return new McpAppHostError(`connect_catalog_${diagnostic}`, messages[diagnostic]);
+}
+
 async function privateConnectMcpConfig(input: {
   serverConfig: ServerConfig;
   workspaceId: string;
   connectionId?: string;
   serverName?: string;
 }): Promise<{ serverName: string; config: Record<string, unknown> } | null> {
+  // Ordinary user-configured servers do not depend on Connect discovery.
+  if (input.connectionId === undefined && !input.serverName?.startsWith(CONNECT_MCP_APP_HOST_NAME_PREFIX)) return null;
   let descriptor = await findOpenWorkConnectMcpAppHostServer(
     input.serverConfig,
     input.workspaceId,
@@ -294,6 +309,9 @@ async function privateConnectMcpConfig(input: {
   );
   if (!descriptor) {
     const refreshed = await refreshOpenWorkConnectMcpAppHostCatalog(input.serverConfig, input.workspaceId);
+    if (refreshed.diagnostic !== "ready" && refreshed.diagnostic !== "empty") {
+      throw connectCatalogError(refreshed.diagnostic);
+    }
     if (refreshed.status === "synced") {
       descriptor = await findOpenWorkConnectMcpAppHostServer(
         input.serverConfig,
@@ -308,7 +326,7 @@ async function privateConnectMcpConfig(input: {
     input.workspaceId,
     descriptor.url,
   );
-  if (!appHostAuthorization) return null;
+  if (!appHostAuthorization) throw connectCatalogError("missing_app_host_auth");
   return {
     serverName: connectMcpAppHostName(descriptor.connectionId),
     config: {

--- a/evals/packages/labs/src/mock-mcp-catalog.ts
+++ b/evals/packages/labs/src/mock-mcp-catalog.ts
@@ -1,0 +1,59 @@
+import { createServer } from "node:http";
+import { close, isRecord, listen, readBody, sendJson } from "../../../worlds/openwork-server-cli.ts";
+
+/** Isolated wire witness for desktop catalog discovery, not a product implementation. */
+export async function startCatalogWitness(privateAuthorization: string) {
+  let catalogText = JSON.stringify({ schemaVersion: "openwork.connect/mcp-servers/1", servers: [] });
+  let catalogStatus = 200;
+  const requests: Array<{ method: string; privateAuth: boolean; appHostCapability: boolean }> = [];
+  const registrations: Array<{ name: string; privateAuth: boolean }> = [];
+  const disconnects: string[] = [];
+  const connected = new Set<string>();
+  const server = createServer(async (request, response) => {
+    const path = new URL(request.url ?? "/", "http://localhost").pathname;
+    const raw = request.method === "POST" ? await readBody(request) : "";
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+    const body = isRecord(parsed) ? parsed : {};
+    if (path === "/mcp/agent") {
+      const privateAuth = request.headers.authorization === privateAuthorization;
+      const method = typeof body.method === "string" ? body.method : "";
+      requests.push({ method, privateAuth, appHostCapability: request.headers["x-openwork-mcp-client-capabilities"] === "mcp-app-host-v1" });
+      if (privateAuth && catalogStatus !== 200) return sendJson(response, catalogStatus, { error: "catalog unavailable" });
+      if (method === "notifications/initialized") {
+        response.writeHead(202).end();
+        return;
+      }
+      const result = method === "initialize"
+        ? { protocolVersion: "2025-06-18", capabilities: { resources: {}, tools: {} }, serverInfo: { name: "catalog-witness", version: "1" } }
+        : method === "resources/read"
+          ? { contents: [{ uri: "openwork://connect/mcp-servers/index.json", mimeType: "application/json", text: catalogText }] }
+          : { tools: ["search_capabilities", "execute_capability"].map((name) => ({ name, description: name, inputSchema: { type: "object" } })) };
+      return sendJson(response, 200, { jsonrpc: "2.0", id: body.id, result });
+    }
+    if (path === "/mcp" && request.method === "POST") {
+      if (typeof body.name === "string") {
+        connected.add(body.name);
+        registrations.push({ name: body.name, privateAuth: raw.includes(privateAuthorization) });
+      }
+      return sendJson(response, 200, Object.fromEntries([...connected].map((name) => [name, { status: "connected" }])));
+    }
+    if (path.startsWith("/mcp/") && path.endsWith("/disconnect")) {
+      const name = decodeURIComponent(path.split("/")[2] ?? "");
+      connected.delete(name);
+      disconnects.push(name);
+      return sendJson(response, 200, true);
+    }
+    if (path === "/mcp") return sendJson(response, 200, Object.fromEntries([...connected].map((name) => [name, { status: "connected" }])));
+    if (path === "/global/health") return sendJson(response, 200, { healthy: true, version: "1.17.11" });
+    if (path === "/experimental/tool/ids") return sendJson(response, 200, ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"]);
+    if (path === "/provider") return sendJson(response, 200, { all: [], default: {}, connected: [] });
+    if (path === "/session" || path === "/experimental/tool") return sendJson(response, 200, []);
+    return sendJson(response, 200, {});
+  });
+  const url = await listen(server);
+  return {
+    url, requests, registrations, disconnects,
+    catalog(text: string, status = 200) { catalogText = text; catalogStatus = status; },
+    stop: () => close(server),
+  };
+}

--- a/evals/specs/mcp-catalog-diagnostics.test.ts
+++ b/evals/specs/mcp-catalog-diagnostics.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { needs, test } from "@openwork/testkit";
+import { startCatalogWitness } from "../packages/labs/src/mock-mcp-catalog.ts";
+import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
+
+// New journey: operators can distinguish catalog failures in the real server's
+// reconciliation response. Quick-add catalog specs exercise Den/UI, not this API.
+test("catalog reconciliation attributes failures without leaking private auth or retaining revoked direct servers", async ({ evidence }) => {
+  needs({ commands: ["bun"] });
+  const root = await mkdtemp(join(tmpdir(), "mcp-catalog-diagnostics-"));
+  const privateAuthorization = "Bearer catalog-private-test-token";
+  const memberAuthorization = "Bearer catalog-member-test-token";
+  const clientToken = "catalog-client-test-token";
+  const witness = await startCatalogWitness(privateAuthorization);
+  const children: ReturnType<typeof bootServer>["child"][] = [];
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
+  const headers = { authorization: `Bearer ${clientToken}`, "content-type": "application/json" };
+  const config = { type: "remote", url: `${witness.url}/mcp/agent`, enabled: true, oauth: false, headers: { Authorization: memberAuthorization } };
+  const index = (servers: unknown[]) => JSON.stringify({ schemaVersion: "openwork.connect/mcp-servers/1", servers });
+  async function boot(name: string, devMode: string) {
+    const home = join(root, name);
+    const workspace = join(home, "workspace");
+    await mkdir(workspace, { recursive: true });
+    const server = bootServer({
+      ...inherited, HOME: home, XDG_CONFIG_HOME: join(home, "config"), XDG_DATA_HOME: join(home, "data"),
+      XDG_STATE_HOME: join(home, "state"), XDG_CACHE_HOME: join(home, "cache"),
+      OPENWORK_RUNTIME_DB: join(home, "runtime.sqlite"), OPENWORK_DEV_MODE: devMode,
+      OPENWORK_OPENCODE_BASE_URL: witness.url, OPENWORK_MANAGE_OPENCODE: "0",
+    }, clientToken, workspace, () => {});
+    children.push(server.child);
+    const base = await server.listening;
+    const response = await fetch(`${base}/workspaces`, { headers, signal: AbortSignal.timeout(10_000) });
+    expect(response.status).toBe(200);
+    const payload: unknown = await response.json();
+    if (!isRecord(payload) || !Array.isArray(payload.items) || !isRecord(payload.items[0]) || typeof payload.items[0].id !== "string") throw new Error("Missing workspace");
+    return `${base}/workspace/${payload.items[0].id}/mcp/openwork-cloud/reconcile`;
+  }
+  async function reconcile(url: string, authorization?: string, enabled = true) {
+    const response = await fetch(url, {
+      method: "POST", headers, signal: AbortSignal.timeout(45_000),
+      body: JSON.stringify({ config: { ...config, enabled }, ...(authorization === undefined ? {} : { appHostAuthorization: authorization }) }),
+    });
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).not.toContain(privateAuthorization.slice("Bearer ".length));
+    expect(text).not.toContain(memberAuthorization.slice("Bearer ".length));
+    const body: unknown = JSON.parse(text);
+    if (!isRecord(body)) throw new Error("Missing reconciliation result");
+    return body;
+  }
+  async function expectResolveError(endpoint: string, code: string) {
+    const response = await fetch(endpoint.replace("/mcp/openwork-cloud/reconcile", "/mcp-apps/resolve"), {
+      method: "POST", headers, signal: AbortSignal.timeout(20_000),
+      body: JSON.stringify({ launch: { connectionId: "catalog-connection", toolName: "show", resourceUri: "ui://fixture/app" } }),
+    });
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    const text = await response.text();
+    expect(text).not.toContain(privateAuthorization.slice("Bearer ".length));
+    expect(text).not.toContain(memberAuthorization.slice("Bearer ".length));
+    expect(JSON.parse(text)).toMatchObject({ code });
+  }
+  try {
+    const endpoint = await boot("trusted-dev", "1");
+    const disabled = await reconcile(endpoint, undefined, false);
+    expect(disabled.connectCatalogDiagnostic).toBeUndefined();
+    expect(disabled.firstFailure).toMatchObject({ code: "cloud_mcp_disabled" });
+    expect((await reconcile(endpoint)).connectCatalogDiagnostic).toBe("missing_app_host_auth");
+    await expectResolveError(endpoint, "connect_catalog_missing_app_host_auth");
+    expect(witness.requests.filter((entry) => entry.privateAuth || entry.method === "resources/read")).toEqual([]);
+
+    witness.catalog(index([]));
+    expect((await reconcile(endpoint, privateAuthorization)).connectCatalogDiagnostic).toBe("empty");
+    await expectResolveError(endpoint, "server_unavailable");
+    expect(witness.requests.some((entry) => entry.method === "resources/read" && entry.privateAuth && entry.appHostCapability)).toBe(true);
+    expect(witness.registrations.some((entry) => entry.name.startsWith("openwork-direct-"))).toBe(false);
+    const descriptor = { connectionId: "catalog-connection", name: "Catalog fixture", description: null, url: `${witness.url}/mcp/agent/connections/catalog-connection`, exposeDirectly: true };
+    witness.catalog(index([descriptor]));
+    expect((await reconcile(endpoint)).connectCatalogDiagnostic).toBe("ready");
+    const directName = witness.registrations.find((entry) => entry.name.startsWith("openwork-direct-"))?.name;
+    expect(directName).toBeDefined();
+
+    for (const invalid of ["not-json", JSON.stringify({ schemaVersion: "unsupported", servers: [] })]) {
+      witness.catalog(invalid);
+      expect((await reconcile(endpoint)).connectCatalogDiagnostic).toBe("invalid_catalog");
+      await expectResolveError(endpoint, "connect_catalog_invalid_catalog");
+    }
+    expect(witness.disconnects).toContain(directName);
+    const projectedCount = witness.registrations.filter((entry) => entry.name.startsWith("openwork-direct-")).length;
+    witness.catalog(index([descriptor, { ...descriptor, connectionId: "rejected", url: "https://untrusted.invalid/mcp" }]));
+    expect((await reconcile(endpoint)).connectCatalogDiagnostic).toBe("invalid_proxy_descriptor");
+    await expectResolveError(endpoint, "connect_catalog_invalid_proxy_descriptor");
+    for (const status of [401, 403, 404, 503]) {
+      witness.catalog(index([]), status);
+      expect((await reconcile(endpoint)).connectCatalogDiagnostic).toBe("discovery_unavailable");
+      await expectResolveError(endpoint, "connect_catalog_discovery_unavailable");
+    }
+    expect(witness.registrations.filter((entry) => entry.name.startsWith("openwork-direct-"))).toHaveLength(projectedCount);
+    expect(witness.registrations.every((entry) => !entry.privateAuth)).toBe(true);
+    evidence.recordAssertionEvidence("Catalog failure attribution and fail-closed projection", "Real reconciliation HTTP responses distinguish missing auth, empty, ready, invalid JSON/schema, invalid proxy, and unavailable HTTP 401/403/404/503; revoked direct entry disconnected and no rejected catalog reprojected it. Engine registrations contain no private auth.", true);
+
+    // Same loopback origin without the explicit development trust exception is
+    // unactivated: supplying private auth must not send it to that origin.
+    witness.catalog(index([]));
+    const untrustedEndpoint = await boot("unactivated", "0");
+    const privateRequestsBefore = witness.requests.filter((entry) => entry.privateAuth).length;
+    expect((await reconcile(untrustedEndpoint, privateAuthorization)).connectCatalogDiagnostic).toBe("untrusted_origin");
+    await expectResolveError(untrustedEndpoint, "connect_catalog_untrusted_origin");
+    expect(witness.requests.filter((entry) => entry.privateAuth)).toHaveLength(privateRequestsBefore);
+    evidence.recordAssertionEvidence("Unactivated origin cannot receive private App-host credentials", "An isolated non-development server reports untrusted_origin for the same unactivated origin; private request count does not increase. Reconciliation responses omit both bearer credentials.", true);
+    evidence.recordAssertionEvidence("App resolve retains catalog failure attribution", "Real resolve HTTP errors distinguish missing private authorization, untrusted origin, invalid catalog/proxy and unavailable discovery from server_unavailable after successful empty discovery; no response exposes bearer credentials.", true);
+  } finally {
+    for (const child of children) await stopChild(child);
+    await witness.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Implementation
- Distinguish missing private authorization, untrusted origins, invalid catalogs/proxies, unavailable discovery, and successful empty/ready discovery.
- Preserve diagnostics in reconciliation and Connect App resolution without exposing credentials or changing transport fallback behavior.
- Add a real-server HTTP journey with isolated catalog witnesses and fail-closed projection assertions.

## Verification
- Exact head: catalog unit tests 15 passed; App host unit tests 25 passed; server typecheck passed; diagnostics journey 1 passed, zero skips.
- Additional existing cloud reconciliation suite: 27 assertions/tests passed, but Bun hung after completion and timed out at 120 seconds on both branch and clean pinned dev control. This supplemental check remains incomplete.
- Initial journey import failure was missing workspace dependencies; installing the required linked packages resolved it.

## Review / verdict
Targeted behavior passed; overall review Incomplete pending CI. Bare pnpm warden:check covered the intended seven-file scope but exited 1 (auth_failed), including after one approved credential repair attempt. Expected skills: diff-security-review, confidentiality-review, spec-provenance-review; actual completed coverage: none (skipped/failed). No native finding IDs were produced, not clearance. No model configuration changed. Clear when all applicable CI/review checks complete without blockers. Evidence publication follows.