### PR TITLE
fix(desktop): resolve the stale ShipIt cache from an overridden HOME

### DIFF
--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -264,12 +264,22 @@ async function enableSquirrelDirectContentsWrite(
   await writeDefaults(["write", shipItDefaultsDomain, "SquirrelMacEnableDirectContentsWrite", "-bool", "YES"]);
 }
 
+// Home the ShipIt cache is resolved against. Everything else in the process
+// isolation points HOME at the profile it owns (electronSurfaceEnv in
+// evals/packages/hosts/src/local.ts), but `app.getPath("home")` resolves from
+// the OS account instead, so an isolated launch that overrides HOME would
+// still clean the developer's real cache. Prefer the overridden HOME and fall
+// back to Electron's for a normal install, where the two agree. Exported for
+// tests.
+export function staleUpdaterStateHome(app, env = process.env) {
+  return env?.HOME?.trim() || app.getPath("home");
+}
+
 // Path of the ShipIt cache that, when stuck, keeps aborting future installs.
 // Exported for tests.
-export function staleUpdaterStatePaths(app, shipItDefaultsDomain = SHIP_IT_DEFAULTS_DOMAIN) {
+export function staleUpdaterStatePaths(app, shipItDefaultsDomain = SHIP_IT_DEFAULTS_DOMAIN, env = process.env) {
   if (process.platform !== "darwin") return [];
-  const home = app.getPath("home");
-  return [path.join(home, "Library", "Caches", shipItDefaultsDomain)];
+  return [path.join(staleUpdaterStateHome(app, env), "Library", "Caches", shipItDefaultsDomain)];
 }
 
 // Remove a previously-failed, half-applied update so the next attempt starts

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import {
   preventPendingUpdaterInstall,
   registerUpdaterIpc,
+  staleUpdaterStateHome,
   staleUpdaterStatePaths,
   targetedStableUpdaterFeed,
 } from "./updater.mjs";
@@ -116,13 +117,35 @@ async function registerFakeUpdaterIpc({ version, platform = "linux", manualNativ
 
 describe("staleUpdaterStatePaths", () => {
   it("targets the ShipIt cache on macOS", { skip: process.platform !== "darwin" }, () => {
-    assert.deepEqual(staleUpdaterStatePaths(fakeApp), [
+    assert.deepEqual(staleUpdaterStatePaths(fakeApp, undefined, {}), [
       "/Users/test/Library/Caches/com.differentai.openwork.ShipIt",
+    ]);
+  });
+
+  it("targets the isolated home when HOME is overridden", { skip: process.platform !== "darwin" }, () => {
+    assert.deepEqual(staleUpdaterStatePaths(fakeApp, undefined, { HOME: "/tmp/eval-home" }), [
+      "/tmp/eval-home/Library/Caches/com.differentai.openwork.ShipIt",
     ]);
   });
 
   it("is a no-op off macOS", { skip: process.platform === "darwin" }, () => {
     assert.deepEqual(staleUpdaterStatePaths(fakeApp), []);
+  });
+});
+
+describe("staleUpdaterStateHome", () => {
+  it("prefers an overridden HOME over the Electron account home", () => {
+    assert.equal(staleUpdaterStateHome(fakeApp, { HOME: "/tmp/eval-home" }), "/tmp/eval-home");
+  });
+
+  it("trims an overridden HOME", () => {
+    assert.equal(staleUpdaterStateHome(fakeApp, { HOME: "  /tmp/eval-home  " }), "/tmp/eval-home");
+  });
+
+  it("falls back to the Electron account home when HOME is absent or blank", () => {
+    assert.equal(staleUpdaterStateHome(fakeApp, {}), "/Users/test");
+    assert.equal(staleUpdaterStateHome(fakeApp, { HOME: "" }), "/Users/test");
+    assert.equal(staleUpdaterStateHome(fakeApp, { HOME: "   " }), "/Users/test");
   });
 });
 


### PR DESCRIPTION
## Summary
- `staleUpdaterStatePaths` resolves the ShipIt cache from an overridden `HOME` before falling back to `app.getPath("home")`.
- The resolved home moves into a new exported `staleUpdaterStateHome(app, env)` helper so the behavior is covered on every platform.

## Why
`app.getPath("home")` resolves from the OS account, not `$HOME`. The eval host points `HOME` at the profile it owns (`electronSurfaceEnv`, `evals/packages/hosts/src/local.ts:493`), so an isolated eval launch that downloaded an update still ran `rm -rf` against the developer's real `~/Library/Caches/com.differentai.openwork.ShipIt` — while their installed app was running. Post-#4726 the pre-activation path no longer reaches this, but any activated eval run that downloads still does, which breaks the isolation contract the host documents ("cannot affect the user's real desktop app").

For a normal install `$HOME` and `app.getPath("home")` agree, so the resolved path is unchanged.

## Issue
- Closes #4750

## Scope
- `apps/desktop/electron/updater.mjs`: add `staleUpdaterStateHome`, thread an injectable `env` through `staleUpdaterStatePaths`.
- `apps/desktop/electron/updater.test.mjs`: new `staleUpdaterStateHome` suite; existing darwin path assertion pinned to an explicit env so it stays deterministic.

## Out of scope
- The `OPENWORK_ELECTRON_USERDATA`-gated alternative in the issue; preferring `HOME` matches what the rest of the isolation already uses and does not change non-isolated behavior.
- Whether `cleanStaleUpdaterState` should run at all during an eval launch.

## Testing
### Ran
- `node --test apps/desktop/electron/updater.test.mjs`
- `node --test --test-name-pattern='staleUpdaterState' apps/desktop/electron/updater.test.mjs`

### Result
- pass: 34 / fail: 0 / skipped: 5 (full file)
- pass: 4 / fail: 0 / skipped: 2 (`staleUpdaterState*` filter)
- No failing files. The two skips are the darwin-gated `staleUpdaterStatePaths` assertions, which cannot run on this Windows host (`node v24.14.1`); the shared logic they exercise is covered by the platform-independent `staleUpdaterStateHome` suite.

## CI status
- pass: pending — this PR has not been through CI yet.
- code-related failures: none known.
- external/env/auth blockers: the darwin-gated assertions need a macOS runner to execute; locally they skip rather than pass, and are not claimed as passing here.

## Manual verification
1. `node --test --test-name-pattern='staleUpdaterState' apps/desktop/electron/updater.test.mjs` → 4 passed, 0 failed, 2 skipped.
2. Darwin behavior confirmed on this host by stubbing `process.platform` and importing the module: default env falls back to `app.getPath("home")` when `HOME` is unset; an overridden `HOME` is honored; the darwin gate stays active (`staleUpdaterStatePaths(fakeApp).length === 1`).
3. `git diff` is limited to the two files above; no `ee/` path is touched.

## Evidence
No video/screenshot: this is main-process path resolution with no UI or runtime-observable behavior, and no packaged macOS eval launch was available to record. Evidence is the unit runs and the source-level darwin check in Manual verification. I am not claiming packaged/native coverage — the issue notes the native quit path was previously only observed via the armed flag, and that remains true here.

## Risk
- Low. For a real install the resolved path is unchanged, since `$HOME` and `app.getPath("home")` agree.
- The behavior change is confined to processes that deliberately override `HOME` (eval launches), which is the reported defect.
- `staleUpdaterStatePaths` gains a third parameter; the only in-tree caller passes two and picks up the default.

## Rollback
Revert the commit. The function returns to reading `app.getPath("home")` unconditionally, restoring the previous behavior with no migration or state to unwind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
