### PR TITLE
fix(den-web): redirect legacy /api/den callers to DEN_API_PUBLIC_URL, not the in-network DEN_API_BASE

### DIFF
--- a/ee/apps/den-web/README.md
+++ b/ee/apps/den-web/README.md
@@ -55,6 +55,7 @@ Tailwind 4 requires Safari 16.4+, Chrome 111+, or Firefox 128+; see the
 ### Optional env vars
 
 - `DEN_API_BASE` (server-only): upstream API base used by server-side health/readiness and compatibility auth proxy routes. Required outside local dev wrappers.
+- `DEN_API_PUBLIC_URL` (server/runtime): browser-reachable Den API origin handed to clients by `/api/runtime-config` and used as the `Location` of the legacy `/api/den/*` 307 redirect. Set it whenever `DEN_API_BASE` is a container-internal URL; when unset, the redirect falls back to `DEN_API_BASE`, then `api.<web host>`.
 - `DEN_AUTH_ORIGIN` (server-only): Origin header sent to Better Auth endpoints when the browser request does not include one. Required outside local dev wrappers.
 - `DEN_WEB_PUBLIC_ORIGIN` (server/runtime): public origin used for metadata.
 - `DEN_WEB_OPENWORK_APP_CONNECT_URL` (runtime): Base URL for "Open in App" links.

--- a/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-api-origin.ts
@@ -19,12 +19,29 @@ export function setDenApiOriginOverride(input: string | null | undefined) {
   denApiOriginOverride = normalizeOrigin(input);
 }
 
-export function denApiOriginForWebOrigin(webOrigin: string): string | null {
-  const configuredOrigin = process.env.DEN_API_BASE?.trim();
-  if (configuredOrigin) {
+// Browser-facing API origin. DEN_API_PUBLIC_URL is the origin the browser can
+// reach (runtime-config hands it to clients); DEN_API_BASE is the server-side
+// upstream, which in containers is an in-network URL the browser cannot reach.
+// Prefer the public one and keep DEN_API_BASE as the documented fallback.
+// Mirrored in next-config-den-api-redirects.cjs (keep in sync).
+function configuredDenApiOrigin(): string | null {
+  for (const value of [process.env.DEN_API_PUBLIC_URL, process.env.DEN_API_BASE]) {
+    const configuredOrigin = value?.trim();
+    if (!configuredOrigin) continue;
     try {
-      return new URL(configuredOrigin).origin;
+      const url = new URL(configuredOrigin);
+      // Scheme-less values like `localhost:18788` parse with a `localhost:`
+      // scheme and an opaque "null" origin; skip them like the build-time rule.
+      if (url.protocol === "http:" || url.protocol === "https:") return url.origin;
     } catch {}
+  }
+  return null;
+}
+
+export function denApiOriginForWebOrigin(webOrigin: string): string | null {
+  const configuredOrigin = configuredDenApiOrigin();
+  if (configuredOrigin) {
+    return configuredOrigin;
   }
 
   let url: URL;

--- a/ee/apps/den-web/app/api/_lib/den-api-redirect.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/den-api-redirect.test.mjs
@@ -1,20 +1,40 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 
 const previousDenBaseUrl = process.env.DEN_BASE_URL;
 const previousDenApiBase = process.env.DEN_API_BASE;
+const previousDenApiPublicUrl = process.env.DEN_API_PUBLIC_URL;
 const previousPublicOrigin = process.env.DEN_WEB_PUBLIC_ORIGIN;
+
+beforeEach(() => {
+  delete process.env.DEN_API_PUBLIC_URL;
+});
 
 afterEach(() => {
   if (previousDenBaseUrl === undefined) delete process.env.DEN_BASE_URL;
   else process.env.DEN_BASE_URL = previousDenBaseUrl;
   if (previousDenApiBase === undefined) delete process.env.DEN_API_BASE;
   else process.env.DEN_API_BASE = previousDenApiBase;
+  if (previousDenApiPublicUrl === undefined) delete process.env.DEN_API_PUBLIC_URL;
+  else process.env.DEN_API_PUBLIC_URL = previousDenApiPublicUrl;
   if (previousPublicOrigin === undefined) delete process.env.DEN_WEB_PUBLIC_ORIGIN;
   else process.env.DEN_WEB_PUBLIC_ORIGIN = previousPublicOrigin;
 });
 
 describe("Den API redirect compatibility route", () => {
+  test("sends browsers to DEN_API_PUBLIC_URL when DEN_API_BASE is an in-network upstream", async () => {
+    process.env.DEN_BASE_URL = "http://localhost:13005";
+    process.env.DEN_API_BASE = "http://den:8788";
+    process.env.DEN_API_PUBLIC_URL = "http://localhost:18788";
+    delete process.env.DEN_WEB_PUBLIC_ORIGIN;
+
+    const { GET } = await import("../den/[...path]/route.ts");
+    const response = await GET(new NextRequest("http://localhost:13005/api/den/health"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost:18788/health");
+  });
+
   test("redirects legacy /api/den callers to the api-prefixed host", async () => {
     delete process.env.DEN_BASE_URL;
     delete process.env.DEN_API_BASE;

--- a/ee/apps/den-web/next-config-den-api-redirects.cjs
+++ b/ee/apps/den-web/next-config-den-api-redirects.cjs
@@ -42,10 +42,12 @@ function publicWebOrigin(env) {
   return webOriginFromDenBaseUrl(env) ?? (trimmed(env.DEN_WEB_PUBLIC_ORIGIN).replace(/\/+$/, "") || null);
 }
 
-// Mirrors denApiOriginForWebOrigin(): DEN_API_BASE wins, else `api.` on the web host.
+// Mirrors denApiOriginForWebOrigin(): the browser-reachable DEN_API_PUBLIC_URL
+// wins, then the server-side DEN_API_BASE, else `api.` on the web host.
 function denApiRedirectOrigin(env = process.env) {
-  const configured = trimmed(env.DEN_API_BASE);
-  if (configured) {
+  for (const value of [env.DEN_API_PUBLIC_URL, env.DEN_API_BASE]) {
+    const configured = trimmed(value);
+    if (!configured) continue;
     const origin = originFromUrl(configured);
     if (origin) return origin;
   }

--- a/ee/apps/den-web/tests/den-api-origin.test.ts
+++ b/ee/apps/den-web/tests/den-api-origin.test.ts
@@ -4,8 +4,16 @@ import { NextRequest } from "next/server";
 import { denApiCredentialsForEndpoint, denApiEndpointForWebOrigin, denApiOriginForWebOrigin, setDenApiOriginOverride } from "../app/(den)/_lib/den-api-origin";
 import { redirectToDenApi } from "../app/api/_lib/den-api-redirect";
 
+const ENV_KEYS = ["DEN_API_BASE", "DEN_API_PUBLIC_URL"] as const;
+const previousEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
 afterEach(() => {
   setDenApiOriginOverride(null);
+  for (const key of ENV_KEYS) {
+    const value = previousEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
 });
 
 describe("Den API browser origin", () => {
@@ -19,6 +27,33 @@ describe("Den API browser origin", () => {
 
   test("leaves existing api hosts stable", () => {
     expect(denApiOriginForWebOrigin("https://api.openworklabs.com")).toBe("https://api.openworklabs.com");
+  });
+
+  test("sends browsers to DEN_API_PUBLIC_URL, not the in-network DEN_API_BASE upstream", () => {
+    process.env.DEN_API_BASE = "http://den:8788";
+    process.env.DEN_API_PUBLIC_URL = "http://localhost:18788/";
+
+    expect(denApiOriginForWebOrigin("http://localhost:13005")).toBe("http://localhost:18788");
+
+    const request = new NextRequest("http://localhost:13005/api/den/health");
+    const response = redirectToDenApi(request, "/api/den");
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost:18788/health");
+    expect(response.headers.get("location")).not.toContain("den:8788");
+  });
+
+  test("keeps the documented DEN_API_BASE fallback when no public URL is configured", () => {
+    process.env.DEN_API_BASE = "http://127.0.0.1:8790";
+    delete process.env.DEN_API_PUBLIC_URL;
+
+    expect(denApiOriginForWebOrigin("http://localhost:3005")).toBe("http://127.0.0.1:8790");
+  });
+
+  test("skips a DEN_API_PUBLIC_URL without a scheme and falls back like the build-time rule", () => {
+    process.env.DEN_API_BASE = "http://den:8788";
+    process.env.DEN_API_PUBLIC_URL = "localhost:18788";
+
+    expect(denApiOriginForWebOrigin("http://localhost:13005")).toBe("http://den:8788");
   });
 
   test("builds direct API URLs instead of same-origin Den proxy URLs", () => {

--- a/ee/apps/den-web/tests/den-api-redirect-rules.test.ts
+++ b/ee/apps/den-web/tests/den-api-redirect-rules.test.ts
@@ -6,9 +6,9 @@ import { redirectToDenApi } from "../app/api/_lib/den-api-redirect";
 import { readPublicWebOrigin } from "../app/_lib/public-web-origin";
 import { denApiRedirectOrigin, denApiRedirects } from "../next-config-den-api-redirects.cjs";
 
-type RedirectEnv = Partial<Record<"DEN_API_BASE" | "DEN_BASE_URL" | "DEN_WEB_PUBLIC_ORIGIN", string>>;
+type RedirectEnv = Partial<Record<"DEN_API_BASE" | "DEN_API_PUBLIC_URL" | "DEN_BASE_URL" | "DEN_WEB_PUBLIC_ORIGIN", string>>;
 
-const ENV_KEYS = ["DEN_API_BASE", "DEN_BASE_URL", "DEN_WEB_PUBLIC_ORIGIN"] as const;
+const ENV_KEYS = ["DEN_API_BASE", "DEN_API_PUBLIC_URL", "DEN_BASE_URL", "DEN_WEB_PUBLIC_ORIGIN"] as const;
 const previousEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
 
 function applyEnv(env: RedirectEnv) {
@@ -33,7 +33,33 @@ describe("Den API build-time redirect rules", () => {
     expect(denApiRedirects({})).toEqual([]);
   });
 
-  test("prefers an explicit DEN_API_BASE origin", () => {
+  test("prefers the browser-reachable DEN_API_PUBLIC_URL over an in-network DEN_API_BASE", () => {
+    // The compose/Helm shape: DEN_API_BASE is the container-internal upstream
+    // for the /api/auth/* proxy; browsers must be sent to the public origin.
+    const env = {
+      DEN_API_BASE: "http://den:8788",
+      DEN_API_PUBLIC_URL: "http://localhost:18788/",
+      DEN_BASE_URL: "http://localhost:13005",
+    };
+
+    expect(denApiRedirectOrigin(env)).toBe("http://localhost:18788");
+    expect(denApiRedirects(env)).toEqual([
+      {
+        source: "/api/den/:path*",
+        destination: "http://localhost:18788/:path*",
+        permanent: false,
+      },
+    ]);
+    expect(denApiRedirects(env)[0]?.destination).not.toContain("den:8788");
+  });
+
+  test("ignores a DEN_API_PUBLIC_URL without a scheme and falls back to DEN_API_BASE", () => {
+    const env = { DEN_API_PUBLIC_URL: "localhost:18788", DEN_API_BASE: "http://den:8788", DEN_BASE_URL: "http://localhost:13005" };
+
+    expect(denApiRedirectOrigin(env)).toBe("http://den:8788");
+  });
+
+  test("falls back to an explicit DEN_API_BASE origin when no public URL is set", () => {
     const env = { DEN_API_BASE: "https://api.openworklabs.com/", DEN_BASE_URL: "https://app.openworklabs.com" };
 
     expect(denApiRedirectOrigin(env)).toBe("https://api.openworklabs.com");
@@ -69,6 +95,9 @@ describe("Den API build-time redirect rules", () => {
       { DEN_API_BASE: "https://api.openworklabs.com", DEN_BASE_URL: "https://app.openworklabs.com" },
       { DEN_BASE_URL: "https://app.openworklabs.com" },
       { DEN_BASE_URL: "http://localhost:3005", DEN_API_BASE: "http://127.0.0.1:8790" },
+      { DEN_BASE_URL: "http://localhost:13005", DEN_API_BASE: "http://den:8788", DEN_API_PUBLIC_URL: "http://localhost:18788" },
+      { DEN_BASE_URL: "http://localhost:13005", DEN_API_BASE: "http://den:8788", DEN_API_PUBLIC_URL: "localhost:18788" },
+      { DEN_BASE_URL: "https://app.openworklabs.com", DEN_API_PUBLIC_URL: "https://api.openworklabs.com/" },
       { DEN_WEB_PUBLIC_ORIGIN: "https://den.example.org" },
       { DEN_API_BASE: "not a url", DEN_BASE_URL: "https://app.openworklabs.com" },
     ];

--- a/evals/specs/den-web-public-api-redirect.test.ts
+++ b/evals/specs/den-web-public-api-redirect.test.ts
@@ -1,0 +1,96 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { denComposeEval } from "../worlds/den-compose-eval.ts";
+
+// Legacy /api/den/* callers (older desktop builds) receive a 307 to the Den API.
+// In the documented Compose and Helm shapes den-web's DEN_API_BASE is the
+// container-internal upstream that the /api/auth/* proxy needs, so the browser
+// must be redirected to DEN_API_PUBLIC_URL instead. Both must hold on one
+// container from the host: the redirect lands on a reachable API, and the auth
+// proxy keeps answering through the in-network upstream.
+const test = spec.world(denComposeEval, {
+  needs: { commands: ["docker"], env: ["OPENWORK_EVAL_DEN_WEB_IMAGE"] },
+  timeout: 600_000,
+});
+
+function location(response: Response): URL {
+  const value = response.headers.get("location");
+  if (!value) throw new Error(`Expected a Location header, got ${response.status} without one.`);
+  return new URL(value, response.url);
+}
+
+async function json(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+test("legacy /api/den redirects send the browser to the public API origin while the auth proxy stays in-network", { timeout: 600_000 }, async ({ world, step, evidence }) => {
+  await step("the documented web container redirects /api/den/* to DEN_API_PUBLIC_URL, not DEN_API_BASE", async () => {
+    const redirect = await fetch(`${world.webUrl}/api/den/health?probe=redirect`, { redirect: "manual" });
+    expect(redirect.status).toBe(307);
+    const target = location(redirect);
+    expect(target.origin).toBe(world.publicApiOrigin);
+    expect(target.pathname).toBe("/health");
+    expect(target.search).toBe("?probe=redirect");
+    expect(target.origin).not.toBe(world.internalApiOrigin);
+    evidence.recordAssertionEvidence(
+      "Redirect targets the browser-reachable API origin",
+      `GET ${world.webUrl}/api/den/health answered 307 with Location origin ${target.origin} (DEN_API_PUBLIC_URL); the in-network ${world.internalApiOrigin} did not leak to the browser.`,
+      true,
+    );
+  });
+
+  await step("following that redirect from the host reaches Den API health", async () => {
+    const followed = await fetch(`${world.webUrl}/api/den/health`, { redirect: "follow" });
+    expect(followed.status).toBe(200);
+    expect(new URL(followed.url).origin).toBe(world.publicApiOrigin);
+    expect(await json(followed)).toMatchObject({ ok: true });
+    evidence.recordAssertionEvidence(
+      "Redirected API call succeeds from outside the compose network",
+      `Following the redirect ended at ${followed.url} with HTTP 200 and ok:true.`,
+      true,
+    );
+  });
+
+  await step("the /api/auth/* proxy on the same container still answers through the in-network upstream", async () => {
+    const ok = await fetch(`${world.webUrl}/api/auth/ok`, { redirect: "manual" });
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get("location")).toBeNull();
+    expect(await json(ok)).toMatchObject({ ok: true });
+    const session = await fetch(`${world.webUrl}/api/auth/get-session`, { redirect: "manual" });
+    expect(session.status).toBe(200);
+    const ready = await fetch(`${world.webUrl}/api/ready`);
+    expect(ready.status).toBe(200);
+    expect(await json(ready)).toMatchObject({ ok: true, checks: { upstream: "ok" } });
+    evidence.recordAssertionEvidence(
+      "Auth proxy is unaffected by the public redirect origin",
+      `GET /api/auth/ok and /api/auth/get-session answered 200 without a redirect, and /api/ready reported upstream ok, so DEN_API_BASE still serves the server-side proxy.`,
+      true,
+    );
+  });
+
+  await step("runtime-config and the legacy redirect agree on the API origin new and old clients use", async () => {
+    const config = await fetch(`${world.webUrl}/api/runtime-config`);
+    expect(config.status).toBe(200);
+    const payload = await json(config);
+    expect(payload).toMatchObject({ denApiUrl: world.publicApiOrigin });
+    evidence.recordAssertionEvidence(
+      "New and legacy clients are pointed at the same origin",
+      `runtime-config denApiUrl equals the /api/den redirect origin ${world.publicApiOrigin}.`,
+      true,
+    );
+  });
+
+  await step("without DEN_API_PUBLIC_URL the documented DEN_API_BASE fallback still applies", async () => {
+    const redirect = await fetch(`${world.fallbackWebUrl}/api/den/health`, { redirect: "manual" });
+    expect(redirect.status).toBe(307);
+    expect(location(redirect).origin).toBe(world.internalApiOrigin);
+    const ok = await fetch(`${world.fallbackWebUrl}/api/auth/ok`, { redirect: "manual" });
+    expect(ok.status).toBe(200);
+    expect(await json(ok)).toMatchObject({ ok: true });
+    evidence.recordAssertionEvidence(
+      "Legacy fallback order is preserved",
+      `The same image without DEN_API_PUBLIC_URL redirected to ${world.internalApiOrigin} (DEN_API_BASE) and its auth proxy still answered 200.`,
+      true,
+    );
+  });
+});

--- a/evals/worlds/den-compose-eval.ts
+++ b/evals/worlds/den-compose-eval.ts
@@ -1,0 +1,150 @@
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { allocateFreePorts } from "@openwork/cdp";
+import { SkipError, type Seed } from "@openwork/env";
+
+// The documented pull-only evaluation stack (packaging/docker/docker-compose.eval.yml)
+// booted as an isolated Compose project, with the `web` service swapped for a
+// locally built den-web image so a den-web source change can be proven across
+// the real container boundary before an image release ships it.
+//
+// Two web containers share one Den API and database:
+//   web          the documented shape: DEN_API_BASE=http://den:8788 (in-network
+//                proxy upstream) plus the browser-reachable DEN_API_PUBLIC_URL.
+//   web-fallback identical, but without DEN_API_PUBLIC_URL, to observe the
+//                documented DEN_API_BASE fallback.
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const COMPOSE_FILE = join(REPO_ROOT, "packaging", "docker", "docker-compose.eval.yml");
+const INTERNAL_API_ORIGIN = "http://den:8788";
+const HEALTHY_WITHIN_MS = 240_000;
+
+export interface DenComposeEvalWorld extends AsyncDisposable {
+  /** Compose project name; every container, network and volume carries it. */
+  project: string;
+  /** den-web image under test (OPENWORK_EVAL_DEN_WEB_IMAGE). */
+  image: string;
+  /** Host URL of the documented `web` service (DEN_API_PUBLIC_URL set). */
+  webUrl: string;
+  /** Host URL of the same image without DEN_API_PUBLIC_URL. */
+  fallbackWebUrl: string;
+  /** Browser-reachable Den API origin, exactly as DEN_API_PUBLIC_URL is configured. */
+  publicApiOrigin: string;
+  /** Container-internal Den API origin the /api/auth proxy must keep using. */
+  internalApiOrigin: string;
+  logs(service: "web" | "web-fallback" | "den"): Promise<string>;
+}
+
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function compose(args: string[], env: NodeJS.ProcessEnv): Promise<string> {
+  const { stdout } = await execFileAsync("docker", ["compose", ...args], {
+    cwd: REPO_ROOT,
+    env,
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 300_000,
+  });
+  return stdout;
+}
+
+async function waitForHealthy(url: string, label: string, logs: () => Promise<string>): Promise<void> {
+  const deadline = Date.now() + HEALTHY_WITHIN_MS;
+  let last = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+      if (response.ok) return;
+      last = `HTTP ${response.status}`;
+    } catch (error) {
+      last = messageText(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Timed out waiting for ${label} at ${url}: ${last}. Last log lines:\n${(await logs()).split(/\r?\n/).slice(-40).join("\n")}`);
+}
+
+export async function denComposeEval(seed: Seed): Promise<DenComposeEvalWorld> {
+  const image = process.env.OPENWORK_EVAL_DEN_WEB_IMAGE?.trim();
+  if (!image) {
+    throw new SkipError("set OPENWORK_EVAL_DEN_WEB_IMAGE to a locally built den-web image (docker build --load -f packaging/docker/Dockerfile.den-web -t <image> .)");
+  }
+  await execFileAsync("docker", ["image", "inspect", image]).catch(() => {
+    throw new Error(`OPENWORK_EVAL_DEN_WEB_IMAGE=${image} is not present locally; build it with docker build --load first.`);
+  });
+
+  const [webPort, apiPort, fallbackPort] = await allocateFreePorts(3);
+  if (webPort === undefined || apiPort === undefined || fallbackPort === undefined) {
+    throw new Error("Could not allocate host ports for the compose evaluation stack.");
+  }
+  const project = `openwork-eval-spec-${randomBytes(4).toString("hex")}`;
+  const root = seed.tmpPath("den-compose-eval");
+  await mkdir(root, { recursive: true });
+  const publicApiOrigin = `http://localhost:${apiPort}`;
+
+  // Override only what the proof needs: the image under test, never pulled,
+  // and a second web container without the public API origin.
+  const overridePath = join(root, "docker-compose.override.yml");
+  await writeFile(overridePath, [
+    "services:",
+    "  web:",
+    `    image: ${image}`,
+    "    pull_policy: never",
+    "  web-fallback:",
+    "    extends:",
+    `      file: ${COMPOSE_FILE}`,
+    "      service: web",
+    `    image: ${image}`,
+    "    pull_policy: never",
+    "    ports: !override",
+    `      - "127.0.0.1:${fallbackPort}:3005"`,
+    "    environment:",
+    "      DEN_API_PUBLIC_URL: !reset null",
+    "",
+  ].join("\n"));
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENWORK_WEB_PORT: String(webPort),
+    OPENWORK_API_PORT: String(apiPort),
+    OPENWORK_AUTH_SECRET: randomBytes(32).toString("hex"),
+    OPENWORK_DB_ENCRYPTION_KEY: randomBytes(32).toString("hex"),
+  };
+  const composeArgs = ["-p", project, "-f", COMPOSE_FILE, "-f", overridePath];
+  const logs = async (service: "web" | "web-fallback" | "den") =>
+    compose([...composeArgs, "logs", "--no-color", "--tail", "80", service], env).catch((error: unknown) => `logs unavailable: ${messageText(error)}`);
+
+  const down = async () => {
+    await compose([...composeArgs, "down", "--volumes", "--remove-orphans", "--timeout", "10"], env)
+      .catch((error: unknown) => console.error(`[openwork/testkit] compose down failed for ${project}: ${messageText(error)}`));
+  };
+
+  try {
+    await compose([...composeArgs, "up", "-d", "--wait", "--wait-timeout", "240"], env);
+    const webUrl = `http://127.0.0.1:${webPort}`;
+    const fallbackWebUrl = `http://127.0.0.1:${fallbackPort}`;
+    await waitForHealthy(`${webUrl}/api/ready`, "web", () => logs("web"));
+    await waitForHealthy(`${fallbackWebUrl}/api/ready`, "web-fallback", () => logs("web-fallback"));
+    await waitForHealthy(`${publicApiOrigin}/health`, "den", () => logs("den"));
+  } catch (error) {
+    await down();
+    throw error;
+  }
+
+  return {
+    project,
+    image,
+    webUrl: `http://127.0.0.1:${webPort}`,
+    fallbackWebUrl: `http://127.0.0.1:${fallbackPort}`,
+    publicApiOrigin,
+    internalApiOrigin: INTERNAL_API_ORIGIN,
+    logs,
+    [Symbol.asyncDispose]: down,
+  };
+}


### PR DESCRIPTION
## Problem

Follow-up to #4768 ("Not fixed here" section). den-web's legacy `/api/den/*` route (a 307 kept for older desktop builds) resolves its `Location` origin from `DEN_API_BASE` first, in both the route handler (`app/(den)/_lib/den-api-origin.ts`) and its build-time mirror (`next-config-den-api-redirects.cjs`). In the documented Compose stack (`packaging/docker/docker-compose.eval.yml`) and the Helm chart, `DEN_API_BASE` is the container-internal upstream the `/api/auth/*` proxy needs (`http://den:8788`, `http://<release>-den-api:8788`), so browsers were redirected to a host they cannot reach:

```
denApiRedirects({ DEN_API_BASE: 'http://den:8788', DEN_API_PUBLIC_URL: 'http://localhost:18788', DEN_BASE_URL: 'http://localhost:13005' })
→ destination http://den:8788/:path*     (expected http://localhost:18788/:path*)
```

`/api/runtime-config` already hands new clients `DEN_API_PUBLIC_URL`; the redirect disagreed with it.

## Change (den-web only)

- `den-api-origin.ts` + `next-config-den-api-redirects.cjs`: browser-facing origin order is now `DEN_API_PUBLIC_URL` → `DEN_API_BASE` → `api.<web host>`. The documented fallback is preserved: without a public URL nothing changes.
- The runtime side now rejects non-http(s) schemes like the mirror already did. Previously a scheme-less value (`localhost:18788`) parsed as scheme `localhost:` and yielded the string `"null"` as origin; the parity test surfaced it.
- The `/api/auth/*` proxy, `/api/ready`, the SSO probe and the dashboard layout keep reading `DEN_API_BASE` — untouched.
- `ee/apps/den-web/README.md`: documents `DEN_API_PUBLIC_URL`.
- No change to `docker-compose.eval.yml` (image pins are #4732's; comments already describe the intended split).

## Proof

**Unit (bun, `ee/apps/den-web`)** — extended `tests/den-api-origin.test.ts`, `tests/den-api-redirect-rules.test.ts` (route/build-time parity across 3 new env shapes) and `app/api/_lib/den-api-redirect.test.mjs` (through the real `app/api/den/[...path]/route.ts`):

```
bun test --conditions development tests/den-api-origin.test.ts tests/den-api-redirect-rules.test.ts app/api/_lib/den-api-redirect.test.mjs app/api/_lib/upstream-proxy.test.mjs app/api/_lib/upstream-proxy-lifecycle.test.mjs tests/web-page.test.ts
 57 pass / 0 fail / 213 expect() calls
pnpm --filter @openwork-ee/den-web typecheck → exit 0
```
`pnpm --filter @openwork-ee/den-web test` → 234 pass / 1 fail: `tests/cloud-super-admins-role-hierarchy.test.ts` ("Workflow Runs" label) — pre-existing, same single failure on clean base `586c4100f` with this diff stashed.

**Runtime boundary (testkit PR lane, local, Docker Desktop)** — new `evals/specs/den-web-public-api-redirect.test.ts` + `evals/worlds/den-compose-eval.ts`. The world boots the documented `docker-compose.eval.yml` as an isolated project (unique name/network/volume, free host ports, random secrets) with the `web` service swapped for a locally built den-web image (`OPENWORK_EVAL_DEN_WEB_IMAGE`, `pull_policy: never`) plus a `web-fallback` container from the same image with `DEN_API_PUBLIC_URL` removed. Five steps, each with the negative half:

1. `GET :web/api/den/health?probe=redirect` → 307, `Location` origin == `DEN_API_PUBLIC_URL`, path/query preserved, origin != `http://den:8788`
2. following that redirect from the host → 200 `{ok:true}` on the public API origin
3. same container: `/api/auth/ok` 200 (no redirect), `/api/auth/get-session` 200, `/api/ready` upstream `ok`
4. `/api/runtime-config` `denApiUrl` == redirect origin
5. `web-fallback` (no `DEN_API_PUBLIC_URL`): 307 → `http://den:8788` (documented `DEN_API_BASE` fallback) and its `/api/auth/ok` still 200

```
docker build --load -f packaging/docker/Dockerfile.den-web -t openwork-den-web:public-redirect-586c410 .
OPENWORK_EVAL_DEN_WEB_IMAGE=openwork-den-web:public-redirect-586c410 pnpm evals:pr specs/den-web-public-api-redirect.test.ts
 Test Files 1 passed (1) · Tests 1 passed (1) · 32.88s · exit 0   (head bcb9470d9, placement: local)
```
Negative control — same spec against the published `openwork-den-web:0.18.46@sha256:82affe9e…` (the pin in the compose file): **fails at step 1** with `expected 'http://den:8788' to be 'http://localhost:<port>'`, i.e. the spec observes exactly the reported defect. Compose project, volumes and network were removed after each run.

The spec declares `needs: { commands: ["docker"], env: ["OPENWORK_EVAL_DEN_WEB_IMAGE"] }` and skips loudly without a prebuilt image, so nightly `evals:pr` does not build images. Daytona lane not used: the proof drives local Docker; no placement dependency.

**Framework checks**: `spec-boundary-ratchet`, `spec-channel-ratchet`, `lint:layers` (39 known violations before and after), `check:browser`, `tsc -p evals` (381 pre-existing errors before and after) — none reference the new files.

**Warden** (`pnpm warden:check`, HEAD `bcb9470d9` vs origin/dev `586c4100f`): diff-security-review, confidentiality-review, spec-provenance-review all completed — No findings, exit 0.

## Release dependency

The published den-web image cannot contain this fix; the Compose/Helm redirect is corrected only once a den-web image with this commit is released and #4732's pin automation moves `docker-compose.eval.yml` to it. Until then `/api/runtime-config` (new clients) is correct and only the legacy `/api/den/*` path is affected.
