### PR TITLE
fix(app): recover Connect after transient startup failures

### DIFF
--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -1,12 +1,15 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   mintCloudControlMcpToken,
   readDenSettings,
+  DenApiError,
   type DenMcpToken,
   type DenSettings,
 } from "../../../app/lib/den";
 import { recordInspectorEvent } from "../../../app/lib/app-inspector";
+import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
+import type { DenAuthStatus } from "../cloud/den-auth-provider";
 import {
   OpenworkServerError,
   type OpenworkCloudMcpFailure,
@@ -30,7 +33,9 @@ import {
 export const SESSION_MCP_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
 export const SESSION_MCP_MAINTENANCE_TIMEOUT_MS = 2 * 60 * 1000;
 export const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
-export const CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS = [1_000, 3_000];
+// Keep the quick warmup retries, then cover a short startup outage without
+// waiting for navigation or the ordinary five-minute maintenance interval.
+export const CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS = [1_000, 3_000, 10_000, 30_000, 60_000];
 
 type CloudMcpMaintenanceClient = CloudMcpClient & Pick<OpenworkServerClient, "listMcp">;
 
@@ -102,6 +107,37 @@ function failedCloudMcpBackgroundSync(input: {
   };
 }
 
+function cloudMcpMaintenanceFailure(error: unknown): CloudMcpBackgroundSyncResult {
+  return failedCloudMcpBackgroundSync({
+    health: null,
+    issue: error instanceof OpenworkServerError || error instanceof DenApiError
+      ? genericCloudMcpMaintenanceIssue({
+          code: error.code,
+          message: error.message,
+          // policy_unavailable is verification failure, not a policy denial.
+          retryable: error.code === "policy_unavailable" || error.status === 408
+            || error.status === 429 || error.status >= 500,
+        })
+      : undefined,
+  });
+}
+
+export function waitForCloudMcpRetry(delayMs: number, signal?: AbortSignal, onlineTarget?: EventTarget): Promise<void> {
+  signal?.throwIfAborted();
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      onlineTarget?.removeEventListener("online", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, delayMs);
+    // Wake on cancellation; the retry loop checks the signal before attempting.
+    signal?.addEventListener("abort", finish, { once: true });
+    onlineTarget?.addEventListener("online", finish, { once: true });
+  });
+}
+
 export function getSessionMcpMaintenanceTargetKey(input: {
   client: Pick<OpenworkServerClient, "baseUrl">;
   cloudSignedIn: boolean;
@@ -131,12 +167,15 @@ function maintenanceErrorDetail(error: unknown): string {
 
 export async function runSessionMcpMaintenanceTask(input: {
   targetKey: string;
-  task: () => Promise<void>;
+  task: (signal: AbortSignal) => Promise<void>;
+  signal?: AbortSignal;
   timeoutMs?: number;
 }): Promise<boolean> {
   if (maintenanceInFlight.has(input.targetKey)) return false;
   const runToken = Symbol("session-mcp-maintenance-run");
   maintenanceInFlight.set(input.targetKey, runToken);
+  const controller = new AbortController();
+  const signal = input.signal ? AbortSignal.any([input.signal, controller.signal]) : controller.signal;
   // A hung await inside one tick must not wedge every future tick for this
   // target (field incident: maintenance stayed blocked until app restart).
   // The run token keeps a late-settling task from releasing a newer run's
@@ -148,11 +187,14 @@ export async function runSessionMcpMaintenanceTask(input: {
   };
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timedOut = new Promise<MaintenanceTaskSettled>((resolve) => {
-    timer = setTimeout(() => resolve({ kind: "timed_out" }), input.timeoutMs ?? SESSION_MCP_MAINTENANCE_TIMEOUT_MS);
+    timer = setTimeout(() => {
+      resolve({ kind: "timed_out" });
+      controller.abort();
+    }, input.timeoutMs ?? SESSION_MCP_MAINTENANCE_TIMEOUT_MS);
   });
   try {
     const settled = await Promise.race([
-      input.task().then(
+      input.task(signal).then(
         (): MaintenanceTaskSettled => ({ kind: "ok" }),
         (error: unknown): MaintenanceTaskSettled => ({ kind: "error", detail: maintenanceErrorDetail(error) }),
       ),
@@ -180,7 +222,19 @@ export async function syncCloudControlMcpInBackground(input: {
   settings?: DenSettings;
   mintToken?: () => Promise<DenMcpToken | null>;
   providerModel?: OpenworkCloudMcpProviderModelContext;
+  isCurrent?: () => boolean;
 }): Promise<CloudMcpBackgroundSyncResult> {
+  // Fence every asynchronous boundary, not just React state updates. A late
+  // probe or token mint must not register credentials for an obsolete target.
+  const guarded = async <T,>(operation: () => Promise<T>): Promise<T> => {
+    const check = () => {
+      if (input.isCurrent?.() === false) throw new DOMException("MCP maintenance context changed", "AbortError");
+    };
+    check();
+    const result = await operation();
+    check();
+    return result;
+  };
   const workspaceId = input.workspaceId.trim();
   const settings = input.settings ?? readDenSettings();
   const orgId = settings.activeOrgId?.trim() ?? "";
@@ -203,12 +257,10 @@ export async function syncCloudControlMcpInBackground(input: {
   // its own message instead of collapsing into the generic maintenance banner.
   let listed: Awaited<ReturnType<CloudMcpMaintenanceClient["listMcp"]>>;
   try {
-    listed = await input.client.listMcp(workspaceId);
+    listed = await guarded(() => input.client.listMcp(workspaceId));
   } catch (error) {
-    if (error instanceof OpenworkServerError) {
-      return failedCloudMcpBackgroundSync({ health: null, code: error.code, message: error.message });
-    }
-    throw error;
+    if (error instanceof Error && error.name === "AbortError") throw error;
+    return cloudMcpMaintenanceFailure(error);
   }
   const configured = listed.items.find((entry) => entry.name === CLOUD_MCP_SERVER_NAME);
   if (configured?.config.enabled === false) {
@@ -227,7 +279,11 @@ export async function syncCloudControlMcpInBackground(input: {
 
   const result = await runOpenworkCloudMcpReconciler({
     mode: "repair",
-    client: input.client,
+    client: {
+      baseUrl: input.client.baseUrl,
+      getOpenworkCloudMcpHealth: (...args) => guarded(() => input.client.getOpenworkCloudMcpHealth(...args)),
+      reconcileOpenworkCloudMcp: (...args) => guarded(() => input.client.reconcileOpenworkCloudMcp(...args)),
+    },
     context: {
       ...scope,
       denAuthToken: settings.authToken,
@@ -237,9 +293,7 @@ export async function syncCloudControlMcpInBackground(input: {
       providerModel: input.providerModel,
       trigger: input.force ? "desktop-background-forced" : "desktop-background",
     },
-    mintToken: input.mintToken
-      ? async () => input.mintToken?.() ?? null
-      : mintCloudControlMcpToken,
+    mintToken: (context) => guarded(() => input.mintToken ? input.mintToken() : mintCloudControlMcpToken(context)),
     force: input.force,
     // Session maintenance is the automatic upgrade path for already-signed-in
     // desktops. OpenCode can keep reporting a stale Cloud MCP entry as
@@ -291,6 +345,7 @@ export async function runCloudMcpMaintenanceWithRetry(input: {
   attempt: () => Promise<CloudMcpBackgroundSyncResult>;
   retryDelaysMs?: number[];
   wait?: (delayMs: number) => Promise<void>;
+  signal?: AbortSignal;
   onAttempt?: (input: {
     result: CloudMcpBackgroundSyncResult;
     attempt: number;
@@ -299,17 +354,24 @@ export async function runCloudMcpMaintenanceWithRetry(input: {
   }) => void;
 }): Promise<CloudMcpBackgroundSyncResult> {
   const retryDelaysMs = input.retryDelaysMs ?? CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS;
-  const wait = input.wait ?? ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  const wait = input.wait ?? ((delayMs: number) => waitForCloudMcpRetry(delayMs, input.signal));
   const maxAttempts = 1 + retryDelaysMs.length;
   let lastResult: CloudMcpBackgroundSyncResult | null = null;
 
   for (let index = 0; index < maxAttempts; index += 1) {
+    input.signal?.throwIfAborted();
     if (index > 0) await wait(retryDelaysMs[index - 1] ?? 0);
+    input.signal?.throwIfAborted();
     try {
       lastResult = await input.attempt();
-    } catch {
-      lastResult = failedCloudMcpBackgroundSync({ health: null });
+    } catch (error) {
+      // A different target can share the reconciler's in-flight promise. If
+      // that owner was superseded, only its own retry loop is cancelled; the
+      // current target retries after the shared operation has settled.
+      input.signal?.throwIfAborted();
+      lastResult = cloudMcpMaintenanceFailure(error);
     }
+    input.signal?.throwIfAborted();
     const willRetry = lastResult.outcome === "failed"
       && lastResult.issue.retryable
       && index < maxAttempts - 1;
@@ -348,6 +410,7 @@ export async function healWorkspaceMcpInBackground(input: {
 
 export function useSessionMcpMaintenance(input: {
   cloudSignedIn: boolean;
+  cloudAuthStatus?: DenAuthStatus;
   client: OpenworkServerClient | null;
   workspaceId: string | null;
   opencodeClient: Client | null;
@@ -358,6 +421,13 @@ export function useSessionMcpMaintenance(input: {
   const [cloudMcpState, setCloudMcpState] = useState<SessionCloudMcpMaintenanceState>(
     IDLE_CLOUD_MCP_MAINTENANCE_STATE,
   );
+  const [settingsVersion, setSettingsVersion] = useState(0);
+  const settings = useMemo(() => readDenSettings(), [input.cloudSignedIn, settingsVersion]);
+  useEffect(() => {
+    const refresh = () => setSettingsVersion((version) => version + 1);
+    window.addEventListener(denSettingsChangedEvent, refresh);
+    return () => window.removeEventListener(denSettingsChangedEvent, refresh);
+  }, []);
 
   useEffect(() => {
     if (input.engineReloadBusy) {
@@ -374,7 +444,6 @@ export function useSessionMcpMaintenance(input: {
       setCloudMcpState(IDLE_CLOUD_MCP_MAINTENANCE_STATE);
       return;
     }
-    const settings = readDenSettings();
     const targetKey = getSessionMcpMaintenanceTargetKey({
       client,
       cloudSignedIn: input.cloudSignedIn,
@@ -385,6 +454,13 @@ export function useSessionMcpMaintenance(input: {
     });
 
     let cancelled = false;
+    let running = false;
+    const controller = new AbortController();
+    const isCurrent = () => {
+      const current = readDenSettings();
+      return !cancelled && current.baseUrl === settings.baseUrl
+        && current.authToken === settings.authToken && current.activeOrgId === settings.activeOrgId;
+    };
     let busyRetryTimer: number | null = null;
     setCloudMcpState(input.cloudSignedIn
       ? { ...IDLE_CLOUD_MCP_MAINTENANCE_STATE, status: "checking" }
@@ -408,7 +484,7 @@ export function useSessionMcpMaintenance(input: {
         stage: issue?.stage ?? null,
         retryable: issue?.retryable ?? null,
       });
-      if (cancelled) return;
+      if (!isCurrent()) return;
       setCloudMcpState({
         status: attemptInput.result.outcome === "ready"
           ? "ready"
@@ -432,20 +508,29 @@ export function useSessionMcpMaintenance(input: {
     };
 
     const tick = async () => {
-      if (cancelled) return;
+      if (!isCurrent() || running) return;
+      running = true;
       const started = await runSessionMcpMaintenanceTask({
         targetKey,
-        task: async () => {
+        signal: controller.signal,
+        // Backoff time must not consume the existing work watchdog budget.
+        timeoutMs: SESSION_MCP_MAINTENANCE_TIMEOUT_MS + CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS.reduce((sum, delay) => sum + delay, 0),
+        task: async (signal) => {
           if (input.cloudSignedIn) {
             await runCloudMcpMaintenanceWithRetry({
+              signal,
+              wait: (delay) => waitForCloudMcpRetry(delay, signal, window),
               attempt: () => syncCloudControlMcpInBackground({
                 client,
                 workspaceId,
+                settings,
+                isCurrent: () => !signal.aborted && isCurrent(),
                 providerModel: input.providerModel,
               }),
               onAttempt: recordCloudAttempt,
             });
           }
+          if (signal.aborted || !isCurrent()) return;
           await healWorkspaceMcpInBackground({
             client,
             workspaceId,
@@ -457,6 +542,7 @@ export function useSessionMcpMaintenance(input: {
           });
         },
       });
+      running = false;
       if (!started) scheduleBusyRetry();
     };
 
@@ -470,6 +556,7 @@ export function useSessionMcpMaintenance(input: {
     const interval = window.setInterval(() => void tick(), SESSION_MCP_MAINTENANCE_INTERVAL_MS);
     return () => {
       cancelled = true;
+      controller.abort();
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("focus", handleFocus);
       window.clearInterval(interval);
@@ -478,12 +565,16 @@ export function useSessionMcpMaintenance(input: {
   }, [
     input.client,
     input.cloudSignedIn,
+    input.cloudAuthStatus,
     input.directory,
     input.engineReloadBusy,
     input.opencodeClient,
     input.providerModel?.model,
     input.providerModel?.provider,
     input.workspaceId,
+    settings.baseUrl,
+    settings.authToken,
+    settings.activeOrgId,
   ]);
 
   return cloudMcpState;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -585,6 +585,7 @@ export function SessionRoute() {
     : undefined, [local.prefs.defaultModel?.modelID, local.prefs.defaultModel?.providerID]);
   const sessionMcpMaintenance = useSessionMcpMaintenance({
     cloudSignedIn: denAuth.isSignedIn,
+    cloudAuthStatus: denAuth.status,
     client: selectedWorkspaceEndpoint?.client ?? null,
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     opencodeClient,

--- a/apps/app/tests/session-mcp-maintenance.test.ts
+++ b/apps/app/tests/session-mcp-maintenance.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
-import type { DenMcpToken, DenSettings } from "../src/app/lib/den";
-import type { OpenworkCloudMcpHealth, OpenworkCloudMcpReconcilePayload } from "../src/app/lib/openwork-server";
+import { DenApiError, type DenMcpToken, type DenSettings } from "../src/app/lib/den";
+import { OpenworkServerError, type OpenworkCloudMcpHealth, type OpenworkCloudMcpReconcilePayload } from "../src/app/lib/openwork-server";
 import {
   __setCloudMcpUserStateStorageForTest,
   readCloudMcpSyncMarker,
@@ -13,6 +13,7 @@ import {
   runCloudMcpMaintenanceWithRetry,
   runSessionMcpMaintenanceTask,
   syncCloudControlMcpInBackground,
+  waitForCloudMcpRetry,
 } from "../src/react-app/domains/connections/use-session-mcp-maintenance";
 
 const NOW = Date.parse("2026-07-09T12:00:00.000Z");
@@ -274,6 +275,187 @@ describe("session MCP maintenance", () => {
     })).resolves.toMatchObject({ outcome: "ready", status: "unchanged" });
     expect(mintCount).toBe(0);
     expect(writeCount).toBe(0);
+  });
+
+  test("startup recovers after the original retry burst without a navigation or online event", async () => {
+    let elapsed = 0;
+    let checks = 0;
+    let writes = 0;
+    const waits: number[] = [];
+    const result = await runCloudMcpMaintenanceWithRetry({
+      attempt: () => syncCloudControlMcpInBackground({
+        client: {
+          baseUrl: "https://worker.openwork.test",
+          listMcp: async () => ({ items: [] }),
+          getOpenworkCloudMcpHealth: async () => {
+            checks += 1;
+            if (elapsed < 10_000) throw new TypeError("Failed to fetch");
+            return cloudHealth(false);
+          },
+          reconcileOpenworkCloudMcp: async () => { writes += 1; return cloudHealth(true); },
+        },
+        settings: SETTINGS,
+        workspaceId: WORKSPACE_ID,
+        now: NOW,
+        mintToken: async () => MINTED,
+      }),
+      wait: async (delay) => { waits.push(delay); elapsed += delay; },
+    });
+    expect(result).toMatchObject({ outcome: "ready" });
+    expect(waits).toEqual([1_000, 3_000, 10_000]);
+    expect(checks).toBe(4);
+    expect(writes).toBe(1);
+  });
+
+  test("persistent policy unavailability has a finite backoff, but authorization denial is terminal", async () => {
+    for (const { code, expectedAttempts } of [
+      { code: "policy_unavailable", expectedAttempts: 6 },
+      { code: "forbidden", expectedAttempts: 1 },
+      { code: "unauthorized", expectedAttempts: 1 },
+    ]) {
+      let attempts = 0;
+      const waits: number[] = [];
+      const result = await runCloudMcpMaintenanceWithRetry({
+        attempt: () => syncCloudControlMcpInBackground({
+          client: {
+            baseUrl: "https://worker.openwork.test",
+            listMcp: async () => { attempts += 1; throw new OpenworkServerError(403, code, "Blocked"); },
+            getOpenworkCloudMcpHealth: async () => { throw new Error("must not probe"); },
+            reconcileOpenworkCloudMcp: async () => { throw new Error("must not register"); },
+          },
+          settings: SETTINGS,
+          workspaceId: WORKSPACE_ID,
+          mintToken: async () => { throw new Error("must not mint"); },
+        }),
+        wait: async (delay) => { waits.push(delay); },
+      });
+      expect(result).toMatchObject({ outcome: "failed", issue: { code, retryable: code === "policy_unavailable" } });
+      expect(attempts).toBe(expectedAttempts);
+      expect(waits).toEqual(code === "policy_unavailable" ? [1_000, 3_000, 10_000, 30_000, 60_000] : []);
+    }
+  });
+
+  test("online wakes a pending backoff without starting a second maintenance run", async () => {
+    const online = new EventTarget();
+    let attempts = 0;
+    const run = runCloudMcpMaintenanceWithRetry({
+      retryDelaysMs: [60_000],
+      attempt: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new TypeError("Failed to fetch");
+        return { outcome: "ready", status: "unchanged", health: cloudHealth(true) };
+      },
+      wait: (delay) => {
+        const waiting = waitForCloudMcpRetry(delay, undefined, online);
+        online.dispatchEvent(new Event("online"));
+        return waiting;
+      },
+    });
+    expect(await run).toMatchObject({ outcome: "ready" });
+    expect(attempts).toBe(2);
+  });
+
+  test("an authorization denial from the Den token endpoint is not treated as a network failure", async () => {
+    let mints = 0;
+    let writes = 0;
+    const waits: number[] = [];
+    const result = await runCloudMcpMaintenanceWithRetry({
+      attempt: () => syncCloudControlMcpInBackground({
+        client: {
+          baseUrl: "https://worker.openwork.test",
+          listMcp: async () => ({ items: [] }),
+          getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+          reconcileOpenworkCloudMcp: async () => { writes += 1; return cloudHealth(true); },
+        },
+        settings: SETTINGS,
+        workspaceId: WORKSPACE_ID,
+        mintToken: async () => { mints += 1; throw new DenApiError(403, "forbidden", "Membership denied"); },
+      }),
+      wait: async (delay) => { waits.push(delay); },
+    });
+    expect(result).toMatchObject({ outcome: "failed", issue: { code: "forbidden", retryable: false, message: "Membership denied" } });
+    expect(mints).toBe(1);
+    expect(writes).toBe(0);
+    expect(waits).toEqual([]);
+  });
+
+  test("a current target retries a shared repair cancelled by a superseded model", async () => {
+    let release = () => {};
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    let current = true;
+    let probes = 0;
+    let writes = 0;
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({ items: [] }),
+      getOpenworkCloudMcpHealth: async () => { probes += 1; await pending; return cloudHealth(false); },
+      reconcileOpenworkCloudMcp: async () => { writes += 1; return cloudHealth(true); },
+    };
+    const old = syncCloudControlMcpInBackground({
+      client, settings: SETTINGS, workspaceId: WORKSPACE_ID, mintToken: async () => MINTED,
+      providerModel: { provider: "openwork", model: "old" }, isCurrent: () => current,
+    });
+    const oldRejection = old.then(
+      () => { throw new Error("obsolete repair must be cancelled"); },
+      (error: unknown) => error,
+    );
+    // Let both list calls join the same pending probe.
+    await Promise.resolve();
+    const replacement = runCloudMcpMaintenanceWithRetry({
+      signal: new AbortController().signal,
+      attempt: () => syncCloudControlMcpInBackground({
+        client, settings: SETTINGS, workspaceId: WORKSPACE_ID, mintToken: async () => MINTED,
+        providerModel: { provider: "openwork", model: "new" },
+      }),
+      wait: async () => {},
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    current = false;
+    release();
+    expect(await oldRejection).toMatchObject({ name: "AbortError" });
+    expect(await replacement).toMatchObject({ outcome: "ready" });
+    expect(probes).toBe(2);
+    expect(writes).toBe(1);
+  });
+
+  test("cancels the sleeping retry when its workspace or account becomes obsolete", async () => {
+    const controller = new AbortController();
+    let attempts = 0;
+    const run = runCloudMcpMaintenanceWithRetry({
+      signal: controller.signal,
+      attempt: async () => { attempts += 1; throw new TypeError("Failed to fetch"); },
+      wait: (delay) => {
+        const waiting = waitForCloudMcpRetry(delay, controller.signal);
+        controller.abort();
+        return waiting;
+      },
+    });
+    await expect(run).rejects.toMatchObject({ name: "AbortError" });
+    expect(attempts).toBe(1);
+  });
+
+  test("a late token mint cannot register into an obsolete workspace or write a readiness marker", async () => {
+    let current = true;
+    let writes = 0;
+    const run = syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: "https://worker.openwork.test",
+        listMcp: async () => ({ items: [] }),
+        getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+        reconcileOpenworkCloudMcp: async () => { writes += 1; return cloudHealth(true); },
+      },
+      settings: SETTINGS,
+      workspaceId: WORKSPACE_ID,
+      mintToken: async () => { current = false; return MINTED; },
+      isCurrent: () => current,
+    });
+    await expect(run).rejects.toMatchObject({ name: "AbortError" });
+    expect(writes).toBe(0);
+    expect(readCloudMcpSyncMarker({
+      denBaseUrl: SETTINGS.baseUrl, serverBaseUrl: "https://worker.openwork.test",
+      orgId: SETTINGS.activeOrgId ?? "", workspaceId: WORKSPACE_ID,
+    })).toBe(null);
   });
 
   test("direct-probes session maintenance so upgraded desktops silently remint missing MCP bearer failures", async () => {

--- a/evals/specs/connect-readiness-preseeded.e2e.test.ts
+++ b/evals/specs/connect-readiness-preseeded.e2e.test.ts
@@ -14,15 +14,44 @@ import {
 
 const test = spec.world(preseededConnect, { timeout: 600_000 });
 
-test("bundled engine connects to preseeded organization skills and connections", async ({ world, user, agent, seed, probe, step, evidence }) => {
-  await user.click("Library");
-  await user.see({ text: "Library" });
+test("bundled engine recovers from a startup outage and uses preseeded organization skills and connections", async ({ world, user, agent, seed, probe, step, evidence }) => {
+  await user.see("composer", { editable: true });
+  const taskRoute = await probe.hash();
+  expect(taskRoute).toBe(`#/workspace/${world.workspaceId}/session`);
   const signedOut = await probe.connectState(world.app);
   expect(signedOut).toMatchObject({ status: "missing", connectEnabled: false });
   expect(signedOut).not.toMatchObject({ status: "available" });
   await user.screenshot();
 
-  await seed.signIn(world.app, world.member, "admin");
+  const tokenRequests = async () => (await world.proxy.requestLog())
+    .filter((request) => request.method === "POST" && request.path === world.tokenPath);
+  const firstFailure = await step("desktop startup maintenance encounters a sustained token-mint outage", async () => {
+    await seed.signIn(world.app, world.member, "admin");
+    const first = await probe.eventually(async () => (await tokenRequests())
+      .find((request) => request.faulted && request.status === 503), {
+      within: 60_000,
+      label: "the desktop reaches the startup token-mint fault",
+    });
+    if (!first) throw new Error("Desktop startup did not encounter the token-mint fault.");
+
+    // Measure from an observed desktop failure, not world boot: slow startup
+    // must not consume the outage before maintenance ever reaches it.
+    const observedAt = Date.now();
+    const outage = await probe.eventually(async () => ({
+      requests: await tokenRequests(),
+      heldForMs: Date.now() - observedAt,
+    }), {
+      within: 60_000,
+      label: "startup remains unavailable beyond the initial 1s/3s retry burst",
+      until: (value) => value.heldForMs >= 10_000 && value.requests.length >= 3,
+    });
+    expect(outage.requests.every((request) => request.faulted && request.status === 503)).toBe(true);
+    expect(await probe.desktopApi(`/workspace/${world.workspaceId}/mcp/openwork-cloud/health`))
+      .toMatchObject({ status: 200, body: { usable: false } });
+    expect(await probe.hash()).toBe(taskRoute);
+    return first;
+  });
+
   const signedIn = await probe.eventually(
     () => probe.connectState(world.app),
     {
@@ -32,6 +61,19 @@ test("bundled engine connects to preseeded organization skills and connections",
     },
   );
   expect(signedIn).toMatchObject({ status: "available", connectEnabled: true });
+
+  await step("restore connectivity without navigation, reload, focus, online, or manual retry", async () => {
+    await world.proxy.faults.clear();
+    await world.proxy.faults.status("/api/runtime-config", 200, { times: 1000, body: world.runtimeConfig });
+  });
+
+  // Observe UI convergence before asking the server to probe health: the test
+  // must not supply the recovery trigger it is asserting happens automatically.
+  await probe.eventually(() => probe.dom('[data-testid="account-status-menu"][data-connect-state="ready"]'), {
+    within: 120_000,
+    label: "the task screen reports Connect ready after background recovery",
+    until: (value) => value.elements.length === 1,
+  });
 
   const health = await probe.eventually(
     // TODO(primitive): probe.cloudMcpHealth
@@ -63,6 +105,14 @@ test("bundled engine connects to preseeded organization skills and connections",
     "openwork-cloud_search_capabilities",
     "openwork-cloud_execute_capability",
   ]));
+  const recoveredMint = (await tokenRequests()).find((request) => !request.faulted && request.status === 200);
+  if (!recoveredMint) throw new Error("Connect became ready without a successful desktop token mint through the restored connection.");
+  // Exclude the five-minute maintenance interval as the recovery mechanism.
+  expect(recoveredMint.at - firstFailure.at).toBeLessThan(120_000);
+  expect(await probe.hash()).toBe(taskRoute);
+  await user.see("composer", { editable: true });
+  evidence.recordAssertionEvidence("Connect recovers from a startup outage without a UI recovery action",
+    "The desktop encountered at least three HTTP 503 token-mint failures over a fault held for at least ten seconds after an observed failure. A later background mint succeeded within two minutes of the first failure; the unchanged task route reported Ready with both engine and direct Cloud tools present before any navigation or agent send.", true);
 
   await step("the preseeded skill is discovered and executed", async () => {
     const search = await seed.api(world.mcpSession, "/mcp/agent", {

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -291,14 +291,19 @@ export async function preseededConnect(seed: Seed) {
   });
   if (provider.response.status !== 201) throw new Error(`Could not publish the Connect fixture model: HTTP ${provider.response.status}`);
   const mcpSession = await mintMcpSession(seed, den, organizationId);
-  const app = await seed.desktop({ den, signIn: false });
+  const proxy = await seed.faultProxy(den);
+  // Keep desktop handoff and subsequent token mints on the shaped connection.
+  const runtimeConfig = { denApiUrl: proxy.ref.apiUrl };
+  await proxy.faults.status("/api/runtime-config", 200, { times: 1000, body: runtimeConfig });
+  const tokenPath = "/api/den/v1/mcp/token";
+  await proxy.faults.status(tokenPath, 503, { times: 1000, body: { error: "connect_startup_unavailable" } });
+  const app = await seed.desktop({ den: { ...den, ref: proxy.ref }, signIn: false });
   const workspace = await seed.workspace(app, seed.tmpPath("preseeded-connect"));
-  // TODO(primitive): seed.route
-  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [workspace.workspaceId]));
+  // Stay on the task route: Settings has its own reconciliation path.
   return {
-    app, den, prompt, proofPhrase, providerName, modelId,
+    app, den, proxy, runtimeConfig, tokenPath, prompt, proofPhrase, providerName, modelId,
     admin: den.admin,
-    member: den.admin,
+    member: { ...den.admin, ...proxy.ref },
     mcpSession,
     pluginId,
     rawSourceText,


### PR DESCRIPTION
## Problem

A transient startup outage can outlast the initial Connect maintenance attempt and its 1s/3s retries. The workspace then keeps showing Needs attention until another lifecycle trigger or the five-minute maintenance tick. Authentication can also recover without changing the signed-in boolean.

## Changes

- Keep the quick retries, then back off by 10s, 30s, and 60s: six attempts total, stopping on success or explicit terminal denial. The ordinary five-minute interval is unchanged.
- Wake a pending backoff when connectivity returns without starting a duplicate maintenance run.
- Observe authentication status and account-setting changes; pin settings to each run and cancel obsolete waits.
- Fence probes, token mints, registrations, and readiness-marker updates against stale workspace/account context.
- Preserve structured authorization errors. Cancellation inherited from an obsolete shared repair does not cancel its current replacement.
- Extend the existing maintenance tests and Connect-readiness journey.

No updater change, policy bypass, forced engine reload loop, or permanent high-frequency polling is introduced. This addresses an existing recovery gap, not a demonstrated updater or network root cause. The short retry burst traces to #2779 / #2796; adjacent policy, registration, and Automation changes are not established causes.

## Verification — Incomplete

Current signed head: `66fa2b65a465743c4194a1098fd0e60f855d05d5`.
Rebased onto `dev@d37c72280b0bf4547e6ec6b41b2e5bcfc437c293`, preserving the intended five-file patch.

Passed on this head:

```sh
corepack pnpm --config.verify-deps-before-run=false --filter @openwork/app exec bun test --isolate ./tests/session-mcp-maintenance.test.ts ./src/react-app/domains/connections/use-session-mcp-maintenance.managed-degraded.test.ts
# exit 0; 18 passed, 0 failed, 0 skipped; 67 assertions
corepack pnpm --config.verify-deps-before-run=false --filter @openwork/app typecheck
# exit 0
git diff --check d37c72280b0bf4547e6ec6b41b2e5bcfc437c293...HEAD
# exit 0
```

The focused tests cover post-burst recovery, bounded persistent failure, explicit policy/auth denials, token-endpoint denial, online wake-up, stale cancellation and late mint, shared-repair cancellation, deduplication, and disabled intent. The earlier retry-schedule mutation demonstrated that the new recovery assertion fails with the old schedule; that is supporting component evidence, not installed-desktop proof.

**Missing proof:** `pnpm evals:e2e connect-readiness-preseeded` remains unrun. No cold-boot covering journey is claimed for this head. The extended journey sustains token-mint 503s past the old burst, restores transport, observes UI Ready before health probing, requires the task route to remain unchanged, and retains real tool/skill execution assertions. Final local review is also deferred.

**Evidence clarification:** the earlier 6-test/7-assertion evidence at `8f9f6d6230da9c574a6d4ac9486e640a95547b65` covers packaged boot, first launch, activation, and updater gating. It does not prove Connect startup-outage recovery and is historical after this rebase. Generic packaged-smoke evidence must not be presented as the covering recovery journey.

Earlier investigation-only static-check failures were not rerun or clean-control classified in this refresh; they are not current-head passing claims.

## Remaining boundary

Server policy fetching still maps some upstream denials and transport failures to `403 policy_unavailable`. The client cannot reconstruct that hidden classification: those failures remain blocked and receive bounded retries. Explicit client/token-endpoint denials stop the burst. Already-dispatched requests cannot be recalled; server policy and identity enforcement remain authoritative.
