### PR TITLE
fix(app)/test(evals): do not let the org default model replace a configured non-cloud default while providers are still loading (opencode-v2-skill-jit)

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-policy.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-policy.ts
@@ -96,3 +96,25 @@ export function resolveEntitledOrgDefaultModel(
     ? { providerID: replacement.providerID, modelID: replacement.modelID }
     : null;
 }
+
+export type OrgDefaultModelReplacementInput = FilterEntitledModelOptionsInput & {
+  currentDefault: ModelRef | null;
+  /** Connected providers of the selected workspace engine. */
+  runtimeOptions: readonly ModelEntitlementOption[];
+  /** Organization-assigned models: the stand-in before a workspace engine exists. */
+  assignedOptions: readonly ModelEntitlementOption[];
+};
+
+/**
+ * Which organization model, if any, should replace the stored default. The
+ * workspace engine's catalog is the source of truth; organization-assigned
+ * models stand in only when that catalog has nothing to offer.
+ */
+export function resolveOrgDefaultModelReplacement(
+  input: OrgDefaultModelReplacementInput,
+): ModelRef | null {
+  return resolveEntitledOrgDefaultModel(
+    input.runtimeOptions.length > 0 ? input.runtimeOptions : input.assignedOptions,
+    input,
+  );
+}

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-policy.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-policy.ts
@@ -101,6 +101,11 @@ export type OrgDefaultModelReplacementInput = FilterEntitledModelOptionsInput & 
   currentDefault: ModelRef | null;
   /** Connected providers of the selected workspace engine. */
   runtimeOptions: readonly ModelEntitlementOption[];
+  /**
+   * A workspace engine is connected but its catalog has not answered yet
+   * (for example while it reloads with a freshly configured provider).
+   */
+  runtimeCatalogPending: boolean;
   /** Organization-assigned models: the stand-in before a workspace engine exists. */
   assignedOptions: readonly ModelEntitlementOption[];
 };
@@ -108,11 +113,15 @@ export type OrgDefaultModelReplacementInput = FilterEntitledModelOptionsInput & 
 /**
  * Which organization model, if any, should replace the stored default. The
  * workspace engine's catalog is the source of truth; organization-assigned
- * models stand in only when that catalog has nothing to offer.
+ * models stand in only when that catalog has nothing to offer. A catalog that
+ * is still loading is not an empty catalog: no verdict is reached until it
+ * answers, so a configured non-cloud default is never replaced by an
+ * organization model merely because the engine has not listed it yet.
  */
 export function resolveOrgDefaultModelReplacement(
   input: OrgDefaultModelReplacementInput,
 ): ModelRef | null {
+  if (input.runtimeCatalogPending) return null;
   return resolveEntitledOrgDefaultModel(
     input.runtimeOptions.length > 0 ? input.runtimeOptions : input.assignedOptions,
     input,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1003,10 +1003,13 @@ export function SessionRoute() {
     return () => window.removeEventListener(openModelPickerEvent, handler);
   }, []);
   const entitledOrgDefaultModel = useMemo(() => {
+    const runtimeProviderList = cloudProviderList ?? providerListQuery.data;
     return resolveOrgDefaultModelReplacement({
-      runtimeOptions: providerListModelEntitlementOptions(
-        cloudProviderList ?? providerListQuery.data,
-      ),
+      runtimeOptions: providerListModelEntitlementOptions(runtimeProviderList),
+      // Same pending rule as computeModelAvailability: a connected workspace
+      // engine whose catalog has not answered (e.g. still reloading after a
+      // provider was configured) must not be read as "provider missing".
+      runtimeCatalogPending: Boolean(selectedWorkspaceId && opencodeClient) && !runtimeProviderList,
       assignedOptions: organizationAssignedModelOptions,
       currentDefault: local.prefs.defaultModel,
       restrictToCloud: restrictToCloudProviders,
@@ -1016,9 +1019,11 @@ export function SessionRoute() {
     checkDesktopRestriction,
     cloudProviderList,
     local.prefs.defaultModel,
+    opencodeClient,
     organizationAssignedModelOptions,
     providerListQuery.data,
     restrictToCloudProviders,
+    selectedWorkspaceId,
   ]);
   useEffect(() => {
     if (entitledOrgDefaultModel) writeStoredDefaultModel(entitledOrgDefaultModel);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -153,7 +153,7 @@ import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provi
 import { assignedModelOptions } from "@/react-app/domains/connections/provider-auth/assigned-model-options";
 import {
   filterEntitledModelOptions,
-  resolveEntitledOrgDefaultModel,
+  resolveOrgDefaultModelReplacement,
   type ModelEntitlementOption,
 } from "@/react-app/domains/connections/provider-auth/provider-policy";
 import {
@@ -1003,17 +1003,15 @@ export function SessionRoute() {
     return () => window.removeEventListener(openModelPickerEvent, handler);
   }, []);
   const entitledOrgDefaultModel = useMemo(() => {
-    const runtimeOptions = providerListModelEntitlementOptions(
-      cloudProviderList ?? providerListQuery.data,
-    );
-    return resolveEntitledOrgDefaultModel(
-      runtimeOptions.length > 0 ? runtimeOptions : organizationAssignedModelOptions,
-      {
-        currentDefault: local.prefs.defaultModel,
-        restrictToCloud: restrictToCloudProviders,
-        checkRestriction: checkDesktopRestriction,
-      },
-    );
+    return resolveOrgDefaultModelReplacement({
+      runtimeOptions: providerListModelEntitlementOptions(
+        cloudProviderList ?? providerListQuery.data,
+      ),
+      assignedOptions: organizationAssignedModelOptions,
+      currentDefault: local.prefs.defaultModel,
+      restrictToCloud: restrictToCloudProviders,
+      checkRestriction: checkDesktopRestriction,
+    });
   }, [
     checkDesktopRestriction,
     cloudProviderList,

--- a/apps/app/tests/org-default-model-replacement.test.ts
+++ b/apps/app/tests/org-default-model-replacement.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+
+import type { DesktopAppRestrictionChecker } from "../src/app/cloud/desktop-app-restrictions";
+import { resolveOrgDefaultModelReplacement } from "../src/react-app/domains/connections/provider-auth/provider-policy";
+
+const allowEverything: DesktopAppRestrictionChecker = () => true;
+const managedModelsPolicy: DesktopAppRestrictionChecker = (input) =>
+  input.restriction === "allowZenModel";
+
+// The organization's assigned cloud model, already known from Den.
+const assignedOptions = [{ providerID: "lpr_acme", modelID: "big-pickle" }];
+// A workspace provider the person just configured in opencode.json.
+const configuredDefault = { providerID: "skill-lifecycle", modelID: "skill-lifecycle-model" };
+
+describe("resolveOrgDefaultModelReplacement", () => {
+  test("does not replace a configured non-cloud default while the workspace catalog is still loading", () => {
+    // Right after an engine reload the engine catalog has not answered yet,
+    // while the organization-assigned models have. That window used to read
+    // as "the configured provider is missing" and swapped in the org model.
+    expect(resolveOrgDefaultModelReplacement({
+      runtimeOptions: [],
+      runtimeCatalogPending: true,
+      assignedOptions,
+      currentDefault: configuredDefault,
+      restrictToCloud: false,
+      checkRestriction: allowEverything,
+    })).toBe(null);
+  });
+
+  test("keeps the configured default once the loaded workspace catalog contains it", () => {
+    expect(resolveOrgDefaultModelReplacement({
+      runtimeOptions: [configuredDefault, ...assignedOptions],
+      runtimeCatalogPending: false,
+      assignedOptions,
+      currentDefault: configuredDefault,
+      restrictToCloud: false,
+      checkRestriction: allowEverything,
+    })).toBe(null);
+  });
+
+  test("falls back to organization-assigned models when no workspace engine catalog exists", () => {
+    // Before workspace creation there is no engine to ask; assigned models
+    // stand in so the composer is not left without a selection.
+    expect(resolveOrgDefaultModelReplacement({
+      runtimeOptions: [],
+      runtimeCatalogPending: false,
+      assignedOptions,
+      currentDefault: configuredDefault,
+      restrictToCloud: false,
+      checkRestriction: allowEverything,
+    })).toEqual({ providerID: "lpr_acme", modelID: "big-pickle" });
+  });
+
+  test("replaces a policy-blocked default from the loaded workspace catalog", () => {
+    expect(resolveOrgDefaultModelReplacement({
+      runtimeOptions: [
+        { providerID: "opencode", modelID: "big-pickle" },
+        { providerID: "lpr_acme", modelID: "gpt-5.4" },
+      ],
+      runtimeCatalogPending: false,
+      assignedOptions: [],
+      currentDefault: { providerID: "opencode", modelID: "big-pickle" },
+      restrictToCloud: true,
+      checkRestriction: managedModelsPolicy,
+    })).toEqual({ providerID: "lpr_acme", modelID: "gpt-5.4" });
+  });
+});

--- a/evals/specs/opencode-v2-skill-jit.e2e.test.ts
+++ b/evals/specs/opencode-v2-skill-jit.e2e.test.ts
@@ -46,7 +46,8 @@ test("workspace skills change during an ongoing conversation", async ({ world, u
     expect(visibleUserMessages).toHaveLength(submitted.length);
     visibleUserMessages.forEach((text, index) => expect(text).toContain(submitted[index]));
     expect(await readTranscriptMessages(probe, "system")).toEqual([]);
-    if (world.live) expect(await world.usedConfiguredModel()).toBe(true);
+    // A silent swap to an organization model must fail here, not as a text mismatch.
+    expect(await world.usedConfiguredModel()).toBe(true);
     if (!record(response) || typeof response.text !== "string") throw new Error("Missing visible answer");
     for (const code of previousCodes) expect(response.text).not.toContain(code);
     expect(await transcript.finish()).toMatchObject({ seen: [true], violations: [], stopped: false });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -155,8 +155,16 @@ export async function configureProvider(
   }, [workspaceId, providerId, modelId, `${providerId}/${modelId}`, JSON.stringify(opencode)]), { awaitPromise: true, timeoutMs: 120_000 });
   if (result !== "ok") throw new Error(`Provider configuration failed: ${String(result)}`);
   await seed.evalIn(app, () => { location.reload(); return true; });
-  const ready = await seed.evalIn(app, browserScript(async (workspaceId, engine, providerId, modelId) => {
+  // The display name the app gives the configured model once its provider list
+  // contains it; a fixture provider declares it in opencode.json, a live one is
+  // read from the engine catalog.
+  const configuredModel = recordValue(recordValue(recordValue(opencode, "provider"), providerId), "models");
+  const configuredNameValue = recordValue(recordValue(configuredModel, modelId), "name");
+  const configuredName = typeof configuredNameValue === "string" ? configuredNameValue : null;
+  const ready = await seed.evalIn(app, browserScript(async (workspaceId, engine, providerId, modelId, configuredName) => {
     const deadline = Date.now() + 60000;
+    const expectedRef = providerId + "/" + modelId;
+    let observed = "";
     while (Date.now() < deadline) {
       const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
       const headers = { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") };
@@ -171,16 +179,37 @@ export async function configureProvider(
         const mounted = base + "/workspace/" + encodeURIComponent(workspaceId);
         const response = await fetch(mounted + (engine === "v2" ? "/opencode2/api/model" : "/opencode/session"), { headers });
         if (response.ok && window.__openworkControl) {
-          if (engine === "v1") return true;
-          const catalog = JSON.stringify(await response.json());
-          if (catalog.includes(providerId) && catalog.includes(modelId)) return true;
+          let catalogName: string | null = null;
+          if (engine === "v2") {
+            const record = (value: unknown): value is Record<string, unknown> =>
+              typeof value === "object" && value !== null && !Array.isArray(value);
+            const catalog: unknown = await response.json();
+            const items: unknown[] = Array.isArray(catalog) ? catalog : record(catalog) && Array.isArray(catalog.data) ? catalog.data : [];
+            const entry = items.find((item) => record(item) && item.id === modelId && item.providerID === providerId);
+            if (!record(entry)) throw new Error("catalog pending");
+            catalogName = typeof entry.name === "string" ? entry.name : null;
+          }
+          // The engine lists the provider; now the app must too. Its composer
+          // shows the model's display name only once the app's own provider
+          // list contains the configured model, and the stored default must
+          // have survived boot rather than being replaced by an organization
+          // model while that list was still loading.
+          const name = configuredName ?? catalogName ?? modelId;
+          const chip = document.querySelector<HTMLElement>('button[aria-label="Change model"]');
+          const chipText = chip?.innerText.trim() ?? "";
+          const stored = localStorage.getItem("openwork.defaultModel");
+          observed = JSON.stringify({ composerModel: chipText, storedDefault: stored, expected: { name, ref: expectedRef } });
+          if (stored === expectedRef && chipText.startsWith(name)) return true;
         }
       } catch {}
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
-    return false;
-  }, [workspaceId, engine, providerId, modelId]), { awaitPromise: true, timeoutMs: 120_000 });
-  if (ready !== true) throw new Error(`Selected ${engine} engine did not become ready after provider configuration.`);
+    return observed || false;
+  }, [workspaceId, engine, providerId, modelId, configuredName]), { awaitPromise: true, timeoutMs: 120_000 });
+  if (ready !== true) {
+    throw new Error(`Selected ${engine} engine did not become ready after provider configuration`
+      + (typeof ready === "string" ? `; last observed ${ready}` : "."));
+  }
 }
 
 async function seedControls(
@@ -2199,13 +2228,18 @@ export async function skillLifecycle(seed: Seed) {
         });
         if (!result.ok) throw new Error("Could not arrange model response");
       },
+      /**
+       * Every completed reply in the conversation came from the arranged
+       * provider and model, never from an organization model that replaced it.
+       * Only a live provider reports token usage; the fixture model streams none.
+       */
       async usedConfiguredModel() {
         const result = await request(`/workspace/${workspace.workspaceId}/opencode2/api/session/${session.sessionId}/message`);
         const messages = isRecord(result.json) && Array.isArray(result.json.data) ? result.json.data.filter(isRecord) : [];
         const replies = messages.filter(message => message.type === "assistant" && message.finish === "stop");
         return replies.length > 0 && replies.every(message => isRecord(message.model)
           && message.model.id === modelId && message.model.providerID === providerId
-          && isRecord(message.tokens) && typeof message.tokens.output === "number" && message.tokens.output > 0);
+          && (!live || (isRecord(message.tokens) && typeof message.tokens.output === "number" && message.tokens.output > 0)));
       },
       async runtimeIdentity() {
         const result = await request("/experimental/engine-v2-preview/status");


### PR DESCRIPTION
## Root cause

Session AD's flake re-check (`reports/e2e-red-2026-09-09/flake-recheck.md`, section `opencode-v2-skill-jit`) found the race behind this spec's intermittent red. The PR-head screenshot showed the session running on the org cloud model "Big Pickle" instead of the arranged mock provider `skill-lifecycle/skill-lifecycle-model`.

`configureProvider` (evals world) writes the mock provider to `opencode.json`, POSTs `engine/reload`, stores the default, then `location.reload()`s. On boot, `session-route.tsx` computed `resolveEntitledOrgDefaultModel(runtimeOptions.length > 0 ? runtimeOptions : organizationAssignedModelOptions, …)`. While the workspace engine is still rebuilding its instance after the reload, the provider-list query has no data yet, so `runtimeOptions` is empty and the decision fell through to the organization-assigned models (already fetched from Den). The configured non-cloud default is never in that list, so `writeStoredDefaultModel` overwrote it with the first entitled org model. Under lane load the engine rebuild is slower than the Den fetch, which is why it only showed in the pooled lane.

## What changed

- `36cb41e1f` **refactor(app)**: extract the inline decision into `resolveOrgDefaultModelReplacement` (`provider-policy.ts`), no behavior change — so it can be unit tested.
- `f642bc4eb` **fix(app)**: add an explicit `runtimeCatalogPending` input (same rule as `computeModelAvailability`: workspace engine connected, catalog not yet answered) and return no replacement while it is true. The fallback to organization-assigned models still applies when there is no workspace engine (the #3714 "before workspace creation" case). New `apps/app/tests/org-default-model-replacement.test.ts` (in the `tests/` glob CI runs).
- `d10304387` **test(evals)**: `configureProvider`'s readiness gate now also waits until the composer's model control shows the configured model's display name (i.e. the *app's* provider list contains it) and the stored default still equals the configured model, and reports the last observed state on timeout. `opencode-v2-skill-jit` asserts `usedConfiguredModel()` in mock mode too, so a silent swap fails on model identity rather than a text mismatch. This tightens the claim; nothing was loosened. The token-usage half of that check stays live-only because the fixture model streams no `usage`.

## Proof

Unit test red → green (run against the refactor commit's helper, then the fix):
```
=== RED (helper at 36cb41e1f, no fix) ===
Expected: null
Received: { providerID: "lpr_acme", modelID: "big-pickle" }
(fail) resolveOrgDefaultModelReplacement > does not replace a configured non-cloud default while the workspace catalog is still loading
 3 pass / 1 fail
=== GREEN (f642bc4eb) ===
 4 pass / 0 fail
```

- `pnpm --filter @openwork/app typecheck` → exit 0 at `d10304387`.
- `pnpm evals:e2e opencode-v2-skill-jit --daytona` with `OPENWORK_EVAL_REF=d10304387235c1ee65870c0b923d90483c085fc6`, 3 sequential single-spec runs, each `source verified d10304387…`, placement `daytona`:

| run | server / desktop sandbox | duration | result |
|---|---|---|---|
| 1 | `openwork-server-20260910-173016-18384-e1cd7861` / `openwork-connector-testkit-admin-20260910-173221-18384-e3b01dbc` | 267 s | passed 1 / failed 0 / skipped 0 |
| 2 | `openwork-server-20260910-173716-54859-bc173712` / `openwork-connector-testkit-admin-20260910-173922-54859-80a192df` | 276 s | passed 1 / failed 0 / skipped 0 |
| 3 | `openwork-server-20260910-174244-84484-5aab387b` / `openwork-connector-testkit-admin-20260910-174439-84484-23abd83e` | 242 s | passed 1 / failed 0 / skipped 0 |

Verdict line (each run): `{"command":"evals:e2e","lane":"e2e","daytona":true,"placement":"daytona",…,"passed":1,"failed":0,"skipped":0,"skips":[],"verdict":"passed"}`. The run-1 screenshot shows the composer chip reading "Skill lifecycle model" (arranged provider), not "Big Pickle". All six sandboxes were deleted by the runner.

## Noticed, not touched

- `apps/app/src/react-app/domains/connections/provider-auth/managed-models-recovery.test.ts:154` is red on `origin/dev`: it asserts the source string `await refreshProvidersAfterCloudSync({ force: true });` but `store.ts` has had `…, isCurrent);` since #4718. It is colocated under `src/`, so CI's `bun test tests/` never runs it (same for the existing `provider-policy.test.ts`).
- `configureProvider`'s new gate is shared by every world that calls it (17 call sites); only `opencode-v2-skill-jit` was run here. All those worlds configure a fixture provider with a model `name`, which the gate uses as the expected display text.
- `store.ts` `preselectEntitledOrgDefaultModel` (post cloud-sync path) uses the engine list it just fetched; a null list yields no replacement, so it was left as is.
