### PR TITLE
feat(release): add opt-in Slack release announcements

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,6 +28,8 @@ jobs:
     if: github.repository == 'different-ai/openwork'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    outputs:
+      stable: ${{ steps.guard.outputs.stable }}
     env:
       BASE_BRANCH: dev
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
@@ -211,3 +213,34 @@ jobs:
             --existing-body /tmp/existing_release_body.md > /tmp/release_notes.md
           gh release edit "$TAG" --notes-file /tmp/release_notes.md
           echo "Replaced the static release body of $TAG with the generated changelog entry."
+
+  notify-slack:
+    # Never expose the Slack secret to the agent-writable changelog checkout.
+    # This fresh job executes only the notifier from the protected dev branch.
+    needs: changelog
+    if: needs.changelog.outputs.stable == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 3
+    continue-on-error: true
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout trusted notifier
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Notify Slack of published release
+        timeout-minutes: 2
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_RELEASE_CHANNEL_ID: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
+        run: node scripts/release/notify-slack.mjs

--- a/docs/release-slack-announcements.md
+++ b/docs/release-slack-announcements.md
@@ -1,0 +1,79 @@
+# Release Slack Announcements
+
+Optional notifications run in a separate job in `.github/workflows/changelog.yml`,
+only after generated GitHub Release notes update successfully. The publishing workflow
+already dispatches changelog generation for stable releases; it needs no change.
+Changelog failures prevent notification. Notification failures produce warnings
+but do not block the already-published release (`continue-on-error`). Published
+does not mean approved for customer rollout. The notification job checks out the
+protected `dev` branch afresh; the changelog-writing agent never receives the Slack
+secret, and its working files are not executed with that secret.
+
+## Setup
+
+1. Reuse the repository's `SLACK_BOT_TOKEN` Actions secret. The Slack bot needs
+   `chat:write` and membership in the target channel (invite the bot).
+2. Opt in with repository Actions variable `SLACK_RELEASE_CHANNEL_ID`. Recommended:
+   `#ai-dump` (`C0C18F7KF6C`), whose current content is AI-generated summaries and
+   automation. Use a channel ID, not a name. There is no hardcoded fallback.
+3. Leave the variable unset to disable notifications. Missing configuration,
+   including an absent Slack token on unrelated runs, skips all network calls.
+
+The step uses the existing `contents: write` GitHub token permission. It posts only
+validated repository/tag text and a canonical GitHub release link, never release
+titles or bodies. Mentions and link/media unfurls are disabled. GitHub credentials
+go only to `api.github.com`; Slack credentials go only to `slack.com`.
+
+Do not backfill: manually rerunning old tags without notification markers can
+announce historical releases after opt-in, including previously undocumented tags.
+These notifications follow release-note updates, not changelog PR merge approval.
+
+## Duplicate Prevention And Recovery
+
+The helper reads the live release by tag, requiring matching `vX.Y.Z`, a published
+timestamp, and both draft and prerelease flags false. Per-tag workflow concurrency
+serializes runs. Before Slack is contacted, the helper PATCHes the release body
+with `<!-- openwork-slack-release:pending -->`. After confirmed Slack success
+(`ok: true`, nonempty `ts`, matching channel), it replaces that marker with
+`<!-- openwork-slack-release:sent -->`. Release-note rewrites preserve both markers.
+
+Either marker suppresses future sends. A pending marker produces a warning and
+requires human verification, not an automatic retry. This is **not exactly-once
+delivery**: GitHub and Slack are not transactional. Failed/uncertain Slack sends or
+final marker updates do not clear pending state. A lost final PATCH response may
+mean GitHub already saved `sent`; either state still suppresses another send.
+
+For a warning, inspect the release body's HTML comment and the configured Slack
+channel for its canonical release link. If delivered, manually reconcile pending
+to sent. Remove pending and rerun only after establishing that no message was
+delivered; if uncertain, leave it pending. Never remove sent to repair release notes.
+A failed/unconfirmed pending prewrite makes no Slack call. Check bot membership,
+`chat:write`, channel ID, token validity, and GitHub release-write permission as
+appropriate. Provider error payloads and secrets are deliberately not logged.
+
+Requests have no retries, reject redirects, and time out after 15 seconds for
+GitHub or 30 seconds for Slack; the workflow step is bounded to two minutes and
+its separate job to three minutes.
+Disabling notifications or changing channels does not reset existing markers.
+
+## Helper Contract And Offline Verification
+
+`scripts/release/notify-slack.mjs` exports
+`async notifyRelease({ repository, tag, githubToken, slackToken, channel, request = fetch })`.
+It returns `{ status: "sent" }`, `{ status: "pending", reason:
+"manual-reconciliation-required" }`, or `{ status: "skipped", reason }` with reason
+`missing-config`, `not-published-stable-release`, or `already-sent`. Invalid config
+and failed/unconfirmed requests reject with sanitized errors. The CLI reads
+`GITHUB_REPOSITORY`, `TAG`, `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`, and
+`SLACK_RELEASE_CHANNEL_ID`; pending or errors emit a warning and exit nonzero.
+
+`slack-release-markers.mjs` exports `SLACK_RELEASE_PENDING_MARKER`,
+`SLACK_RELEASE_SENT_MARKER`, and `getSlackReleaseMarkers(body)`. The helper accepts
+a string and returns each exact marker present once, pending first, even if the
+body contains duplicates or inline markers.
+
+Use an injected `request` stub for dry/offline verification. There is no live
+test or CLI dry-run mode: running with complete real configuration mutates the
+release and can send Slack. Do not use real tokens or commit Slack transcripts or
+private data as fixtures. Syntax-only checks can use `node --check` on these
+scripts; specs are maintained separately.

--- a/evals/specs/slack-release-announcements.test.ts
+++ b/evals/specs/slack-release-announcements.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { text } from "node:stream/consumers";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { faultProxy, test } from "@openwork/testkit";
+
+const config = {
+  repository: "different-ai/openwork",
+  tag: "v0.18.38",
+  githubToken: "synthetic-github-only",
+  slackToken: "synthetic-slack-only",
+  channel: "C012RELEASE",
+};
+const { notifyRelease }: {
+  notifyRelease: (input: Partial<typeof config> & { request: typeof fetch }) => Promise<unknown>;
+} = await import(new URL("../../scripts/release/notify-slack.mjs", import.meta.url).href);
+
+const pending = "<!-- openwork-slack-release:pending -->";
+const sent = "<!-- openwork-slack-release:sent -->";
+const lookupPath = `/repos/${config.repository}/releases/tags/${config.tag}`;
+const patchPath = `/repos/${config.repository}/releases/42`;
+const slackPath = "/api/chat.postMessage";
+const stable = {
+  id: 42,
+  tag_name: config.tag,
+  draft: false,
+  prerelease: false,
+  published_at: "2026-09-10T10:00:00Z",
+  name: "UNTRUSTED TITLE <!channel> @everyone",
+  body: "UNTRUSTED BODY <!here> <@U123> @channel https://untrusted.invalid/notes",
+  html_url: "https://untrusted.invalid/release",
+};
+
+test("stable release notifications are credential-isolated, safe and at-most-once across provider failures", { timeout: 90_000 }, async ({ evidence }) => {
+  let release: Record<string, unknown> = { ...stable };
+  let slackReply: unknown = { ok: true, channel: config.channel, ts: "123.456" };
+  let slackMode = "json";
+  let unconfirmedPatch = false;
+  let failFinalPatch = false;
+  let patches = 0;
+  const requests: { method: string; path: string; headers: IncomingHttpHeaders; body: unknown }[] = [];
+  const witnessErrors: unknown[] = [];
+  const witness = createServer((incoming, response) => {
+    void (async () => {
+      const raw = await text(incoming);
+      const body: unknown = raw ? JSON.parse(raw) : null;
+      assert(incoming.method && incoming.url);
+      requests.push({ method: incoming.method, path: incoming.url, headers: incoming.headers, body });
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET" && incoming.url === lookupPath) {
+        response.end(JSON.stringify(release));
+      } else if (incoming.method === "PATCH" && incoming.url === patchPath) {
+        patches += 1;
+        assert(typeof body === "object" && body !== null && "body" in body && typeof body.body === "string");
+        if (failFinalPatch && patches === 2) {
+          response.writeHead(503);
+          response.end(JSON.stringify({ error: `${config.githubToken} must not escape` }));
+          return;
+        }
+        if (!unconfirmedPatch) release.body = body.body;
+        response.end(JSON.stringify(release));
+      } else if (incoming.method === "POST" && incoming.url === slackPath) {
+        if (slackMode === "timeout") {
+          // Slack has received the POST, but its response never completes. Use
+          // the notifier's real AbortSignal timeout, not a synthetic rejection.
+          response.writeHead(200);
+          response.write('{"ok":');
+        } else {
+          response.end(slackMode === "malformed" ? "not json" : JSON.stringify(slackReply));
+        }
+      } else {
+        throw new Error(`Unexpected witness route: ${incoming.method} ${incoming.url}`);
+      }
+    })().catch((error: unknown) => {
+      witnessErrors.push(error);
+      response.writeHead(500);
+      response.end("witness failed");
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    witness.once("error", reject);
+    witness.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = witness.address();
+    assert(address && typeof address === "object");
+    const origin = `http://127.0.0.1:${address.port}`;
+    await using proxy = await faultProxy({ apiUrl: origin, webUrl: origin });
+    const routes = new Map([
+      [`https://api.github.com${lookupPath}`, lookupPath],
+      [`https://api.github.com${patchPath}`, patchPath],
+      [`https://slack.com${slackPath}`, slackPath],
+    ]);
+    const requestedUrls: string[] = [];
+    const slackSignals: AbortSignal[] = [];
+    const request: typeof fetch = async (url, options) => {
+      assert(typeof url === "string");
+      requestedUrls.push(url);
+      const path = routes.get(url);
+      assert(path, `Provider URL is not allowlisted: ${url}`);
+      assert.equal(options?.redirect, "error");
+      assert(options?.signal instanceof AbortSignal);
+      if (path === slackPath) slackSignals.push(options.signal);
+      // Rewrite only the three exact provider URLs; preserve payload, headers,
+      // redirect policy and timeout signal through real HTTP and faultProxy.
+      return fetch(`${proxy.ref.webUrl}${path}`, options);
+    };
+    const run = (overrides: Partial<typeof config> = {}) => notifyRelease({ ...config, ...overrides, request });
+    let logStart = 0;
+    const trace = async () => (await proxy.requestLog()).slice(logStart).map(({ method, path }) => `${method} ${path}`);
+    const get = `GET ${lookupPath}`;
+    const patch = `PATCH ${patchPath}`;
+    const post = `POST ${slackPath}`;
+    const reset = async (overrides: Record<string, unknown> = {}) => {
+      release = { ...stable, ...overrides };
+      requests.length = 0;
+      requestedUrls.length = 0;
+      slackReply = { ok: true, channel: config.channel, ts: "123.456" };
+      slackMode = "json";
+      slackSignals.length = 0;
+      unconfirmedPatch = false;
+      failFinalPatch = false;
+      patches = 0;
+      logStart = (await proxy.requestLog()).length;
+      await proxy.faults.clear();
+    };
+    const proved = async (claim: string) => {
+      assert.deepEqual(witnessErrors, []);
+      for (const observed of requests) {
+        const slack = observed.path === slackPath;
+        assert.equal(observed.headers.authorization, `Bearer ${slack ? config.slackToken : config.githubToken}`);
+        assert(!JSON.stringify(observed).includes(slack ? config.githubToken : config.slackToken));
+      }
+      evidence.recordAssertionEvidence(claim, JSON.stringify({ requests: await trace(), body: release.body }), true);
+    };
+
+    assert.deepEqual(await run(), { status: "sent" });
+    assert.deepEqual(await trace(), [get, patch, post, patch]);
+    assert.deepEqual(requests.filter((entry) => entry.method === "PATCH").map((entry) => entry.body), [
+      { body: `${stable.body}\n\n${pending}` },
+      { body: `${stable.body}\n\n${sent}` },
+    ]);
+    assert.deepEqual(requests.find((entry) => entry.path === slackPath)?.body, {
+      channel: config.channel,
+      text: "different-ai/openwork v0.18.38 is published. Generated release notes: https://github.com/different-ai/openwork/releases/tag/v0.18.38\nPublication is not approval for customer rollout.",
+      mrkdwn: false,
+      parse: "none",
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+    assert.equal(release.body, `${stable.body}\n\n${sent}`);
+    assert.deepEqual(await run(), { status: "skipped", reason: "already-sent" });
+    assert.deepEqual(await trace(), [get, patch, post, patch, get]);
+    await proved("A stable release posts exactly once to the configured channel with only the canonical link, no untrusted title/body/mentions, and separate provider credentials");
+
+    for (const field of Object.keys(config)) {
+      for (const value of [undefined, "", " \t "]) {
+        await reset();
+        assert.deepEqual(await run({ [field]: value }), { status: "skipped", reason: "missing-config" });
+        assert.deepEqual(requestedUrls, []);
+        assert.deepEqual(await trace(), []);
+        assert.deepEqual(requests, []);
+        await proved(`Missing ${field} (${JSON.stringify(value)}) makes no provider request`);
+      }
+    }
+    for (const invalid of [
+      ...["0.18.38", "v0.18", "v0.18.38-beta.1", "v0.18.38+build", "v0.18.38\n", "v0.18.38/../latest", "v0.18.38<!channel>"].map((tag) => ({ tag })),
+      { repository: "different-ai/openwork/../other" },
+      { repository: "different-ai/.." },
+      { channel: "#releases" },
+      { channel: "C012RELEASE\n" },
+    ]) {
+      await reset();
+      await assert.rejects(run(invalid), { message: "Invalid release notification configuration." });
+      assert.deepEqual(requestedUrls, []);
+      assert.deepEqual(await trace(), []);
+      assert.deepEqual(requests, []);
+      await proved(`Invalid configuration ${JSON.stringify(invalid)} cannot reach a provider`);
+    }
+    for (const excluded of [
+      { draft: true }, { prerelease: true }, { published_at: null }, { published_at: "" },
+      { tag_name: "v0.18.39" }, { tag_name: "v0.18.38-beta.1" },
+    ]) {
+      await reset(excluded);
+      assert.deepEqual(await run(), { status: "skipped", reason: "not-published-stable-release" });
+      assert.deepEqual(await trace(), [get]);
+      assert.equal(release.body, stable.body);
+      await proved(`Release ${JSON.stringify(excluded)} is read but never patched or posted`);
+    }
+    for (const invalid of [{ id: 0 }, { draft: "false" }, { body: {} }, { published_at: 42 }]) {
+      await reset(invalid);
+      await assert.rejects(run(), { message: "Invalid GitHub release response." });
+      assert.deepEqual(await trace(), [get]);
+      await proved(`Malformed GitHub release ${JSON.stringify(invalid)} fails closed`);
+    }
+    for (const markers of [[pending], [sent], [pending, sent]]) {
+      const directory = await mkdtemp(join(tmpdir(), "slack-release-notes-"));
+      let body: string;
+      try {
+        const docs = join(directory, "changelog.mdx");
+        const existing = join(directory, "existing.md");
+        await writeFile(docs, `## [${config.tag}](https://github.com/${config.repository}/compare/v0.18.37...${config.tag}): Updated notes\n\n- A documented fix.\n`);
+        await writeFile(existing, `${stable.body}\n\n${markers.join("\n")}`);
+        const generated = await promisify(execFile)(process.execPath, [
+          fileURLToPath(new URL("../../scripts/release/release-notes-from-changelog.mjs", import.meta.url)),
+          config.tag, "--docs", docs, "--existing-body", existing,
+        ], { timeout: 10_000 });
+        body = generated.stdout;
+        assert(body.includes("A documented fix."));
+        assert(!body.includes("UNTRUSTED BODY"));
+        for (const marker of [pending, sent]) assert.equal(body.includes(marker), markers.includes(marker));
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+      await reset({ body });
+      const result = markers.includes(pending)
+        ? { status: "pending", reason: "manual-reconciliation-required" }
+        : { status: "skipped", reason: "already-sent" };
+      assert.deepEqual(await run(), result);
+      assert.deepEqual(await run(), result);
+      assert.deepEqual(await trace(), [get, get]);
+      assert.equal(release.body, body);
+      await proved(`${markers.join(" + ")} survives actual release-note regeneration and suppresses all writes on repeated runs`);
+    }
+    for (const failure of ["lookup", "prewrite", "unconfirmed-prewrite"]) {
+      await reset();
+      if (failure === "unconfirmed-prewrite") unconfirmedPatch = true;
+      else await proxy.faults.status(failure === "lookup" ? lookupPath : patchPath, 503);
+      await assert.rejects(run(), { message: failure === "lookup" ? "GitHub release lookup failed."
+        : failure === "prewrite" ? "GitHub notification marker update failed."
+          : "GitHub notification marker update was not confirmed." });
+      assert.deepEqual(await trace(), failure === "lookup" ? [get] : [get, patch]);
+      assert.equal(release.body, stable.body);
+      assert.equal(requests.filter((entry) => entry.path === slackPath).length, 0);
+      await proved(`${failure} prevents Slack from being called without a confirmed durable pending marker`);
+    }
+    for (const failure of [
+      { name: "rejected", reply: { ok: false, error: `${config.slackToken} rejected` } },
+      { name: "wrong-channel", reply: { ok: true, channel: "COTHER", ts: "123.456" } },
+      { name: "missing-timestamp", reply: { ok: true, channel: config.channel } },
+      { name: "blank-timestamp", reply: { ok: true, channel: config.channel, ts: " " } },
+      { name: "null", reply: null },
+      { name: "malformed" }, { name: "http-429" }, { name: "http-503" }, { name: "timeout" },
+    ]) {
+      await reset();
+      slackReply = failure.reply;
+      slackMode = failure.name;
+      if (failure.name.startsWith("http-")) {
+        await proxy.faults.status(slackPath, Number(failure.name.slice(5)), { body: { error: config.slackToken } });
+      }
+      const transportFailure = ["malformed", "http-429", "http-503", "timeout"].includes(failure.name);
+      await assert.rejects(run(), { message: transportFailure ? "Slack notification request failed."
+        : "Slack notification was not confirmed; the release remains pending." });
+      if (failure.name === "timeout") assert.equal(slackSignals.at(-1)?.aborted, true);
+      assert.equal(release.body, `${stable.body}\n\n${pending}`);
+      assert.deepEqual(await trace(), [get, patch, post]);
+      assert.deepEqual(await run(), { status: "pending", reason: "manual-reconciliation-required" });
+      assert.deepEqual(await trace(), [get, patch, post, get]);
+      assert.equal(release.body, `${stable.body}\n\n${pending}`);
+      await proved(`Slack ${failure.name} leaves pending, sanitizes provider errors, and never retries on rerun`);
+    }
+    await reset();
+    failFinalPatch = true;
+    await assert.rejects(run(), { message: "GitHub notification marker update failed." });
+    assert.equal(release.body, `${stable.body}\n\n${pending}`);
+    assert.equal(requests.filter((entry) => entry.path === slackPath).length, 1);
+    assert.deepEqual(await trace(), [get, patch, post, patch]);
+    assert.deepEqual(await run(), { status: "pending", reason: "manual-reconciliation-required" });
+    assert.deepEqual(await trace(), [get, patch, post, patch, get]);
+    assert.equal(release.body, `${stable.body}\n\n${pending}`);
+    await proved("A confirmed Slack send followed by a failed final PATCH preserves pending and cannot produce another POST");
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      witness.close((error) => error ? reject(error) : resolve());
+      witness.closeAllConnections();
+    });
+  }
+});

--- a/scripts/release/notify-slack.mjs
+++ b/scripts/release/notify-slack.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import {
+  getSlackReleaseMarkers,
+  SLACK_RELEASE_PENDING_MARKER,
+  SLACK_RELEASE_SENT_MARKER,
+} from "./slack-release-markers.mjs";
+
+export async function notifyRelease({ repository, tag, githubToken, slackToken, channel, request = fetch }) {
+  if ([repository, tag, githubToken, slackToken, channel].some((value) => typeof value !== "string" || !value.trim())) {
+    return { status: "skipped", reason: "missing-config" };
+  }
+  if (
+    tag !== tag.trim() || !/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag) ||
+    repository !== repository.trim() || !/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\/[A-Za-z0-9_.-]+$/.test(repository) ||
+    [".", ".."].includes(repository.split("/")[1]) ||
+    channel !== channel.trim() || !/^[CG][A-Z0-9]+$/.test(channel)
+  ) {
+    throw new Error("Invalid release notification configuration.");
+  }
+
+  async function requestJson(url, options, timeout, operation) {
+    try {
+      const response = await request(url, { ...options, redirect: "error", signal: AbortSignal.timeout(timeout) });
+      if (response.ok !== true) throw new Error();
+      return await response.json();
+    } catch {
+      // Never surface provider bodies, headers, or transport errors containing credentials.
+      throw new Error(`${operation} failed.`);
+    }
+  }
+
+  const githubHeaders = {
+    Authorization: `Bearer ${githubToken}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const releasesUrl = `https://api.github.com/repos/${repository}/releases`;
+  const release = await requestJson(`${releasesUrl}/tags/${tag}`, {
+    method: "GET",
+    headers: githubHeaders,
+  }, 15_000, "GitHub release lookup");
+  if (
+    !release || !Number.isSafeInteger(release.id) || release.id <= 0 ||
+    typeof release.tag_name !== "string" || typeof release.draft !== "boolean" ||
+    typeof release.prerelease !== "boolean" ||
+    (release.published_at !== null && typeof release.published_at !== "string") ||
+    (release.body !== null && typeof release.body !== "string")
+  ) {
+    throw new Error("Invalid GitHub release response.");
+  }
+  if (release.tag_name !== tag || release.draft || release.prerelease || !release.published_at) {
+    return { status: "skipped", reason: "not-published-stable-release" };
+  }
+
+  const body = release.body ?? "";
+  const markers = getSlackReleaseMarkers(body);
+  if (markers.includes(SLACK_RELEASE_PENDING_MARKER)) {
+    return { status: "pending", reason: "manual-reconciliation-required" };
+  }
+  if (markers.includes(SLACK_RELEASE_SENT_MARKER)) {
+    return { status: "skipped", reason: "already-sent" };
+  }
+
+  async function updateBody(nextBody) {
+    const updated = await requestJson(`${releasesUrl}/${release.id}`, {
+      method: "PATCH",
+      headers: { ...githubHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ body: nextBody }),
+    }, 15_000, "GitHub notification marker update");
+    if (updated?.id !== release.id || updated.body !== nextBody) {
+      throw new Error("GitHub notification marker update was not confirmed.");
+    }
+  }
+
+  // A durable prewrite suppresses retries even if Slack accepts a request whose response is lost.
+  const pendingBody = `${body}${body ? "\n\n" : ""}${SLACK_RELEASE_PENDING_MARKER}`;
+  await updateBody(pendingBody);
+  const posted = await requestJson("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${slackToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      channel,
+      text: `${repository} ${tag} is published. Generated release notes: https://github.com/${repository}/releases/tag/${tag}\nPublication is not approval for customer rollout.`,
+      mrkdwn: false,
+      parse: "none",
+      unfurl_links: false,
+      unfurl_media: false,
+    }),
+  }, 30_000, "Slack notification request");
+  if (posted?.ok !== true || typeof posted.ts !== "string" || !posted.ts.trim() || posted.channel !== channel) {
+    throw new Error("Slack notification was not confirmed; the release remains pending.");
+  }
+  await updateBody(pendingBody.replace(SLACK_RELEASE_PENDING_MARKER, SLACK_RELEASE_SENT_MARKER));
+  return { status: "sent" };
+}
+
+if (import.meta.main) {
+  try {
+    const result = await notifyRelease({
+      repository: process.env.GITHUB_REPOSITORY,
+      tag: process.env.TAG,
+      githubToken: process.env.GITHUB_TOKEN,
+      slackToken: process.env.SLACK_BOT_TOKEN,
+      channel: process.env.SLACK_RELEASE_CHANNEL_ID,
+    });
+    if (result.status === "pending") {
+      console.warn("::warning::Slack release notification is pending; verify Slack and reconcile the release marker manually.");
+      process.exitCode = 1;
+    } else {
+      console.log(JSON.stringify(result));
+    }
+  } catch {
+    console.warn("::warning::Slack release notification failed; verify Slack and reconcile any pending release marker before rerunning.");
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/release-notes-from-changelog.mjs
+++ b/scripts/release/release-notes-from-changelog.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 // Extract one release's entry from packages/docs/changelog.mdx and print it as
 // GitHub Release notes markdown. Lines of the existing release body that carry
-// the Windows code-signing note (*Windows ...*) are preserved at the end so the
-// generated notes replace only the static "What's new" boilerplate.
+// the Windows code-signing note (*Windows ...*) and Slack notification markers
+// are preserved at the end so rewrites cannot re-enable an attempted notification.
 //
 // Usage:
 //   node scripts/release/release-notes-from-changelog.mjs <tag> [--docs <path>] [--existing-body <path>]
 
 import { readFileSync } from "node:fs";
+import { getSlackReleaseMarkers } from "./slack-release-markers.mjs";
 
 const args = process.argv.slice(2);
 const tag = args.find((arg) => !arg.startsWith("--"));
@@ -57,9 +58,11 @@ if (body.length === 0) fail(`${tag} has an empty changelog entry in ${docsPath}`
 
 const preserved = [];
 if (existingBodyPath) {
-  for (const line of readFileSync(existingBodyPath, "utf8").split("\n")) {
+  const existingBody = readFileSync(existingBodyPath, "utf8");
+  for (const line of existingBody.split("\n")) {
     if (/^\*Windows .*\*\s*$/.test(line)) preserved.push(line.trim());
   }
+  preserved.push(...getSlackReleaseMarkers(existingBody));
 }
 
 const notes = [

--- a/scripts/release/release-notes-from-changelog.test.mjs
+++ b/scripts/release/release-notes-from-changelog.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync, spawnSync } from "node:child_process"
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import test from "node:test"
@@ -42,12 +42,12 @@ OpenWork v0.18.38 desktop release.
 *Windows installers are signed using Microsoft Artifact Signing.*
 `
 
-function fixture() {
+function fixture(existingBody = staticBody) {
   const dir = mkdtempSync(join(tmpdir(), "release-notes-"))
   const docs = join(dir, "changelog.mdx")
   const existing = join(dir, "existing.md")
   writeFileSync(docs, changelog)
-  writeFileSync(existing, staticBody)
+  writeFileSync(existing, existingBody)
   return { docs, existing }
 }
 
@@ -85,4 +85,54 @@ test("release notes extraction fails loudly for an undocumented tag", () => {
   } finally {
     rmSync(join(docs, ".."), { recursive: true, force: true })
   }
+})
+
+test("regenerating notes preserves pending and sent notification markers without duplicating them", () => {
+  const pending = "<!-- openwork-slack-release:pending -->"
+  const sent = "<!-- openwork-slack-release:sent -->"
+  for (const markers of [[pending], [sent], [pending, sent]]) {
+    const { docs, existing } = fixture(`${staticBody}\n${markers.join("\n")}\n${markers.join("\n")}\n`)
+    try {
+      const args = [script, "v0.18.38", "--docs", docs, "--existing-body", existing]
+      const notes = execFileSync(process.execPath, args, { encoding: "utf8", timeout: 10_000 })
+      assert(notes.startsWith("## Target release title\n"))
+      assert(notes.includes("*Windows installers are signed using Microsoft Artifact Signing.*"))
+      assert(!notes.includes("openwork-* naming convention"))
+      for (const marker of [pending, sent]) {
+        assert.equal(notes.split(marker).length - 1, markers.includes(marker) ? 1 : 0)
+      }
+      writeFileSync(existing, notes)
+      assert.equal(execFileSync(process.execPath, args, { encoding: "utf8", timeout: 10_000 }), notes)
+    } finally {
+      rmSync(join(docs, ".."), { recursive: true, force: true })
+    }
+  }
+})
+
+test("Slack notification runs in a fresh non-blocking job after changelog, under per-tag concurrency", () => {
+  const workflow = readFileSync(new URL("../../.github/workflows/changelog.yml", import.meta.url), "utf8")
+  const [changelog, notification] = workflow.split(/^  notify-slack:\n/m)
+  assert(notification)
+  assert(!changelog.includes("SLACK_BOT_TOKEN"))
+  assert(changelog.includes("outputs:\n      stable: ${{ steps.guard.outputs.stable }}"))
+  const update = changelog.split(/^      - name: /m).at(-1)
+  const notify = notification.split(/^      - name: /m).at(-1)
+  assert(update?.startsWith("Update GitHub Release notes\n"))
+  assert(update.includes('gh release edit "$TAG" --notes-file /tmp/release_notes.md'))
+  assert(update.includes("--existing-body /tmp/existing_release_body.md"))
+  assert(notify?.startsWith("Notify Slack of published release\n"))
+  assert.match(notification, /^    needs: changelog$/m)
+  assert.match(notification, /^    if: needs\.changelog\.outputs\.stable == 'true'$/m)
+  assert.match(notification, /^    continue-on-error: true$/m)
+  assert.match(notification, /^    timeout-minutes: 3$/m)
+  assert(notification.includes("permissions:\n      contents: write"))
+  assert(notification.includes("uses: actions/checkout@v6\n        with:\n          ref: dev\n          persist-credentials: false"))
+  assert(!notification.includes("download-artifact"))
+  assert.match(notify, /^        timeout-minutes: 2$/m)
+  assert(notify.includes("TAG: ${{ github.event.release.tag_name || inputs.tag }}"))
+  assert(notify.includes("GITHUB_TOKEN: ${{ github.token }}"))
+  assert(notify.includes("SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}"))
+  assert(notify.includes("SLACK_RELEASE_CHANNEL_ID: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}"))
+  assert.match(notify, /^        run: node scripts\/release\/notify-slack\.mjs$/m)
+  assert(workflow.includes("concurrency:\n  group: changelog-${{ github.event.release.tag_name || inputs.tag }}\n  cancel-in-progress: false\n"))
 })

--- a/scripts/release/slack-release-markers.mjs
+++ b/scripts/release/slack-release-markers.mjs
@@ -1,0 +1,6 @@
+export const SLACK_RELEASE_PENDING_MARKER = "<!-- openwork-slack-release:pending -->";
+export const SLACK_RELEASE_SENT_MARKER = "<!-- openwork-slack-release:sent -->";
+
+export function getSlackReleaseMarkers(body) {
+  return [SLACK_RELEASE_PENDING_MARKER, SLACK_RELEASE_SENT_MARKER].filter((marker) => body.includes(marker));
+}


### PR DESCRIPTION
## Summary

Add opt-in Slack announcements after a stable release's generated GitHub Release notes are updated. Requested as a **draft PR**; this does not enable production posting.

- A separate, nonblocking job checks out protected `dev` afresh. The changelog-writing agent never receives the Slack secret, and agent-writable files are not reused with it.
- Read live GitHub release state; skip drafts, prereleases, unpublished/mismatched tags, and missing configuration.
- Post a short canonical release link without raw release content, mass mentions, or unfurls. Publication is not approval for customer rollout.
- Persist a pending marker **before** contacting Slack, then mark sent only after confirmed acceptance. Both states survive notes regeneration and suppress reruns. Uncertain delivery requires human reconciliation, not automatic retry; this is not an exactly-once guarantee.

## Channel recommendation

**`#ai-dump` (`C0C18F7KF6C`)** is the appropriate destination. Its current content includes the automated “What we shipped” digests, and the [September 8 channel announcement](https://differentai.slack.com/archives/C0AJU2NQJEB/p1788894635805449) explicitly designates it for AI-generated content and automation.

`#deploy-logs` is dominated by Render deployment events, while `#all-general` is used for human release coordination. The destination remains configurable rather than hardcoded.

## Opt-in / operational follow-up

After review/merge, an administrator can:
1. Ensure the bot represented by `SLACK_BOT_TOKEN` has `chat:write` and is invited to the chosen channel.
2. Set the repository Actions variable `SLACK_RELEASE_CHANNEL_ID=C0C18F7KF6C`.
3. Verify delivery on the next newly published stable release. Do not rerun historical tags merely to test it: unmarked historical releases can be announced after opt-in.

Leave the variable unset to disable. No secrets, repository variables, live releases, or Slack messages were changed during this work. Setup and recovery: [`docs/release-slack-announcements.md`](docs/release-slack-announcements.md).

## Verification

**Overall: Incomplete — live GitHub Actions → Slack delivery is intentionally not exercised.** The deterministic local boundary check and supplementary regressions passed on PR head `c627da22e`. This remains a draft as requested.

Local fallback: `DAYTONA_API_KEY` and `DAYTONA_API_URL` were unavailable in the task environment; no remote credential setup was attempted. Node 24.20.0, pnpm 11.4.0. The test uses synthetic credentials, real loopback HTTP, and `faultProxy`; no live provider requests.

| Command | Exit | Result |
| --- | --- | --- |
| `pnpm evals:pr specs/slack-release-announcements.test.ts` | 0 | 1 test passed, 0 failed, 0 skipped; table-driven provider success/failure/timeout and rerun cases |
| `node --test scripts/release/release-notes-from-changelog.test.mjs` | 0 | 4 passed, 0 failed, 0 skipped; extraction, marker preservation, separate-job configuration |
| `node --check scripts/release/notify-slack.mjs` | 0 | Syntax check passed |
| `git diff --check` | 0 | Passed |

The HTTP-boundary assertions cover canonical payload/destination, provider credential separation, absent config, invalid input, ineligible releases, prewrite failures, rejected/malformed/timeout Slack responses, final-marker failure, no automatic retries, and actual note regeneration preserving duplicate suppression.

`node evals/scripts/spec-boundary-ratchet.mjs` exits **1** on the branch and identically on a **clean detached control at base `586c4100f3770b46f29f9969f0a0e6bb667aafe2`**. The existing failures are in `bench-opencode-engines`, `bench-openwork-app-v1`, `engine-v2-preview-flag`, `opencode-v2-chat-routing`, `opencode-v2-provider-hot-inject`, and `route-session-list`. The new Slack spec has no ratchet violations. No baselines were weakened.

Head-bound testkit evidence is published separately in the verification comment. Remaining proof: administrator-enabled, real-provider delivery on a new stable release, including confirming a later changelog rerun does not duplicate the post.
