### PR TITLE
fix(app): preserve the v2 sessionless first prompt

### DIFF
--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -67,12 +67,25 @@ async function routeSessionEndpoint(endpoint: ResolvedWorkspaceEndpoint): Promis
     : endpoint;
 }
 
-export async function createRouteSession(endpoint: ResolvedWorkspaceEndpoint, directory?: string): Promise<Session> {
+/**
+ * Create a session and report the engine endpoint that owns it. Callers that
+ * key follow-up state by `opencodeBaseUrl` (the hero's one-step auto-send) must
+ * use this endpoint, not the workspace's default v1 one, or the mounted
+ * session surface never finds that state when chat is routed to v2.
+ */
+export async function createRouteSessionOnEngine(
+  endpoint: ResolvedWorkspaceEndpoint,
+  directory?: string,
+): Promise<{ session: Session; endpoint: ResolvedWorkspaceEndpoint }> {
   const native = await routeSessionEndpoint(endpoint);
   const client = isOpencodeV2BaseUrl(native.opencodeBaseUrl)
     ? createClientV2(native.opencodeBaseUrl, directory, { token: native.token })
     : createClient(native.opencodeBaseUrl, directory, { token: native.token, mode: "openwork" });
-  return unwrap(await client.session.create({ directory }));
+  return { session: unwrap(await client.session.create({ directory })), endpoint: native };
+}
+
+export async function createRouteSession(endpoint: ResolvedWorkspaceEndpoint, directory?: string): Promise<Session> {
+  return (await createRouteSessionOnEngine(endpoint, directory)).session;
 }
 
 export async function deleteRouteSession(endpoint: ResolvedWorkspaceEndpoint, sessionId: string): Promise<boolean> {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -81,6 +81,7 @@ import {
   describeTaskCreateRetry,
   describeWorkspaceCreateError,
   createRouteSession,
+  createRouteSessionOnEngine,
   deleteRouteSession,
   downloadWorkspaceJson,
   folderNameFromPath,
@@ -3495,9 +3496,11 @@ export function SessionRoute() {
           };
           const workspace = workspaces.find((item) => item.id === workspaceId);
           if (!workspace) throw new Error("Workspace is unavailable. Try again.");
-          const endpoint = endpointForWorkspace(workspace);
-          if (!endpoint?.token) throw new Error("Workspace is disconnected. Reconnect and try again.");
-          const session = await createRouteSession(endpoint, workspace.path?.trim() || undefined);
+          const workspaceEndpoint = endpointForWorkspace(workspace);
+          if (!workspaceEndpoint?.token) throw new Error("Workspace is disconnected. Reconnect and try again.");
+          // The scoped auto-send mark must name the engine that owns the new
+          // session; the session surface consumes it under that same base URL.
+          const { session, endpoint } = await createRouteSessionOnEngine(workspaceEndpoint, workspace.path?.trim() || undefined);
           const continuation = handoff
             ? snapshotComposerSessionState(handoff.getContinuation())
             : null;

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   classifyRouteSessionReadError,
   createRouteSession,
+  createRouteSessionOnEngine,
   deleteRouteSession,
   mergeRouteWorkspaces,
   readRouteSessionsWithRetry,
@@ -52,7 +53,10 @@ describe("workspace session mutations", () => {
           baseUrl: "http://owner.test", token: "fixture-token",
         });
         if (!endpoint) throw new Error("Workspace endpoint missing");
-        expect((await createRouteSession(endpoint, "/existing")).id).toBe("ses_created");
+        const created = await createRouteSessionOnEngine(endpoint, "/existing");
+        expect(created.session.id).toBe("ses_created");
+        expect(created.endpoint.opencodeBaseUrl).toBe(`http://owner.test/workspace/ws_existing/${engine === "v2" ? "opencode2" : "opencode"}`);
+        expect(endpoint.opencodeBaseUrl).toBe("http://owner.test/workspace/ws_existing/opencode");
         expect(await deleteRouteSession(endpoint, "ses_created")).toBe(true);
         expect(requests).toEqual([
           "GET /experimental/engine-v2-preview/status",

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -21,6 +21,8 @@ const definitions = {
   },
   'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },
   'workspace-new-task-hit-target.e2e.test.ts': { name: 'Keep new tasks and sends instantly responsive', placement: 'local' },
+  // Serves the model mock from the spec process's 127.0.0.1; only the local lane can reach it.
+  'v2-sessionless-first-send.e2e.test.ts': { name: 'Send the first prompt from the New task route', placement: 'local' },
   'streamed-markdown-answer.e2e.test.ts': {
     cases: [{ id: 'CONT-01', engines: ['v1', 'v2'], surfaces: ['web', 'electron'], defaultSurface: 'web', optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2', surface: 'web' } }],
   },

--- a/evals/specs/v2-sessionless-first-send.e2e.test.ts
+++ b/evals/specs/v2-sessionless-first-send.e2e.test.ts
@@ -1,8 +1,11 @@
 import { expect } from "vitest";
-import { spec } from "@openwork/testkit";
+import { resolveEvalEngine, spec } from "@openwork/testkit";
 import { sessionlessFirstSendWorld } from "../worlds/first-run.ts";
 
-const test = spec.world(sessionlessFirstSendWorld, { timeout: 420_000 });
+const test = spec.world(sessionlessFirstSendWorld, {
+  timeout: 420_000,
+  needs: { env: ["OPENWORK_EVAL_ENGINE"] },
+});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -37,7 +40,7 @@ function nativeSessionIds(body: unknown): string[] {
   return nativeItems(body).flatMap((session) => isRecord(session) && typeof session.id === "string" ? [session.id] : []).sort();
 }
 
-test("Run task on the sessionless New task route creates the session and delivers the first prompt", async ({ world, user, probe, step, evidence }) => {
+test(`${resolveEvalEngine()}: Run task on the sessionless New task route creates the session and delivers the first prompt`, async ({ world, user, probe, step, evidence }) => {
   const { prompt, engine } = world;
   const persistedPrefix = `${world.sessionlessRoute}/`;
   const readSessions = async () => {
@@ -48,6 +51,10 @@ test("Run task on the sessionless New task route creates the session and deliver
 
   await step("the person lands on the sessionless New task route with an empty, editable composer", async () => {
     await world.openNewTask();
+    const routing = await probe.desktopApi("/experimental/engine-v2-preview/status");
+    expect(routing.status).toBe(200);
+    expect(routing.body).toMatchObject({ chatRouting: engine === "v2" });
+    if (engine === "v2") expect(routing.body).toMatchObject({ enabled: true, running: true });
     expect(await probe.hash()).toBe(world.sessionlessRoute);
     await user.see("composer", { editable: true });
     const composer = await probe.eventually(() => probe.composer(), {

--- a/evals/specs/v2-sessionless-first-send.e2e.test.ts
+++ b/evals/specs/v2-sessionless-first-send.e2e.test.ts
@@ -1,0 +1,115 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { sessionlessFirstSendWorld } from "../worlds/first-run.ts";
+
+const test = spec.world(sessionlessFirstSendWorld, { timeout: 420_000 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Engine-native message list, normalized across v1 (array) and v2 ({ data }) bodies. */
+function nativeMessages(body: unknown): { role: string; text: string }[] {
+  const items = Array.isArray(body) ? body : isRecord(body) && Array.isArray(body.data) ? body.data : [];
+  return items.flatMap((message) => {
+    if (!isRecord(message)) return [];
+    const info = isRecord(message.info) ? message.info : message;
+    const parts = Array.isArray(message.parts) ? message.parts : [];
+    return [{
+      role: typeof info.role === "string" ? info.role : "",
+      text: parts.map((part) => isRecord(part) && typeof part.text === "string" ? part.text : "").join("\n"),
+    }];
+  });
+}
+
+function nativeSessionIds(body: unknown): string[] {
+  const items = Array.isArray(body) ? body : isRecord(body) && Array.isArray(body.data) ? body.data : [];
+  return items.flatMap((session) => isRecord(session) && typeof session.id === "string" ? [session.id] : []).sort();
+}
+
+test("Run task on the sessionless New task route creates the session and delivers the first prompt", async ({ world, user, probe, step, evidence }) => {
+  const { prompt, engine } = world;
+  const persistedPrefix = `${world.sessionlessRoute}/`;
+  const readSessions = async () => {
+    const response = await probe.desktopApi(world.sessionsPath);
+    expect(response.status, world.sessionsPath).toBe(200);
+    return nativeSessionIds(response.body);
+  };
+
+  await step("the person lands on the sessionless New task route with an empty, editable composer", async () => {
+    await world.openNewTask();
+    expect(await probe.hash()).toBe(world.sessionlessRoute);
+    await user.see("composer", { editable: true });
+    const composer = await probe.eventually(() => probe.composer(), {
+      within: 60_000,
+      label: "empty New task composer with its model ready",
+      until: (state) => state.composerEditable && state.draftText.trim() === "" && !state.modelUnavailable,
+    });
+    expect(composer.userMessageCount).toBe(0);
+  });
+  const sessionsBefore = await readSessions();
+
+  await step("typing a prompt enables Run task", async () => {
+    await user.type("composer", prompt);
+    await user.see("composer", { text: prompt });
+    const composer = await probe.eventually(() => probe.composer(), {
+      within: 30_000,
+      label: "enabled Run task",
+      until: (state) => state.runTaskEnabled && state.draftText.trim() === prompt,
+    });
+    expect(composer.route).toBe(world.sessionlessRoute);
+  });
+
+  const sentAt = Date.now();
+  await user.click("Run task");
+  const hash = await probe.eventually(() => probe.hash(), {
+    within: 30_000,
+    label: "navigation to the created session",
+    until: (value) => value.startsWith(persistedPrefix) && value.slice(persistedPrefix.length).startsWith("ses_"),
+  });
+  const sessionId = hash.slice(persistedPrefix.length);
+  expect(sessionId).toMatch(/^ses_[^/?#]+$/);
+
+  await step("the prompt is visible in the new thread and the composer is empty", async () => {
+    await user.see({ text: prompt }, { timeoutMs: 20_000 });
+    const composer = await probe.eventually(() => probe.composer(), {
+      within: 20_000,
+      label: "composer cleared and one user turn shown",
+      until: (state) => state.draftText.trim() === "" && state.userMessageCount === 1,
+    });
+    expect(composer.route).toBe(`${persistedPrefix}${sessionId}`);
+    expect(composer.userMessageCount).toBe(1);
+  });
+
+  await step(`the ${engine} engine holds the user prompt for that session`, async () => {
+    const path = world.messagesPath(sessionId);
+    const messages = await probe.eventually(async () => {
+      const response = await probe.desktopApi(path);
+      expect(response.status, path).toBe(200);
+      return nativeMessages(response.body);
+    }, {
+      within: 20_000,
+      intervalMs: 1_000,
+      label: `${engine} engine user message for ${sessionId}`,
+      until: (value) => value.some((message) => message.role === "user" && message.text.includes(prompt)),
+    });
+    expect(messages.filter((message) => message.role === "user" && message.text.includes(prompt))).toHaveLength(1);
+    evidence.recordAssertionEvidence(
+      `the ${engine} engine received the sessionless first send`,
+      `GET ${path} listed a user message containing the prompt ${Date.now() - sentAt}ms after Run task; the thread showed the same prompt once and the composer was empty.`,
+      true,
+    );
+  });
+
+  await step("exactly one session was created and the engine reply arrives in it", async () => {
+    const sessionsAfter = await probe.eventually(readSessions, {
+      within: 20_000,
+      label: "engine session list includes the created session",
+      until: (ids) => ids.includes(sessionId),
+    });
+    expect(sessionsAfter.filter((id) => !sessionsBefore.includes(id))).toEqual([sessionId]);
+    await user.see({ text: world.reply }, { timeoutMs: 120_000 });
+    expect(await probe.hash()).toBe(`${persistedPrefix}${sessionId}`);
+    expect((await probe.composer()).userMessageCount).toBe(1);
+  });
+});

--- a/evals/specs/v2-sessionless-first-send.e2e.test.ts
+++ b/evals/specs/v2-sessionless-first-send.e2e.test.ts
@@ -12,14 +12,19 @@ function textOf(value: unknown): string {
   return isRecord(value) && typeof value.text === "string" ? value.text : "";
 }
 
+function nativeItems(body: unknown): unknown[] {
+  if (Array.isArray(body)) return body;
+  if (isRecord(body) && Array.isArray(body.data)) return body.data;
+  throw new Error(`Unexpected native list: ${JSON.stringify(body)}`);
+}
+
 /**
  * Engine-native message list, normalized the way the app reads each engine:
  * v1 returns an array of `{ info: { role }, parts: [{ text }] }`; v2 returns
  * `{ data: [{ role | type, content: [{ text }] | text }] }`.
  */
 function nativeMessages(body: unknown): { role: string; text: string }[] {
-  const items = Array.isArray(body) ? body : isRecord(body) && Array.isArray(body.data) ? body.data : [];
-  return items.flatMap((message) => {
+  return nativeItems(body).flatMap((message) => {
     if (!isRecord(message)) return [];
     const info = isRecord(message.info) ? message.info : message;
     const role = typeof info.role === "string" ? info.role : typeof info.type === "string" ? info.type : "";
@@ -29,8 +34,7 @@ function nativeMessages(body: unknown): { role: string; text: string }[] {
 }
 
 function nativeSessionIds(body: unknown): string[] {
-  const items = Array.isArray(body) ? body : isRecord(body) && Array.isArray(body.data) ? body.data : [];
-  return items.flatMap((session) => isRecord(session) && typeof session.id === "string" ? [session.id] : []).sort();
+  return nativeItems(body).flatMap((session) => isRecord(session) && typeof session.id === "string" ? [session.id] : []).sort();
 }
 
 test("Run task on the sessionless New task route creates the session and delivers the first prompt", async ({ world, user, probe, step, evidence }) => {
@@ -66,7 +70,6 @@ test("Run task on the sessionless New task route creates the session and deliver
     expect(composer.route).toBe(world.sessionlessRoute);
   });
 
-  const sentAt = Date.now();
   await user.click("Run task");
   const hash = await probe.eventually(() => probe.hash(), {
     within: 30_000,
@@ -76,46 +79,47 @@ test("Run task on the sessionless New task route creates the session and deliver
   const sessionId = hash.slice(persistedPrefix.length);
   expect(sessionId).toMatch(/^ses_[^/?#]+$/);
 
-  await step("the prompt is visible in the new thread and the composer is empty", async () => {
-    await user.see({ text: prompt }, { timeoutMs: 20_000 });
-    const composer = await probe.eventually(() => probe.composer(), {
-      within: 20_000,
-      label: "composer cleared and one user turn shown",
-      until: (state) => state.draftText.trim() === "" && state.userMessageCount === 1,
-    });
+  await step(`the ${engine} first send clears the composer and reaches both thread and engine`, async () => {
+    await user.see("composer", { text: "" });
+    // Observe BOTH boundaries even on a regression: a missing visible message
+    // must not short-circuit the native probe and hide the empty engine list.
+    const path = world.messagesPath(sessionId);
+    const [visible, native] = await Promise.allSettled([
+      user.see({ text: prompt }, { timeoutMs: 20_000 }),
+      probe.eventually(() => probe.desktopApi(path), {
+        within: 20_000,
+        intervalMs: 1_000,
+        label: `${engine} engine user message for ${sessionId}`,
+        until: (response) => response.status === 200 && nativeMessages(response.body)
+          .some((message) => message.role === "user" && message.text.includes(prompt)),
+      }),
+    ]);
+    for (const [boundary, result] of [["thread", visible], ["engine", native]] satisfies [string, PromiseSettledResult<unknown>][]) {
+      evidence.recordAssertionEvidence(
+        `${engine} sessionless first prompt reaches the ${boundary}`,
+        result.status === "fulfilled" ? `The ${boundary} retained the submitted prompt.` : String(result.reason),
+        result.status === "fulfilled",
+      );
+    }
+    expect(visible.status, "prompt visible outside the empty composer").toBe("fulfilled");
+    if (native.status === "rejected") throw native.reason;
+    const messages = nativeMessages(native.value.body);
+    expect(messages.filter((message) => message.role === "user" && message.text.includes(prompt))).toHaveLength(1);
+    const composer = await probe.composer();
     expect(composer.route).toBe(`${persistedPrefix}${sessionId}`);
+    expect(composer.draftText.trim()).toBe("");
     expect(composer.userMessageCount).toBe(1);
   });
 
-  await step(`the ${engine} engine holds the user prompt for that session`, async () => {
-    const path = world.messagesPath(sessionId);
-    const messages = await probe.eventually(async () => {
-      const response = await probe.desktopApi(path);
-      expect(response.status, path).toBe(200);
-      return nativeMessages(response.body);
-    }, {
-      within: 20_000,
-      intervalMs: 1_000,
-      label: `${engine} engine user message for ${sessionId}`,
-      until: (value) => value.some((message) => message.role === "user" && message.text.includes(prompt)),
-    });
-    expect(messages.filter((message) => message.role === "user" && message.text.includes(prompt))).toHaveLength(1);
-    evidence.recordAssertionEvidence(
-      `the ${engine} engine received the sessionless first send`,
-      `GET ${path} listed a user message containing the prompt ${Date.now() - sentAt}ms after Run task; the thread showed the same prompt once and the composer was empty.`,
-      true,
-    );
-  });
-
   await step("exactly one session was created and the engine reply arrives in it", async () => {
-    const sessionsAfter = await probe.eventually(readSessions, {
-      within: 20_000,
-      label: "engine session list includes the created session",
-      until: (ids) => ids.includes(sessionId),
-    });
-    expect(sessionsAfter.filter((id) => !sessionsBefore.includes(id))).toEqual([sessionId]);
     await user.see({ text: world.reply }, { timeoutMs: 120_000 });
+    expect(await readSessions()).toEqual([...sessionsBefore, sessionId].sort());
     expect(await probe.hash()).toBe(`${persistedPrefix}${sessionId}`);
     expect((await probe.composer()).userMessageCount).toBe(1);
+    evidence.recordAssertionEvidence(
+      `${engine} creates exactly one session without replaying the first send`,
+      "After the real engine reply, the session inventory is the original inventory plus exactly the routed session; one user row remains and the composer is empty.",
+      true,
+    );
   });
 });

--- a/evals/specs/v2-sessionless-first-send.e2e.test.ts
+++ b/evals/specs/v2-sessionless-first-send.e2e.test.ts
@@ -8,17 +8,23 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** Engine-native message list, normalized across v1 (array) and v2 ({ data }) bodies. */
+function textOf(value: unknown): string {
+  return isRecord(value) && typeof value.text === "string" ? value.text : "";
+}
+
+/**
+ * Engine-native message list, normalized the way the app reads each engine:
+ * v1 returns an array of `{ info: { role }, parts: [{ text }] }`; v2 returns
+ * `{ data: [{ role | type, content: [{ text }] | text }] }`.
+ */
 function nativeMessages(body: unknown): { role: string; text: string }[] {
   const items = Array.isArray(body) ? body : isRecord(body) && Array.isArray(body.data) ? body.data : [];
   return items.flatMap((message) => {
     if (!isRecord(message)) return [];
     const info = isRecord(message.info) ? message.info : message;
-    const parts = Array.isArray(message.parts) ? message.parts : [];
-    return [{
-      role: typeof info.role === "string" ? info.role : "",
-      text: parts.map((part) => isRecord(part) && typeof part.text === "string" ? part.text : "").join("\n"),
-    }];
+    const role = typeof info.role === "string" ? info.role : typeof info.type === "string" ? info.type : "";
+    const parts = Array.isArray(message.parts) ? message.parts : Array.isArray(message.content) ? message.content : [message];
+    return [{ role, text: parts.map(textOf).join("\n") }];
   });
 }
 

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -198,9 +198,7 @@ export async function sessionlessFirstSendWorld(seed: Seed) {
     port: await allocateFreePort(),
     agentWorkloads: [{ promptMarker: prompt, latestUserTurn: true, finalReply: reply, steps: [] }],
   }));
-  const app = await seed.desktop({ name: "sessionless-first-send", model: `${providerId}/${modelId}` });
-  const workspacePath = seed.tmpPath("sessionless-first-send");
-  const workspace = await seed.workspace(app, workspacePath);
+  const { app, workspace, workspacePath } = await workspaceWorld(seed);
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
     provider: {
       [providerId]: {

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -199,6 +199,7 @@ export async function sessionlessFirstSendWorld(seed: Seed) {
     agentWorkloads: [{ promptMarker: prompt, latestUserTurn: true, finalReply: reply, steps: [] }],
   }));
   const { app, workspace, workspacePath } = await workspaceWorld(seed);
+  const documentStartedAt = await evalIn(app, () => performance.timeOrigin);
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
     provider: {
       [providerId]: {
@@ -208,6 +209,12 @@ export async function sessionlessFirstSendWorld(seed: Seed) {
         models: { [modelId]: { name: "First send model" } },
       },
     },
+  });
+  // configureProvider schedules a reload; its readiness probe can still run in
+  // the old document. Never type the test prompt into that departing composer.
+  await waitForBehavior(app, browserScript((startedAt) => performance.timeOrigin !== startedAt
+    && Boolean(window.__openworkControl), [documentStartedAt]), {
+    timeoutMs: 60_000, label: "provider-configured replacement document mounted",
   });
   const resources = setup.move();
   const mount = `/workspace/${encodeURIComponent(workspace.workspaceId)}`;

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -21,6 +21,7 @@ import {
 } from "@openwork/hosts";
 import { startEgressLab, startMockMcp } from "@openwork/labs";
 import { diagnoseEgressLabProduct } from "@openwork/behaviors";
+import { configureProvider } from "./chat.ts";
 import { matchVerdictExpectations } from "@openwork/matchers";
 import {
   assignPluginToMarketplace,
@@ -178,6 +179,57 @@ export async function sessionWorld(seed: Seed) {
   const base = await workspaceWorld(seed);
   const session = await seed.session(base.app);
   return { ...base, session };
+}
+
+/**
+ * A workspace with a mock model and NO session: the person lands on the
+ * sessionless New task route and the first Run task must create the session
+ * and deliver the prompt through whichever engine (v1 or v2) is selected.
+ */
+export async function sessionlessFirstSendWorld(seed: Seed) {
+  const engine = resolveEvalEngine();
+  const providerId = "first-send-mock";
+  const modelId = "first-send-model";
+  const nonce = `${Date.now().toString(36)}-${process.pid}`;
+  const prompt = `Summarize this workspace in one sentence. FIRST-SEND-${nonce}`;
+  const reply = `Workspace summary finished ${nonce}.`;
+  await using setup = new AsyncDisposableStack();
+  const mock = setup.use(await startMockMcp({
+    port: await allocateFreePort(),
+    agentWorkloads: [{ promptMarker: prompt, latestUserTurn: true, finalReply: reply, steps: [] }],
+  }));
+  const app = await seed.desktop({ name: "sessionless-first-send", model: `${providerId}/${modelId}` });
+  const workspacePath = seed.tmpPath("sessionless-first-send");
+  const workspace = await seed.workspace(app, workspacePath);
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "First send mock",
+        options: { baseURL: `${mock.url}/v1`, apiKey: "sk-first-send" },
+        models: { [modelId]: { name: "First send model" } },
+      },
+    },
+  });
+  const resources = setup.move();
+  const mount = `/workspace/${encodeURIComponent(workspace.workspaceId)}`;
+  return {
+    app,
+    workspace,
+    workspacePath,
+    engine,
+    prompt,
+    reply,
+    sessionlessRoute: `#/workspace/${workspace.workspaceId}/session`,
+    /** Engine-native message list for one session, on the selected engine's mount. */
+    messagesPath: (sessionId: string) => engine === "v2"
+      ? `${mount}/opencode2/api/session/${encodeURIComponent(sessionId)}/message`
+      : `${mount}/opencode/session/${encodeURIComponent(sessionId)}/message`,
+    /** Engine-native session list on the selected engine's mount. */
+    sessionsPath: engine === "v2" ? `${mount}/opencode2/api/session` : `${mount}/opencode/session?limit=100`,
+    openNewTask: () => go(app, `/workspace/${workspace.workspaceId}/session`),
+    [Symbol.asyncDispose]: () => resources.disposeAsync(),
+  };
 }
 
 export async function parentChildPermissionWorld(seed: Seed) {

--- a/warden.toml
+++ b/warden.toml
@@ -16,6 +16,9 @@ ignorePaths = [
   "**/*.min.js",
 ]
 
+[defaults.scan]
+maxFileLines = 5000
+
 [defaults.agent]
 model = "openai/gpt-5.6-luna"
 


### PR DESCRIPTION
## Current revision — CI advisory addressed

Current head: `c86bc3c72713ee3a0cd11f4459d43b1334966322`.

Addressed **V2L-CBB** (medium, spec-provenance-review): require explicit `OPENWORK_EVAL_ENGINE`, prefix each test verdict with v1/v2, and assert the live native engine-routing status before typing. No app or Warden-policy change in this follow-up commit.

- Omitted engine: named command returns **exit 2 / Incomplete**, 0 passed and 1 skipped, rather than a false v2 pass. This negative guard check is not counted as a passing journey.
- Final-head explicit v2 and v1 journeys: **1 passed / 0 failed / 0 skipped each**.
- Final-head v1 instant-send journey: **1 passed / 0 failed / 0 skipped**.
- App typecheck, 64 targeted unit tests, 13 catalog tests, 831 browser callback checks, and scoped eval typecheck passed again.
- Final bare Warden run `cdbda42d` (2026-09-10T14:54:50Z): **exit 0, all four expected skills completed, no findings/skipped files**. Before/after refs unchanged: HEAD `c86bc3c7…`, origin/dev `326ff094…`. Repeated because origin/dev moved during the preceding local review. Private logs remain private.
- The current combined test-evidence comment contains the three matching final-head records. Earlier proof below is retained as historical provenance.
- The review-machinery human-approval guard remains intact; no admin override, removal of coverage, or self-approval.

## Problem

With v2 selected, clicking an **enabled** Run task on `#/workspace/<id>/session` creates and opens a session and clears the composer, but never sends the prompt. The new thread stays at “Try one of these” and its native message list stays empty. This is **not** #4757's disabled first-snapshot send gate.

## Root cause and evidence

`createRouteSession` resolves the owning server's engine and creates a v2 session, but the hero previously keyed its submitted composer snapshot using the original workspace endpoint (`.../opencode`). `SessionSurface` looks for the scoped payload using its routed endpoint (`.../opencode2`). Those keys never match. The empty continuation is correctly transferred; the submitted snapshot is stranded under the wrong key, so auto-send never runs. This is an app handoff defect, not an engine defect.

- Journey written before the app fix. Unfixed source at `634df629a919db504e27d0f00962dc772344e42a`: **v2 failed / v1 passed**, with identical fixture and assertions. Latest unfixed v2 run captures both the missing thread prompt and native HTTP 200 body `{"data":[],"cursor":{"previous":null,"next":null}}` after 20 seconds.
- Temporary read-only CDP/Vite witness on the unfixed app: `legacyMark=false`, `v1ScopedMark=true`, `v2ScopedMark=false`; only the v1-keyed payload contained the submitted prompt. The v1 control had consumed its mark. Diagnostic imports were removed; the committed journey uses no `probe.eval`.
- Separately supplied packaged-Linux evidence, **not rerun by this PR owner**: actual public **0.18.46** and packaged dev `4e634905e` each failed sessionless first-send 3/3, while their existing-session controls passed. Packaged dev `07bdea2f1` subsequently failed 1/1 with its control passing 1/1. All used measured v2 beta-19086 SHA-256 `5a8c0975a7740e20fd29b4ee59e5499e50fd98715798bb151128f5e7aaa0e750`. Those report/package/evidence trees remain untouched. These are historical baselines, not a claim that this fix has shipped or that a fixed Linux package was tested.

## Fix

- Return the resolved engine endpoint alongside the created session through `createRouteSessionOnEngine`; keep the existing session-only wrapper for other callers.
- Use that returned endpoint when scoping the hero handoff. No extra engine request, key normalization, v1 fallback, or change to the consumer's isolation guards.
- Add the missing sessionless journey on top of `workspaceWorld`, register local placement, wait for an enabled Run task, and assert native + visible prompt, cleared composer, reply, and exactly one new session. Native body parsing follows the app's v1/v2 adapter shapes.
- Extend existing workspace route unit coverage to assert the returned endpoint and that the workspace endpoint is not mutated.
- Raise Warden's file-line scan limit from the default 3,000 to 5,000: otherwise it silently skips the critical `session-route.tsx`. All skills and fail policies remain enabled; no `.github/` changes.

## Proof

Initial validated source-built head: `ed9ed79f959f7516c6392c9877f2587432414896`, integrated dev pin `7d5097d4258da3c8568d0735712ea47c6c2fb482` (superseded by the current revision above). Isolated **local** Electron lane explicitly requested; fresh profiles and synthetic loopback provider, no production service work. Root **and** `evals/` installed with `pnpm install --frozen-lockfile`. Node 24.20.0 / pnpm 11.4.0 / Bun 1.4.0.

| Command | Exit | Result |
|---|---:|---|
| `pnpm evals:e2e v2-sessionless-first-send --local --engine v2` | 0 | 1 passed, 0 failed/skipped |
| `pnpm evals:e2e v2-sessionless-first-send --local --engine v1` | 0 | 1 passed, 0 failed/skipped |
| `pnpm evals:e2e workspace-new-task-hit-target --local --engine v1` | 0 | 1 passed, 0 failed/skipped |
| `pnpm --filter @openwork/app typecheck` | 0 | Passed |
| `bun test tests/composer-*.test.ts tests/opencode-session-native.test.ts` (in `apps/app`) | 0 | 39 passed, 0 failed |
| `bun test tests/workspace-routes.test.ts` (in `apps/app`) | 0 | 24 passed, 0 failed |
| `bun test tests/composer-focus-continuity.test.tsx` (in `apps/app`) | 0 | 1 passed, 0 failed |
| `node --test evals/scripts/journey-ci.test.mjs` | 0 | 13 passed, 0 failed/skipped |
| `pnpm --dir evals check:browser` | 0 | 831 callbacks checked |
| Scoped eval typecheck, including the new spec and worlds | 0 | No diagnostics |
| `git diff --check` | 0 | Passed |

The three final-head journey records are published together in the test-evidence comment. Assertions decide the verdict, not screenshots.

<details>
<summary>Full eval baseline debt and iteration accounting</summary>

These checks remain red and are **not** presented as clean: full eval typecheck (exit 2, 366 diagnostics), spec-layer typecheck (exit 2, 9 diagnostics), channel ratchet (exit 1, 19 violations), boundary ratchet (exit 1, 14 violations). Each exact command was rerun on pristine source `634df629a`; complete normalized diagnostic logs match, accounting for inserted world-helper line offsets. No diagnostic intersects this PR's changed lines. The new spec has zero raw channel escapes and crosses the product boundary.

The extra `bun test tests/composer-editable-on-snapshot-error.test.tsx` check fails (0 passed / 1 failed) with `Platform context is missing`; the same standalone command fails identically on clean `634df629a`. No unrelated test repairs are included.

For the scoped typecheck, create a temporary `evals/tsconfig.sessionless-check.json`, run `pnpm --dir evals exec tsc -p tsconfig.sessionless-check.json`, then remove the temporary config:

```json
{
  "extends": "./tsconfig.primitives.json",
  "compilerOptions": { "lib": ["es2024", "dom", "dom.iterable", "esnext.disposable"] },
  "include": ["packages/cdp/src/**/*.ts", "packages/test-evidence/src/**/*.ts", "packages/testkit/src/**/*.ts", "worlds/**/*.ts", "specs/v2-sessionless-first-send.e2e.test.ts"]
}
```

An initial fixed-v2 run exposed that raw native v2 uses `type/content`, unlike the app-mapped `info/parts`; the parser was corrected from the adapter and the unfixed control rerun. One pre-final v1 run lost typing before the click during the fixture's scheduled provider-setup reload; the world now waits for a changed `performance.timeOrigin` and mounted controls. Both unfixed controls and final-head journeys were rerun after that setup fix. One final pre-test invocation exited 254 when concurrent pnpm auto-installs raced on a Rollup symlink; serialized frozen installs succeeded and all journeys then ran sequentially. Historical failures remain retained, not counted as passes.

</details>

## Initial Warden review (historical; current review above)

Final bare `pnpm warden:check`: **exit 0, all four expected skills completed, no findings and no skipped files**. Security and confidentiality each reviewed all 7 changed files, provenance reviewed both eval files, desktop/Den sync reviewed all 3 app files including both `session-route.tsx` chunks.

- Run: `88eb53f0` (2026-09-10T05:04:34Z).
- Before/after refs identical: HEAD `ed9ed79f959f7516c6392c9877f2587432414896`; `origin/dev` `7d5097d4258da3c8568d0735712ea47c6c2fb482`.
- Expected = actual: `diff-security-review`, `confidentiality-review`, `spec-provenance-review`, `desktop-den-sync-review`.
- Finding IDs / disposition: none; full changed-file coverage reviewed with no blockers. Private model logs are not attached.
- Earlier missing-credential and file-limit runs were **Incomplete**, not clearance. Credentials were injected process-locally; the line-limit coverage gap was fixed before the final run. Local review does not substitute for GitHub Warden clearance.

No release, customer messages, or changes in the external evidence worktrees.
