### PR TITLE
test(app): fix pre-existing red in composer-editable-on-snapshot-error (missing PlatformProvider / run-mode menu)

### DIFF
--- a/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
+++ b/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
@@ -79,6 +79,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
     { getReactQueryClient },
     { LocalProvider },
     { ShellConfigProvider },
+    { PlatformProvider, createDefaultPlatform },
   ] = await Promise.all([
     import("../src/app/lib/openwork-server"),
     import("../src/react-app/domains/connections/cloud-mcp-submit-readiness"),
@@ -86,6 +87,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
     import("../src/react-app/infra/query-client"),
     import("../src/react-app/kernel/local-provider"),
     import("../src/react-app/shell/shell-config"),
+    import("../src/react-app/kernel/platform"),
   ]);
   const registeredDom = typeof globalThis.window === "undefined" || typeof globalThis.document === "undefined";
   if (registeredDom) GlobalRegistrator.register({ url: "http://localhost/" });
@@ -104,6 +106,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
   let rejectSnapshot = false;
   let fetchedSnapshot = createSnapshot(sessionId, "Cached transcript remains visible.");
   mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
+  mock.module("@/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
   mock.module("@/app/lib/opencode-session-native", () => ({
     composeNativeSessionSnapshot: async () => {
       if (rejectSnapshot) throw new Error("snapshot refresh failed");
@@ -124,8 +127,10 @@ test("the composer stays editable when snapshot refresh fails or the model is un
   const root = createRoot(container);
   const unavailableRoot = createRoot(unavailableContainer);
   let sendCount = 0;
+  const platform = createDefaultPlatform();
 
   const surface = (targetSessionId: string, modelUnavailable: boolean) => (
+    <PlatformProvider value={platform}>
     <QueryClientProvider client={queryClient}>
       <LocalProvider>
         <ShellConfigProvider>
@@ -172,6 +177,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
         </ShellConfigProvider>
       </LocalProvider>
     </QueryClientProvider>
+    </PlatformProvider>
   );
 
   try {


### PR DESCRIPTION
## Summary

`apps/app/tests/composer-editable-on-snapshot-error.test.tsx` fails on clean `origin/dev` with `Platform context is missing`. This is a **test-only** fix: the session surface grew two provider requirements after the test was written, and the real app root already supplies both, so there is no product regression. Found as a pre-existing red during #4797 and left unowned.

## Diagnosis (diagnose-a-red-run)

**Red on clean `origin/dev` @ `e925c7c99`** (control worktree, `apps/app`):
```
bun test --isolate tests/composer-editable-on-snapshot-error.test.tsx
error: Platform context is missing
  at usePlatform (src/react-app/kernel/platform.tsx:55:15)
  at useNativeContextMenu (src/components/ui/action-context-menu.tsx:11:31)
0 pass / 1 fail  (exit 1)
```

**Bisect** (`git bisect start e925c7c99 947ed0cf4`, good = the commit that added the test, 8 steps) shows two stacked breaks:

1. **`94649b44a` feat: choose workspace run modes from the composer (#4293)** — first bad commit. `SessionSurface` now renders `<WorkspaceRunModeMenu>`, which calls `useDesktopRestriction` → `useDesktopConfig()` → throws `useDesktopConfig must be used within a DesktopConfigProvider`.
2. **`be5ab613c` feat(desktop): use native right-click menus (#4650)** — message list now renders `<ActionContextMenu>` → `usePlatform()` → throws `Platform context is missing` (the error visible on HEAD, masking #1).

**Product check:** `PlatformProvider` is mounted in `src/index.react.tsx:51` and `DesktopConfigProvider` in `src/react-app/shell/providers.tsx:61,71`, so the shipped tree is fine. The sibling test `composer-focus-continuity.test.tsx` was already patched for exactly these two breaks in #4631 (mock `WorkspaceRunModeMenu`) and #4640 (`PlatformProvider` wrapper); this test was missed.

## Fix

Mirror the sibling test: wrap the surface in `PlatformProvider` with `createDefaultPlatform()` and mock `WorkspaceRunModeMenu` to `null`. +6 lines, one file, no `src/` changes.

## Why CI did not catch it

PR CI (`.github/workflows/ci-tests.yml` → `openwork-tests-core`) only runs `pnpm test:core`, a hand-picked list of 18 app test files that does not include this one. The full `pnpm --filter @openwork/app test` only runs in `openwork-tests-extended`, which is gated to `schedule` (nightly 07:37 UTC) and `workflow_dispatch` and does not block PRs. So this red has been visible only in the nightly since #4293 (Sep 5).

## Evidence

**Daytona lane** (matching E2E spec, run on PR head; published in the sticky test-evidence comment below):
```
OPENWORK_EVAL_E2E_TESTS=1 pnpm evals:e2e composer-editable-during-snapshot-error
  placement: daytona · 1 passed / 0 failed / 0 skipped · 125 s · verdict passed
```
This proves the product behavior the unit test covers is intact on the real desktop app, supporting the "test drift, not regression" classification.

**Local lane** (bun unit tests; there is no testkit wrapper for `apps/app` unit tests):

Target test on PR head `f2629144f`:
```
cd apps/app && bun test --isolate tests/composer-editable-on-snapshot-error.test.tsx
1 pass / 0 fail / 5 expect() calls  (exit 0)
```

Full app unit suite, PR head vs clean `origin/dev` control (same command, same bun 1.4.0 / pnpm 11.4.0 / node 24.20.0):
```
pnpm --filter @openwork/app test
  origin/dev e925c7c99 : 1590 pass / 20 fail  (exit 1)
  PR head    f2629144f : 1591 pass / 19 fail  (exit 1)
```
The only difference in the failing set is this test going green. The suite exit is still 1 because of the pre-existing reds below.

## Other pre-existing reds (not fixed here — separate ownership)

Identical on clean `origin/dev` and this branch (19 tests, 8 files):

| File | Failing tests | First error |
|---|---|---|
| `tests/message-list-loading.test.tsx` | 10 | `Platform context is missing` — same root cause as #4650, needs `PlatformProvider` |
| `tests/message-list-step-fold.test.tsx` | 3 | `Platform context is missing` — same root cause as #4650 |
| `tests/command-palette-settings.test.ts` | 2 | `expect(...).toBe / toEqual` |
| `tests/app-mentions.test.ts` | 1 | `expect(...).toContain` |
| `tests/managed-brand-header.test.ts` | 1 | `expect(...).not.toContain` |
| `tests/prompt-file-parts.test.ts` | 1 | `expect(...).toEqual` |
| `tests/tool-error-attribution-ui.test.tsx` | 1 | `expect(...).toContain` |
| `tests/mcp-local-server-recovery.test.ts` | — (error outside a test) | `Computer Use requires the bundled OpenWork helper on macOS.` (likely macOS-env only) |

The 13 `message-list-*` failures are the same `PlatformProvider` drift from #4650 and are a natural follow-up, kept out of this PR to keep the diff minimal.

## Verdict

**Passed** for the claim in scope (this test is green on the PR head; no `src/` change). The full-suite command is still red on `dev` for the pre-existing failures listed above.
