### PR TITLE
fix(app): identify the session in archive notifications

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -2048,7 +2048,7 @@ export default {
   "session_management.unarchive_session": "Unarchive session",
   "session_management.archive_failed": "Couldn't archive session",
   "session_management.unarchive_failed": "Couldn't unarchive session",
-  "session_management.session_archived": "Session archived",
+  "session_management.session_archived": "Session archived: {title}",
   "session_management.session_unarchived": "Session unarchived",
   "session_management.archive_working_title": "This session is still working",
   "session_management.archive_working_description": "Stop the current task and all its subtasks, cancel queued messages, and archive this conversation? Changes already made won't be undone. Actions already submitted to external services may still complete.",

--- a/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
@@ -99,7 +99,7 @@ export function useSessionArchive(input: {
   }
 
   function showUndo(target: ArchiveTarget, archived: boolean, undo?: typeof undoNavigation.current) {
-    const message = archived ? `${t("session_management.session_archived")}: ${target.title}` : t("session_management.session_unarchived");
+    const message = archived ? t("session_management.session_archived", { title: target.title }) : t("session_management.session_unarchived");
     toast.undo(<span title={message}>{message}</span>, {
       id: `session-archive:${target.sessionId}`,
       icon: archived ? Archive : ArchiveRestore,

--- a/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
@@ -25,7 +25,7 @@ import { dispatchQueuedDrain, getQueuedDrainState, hasPendingQueuedAdmission } f
 import { clearQueuedSendContext } from "../sync/queued-send-context";
 import { applySessionArchived } from "../sync/session-sync";
 
-type ArchiveTarget = { workspace: RouteWorkspace; endpoint: ResolvedWorkspaceEndpoint; sessionId: string; draftScope: string | null };
+type ArchiveTarget = { workspace: RouteWorkspace; endpoint: ResolvedWorkspaceEndpoint; sessionId: string; title: string; draftScope: string | null };
 
 export function useSessionArchive(input: {
   workspaces: RouteWorkspace[];
@@ -99,7 +99,8 @@ export function useSessionArchive(input: {
   }
 
   function showUndo(target: ArchiveTarget, archived: boolean, undo?: typeof undoNavigation.current) {
-    toast.undo(archived ? t("session_management.session_archived") : t("session_management.session_unarchived"), {
+    const message = archived ? `${t("session_management.session_archived")}: ${target.title}` : t("session_management.session_unarchived");
+    toast.undo(<span title={message}>{message}</span>, {
       id: `session-archive:${target.sessionId}`,
       icon: archived ? Archive : ArchiveRestore,
       undo: { label: t("common.undo"), onClick: () => {
@@ -271,7 +272,8 @@ export function useSessionArchive(input: {
       toast.error(endpoint && isOpencodeV2BaseUrl(endpoint.opencodeBaseUrl) ? V2_SESSION_ARCHIVE_UNAVAILABLE : "The session's workspace is not connected.");
       return false;
     }
-    const target = { workspace, endpoint, sessionId, draftScope: input.draftScope };
+    const title = input.sessionsByWorkspaceId[workspace.id]?.find(session => session.id === sessionId)?.title?.trim() || t("session.default_title");
+    const target = { workspace, endpoint, sessionId, title, draftScope: input.draftScope };
     if (!archived) return restore(target, true);
     return new Promise<boolean>(resolve => {
       pending.current = resolve;

--- a/evals/specs/session-archive-undo.e2e.test.ts
+++ b/evals/specs/session-archive-undo.e2e.test.ts
@@ -24,6 +24,12 @@ test("session archive is honest about availability and can be undone when suppor
       label: "undo pill finishes sliding in",
       until: (settled) => settled,
     });
+    expect(await world.archiveToast()).toMatchObject({
+      text: `Session archived: ${world.candidate.title}`,
+      fullTitle: `Session archived: ${world.candidate.title}`,
+      fitsViewport: true,
+      actionsInside: true,
+    });
   };
 
   await step("both sessions are active and nothing is archived", async () => {
@@ -120,6 +126,53 @@ test("session archive is honest about availability and can be undone when suppor
     expect(sidebar.archivedSection).toBe(false);
     await user.notSee({ text: "Session unarchived" });
     await user.notSee(undoButton);
+  });
+
+  for (const title of ["Programmatic archive candidate", `Long archive candidate ${"identity-preserving-title-".repeat(30)}`]) {
+    await step("programmatic nonfocused archive names its target and Undo restores only that target", async () => {
+      expect(await agent.run("session.rename", { sessionId: candidateId, title })).toMatchObject({ ok: true });
+      expect(await agent.run("session.archive", { sessionId: candidateId, archived: true })).toMatchObject({ ok: true });
+      await user.see({ text: `Session archived: ${title}` });
+      await probe.eventually(() => world.undoToastSettled(), { within: 10_000, label: "programmatic toast settles", until: Boolean });
+      expect(await world.archiveToast()).toMatchObject({
+        text: `Session archived: ${title}`,
+        fullTitle: `Session archived: ${title}`,
+        fitsViewport: true,
+        actionsInside: true,
+        ...(title.startsWith("Long") ? { truncated: true } : {}),
+      });
+      expect(await probe.hash()).toContain(`/session/${neighborId}`);
+      const stamps = await world.archivedAt();
+      expect(stamps[candidateId]).toBeGreaterThan(0);
+      expect(stamps[neighborId]).toBe(0);
+      await user.click(undoButton);
+      await user.notSee(archivedToast);
+      const restored = await probe.eventually(() => world.archivedAt(), {
+        within: 30_000, label: "programmatic Undo restores candidate", until: value => value[candidateId] === 0,
+      });
+      expect(restored[neighborId]).toBe(0);
+      expect(await probe.hash()).toContain(`/session/${neighborId}`);
+    });
+  }
+
+  await step("programmatic View opens its named target rather than the focused neighbor", async () => {
+    await agent.run("session.rename", { sessionId: candidateId, title: world.candidate.title });
+    await agent.run("session.archive", { sessionId: candidateId, archived: true });
+    await user.see({ text: `Session archived: ${world.candidate.title}` });
+    await probe.eventually(() => world.undoToastSettled(), { within: 10_000, label: "View toast settles", until: Boolean });
+    await user.click(viewButton);
+    await probe.eventually(() => probe.hash(), {
+      within: 30_000, label: "programmatic View opens candidate", until: hash => hash.includes(`/session/${candidateId}`),
+    });
+    const stamps = await world.archivedAt();
+    expect(stamps[candidateId]).toBeGreaterThan(0);
+    expect(stamps[neighborId]).toBe(0);
+    await agent.run("session.archive", { sessionId: candidateId, archived: false });
+    await probe.eventually(() => world.archivedAt(), {
+      within: 30_000, label: "candidate restored for manual View check", until: value => value[candidateId] === 0,
+    });
+    await user.see("composer", { editable: true });
+    await agent.run("session.open", { sessionId: neighborId });
   });
 
   await step("View opens the archived session and leaves it archived", async () => {

--- a/evals/specs/session-archive-undo.e2e.test.ts
+++ b/evals/specs/session-archive-undo.e2e.test.ts
@@ -128,15 +128,24 @@ test("session archive is honest about availability and can be undone when suppor
     await user.notSee(undoButton);
   });
 
-  for (const title of ["Programmatic archive candidate", `Long archive candidate ${"identity-preserving-title-".repeat(30)}`]) {
-    await step("programmatic nonfocused archive names its target and Undo restores only that target", async () => {
-      expect(await agent.run("session.rename", { sessionId: candidateId, title })).toMatchObject({ ok: true });
+  for (const title of ["Programmatic archive candidate", `Long archive candidate ${"identity-preserving-title-".repeat(30)}`, "", " \t "]) {
+    const displayTitle = title.trim() || "New session";
+    const titleKind = title === "" ? "empty" : !title.trim() ? "whitespace-only" : title.startsWith("Long") ? "long" : "named";
+    await step(`programmatic nonfocused archive identifies the ${titleKind} target and Undo restores only that target`, async () => {
+      if (title.trim()) {
+        expect(await agent.run("session.rename", { sessionId: candidateId, title })).toMatchObject({ ok: true });
+      } else {
+        await agent.run("session.rename", { sessionId: candidateId, title: "Before blank title" });
+        await user.see(candidateRow, { text: "Before blank title" });
+        expect(await world.setCandidateTitle(title)).toBe(title);
+        await user.see(candidateRow, { text: displayTitle });
+      }
       expect(await agent.run("session.archive", { sessionId: candidateId, archived: true })).toMatchObject({ ok: true });
-      await user.see({ text: `Session archived: ${title}` });
+      await user.see({ text: `Session archived: ${displayTitle}` });
       await probe.eventually(() => world.undoToastSettled(), { within: 10_000, label: "programmatic toast settles", until: Boolean });
       expect(await world.archiveToast()).toMatchObject({
-        text: `Session archived: ${title}`,
-        fullTitle: `Session archived: ${title}`,
+        text: `Session archived: ${displayTitle}`,
+        fullTitle: `Session archived: ${displayTitle}`,
         fitsViewport: true,
         actionsInside: true,
         ...(title.startsWith("Long") ? { truncated: true } : {}),

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1910,6 +1910,21 @@ export async function archiveSessions(seed: Seed) {
   }
 
   return { app, engine, workspace, workspacePath, candidate, neighbor, archivedAt, sidebar, undoToastSettled,
+    // The rename UI rejects blank input; arrange persisted legacy titles through the native API.
+    setCandidateTitle: (title: string) => seed.evalIn(app, browserScript(async (workspaceId, sessionId, title) => {
+      const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+      if (!info?.running || !info.baseUrl) throw new Error("OpenWork server is unavailable");
+      const response = await fetch(`${info.baseUrl.replace(/\/+$/, "")}/workspace/${encodeURIComponent(workspaceId)}/opencode/session/${encodeURIComponent(sessionId)}`, {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${info.ownerToken ?? info.clientToken ?? ""}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ title }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) throw new Error(`Setting fixture title failed with HTTP ${response.status}`);
+      const session = await response.json();
+      if (session.id !== sessionId || typeof session.title !== "string") throw new Error("Unexpected session title response");
+      return session.title;
+    }, [workspace.workspaceId, candidate.sessionId, title]), { awaitPromise: true, timeoutMs: 20_000 }),
     archiveToast: () => seed.evalIn(app, () => {
       const pill = document.querySelector<HTMLElement>("[data-undo-toast]");
       const message = pill?.querySelector("p");

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1910,6 +1910,21 @@ export async function archiveSessions(seed: Seed) {
   }
 
   return { app, engine, workspace, workspacePath, candidate, neighbor, archivedAt, sidebar, undoToastSettled,
+    archiveToast: () => seed.evalIn(app, () => {
+      const pill = document.querySelector<HTMLElement>("[data-undo-toast]");
+      const message = pill?.querySelector("p");
+      const bounds = pill?.getBoundingClientRect();
+      return {
+        text: message?.textContent,
+        fullTitle: message?.querySelector("[title]")?.getAttribute("title"),
+        truncated: Boolean(message && message.scrollWidth > message.clientWidth && getComputedStyle(message).textOverflow === "ellipsis"),
+        fitsViewport: Boolean(bounds && bounds.left >= 0 && bounds.right <= window.innerWidth),
+        actionsInside: Boolean(pill && bounds && [...pill.querySelectorAll("button")].every(button => {
+          const action = button.getBoundingClientRect();
+          return action.width > 0 && action.left >= bounds.left && action.right <= bounds.right;
+        })),
+      };
+    }),
     hoverArchiveButton: async () => {
       // Disabled buttons reject pointer hits; hover their visible bounds without clicking.
       const button = await waitForLocated(app, { testId: `session-archive-${candidate.sessionId}` }, { timeoutMs: 10_000 });


### PR DESCRIPTION
## Problem and RCA
Agent-driven archive actions can affect a nonfocused conversation. The shared archive hook retained the correct session ID for View/Undo but displayed only generic success text, leaving the affected conversation ambiguous.

## Product/design decision
Show `Session archived: <title>` for both manual and programmatic actions, preserving View and Undo. Snapshot the target title before mutation, use New session for blank legacy titles, truncate long titles with full hover text. No confirmation modal for this reversible action.

Options considered: generic toast (ambiguous); named toast (chosen, smallest contextual fix); confirmation dialog (unnecessary interruption); durable activity log/bulk summary (useful future scope, not needed here).

Research: ChatGPT archives without confirmation and supports recovery in Archived Chats (https://help.openai.com/en/articles/8809935). Gmail keeps archived messages discoverable and restorable (https://support.google.com/mail/answer/6576). Material recommends concise operation-related snackbar text and Undo (https://m3.material.io/components/snackbar/guidelines). These documented patterns do not establish competitors exact current toast wording. Agent-driven actions need explicit object identity because direct-click context is absent.

## Verification
- Daytona exact head a33888c2bd8400f33d3b4e7b100398e80b65d231: `pnpm evals:e2e session-archive-undo --engine v1 --daytona` — 1 passed, 0 failed, 0 skipped; 9 steps passed.
- Covers manual identity, nonfocused programmatic identity, Undo target isolation, View target, long-title layout, empty/whitespace fallback.
- App `pnpm typecheck`: exit 0. `git diff --check`: passed.
- Broad `pnpm evals:typecheck`: exit 2, 399 diagnostics both on final branch and clean origin/dev control 2ed12f72d7d1b434b539dde5361db2204d76036a; matching content after path/line offsets. No introduced diagnostics.
- Commit-bound test evidence will be published below. Screenshots are reference-only; assertions determine pass/fail.

Isolated worktree; unrelated ongoing changes excluded.