### PR TITLE
fix(helm): default image.tag to the chart appVersion and size the migration hook for cold pulls

### DIFF
--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -27,11 +27,10 @@ For Kubernetes installs, use the published Helm chart:
 ```bash
 helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --version <chart-version> \
-  --set image.tag=<chart-version> \
   -f values.prod.yaml
 ```
 
-`--version` pins the chart only. The published chart defaults `image.tag` to `latest`, which floats to the newest release on every pull, so set `image.tag` (on the command line or in `values.prod.yaml`) to the same version as the chart. The images are `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference` on GHCR unless you mirror them into an internal registry.
+`--version` pins the chart and its images: the published chart's `image.tag` defaults to the chart `appVersion`, which is the same release number. Charts 0.18.46 and earlier instead default `image.tag` to `latest`, which floats to the newest release on every pull; on those versions also pass `--set image.tag=<chart-version>`. The images are `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference` on GHCR unless you mirror them into an internal registry.
 
 Choose a tested provider path in [Deploy to your cloud](/self-host/deploy-to-your-cloud/overview). The public guides cover AWS, Azure, and Google Cloud, including managed MySQL, ingress, DNS, TLS, migrations, and secure creation of the first administrator.
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -16,21 +16,21 @@ Published releases are available as an OCI Helm chart:
 ```bash
 helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
   --version REPLACE_OPENWORK_VERSION \
-  --set image.tag=REPLACE_OPENWORK_VERSION \
   -f values.prod.yaml
 ```
 
-`--version` pins the chart only. The chart defaults `image.tag` to `latest`,
-which floats to the newest published release on every pull, so always set
-`image.tag` to the same version as `--version`, either with `--set` as above or
-in `values.prod.yaml`.
+`--version` pins the chart and the images: the published chart's `appVersion`
+equals its version and `image.tag` defaults to that `appVersion`, so
+`--version X` deploys the `X` images. Set `image.tag` only to deviate from the
+chart version, for example when you mirror a specific image build. Charts
+published before this default (0.18.46 and earlier) ship `image.tag: latest`,
+which floats to the newest release on every pull; check with
+`helm show values oci://ghcr.io/different-ai/charts/openwork-ee --version X | grep -A1 '^image:'`
+and, when it prints `tag: latest`, also pass `--set image.tag=X`.
 
 Create a values file for the target environment:
 
 ```yaml
-image:
-  tag: "REPLACE_OPENWORK_VERSION"
-
 config:
   tenancy:
     # Default chart behavior is single-org for private/self-hosted installs.
@@ -127,11 +127,16 @@ imagePullSecrets:
   - name: ghcr-pull-secret
 ```
 
-For local development from a repository checkout, render or install directly:
+For local development from a repository checkout, render or install directly.
+The checkout's `Chart.yaml` carries a placeholder `appVersion` (the publish
+workflow stamps the real one with `helm package --app-version`), so a checkout
+install must set `image.tag` explicitly:
 
 ```bash
 helm template openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
-helm upgrade --install openwork-ee ./packaging/helm/openwork-ee -f values.prod.yaml
+helm upgrade --install openwork-ee ./packaging/helm/openwork-ee \
+  --set image.tag=REPLACE_OPENWORK_VERSION \
+  -f values.prod.yaml
 ```
 
 ### Automations rollout
@@ -489,7 +494,8 @@ For a Collector without authentication, use:
 Install or upgrade OpenWork with the values file:
 
 ```bash
-helm upgrade --install openwork-ee ./packaging/helm/openwork-ee \
+helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee \
+  --version REPLACE_OPENWORK_VERSION \
   --namespace openwork \
   --create-namespace \
   --values values-observability.yaml
@@ -873,6 +879,8 @@ migrations:
   enabled: true
   hook: true
   hookDeletePolicy: before-hook-creation,hook-succeeded
+  backoffLimit: 2
+  activeDeadlineSeconds: 1800
   command:
     - node
   args:
@@ -880,6 +888,34 @@ migrations:
 ```
 
 The default hook executes the precompiled Den DB bootstrap runner already built into the Den API image. On a completely empty database it applies the build-time current-schema SQL snapshot, records the committed migrations as the baseline, then runs pending migrations with Drizzle ORM. On an existing schema without a Drizzle ledger, it records the baseline before migrating.
+
+### First install on a cold cluster
+
+The hook Job runs the Den API image, and `activeDeadlineSeconds` counts from Job
+creation, so it includes pulling that image (about 800 MB) onto a node that has
+never run OpenWork. A `DeadlineExceeded` failure on a first install, with
+`kubectl describe pod` showing the pod still `Pulling`, means the pull took
+longer than the deadline, not that the migration failed. Two timers apply:
+
+- `migrations.activeDeadlineSeconds` (default `1800`): the Job's own limit.
+- Helm `--timeout` (default `5m0s`): how long Helm waits for the hook. Pass at
+  least `--timeout 30m` on a first install so Helm does not give up before the
+  Job does.
+
+To keep a cold install predictable, pre-pull or mirror the images so the hook
+starts immediately: mirror `openwork-den-api` and `openwork-den-web` into a
+registry near the cluster and set `denApi.image.repository` and
+`denWeb.image.repository` (see
+[Air-gapped deployment](../../../packages/docs/start-here/air-gapped-deployment.mdx)),
+or pull the tag on each node ahead of time with the node's container runtime
+(`crictl pull ghcr.io/different-ai/openwork-den-api:<version>`). The default
+`image.pullPolicy: IfNotPresent` reuses a pre-pulled image.
+
+To recover from a failed first install, rerun the same `helm upgrade --install`
+command: the `before-hook-creation` delete policy replaces the failed Job and
+Helm 3.2.1 or newer upgrades over a `failed` first revision. Only if Helm
+reports `has no deployed releases`, or `helm list` shows the release as
+`pending-install`, run `helm uninstall` and install again.
 
 For retained-log troubleshooting, temporarily disable hook behavior and reduce
 retries:

--- a/packaging/helm/openwork-ee/templates/_helpers.tpl
+++ b/packaging/helm/openwork-ee/templates/_helpers.tpl
@@ -31,6 +31,15 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{/*
+Image tag resolution: component override, then image.tag, then the chart
+appVersion. Published charts are packaged with --app-version <release>, so
+`helm install --version X` pins the images to X without extra values.
+*/}}
+{{- define "openwork-ee.imageTag" -}}
+{{- .componentTag | default .root.Values.image.tag | default .root.Chart.AppVersion -}}
+{{- end -}}
+
 {{- define "openwork-ee.componentSelectorLabels" -}}
 {{ include "openwork-ee.selectorLabels" .root }}
 app.kubernetes.io/component: {{ .component }}

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -81,7 +81,7 @@ spec:
       {{- end }}
       containers:
         - name: den-api
-          image: "{{ .Values.denApi.image.repository }}:{{ default .Values.image.tag .Values.denApi.image.tag }}"
+          image: "{{ .Values.denApi.image.repository }}:{{ include "openwork-ee.imageTag" (dict "root" . "componentTag" .Values.denApi.image.tag) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/packaging/helm/openwork-ee/templates/den-web.yaml
+++ b/packaging/helm/openwork-ee/templates/den-web.yaml
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       containers:
         - name: den-web
-          image: "{{ .Values.denWeb.image.repository }}:{{ default .Values.image.tag .Values.denWeb.image.tag }}"
+          image: "{{ .Values.denWeb.image.repository }}:{{ include "openwork-ee.imageTag" (dict "root" . "componentTag" .Values.denWeb.image.tag) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/packaging/helm/openwork-ee/templates/inference.yaml
+++ b/packaging/helm/openwork-ee/templates/inference.yaml
@@ -61,7 +61,7 @@ spec:
       {{- end }}
       containers:
         - name: inference
-          image: "{{ .Values.inference.image.repository }}:{{ default .Values.image.tag .Values.inference.image.tag }}"
+          image: "{{ .Values.inference.image.repository }}:{{ include "openwork-ee.imageTag" (dict "root" . "componentTag" .Values.inference.image.tag) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/packaging/helm/openwork-ee/templates/migration-job.yaml
+++ b/packaging/helm/openwork-ee/templates/migration-job.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: migrate
-          image: "{{ .Values.denApi.image.repository }}:{{ default .Values.image.tag .Values.denApi.image.tag }}"
+          image: "{{ .Values.denApi.image.repository }}:{{ include "openwork-ee.imageTag" (dict "root" . "componentTag" .Values.denApi.image.tag) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.customCa.enabled }}
           volumeMounts:

--- a/packaging/helm/openwork-ee/templates/tests/env-probe-job.yaml
+++ b/packaging/helm/openwork-ee/templates/tests/env-probe-job.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
         - name: env-probe
-          image: "{{ .Values.denApi.image.repository }}:{{ default .Values.image.tag .Values.denApi.image.tag }}"
+          image: "{{ .Values.denApi.image.repository }}:{{ include "openwork-ee.imageTag" (dict "root" . "componentTag" .Values.denApi.image.tag) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.customCa.enabled }}
           volumeMounts:

--- a/packaging/helm/openwork-ee/tests/image-tag-and-migration-hook.sh
+++ b/packaging/helm/openwork-ee/tests/image-tag-and-migration-hook.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Image tag pinning and migration hook defaults.
+#
+# - With image.tag unset, every image renders with the chart appVersion, which
+#   the publish workflow stamps via `helm package --app-version <release>`.
+# - image.tag and per-component tags still override that default.
+# - Every shipped example values file renders the same tag for every image.
+# - The migration hook keeps a retry-safe delete policy and a deadline sized for
+#   a cold image pull.
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart not to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+# Every `image:` line in the rendered output must end with the expected tag.
+assert_all_image_tags() {
+  local file="$1"
+  local expected_tag="$2"
+  local images
+  images="$(grep -E '^[[:space:]]+image: ' "$file" | sed -E 's/^[[:space:]]+image: "?([^"]+)"?$/\1/')"
+  if [[ -z "$images" ]]; then
+    printf 'Expected rendered chart to contain image lines\n' >&2
+    return 1
+  fi
+  while IFS= read -r image; do
+    if [[ "$image" != *":$expected_tag" ]]; then
+      printf 'Expected image %s to use tag %s\n' "$image" "$expected_tag" >&2
+      return 1
+    fi
+  done <<< "$images"
+}
+
+# 1. Checkout default: image.tag is blank and falls back to Chart.yaml appVersion.
+chart_app_version="$(sed -n -E 's/^appVersion: *"?([^"]+)"?$/\1/p' "$chart_dir/Chart.yaml")"
+default_rendered="$tmp_dir/default.yaml"
+helm template openwork-ee "$chart_dir" --set inference.enabled=true > "$default_rendered"
+assert_all_image_tags "$default_rendered" "$chart_app_version"
+assert_not_contains "$default_rendered" ':latest"'
+
+# 2. Published shape: `helm package --version X --app-version X` pins images to X.
+published_version="0.99.123"
+helm package "$chart_dir" --version "$published_version" --app-version "$published_version" --destination "$tmp_dir" > /dev/null
+published_rendered="$tmp_dir/published.yaml"
+helm template openwork-ee "$tmp_dir/openwork-ee-$published_version.tgz" --set inference.enabled=true > "$published_rendered"
+assert_all_image_tags "$published_rendered" "$published_version"
+assert_contains "$published_rendered" "ghcr.io/different-ai/openwork-den-api:$published_version"
+assert_contains "$published_rendered" "ghcr.io/different-ai/openwork-den-web:$published_version"
+assert_contains "$published_rendered" "ghcr.io/different-ai/openwork-inference:$published_version"
+
+# 3. image.tag overrides appVersion; a component tag overrides image.tag.
+override_rendered="$tmp_dir/override.yaml"
+helm template openwork-ee "$tmp_dir/openwork-ee-$published_version.tgz" \
+  --set image.tag=1.2.3 --set denWeb.image.tag=9.9.9 > "$override_rendered"
+assert_contains "$override_rendered" 'ghcr.io/different-ai/openwork-den-api:1.2.3"'
+assert_contains "$override_rendered" 'ghcr.io/different-ai/openwork-den-web:9.9.9"'
+assert_not_contains "$override_rendered" ":$published_version\""
+
+# 4. Every shipped example values file renders one consistent tag for all images.
+for example in "$chart_dir"/examples/values.*.yaml; do
+  example_rendered="$tmp_dir/$(basename "$example").rendered.yaml"
+  helm template openwork-ee "$chart_dir" -f "$example" > "$example_rendered"
+  example_tag="$(sed -n -E 's/^  tag: *"?([^"]+)"?$/\1/p' "$example" | head -n 1)"
+  if [[ -z "$example_tag" ]]; then
+    printf 'Expected %s to set image.tag\n' "$example" >&2
+    exit 1
+  fi
+  assert_all_image_tags "$example_rendered" "$example_tag"
+done
+
+# 5. Migration hook: retry-safe delete policy and a deadline that survives a cold pull.
+assert_contains "$default_rendered" '"helm.sh/hook": pre-install,pre-upgrade'
+assert_contains "$default_rendered" '"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"'
+assert_contains "$default_rendered" 'activeDeadlineSeconds: 1800'
+assert_contains "$default_rendered" 'backoffLimit: 2'
+
+printf 'image-tag-and-migration-hook chart checks passed\n'

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -2,7 +2,11 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  tag: latest
+  # Blank pins every image to the chart appVersion, which the publish workflow
+  # stamps with the release version, so `--version X` deploys the X images.
+  # Set a tag only to deviate from the chart version (for example a repository
+  # checkout, whose appVersion is a placeholder, or a mirrored image).
+  tag: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -298,7 +302,10 @@ migrations:
   hook: true
   hookDeletePolicy: before-hook-creation,hook-succeeded
   backoffLimit: 2
-  activeDeadlineSeconds: 600
+  # Counts from Job creation and includes pulling the den-api image (~800 MB),
+  # so it must cover a cold pull on the slowest node. Pass a matching Helm
+  # --timeout (default 5m) or the release fails before this deadline.
+  activeDeadlineSeconds: 1800
   podAnnotations: {}
   resources: {}
   command:


### PR DESCRIPTION
## Summary

Chart half of the live Helm validation findings (v0.18.45). Stacked on #4765 (docs); once that merges, only the last commit remains in this diff.

### #4752 — `image.tag` defaults to the chart `appVersion`

**Choice: default to `appVersion` (option 2), not docs-only.** `publish-ee-images.yml` already runs `helm package --version ${tag#v} --app-version ${tag#v}`, so the published chart's `appVersion` is always the release number; falling back to it makes `helm install --version X` pin the `X` images by construction, which is what `self-host.mdx` promised. The trade-off is the repository checkout, whose `Chart.yaml` has a placeholder `appVersion: 0.1.0`; a checkout install now needs `--set image.tag=…` (documented in the README's local-development section). Nothing in-repo installs the checkout without a tag: `evals/packages/env/src/kind-stack.ts` always passes `--set image.tag=`, and every `examples/values.*.yaml` sets `image.tag` explicitly.

- `templates/_helpers.tpl`: new `openwork-ee.imageTag` helper — component tag → `image.tag` → `.Chart.AppVersion`.
- The five image lines (den-api, den-web, inference, migration Job, env-probe test Job) use it.
- `values.yaml`: `image.tag: ""` with a comment.
- README + `self-host.mdx`: `--version` now pins chart *and* images; charts 0.18.46 and earlier ship `image.tag: latest`, so the docs say how to check (`helm show values … | grep -A1 '^image:'`) and to add `--set image.tag=X` on those. The observability quick start's install command now uses the OCI chart + `--version` instead of the checkout path.

### #4753 — migration hook on a cold first install

- `hookDeletePolicy` was **already** `before-hook-creation,hook-succeeded` and `backoffLimit: 2` was already set; both kept.
- `migrations.activeDeadlineSeconds`: `600` → `1800`. The deadline counts from Job creation and includes the ~800 MB den-api pull, and `backoffLimit` cannot help when the deadline is the limiting factor.
- README "First install on a cold cluster": explains the two timers (`activeDeadlineSeconds` and Helm `--timeout`, default 5m — raising the Job deadline alone is not enough), pre-pull (`crictl pull`) / mirroring for cold clusters, and recovery. Recovery note is based on a live test (below): with Helm ≥ 3.2.1 rerunning `helm upgrade --install` upgrades over a `failed` first revision and `before-hook-creation` replaces the failed Job; `helm uninstall` is only needed for `has no deployed releases` / `pending-install`.

Closes #4752
Closes #4753

## Verification

All commands from the branch; `helm` v3.20.2.

```
helm lint packaging/helm/openwork-ee                       # 1 chart(s) linted, 0 chart(s) failed
helm template openwork-ee packaging/helm/openwork-ee --set ingress.enabled=true --set inference.enabled=true   # ok
for t in packaging/helm/openwork-ee/tests/*.sh; do bash "$t"; done   # all 7 pass (same loop as publish-ee-images.yml)
```

New `tests/image-tag-and-migration-hook.sh` asserts: checkout render uses `Chart.yaml` appVersion for every `image:` line and never `:latest`; a chart packaged with `helm package --version 0.99.123 --app-version 0.99.123` renders `openwork-den-api|den-web|inference:0.99.123`; `image.tag` and `denWeb.image.tag` overrides win; each `examples/values.*.yaml` renders one consistent tag for all images; hook annotations `pre-install,pre-upgrade` and `"before-hook-creation,hook-succeeded"`, `activeDeadlineSeconds: 1800`, `backoffLimit: 2`.

Docs checks for the `self-host.mdx` line (`packages/docs`): `npx -y mint@4.2.868 validate` and `broken-links` both pass.

### Live install + upgrade (local kind via podman, not Daytona)

Chart packaged from this branch as `0.18.45` and `0.18.46` with `--app-version`, installed with **no `image.tag`** against an in-cluster MySQL 8.4, then upgraded:

```
REVISION  STATUS      CHART                 APP VERSION  DESCRIPTION
1         superseded  openwork-ee-0.18.45   0.18.45      Install complete
2         deployed    openwork-ee-0.18.46   0.18.46      Upgrade complete

05:03:52Z SuccessfulCreate openwork-ee-migrate          (pod image ghcr.io/different-ai/openwork-den-api:0.18.45)
05:03:58Z Completed        openwork-ee-migrate
05:03:58Z SuccessfulCreate openwork-ee-den-api-7f65568d77 / openwork-ee-den-web-7bb9667c49   ← after the hook
05:04:42Z SuccessfulCreate openwork-ee-migrate          (0.18.46)
05:04:45Z Completed        openwork-ee-migrate
05:04:45Z SuccessfulCreate openwork-ee-den-api-5c94bc75bc / openwork-ee-den-web-85bd79b5f9
```

Running pods: `openwork-den-api:0.18.45` / `openwork-den-web:0.18.45` after install, `:0.18.46` after upgrade; hook Job deleted by `hook-succeeded`; `helm test` env-probe `Succeeded` with `openwork-den-api:0.18.46`. Images were pre-pulled onto the node so the run fit the time budget — the cold-pull timing itself was not reproduced.

Failed-first-install recovery (same cluster, busybox stand-in with `migrations.args={exit 1}`): install → `failed pre-install: job … failed: BackoffLimitExceeded`, release `failed`; rerunning `helm upgrade --install` (args `exit 0`) → revision 2 `deployed`, no `helm uninstall` needed, failed Job replaced.

Bonus for #4765: through the in-cluster den-web port-forward, `GET /api/den/openapi.json` → `307 -> http://openwork-ee-den-api:8788/openapi.json` (the reported bug), while `GET /api/auth/get-session` → `200 null` and den-api's access log shows `http_route: /api/auth/*` 200.

Daytona was not used: the sandboxes there are unprivileged containers, so a local kind cluster was the cheaper live lane.