### PR TITLE
fix(desktop): keep an unactivated enterprise install off the network until a workspace address is submitted

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -36,10 +36,12 @@ import {
   desktopFetch,
   desktopFetchViaMain,
   getDesktopBootstrapConfig as getDesktopBootstrapConfigFromShell,
+  readDesktopDistributionInfo,
   readInitialDesktopBootstrapConfig,
   setDesktopBootstrapConfig as setDesktopBootstrapConfigInShell,
   type DesktopBootstrapConfig as ShellDesktopBootstrapConfig,
 } from "./desktop";
+import { enterpriseActivationRequired } from "./enterprise-activation";
 import { getOpenworkGatewayOrigin } from "./gateway-runtime";
 import { clearDesktopSignInIntent, clearOrgSelectionPending } from "./den-sign-in-intent";
 import { clearDashboardTileCacheStorage } from "./dashboard-cache-storage";
@@ -1023,6 +1025,24 @@ async function resolveDenBootstrapConfigWithRuntimeApi(
 }
 
 /**
+ * Boot-time resolution of the bootstrap the shell already holds. An
+ * unactivated activation-required install has no organization server yet —
+ * its bootstrap is only the build default — so the runtime-config probe would
+ * be the install's first request to a host nobody chose. Skip it: the address
+ * the person submits is resolved by `setDenBootstrapConfig`, and a completed
+ * activation resolves here on the next boot.
+ */
+async function resolveBootBootstrapConfig(
+  input: Parameters<typeof resolveDenBootstrapConfig>[0],
+): Promise<DenBootstrapConfig> {
+  const resolved = resolveDenBootstrapConfig(input);
+  if (enterpriseActivationRequired(readDesktopDistributionInfo(), resolved)) {
+    return resolved;
+  }
+  return resolveDenBootstrapConfigWithRuntimeApi(input);
+}
+
+/**
  * Resolve a handoff destination's base URLs. On desktop, when the caller does
  * not already know the destination's API base, prefer the API base the
  * destination publishes in its runtime config — the same source the durable
@@ -1215,7 +1235,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
 
   const initialBootstrap = readInitialDesktopBootstrapConfig();
   if (initialBootstrap) {
-    const resolved = await resolveDenBootstrapConfigWithRuntimeApi(initialBootstrap);
+    const resolved = await resolveBootBootstrapConfig(initialBootstrap);
     if (generation !== desktopBootstrapGeneration) return readDenBootstrapConfig();
     applyDesktopBootstrapConfig(resolved);
     adoptUntaggedDenSessionOrigin();
@@ -1230,7 +1250,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
   for (let attempt = 1; attempt <= SHELL_BOOTSTRAP_ATTEMPTS; attempt += 1) {
     try {
       const bootstrap = await getDesktopBootstrapConfigFromShell();
-      const resolved = await resolveDenBootstrapConfigWithRuntimeApi(bootstrap);
+      const resolved = await resolveBootBootstrapConfig(bootstrap);
       if (generation !== desktopBootstrapGeneration) return readDenBootstrapConfig();
       applyDesktopBootstrapConfig(resolved);
       adoptUntaggedDenSessionOrigin();
@@ -1271,7 +1291,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
       if (generation !== desktopBootstrapGeneration) return;
       try {
         const bootstrap = await getDesktopBootstrapConfigFromShell();
-        const resolved = await resolveDenBootstrapConfigWithRuntimeApi(bootstrap);
+        const resolved = await resolveBootBootstrapConfig(bootstrap);
         if (generation !== desktopBootstrapGeneration) return;
         applyDesktopBootstrapConfig(resolved);
         adoptUntaggedDenSessionOrigin();
@@ -1297,7 +1317,7 @@ export async function refreshDenBootstrapConfigFromShell(): Promise<DenBootstrap
     const generation = ++desktopBootstrapGeneration;
     try {
       const bootstrap = await getDesktopBootstrapConfigFromShell();
-      const resolved = await resolveDenBootstrapConfigWithRuntimeApi(bootstrap);
+      const resolved = await resolveBootBootstrapConfig(bootstrap);
       if (generation === desktopBootstrapGeneration) {
         applyDesktopBootstrapConfig(resolved);
         adoptUntaggedDenSessionOrigin();

--- a/apps/app/src/app/lib/enterprise-activation.ts
+++ b/apps/app/src/app/lib/enterprise-activation.ts
@@ -1,18 +1,41 @@
 import type { DenBootstrapConfig } from "./den";
 import type { DesktopDistributionInfo } from "./desktop";
 
-export function enterpriseActivationRequired(
-  distribution: DesktopDistributionInfo,
-  bootstrap: Pick<DenBootstrapConfig, "requireActivation" | "enterpriseActivation">,
-) {
-  const requireActivation = distribution.flavor === "enterprise"
+type ActivationBootstrap = Pick<DenBootstrapConfig, "requireActivation" | "enterpriseActivation">;
+
+/** Whether this install has to be activated at all, regardless of whether it already is. */
+function activationRequirement(distribution: DesktopDistributionInfo, bootstrap: ActivationBootstrap) {
+  return distribution.flavor === "enterprise"
     ? distribution.requireActivation
     : (typeof bootstrap.requireActivation === "boolean"
         ? bootstrap.requireActivation
         : distribution.requireActivation);
-  return requireActivation
+}
+
+export function enterpriseActivationRequired(
+  distribution: DesktopDistributionInfo,
+  bootstrap: ActivationBootstrap,
+) {
+  return activationRequirement(distribution, bootstrap)
     && !(
       bootstrap.enterpriseActivation?.activatedAt
       && bootstrap.enterpriseActivation?.denBaseUrl
     );
+}
+
+/**
+ * Whether this install may reach hosts beyond its organization server: the
+ * hosted runtime-config probe, product analytics, Cloud inventory. Installs
+ * that never require activation always may. An activation-required install
+ * may only once it is activated and, when the caller tracks it, once the
+ * desktop config has resolved so an organization policy is known before the
+ * first request leaves the machine.
+ */
+export function outboundEgressAllowed(
+  distribution: DesktopDistributionInfo,
+  bootstrap: ActivationBootstrap,
+  options: { desktopConfigLoading?: boolean } = {},
+) {
+  if (!activationRequirement(distribution, bootstrap)) return true;
+  return !enterpriseActivationRequired(distribution, bootstrap) && options.desktopConfigLoading !== true;
 }

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -15,11 +15,13 @@ import {
   denSettingsChangedEvent,
   denSessionUpdatedEvent,
 } from "../../app/lib/den-session-events";
-import { evalRelaunchDesktopApp } from "../../app/lib/desktop";
+import { evalRelaunchDesktopApp, readDesktopDistributionInfo } from "../../app/lib/desktop";
+import { outboundEgressAllowed } from "../../app/lib/enterprise-activation";
 import { isDesktopRuntime } from "../../app/lib/runtime-env";
 import { Button } from "../../components/ui/button";
 import { t } from "../../i18n";
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
+import { useDesktopConfig } from "../domains/cloud/desktop-config-provider";
 import {
   clearCloudInventoryCache,
   prefetchCloudInventory,
@@ -375,22 +377,43 @@ function BrandThemeControlActions() {
 
 let appOpenedCaptured = false;
 
+/**
+ * Analytics and the Cloud inventory prefetch mount above the activation gate.
+ * An activation-required install holds them back until it is activated and
+ * its desktop config has resolved once — the same readiness the updater waits
+ * for — so nothing leaves the machine before the organization server is known
+ * and an organization policy could be honoured. Other installs are unaffected.
+ */
+function useOutboundEgressAllowed() {
+  const bootstrap = useSyncExternalStore(
+    subscribeToDenBootstrap,
+    readDenBootstrapSnapshot,
+    readDenBootstrapSnapshot,
+  );
+  const desktopConfig = useDesktopConfig();
+  return outboundEgressAllowed(readDesktopDistributionInfo(), bootstrap, {
+    desktopConfigLoading: desktopConfig.loading,
+  });
+}
+
 export function AppRoot() {
   useDesktopFontZoomBehavior();
   useVisualViewportInset();
+  const egressAllowed = useOutboundEgressAllowed();
 
   // Module-level dedupe keeps StrictMode double-mounts from double-counting.
   useEffect(() => {
-    if (appOpenedCaptured) return;
+    if (!egressAllowed || appOpenedCaptured) return;
     appOpenedCaptured = true;
     initAnalytics();
     captureAnalyticsEvent("app_opened", {});
-  }, []);
+  }, [egressAllowed]);
 
   // Fetch what the organization shares with this member up front. Settings
   // mounts cold every time the extensions panel opens, so without this the
   // readiness groups wait on a Den round-trip the app could have done already.
   useEffect(() => {
+    if (!egressAllowed) return;
     prefetchCloudInventory();
     const handleSessionChanged = () => {
       clearCloudInventoryCache();
@@ -398,7 +421,7 @@ export function AppRoot() {
     };
     window.addEventListener(denSettingsChangedEvent, handleSessionChanged);
     return () => window.removeEventListener(denSettingsChangedEvent, handleSessionChanged);
-  }, []);
+  }, [egressAllowed]);
 
   return (
     <>

--- a/apps/app/tests/preactivation-egress.test.ts
+++ b/apps/app/tests/preactivation-egress.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  initializeDenBootstrapConfig,
+  readDenBootstrapConfig,
+  refreshDenBootstrapConfigFromShell,
+  setDenBootstrapConfig,
+} from "../src/app/lib/den";
+import { outboundEgressAllowed } from "../src/app/lib/enterprise-activation";
+
+/**
+ * An activation-required install must not make any request outside loopback
+ * before the person submits a workspace address. The renderer's boot-time
+ * bootstrap resolution and the AppRoot-level analytics / Cloud-inventory
+ * effects both mount above the activation gate, so each is gated on its own.
+ */
+
+const originalWindow = globalThis.window;
+
+const publicDistribution = {
+  flavor: "public" as const,
+  appName: "OpenWork",
+  appIdentifier: "com.differentai.openwork",
+  protocolScheme: "openwork",
+  requireSignin: false,
+  requireActivation: false,
+};
+
+const enterpriseDistribution = {
+  flavor: "enterprise" as const,
+  appName: "OpenWork Enterprise",
+  appIdentifier: "com.differentai.openwork",
+  protocolScheme: "openwork",
+  requireSignin: true,
+  requireActivation: true,
+};
+
+const activation = { activatedAt: "2026-07-27T12:00:00.000Z", denBaseUrl: "https://den.example.test" };
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+type ShellBootstrap = {
+  baseUrl: string;
+  apiBaseUrl?: string | null;
+  requireSignin: boolean;
+  enterpriseActivation?: { activatedAt: string; denBaseUrl: string };
+};
+
+describe("pre-activation outbound egress", () => {
+  let fetches: string[];
+  let shellBootstrap: ShellBootstrap;
+
+  function installWindow(distribution: typeof publicDistribution | typeof enterpriseDistribution) {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: memoryStorage(),
+        dispatchEvent: () => true,
+        __OPENWORK_ELECTRON__: {
+          meta: { distribution },
+          invokeDesktop: async (command: string, ...args: unknown[]) => {
+            if (command === "getDesktopBootstrapConfig") return shellBootstrap;
+            if (command === "setDesktopBootstrapConfig") {
+              const payload = args[0];
+              if (typeof payload !== "object" || payload === null) throw new Error("bootstrap payload required");
+              shellBootstrap = { ...shellBootstrap, ...payload };
+              return shellBootstrap;
+            }
+            if (command === "__fetch" && typeof args[0] === "string") {
+              fetches.push(args[0]);
+              return {
+                status: 200,
+                statusText: "OK",
+                headers: [["content-type", "application/json"]],
+                body: JSON.stringify({ denApiUrl: `${new URL(args[0]).origin}/api/den` }),
+              };
+            }
+            throw new Error(`Unexpected desktop command: ${command}`);
+          },
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    fetches = [];
+    // What the shell hands a machine that has never run OpenWork: the build
+    // default, which for the hosted deployment is a host nobody chose.
+    shellBootstrap = { baseUrl: "https://app.openworklabs.com", requireSignin: true };
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("an unactivated enterprise install does not probe the hosted runtime config at boot", async () => {
+    installWindow(enterpriseDistribution);
+
+    await initializeDenBootstrapConfig();
+    await refreshDenBootstrapConfigFromShell();
+
+    expect(fetches).toEqual([]);
+    expect(readDenBootstrapConfig().baseUrl).toBe("https://app.openworklabs.com");
+  });
+
+  test("an activated enterprise install resolves its Den's runtime config at boot", async () => {
+    installWindow(enterpriseDistribution);
+    shellBootstrap = { baseUrl: activation.denBaseUrl, requireSignin: true, enterpriseActivation: activation };
+
+    await initializeDenBootstrapConfig();
+
+    expect(fetches).toEqual(["https://den.example.test/api/runtime-config"]);
+    expect(readDenBootstrapConfig().apiBaseUrl).toBe("https://den.example.test/api/den");
+  });
+
+  test("a submitted workspace address is resolved even before activation completes", async () => {
+    installWindow(enterpriseDistribution);
+    await initializeDenBootstrapConfig();
+    expect(fetches).toEqual([]);
+
+    await setDenBootstrapConfig({ baseUrl: "https://den.example.test", requireSignin: true });
+
+    expect(fetches).toContain("https://den.example.test/api/runtime-config");
+    expect(fetches.every((url) => new URL(url).hostname === "den.example.test")).toBe(true);
+  });
+
+  test("the public flavor keeps probing the runtime config at boot", async () => {
+    installWindow(publicDistribution);
+
+    await initializeDenBootstrapConfig();
+
+    expect(fetches).toEqual(["https://app.openworklabs.com/api/runtime-config"]);
+  });
+});
+
+describe("outboundEgressAllowed", () => {
+  test("never holds back an install that does not require activation", () => {
+    expect(outboundEgressAllowed(publicDistribution, {})).toBe(true);
+    expect(outboundEgressAllowed(publicDistribution, {}, { desktopConfigLoading: true })).toBe(true);
+  });
+
+  test("holds an activation-required install back until activated and its desktop config has resolved once", () => {
+    expect(outboundEgressAllowed(enterpriseDistribution, {})).toBe(false);
+    expect(outboundEgressAllowed(enterpriseDistribution, {}, { desktopConfigLoading: false })).toBe(false);
+    expect(outboundEgressAllowed(enterpriseDistribution, { enterpriseActivation: activation }, { desktopConfigLoading: true })).toBe(false);
+    expect(outboundEgressAllowed(enterpriseDistribution, { enterpriseActivation: activation }, { desktopConfigLoading: false })).toBe(true);
+    expect(outboundEgressAllowed(enterpriseDistribution, { enterpriseActivation: activation })).toBe(true);
+  });
+
+  test("honours a bootstrap that opts another artifact into activation", () => {
+    expect(outboundEgressAllowed(publicDistribution, { requireActivation: true })).toBe(false);
+    expect(outboundEgressAllowed(publicDistribution, { requireActivation: true, enterpriseActivation: activation })).toBe(true);
+  });
+});
+
+describe("AppRoot egress wiring", () => {
+  const appRootSource = readFileSync(new URL("../src/react-app/shell/app-root.tsx", import.meta.url), "utf8");
+
+  test("gates analytics and the Cloud inventory prefetch on outbound egress being allowed", () => {
+    const analyticsEffect = appRootSource.slice(
+      appRootSource.indexOf("if (!egressAllowed || appOpenedCaptured) return;"),
+      appRootSource.indexOf('captureAnalyticsEvent("app_opened", {});'),
+    );
+    expect(analyticsEffect).toContain("initAnalytics();");
+    expect(appRootSource).toContain("if (!egressAllowed) return;\n    prefetchCloudInventory();");
+    expect(appRootSource).toContain("desktopConfigLoading: desktopConfig.loading,");
+    expect(appRootSource).not.toMatch(/useEffect\(\(\) => \{\n    if \(appOpenedCaptured\) return;/);
+  });
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -416,6 +416,28 @@ async function resolveArchitectureInfo() {
   };
 }
 
+// On Windows and Linux Chromium's spellchecker downloads its Hunspell
+// dictionary from Google (redirector.gvt1.com). Electron starts that load the
+// moment the default session object is first created, so an unactivated
+// install clears the dictionary list in the same synchronous step (the
+// download itself waits on a file-thread hop) and restores it once activation
+// completes. macOS uses the native spellchecker; these calls are no-ops there.
+// An empty persisted list is re-defaulted by Electron on the next boot, so a
+// quit before activation cannot leave the spellchecker off for good.
+let spellcheckerLanguagesHeldForActivation = null;
+function holdSpellcheckerUntilActivation(bootstrapConfig) {
+  if (!desktopActivationRequired(DESKTOP_DISTRIBUTION, bootstrapConfig)) return;
+  const defaultSession = session.defaultSession;
+  spellcheckerLanguagesHeldForActivation = defaultSession.getSpellCheckerLanguages();
+  defaultSession.setSpellCheckerLanguages([]);
+}
+function releaseSpellcheckerAfterActivation() {
+  const languages = spellcheckerLanguagesHeldForActivation;
+  spellcheckerLanguagesHeldForActivation = null;
+  if (!languages || languages.length === 0) return;
+  session.defaultSession.setSpellCheckerLanguages(languages);
+}
+
 const APP_ICON_PATH = resolveAppIconPath();
 const APP_ICON_IMAGE = APP_ICON_PATH ? nativeImage.createFromPath(APP_ICON_PATH) : null;
 const BRAND_ICON_MAX_BYTES = 2 * 1024 * 1024;
@@ -1208,7 +1230,7 @@ async function persistConnectLinkClaims(claims) {
     desktopActivationRequired(DESKTOP_DISTRIBUTION, previous)
     && !desktopActivationRequired(DESKTOP_DISTRIBUTION, config)
   ) {
-    session.defaultSession.setSpellCheckerEnabled(true);
+    releaseSpellcheckerAfterActivation();
     await uiControlServer.start().catch((error) => {
       console.warn("[ui-control] failed to start", error);
     });
@@ -2008,7 +2030,7 @@ const desktopCommandHandlers = {
         desktopActivationRequired(DESKTOP_DISTRIBUTION, previous)
         && !desktopActivationRequired(DESKTOP_DISTRIBUTION, next)
       ) {
-        session.defaultSession.setSpellCheckerEnabled(true);
+        releaseSpellcheckerAfterActivation();
         await uiControlServer.start().catch((error) => {
           console.warn("[ui-control] failed to start", error);
         });
@@ -2868,6 +2890,7 @@ or use: pnpm dev:worktree`);
   });
 
   app.whenReady().then(async () => {
+    holdSpellcheckerUntilActivation(workspaceStore.readDesktopBootstrapConfigSync());
     const systemCaCertificates = await runtimeManager.systemCaCertificates();
     session.defaultSession.setCertificateVerifyProc(createSystemCaCertificateVerifyProc(systemCaCertificates));
     installMediaPermissionHandlers(session, () => mainWindow);
@@ -2880,13 +2903,6 @@ or use: pnpm dev:worktree`);
       console.warn("[nuke] pending cleanup failed", error);
     });
     const bootstrapConfig = await workspaceStore.getDesktopBootstrapConfig();
-    // On Windows and Linux Chromium's spellchecker downloads its Hunspell
-    // dictionary from Google (redirector.gvt1.com) as soon as a text field
-    // mounts. An unactivated install must not reach anything before its Den
-    // is known, so the spellchecker stays off until activation completes.
-    if (desktopActivationRequired(DESKTOP_DISTRIBUTION, bootstrapConfig)) {
-      session.defaultSession.setSpellCheckerEnabled(false);
-    }
     currentDisplayAppName = applyBrandAppName(
       BLANK_SLATE_LAUNCH.enabled || DESKTOP_DISTRIBUTION.flavor === "enterprise"
         ? null

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -397,7 +397,11 @@ async function resolveArchitectureInfo() {
   const version = app.getVersion();
   const targetArch = systemArch === "arm64" || systemArch === "x64" ? systemArch : appArch;
   const assetName = `openwork-${platformDownloadSlug()}-${downloadAssetArch(targetArch)}-${version}.${downloadAssetExtension()}`;
-  const latestDownloadUrl = await resolveCorrectArchitectureDownloadUrl(targetArch);
+  // The public release manifest only matters when the installed build does not
+  // match the machine; a matching install never shows a download, so it must
+  // not contact the release host (an unactivated enterprise install in
+  // particular has no business reaching anything before its Den is known).
+  const latestDownloadUrl = appArch === systemArch ? null : await resolveCorrectArchitectureDownloadUrl(targetArch);
   const hasCorrectArchitectureDownload = Boolean(latestDownloadUrl);
   return {
     appArch,

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1208,6 +1208,7 @@ async function persistConnectLinkClaims(claims) {
     desktopActivationRequired(DESKTOP_DISTRIBUTION, previous)
     && !desktopActivationRequired(DESKTOP_DISTRIBUTION, config)
   ) {
+    session.defaultSession.setSpellCheckerEnabled(true);
     await uiControlServer.start().catch((error) => {
       console.warn("[ui-control] failed to start", error);
     });
@@ -2007,6 +2008,7 @@ const desktopCommandHandlers = {
         desktopActivationRequired(DESKTOP_DISTRIBUTION, previous)
         && !desktopActivationRequired(DESKTOP_DISTRIBUTION, next)
       ) {
+        session.defaultSession.setSpellCheckerEnabled(true);
         await uiControlServer.start().catch((error) => {
           console.warn("[ui-control] failed to start", error);
         });
@@ -2878,6 +2880,13 @@ or use: pnpm dev:worktree`);
       console.warn("[nuke] pending cleanup failed", error);
     });
     const bootstrapConfig = await workspaceStore.getDesktopBootstrapConfig();
+    // On Windows and Linux Chromium's spellchecker downloads its Hunspell
+    // dictionary from Google (redirector.gvt1.com) as soon as a text field
+    // mounts. An unactivated install must not reach anything before its Den
+    // is known, so the spellchecker stays off until activation completes.
+    if (desktopActivationRequired(DESKTOP_DISTRIBUTION, bootstrapConfig)) {
+      session.defaultSession.setSpellCheckerEnabled(false);
+    }
     currentDisplayAppName = applyBrandAppName(
       BLANK_SLATE_LAUNCH.enabled || DESKTOP_DISTRIBUTION.flavor === "enterprise"
         ? null

--- a/apps/desktop/scripts/packaged-smoke.mjs
+++ b/apps/desktop/scripts/packaged-smoke.mjs
@@ -80,6 +80,8 @@ try {
     // Only the enterprise flavor has an activation gate that must hold the updater back.
     if (flavor === "enterprise") {
       bootPackagedDesktop("desktop-updater-gate-enterprise", "packaged-preactivation-updater", flavorBinary, 300_000);
+      // ...and must make no request outside loopback until a workspace address is submitted.
+      bootPackagedDesktop("desktop-egress-gate-enterprise", "packaged-preactivation-egress", flavorBinary, 300_000);
     }
   }
   // The same enterprise artifact, booted as an already-activated install (the update path for existing customers).

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -10,6 +10,8 @@ const definitions = {
   'packaged-first-launch.e2e.test.ts': { name: 'Open a fresh cloud or enterprise install', placement: 'local' },
   // Boots the packaged enterprise artifact twice (fresh and pre-activated); only packaged-smoke provides that binary.
   'packaged-preactivation-updater.e2e.test.ts': { name: 'Keep an unactivated enterprise install from updating itself', placement: 'local' },
+  // Boots the packaged enterprise artifact twice (fresh and pre-activated) behind a refusing proxy; only packaged-smoke provides that binary.
+  'packaged-preactivation-egress.e2e.test.ts': { name: 'Keep an unactivated enterprise install off the network', placement: 'local' },
   'packaged-activated-launch.e2e.test.ts': { name: 'Open an already-activated enterprise install', placement: 'local' },
   // Boots the packaged enterprise artifact and asks it to quit (SIGTERM and Browser.close); only packaged-smoke provides that binary.
   'desktop-quit-path.e2e.test.ts': { name: 'Quit an enterprise install cleanly', placement: 'local' },

--- a/evals/specs/packaged-preactivation-egress.e2e.test.ts
+++ b/evals/specs/packaged-preactivation-egress.e2e.test.ts
@@ -1,0 +1,145 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import type { Probe } from "@openwork/testkit";
+import {
+  SUBMITTED_WORKSPACE_ADDRESS,
+  packagedActivatedEgressWorld,
+  packagedPreactivationEgressWorld,
+} from "../worlds/packaged-preactivation-egress.ts";
+import type { EgressRequest } from "../worlds/packaged-preactivation-egress.ts";
+
+/**
+ * An enterprise install must not talk to anyone before the person tells it
+ * which organization it belongs to. Until the workspace address is submitted
+ * the only server the app could reach is a build default — the hosted
+ * runtime-config probe at app.openworklabs.com — plus product analytics and
+ * Cloud inventory, none of which the organization chose or can see. The
+ * renderer made those requests above the activation gate on every fresh boot.
+ *
+ * Both halves boot the same packaged enterprise binary on a fresh profile
+ * behind a refusing proxy that records every non-loopback request. The
+ * negative half has no bootstrap and watches a quiet window, then submits a
+ * workspace address and checks that only that host is contacted. The positive
+ * control seeds an activation stamp for a Den on that same host and shows the
+ * same witness does see the runtime-config probe and analytics once activated.
+ */
+const ACTIVATION_HEADING = "Link this app to your organization";
+
+/**
+ * The unfixed build probed runtime-config before first paint and flushed the
+ * "app_opened" analytics event 10 s after mount; 25 s leaves margin for a slow
+ * renderer boot on top of that flush interval.
+ */
+const QUIET_WINDOW_MS = 25_000;
+
+/** How long the submitted address may take to produce its first request. */
+const SUBMISSION_WINDOW_MS = 20_000;
+
+const SUBMITTED_HOST = new URL(SUBMITTED_WORKSPACE_ADDRESS).hostname;
+const ANALYTICS_HOST = "us.i.posthog.com";
+
+const preactivation = spec.world(packagedPreactivationEgressWorld, { timeout: 180_000 });
+const activated = spec.world(packagedActivatedEgressWorld, { timeout: 180_000 });
+
+function describeEgress(requests: readonly EgressRequest[]): string {
+  return JSON.stringify(requests.map((request) => `${request.method} ${request.target}`));
+}
+
+async function requireEnterpriseFlavor(world: { flavor: () => Promise<string | null> }, probe: Probe) {
+  const flavor = await probe.eventually(() => world.flavor(), {
+    within: 30_000,
+    label: "packaged distribution flavor",
+    until: (value) => value !== null,
+  });
+  if (flavor !== "enterprise") {
+    throw new Error(`Activation gates only the enterprise flavor; OPENWORK_EVAL_ELECTRON_BINARY points at a ${flavor ?? "unknown"} build`);
+  }
+}
+
+preactivation("an unactivated enterprise install makes no request outside loopback until a workspace address is submitted", async ({ world, user, probe, evidence }) => {
+  await requireEnterpriseFlavor(world, probe);
+  await probe.eventually(() => world.rootText(), {
+    within: 60_000,
+    label: "enterprise activation gate mounted in #root",
+    until: (text) => text.includes(ACTIVATION_HEADING),
+  });
+  await user.see({ text: ACTIVATION_HEADING });
+
+  // The renderer is up. Watch the proxy for the whole quiet window, stopping
+  // early only if a request does appear.
+  const quietUntil = Date.now() + QUIET_WINDOW_MS;
+  const beforeSubmission = await probe.eventually(() => world.egress(), {
+    within: QUIET_WINDOW_MS + 10_000,
+    intervalMs: 1_000,
+    label: "non-loopback requests before a workspace address is submitted",
+    until: (requests) => requests.length > 0 || Date.now() >= quietUntil,
+  });
+  // The install is still unactivated at the end of the window, so any request
+  // above went to a host nobody chose.
+  await user.see({ text: ACTIVATION_HEADING });
+  await user.screenshot();
+
+  expect(beforeSubmission, `requests left loopback before a workspace address was submitted: ${describeEgress(beforeSubmission)}`).toEqual([]);
+  evidence.recordAssertionEvidence(
+    `An unactivated enterprise install makes no non-loopback request within ${QUIET_WINDOW_MS / 1000}s of showing "${ACTIVATION_HEADING}"`,
+    `proxy log: ${describeEgress(beforeSubmission)}`,
+    beforeSubmission.length === 0,
+  );
+
+  // Submitting a workspace address is the moment the organization server
+  // becomes known. A pasted sign-in link names that server and finishes in
+  // the app itself, so the exchange contacts the submitted host and nothing
+  // else — and the witness proves it sees renderer traffic at all.
+  const signInLink = `openwork://den-auth?grant=eval-grant-refused-by-witness&denBaseUrl=${encodeURIComponent(SUBMITTED_WORKSPACE_ADDRESS)}`;
+  await user.type({ testId: "organization-server-input" }, signInLink);
+  await user.click({ testId: "organization-server-continue" });
+  await user.see({ text: `Connect this app to ${SUBMITTED_WORKSPACE_ADDRESS}?` });
+  await user.click({ testId: "organization-server-confirm" });
+
+  const afterSubmission = await probe.eventually(() => world.egress(), {
+    within: SUBMISSION_WINDOW_MS,
+    intervalMs: 500,
+    label: `a request to the submitted workspace address ${SUBMITTED_HOST}`,
+    until: (requests) => requests.some((request) => request.host === SUBMITTED_HOST),
+  });
+  // The proxy refused the exchange, so activation is still pending: the gate
+  // stays up and analytics must still be silent.
+  await user.see({ text: ACTIVATION_HEADING });
+  await user.screenshot();
+
+  const foreignHosts = [...new Set(afterSubmission.filter((request) => request.host !== SUBMITTED_HOST).map((request) => request.host))];
+  expect(afterSubmission.some((request) => request.host === SUBMITTED_HOST), "the submitted workspace address was never contacted").toBe(true);
+  expect(foreignHosts, `hosts other than the submitted workspace address were contacted: ${describeEgress(afterSubmission)}`).toEqual([]);
+  evidence.recordAssertionEvidence(
+    `After a workspace address is submitted, the install contacts only ${SUBMITTED_HOST}`,
+    `proxy log: ${describeEgress(afterSubmission)}`,
+    foreignHosts.length === 0 && afterSubmission.length > 0,
+  );
+});
+
+activated("an activated enterprise install still resolves its Den and reports analytics", async ({ world, user, probe, evidence }) => {
+  await requireEnterpriseFlavor(world, probe);
+
+  // Same binary, same witness. Activation is complete at boot, so the
+  // runtime-config probe for the activated Den happens during bootstrap and
+  // the "app_opened" analytics batch flushes within the 10 s interval.
+  const requests = await probe.eventually(() => world.egress(), {
+    within: 90_000,
+    intervalMs: 1_000,
+    label: "Den runtime-config probe and analytics flush after activation",
+    until: (value) => value.some((request) => request.host === SUBMITTED_HOST)
+      && value.some((request) => request.host === ANALYTICS_HOST),
+  });
+  const rootText = await world.rootText();
+  await user.notSee({ text: ACTIVATION_HEADING }, { timeoutMs: 1_000 });
+  await user.screenshot();
+
+  expect(rootText, "the activation gate must not be on screen for an activated install").not.toContain(ACTIVATION_HEADING);
+  expect(requests.some((request) => request.host === SUBMITTED_HOST), `the activated Den was never contacted: ${describeEgress(requests)}`).toBe(true);
+  expect(requests.some((request) => request.host === ANALYTICS_HOST), `analytics never flushed after activation: ${describeEgress(requests)}`).toBe(true);
+  evidence.recordAssertionEvidence(
+    `An activated enterprise install contacts its Den (${SUBMITTED_HOST}) and flushes analytics (${ANALYTICS_HOST}) without any user action`,
+    `proxy log: ${describeEgress(requests)}`,
+    requests.some((request) => request.host === SUBMITTED_HOST) && requests.some((request) => request.host === ANALYTICS_HOST),
+  );
+});

--- a/evals/worlds/packaged-preactivation-egress.ts
+++ b/evals/worlds/packaged-preactivation-egress.ts
@@ -23,6 +23,10 @@ import type { ElectronSurfaceOptions } from "@openwork/hosts";
  * absolute URL or a `CONNECT host:443` tunnel for HTTPS. Loopback is bypassed
  * by Chromium's implicit proxy rules and never shows up. The proxy answers
  * 403 and closes, so nothing actually leaves the machine during the run.
+ * Chromium's own background traffic is caught too: on Linux the unfixed build
+ * also surfaced the spellchecker's Hunspell dictionary download
+ * (redirector.gvt1.com), which macOS never makes because it uses the native
+ * spellchecker.
  *
  * Not covered: Node's own `fetch` in the main process ignores Chromium proxy
  * switches. The desktop only uses it for its loopback local server.

--- a/evals/worlds/packaged-preactivation-egress.ts
+++ b/evals/worlds/packaged-preactivation-egress.ts
@@ -1,0 +1,173 @@
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
+import { attachSurface, evaluateOnSurface } from "@openwork/cdp";
+import type { AttachedSurface, SurfaceHandle } from "@openwork/cdp";
+import { SkipError } from "@openwork/env";
+import type { Seed } from "@openwork/env";
+import { localHost } from "@openwork/hosts";
+import type { ElectronSurfaceOptions } from "@openwork/hosts";
+
+/**
+ * A packaged enterprise desktop on a machine that has never run OpenWork,
+ * booted behind a logging forward proxy that refuses everything. Before the
+ * person enters their workspace address the install knows no organization
+ * server, so any request that leaves loopback goes to a host nobody chose:
+ * the hosted runtime-config probe, PostHog analytics, Cloud inventory.
+ *
+ * The witness is Chromium's `--proxy-server` switch, which the desktop accepts
+ * through ELECTRON_EXTRA_LAUNCH_ARGS. Every renderer `fetch`, every
+ * main-process `net.fetch` (the `__fetch` bridge Den calls use) and
+ * electron-updater all go through Chromium's network stack, so each request
+ * for a non-loopback host arrives here as either a plain request with an
+ * absolute URL or a `CONNECT host:443` tunnel for HTTPS. Loopback is bypassed
+ * by Chromium's implicit proxy rules and never shows up. The proxy answers
+ * 403 and closes, so nothing actually leaves the machine during the run.
+ *
+ * Not covered: Node's own `fetch` in the main process ignores Chromium proxy
+ * switches. The desktop only uses it for its loopback local server.
+ */
+
+export interface EgressRequest {
+  /** HTTP method; `CONNECT` for an HTTPS tunnel. */
+  method: string;
+  /** `host:port` for CONNECT, the absolute URL otherwise. */
+  target: string;
+  /** Hostname the request was for, lower-cased. */
+  host: string;
+  at: string;
+}
+
+function hostOf(method: string, target: string): string {
+  if (method === "CONNECT") return target.replace(/:\d+$/, "").toLowerCase();
+  try {
+    return new URL(target).hostname.toLowerCase();
+  } catch {
+    return target.toLowerCase();
+  }
+}
+
+export async function startEgressWitness(): Promise<{
+  port: number;
+  requests: EgressRequest[];
+  close(): Promise<void>;
+}> {
+  const requests: EgressRequest[] = [];
+  const record = (method: string, target: string) => {
+    requests.push({ method, target, host: hostOf(method, target), at: new Date().toISOString() });
+  };
+  const server: Server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    record(request.method ?? "GET", request.url ?? "");
+    response.writeHead(403, { "Content-Type": "text/plain", Connection: "close" });
+    response.end("egress refused by test witness");
+  });
+  server.on("connect", (request: IncomingMessage, socket: Duplex) => {
+    record("CONNECT", request.url ?? "");
+    socket.end("HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    server.close();
+    throw new Error("Egress witness did not bind a TCP port");
+  }
+  return {
+    port: address.port,
+    requests,
+    close: () => new Promise<void>((resolve) => {
+      server.closeAllConnections();
+      server.close(() => resolve());
+    }),
+  };
+}
+
+async function launchPackagedEnterprise(name: string, bootstrap?: ElectronSurfaceOptions["bootstrap"]) {
+  if (!process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim()) {
+    throw new SkipError("OPENWORK_EVAL_ELECTRON_BINARY points at a packaged enterprise desktop binary");
+  }
+  const witness = await startEgressWitness();
+  const host = localHost();
+  let handle: SurfaceHandle;
+  try {
+    handle = await host.spawnElectron(name, {
+      profile: "fresh",
+      prepareSharedResources: false,
+      env: {
+        OPENWORK_DEV_MODE: "0",
+        OPENWORK_ELECTRON_START_URL: "",
+        ELECTRON_START_URL: "",
+        ELECTRON_EXTRA_LAUNCH_ARGS: `--proxy-server=http://127.0.0.1:${witness.port}`,
+      },
+      ...(bootstrap ? { bootstrap } : {}),
+    });
+  } catch (error) {
+    await witness.close().catch(() => undefined);
+    throw error;
+  }
+  let app: AttachedSurface | null = null;
+  const dispose = async () => {
+    try {
+      await app?.stop();
+    } finally {
+      try {
+        await host.disposeSurface(handle);
+      } finally {
+        await witness.close();
+      }
+    }
+  };
+  try {
+    app = await attachSurface(handle, { timeoutMs: 60_000 });
+  } catch (error) {
+    await dispose().catch(() => undefined);
+    throw error;
+  }
+  const attached = app;
+  return {
+    app: attached,
+    /** Flavor baked into the packaged artifact, as the renderer sees it. */
+    flavor: () => evaluateOnSurface(attached, (): string | null => {
+      const electron: unknown = Reflect.get(window, "__OPENWORK_ELECTRON__");
+      if (typeof electron !== "object" || electron === null) return null;
+      const meta: unknown = Reflect.get(electron, "meta");
+      if (typeof meta !== "object" || meta === null) return null;
+      const distribution: unknown = Reflect.get(meta, "distribution");
+      if (typeof distribution !== "object" || distribution === null) return null;
+      const flavor: unknown = Reflect.get(distribution, "flavor");
+      return typeof flavor === "string" ? flavor : null;
+    }),
+    /** Text React actually mounted, as opposed to the body chrome. */
+    rootText: () => evaluateOnSurface(attached, () => document.getElementById("root")?.innerText ?? ""),
+    /** Every non-loopback request the desktop has made so far, in order. */
+    egress: () => [...witness.requests],
+    [Symbol.asyncDispose]: dispose,
+  };
+}
+
+/** First launch on a machine that has never run OpenWork: no bootstrap, so activation is required. */
+export function packagedPreactivationEgressWorld(_seed: Seed) {
+  return launchPackagedEnterprise("packaged-preactivation-egress");
+}
+
+/**
+ * Organization server used as the submitted workspace address. It is never
+ * resolved: with a proxy configured Chromium hands the hostname to the proxy,
+ * which refuses it, so the address is deterministic on any network.
+ */
+export const SUBMITTED_WORKSPACE_ADDRESS = "https://den.example.test";
+
+/**
+ * Positive control: the same binary already activated against a Den on that
+ * unreachable host. Activation completes at boot, so the requests the fresh
+ * install must hold back are expected here and prove the witness sees them.
+ */
+export function packagedActivatedEgressWorld(_seed: Seed) {
+  return launchPackagedEnterprise("packaged-activated-egress", {
+    baseUrl: SUBMITTED_WORKSPACE_ADDRESS,
+    requireSignin: true,
+    enterpriseActivation: { activatedAt: "2026-01-01T00:00:00.000Z", denBaseUrl: SUBMITTED_WORKSPACE_ADDRESS },
+  });
+}

--- a/packages/docs/start-here/outbound-network-access.mdx
+++ b/packages/docs/start-here/outbound-network-access.mdx
@@ -47,6 +47,10 @@ Common misses:
 
 `code.claude.com` and `schemas.agentskills.io` appear in source or schema metadata. They are findable in the manifest, but OpenWork does not fetch them for normal runtime behavior.
 
+### Before enterprise activation
+
+An OpenWork Enterprise install that has not yet been linked to your organization makes no request outside the machine. Until the person enters the workspace address, the desktop does not probe `app.openworklabs.com` for runtime configuration, does not send analytics to `us.i.posthog.com`, does not check `github.com` for updates or downloads (the one exception is an install whose architecture does not match the machine, which looks up the correct download), and does not fetch OpenWork Cloud inventory. The first outbound request goes to the workspace address that was entered. Analytics and update checks start only after activation completes and your desktop policy has been read once.
+
 ## Den runtime destinations
 
 Approve Den separately from desktop clients. A self-hosted Den behind VPN or inside Kubernetes uses the server network, not the user's laptop network.

--- a/packages/docs/start-here/outbound-network-access.mdx
+++ b/packages/docs/start-here/outbound-network-access.mdx
@@ -49,7 +49,7 @@ Common misses:
 
 ### Before enterprise activation
 
-An OpenWork Enterprise install that has not yet been linked to your organization makes no request outside the machine. Until the person enters the workspace address, the desktop does not probe `app.openworklabs.com` for runtime configuration, does not send analytics to `us.i.posthog.com`, does not check `github.com` for updates or downloads (the one exception is an install whose architecture does not match the machine, which looks up the correct download), and does not fetch OpenWork Cloud inventory. The first outbound request goes to the workspace address that was entered. Analytics and update checks start only after activation completes and your desktop policy has been read once.
+An OpenWork Enterprise install that has not yet been linked to your organization makes no request outside the machine. Until the person enters the workspace address, the desktop does not probe `app.openworklabs.com` for runtime configuration, does not send analytics to `us.i.posthog.com`, does not check `github.com` for updates or downloads (the one exception is an install whose architecture does not match the machine, which looks up the correct download), does not fetch OpenWork Cloud inventory, and on Windows and Linux does not download the Chromium spellchecker dictionary from `redirector.gvt1.com`. The first outbound request goes to the workspace address that was entered. Analytics and update checks start only after activation completes and your desktop policy has been read once.
 
 ## Den runtime destinations
 


### PR DESCRIPTION
## Problem

An unactivated enterprise build made non-loopback requests before the person entered a workspace address, i.e. to hosts nobody in the organization chose:

- `app.openworklabs.com/api/runtime-config` — `resolveDenBootstrapConfigWithRuntimeApi` guarded only on `isDesktopRuntime()`, so `initializeDenBootstrapConfig` probed the hosted default on every fresh boot.
- PostHog (`us.i.posthog.com`) — `AppRoot` called `initAnalytics()` / `captureAnalyticsEvent("app_opened")` above `EnterpriseActivationGate`; `isAnalyticsEnabled()` had no activation check.
- Cloud inventory prefetch — also above the gate (a no-op without a token today, gated anyway).
- **Found while writing the spec:** `github.com` — `ArchitectureMismatchGate` → `openwork:system:architecture` → `resolveArchitectureInfo()` fetched the public release manifest on every boot, even when the installed build already matched the machine.
- **Found by the spec on Linux CI:** `redirector.gvt1.com` — Chromium's spellchecker downloads its Hunspell dictionary from Google as soon as a text field mounts (Windows/Linux only; macOS uses the native spellchecker).

## Fix (smallest)

- `apps/app/src/app/lib/den.ts` — boot-time paths (`initializeDenBootstrapConfig` ×3, `refreshDenBootstrapConfigFromShell`) go through `resolveBootBootstrapConfig`, which skips the runtime-config probe while `enterpriseActivationRequired()`. `setDenBootstrapConfig` (the submitted address) and an activated bootstrap still resolve it.
- `apps/app/src/app/lib/enterprise-activation.ts` — new `outboundEgressAllowed(distribution, bootstrap, { desktopConfigLoading })`: always true for installs that never require activation; for activation-required installs true only once activated **and** the desktop config has resolved once (same readiness `DesktopUpdaterProvider` waits for).
- `apps/app/src/react-app/shell/app-root.tsx` — analytics init/capture and the Cloud inventory prefetch wait for `useOutboundEgressAllowed()`.
- `apps/desktop/electron/main.mjs` — `resolveArchitectureInfo` only fetches the release manifest when `appArch !== systemArch`; a matching install never shows the download so the fetched URL was unused.
- `apps/desktop/electron/main.mjs` — `holdSpellcheckerUntilActivation()` runs synchronously with the **first** `session.defaultSession` access (Electron's `Session` constructor calls `SpellcheckService::InitializeDictionaries` right there; the download itself waits on a file-thread hop) and clears the dictionary list while activation is required; `releaseSpellcheckerAfterActivation()` restores the held languages on both existing activation transitions (connect link, bootstrap write from the handoff exchange). Electron re-defaults an empty persisted list at the next boot, so quitting before activation cannot leave the spellchecker off. macOS uses the native spellchecker; the calls are no-ops there.
- `packages/docs/start-here/outbound-network-access.mdx` — new "Before enterprise activation" note.

**Den policy switch:** there is no analytics/telemetry switch in `desktopPolicyDefinitions` / `desktopConfigSchema` today, so none is honoured; the local `analyticsEnabled` preference still applies after activation. Waiting for the desktop config to resolve once means a future policy would be read before the first event.

Public/cloud flavors: `outboundEgressAllowed` returns `true` immediately when activation is not required, so their boot is unchanged (unit-tested).

## Proof

**Spec** `evals/specs/packaged-preactivation-egress.e2e.test.ts` + `evals/worlds/packaged-preactivation-egress.ts`: boots the packaged enterprise binary on a fresh profile behind a refusing logging forward proxy (`ELECTRON_EXTRA_LAUNCH_ARGS=--proxy-server=…`, which Chromium's stack, `net.fetch` in main and electron-updater all honour; loopback is implicitly bypassed).

1. Negative half: activation gate on screen → 25 s quiet window → **zero** non-loopback requests. Then a workspace address is submitted (pasted sign-in link naming `https://den.example.test`) → the only host contacted is `den.example.test`; the gate stays up (proxy refuses the exchange) and analytics stay silent.
2. Positive control: same binary with an activation stamp for that Den → the witness sees the runtime-config probe to `den.example.test` **and** the PostHog flush, proving the proxy observes renderer + main traffic and that analytics resume after activation.

Red on `origin/dev` (unfixed binary, macOS): `["CONNECT app.openworklabs.com:443","CONNECT github.com:443"]` during the quiet window; the first CI run on Linux additionally surfaced `CONNECT redirector.gvt1.com:443` (spellchecker), fixed in the follow-up commits (the first attempt with `setSpellCheckerEnabled(false)` ran too late; see commit messages). Green on this branch. Added to `packaged-smoke.mjs` (enterprise flavor) and the journey catalog so CI's packaged smoke gate runs it on Linux.

**Unit tests** `apps/app/tests/preactivation-egress.test.ts` (8 tests; 3 red on dev): boot skips runtime-config for unactivated enterprise, resolves it for activated / public / submitted address; `outboundEgressAllowed` matrix; AppRoot wiring.

Lane: local (packaged specs are `placement: local` — the packaged enterprise binary is only produced by packaged-smoke; not a Daytona lane). Test-evidence sections are published in the sticky comment below.

Related: ASTRA-1 follow-up E1.


