### PR TITLE
test(evals): prove the documented pull-only Compose stack with its published images

### DIFF
--- a/evals/specs/den-compose-eval-published-stack.test.ts
+++ b/evals/specs/den-compose-eval-published-stack.test.ts
@@ -1,0 +1,276 @@
+import { randomBytes } from "node:crypto";
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { denComposePublished } from "../worlds/den-compose-published.ts";
+
+// What a customer following packages/docs/self-host/evaluate-with-docker-compose.mdx
+// gets today: the documented docker-compose.eval.yml with its published,
+// digest-pinned images, booted pull-only in the private first-administrator
+// shape. No image is swapped, so a merged source fix counts only once the
+// compose file pins an image that ships it.
+//
+// Opt-in (OPENWORK_EVAL_PUBLISHED_COMPOSE=1): the world pulls ~1 GB of
+// published images, which PR CI must not do on every run.
+const test = spec.world(denComposePublished, {
+  needs: { commands: ["docker"], optIn: ["OPENWORK_EVAL_PUBLISHED_COMPOSE"] },
+  timeout: 600_000,
+});
+
+// Minimal cookie jar: den-web's /api/auth/* proxy sets the session cookie on the
+// web origin, and the /setup page relies on the browser sending it back.
+class CookieJar {
+  private readonly cookies = new Map<string, string>();
+
+  absorb(response: Response): void {
+    for (const header of response.headers.getSetCookie()) {
+      const [pair] = header.split(";");
+      const separator = pair?.indexOf("=") ?? -1;
+      if (!pair || separator <= 0) continue;
+      const name = pair.slice(0, separator).trim();
+      const value = pair.slice(separator + 1).trim();
+      if (value) this.cookies.set(name, value);
+      else this.cookies.delete(name);
+    }
+  }
+
+  header(): string {
+    return [...this.cookies].map(([name, value]) => `${name}=${value}`).join("; ");
+  }
+
+  names(): string[] {
+    return [...this.cookies.keys()];
+  }
+}
+
+function location(response: Response): URL {
+  const value = response.headers.get("location");
+  if (!value) throw new Error(`Expected a Location header, got ${response.status} without one.`);
+  return new URL(value, response.url);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown, key: string): string {
+  if (!isRecord(value)) return "";
+  const field = value[key];
+  return typeof field === "string" ? field : "";
+}
+
+function readRecord(value: unknown, key: string): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const field = value[key];
+  return isRecord(field) ? field : null;
+}
+
+interface BrowserLike {
+  webUrl: string;
+  apiOrigin: string;
+  jar: CookieJar;
+}
+
+// Requests shaped like the /setup page issues them: same-origin /api/auth/*
+// through den-web's proxy, everything else straight at runtime-config's denApiUrl.
+async function browserFetch(browser: BrowserLike, path: string, init: { method?: string; body?: unknown } = {}): Promise<Response> {
+  const url = path.startsWith("/api/auth/") ? `${browser.webUrl}${path}` : `${browser.apiOrigin}${path}`;
+  const headers: Record<string, string> = { accept: "application/json", origin: browser.webUrl };
+  const cookie = browser.jar.header();
+  if (cookie) headers.cookie = cookie;
+  if (init.body !== undefined) headers["content-type"] = "application/json";
+  const response = await fetch(url, {
+    method: init.method ?? (init.body === undefined ? "GET" : "POST"),
+    headers,
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    redirect: "manual",
+    signal: AbortSignal.timeout(30_000),
+  });
+  browser.jar.absorb(response);
+  return response;
+}
+
+test("the documented pull-only stack serves readiness, runtime-config and the auth proxy from published images", { timeout: 600_000 }, async ({ world, step, evidence }) => {
+  await step("the docs point at the compose definition this checkout ships", async () => {
+    expect(world.composeSha256).toBe(world.documented.sha256);
+    evidence.recordAssertionEvidence(
+      "Documented download matches the checkout",
+      `evaluate-with-docker-compose.mdx tells the customer to download commit ${world.documented.commit} and verify ${world.documented.sha256}; the checkout's docker-compose.eval.yml hashes to ${world.composeSha256}.`,
+      true,
+    );
+  });
+
+  await step("the stack pulled the published images the compose file pins, and they carry their release labels", async () => {
+    for (const image of world.images) {
+      expect(image.reference).toMatch(/^ghcr\.io\/different-ai\/openwork-den-(?:api|web):\d+\.\d+\.\d+@sha256:[0-9a-f]{64}$/);
+      expect(image.reference).not.toContain(":latest");
+      expect(image.revision).toMatch(/^[0-9a-f]{40}$/);
+      expect(image.reference).toContain(`:${image.version}@`);
+    }
+    evidence.recordAssertionEvidence(
+      "Published, digest-pinned images under test",
+      world.images.map((image) => `${image.service}: ${image.reference} (revision ${image.revision}, version ${image.version})`).join("; "),
+      true,
+    );
+  });
+
+  await step("readiness, runtime-config and the auth proxy answer 200 from the host", async () => {
+    const ready = await fetch(`${world.webUrl}/api/ready`);
+    expect(ready.status).toBe(200);
+    expect(await ready.json()).toMatchObject({ ok: true, checks: { configuration: "ok", upstream: "ok" } });
+
+    const config = await fetch(`${world.webUrl}/api/runtime-config`);
+    expect(config.status).toBe(200);
+    expect(await config.json()).toMatchObject({
+      denApiUrl: world.publicApiOrigin,
+      orgMode: "single_org",
+      singleOrgAllowPublicSignup: false,
+    });
+
+    const session = await fetch(`${world.webUrl}/api/auth/get-session`, { redirect: "manual" });
+    expect(session.status).toBe(200);
+    expect(session.headers.get("location")).toBeNull();
+    expect(await session.json()).toBeNull();
+    evidence.recordAssertionEvidence(
+      "Web gateway is ready for a browser",
+      `GET /api/ready 200 with configuration+upstream ok, /api/runtime-config 200 handing browsers ${world.publicApiOrigin} with public signup disabled, /api/auth/get-session 200 (null session, no redirect).`,
+      true,
+    );
+  });
+});
+
+test("the documented private first-administrator bootstrap completes through the web auth proxy with cookies", { timeout: 600_000 }, async ({ world, step, evidence }) => {
+  const config = await (await fetch(`${world.webUrl}/api/runtime-config`)).json();
+  const browser: BrowserLike = { webUrl: world.webUrl, apiOrigin: readString(config, "denApiUrl"), jar: new CookieJar() };
+  expect(browser.apiOrigin).toBe(world.publicApiOrigin);
+  const password = `Astra!${randomBytes(12).toString("hex")}`;
+  let grant = "";
+
+  await step("/setup is served and reports bootstrap available while nobody else can sign up", async () => {
+    const page = await fetch(`${world.webUrl}/setup`);
+    expect(page.status).toBe(200);
+    const status = await browserFetch(browser, "/v1/auth/bootstrap/status");
+    expect(status.status).toBe(200);
+    expect(await status.json()).toEqual({ status: "available" });
+
+    const stranger = await browserFetch(browser, "/api/auth/sign-up/email", { body: { name: "Nobody", email: "nobody@example.com", password } });
+    expect(stranger.status).toBe(403);
+    expect(await stranger.json()).toMatchObject({ error: "single_org_signup_disabled" });
+    expect(browser.jar.names()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "Private deployment starts closed",
+      `GET /setup 200; bootstrap status available; an unknown email signing up through the web proxy got HTTP 403 single_org_signup_disabled and no cookie.`,
+      true,
+    );
+  });
+
+  await step("only the configured owner email with the configured one-time code receives a grant", async () => {
+    const wrongCode = await browserFetch(browser, "/v1/auth/bootstrap/verify", { body: { email: world.ownerEmail, code: randomBytes(16).toString("hex") } });
+    expect(wrongCode.status).toBe(403);
+    const wrongEmail = await browserFetch(browser, "/v1/auth/bootstrap/verify", { body: { email: "nobody@example.com", code: world.setupCode } });
+    expect(wrongEmail.status).toBe(403);
+    const verified = await browserFetch(browser, "/v1/auth/bootstrap/verify", { body: { email: world.ownerEmail, code: world.setupCode } });
+    expect(verified.status).toBe(200);
+    grant = readString(await verified.json(), "grant");
+    expect(grant.length).toBeGreaterThan(0);
+    evidence.recordAssertionEvidence(
+      "Setup code is owner-bound",
+      `Wrong code HTTP ${wrongCode.status}, wrong email HTTP ${wrongEmail.status}, configured owner+code HTTP 200 with a grant.`,
+      true,
+    );
+  });
+
+  await step("the account is created through den-web's /api/auth proxy and the session cookie lands on the web origin", async () => {
+    const created = await browserFetch(browser, "/api/auth/sign-up/email", {
+      body: { email: world.ownerEmail, name: "Evaluation Administrator", password, bootstrapGrant: grant },
+    });
+    expect(created.status).toBe(200);
+    const payload = await created.json();
+    expect(readString(payload, "token").length).toBeGreaterThan(0);
+    expect(readRecord(payload, "user")).toMatchObject({ email: world.ownerEmail });
+    expect(browser.jar.names()).toContain("openwork-den.session_token");
+
+    const session = await browserFetch(browser, "/api/auth/get-session");
+    expect(session.status).toBe(200);
+    const sessionPayload = await session.json();
+    expect(readRecord(sessionPayload, "user")).toMatchObject({ email: world.ownerEmail });
+
+    const install = await fetch(`${world.webUrl}/install`, { headers: { cookie: browser.jar.header() } });
+    expect(install.status).toBe(200);
+    evidence.recordAssertionEvidence(
+      "First administrator signs in with a cookie",
+      `POST /api/auth/sign-up/email with the grant answered 200 and set openwork-den.session_token on ${world.webUrl}; /api/auth/get-session with that cookie returns ${world.ownerEmail}; /install (where /setup navigates) answers 200.`,
+      true,
+    );
+  });
+
+  await step("the administrator owns the singleton organization", async () => {
+    const orgs = await browserFetch(browser, "/v1/me/orgs");
+    expect(orgs.status).toBe(200);
+    const payload = await orgs.json();
+    const list = isRecord(payload) && Array.isArray(payload.orgs) ? payload.orgs : [];
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ slug: "default", role: "owner", memberCount: 1 });
+    evidence.recordAssertionEvidence(
+      "Owner of the single organization",
+      `GET /v1/me/orgs with the web session cookie lists one organization (slug default) with role owner and one member.`,
+      true,
+    );
+  });
+
+  await step("setup closes: the code and grant cannot create another account", async () => {
+    const status = await browserFetch(browser, "/v1/auth/bootstrap/status");
+    expect(await status.json()).toEqual({ status: "complete" });
+    const reuse = await browserFetch(browser, "/v1/auth/bootstrap/verify", { body: { email: world.ownerEmail, code: world.setupCode } });
+    expect(reuse.status).toBe(409);
+    const stale = new CookieJar();
+    const second = await browserFetch({ ...browser, jar: stale }, "/api/auth/sign-up/email", {
+      body: { email: "second@example.com", name: "Second", password, bootstrapGrant: grant },
+    });
+    expect(second.status).toBe(403);
+    expect(stale.names()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "Bootstrap is single-use",
+      `Status complete; reusing the code HTTP ${reuse.status}; a second signup with the spent grant HTTP ${second.status} and no cookie.`,
+      true,
+    );
+  });
+
+  await step("normal password sign-in works after sign-out", async () => {
+    const signOut = await browserFetch(browser, "/api/auth/sign-out", { body: {} });
+    expect(signOut.status).toBe(200);
+    const cleared = await browserFetch(browser, "/api/auth/get-session");
+    expect(await cleared.json()).toBeNull();
+    const signIn = await browserFetch(browser, "/api/auth/sign-in/email", { body: { email: world.ownerEmail, password } });
+    expect(signIn.status).toBe(200);
+    const restored = await browserFetch(browser, "/api/auth/get-session");
+    expect(readRecord(await restored.json(), "user")).toMatchObject({ email: world.ownerEmail });
+    evidence.recordAssertionEvidence(
+      "Break-glass password sign-in",
+      `sign-out 200 then get-session null; sign-in/email 200 then get-session returns ${world.ownerEmail} again through the web proxy.`,
+      true,
+    );
+  });
+});
+
+test("legacy /api/den redirects from the published web image reach a browser-reachable origin", { timeout: 600_000 }, async ({ world, step, evidence }) => {
+  await step("the redirect Location must not name the container-internal Den API host", async () => {
+    const redirect = await fetch(`${world.webUrl}/api/den/health`, { redirect: "manual" });
+    expect(redirect.status).toBe(307);
+    const target = location(redirect);
+    const web = world.images.find((image) => image.service === "web");
+    evidence.recordAssertionEvidence(
+      "Observed redirect target of the published den-web image",
+      `${web?.reference ?? "web"} (revision ${web?.revision ?? "unknown"}) answered GET /api/den/health with 307 Location ${target.href}; DEN_API_PUBLIC_URL is ${world.publicApiOrigin}, DEN_API_BASE is ${world.internalApiOrigin}.`,
+      target.origin === world.publicApiOrigin,
+    );
+    expect(target.origin).not.toBe(world.internalApiOrigin);
+    expect(target.origin).toBe(world.publicApiOrigin);
+    expect(target.pathname).toBe("/health");
+  });
+
+  await step("following the redirect from the host reaches Den API health", async () => {
+    const followed = await fetch(`${world.webUrl}/api/den/health`, { redirect: "follow" });
+    expect(followed.status).toBe(200);
+    expect(await followed.json()).toMatchObject({ ok: true });
+  });
+});

--- a/evals/worlds/den-compose-published.ts
+++ b/evals/worlds/den-compose-published.ts
@@ -1,0 +1,186 @@
+import { execFile } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { allocateFreePorts } from "@openwork/cdp";
+
+// The documented pull-only evaluation stack (packaging/docker/docker-compose.eval.yml)
+// exactly as packages/docs/self-host/evaluate-with-docker-compose.mdx ships it:
+// the published, digest-pinned images, no override, booted as an isolated
+// Compose project in the documented "private first administrator" shape
+// (OPENWORK_ALLOW_SIGNUP=false + OPENWORK_OWNER_EMAILS + OPENWORK_SETUP_CODE).
+//
+// Unlike den-compose-eval.ts this world never swaps an image, so it observes
+// what a customer following the docs gets today, including defects that a
+// merged source fix has not yet shipped in a published image.
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const COMPOSE_FILE = join(REPO_ROOT, "packaging", "docker", "docker-compose.eval.yml");
+const DOCS_FILE = join(REPO_ROOT, "packages", "docs", "self-host", "evaluate-with-docker-compose.mdx");
+const INTERNAL_API_ORIGIN = "http://den:8788";
+const HEALTHY_WITHIN_MS = 240_000;
+
+export interface DocumentedComposeDownload {
+  /** Commit the docs tell the customer to download docker-compose.eval.yml from. */
+  commit: string;
+  /** SHA-256 the docs tell the customer to verify against. */
+  sha256: string;
+}
+
+export interface PublishedComposeImage {
+  service: "den" | "web";
+  /** Image reference as pinned in the compose file (tag@digest). */
+  reference: string;
+  /** OCI revision label of the running container, or "" when the image carries none. */
+  revision: string;
+  /** OCI version label of the running container, or "" when the image carries none. */
+  version: string;
+}
+
+export interface DenComposePublishedWorld extends AsyncDisposable {
+  /** Compose project name; every container, network and volume carries it. */
+  project: string;
+  /** Host URL of the documented `web` service. */
+  webUrl: string;
+  /** Browser-reachable Den API origin, exactly as DEN_API_PUBLIC_URL is configured. */
+  publicApiOrigin: string;
+  /** Container-internal Den API origin that must never reach a browser. */
+  internalApiOrigin: string;
+  /** Owner email allowed to claim the organization at /setup. */
+  ownerEmail: string;
+  /** One-time setup code handed to Den API; process-only, never written to disk. */
+  setupCode: string;
+  /** Download instructions the docs currently publish. */
+  documented: DocumentedComposeDownload;
+  /** SHA-256 of the compose definition this world actually booted. */
+  composeSha256: string;
+  /** Published images the stack pulled, with their OCI labels. */
+  images: PublishedComposeImage[];
+  logs(service: "web" | "den"): Promise<string>;
+}
+
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function compose(args: string[], env: NodeJS.ProcessEnv): Promise<string> {
+  const { stdout } = await execFileAsync("docker", ["compose", ...args], {
+    cwd: REPO_ROOT,
+    env,
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 300_000,
+  });
+  return stdout;
+}
+
+async function waitForHealthy(url: string, label: string, logs: () => Promise<string>): Promise<void> {
+  const deadline = Date.now() + HEALTHY_WITHIN_MS;
+  let last = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+      if (response.ok) return;
+      last = `HTTP ${response.status}`;
+    } catch (error) {
+      last = messageText(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Timed out waiting for ${label} at ${url}: ${last}. Last log lines:\n${(await logs()).split(/\r?\n/).slice(-40).join("\n")}`);
+}
+
+async function documentedDownload(): Promise<DocumentedComposeDownload> {
+  const docs = await readFile(DOCS_FILE, "utf8");
+  const commit = /raw\.githubusercontent\.com\/different-ai\/openwork\/([0-9a-f]{40})\/packaging\/docker\/docker-compose\.eval\.yml/.exec(docs)?.[1];
+  const sha256 = /'([0-9a-f]{64})'\s*\\?\s*'docker-compose\.eval\.yml'/.exec(docs)?.[1];
+  if (!commit || !sha256) {
+    throw new Error(`Could not read the documented compose download (commit URL and checksum) from ${DOCS_FILE}.`);
+  }
+  return { commit, sha256 };
+}
+
+function pinnedImage(composeSource: string, service: "den" | "web"): string {
+  const block = new RegExp(`^  ${service}:\\n(?:    .*\\n)*?    image: (\\S+)`, "m").exec(composeSource);
+  if (!block?.[1]) throw new Error(`Could not read the pinned image for service ${service} from ${COMPOSE_FILE}.`);
+  return block[1];
+}
+
+async function containerLabels(container: string): Promise<{ revision: string; version: string }> {
+  const { stdout } = await execFileAsync("docker", [
+    "inspect",
+    container,
+    "--format",
+    '{{index .Config.Labels "org.opencontainers.image.revision"}}\t{{index .Config.Labels "org.opencontainers.image.version"}}',
+  ]);
+  const [revision = "", version = ""] = stdout.trim().split("\t");
+  return { revision, version };
+}
+
+export async function denComposePublished(): Promise<DenComposePublishedWorld> {
+  const composeSource = await readFile(COMPOSE_FILE, "utf8");
+  const composeSha256 = createHash("sha256").update(composeSource).digest("hex");
+  const documented = await documentedDownload();
+
+  const [webPort, apiPort] = await allocateFreePorts(2);
+  if (webPort === undefined || apiPort === undefined) {
+    throw new Error("Could not allocate host ports for the published compose evaluation stack.");
+  }
+  const project = `openwork-eval-published-${randomBytes(4).toString("hex")}`;
+  const publicApiOrigin = `http://localhost:${apiPort}`;
+  const ownerEmail = "admin@example.com";
+  const setupCode = randomBytes(16).toString("hex");
+
+  // Every value here is one the docs name; they reach Compose through the
+  // process environment (the documented alternative to the .env file).
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENWORK_WEB_PORT: String(webPort),
+    OPENWORK_API_PORT: String(apiPort),
+    OPENWORK_AUTH_SECRET: randomBytes(32).toString("hex"),
+    OPENWORK_DB_ENCRYPTION_KEY: randomBytes(32).toString("hex"),
+    OPENWORK_ALLOW_SIGNUP: "false",
+    OPENWORK_OWNER_EMAILS: ownerEmail,
+    OPENWORK_SETUP_CODE: setupCode,
+  };
+  const composeArgs = ["-p", project, "-f", COMPOSE_FILE];
+  const logs = async (service: "web" | "den") =>
+    compose([...composeArgs, "logs", "--no-color", "--tail", "80", service], env).catch((error: unknown) => `logs unavailable: ${messageText(error)}`);
+
+  const down = async () => {
+    await compose([...composeArgs, "down", "--volumes", "--remove-orphans", "--timeout", "10"], env)
+      .catch((error: unknown) => console.error(`[openwork/testkit] compose down failed for ${project}: ${messageText(error)}`));
+  };
+
+  const webUrl = `http://127.0.0.1:${webPort}`;
+  let images: PublishedComposeImage[];
+  try {
+    await compose([...composeArgs, "up", "-d", "--wait", "--wait-timeout", "240"], env);
+    await waitForHealthy(`${publicApiOrigin}/health`, "den", () => logs("den"));
+    await waitForHealthy(`${webUrl}/api/health`, "web", () => logs("web"));
+    images = await Promise.all((["den", "web"] as const).map(async (service) => ({
+      service,
+      reference: pinnedImage(composeSource, service),
+      ...(await containerLabels(`${project}-${service}-1`)),
+    })));
+  } catch (error) {
+    await down();
+    throw error;
+  }
+
+  return {
+    project,
+    webUrl,
+    publicApiOrigin,
+    internalApiOrigin: INTERNAL_API_ORIGIN,
+    ownerEmail,
+    setupCode,
+    documented,
+    composeSha256,
+    images,
+    logs,
+    [Symbol.asyncDispose]: down,
+  };
+}


### PR DESCRIPTION
## Summary
This PR adds an opt-in PR-lane evaluation spec and world that boot the documented pull-only Docker Compose stack exactly as published. It proves the commit-pinned checksum and image labels, host readiness and runtime config, the private first-administrator flow through den-web's auth proxy with cookies, and the browser-reachable legacy API redirect.

It does not change product, packaging, documentation, images, or charts, and it does not remove the manual release-pin drift that left the evaluation stack on an older image; the companion pin is #5093 and release pin automation remains separate in #4910.

Context: the v0.18.46 control still redirects browsers to the container-internal `http://den:8788` origin. With the companion v0.18.48 pin, the same unchanged assertions pass all three tests and demonstrate that the documented artifact now carries the redirect and installer fixes.

## Scope
- `evals/specs/den-compose-eval-published-stack.test.ts`
- `evals/worlds/den-compose-published.ts`
- Opt-in with `OPENWORK_EVAL_PUBLISHED_COMPOSE=1`; ordinary PR CI skips loudly unless Docker and the opt-in are present.
- Pull-only: no Compose override, local image substitution, or build.

## Testing
- Local lane: Podman 6.1.0 arm64.
- Head `1a2386bdc1fa46c0cc2e806038127ab379329c2f`: `OPENWORK_EVAL_PUBLISHED_COMPOSE=1 pnpm evals:pr specs/den-compose-eval-published-stack.test.ts` — exit 0, 3 passed / 0 failed / 0 skipped.
- v0.18.46 control `c020e783a5bd3d34017ce2034dcf45ed61e9737f` with byte-identical spec/world — exit 1, 2 passed / 1 failed / 0 skipped; the redirect target remained `http://den:8788`.
- Every isolated Compose project removed its containers, network, and volume after success or failure.

## Evidence
- [Head-matching test evidence](https://github.com/different-ai/openwork/pull/4806#issuecomment-5708478691) records all three passing tests and ten assertions.

## Risk and rollback
- Test-only and opt-in; no runtime behavior changes. Revert the test commit to remove the gate.

## Merge order
Merge #5093 first, then retarget this PR from `chore/compose-eval-pin-0.18.48` to `dev`.