### PR TITLE
fix(app): say what belongs in the notification center

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1075,7 +1075,7 @@ export default {
   "model_picker.recommended": "Recent",
   "notifications.clear_all": "Clear all",
   "notifications.empty": "No notifications yet",
-  "notifications.empty_hint": "Updates from OpenWork Cloud and your workspaces will show up here.",
+  "notifications.empty_hint": "Background updates show up here: new models, extension changes, applied reloads, and errors that need your attention. Confirmations of your own actions, like archiving a session, appear briefly instead.",
   "notifications.engine_reloaded": "Updates applied",
   "notifications.just_now": "Just now",
   "notifications.reconnect_failed": "Couldn't reconnect to the OpenWork server",

--- a/docs/features/notification-center-scope.md
+++ b/docs/features/notification-center-scope.md
@@ -1,0 +1,126 @@
+# Notification center scope: what belongs in the bell, what stays a toast
+
+Report on the question "the Notifications panel says *No notifications yet*
+while workspace events such as the archived-session toast never appear there —
+is that intentional?"
+
+## Verdict
+
+**Intentional delivery scope, misleading empty-state copy.** The archived-session
+toast is a *user-action confirmation*, and the notification center was designed
+to exclude that class. The only defect is the empty-state hint, which promised
+"updates from … your workspaces" without saying that confirmations of your own
+actions are deliberately kept out. This change fixes the copy and adds an E2E
+spec that pins the contract. No delivery behavior changed.
+
+## Documented intent (not inferred)
+
+- PR [#2215](https://github.com/different-ai/openwork/pull/2215) "notification
+  center + auto-reload engine when idle" (merged 2026-06-13) introduced three
+  delivery classes:
+
+  | Class | Behavior | Examples named in the PR |
+  | --- | --- | --- |
+  | Feedback | toast only | skill installed, validation warnings, action errors |
+  | Event | center entry + badge, never a popup | provider sync, reload receipts, pending updates |
+  | Alert | center entry + one toast; bursts collapse into one summary toast | reload failure, updater / auto-reconnect errors |
+
+- The entry-point module `apps/app/src/react-app/shell/notifications.ts`
+  restates it in its header: "Direct feedback for user actions (e.g. 'skill
+  installed') should keep using `toast` … and stay out of the center."
+- PR [#4818](https://github.com/different-ai/openwork/pull/4818) (the archive
+  toast identity fix, merged 2026-09-10) explicitly considered a "durable
+  activity log / bulk summary" for archive actions and recorded it as "useful
+  future scope, not needed here".
+- No product doc in `docs/` or the bundled OpenWork documentation describes the
+  in-app bell; the only prose is the Desktop Notifications settings copy, which
+  calls native OS notifications "separate from the in-app notification bell".
+- No GitHub issue asks for user-action confirmations in the center.
+
+## Observed implementation (origin/dev 2fcbae60e)
+
+- Store: `react-app/kernel/notification-store.ts`, Zustand + `localStorage`
+  key `openwork:notifications:v1`, 100 entries / 30 days, unread entries with
+  the same `dedupeKey` coalesce, actions are serializable descriptors
+  (`open-model-picker`, `reload-engine`, `open-extensions-marketplace`,
+  `install-marketplace-plugin`) so they remain valid after a restart.
+- Scope: one store per app profile, shared across workspaces and accounts; no
+  per-entry dismiss, closing the panel marks everything read, "Clear all"
+  drops everything.
+- Producers of center entries today: provider sync (`new-providers-listener`),
+  engine reload receipts / pending updates / reload failure
+  (`reload-coordinator`), marketplace plugin added / updated / removed
+  (`extensions-store`), background failure sinks in `settings-route`
+  (updater check, workspace refresh, server reconnect), and session title
+  generation failure (`session-sync`).
+- Archive / unarchive (`domains/session/sidebar/use-session-archive.tsx`) uses
+  `toast.undo(...)` with closure-based Undo and View actions and never calls
+  `notifyEvent` / `notifyAlert`. Task completion, failure, permission and
+  question prompts go to native OS notifications only
+  (`shell/desktop-notifications.ts`) when the window is not in view; they are
+  not written to the center either.
+- The user's report is therefore consistent with the code: the center is
+  empty until a background event happens, and archiving never writes to it.
+
+## Comparators (primary sources)
+
+| Product | Ephemeral confirmation | Durable in-app inbox | Own-action confirmations in the inbox? |
+| --- | --- | --- | --- |
+| VS Code | Toast (auto-hides; 3 at a time, spam-protected) | Notification center keeps every notification until closed; `SILENT` priority = center only, Do Not Disturb hides non-error toasts but the center still shows them ([docs](https://code.visualstudio.com/docs/editing/getting-started/userinterface), [notification.ts](https://github.com/microsoft/vscode/blob/99489178/src/vs/platform/notification/common/notification.ts), [PR #149645](https://github.com/microsoft/vscode/pull/149645)) | Only if the producer used the notification API; ordinary editor actions do not notify. |
+| Cursor | In-app completion sound; OS banner when the app is in the background for "done" and "needs attention" ([forum answer by Cursor staff](https://forum.cursor.com/t/agent-eta-completion-notification-sound/168130)) | No documented in-app inbox | Not documented. |
+| Linear | Real-time desktop / mobile / Slack alerts | Inbox "for work that needs attention", subscription-driven, snooze / read / archive, 2,000-entry cap ([Inbox](https://linear.app/docs/inbox), [Notifications](https://linear.app/docs/notifications)) | Inbox is fed by key events on *subscribed* issues, not by a log of your own clicks. |
+| Slack | Badge + push | Activity view: DMs, mentions, threads, reactions, invitations, apps, reminders; clear vs. mark read are distinct, cleared items remain in a "Cleared" filter ([Activity](https://slack.com/help/articles/19693583638803-Get-your-work-done-from-the-Activity-view), [new Activity](https://slack.com/help/articles/46751260742035-Introducing-the-new-Activity-view-in-Slack)) | No; Activity is other people's activity directed at you. |
+| Notion | Desktop push 10 s after an @-mention; suppressed while viewing the page | Sidebar Inbox: mentions, replies, person-property assignment, reminders, invitations; read / unread / archive ([Inbox & notifications](https://www.notion.com/help/updates-and-notifications), [Notification settings](https://www.notion.com/help/notification-settings)) | No; you are not notified for your own edits. |
+| Material Design | Snackbar with Undo is the recommended pattern for reversible operations ([M3 snackbar](https://m3.material.io/components/snackbar/guidelines)) | — | — |
+
+Pattern: durable inboxes hold things that *happened to you* (background
+outcomes, other people, system state) and need attention; confirmations of
+what you just did are transient, ideally with Undo. Only VS Code keeps a
+history of every toast, and it does so because its toasts *are* its
+notifications — it has no separate feedback channel. None of these products
+document logging the user's own archive-style actions to a notification inbox.
+
+## Options evaluated
+
+| Option | Noise | Expectation fit | Undo validity | Persistence | Isolation / privacy | Scope |
+| --- | --- | --- | --- | --- | --- | --- |
+| A. Keep scoped inbox, fix copy (chosen) | none added | closes the gap the copy created | n/a | unchanged | unchanged | one string + spec |
+| B. Retain important errors / background completions / actionable events | low | good; matches Alert/Event classes already defined | needs serializable actions (e.g. `open-session`) | fine | task events would need workspace + session identity in a profile-wide store | new action types, new producers for task.completed / failed / permission; product decision on which events |
+| C. Retain all toasts / events | high; every archive, rename, install, error becomes an unread badge | over-delivers; contradicts #2215 | closure-based Undo cannot be persisted; a persisted "Undo archive" can be stale (already restored, deleted, workspace gone) | 100-entry cap fills fast | archive titles from every workspace land in one profile-wide list | large; reverses a merged design |
+| D. Separate activity / history log from attention inbox | none in the inbox | best long term | history entries are records, not actions | needs its own store and retention | needs per-workspace filtering | new surface; needs a product owner |
+
+Option A is the smallest evidence-backed resolution. Options B and D are
+reasonable follow-ups but need an explicit product decision; the parallel
+archive fix (#4818) already listed D as future scope. Option C is not
+recommended.
+
+## Root cause of the mismatch
+
+The empty-state hint `notifications.empty_hint` ("Updates from OpenWork Cloud
+and your workspaces will show up here.") described the *sources* of entries
+without describing the *class*. A person who just archived a session and saw a
+"Session archived" toast reads "your workspaces" as covering that event, opens
+the bell, and finds it empty. The hint now names what qualifies (new models,
+extension changes, applied reloads, errors needing attention) and says that
+confirmations of your own actions appear briefly instead. Other locales do not
+define this key and fall back to English.
+
+## Regression proof
+
+`evals/specs/notification-center-scope.e2e.test.ts` (world
+`evals/worlds/notification-center.ts`) asserts on a real desktop:
+
+1. fresh profile: `notifications.list` is empty, the bell has no badge, the
+   panel shows the new hint and not the old one;
+2. archiving a session (v1 engine) shows the undoable toast and leaves
+   `notifications.list` empty and the bell unbadged, before and after Undo;
+3. the real provider-sync window event lands as exactly one unread
+   `providers` entry with the `open-model-picker` action and a `1` badge, a
+   second sync coalesces into the same entry, and a repeat of an already-seen
+   provider adds nothing, with no popup for any of them;
+4. the entry survives a reload unread, closing the panel marks it read and
+   clears the badge, and the read state survives another reload.
+
+Not covered here, by design: task completion / failure / permission prompts
+(OS notifications, separate contract) and per-workspace isolation of the
+profile-wide store (no behavior change in this PR).

--- a/evals/specs/notification-center-scope.e2e.test.ts
+++ b/evals/specs/notification-center-scope.e2e.test.ts
@@ -1,0 +1,123 @@
+import { expect } from "vitest";
+import type { Target } from "@openwork/cdp";
+import { spec } from "@openwork/testkit";
+import { notificationCenter } from "../worlds/notification-center.ts";
+
+const test = spec.world(notificationCenter);
+
+const bell: Target = { role: "button", label: /^Notifications/ };
+const emptyTitle: Target = { text: "No notifications yet" };
+const emptyHint: Target = { text: "Confirmations of your own actions, like archiving a session, appear briefly instead." };
+const archivedToast: Target = { text: "Session archived" };
+const undoButton: Target = { role: "button", label: "Undo" };
+
+type ListedNotification = { kind: string; title: string; readAt: number | null; count: number; actionType: string | null };
+
+function listed(value: unknown): ListedNotification[] {
+  if (!Array.isArray(value)) throw new Error(`notifications.list did not return a list: ${JSON.stringify(value)}`);
+  return value.map((entry) => {
+    if (typeof entry !== "object" || entry === null) throw new Error("Malformed notification entry");
+    const kind: unknown = Reflect.get(entry, "kind");
+    const title: unknown = Reflect.get(entry, "title");
+    const readAt: unknown = Reflect.get(entry, "readAt");
+    const count: unknown = Reflect.get(entry, "count");
+    const actionType: unknown = Reflect.get(entry, "actionType");
+    if (typeof kind !== "string" || typeof title !== "string" || typeof count !== "number"
+      || (readAt !== null && typeof readAt !== "number") || (actionType !== null && typeof actionType !== "string")) {
+      throw new Error(`Malformed notification entry: ${JSON.stringify(entry)}`);
+    }
+    return { kind, title, readAt, count, actionType };
+  });
+}
+
+test("notification center keeps background events and leaves action confirmations to toasts", async ({ world, user, agent, probe, step }) => {
+  const candidateId = world.candidate.sessionId;
+  const center = async () => listed(await agent.run("notifications.list"));
+
+  await step("a fresh desktop has an empty center whose copy states what belongs there", async () => {
+    expect(await center()).toEqual([]);
+    expect(await world.bell()).toEqual({ label: "Notifications", badge: null });
+    await user.click(bell);
+    await user.see(emptyTitle);
+    await user.see(emptyHint);
+    await user.notSee({ text: "Updates from OpenWork Cloud and your workspaces" });
+    await user.screenshot();
+    await user.press("Escape");
+    await user.notSee(emptyTitle);
+  });
+
+  if (world.engine !== "v2") {
+    await step("archiving a session confirms with an undoable toast and adds nothing to the center", async () => {
+      const archiveButton: Target = { role: "button", label: "Archive session", testId: `session-archive-${candidateId}` };
+      await user.hover({ testId: `sidebar-session-${candidateId}` });
+      await user.see(archiveButton);
+      await user.click(archiveButton);
+      await user.see({ text: `Session archived: ${world.candidate.title}` }, { timeoutMs: 30_000 });
+      await user.see(undoButton);
+      const stamps = await probe.eventually(() => world.archivedAt(), {
+        within: 30_000, label: "candidate archived on the server", until: (value) => value[candidateId] > 0,
+      });
+      expect(stamps[candidateId]).toBeGreaterThan(0);
+      expect(await center()).toEqual([]);
+      expect(await world.bell()).toEqual({ label: "Notifications", badge: null });
+      await user.click(undoButton);
+      await user.notSee(archivedToast);
+      await probe.eventually(() => world.archivedAt(), {
+        within: 30_000, label: "Undo restores the candidate", until: (value) => value[candidateId] === 0,
+      });
+      expect(await center()).toEqual([]);
+      expect(await world.bell()).toEqual({ label: "Notifications", badge: null });
+    });
+  }
+
+  await step("a provider sync lands in the center as one unread entry and repeats coalesce", async () => {
+    expect(await world.providerSync([{ id: "sync-alpha", name: "Alpha", providerId: "alpha" }])).toBe(1);
+    const first = await probe.eventually(center, {
+      within: 10_000, label: "provider sync reaches the center", until: (value) => value.length > 0,
+    });
+    expect(first).toEqual([{ kind: "providers", title: "1 new provider available", readAt: null, count: 1, actionType: "open-model-picker" }]);
+    expect(await world.bell()).toEqual({ label: "Notifications (1)", badge: "1" });
+    await user.notSee({ text: "1 new provider available" });
+
+    expect(await world.providerSync([{ id: "sync-beta", name: "Beta", providerId: "beta" }])).toBe(1);
+    const merged = await probe.eventually(center, {
+      within: 10_000, label: "second sync merges into the unread entry", until: (value) => value[0]?.title === "2 new providers available",
+    });
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ kind: "providers", readAt: null, actionType: "open-model-picker" });
+    expect(await world.bell()).toEqual({ label: "Notifications (1)", badge: "1" });
+
+    expect(await world.providerSync([{ id: "sync-alpha", name: "Alpha", providerId: "alpha" }])).toBe(1);
+    await user.notSee({ text: "3 new providers available" });
+    expect(await center()).toEqual(merged);
+  });
+
+  await step("the entry survives a reload unread, then reading it clears the badge and persists", async () => {
+    await user.reload();
+    const persisted = await probe.eventually(center, {
+      within: 30_000, label: "notification center restores from storage", until: (value) => value.length === 1,
+    });
+    expect(persisted[0]).toMatchObject({ title: "2 new providers available", readAt: null });
+    expect(await world.bell()).toEqual({ label: "Notifications (1)", badge: "1" });
+
+    await user.click(bell);
+    await user.see({ text: "2 new providers available" });
+    await user.see({ role: "button", label: "Select a model" });
+    await user.notSee(emptyTitle);
+    await user.screenshot();
+    await user.press("Escape");
+    const read = await probe.eventually(center, {
+      within: 10_000, label: "closing the panel marks the entry read", until: (value) => value[0]?.readAt !== null,
+    });
+    expect(read).toHaveLength(1);
+    expect(await world.bell()).toEqual({ label: "Notifications", badge: null });
+
+    await user.reload();
+    const stillRead = await probe.eventually(center, {
+      within: 30_000, label: "read state restores from storage", until: (value) => value.length === 1,
+    });
+    expect(stillRead[0]).toMatchObject({ title: "2 new providers available" });
+    expect(typeof stillRead[0]?.readAt).toBe("number");
+    expect(await world.bell()).toEqual({ label: "Notifications", badge: null });
+  });
+});

--- a/evals/specs/notification-center-scope.e2e.test.ts
+++ b/evals/specs/notification-center-scope.e2e.test.ts
@@ -7,7 +7,8 @@ const test = spec.world(notificationCenter);
 
 const bell: Target = { role: "button", label: /^Notifications/ };
 const emptyTitle: Target = { text: "No notifications yet" };
-const emptyHint: Target = { text: "Confirmations of your own actions, like archiving a session, appear briefly instead." };
+const emptyHint: Target = { text: /^Background updates show up here: .*Confirmations of your own actions, like archiving a session, appear briefly instead\.$/ };
+const staleHint: Target = { text: /Updates from OpenWork Cloud and your workspaces/ };
 const archivedToast: Target = { text: "Session archived" };
 const undoButton: Target = { role: "button", label: "Undo" };
 
@@ -40,7 +41,7 @@ test("notification center keeps background events and leaves action confirmation
     await user.click(bell);
     await user.see(emptyTitle);
     await user.see(emptyHint);
-    await user.notSee({ text: "Updates from OpenWork Cloud and your workspaces" });
+    await user.notSee(staleHint);
     await user.screenshot();
     await user.press("Escape");
     await user.notSee(emptyTitle);

--- a/evals/specs/notification-center-scope.e2e.test.ts
+++ b/evals/specs/notification-center-scope.e2e.test.ts
@@ -43,8 +43,8 @@ test("notification center keeps background events and leaves action confirmation
     await user.see(emptyHint);
     await user.notSee(staleHint);
     await user.screenshot();
-    await user.press("Escape");
-    await user.notSee(emptyTitle);
+    await user.click(bell);
+    await user.notSee(emptyTitle, { timeoutMs: 10_000 });
   });
 
   if (world.engine !== "v2") {
@@ -106,7 +106,8 @@ test("notification center keeps background events and leaves action confirmation
     await user.see({ role: "button", label: "Select a model" });
     await user.notSee(emptyTitle);
     await user.screenshot();
-    await user.press("Escape");
+    await user.click(bell);
+    await user.notSee({ text: "2 new providers available" }, { timeoutMs: 10_000 });
     const read = await probe.eventually(center, {
       within: 10_000, label: "closing the panel marks the entry read", until: (value) => value[0]?.readAt !== null,
     });

--- a/evals/specs/notification-center-scope.e2e.test.ts
+++ b/evals/specs/notification-center-scope.e2e.test.ts
@@ -34,6 +34,12 @@ function listed(value: unknown): ListedNotification[] {
 test("notification center keeps background events and leaves action confirmations to toasts", async ({ world, user, agent, probe, step }) => {
   const candidateId = world.candidate.sessionId;
   const center = async () => listed(await agent.run("notifications.list"));
+  /** Escape closes the panel; the exit animation must finish before absence can be observed. */
+  const closeCenter = async (panelText: string) => {
+    await user.press("Escape");
+    await probe.eventually(() => probe.has(panelText), { within: 10_000, label: "notification panel closes", until: (open) => !open });
+    await user.notSee({ text: panelText });
+  };
 
   await step("a fresh desktop has an empty center whose copy states what belongs there", async () => {
     expect(await center()).toEqual([]);
@@ -43,8 +49,7 @@ test("notification center keeps background events and leaves action confirmation
     await user.see(emptyHint);
     await user.notSee(staleHint);
     await user.screenshot();
-    await user.click(bell);
-    await user.notSee(emptyTitle, { timeoutMs: 10_000 });
+    await closeCenter("No notifications yet");
   });
 
   if (world.engine !== "v2") {
@@ -106,8 +111,7 @@ test("notification center keeps background events and leaves action confirmation
     await user.see({ role: "button", label: "Select a model" });
     await user.notSee(emptyTitle);
     await user.screenshot();
-    await user.click(bell);
-    await user.notSee({ text: "2 new providers available" }, { timeoutMs: 10_000 });
+    await closeCenter("2 new providers available");
     const read = await probe.eventually(center, {
       within: 10_000, label: "closing the panel marks the entry read", until: (value) => value[0]?.readAt !== null,
     });

--- a/evals/worlds/notification-center.ts
+++ b/evals/worlds/notification-center.ts
@@ -1,0 +1,35 @@
+import { browserScript } from "@openwork/cdp";
+import type { Seed } from "@openwork/env";
+import { archiveSessions } from "./session-shell.ts";
+
+/** Real provider-sync payload shape the app dispatches on `openwork-new-providers-available`. */
+export interface SyncedProvider {
+  id: string;
+  name: string;
+  providerId: string;
+}
+
+/**
+ * Archive-capable desktop plus the two background signals the notification
+ * center contract distinguishes: a user-action confirmation (archive toast)
+ * and a background event (provider sync landing in the center).
+ */
+export async function notificationCenter(seed: Seed) {
+  const world = await archiveSessions(seed);
+  return {
+    ...world,
+    /** Fire the same window event the provider sync dispatches after sign-in or a config change. */
+    providerSync: (providers: SyncedProvider[]) => seed.evalIn(world.app, browserScript((providers) => {
+      window.dispatchEvent(new CustomEvent("openwork-new-providers-available", {
+        detail: { providers, newProviderCount: providers.length, newModelCount: 0, source: "cloud_sync" },
+      }));
+      return providers.length;
+    }, [providers])),
+    /** The sidebar bell's accessible name carries the unread count; the badge is its visible twin. */
+    bell: () => seed.evalIn(world.app, () => {
+      const button = document.querySelector<HTMLButtonElement>('button[data-sidebar="menu-button"][aria-label^="Notifications"]');
+      const badge = button?.querySelector("span.rounded-full");
+      return { label: button?.getAttribute("aria-label") ?? null, badge: badge?.textContent?.trim() ?? null };
+    }),
+  };
+}


### PR DESCRIPTION
## Problem and RCA
A fresh desktop shows the Notifications bell with "No notifications yet / Updates from OpenWork Cloud and your workspaces will show up here", yet archiving a session (and other confirmations) never appears there. The delivery scope is intentional: #2215 defined three classes — Feedback (toast only: skill installed, action errors), Event (center only: provider sync, reload receipts), Alert (center + one toast) — and `shell/notifications.ts` restates that direct feedback for user actions stays out of the center. The archive toast is Feedback class and never calls `notifyEvent`/`notifyAlert`. The only defect is the empty-state hint: it named sources ("your workspaces") without naming the class, so a person who just saw "Session archived" opens the bell and finds nothing.

## Product/design decision
Keep the scoped center (option A) and fix the copy to say what qualifies and that confirmations of your own actions appear briefly instead. No delivery behavior changes. Options considered and why not here: retaining important background completions/actionable events (needs new serializable actions and a product decision on which task events belong), retaining all toasts (noise, stale persisted Undo, profile-wide list mixes every workspace, reverses #2215), and a separate activity/history log (#4818 already recorded it as future scope). Full write-up with comparators (VS Code, Cursor, Linear, Slack, Notion, Material) in `docs/features/notification-center-scope.md`.

## Verification
- Lane: Daytona, exact head 13f0240f63d66390e0d701576b498a6ea1a0f56d: `OPENWORK_EVAL_REF=13f0240f63d66390e0d701576b498a6ea1a0f56d pnpm evals:e2e notification-center-scope.e2e.test.ts --engine v1` — 1 passed, 0 failed, 0 skipped (exit 0).
- The spec asserts: empty center shows the new hint and not the old one; archiving a session shows the undoable toast and leaves `notifications.list` empty and the bell unbadged before and after Undo; the real provider-sync window event lands as one unread `providers` entry with a `1` badge and no popup, a second sync coalesces into it, a repeat of a seen provider adds nothing; the entry survives a reload unread, closing the panel marks it read and clears the badge, and the read state survives another reload.
- `pnpm --filter @openwork/app typecheck`: exit 0. `git diff --check`: clean. Broad `pnpm --dir evals exec tsc -p tsconfig.json --noEmit` is red on `origin/dev` too (den-db schema types, pre-existing); no diagnostics in the new spec/world.
- Test evidence for the PR head is published below; screenshots are reference only.
