### PR TITLE
fix(app): restore prompt recall after restart

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -46,12 +46,6 @@ export type ComposerStateStore = {
   pendingFocusSessionId: string | null;
   sessions: Record<string, ComposerSessionState>;
   queuedDrafts: Record<string, QueuedComposerItem[]>;
-  /**
-   * Sent-prompt history per session, oldest first. Kept outside
-   * `sessions` because `clearSession` resets the composer after every
-   * send and must not wipe the recall history (#2012).
-   */
-  history: Record<string, string[]>;
   setDraft: (sessionId: string, draft: string) => void;
   replaceDraft: (sessionId: string, draft: string, revertMessageId?: string | null) => void;
   hydrateDraft: (sessionId: string, draft: string) => void;
@@ -59,7 +53,6 @@ export type ComposerStateStore = {
   setAttachments: (sessionId: string, attachments: ComposerAttachment[]) => void;
   setMentions: (sessionId: string, mentions: Record<string, ComposerMentionKind>) => void;
   setPasteParts: (sessionId: string, pasteParts: ComposerPastePart[]) => void;
-  appendHistory: (sessionId: string, text: string) => void;
   appendQueuedDraft: (sessionId: string, draft: ComposerDraft) => void;
   removeQueuedDraft: (sessionId: string, id: string) => void;
   updateQueuedDraft: (sessionId: string, id: string, draft: ComposerDraft) => void;
@@ -72,9 +65,7 @@ export type ComposerStateStore = {
 const EMPTY_ATTACHMENTS: ComposerAttachment[] = [];
 const EMPTY_MENTIONS: Record<string, ComposerMentionKind> = {};
 const EMPTY_PASTE_PARTS: ComposerPastePart[] = [];
-const EMPTY_HISTORY: string[] = [];
 const EMPTY_QUEUED_DRAFTS: QueuedComposerItem[] = [];
-const HISTORY_LIMIT = 50;
 const composerSessionDraftScopes = new Map<string, string>();
 
 export function claimComposerSessionDraftScope(sessionId: string, scopeKey: string) {
@@ -125,7 +116,6 @@ export const useComposerStateStore = create<ComposerStateStore>((set) => ({
   pendingFocusSessionId: null,
   sessions: {},
   queuedDrafts: {},
-  history: {},
   setDraft: (sessionId, draft) => set((state) => {
     const current = getWritableSession(state, sessionId);
     const revertMessageId = draft ? current.revertMessageId : null;
@@ -184,16 +174,6 @@ export const useComposerStateStore = create<ComposerStateStore>((set) => ({
     const current = getWritableSession(state, sessionId);
     if (current.pasteParts === pasteParts) return state;
     return { sessions: { ...state.sessions, [sessionId]: { ...current, pasteParts } } };
-  }),
-  appendHistory: (sessionId, text) => set((state) => {
-    const trimmed = text.trim();
-    if (!trimmed) return state;
-    const current = state.history[sessionId] ?? EMPTY_HISTORY;
-    // Skip consecutive duplicates so spamming the same prompt does not
-    // fill the recall buffer.
-    if (current[current.length - 1] === trimmed) return state;
-    const next = [...current, trimmed].slice(-HISTORY_LIMIT);
-    return { history: { ...state.history, [sessionId]: next } };
   }),
   appendQueuedDraft: (sessionId, draft) => set((state) => {
     const current = state.queuedDrafts[sessionId] ?? EMPTY_QUEUED_DRAFTS;
@@ -267,10 +247,6 @@ export function getComposerMentions(state: ComposerStateStore, sessionId: string
 
 export function getComposerPasteParts(state: ComposerStateStore, sessionId: string): ComposerPastePart[] {
   return state.sessions[sessionId]?.pasteParts ?? EMPTY_PASTE_PARTS;
-}
-
-export function getComposerHistory(state: ComposerStateStore, sessionId: string): string[] {
-  return state.history[sessionId] ?? EMPTY_HISTORY;
 }
 
 export function getComposerQueuedDrafts(state: ComposerStateStore, sessionId: string): QueuedComposerItem[] {

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -4,6 +4,8 @@ import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-serve
 import { mergeSnapshotAndLiveMessages } from "../sync/message-merge";
 import { applyRevertCursor } from "../sync/transcript-reconcile";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
+import { parseConnectSkillToken } from "./composer/connect-skill-token";
+import { parseSlashCommandInvocation } from "./composer/slash-command";
 
 export function resolveRenderedSessionSnapshot(input: {
   sessionId: string;
@@ -49,7 +51,23 @@ export function deriveComposerHistory(messages: readonly UIMessage[]): string[] 
   // and ignored text, and message identity reconciles snapshots with live sends.
   for (const message of messages) {
     if (message.role !== "user") continue;
-    const text = message.parts.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n").trim();
+    let unsafe = false;
+    const text = message.parts.flatMap((part) => {
+      if (part.type !== "text") return [];
+      const metadata = part.providerMetadata?.opencode;
+      const token = metadata && typeof metadata === "object" && "composerToken" in metadata
+        ? metadata.composerToken : undefined;
+      if (typeof token === "string") {
+        const skill = parseConnectSkillToken(token);
+        if (skill && part.text === `/${skill.slug}`) return [token];
+        unsafe = true;
+      }
+      // Older labels have no durable skill identity. Never recall them as commands
+      // or try to recover that identity from generated model instructions.
+      if (parseSlashCommandInvocation(part.text.replace(/\s+/g, " "))) unsafe = true;
+      return [part.text];
+    }).join("\n").trim();
+    if (unsafe) continue;
     if (text && history.at(-1) !== text) history.push(text);
   }
   return history.slice(-50);

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -26,7 +26,7 @@ export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
   snapshot: OpenworkSessionSnapshot | null | undefined;
 }) {
-  const revertMessageId = (input.snapshot?.session as any)?.revert?.messageID ?? null;
+  const revertMessageId = input.snapshot?.session.revert?.messageID ?? null;
   const liveMessages = input.transcriptState ?? [];
 
   const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
@@ -41,4 +41,16 @@ export function deriveRenderedSessionMessages(input: {
     : liveMessages;
 
   return applyRevertCursor(messages, revertMessageId);
+}
+
+export function deriveComposerHistory(messages: readonly UIMessage[]): string[] {
+  const history: string[] = [];
+  // Use the reconciled transcript: native projections already exclude synthetic
+  // and ignored text, and message identity reconciles snapshots with live sends.
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const text = message.parts.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n").trim();
+    if (text && history.at(-1) !== text) history.push(text);
+  }
+  return history.slice(-50);
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -76,7 +76,7 @@ import { PaperGrainGradient } from "@openwork/ui/react";
 import { useShellConfig } from "@/react-app/shell/shell-config";
 import { useReactRenderWatchdog } from "@/react-app/shell/react-render-watchdog";
 import { SessionDebugPanel } from "./debug-panel";
-import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
+import { deriveComposerHistory, deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
 import {
   ADMISSION_OUTCOME_GRACE_MS,
   createSingleFlight,
@@ -115,7 +115,6 @@ import {
   composerDraftNeedsHydration,
   getComposerAttachments,
   getComposerDraft,
-  getComposerHistory,
   getComposerMentions,
   getComposerPasteParts,
   getComposerQueuedDrafts,
@@ -1097,8 +1096,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
     setHydratedDraftScopeKey(persistedDraftKey);
   }, [hydrateComposerDraft, persistedDraftKey, persistedDraftSnapshot, props.sessionId]);
-  const inputHistory = useComposerStateStore((state) => getComposerHistory(state, props.sessionId));
-  const appendComposerHistory = useComposerStateStore((state) => state.appendHistory);
   // Queued follow-up drafts live in the shared composer store keyed by session
   // id. That keeps a queued message in session A from being drained into
   // session B when the route swaps the same surface component to another
@@ -1533,6 +1530,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return claimed.length ? { ...item, previousMessageIds: [...item.previousMessageIds, ...claimed] } : item;
     }) };
   }, [baseRenderedMessages, pendingMessages, props.opencodeBaseUrl]);
+  const inputHistory = useMemo(() => deriveComposerHistory(pendingReconciliation.messages), [pendingReconciliation.messages]);
   const remainingPendingMessages = pendingReconciliation.remaining;
   useEffect(() => {
     if (!pendingMessages || (pendingMessages.length === remainingPendingMessages.length
@@ -2069,7 +2067,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
       if (result.outcome === "blocked" || result.outcome === "cancelled") return result;
       // Only report a run after the pre-send gate released the exact queued
       // submission and the route accepted or sent it.
-      appendComposerHistory(props.sessionId, nextDraft.text);
       useSessionActivityStore.getState().setRunStatus(props.workspaceId, props.sessionId, { type: "busy" });
       if (activeSessionOwnerRef.current === sessionOwner) {
         setAwaitingAssistantBaseline(renderedMessages.length);
@@ -2098,7 +2095,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       pendingSendsRef.current.delete(submissionId);
       setPendingSendSessions([...pendingSendsRef.current.values()]);
     }
-  }, [archived, archiveStateKnown, appendComposerHistory, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, renderedMessages.length, sessionOwner, setError]);
+  }, [archived, archiveStateKnown, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, renderedMessages.length, sessionOwner, setError]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
@@ -381,7 +381,6 @@ async function attemptDrain(sessionId: string) {
       return;
     }
     if (getQueuedSendGeneration(sessionId) !== generation) return;
-    useComposerStateStore.getState().appendHistory(sessionId, draft.text);
     useSessionActivityStore.getState().setRunStatus(
       context.workspaceId,
       sessionId,

--- a/apps/app/src/react-app/domains/session/sync/mention-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/mention-parts.ts
@@ -2,14 +2,18 @@ import type { TextPartInput } from "@opencode-ai/sdk/v2/client";
 import type { ComposerPart } from "@/app/types";
 import { appMentionInstruction } from "../surface/composer/app-mentions";
 import { computerMentionInstruction } from "../surface/composer/computer-mentions";
-import { connectSkillPrompt } from "../surface/composer/connect-skill-token";
+import { connectSkillPrompt, encodeConnectSkillToken } from "../surface/composer/connect-skill-token";
 
 type InstructionMention = Extract<ComposerPart, { type: "computer" | "app" | "skill" | "connect-skill" }>;
 
 /** Keep generated instructions out of user text in every send path. */
 export function mentionPromptParts(part: InstructionMention): [TextPartInput, TextPartInput & { synthetic: true }] {
   const { label, instruction } = mentionContent(part);
-  return [{ type: "text", text: label }, { type: "text", text: instruction, synthetic: true }];
+  return [{
+    type: "text",
+    text: label,
+    ...(part.type === "connect-skill" ? { metadata: { openworkComposerToken: encodeConnectSkillToken(part) } } : {}),
+  }, { type: "text", text: instruction, synthetic: true }];
 }
 
 function mentionContent(part: InstructionMention): { label: string; instruction: string } {

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -15,6 +15,7 @@ import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
 import {
   attachmentNoteToUIParts,
+  textPartToUIPart,
   createSessionErrorUIMessage,
   snapshotToUIMessages,
 } from "./usechat-adapter";
@@ -797,13 +798,7 @@ function toFileUIParts(part: FilePart): UIMessage["parts"] {
 
 function toUIPart(part: Part): UIMessage["parts"][number] | null {
   if (part.type === "text") {
-    if (part.synthetic || part.ignored) return null;
-    return {
-      type: "text",
-      text: part.text,
-      state: "done",
-      providerMetadata: { opencode: { partId: part.id } },
-    };
+    return textPartToUIPart(part);
   }
   if (part.type === "reasoning") {
     return {

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -141,6 +141,20 @@ export function attachmentNoteToUIParts(part: TextPart): UIMessage["parts"] {
   });
 }
 
+export function textPartToUIPart(part: TextPart): UIMessage["parts"][number] | null {
+  if (part.synthetic || part.ignored) return null;
+  const composerToken = part.metadata?.openworkComposerToken;
+  return {
+    type: "text",
+    text: part.text,
+    state: "done",
+    providerMetadata: { opencode: {
+      partId: part.id,
+      ...(typeof composerToken === "string" ? { composerToken } : {}),
+    } },
+  };
+}
+
 type SnapshotMessages = OpenworkSessionSnapshot["messages"];
 const snapshotMessagesCache = new WeakMap<SnapshotMessages, UIMessage[]>();
 const snapshotMessageCache = new WeakMap<SnapshotMessages[number], UIMessage[]>();
@@ -165,13 +179,8 @@ export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessa
         : {}),
       parts: message.parts.flatMap<UIMessage["parts"][number]>((part) => {
         if (part.type === "text") {
-          if (part.synthetic || part.ignored) return attachmentNoteToUIParts(part);
-          return [{
-            type: "text",
-            text: getTextPartValue(part),
-            state: "done" as const,
-            providerMetadata: { opencode: { partId: part.id } },
-          }];
+          const mapped = textPartToUIPart(part);
+          return mapped ? [mapped] : attachmentNoteToUIParts(part);
         }
         if (part.type === "reasoning") {
           return [{

--- a/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
+++ b/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
@@ -79,6 +79,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
     { getReactQueryClient },
     { LocalProvider },
     { ShellConfigProvider },
+    { PlatformProvider, createDefaultPlatform },
   ] = await Promise.all([
     import("../src/app/lib/openwork-server"),
     import("../src/react-app/domains/connections/cloud-mcp-submit-readiness"),
@@ -86,6 +87,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
     import("../src/react-app/infra/query-client"),
     import("../src/react-app/kernel/local-provider"),
     import("../src/react-app/shell/shell-config"),
+    import("../src/react-app/kernel/platform"),
   ]);
   const registeredDom = typeof globalThis.window === "undefined" || typeof globalThis.document === "undefined";
   if (registeredDom) GlobalRegistrator.register({ url: "http://localhost/" });
@@ -104,6 +106,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
   let rejectSnapshot = false;
   let fetchedSnapshot = createSnapshot(sessionId, "Cached transcript remains visible.");
   mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
+  mock.module("@/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
   mock.module("@/app/lib/opencode-session-native", () => ({
     composeNativeSessionSnapshot: async () => {
       if (rejectSnapshot) throw new Error("snapshot refresh failed");
@@ -123,6 +126,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
   document.body.append(container, unavailableContainer);
   const root = createRoot(container);
   const unavailableRoot = createRoot(unavailableContainer);
+  const platform = createDefaultPlatform();
   let sendCount = 0;
 
   const surface = (targetSessionId: string, modelUnavailable: boolean) => (
@@ -175,7 +179,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
   );
 
   try {
-    await act(async () => root.render(surface(sessionId, false)));
+    await act(async () => root.render(<PlatformProvider value={platform}>{surface(sessionId, false)}</PlatformProvider>));
     await waitFor(() => container.textContent?.includes("Cached transcript remains visible.") === true, "the cached transcript");
 
     rejectSnapshot = true;
@@ -198,7 +202,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
     rejectSnapshot = false;
     fetchedSnapshot = createSnapshot(unavailableSessionId, "Unavailable model transcript.");
     queryClient.setQueryData(snapshotKey(workspaceId, unavailableSessionId), fetchedSnapshot);
-    await act(async () => unavailableRoot.render(surface(unavailableSessionId, true)));
+    await act(async () => unavailableRoot.render(<PlatformProvider value={platform}>{surface(unavailableSessionId, true)}</PlatformProvider>));
     await waitFor(
       () => unavailableContainer.querySelector('[contenteditable="true"][data-lexical-editor="true"]') !== null,
       "the unavailable-model Lexical editor",
@@ -209,7 +213,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
       root.unmount();
       unavailableRoot.unmount();
     });
-    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });
+    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {} });
     queryClient.clear();
     container.remove();
     unavailableContainer.remove();

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -1006,7 +1006,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   } finally {
     await act(async () => root.unmount());
     resetQueuedDrainForTests();
-    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {}, pendingMessages: {}, failedDrafts: {} });
+    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, pendingMessages: {}, failedDrafts: {} });
     queryClient.clear();
     container.remove();
     mock.restore();

--- a/apps/app/tests/composer-prompt-history.test.ts
+++ b/apps/app/tests/composer-prompt-history.test.ts
@@ -1,6 +1,12 @@
 import { expect, test } from "bun:test";
+import type { TextPart } from "@opencode-ai/sdk/v2/client";
 import type { UIMessage } from "ai";
 import type { OpenworkSessionMessage, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import type { ComposerPart } from "../src/app/types";
+import { draftToParts } from "../src/react-app/domains/session/sync/draft-parts";
+import { textPartToUIPart } from "../src/react-app/domains/session/sync/usechat-adapter";
+import { encodeConnectSkillToken, parseConnectSkillToken } from "../src/react-app/domains/session/surface/composer/connect-skill-token";
+import { parseSlashCommandInvocation } from "../src/react-app/domains/session/surface/composer/slash-command";
 import {
   deriveComposerHistory,
   deriveRenderedSessionMessages,
@@ -99,4 +105,81 @@ test("reverted messages and removed pending sends do not linger in a second hist
   expect(deriveComposerHistory(pending)).toEqual(["Submitted"]);
   expect(deriveComposerHistory([])).toEqual([]);
   expect(deriveComposerHistory([])).not.toContain("Submitted");
+});
+
+test("Connect skill identity round-trips through durable text-part metadata in both draft branches, without changing display or model instructions", async () => {
+  const skill = {
+    type: "connect-skill", slug: "compact", name: "Com|pact ] %",
+    marketplace: "Team tools", capability: "plugin:team:compact",
+  } satisfies ComposerPart;
+  const token = encodeConnectSkillToken(skill);
+  for (const prefix of ["", "Please use "]) {
+    for (const attachmentToken of ["", "[attachment removed]"]) {
+      const parts = await draftToParts({
+        mode: "prompt", text: `${prefix}${token} Keep the details.${attachmentToken}`,
+        parts: [...(prefix ? [{ type: "text", text: prefix } satisfies ComposerPart] : []), skill, { type: "text", text: " Keep the details." }],
+        attachments: [],
+      }, "/fixture", "session-a", null);
+      const stored = message("connected", "");
+      stored.parts = parts.map((part, index) => ({ ...part, id: `part-${index}`, sessionID: "session-a", messageID: stored.info.id }));
+      const before = structuredClone(stored);
+      const expected = [prefix, token, " Keep the details."].filter(Boolean).join("\n").trim();
+      const rendered = deriveRenderedSessionMessages({ snapshot: snapshot([stored]), transcriptState: [] });
+      expect(history(snapshot(structuredClone([stored])))).toEqual([expected]);
+      expect(rendered[0]?.parts.filter((part) => part.type === "text").map((part) => part.text).join(""))
+        .toBe(`${prefix}/compact Keep the details.`);
+      const liveParts = stored.parts.flatMap((part) => {
+        if (part.type !== "text") return [];
+        const mapped = textPartToUIPart(part);
+        return mapped ? [mapped] : [];
+      });
+      const live: UIMessage[] = [{ id: stored.info.id, role: "user", parts: liveParts }];
+      expect(history(null, live)).toEqual([expected]);
+      expect(history(snapshot([stored]), live)).toEqual([expected]);
+      expect(parseSlashCommandInvocation(expected)).toBeNull();
+      expect(expected).not.toContain("execute_capability");
+      const recalledToken = expected.match(/\[connect-skill [^\]]+\]/)?.[0] ?? "";
+      const identity = parseConnectSkillToken(recalledToken);
+      expect(identity).toEqual({ slug: skill.slug, name: skill.name, marketplace: skill.marketplace, capability: skill.capability });
+      if (!identity) throw new Error("Missing recalled skill identity");
+      const resent = await draftToParts({ mode: "prompt", text: recalledToken, parts: [{ type: "connect-skill", ...identity }], attachments: [] }, "/fixture", "session-a", null);
+      expect(resent.filter((part) => part.type === "text" && part.synthetic))
+        .toEqual(parts.filter((part) => part.type === "text" && part.synthetic));
+      expect(stored).toEqual(before);
+    }
+  }
+});
+
+test("legacy slash labels and native commands are excluded rather than replayed with lost identity", () => {
+  const legacy = message("legacy", "/compact");
+  legacy.parts.push(
+    { id: "instructions", messageID: legacy.info.id, sessionID: "session-a", type: "text", synthetic: true, text: "PRIVATE Connect skill instructions with plugin:team:compact" },
+    { id: "suffix", messageID: legacy.info.id, sessionID: "session-a", type: "text", text: " Keep the details." },
+  );
+  expect(history(snapshot([legacy]))).toEqual([]);
+  const inline = structuredClone(legacy);
+  inline.parts.unshift({ id: "prefix", messageID: legacy.info.id, sessionID: "session-a", type: "text", text: "Please use " });
+  expect(history(snapshot([inline]))).toEqual([]);
+  for (const text of [" /compact Keep the details.", "/compact\nKeep the details."]) {
+    expect(history(null, [{ id: "pending", role: "user", parts: [{ type: "text", text }] }])).toEqual([]);
+  }
+  expect(history(snapshot([message("command", "/compact"), message("path", "/workspace/notes.txt"), message("local", "[skill summarize] Keep the details.")])))
+    .toEqual(["/workspace/notes.txt", "[skill summarize] Keep the details."]);
+});
+
+test("invalid or mismatched token metadata cannot turn a label into a recalled skill; hidden metadata stays hidden", () => {
+  const token = encodeConnectSkillToken({ slug: "compact", name: "Compact", marketplace: "Team", capability: "skill:compact" });
+  for (const metadata of [{ openworkComposerToken: "[connect-skill incomplete]" }, { openworkComposerToken: token }, { openworkComposerToken: 42 }]) {
+    const stored = message("invalid", "/different");
+    stored.parts = [{ id: "invalid", sessionID: "session-a", messageID: "invalid", type: "text", text: "/different", metadata }];
+    expect(history(snapshot([stored]))).toEqual([]);
+  }
+  for (const flags of [{ synthetic: true }, { ignored: true }]) {
+    const stored = message("hidden", "");
+    const part = { id: "hidden", sessionID: "session-a", messageID: "hidden", type: "text", text: "/compact", metadata: { openworkComposerToken: token }, ...flags } satisfies TextPart;
+    stored.parts = [part];
+    expect(history(snapshot([stored]))).toEqual([]);
+    expect(textPartToUIPart(part)).toBeNull();
+  }
+  expect(history(snapshot([message("original-token", `${token} Keep the details.`)]))).toEqual([`${token} Keep the details.`]);
 });

--- a/apps/app/tests/composer-prompt-history.test.ts
+++ b/apps/app/tests/composer-prompt-history.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import type { OpenworkSessionMessage, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import {
+  deriveComposerHistory,
+  deriveRenderedSessionMessages,
+  resolveRenderedSessionSnapshot,
+} from "../src/react-app/domains/session/surface/session-render-state";
+
+function message(id: string, text: string, created = 1): OpenworkSessionMessage {
+  return {
+    info: {
+      id, sessionID: "session-a", role: "user", time: { created },
+      agent: "build", model: { providerID: "test", modelID: "test" },
+    },
+    parts: [{ id: `part-${id}`, sessionID: "session-a", messageID: id, type: "text", text }],
+  };
+}
+
+function snapshot(messages: OpenworkSessionMessage[]): OpenworkSessionSnapshot {
+  return {
+    session: {
+      id: "session-a", slug: "history", projectID: "project-a", directory: "/fixture",
+      title: "History", version: "0", time: { created: 1, updated: 100 },
+    },
+    messages, todos: [], status: { type: "idle" },
+  };
+}
+
+function history(stored: OpenworkSessionSnapshot | null, live: UIMessage[] = []) {
+  return deriveComposerHistory(deriveRenderedSessionMessages({ snapshot: stored, transcriptState: live }));
+}
+
+test("cold recall restores only user-authored text, not synthetic instructions, ignored text, files or assistant output", () => {
+  const first = message("first", "  First line");
+  first.parts.push(
+    { id: "second-line", sessionID: "session-a", messageID: "first", type: "text", text: "Second line  " },
+    { id: "synthetic", sessionID: "session-a", messageID: "first", type: "text", text: "PRIVATE INSTRUCTION", synthetic: true },
+    { id: "ignored", sessionID: "session-a", messageID: "first", type: "text", text: "IGNORED TEXT", ignored: true },
+    { id: "file", sessionID: "session-a", messageID: "first", type: "file", mime: "text/plain", url: "file:///private.txt" },
+  );
+  const hidden = message("hidden", "HIDDEN ONLY");
+  hidden.parts = [{ id: "hidden-part", sessionID: "session-a", messageID: "hidden", type: "text", text: "HIDDEN ONLY", synthetic: true }];
+  const stored = snapshot([first, message("blank", " \n "), hidden]);
+  const before = structuredClone(stored);
+  const recalled = history(stored, [{ id: "assistant", role: "assistant", parts: [{ type: "text", text: "Assistant answer" }] }]);
+  expect(recalled).toEqual(["First line\nSecond line"]);
+  for (const excluded of ["PRIVATE INSTRUCTION", "IGNORED TEXT", "private.txt", "HIDDEN ONLY", "Assistant answer"]) {
+    expect(recalled.join("\n")).not.toContain(excluded);
+  }
+  expect(stored).toEqual(before);
+});
+
+test("recall caps at 50 after trimming and consecutive deduplication, retaining nonconsecutive repetitions", () => {
+  const messages = Array.from({ length: 60 }, (_, index) => message(`message-${index}`, `Prompt ${index}`, index));
+  messages.push(message("repeat-last", " Prompt 59 ", 60), message("repeat-earlier", "Prompt 58", 61));
+  const recalled = history(snapshot(messages));
+  expect(recalled).toEqual([...Array.from({ length: 49 }, (_, index) => `Prompt ${index + 11}`), "Prompt 58"]);
+  expect(recalled).toHaveLength(50);
+  expect(recalled).not.toContain("Prompt 10");
+  expect(recalled.filter((text) => text === "Prompt 59")).toHaveLength(1);
+  expect(recalled.filter((text) => text === "Prompt 58")).toHaveLength(2);
+});
+
+test("an older fetch cannot clobber a new live send and repeated snapshots do not duplicate acknowledged prompts", () => {
+  const stored = snapshot([message("one", "Repeated prompt", 1), message("two", "Other prompt", 2)]);
+  const live: UIMessage[] = [{ id: "three", role: "user", metadata: { opencode: { created: 3 } }, parts: [{ type: "text", text: "Repeated prompt" }] }];
+  const expected = ["Repeated prompt", "Other prompt", "Repeated prompt"];
+  expect(history(null, live)).toEqual(["Repeated prompt"]);
+  expect(history(stored, live)).toEqual(expected);
+  const acknowledged = snapshot([...stored.messages, message("three", "Repeated prompt", 3)]);
+  for (let fetch = 0; fetch < 3; fetch += 1) {
+    expect(history(structuredClone(acknowledged), live)).toEqual(expected);
+  }
+  expect(history(stored, live)).not.toEqual(["Repeated prompt", "Other prompt"]);
+  expect(history(acknowledged, live)).toHaveLength(3);
+  expect(stored.messages).toHaveLength(2);
+  expect(live).toHaveLength(1);
+});
+
+test("switching sessions never recalls the previous session's cached snapshot", () => {
+  const stored = snapshot([message("private", "Private prompt")]);
+  const selected = resolveRenderedSessionSnapshot({
+    sessionId: "session-b", currentSnapshot: stored,
+    cachedRendered: { sessionId: "session-a", snapshot: stored },
+  });
+  expect(selected).toBeNull();
+  expect(history(selected)).toEqual([]);
+  expect(history(selected)).not.toContain("Private prompt");
+  expect(history(stored)).toEqual(["Private prompt"]);
+});
+
+test("reverted messages and removed pending sends do not linger in a second history store", () => {
+  const stored = snapshot([message("one", "Keep", 1), message("two", "Reverted", 2)]);
+  stored.session.revert = { messageID: "two" };
+  expect(history(stored)).toEqual(["Keep"]);
+  expect(history(stored)).not.toContain("Reverted");
+  const pending: UIMessage[] = [{ id: "pending", role: "user", parts: [{ type: "text", text: "Submitted" }] }];
+  expect(deriveComposerHistory(pending)).toEqual(["Submitted"]);
+  expect(deriveComposerHistory([])).toEqual([]);
+  expect(deriveComposerHistory([])).not.toContain("Submitted");
+});

--- a/apps/app/tests/composer-state-store.test.ts
+++ b/apps/app/tests/composer-state-store.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../src/react-app/domains/session/surface/composer-state-store";
 
 function reset() {
-  useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });
+  useComposerStateStore.setState({ sessions: {}, queuedDrafts: {} });
 }
 
 function draft(text: string): ComposerDraft {

--- a/evals/specs/composer-prompt-history.e2e.test.ts
+++ b/evals/specs/composer-prompt-history.e2e.test.ts
@@ -13,6 +13,9 @@ test("composer recalls durable prompts across reloads and a real desktop restart
       if (boot === "restart") {
         const restarted = await world.restart();
         expect(restarted.origin).not.toBe(restarted.previousOrigin);
+        // A desktop relaunch opens the workspace landing page; reopen the
+        // persisted conversation rather than testing automatic route restore.
+        await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });
       } else {
         await user.reload();
       }

--- a/evals/specs/composer-prompt-history.e2e.test.ts
+++ b/evals/specs/composer-prompt-history.e2e.test.ts
@@ -3,7 +3,10 @@ import { spec } from "@openwork/testkit";
 import { composerPromptHistory } from "../worlds/composer-prompt-history.ts";
 import { longHistoryLast, longHistoryOtherTitle, longHistoryTitle } from "../worlds/chat.ts";
 
-const test = spec.world(composerPromptHistory, { timeout: 600_000 });
+const test = spec.world(composerPromptHistory, {
+  timeout: 600_000,
+  resources: { surfaces: ["desktop"], services: [], nativeReason: "Prompt recall must survive an Electron main-process relaunch with the same profile." },
+});
 
 test("composer recalls durable prompts across reloads and a real desktop restart without leaking into another session", async ({ user, step, world }) => {
   await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });

--- a/evals/specs/composer-prompt-history.e2e.test.ts
+++ b/evals/specs/composer-prompt-history.e2e.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { composerPromptHistory } from "../worlds/composer-prompt-history.ts";
+import { longHistoryLast, longHistoryOtherTitle, longHistoryTitle } from "../worlds/chat.ts";
+
+const test = spec.world(composerPromptHistory, { timeout: 600_000 });
+
+test("composer recalls durable prompts across reloads and a real desktop restart without leaking into another session", async ({ user, step, world }) => {
+  await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });
+  await user.see({ text: longHistoryLast }, { timeoutMs: 60_000 });
+  for (const boot of ["reload", "second reload", "restart"]) {
+    await step(`recall after ${boot}`, async () => {
+      if (boot === "restart") {
+        const restarted = await world.restart();
+        expect(restarted.origin).not.toBe(restarted.previousOrigin);
+      } else {
+        await user.reload();
+      }
+      await user.see({ text: longHistoryLast }, { timeoutMs: 60_000 });
+      await user.see("composer", { editable: true, text: "" });
+      await user.click("composer");
+      await user.press("ArrowUp");
+      await user.see("composer", { text: longHistoryLast });
+      await user.press("ArrowUp");
+      await user.see("composer", { text: "Stored history message 149 of 150." });
+      await user.press("ArrowDown");
+      await user.see("composer", { text: longHistoryLast });
+      await user.press("ArrowDown");
+      await user.see("composer", { text: "" });
+    });
+  }
+  await step("an unsent draft is not overwritten by recall", async () => {
+    const draft = "Keep this unsent draft";
+    await user.type("composer", draft);
+    await user.press("ArrowUp");
+    await user.see("composer", { text: draft });
+    await user.reload();
+    await user.see("composer", { editable: true, text: draft });
+    await user.click("composer");
+    await user.press("ArrowUp");
+    await user.see("composer", { text: draft });
+  });
+  await step("an unrelated empty conversation has no recall history", async () => {
+    await user.click({ role: "button", label: new RegExp(`^${longHistoryOtherTitle}`) });
+    await user.see("composer", { editable: true, text: "" });
+    await user.click("composer");
+    await user.press("ArrowUp");
+    await user.see("composer", { text: "" });
+    await user.notSee({ text: longHistoryLast });
+  });
+});

--- a/evals/worlds/composer-prompt-history.ts
+++ b/evals/worlds/composer-prompt-history.ts
@@ -11,7 +11,7 @@ export async function composerPromptHistory(seed: Seed) {
     async restart() {
       const previousOrigin = await evalIn(base.app, () => performance.timeOrigin);
       // Real main-process relaunch, keeping the seed-owned profile and engine data.
-      await evalIn(base.app, async () => { await window.__OPENWORK_ELECTRON__.shell.relaunch(); })
+      await evalIn(base.app, async () => { await window.__OPENWORK_ELECTRON__.shell.relaunch(); }, { reattachAttempts: 0 })
         .catch(() => undefined); // Quit may destroy the context before the IPC reply; never dispatch twice.
       const deadline = Date.now() + 90_000;
       while (Date.now() < deadline) {

--- a/evals/worlds/composer-prompt-history.ts
+++ b/evals/worlds/composer-prompt-history.ts
@@ -1,0 +1,39 @@
+import { reattachSurface } from "@openwork/cdp";
+import { evalIn } from "@openwork/behaviors";
+import { resolveEvalEngine, SkipError, type Seed } from "@openwork/env";
+import { longHistory } from "./chat.ts";
+
+export async function composerPromptHistory(seed: Seed) {
+  if (resolveEvalEngine() !== "v1") throw new SkipError("native v1 stored history (OPENWORK_EVAL_ENGINE=v1)");
+  const base = await longHistory(seed);
+  return {
+    ...base,
+    async restart() {
+      const previousOrigin = await evalIn(base.app, () => performance.timeOrigin);
+      // Real main-process relaunch, keeping the seed-owned profile and engine data.
+      await evalIn(base.app, async () => { await window.__OPENWORK_ELECTRON__.shell.relaunch(); })
+        .catch(() => undefined); // Quit may destroy the context before the IPC reply; never dispatch twice.
+      const deadline = Date.now() + 90_000;
+      while (Date.now() < deadline) {
+        try {
+          await reattachSurface(base.app, { timeoutMs: 3_000 });
+          const origin = await evalIn(base.app, () => performance.timeOrigin, { timeoutMs: 3_000 });
+          if (origin !== previousOrigin) return { previousOrigin, origin };
+        } catch { /* The old renderer and socket disappear during restart. */ }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      throw new Error("Electron did not relaunch within 90 seconds");
+    },
+    async [Symbol.asyncDispose]() {
+      await base.app.client.send("Browser.close").catch(() => undefined);
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        const alive = await fetch(`${base.app.handle.cdpUrl}/json/version`, { signal: AbortSignal.timeout(1_000) })
+          .then((response) => response.ok, () => false);
+        if (!alive) return;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      throw new Error("Relaunched Electron did not close before profile cleanup");
+    },
+  };
+}


### PR DESCRIPTION
## Root cause
Composer ArrowUp/ArrowDown recall used a process-local Zustand buffer populated only by send handlers. Restart restored native conversation messages and unsent drafts but left the recall buffer empty. Loading more transcript history could not help because recall never consumed it.

## Fix
- Derive a capped (50), consecutive-deduplicated recall list from the reconciled conversation transcript instead of maintaining a second volatile store.
- Restore stored user text while retaining live-message reconciliation, session isolation, and revert behavior; ignore assistant/synthetic/ignored text.
- Preserve Connect skill identity in native text-part metadata without changing rendered labels or exposing generated instructions. Ambiguous legacy slash-leading labels/native commands without identity metadata are conservatively excluded from recall.
- Repair the touched composer test fixture providers; explicitly declare native E2E resources and prevent retries of the relaunch mutation.

## Verification
Tested head: 44d08770238e0108db97921c867f8895e23fc536.

**Passed — Daytona desktop regression** (exit 0, 1 passed / 0 failed / 0 skipped):
`OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_REF=44d08770238e0108db97921c867f8895e23fc536 OPENWORK_EVAL_DAYTONA_REF=44d08770238e0108db97921c867f8895e23fc536 OPENWORK_EVAL_DAYTONA=1 infisical run --silent -- pnpm evals:e2e composer-prompt-history`

25 UI observations across 5 steps: two reloads, full Electron main-process relaunch and reopening the conversation, newest/older prompt navigation, restoring empty input, preserving an unsent draft, and isolation from another conversation. Stored messages are seeded through the native API; this does not claim model-turn/queued-send E2E coverage. Temporary Daytona sandboxes deleted after runs.

Published head-matching evidence: https://github.com/different-ai/openwork/pull/4790#issuecomment-5620462040

**Supporting local checks:**
- `pnpm --filter @openwork/app exec bun test --isolate tests/composer-prompt-history.test.ts tests/composer-state-store.test.ts tests/composer-focus-continuity.test.tsx tests/composer-editable-on-snapshot-error.test.tsx tests/connect-skill-token.test.ts tests/session-sync-tool-parts.test.ts` — exit 0, 39 passed / 0 failed, 461 assertions.
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `git diff --check` — exit 0.

All work isolated in a dedicated git worktree; unrelated work untouched.