### PR TITLE
fix(app): return every loaded session from session.list_sessions

### DIFF
--- a/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
+++ b/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
@@ -24,6 +24,12 @@ export type ListedControlSession = {
   pinned: boolean;
 };
 
+export type ListControlSessionsState = {
+  workspaces: ControlSessionWorkspace[];
+  sessionsByWorkspaceId: Record<string, ControlSessionLike[]>;
+  pinnedIds: readonly string[];
+};
+
 export function controlWorkspaceLabel(workspace: ControlSessionWorkspace) {
   return workspace.displayName?.trim() || workspace.name?.trim() || workspace.path?.trim() || "workspace";
 }
@@ -33,23 +39,25 @@ function matchesWorkspace(workspace: ControlSessionWorkspace, query: string) {
   return workspace.id.toLowerCase() === lower || controlWorkspaceLabel(workspace).toLowerCase() === lower;
 }
 
+function argsRecord(args: unknown): Record<string, unknown> {
+  return args && typeof args === "object" ? args as Record<string, unknown> : {};
+}
+
 /**
- * Sessions the app already holds in memory, pinned first then newest first.
- * The list is only truncated when the caller asks for a `limit`; a silent cap
- * made large workspaces impossible to inventory through the control surface.
+ * `session.list_sessions`: sessions the app already holds in memory, pinned
+ * first then newest first. `args` is the raw control-action payload; the list
+ * is only truncated when it carries a positive integer `limit`, and an
+ * unknown `workspaceId` yields no sessions rather than another workspace's.
+ * A silent cap here made large workspaces impossible to inventory.
  */
-export function listControlSessions(input: {
-  workspaces: ControlSessionWorkspace[];
-  sessionsByWorkspaceId: Record<string, ControlSessionLike[]>;
-  pinnedIds: readonly string[];
-  workspaceId?: string;
-  limit?: number;
-}): ListedControlSession[] {
-  const workspaceQuery = input.workspaceId?.trim() ?? "";
+export function listControlSessions(args: unknown, state: ListControlSessionsState): ListedControlSession[] {
+  const record = argsRecord(args);
+  const workspaceQuery = typeof record.workspaceId === "string" ? record.workspaceId.trim() : "";
+  const limit = record.limit;
   const out: ListedControlSession[] = [];
-  for (const workspace of input.workspaces) {
+  for (const workspace of state.workspaces) {
     if (workspaceQuery && !matchesWorkspace(workspace, workspaceQuery)) continue;
-    for (const session of input.sessionsByWorkspaceId[workspace.id] ?? []) {
+    for (const session of state.sessionsByWorkspaceId[workspace.id] ?? []) {
       const sessionId = session.id?.trim() ?? "";
       if (!sessionId) continue;
       out.push({
@@ -57,11 +65,10 @@ export function listControlSessions(input: {
         title: getDisplaySessionTitle(session.title ?? ""),
         workspace: controlWorkspaceLabel(workspace),
         updatedAt: session.time?.updated ?? session.time?.created ?? 0,
-        pinned: input.pinnedIds.includes(sessionId),
+        pinned: state.pinnedIds.includes(sessionId),
       });
     }
   }
   out.sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.updatedAt - a.updatedAt);
-  const limit = input.limit;
-  return limit !== undefined && Number.isInteger(limit) && limit > 0 ? out.slice(0, limit) : out;
+  return typeof limit === "number" && Number.isInteger(limit) && limit > 0 ? out.slice(0, limit) : out;
 }

--- a/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
+++ b/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
@@ -1,0 +1,67 @@
+import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
+
+export type ControlSessionWorkspace = {
+  id: string;
+  name?: string | null;
+  path?: string | null;
+  displayName?: string | null;
+};
+
+export type ControlSessionLike = {
+  id?: string;
+  title?: string;
+  time?: {
+    updated?: number;
+    created?: number;
+  };
+};
+
+export type ListedControlSession = {
+  sessionId: string;
+  title: string;
+  workspace: string;
+  updatedAt: number;
+  pinned: boolean;
+};
+
+export function controlWorkspaceLabel(workspace: ControlSessionWorkspace) {
+  return workspace.displayName?.trim() || workspace.name?.trim() || workspace.path?.trim() || "workspace";
+}
+
+function matchesWorkspace(workspace: ControlSessionWorkspace, query: string) {
+  const lower = query.toLowerCase();
+  return workspace.id.toLowerCase() === lower || controlWorkspaceLabel(workspace).toLowerCase() === lower;
+}
+
+/**
+ * Sessions the app already holds in memory, pinned first then newest first.
+ * The list is only truncated when the caller asks for a `limit`; a silent cap
+ * made large workspaces impossible to inventory through the control surface.
+ */
+export function listControlSessions(input: {
+  workspaces: ControlSessionWorkspace[];
+  sessionsByWorkspaceId: Record<string, ControlSessionLike[]>;
+  pinnedIds: readonly string[];
+  workspaceId?: string;
+  limit?: number;
+}): ListedControlSession[] {
+  const workspaceQuery = input.workspaceId?.trim() ?? "";
+  const out: ListedControlSession[] = [];
+  for (const workspace of input.workspaces) {
+    if (workspaceQuery && !matchesWorkspace(workspace, workspaceQuery)) continue;
+    for (const session of input.sessionsByWorkspaceId[workspace.id] ?? []) {
+      const sessionId = session.id?.trim() ?? "";
+      if (!sessionId) continue;
+      out.push({
+        sessionId,
+        title: getDisplaySessionTitle(session.title ?? ""),
+        workspace: controlWorkspaceLabel(workspace),
+        updatedAt: session.time?.updated ?? session.time?.created ?? 0,
+        pinned: input.pinnedIds.includes(sessionId),
+      });
+    }
+  }
+  out.sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.updatedAt - a.updatedAt);
+  const limit = input.limit;
+  return limit !== undefined && Number.isInteger(limit) && limit > 0 ? out.slice(0, limit) : out;
+}

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -5,19 +5,10 @@ import type { createClient } from "../../../../app/lib/opencode";
 import type { OpenworkServerClient, OpenworkWorkspaceInfo } from "../../../../app/lib/openwork-server";
 import { deleteRouteSession } from "../../../shell/route-workspaces";
 import type { ResolvedWorkspaceEndpoint } from "../../../../app/lib/workspace-endpoint";
-import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { useSessionManagementStore } from "../sidebar/session-management-store";
 import { isSameWorkbenchSession, useWorkbenchStore } from "../chat/workbench-store";
-
-type SessionLike = {
-  id?: string;
-  title?: string;
-  time?: {
-    updated?: number;
-    created?: number;
-  };
-};
+import { controlWorkspaceLabel as workspaceLabel, listControlSessions, type ControlSessionLike as SessionLike } from "./list-control-sessions";
 
 type SessionControlWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
@@ -42,10 +33,6 @@ type UseSessionControlActionsInput = {
   archiveSession: (sessionId: string, archived: boolean) => Promise<boolean>;
 };
 
-function workspaceLabel(workspace: SessionControlWorkspace) {
-  return workspace.displayName?.trim() || workspace.name?.trim() || workspace.path?.trim() || "workspace";
-}
-
 function findSessionWorkspace(
   workspaces: SessionControlWorkspace[],
   sessionsByWorkspaceId: Record<string, SessionLike[]>,
@@ -67,6 +54,11 @@ function stringArg(args: unknown, name: string) {
 
 function booleanArg(args: unknown, name: string) {
   return objectArgs(args)[name] === true;
+}
+
+function numberArg(args: unknown, name: string) {
+  const value = objectArgs(args)[name];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 export function useSessionControlActions(input: UseSessionControlActionsInput) {
@@ -108,25 +100,21 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const listSessionsControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.list_sessions",
     label: "List available sessions",
-    description: "Return sessions across workspaces. Entries include `pinned`, and pinned sessions come first.",
+    description: "Return every loaded session across workspaces (pinned first, then newest). Entries include `pinned`. Pass `limit` to cap the count or `workspaceId` to narrow to one workspace.",
     kind: "query",
     effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
-    execute: () => {
-      const out: { sessionId: string; title: string; workspace: string; updatedAt: number; pinned: boolean }[] = [];
-      for (const workspace of workspaces) {
-        const list = sessionsByWorkspaceId[workspace.id] ?? [];
-        for (const session of list) {
-          const sessionId = session.id?.trim() ?? "";
-          if (!sessionId) continue;
-          const title = getDisplaySessionTitle(session.title ?? "");
-          const updatedAt = session.time?.updated ?? session.time?.created ?? 0;
-          out.push({ sessionId, title, workspace: workspaceLabel(workspace), updatedAt, pinned: pinnedIds.includes(sessionId) });
-        }
-      }
-      out.sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.updatedAt - a.updatedAt);
-      return out.slice(0, 30);
-    },
+    args: [
+      { name: "limit", type: "number", required: false, description: "Maximum sessions to return. Omit to return all loaded sessions." },
+      { name: "workspaceId", type: "string", required: false, description: "Workspace ID or display name. Omit to include every workspace." },
+    ],
+    execute: (args) => listControlSessions({
+      workspaces,
+      sessionsByWorkspaceId,
+      pinnedIds,
+      workspaceId: stringArg(args, "workspaceId") || undefined,
+      limit: numberArg(args, "limit"),
+    }),
   }), [pinnedIds, sessionsByWorkspaceId, workspaces]);
   useControlAction(listSessionsControlAction);
 

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -56,11 +56,6 @@ function booleanArg(args: unknown, name: string) {
   return objectArgs(args)[name] === true;
 }
 
-function numberArg(args: unknown, name: string) {
-  const value = objectArgs(args)[name];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
 export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const {
     canCreateTask,
@@ -108,13 +103,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
       { name: "limit", type: "number", required: false, description: "Maximum sessions to return. Omit to return all loaded sessions." },
       { name: "workspaceId", type: "string", required: false, description: "Workspace ID or display name. Omit to include every workspace." },
     ],
-    execute: (args) => listControlSessions({
-      workspaces,
-      sessionsByWorkspaceId,
-      pinnedIds,
-      workspaceId: stringArg(args, "workspaceId") || undefined,
-      limit: numberArg(args, "limit"),
-    }),
+    execute: (args) => listControlSessions(args, { workspaces, sessionsByWorkspaceId, pinnedIds }),
   }), [pinnedIds, sessionsByWorkspaceId, workspaces]);
   useControlAction(listSessionsControlAction);
 

--- a/docs/mcp-ui-control-profile.md
+++ b/docs/mcp-ui-control-profile.md
@@ -213,7 +213,7 @@ The exact list depends on the current OpenWork route and state. Common actions i
 | Action | Description |
 |--------|-------------|
 | `session.create_task` | Create a new session in the selected workspace |
-| `session.list_sessions` | List sessions across workspaces |
+| `session.list_sessions` | List all loaded sessions across workspaces (optional `limit`, `workspaceId`) |
 | `session.open` | Navigate to a session by ID |
 | `session.rename` | Rename a session |
 | `session.delete` | Delete a session (requires confirmation) |

--- a/evals/specs/session-list-sessions-inventory.test.ts
+++ b/evals/specs/session-list-sessions-inventory.test.ts
@@ -3,6 +3,10 @@ import { test } from "@openwork/testkit";
 
 import { listControlSessions } from "../../apps/app/src/react-app/domains/session/control/list-control-sessions";
 
+// The hook's execute is `(args) => listControlSessions(args, state)`, so every
+// call below passes the raw control-action payload exactly as the control
+// bridge delivers it (null / {} / a JSON object).
+
 const workspaces = [
   { id: "ws_alpha", displayName: "Alpha" },
   { id: "ws_beta", name: "beta-repo" },
@@ -18,61 +22,73 @@ function sessions(prefix: string, count: number, startAt: number) {
 
 // ~100 sessions in one workspace mirrors the reported inventory that the old
 // hard-coded 30-row cap silently dropped.
-const sessionsByWorkspaceId = {
-  ws_alpha: sessions("alpha", 100, 1_000),
-  ws_beta: sessions("beta", 20, 5_000),
+const state = {
+  workspaces,
+  sessionsByWorkspaceId: {
+    ws_alpha: sessions("alpha", 100, 1_000),
+    ws_beta: sessions("beta", 20, 5_000),
+  },
+  pinnedIds: [],
 };
 
 test("session.list_sessions returns every loaded session instead of a silent 30-row cap", async ({ evidence }) => {
-  const listed = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [] });
+  const withNull = listControlSessions(null, state);
+  const withEmpty = listControlSessions({}, state);
 
-  expect(listed).toHaveLength(120);
-  expect(new Set(listed.map((session) => session.sessionId)).size).toBe(120);
-  expect(listed.slice(0, 20).every((session) => session.workspace === "beta-repo")).toBe(true);
-  expect(listed[20]?.sessionId).toBe("alpha_99");
-  expect(listed.at(-1)?.sessionId).toBe("alpha_0");
+  expect(withNull).toHaveLength(120);
+  expect(withEmpty).toEqual(withNull);
+  expect(new Set(withNull.map((session) => session.sessionId)).size).toBe(120);
+  expect(withNull.slice(0, 20).every((session) => session.workspace === "beta-repo")).toBe(true);
+  expect(withNull[20]?.sessionId).toBe("alpha_99");
+  expect(withNull.at(-1)?.sessionId).toBe("alpha_0");
   evidence.recordAssertionEvidence(
     "Large session inventories are fully visible to the control surface",
-    `120 loaded sessions across two workspaces were all returned, newest first, with no truncation.`,
-    listed.length === 120,
+    `120 loaded sessions across two workspaces were all returned for both null and {} args, newest first, with no truncation.`,
+    withNull.length === 120 && withEmpty.length === 120,
   );
 });
 
-test("session.list_sessions caps output only when the caller passes limit", async ({ evidence }) => {
-  const capped = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], limit: 30 });
-  const ignoredLimit = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], limit: 0 });
+test("session.list_sessions caps output only when args carry a positive integer limit", async ({ evidence }) => {
+  const capped = listControlSessions({ limit: 30 }, state);
+  const zero = listControlSessions({ limit: 0 }, state);
+  const fractional = listControlSessions({ limit: 2.5 }, state);
+  const stringy = listControlSessions({ limit: "30" }, state);
 
   expect(capped).toHaveLength(30);
   expect(capped.map((session) => session.sessionId)).toEqual([
     ...Array.from({ length: 20 }, (_, index) => `beta_${19 - index}`),
     ...Array.from({ length: 10 }, (_, index) => `alpha_${99 - index}`),
   ]);
-  expect(ignoredLimit).toHaveLength(120);
+  expect(zero).toHaveLength(120);
+  expect(fractional).toHaveLength(120);
+  expect(stringy).toHaveLength(120);
   evidence.recordAssertionEvidence(
-    "Truncation is opt-in",
-    `limit: 30 returned the 30 newest sessions; limit: 0 was ignored and returned all 120.`,
-    capped.length === 30 && ignoredLimit.length === 120,
+    "Truncation is opt-in and only honours a positive integer limit",
+    `limit: 30 returned the 30 newest sessions; 0, 2.5 and "30" were ignored and returned all 120.`,
+    capped.length === 30 && zero.length === 120 && fractional.length === 120 && stringy.length === 120,
   );
 });
 
 test("session.list_sessions narrows to one workspace by id or display name without leaking others", async ({ evidence }) => {
-  const byId = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], workspaceId: "ws_alpha" });
-  const byName = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], workspaceId: "alpha" });
-  const unknown = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], workspaceId: "ws_missing" });
+  const byId = listControlSessions({ workspaceId: "ws_alpha" }, state);
+  const byName = listControlSessions({ workspaceId: " alpha " }, state);
+  const unknown = listControlSessions({ workspaceId: "ws_missing" }, state);
+  const combined = listControlSessions({ workspaceId: "ws_alpha", limit: 5 }, state);
 
   expect(byId).toHaveLength(100);
   expect(byId.every((session) => session.workspace === "Alpha")).toBe(true);
   expect(byName.map((session) => session.sessionId)).toEqual(byId.map((session) => session.sessionId));
   expect(unknown).toEqual([]);
+  expect(combined.map((session) => session.sessionId)).toEqual(["alpha_99", "alpha_98", "alpha_97", "alpha_96", "alpha_95"]);
   evidence.recordAssertionEvidence(
-    "Workspace filter is exact and never falls back to another workspace",
-    `ws_alpha and "alpha" both returned the same 100 sessions; an unknown workspace returned none.`,
-    byId.length === 100 && unknown.length === 0,
+    "Workspace filter is exact, composes with limit, and never falls back to another workspace",
+    `ws_alpha and " alpha " both returned the same 100 sessions; an unknown workspace returned none; limit 5 kept the 5 newest alpha sessions.`,
+    byId.length === 100 && unknown.length === 0 && combined.length === 5,
   );
 });
 
 test("session.list_sessions keeps pinned sessions first and skips entries without ids", async ({ evidence }) => {
-  const listed = listControlSessions({
+  const listed = listControlSessions(null, {
     workspaces,
     sessionsByWorkspaceId: {
       ws_alpha: [...sessions("alpha", 3, 1_000), { title: "no id" }, { id: "  " }],

--- a/evals/specs/session-list-sessions-inventory.test.ts
+++ b/evals/specs/session-list-sessions-inventory.test.ts
@@ -1,0 +1,92 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { listControlSessions } from "../../apps/app/src/react-app/domains/session/control/list-control-sessions";
+
+const workspaces = [
+  { id: "ws_alpha", displayName: "Alpha" },
+  { id: "ws_beta", name: "beta-repo" },
+];
+
+function sessions(prefix: string, count: number, startAt: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `${prefix}_${index}`,
+    title: `${prefix} task ${index}`,
+    time: { updated: startAt + index },
+  }));
+}
+
+// ~100 sessions in one workspace mirrors the reported inventory that the old
+// hard-coded 30-row cap silently dropped.
+const sessionsByWorkspaceId = {
+  ws_alpha: sessions("alpha", 100, 1_000),
+  ws_beta: sessions("beta", 20, 5_000),
+};
+
+test("session.list_sessions returns every loaded session instead of a silent 30-row cap", async ({ evidence }) => {
+  const listed = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [] });
+
+  expect(listed).toHaveLength(120);
+  expect(new Set(listed.map((session) => session.sessionId)).size).toBe(120);
+  expect(listed.slice(0, 20).every((session) => session.workspace === "beta-repo")).toBe(true);
+  expect(listed[20]?.sessionId).toBe("alpha_99");
+  expect(listed.at(-1)?.sessionId).toBe("alpha_0");
+  evidence.recordAssertionEvidence(
+    "Large session inventories are fully visible to the control surface",
+    `120 loaded sessions across two workspaces were all returned, newest first, with no truncation.`,
+    listed.length === 120,
+  );
+});
+
+test("session.list_sessions caps output only when the caller passes limit", async ({ evidence }) => {
+  const capped = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], limit: 30 });
+  const ignoredLimit = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], limit: 0 });
+
+  expect(capped).toHaveLength(30);
+  expect(capped.map((session) => session.sessionId)).toEqual([
+    ...Array.from({ length: 20 }, (_, index) => `beta_${19 - index}`),
+    ...Array.from({ length: 10 }, (_, index) => `alpha_${99 - index}`),
+  ]);
+  expect(ignoredLimit).toHaveLength(120);
+  evidence.recordAssertionEvidence(
+    "Truncation is opt-in",
+    `limit: 30 returned the 30 newest sessions; limit: 0 was ignored and returned all 120.`,
+    capped.length === 30 && ignoredLimit.length === 120,
+  );
+});
+
+test("session.list_sessions narrows to one workspace by id or display name without leaking others", async ({ evidence }) => {
+  const byId = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], workspaceId: "ws_alpha" });
+  const byName = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], workspaceId: "alpha" });
+  const unknown = listControlSessions({ workspaces, sessionsByWorkspaceId, pinnedIds: [], workspaceId: "ws_missing" });
+
+  expect(byId).toHaveLength(100);
+  expect(byId.every((session) => session.workspace === "Alpha")).toBe(true);
+  expect(byName.map((session) => session.sessionId)).toEqual(byId.map((session) => session.sessionId));
+  expect(unknown).toEqual([]);
+  evidence.recordAssertionEvidence(
+    "Workspace filter is exact and never falls back to another workspace",
+    `ws_alpha and "alpha" both returned the same 100 sessions; an unknown workspace returned none.`,
+    byId.length === 100 && unknown.length === 0,
+  );
+});
+
+test("session.list_sessions keeps pinned sessions first and skips entries without ids", async ({ evidence }) => {
+  const listed = listControlSessions({
+    workspaces,
+    sessionsByWorkspaceId: {
+      ws_alpha: [...sessions("alpha", 3, 1_000), { title: "no id" }, { id: "  " }],
+      ws_beta: sessions("beta", 2, 5_000),
+    },
+    pinnedIds: ["alpha_0"],
+  });
+
+  expect(listed.map((session) => session.sessionId)).toEqual(["alpha_0", "beta_1", "beta_0", "alpha_2", "alpha_1"]);
+  expect(listed[0]?.pinned).toBe(true);
+  expect(listed.slice(1).every((session) => !session.pinned)).toBe(true);
+  evidence.recordAssertionEvidence(
+    "Pinned-first ordering and id hygiene survive the refactor",
+    `alpha_0 (pinned, oldest) led the list; two id-less entries were dropped.`,
+    listed[0]?.sessionId === "alpha_0" && listed.length === 5,
+  );
+});

--- a/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
+++ b/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
@@ -7,7 +7,7 @@ OpenWork's cross-chat memory currently comes from saved session history. It is n
 
 When an agent is running inside the OpenWork app, it can use OpenWork's semantic UI actions to look up past chats:
 
-- `session.list_sessions` lists recent sessions across the workspaces the app knows about.
+- `session.list_sessions` lists every loaded session across the workspaces the app knows about (pinned first, then newest). Pass `limit` to cap the count or `workspaceId` to narrow to one workspace.
 - `session.open` opens a matching session by ID.
 - `session.read_transcript` reads recent messages from the currently open session.
 - `session.latest_message` reads the newest message in the currently open session.

--- a/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
+++ b/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
@@ -15,7 +15,7 @@ When an agent is running inside the OpenWork app, it can use OpenWork's semantic
 That means you can ask things like:
 
 - `What did I say in the customer migration session?`
-- `Find the session about Ramki and remind me what we decided.`
+- `Find the session about the pricing page redesign and remind me what we decided.`
 - `Open the onboarding bug chat and summarize the next steps.`
 - `What did I ask you to do in session ses_abc123?`
 


### PR DESCRIPTION
## Problem

A session reported:

> There are ~100 candidate sessions in this workspace and the list API caps at 30. I'll inventory directly from the OpenCode storage on disk.

The agent could not inventory the workspace through the app's control surface and fell back to scraping OpenCode storage on disk.

## Root cause

`session.list_sessions` (`apps/app/src/react-app/domains/session/control/session-control-actions.ts`) has hard-coded `out.slice(0, 30)` since the original UI control bridge landed in #1644. Meanwhile the app already holds the workspace's sessions in memory (`listRouteSessions` now pages exhaustively since #4783), so the data was present and simply dropped. The action exposed no `limit` / `workspaceId` args and no truncation indicator, so callers had no way to know the list was partial or to ask for more.

## Fix

- Return every loaded session by default (pinned first, then newest — unchanged ordering).
- Add optional `limit` (opt-in cap; only a positive integer is honoured) and `workspaceId` (exact id or display-name match; an unknown workspace returns `[]` rather than falling back to another workspace).
- Extract the listing into pure `list-control-sessions.ts` taking the raw control-action payload, so the hook's `execute` is a one-line pass-through and arg forwarding is provable without booting Electron. The result stays a plain array so the ~12 existing `.e2e.test.ts` specs that consume `session.list_sessions` through the control API are unaffected (they also continue to exercise registration).
- Update the two docs that describe the action; replace a real-looking personal name in a public docs example with a fictional topic (Warden 2T3-GM4).

## Proof — **Passed**

Lane: **local** (PR-lane pure spec; Daytona not required for an app-less spec). Head `6a61a8c9d`.

```
$ pnpm evals:pr specs/session-list-sessions-inventory.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)      # exit 0

$ pnpm --filter @openwork/app typecheck   # exit 0
```

Witness check — with `out.slice(0, 30)` re-applied to the helper, the same spec fails `3 failed | 1 passed (4)`.

CI: all required checks green; the spec also ran in the dispatched extended lane on both runners (`✓ pr specs/session-list-sessions-inventory.test.ts (4 tests)`).

Pre-existing extended-lane reds (control): a `workflow_dispatch` of `ci-tests.yml` on clean `dev`@586c4100f ([run 34490136184](https://github.com/different-ai/openwork/actions/runs/34490136184)) fails the same four steps with the **identical 20 failing tests** as this branch's run ([34489353444](https://github.com/different-ai/openwork/actions/runs/34489353444)); 0 failures are unique to this branch. Root cause there is environmental: `Local Den requires MySQL on 127.0.0.1:3306` (48 occurrences). Control: `240 failed | 190 passed` files, `20 failed | 1801 passed`; this branch: `240 failed | 191 passed`, `20 failed | 1805 passed` — the delta is exactly this spec.

Claims covered by `evals/specs/session-list-sessions-inventory.test.ts` (each called with the raw `args` payload the control bridge delivers):
1. `null` and `{}` args return all 120 loaded sessions across two workspaces, newest first, no truncation.
2. `limit: 30` returns exactly the 30 newest; `0`, `2.5`, and `"30"` are ignored.
3. `workspaceId` by id and by (trimmed) display name return the same 100 sessions; unknown workspace returns none; composes with `limit`.
4. Pinned-first ordering and id-less entry hygiene survive the refactor.
