### PR TITLE
fix(app): keep an unsent new-task prompt reachable after opening another session

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -2013,6 +2013,7 @@ export default {
   "workspace_list.session_actions": "Session actions",
   "workspace_list.title": "Workspaces",
   "workspace_list.session_active": "Session active",
+  "workspace_list.new_task_draft": "Draft",
   "workspace_list.session_needs_attention": "Needs your action",
   "workspace_list.session_unread": "Unread result",
   "workspace_list.session_streaming": "Session streaming",

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -40,6 +40,8 @@ export type NewTaskComposerContext = {
   workspaceId: string | null;
   /** Stable identity for draft ownership across workspace, endpoint, and account changes. */
   draftOwnerKey?: string;
+  /** Account/organization scope the persisted new-task draft is stored under; null while unverified. */
+  draftScope?: string | null;
   selectedModel: ModelRef;
   modelOptions?: readonly ModelOption[];
   modelUnavailable?: boolean;

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ArrowRight, X, Zap } from "lucide-react";
 
 import { DEFAULT_MODEL } from "@/app/constants";
@@ -15,6 +15,8 @@ import {
   useOpenWorkModelsPromoEligibility,
 } from "@/react-app/domains/cloud/openwork-models-promo";
 import { usePlatform } from "@/react-app/kernel/platform";
+import { persistableComposerDraftText } from "@/react-app/domains/session/surface/composer-state-store";
+import { useNewTaskDraftState } from "@/react-app/domains/session/sync/draft-store";
 import {
   NewTaskComposer,
   type NewTaskComposerContext,
@@ -73,7 +75,19 @@ export type SessionEmptyHeroProps = {
  * built-in defaults otherwise.
  */
 export function SessionEmptyHero(props: SessionEmptyHeroProps) {
-  const [prompt, setPrompt] = useState("");
+  // The session is created on submit, so until then the prompt has no
+  // conversation to live in. Persist it under the workspace's reserved slot so
+  // opening another session (or restarting) does not lose it; the sidebar
+  // offers a Draft row for the same slot. The parent keys this component by
+  // draft owner, so the initial read is the only hydration needed.
+  const persistedDraft = useNewTaskDraftState(props.composer?.draftScope, props.composer?.workspaceId);
+  const [prompt, setPromptState] = useState(() => persistedDraft.snapshot?.text ?? "");
+  const persistPrompt = persistedDraft.save;
+  const setPrompt = useCallback((value: string) => {
+    setPromptState(value);
+    // Attachment chips only exist in memory (File objects); the stored text drops their tokens.
+    persistPrompt({ text: persistableComposerDraftText(value), mode: "prompt" });
+  }, [persistPrompt]);
   const orgRestrictions = useOrgRestrictions();
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const canAddProviders = !checkDesktopRestriction({ restriction: "allowCustomProviders" });

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1377,6 +1377,7 @@ export function SessionPage(props: SessionPageProps) {
           connectingWorkspaceId={props.sidebar.connectingWorkspaceId}
           workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
           newTaskDisabled={props.sidebar.newTaskDisabled}
+          newTaskDraftScope={props.newTaskComposer?.draftScope ?? null}
           onSelectWorkspace={props.sidebar.onSelectWorkspace}
           onOpenSession={openSessionTab}
           onPrefetchSession={props.sidebar.onPrefetchSession}
@@ -1921,6 +1922,10 @@ export function SessionPage(props: SessionPageProps) {
                   ) : (
                     <div className="flex flex-1 items-center justify-center py-16">
                       <SessionEmptyHero
+                        // Remount per draft owner so the hero reads that
+                        // workspace's persisted new-task draft instead of
+                        // carrying the previous workspace's text across.
+                        key={props.newTaskComposer?.draftOwnerKey}
                         providerCount={providerCount}
                         onRunTask={(prompt, attachments, handoff) =>
                           props.sidebar.onCreateTaskWithPrompt?.(props.selectedWorkspaceId, prompt, attachments, handoff)

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -10,6 +10,8 @@ export type SidebarContextValue = {
   showSessionActions?: boolean;
   sessionStatusById?: Record<string, string>;
   newTaskDisabled: boolean;
+  /** Account/organization scope of persisted composer drafts; null while unverified. */
+  newTaskDraftScope: string | null;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -144,6 +144,7 @@ import {
 } from "./sidebar-lanes";
 import { WorkspaceAvatarPicker } from "./workspace-avatar-picker";
 import { isSameWorkbenchSession, useWorkbenchStore, workbenchSessionKey } from "../chat/workbench-store";
+import { useNewTaskDraftState } from "../sync/draft-store";
 import { SidebarDestination } from "./sidebar-destination";
 import { SessionTitle } from "./session-title";
 
@@ -752,6 +753,8 @@ export type AppSidebarProps = {
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   newTaskDisabled: boolean;
+  /** Account/organization scope of persisted composer drafts; null while unverified. */
+  newTaskDraftScope?: string | null;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
@@ -891,6 +894,7 @@ export function AppSidebar(props: AppSidebarProps) {
     showSessionActions: props.showSessionActions,
     sessionStatusById: props.sessionStatusById,
     newTaskDisabled: props.newTaskDisabled,
+    newTaskDraftScope: props.newTaskDraftScope ?? null,
     connectingWorkspaceId: props.connectingWorkspaceId,
     workspaceConnectionStateById: props.workspaceConnectionStateById,
     onSelectWorkspace: props.onSelectWorkspace,
@@ -1500,6 +1504,7 @@ function WorkspaceSidebarGroup({
 
             <CollapsibleContent className="pt-px">
               <SidebarMenuSub>
+                {showRemoteConnectionIssue ? null : <NewTaskDraftMenuItem workspaceId={workspace.id} />}
                 {showRemoteConnectionIssue ? (
                   <RemoteConnectionIssueCard
                     message={connectionIssueMessage}
@@ -1594,6 +1599,46 @@ function WorkspaceSidebarGroup({
 const SESSION_DRAG_TYPE = "application/x-openwork-session-id";
 const EMPTY_PINNED_IDS = new Set<string>();
 const UNGROUPED_GROUP_ID = "__openwork_ungrouped";
+
+/**
+ * The prompt typed in this workspace's new-task composer before its session
+ * exists. Opening another conversation unmounts that composer, so this row is
+ * the way back to the unsent text; it disappears once the task is sent.
+ */
+function NewTaskDraftMenuItem({ workspaceId }: { workspaceId: string }) {
+  const ctx = useSidebarContext();
+  const { snapshot } = useNewTaskDraftState(ctx.newTaskDraftScope, workspaceId);
+  const text = snapshot?.text.trim() ?? "";
+  if (!text) return null;
+  const isSelected = ctx.selectedWorkspaceId === workspaceId && ctx.selectedSessionId === null;
+  const label = t("workspace_list.new_task_draft");
+  const preview = text.split("\n")[0] ?? text;
+  return (
+    <SidebarMenuSubItem
+      className="flex items-center"
+      data-sidebar-new-task-draft={workspaceId}
+    >
+      <SidebarMenuSubButton
+        render={<button type="button" />}
+        isActive={isSelected}
+        data-testid={`sidebar-new-task-draft-${workspaceId}`}
+        onClick={() => ctx.onCreateTaskInWorkspace(workspaceId)}
+        aria-label={`${label}: ${preview}`}
+        title={text}
+        className="relative h-8 w-full rounded-md pe-2.5 text-start text-[13px] text-sidebar-foreground/80 transition-[background-color] duration-75 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] data-active:text-sidebar-foreground"
+        style={{ paddingInlineStart: sidebarRowPaddingInlineStart(0) }}
+      >
+        <SidebarGlyphSlot>
+          <SquarePen className="size-3.5 text-muted-foreground" aria-hidden />
+        </SidebarGlyphSlot>
+        <span className="min-w-0 flex-1 truncate">
+          <span className="text-muted-foreground">{label}: </span>
+          {preview}
+        </span>
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
+  );
+}
 
 function SessionGroupActions({ group, groups, workspaceId, count }: {
   group: SessionGroupDefinition;

--- a/apps/app/src/react-app/domains/session/sync/draft-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-store.ts
@@ -48,6 +48,12 @@ export const SESSION_DRAFT_STORAGE_KEY = "openwork.session-drafts.v2";
 export const LEGACY_SESSION_DRAFT_STORAGE_KEY = "openwork.session-drafts.v1";
 export const LOCAL_SESSION_DRAFT_SCOPE = "local";
 export const MAX_SESSION_DRAFT_COUNT = 100;
+/**
+ * Reserved session slot for the prompt typed in a workspace's new-task
+ * composer before its session exists. Engine session ids are `ses_…`, so this
+ * can never collide with a real conversation.
+ */
+export const NEW_TASK_DRAFT_SESSION_ID = "__new-task__";
 
 const EMPTY_DOCUMENT: DraftDocument = {
   version: 2,
@@ -403,4 +409,14 @@ export function useSessionDraftState(
     () => ({ scopeKey: key, snapshot, save, clear }),
     [clear, key, save, snapshot],
   );
+}
+
+/**
+ * The persisted prompt of a workspace's not-yet-created session. Navigating
+ * to another conversation unmounts the new-task composer, so its text has to
+ * outlive the component to be recoverable; the sidebar reads the same slot to
+ * offer a way back.
+ */
+export function useNewTaskDraftState(scopeId: string | null | undefined, workspaceId: string | null | undefined) {
+  return useSessionDraftState(scopeId, workspaceId ?? "", NEW_TASK_DRAFT_SESSION_ID);
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1959,6 +1959,7 @@ export function SessionRoute() {
         selectedWorkspaceEndpoint?.opencodeBaseUrl ?? null,
         selectedWorkspaceId || null,
       ]),
+      draftScope: sessionDraftScope,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
       modelOptions: organizationAssignedModelOptions,
       modelUnavailable: selectedModelUnavailable,

--- a/apps/app/tests/new-task-draft-state.test.tsx
+++ b/apps/app/tests/new-task-draft-state.test.tsx
@@ -1,0 +1,107 @@
+/** @jsxImportSource react */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const registeredDom = typeof globalThis.window === "undefined" || typeof globalThis.document === "undefined";
+
+beforeAll(() => {
+  if (registeredDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+});
+
+afterAll(async () => {
+  if (registeredDom) await GlobalRegistrator.unregister();
+});
+
+type Snapshot = { text: string } | null;
+type Handle = {
+  save: (text: string) => { status: string };
+  snapshot: Snapshot;
+  scopeKey: string;
+};
+
+async function mountNewTaskDraft(scope: string | null, workspaceId: string | null) {
+  const {
+    NEW_TASK_DRAFT_SESSION_ID,
+    SESSION_DRAFT_STORAGE_KEY,
+    sessionDraftScopeKey,
+    useNewTaskDraftState,
+  } = await import("../src/react-app/domains/session/sync/draft-store");
+  const handle: { current: Handle | null } = { current: null };
+  function Probe() {
+    const state = useNewTaskDraftState(scope, workspaceId);
+    handle.current = {
+      save: (text) => state.save({ text, mode: "prompt" }),
+      snapshot: state.snapshot,
+      scopeKey: state.scopeKey,
+    };
+    return null;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => root.render(<Probe />));
+  return {
+    handle,
+    expectedKey: sessionDraftScopeKey(scope, workspaceId ?? "", NEW_TASK_DRAFT_SESSION_ID),
+    storageKey: SESSION_DRAFT_STORAGE_KEY,
+    unmount: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function storedKeys(storageKey: string) {
+  const raw = window.localStorage.getItem(storageKey);
+  if (!raw) return [];
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null || !("drafts" in parsed) || typeof parsed.drafts !== "object" || parsed.drafts === null) return [];
+  return Object.keys(parsed.drafts);
+}
+
+test("a workspace's new-task draft outlives its composer and stays scoped to that workspace and account", async () => {
+  window.localStorage.clear();
+  const draft = "Ask about the deploy checklist";
+
+  const first = await mountNewTaskDraft("local", "ws_alpha");
+  expect(first.handle.current?.snapshot).toBeNull();
+  await act(async () => {
+    expect(first.handle.current?.save(draft).status).toBe("saved");
+  });
+  expect(first.handle.current?.snapshot?.text).toBe(draft);
+  expect(storedKeys(first.storageKey)).toEqual([first.expectedKey]);
+  await first.unmount();
+
+  // Navigating to another session unmounts the hero; a fresh mount reads the same text back.
+  const again = await mountNewTaskDraft("local", "ws_alpha");
+  expect(again.handle.current?.snapshot?.text).toBe(draft);
+
+  // Another workspace, or another signed-in identity, must not see the draft.
+  const otherWorkspace = await mountNewTaskDraft("local", "ws_beta");
+  expect(otherWorkspace.handle.current?.snapshot).toBeNull();
+  const otherAccount = await mountNewTaskDraft("cloud:usr_bob:org_ops", "ws_alpha");
+  expect(otherAccount.handle.current?.snapshot).toBeNull();
+  await otherWorkspace.unmount();
+  await otherAccount.unmount();
+
+  // Sending (or deleting the text) clears the slot so the sidebar row disappears.
+  await act(async () => {
+    expect(again.handle.current?.save("").status).toBe("saved");
+  });
+  expect(again.handle.current?.snapshot).toBeNull();
+  expect(storedKeys(again.storageKey)).toEqual([]);
+  await again.unmount();
+});
+
+test("without a workspace the new-task draft is not persisted anywhere", async () => {
+  window.localStorage.clear();
+  const chatFirst = await mountNewTaskDraft("local", null);
+  expect(chatFirst.handle.current?.scopeKey).toBe("");
+  expect(chatFirst.handle.current?.save("typed before any workspace exists").status).toBe("unavailable");
+  expect(chatFirst.handle.current?.snapshot).toBeNull();
+  expect(window.localStorage.getItem(chatFirst.storageKey)).toBeNull();
+  await chatFirst.unmount();
+});

--- a/evals/specs/new-task-draft-return.e2e.test.ts
+++ b/evals/specs/new-task-draft-return.e2e.test.ts
@@ -1,0 +1,69 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import type { Seed } from "@openwork/env";
+
+async function draftReturn(seed: Seed) {
+  const workspacePath = seed.tmpPath("new-task-draft-return");
+  const app = await seed.appWeb({ name: "new-task-draft-return", workspacePath });
+  const workspace = await seed.workspace(app, workspacePath);
+  const session = await seed.session(app, { title: "Existing conversation" });
+  return { app, workspace, session };
+}
+
+const test = spec.world(draftReturn, {
+  resources: { surfaces: ["appWeb"], services: [] },
+});
+
+// The workspace "+" and the sidebar "New session" button share one handler:
+// both open the workspace's empty composer, which creates its session only on
+// send. Until then the typed prompt has no conversation to live in.
+const newSession = { role: "button" as const, label: "New session" };
+
+test("an unsent new-task prompt survives opening another session and is reachable from the sidebar", async ({ user, probe, step, world }) => {
+  const draft = "Ask about the deploy checklist before Friday";
+  const existing = { testId: `sidebar-session-${world.session.sessionId}` };
+  const draftRow = { testId: `sidebar-new-task-draft-${world.workspace.workspaceId}` };
+  const draftKeys = () => probe.storage("openwork.session-drafts.v2", (value) => {
+    if (typeof value !== "object" || value === null || !("drafts" in value) || typeof value.drafts !== "object" || value.drafts === null) return [];
+    return Object.keys(value.drafts);
+  });
+
+  await step("start a new task and type without sending", async () => {
+    await user.click(newSession);
+    await user.see("composer", { editable: true, text: "" });
+    await user.notSee(draftRow);
+    await user.type("composer", draft, { verify: true });
+    await user.see(draftRow, { text: `Draft: ${draft}` });
+    const keys = await draftKeys();
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toContain("__new-task__");
+    expect(keys[0]).not.toContain(world.session.sessionId);
+  });
+
+  await step("open the existing conversation to look something up", async () => {
+    await user.click(existing);
+    await user.see("composer", { editable: true, text: "" });
+    await user.see(draftRow, { text: `Draft: ${draft}` });
+  });
+
+  await step("come back to the draft from the sidebar", async () => {
+    await user.click(draftRow);
+    await user.see("composer", { editable: true, text: draft });
+    await user.screenshot();
+  });
+
+  await step("the draft also survives a restart of the renderer", async () => {
+    await user.reload();
+    await user.see(draftRow, { text: `Draft: ${draft}` });
+    await user.click(draftRow);
+    await user.see("composer", { editable: true, text: draft });
+  });
+
+  await step("clearing the prompt removes the draft and its sidebar row", async () => {
+    await user.type("composer", " ", { replace: true });
+    await user.press("Backspace");
+    await user.see("composer", { editable: true, text: "" });
+    await user.notSee(draftRow);
+    expect(await draftKeys()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Hover a workspace in the sidebar and click **+** (or the sidebar **New session** button). The empty composer opens and you start typing. To check a detail you click an existing session in the sidebar. There is now no way back: the new-task composer is gone, and clicking **+** again shows an empty composer — the prompt you were writing is lost.

## Root cause

Both entry points call `onCreateTaskInWorkspace`, which deliberately navigates to the workspace route **without** a session (`/workspace/:id/session`): the session is created only on send so opening the composer never waits on the engine and never litters empty sessions. Until send, the prompt lived in `SessionEmptyHero`'s `useState("")`.

Because there is no session id yet, that text was invisible to every mechanism that would otherwise preserve or surface it:

- the persisted draft store (`draft-store.ts`) is keyed by session id;
- the workbench tabs (`workbench-store.ts`) are keyed by session id;
- conversation back/forward history (`conversation-tab-history.ts`) explicitly resets when `sessionId` is null.

Opening any session unmounted the hero, dropping the text, and nothing in the UI represented the draft.

## Fix

1. **Persist the new-task prompt** under a reserved per-workspace slot (`NEW_TASK_DRAFT_SESSION_ID = "__new-task__"`) in the existing draft store, via `useNewTaskDraftState(scope, workspaceId)`. It inherits the account/organization scoping session drafts already have, survives navigation *and* restarts, and stores text only (attachment chips are in-memory `File`s, same as session drafts). The hero hydrates from it on mount; the existing send path already clears the draft on submit and restores it on failure, so no extra plumbing is needed there.
2. **Show a `Draft: <first line>` row** under the workspace's sessions in the sidebar while the slot is non-empty (`data-testid="sidebar-new-task-draft-<workspaceId>"`). It is highlighted when you are on the new-task route, clicking it returns to the composer with the text restored, and it disappears once the task is sent or the text is cleared. **+** / **New session** also return to the restored draft.
3. The per-workspace hero is keyed by `draftOwnerKey`, so switching workspace reads *that* workspace's draft instead of carrying text across (the `NewTaskComposer` owner-change reset is unchanged and still covered by `composer-focus-continuity.test.tsx`).

Chat-first mode (no workspace yet) has no persistence slot and behaves exactly as before.

## Verification

- `apps/app/tests/new-task-draft-state.test.tsx` — the slot outlives its component, is scoped per workspace and per account, clears on empty text, and is a no-op without a workspace. `bun test --isolate tests/new-task-draft-state.test.tsx` → 2 pass.
- `evals/specs/new-task-draft-return.e2e.test.ts` (appWeb) — replays the report end to end: type without sending → Draft row appears (and `openwork.session-drafts.v2` holds exactly one `__new-task__` key, not the real session's) → open the existing session (its composer is empty, the Draft row stays) → click the Draft row → composer shows the text → reload → still there → clear text → row and storage key gone.
  - `pnpm evals:e2e new-task-draft-return --local` → **1 passed** (19 s).
  - Negative control on the unfixed source (`apps/app/src` stashed): **1 failed** — `Timed out … seeing testId=sidebar-new-task-draft-…`, with the typed text visible in the hero but no way back.
- `pnpm --filter @openwork/app typecheck` clean; `pnpm --filter @openwork/app test:core` 220 pass; `node scripts/i18n-audit.mjs --ci` clean.
- Full `@openwork/app` bun suite: 68 failures on both `origin/dev` and this branch (identical set; pre-existing, not in the PR gate). Zero new failures.
