### PR TITLE
docs(codemode): drop the OpenAPI pointer that vendoring removed

### DIFF
--- a/packages/codemode/codemode.md
+++ b/packages/codemode/codemode.md
@@ -6,8 +6,9 @@ It records current behavior, intentional boundaries, durable rationale, and mate
 Completed implementation history, branch names, test counts, and closed findings belong in git, not here. Remove
 completed work instead of preserving checked-off chronology.
 
-Detailed package API documentation lives in [README.md](./README.md). OpenAPI-specific follow-ups live in
-[src/openapi/TODO.md](./src/openapi/TODO.md).
+Detailed package API documentation lives in [README.md](./README.md). This vendored copy carries no OpenAPI
+implementation, so there are no OpenAPI-specific follow-ups here; [UPSTREAM.md](./UPSTREAM.md) records the files
+dropped at vendoring.
 
 ## How CodeMode Works
 


### PR DESCRIPTION
## Summary
- `packages/codemode/codemode.md` no longer points at `src/openapi/TODO.md`; it points at `UPSTREAM.md`, where the drop is recorded.

## Why
The design doc told readers "OpenAPI-specific follow-ups live in [src/openapi/TODO.md](./src/openapi/TODO.md)", but `src/openapi/` is listed under "Dropped upstream files" in the `UPSTREAM.md` that ships beside it, so the link 404s and the doc contradicts its own vendoring manifest.

## Issue
- Closes #4799

## Scope
- `packages/codemode/codemode.md`: replace the dangling second sentence with a pointer to `UPSTREAM.md`.
- One sentence; no other content reflowed.

## Out of scope
- Whether the vendored `codemode.md` should keep tracking upstream verbatim. The repo already diverges locally (`UPSTREAM.md` documents local drops), so aligning the local doc with the local tree is the smaller change.
- Any other doc reference. The seven remaining relative-link hits under `ee/apps/landing/**` are Next.js route paths (`/terms`, `/privacy`, `/pricing`), not files.

## Testing
### Ran
- `git diff --check`
- A relative-link sweep over all 180 tracked `.md` files, resolving each relative link/image against the tracked file set and the on-disk tree.

### Result
- pass: `git diff --check` clean.
- pass: unresolved relative links went 11 -> 10, and the `packages/codemode/codemode.md:10` entry is gone from the report.
- The 10 that remain are unchanged by this PR and none are actionable here: 7 Next.js route paths under `ee/`, 1 illustrative CLI path (`./shot.png` in `.opencode/skills/upload-photo/SKILL.md`, an example argument rather than a repo asset), 1 bare conversation UUID in `HANDOFF.md`, and 1 forward reference to `evals/specs/litellm-per-member-credentials.e2e.test.ts` that lands with the still-open #4264 (which edits those same two docs).

## CI status
- pass: pending — this PR has not been through CI yet.
- code-related failures: none expected; docs-only, single file.
- external/env/auth blockers: none known for this change.

## Manual verification
1. `git ls-files packages/codemode` lists no `openapi` path; `GET .../contents/packages/codemode/src/openapi?ref=dev` returns 404.
2. `packages/codemode/UPSTREAM.md` lists `src/openapi/` under "Dropped upstream files".
3. `ls packages/codemode/UPSTREAM.md` confirms the new link target resolves.

## Evidence
`N/A (docs-only)`

## Risk
- Minimal. Docs-only, one file, no code or build input. The replacement target exists in the same directory.

## Rollback
Revert the commit; the previous sentence returns verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
