### PR TITLE
fix(app): verify session ownership by the engine's resolved workspace directory

### DIFF
--- a/apps/app/src/app/lib/opencode-interruption.ts
+++ b/apps/app/src/app/lib/opencode-interruption.ts
@@ -1,6 +1,7 @@
 import type { Client } from "../types";
 import type { Message, Part } from "@opencode-ai/sdk/v2/client";
 import { createPromptMessageID, isPromptAdmissionUnknown, PromptAdmissionUnknownError, unwrap } from "./opencode";
+import { engineDirectory } from "./session-ownership";
 
 type Submission = {
   messageID?: string;
@@ -195,18 +196,20 @@ async function stopForegroundTree(
   // Stop must reach the engine even when session/transcript reads are broken.
   // Read concurrently to retain child references, but never gate the root abort
   // on discovery. Failed discovery still prevents claiming a complete handoff.
-  const [aborted, rootResult, childResult] = await Promise.allSettled([
+  const [aborted, rootResult, childResult, ownerResult] = await Promise.allSettled([
     abort(rootID),
     client.session.get({ sessionID: rootID, directory }, options).then(unwrap),
     children(rootID),
+    directory === undefined ? undefined : engineDirectory(client, directory, options),
   ]);
   // Do not let a fast discovery failure cancel an abort still in flight.
   if (aborted.status === "rejected") throw aborted.reason;
   if (rootResult.status === "rejected") throw rootResult.reason;
   if (childResult.status === "rejected") throw childResult.reason;
+  if (ownerResult.status === "rejected") throw ownerResult.reason;
   const root = rootResult.value;
   const before = childResult.value;
-  if (root.id !== rootID || (directory !== undefined && root.directory !== directory)) {
+  if (root.id !== rootID || (ownerResult.value !== undefined && root.directory !== ownerResult.value)) {
     throw new Error("Could not verify the conversation's workspace. Stop was not confirmed.");
   }
   const targets = new Set<string>();

--- a/apps/app/src/app/lib/session-ownership.ts
+++ b/apps/app/src/app/lib/session-ownership.ts
@@ -1,0 +1,41 @@
+import type { Client } from "../types";
+import { unwrap } from "./opencode";
+import { isOpencodeV2Client } from "./opencode-v2-adapter";
+
+type Options = { signal?: AbortSignal };
+
+/**
+ * The directory the engine serves for a workspace path.
+ *
+ * OpenCode resolves the directory it is asked to open through `realpath` and
+ * stamps that resolved path on every session it stores. The desktop keeps the
+ * path as the workspace was added, which can still cross a symlink (macOS
+ * `/var` -> `/private/var`, `/tmp` -> `/private/tmp`, a linked folder), so it
+ * cannot be compared to `session.directory` by string equality. Only the engine
+ * can say whether both name the same place; ownership checks compare against
+ * its answer instead of the raw workspace path.
+ */
+export async function engineDirectory(client: Client, directory: string, options?: Options): Promise<string> {
+  // The v2 preview exposes no /path route; it keeps the exact comparison.
+  if (isOpencodeV2Client(client)) return directory;
+  return unwrap(await client.path.get({ directory }, options)).directory;
+}
+
+/** The root and every descendant, each verified to belong to the workspace the engine serves for `directory`. */
+export async function readSessionTree(client: Client, sessionId: string, directory: string, options?: Options): Promise<string[]> {
+  const [root, owner] = await Promise.all([
+    client.session.get({ sessionID: sessionId, directory }, options).then(unwrap),
+    engineDirectory(client, directory, options),
+  ]);
+  if (root.id !== sessionId || root.directory !== owner) throw new Error("Could not verify the conversation's workspace.");
+  const ids = [sessionId];
+  for (let index = 0; index < ids.length; index += 1) {
+    const children = unwrap(await client.session.children({ sessionID: ids[index], directory }, options));
+    for (const child of children) {
+      if (child.parentID !== ids[index] || child.directory !== owner) throw new Error("Could not verify a subtask's owner.");
+      if (!ids.includes(child.id)) ids.push(child.id);
+      if (ids.length > 256) throw new Error("Too many subtasks to verify safely.");
+    }
+  }
+  return ids;
+}

--- a/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
@@ -6,6 +6,7 @@ import { createClient, unwrap } from "@/app/lib/opencode";
 import { hasTerminalSessionReply, holdSessionWork, interruptSessionTurn, sessionHasPendingSubmission, sessionNeedsStop } from "@/app/lib/opencode-interruption";
 import { setSessionArchived } from "@/app/lib/opencode-session";
 import { isOpencodeV2BaseUrl, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
+import { readSessionTree } from "@/app/lib/session-ownership";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
@@ -151,20 +152,7 @@ export function useSessionArchive(input: {
     let archived = false;
     try {
       if (isOpencodeV2BaseUrl(baseUrl)) throw new Error(V2_SESSION_ARCHIVE_UNAVAILABLE);
-      const readTree = async () => {
-        const root = unwrap(await client.session.get({ sessionID: sessionId, directory: workspace.path }, options));
-        if (root.id !== sessionId || root.directory !== workspace.path) throw new Error("Could not verify the conversation's workspace.");
-        const ids = [sessionId];
-        for (let index = 0; index < ids.length; index += 1) {
-          const children = unwrap(await client.session.children({ sessionID: ids[index], directory: workspace.path }, options));
-          for (const child of children) {
-            if (child.parentID !== ids[index] || child.directory !== workspace.path) throw new Error("Could not verify a subtask's owner.");
-            if (!ids.includes(child.id)) ids.push(child.id);
-            if (ids.length > 256) throw new Error("Too many subtasks to verify safely.");
-          }
-        }
-        return ids;
-      };
+      const readTree = () => readSessionTree(client, sessionId, workspace.path, options);
       // Native Stop reaches the root immediately, concurrent with discovery.
       // Archive also accounts for older/background subtasks that would be hidden.
       let rootStop: Promise<void> | undefined;

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -71,6 +71,12 @@ async function withSessionFetch(
     value: (input: RequestInfo | URL, init?: RequestInit) => {
       const request = new Request(input, init);
       requests.push(request);
+      const url = new URL(request.url);
+      // The engine serves these fixtures' directories as given; no symlink resolution applies.
+      if (request.method === "GET" && url.pathname.endsWith("/path")) {
+        const directory = url.searchParams.get("directory") ?? "";
+        return Promise.resolve(Response.json({ home: "/", state: "/", config: "/", worktree: directory, directory }));
+      }
       return Promise.resolve(respond(request));
     },
   });
@@ -779,7 +785,7 @@ describe("native Stop and follow-up handoff", () => {
           .map((request) => new URL(request.url).pathname.split("/").at(-1)))
           .toEqual([root.id, "ses_child", "ses_nested", "ses_late"]);
         for (const request of requests) {
-          expect(request.url.startsWith(`${baseUrl}/session/`)).toBe(true);
+          expect(request.url.startsWith(`${baseUrl}/session/`) || request.url.startsWith(`${baseUrl}/path?`)).toBe(true);
           expect(request.headers.get("Authorization")).toBe(`Bearer ${endpoint.token}`);
           if (!request.url.endsWith("/prompt_async")) expect(new URL(request.url).searchParams.get("directory")).toBe(root.directory);
         }

--- a/apps/app/tests/session-ownership.test.ts
+++ b/apps/app/tests/session-ownership.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createClient } from "../src/app/lib/opencode";
+import { interruptSessionTurn } from "../src/app/lib/opencode-interruption";
+import { readSessionTree } from "../src/app/lib/session-ownership";
+
+// The desktop keeps the workspace path as it was added; the engine serves and
+// stamps sessions with its realpath (opencode FSUtil.resolve -> realpathSync).
+// This is the layout a fresh macOS dev profile lands in: `/var` -> `/private/var`.
+const WORKSPACE = "/var/folders/synthetic/OpenWork Chat";
+const ELSEWHERE = "/var/folders/synthetic/Elsewhere";
+const real = (path: string) => path.replace(/^\/var(?=\/|$)/, "/private/var");
+const baseUrl = "http://engine.invalid/workspace/ws-linked/opencode";
+
+type Session = { id: string; parentID?: string; directory: string; title: string };
+const sessions: Session[] = [
+  { id: "ses_root", directory: real(WORKSPACE), title: "Split pane conversation" },
+  { id: "ses_child", parentID: "ses_root", directory: real(WORKSPACE), title: "Subtask" },
+  { id: "ses_sibling", directory: real(WORKSPACE), title: "Other pane" },
+  { id: "ses_foreign", directory: real(ELSEWHERE), title: "Another workspace" },
+  { id: "ses_stray", directory: real(WORKSPACE), title: "Stray parent" },
+  { id: "ses_stray_child", parentID: "ses_stray", directory: real(ELSEWHERE), title: "Foreign subtask" },
+];
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+/** A fake engine that answers /path with the real directory, the way OpenCode does after realpath. */
+function serveEngine() {
+  const requests: { method: string; path: string; directory: string | null }[] = [];
+  const info = (session: Session) => ({ ...session, projectID: "global", version: "synthetic", time: { created: 1, updated: 1 } });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      const path = url.pathname.replace(/^\/workspace\/ws-linked\/opencode/, "");
+      const directory = url.searchParams.get("directory");
+      requests.push({ method: request.method, path, directory });
+      const match = /^\/session\/([^/]+)(?:\/(children|message|abort))?$/.exec(path);
+      const session = match ? sessions.find((item) => item.id === match[1]) : undefined;
+      if (path === "/path" && request.method === "GET" && directory) {
+        return Response.json({ home: "/synthetic", state: "/synthetic/state", config: "/synthetic/config", worktree: real(directory), directory: real(directory) });
+      }
+      if (path === "/session/status" && request.method === "GET") return Response.json({});
+      if (session && match && match[2] === undefined && request.method === "GET") return Response.json(info(session));
+      if (session && match && match[2] === "children" && request.method === "GET") return Response.json(sessions.filter((item) => item.parentID === session.id).map(info));
+      if (session && match && match[2] === "message" && request.method === "GET") return Response.json([]);
+      if (session && match && match[2] === "abort" && request.method === "POST") return Response.json(true);
+      return Response.json({ name: "NotFoundError", data: { message: `Unknown ${request.method} ${path}` } }, { status: 404 });
+    },
+  });
+  return requests;
+}
+
+describe("session ownership across a linked workspace path", () => {
+  test("archive reads the tree by the engine's resolved directory and still refuses other workspaces", async () => {
+    const requests = serveEngine();
+    const client = createClient(baseUrl, WORKSPACE, { token: "synthetic", mode: "openwork" });
+    expect(await readSessionTree(client, "ses_root", WORKSPACE)).toEqual(["ses_root", "ses_child"]);
+    expect(await readSessionTree(client, "ses_sibling", WORKSPACE)).toEqual(["ses_sibling"]);
+    const resolved = requests.filter((request) => request.path === "/path");
+    expect(resolved.length).toBeGreaterThanOrEqual(2);
+    expect(resolved.every((request) => request.method === "GET" && request.directory === WORKSPACE)).toBe(true);
+    await expect(readSessionTree(client, "ses_foreign", WORKSPACE)).rejects.toThrow("Could not verify the conversation's workspace.");
+    await expect(readSessionTree(client, "ses_stray", WORKSPACE)).rejects.toThrow("Could not verify a subtask's owner.");
+    const elsewhere = createClient(baseUrl, ELSEWHERE, { token: "synthetic", mode: "openwork" });
+    await expect(readSessionTree(elsewhere, "ses_root", ELSEWHERE)).rejects.toThrow("Could not verify the conversation's workspace.");
+    expect(await readSessionTree(elsewhere, "ses_foreign", ELSEWHERE)).toEqual(["ses_foreign"]);
+    expect(requests.every((request) => request.method === "GET")).toBe(true);
+  });
+
+  test("Stop settles the root in a linked workspace and still refuses a session from another workspace", async () => {
+    const requests = serveEngine();
+    const client = createClient(baseUrl, WORKSPACE, { token: "synthetic", mode: "openwork" });
+    await interruptSessionTurn(baseUrl, client, "ses_root", WORKSPACE, { timeoutMs: 10_000 });
+    expect(requests.filter((request) => request.method === "POST").map((request) => request.path)).toEqual(["/session/ses_root/abort", "/session/ses_root/abort"]);
+    expect(requests.some((request) => request.path === "/path" && request.directory === WORKSPACE)).toBe(true);
+    const before = requests.length;
+    await expect(interruptSessionTurn(baseUrl, client, "ses_foreign", WORKSPACE, { timeoutMs: 10_000 }))
+      .rejects.toThrow("Could not verify the conversation's workspace. Stop was not confirmed.");
+    // The native abort still reaches the engine first; only the settlement claim is withheld and no cascade follows.
+    expect(requests.slice(before).filter((request) => request.method === "POST").map((request) => request.path)).toEqual(["/session/ses_foreign/abort"]);
+  });
+});

--- a/evals/packages/cdp/src/browser-globals.d.ts
+++ b/evals/packages/cdp/src/browser-globals.d.ts
@@ -55,7 +55,7 @@ declare global {
       };
       slice(name: "route"): {
         selectedWorkspaceId: string | null;
-        workspaces: { id: string; name?: string; displayName?: string; displayNameResolved?: string; loading?: boolean; error?: string | null }[];
+        workspaces: { id: string; name?: string; path?: string; displayName?: string; displayNameResolved?: string; loading?: boolean; error?: string | null }[];
         sessionsByWorkspaceId: Record<string, { id: string; title?: string }[]>;
       };
     };

--- a/evals/specs/session-archive-linked-workspace.e2e.test.ts
+++ b/evals/specs/session-archive-linked-workspace.e2e.test.ts
@@ -13,7 +13,7 @@ const test = spec.world(archiveSessionsInLinkedWorkspace, {
 const archivedToast = { text: "Session archived" };
 const archiveFailedToast = { text: "Couldn't archive session" };
 
-test("archiving a split-pane session works when the desktop stores the workspace by a linked path", async ({ world, user, agent, probe, step }) => {
+test("archiving a split-pane session works when the desktop stores the workspace by a linked path", async ({ world, user, agent, probe, step, evidence }) => {
   const candidate = world.candidate.sessionId;
   const sibling = world.neighbor.sessionId;
   const route = (sessionId: string | null) => `#/workspace/${world.workspace.workspaceId}/session${sessionId ? `/${sessionId}` : ""}`;
@@ -32,6 +32,11 @@ test("archiving a split-pane session works when the desktop stores the workspace
     const stamps = await world.archivedAt();
     expect(stamps[candidate]).toBe(0);
     expect(stamps[sibling]).toBe(0);
+    evidence.recordAssertionEvidence(
+      "The desktop and the engine spell the same workspace differently",
+      `The persisted workspace path was the linked path ${world.workspacePath}; the engine stamped both seeded sessions with ${world.realWorkspacePath}, which differs from it. Neither session was archived.`,
+      true,
+    );
   });
 
   let sideChat = "";
@@ -69,6 +74,11 @@ test("archiving a split-pane session works when the desktop stores the workspace
     });
     expect(await probe.hash()).toBe(route(candidate));
     expect(await world.mutationRequests()).toEqual([expect.objectContaining({ method: "PATCH", path: expect.stringContaining(`/session/${sideChat}`) })]);
+    evidence.recordAssertionEvidence(
+      "A split-pane session in a linked-path workspace archives instead of failing verification",
+      `session.archive on the side chat ${sideChat} showed "Session archived" and never "Couldn't archive session" or "Could not verify the conversation's workspace."; the engine stamped only that session archived, the conversation and its neighbor stayed at 0, the secondary pane closed while the conversation route stayed selected, and exactly one PATCH targeted that session.`,
+      true,
+    );
   });
 
   await step("archiving the conversation from the sidebar succeeds, keeps its neighbor, and Undo restores it", async () => {
@@ -89,7 +99,6 @@ test("archiving a split-pane session works when the desktop stores the workspace
     });
     expect(sidebar.active).toContain(sibling);
     await probe.eventually(() => probe.hash(), { within: 15_000, label: "archive returns to the workspace start", until: (hash) => hash === route(null) });
-    await user.screenshot();
     await probe.eventually(() => world.undoToastSettled(), { within: 10_000, label: "undo pill settles", until: Boolean });
     await user.click({ role: "button", label: "Undo" });
     const restored = await probe.eventually(() => world.archivedAt(), {
@@ -98,5 +107,10 @@ test("archiving a split-pane session works when the desktop stores the workspace
     expect(restored[sibling]).toBe(0);
     expect(restored[sideChat]).toBeGreaterThan(0);
     await probe.eventually(() => probe.hash(), { within: 15_000, label: "Undo reopens the conversation", until: (hash) => hash === route(candidate) });
+    evidence.recordAssertionEvidence(
+      "The sidebar Archive button works in a linked-path workspace and Undo restores only its target",
+      `Hovering the conversation row and clicking Archive showed "Session archived" without the failure toast or a working-session prompt; the engine stamped the conversation archived while its neighbor stayed at 0, the sidebar moved only the conversation into Archived, the route returned to the workspace start, and Undo restored the conversation (neighbor still 0, the earlier side chat still archived) and reopened it.`,
+      true,
+    );
   });
 });

--- a/evals/specs/session-archive-linked-workspace.e2e.test.ts
+++ b/evals/specs/session-archive-linked-workspace.e2e.test.ts
@@ -1,0 +1,102 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { archiveSessionsInLinkedWorkspace } from "../worlds/session-shell.ts";
+
+const test = spec.world(archiveSessionsInLinkedWorkspace, {
+  timeout: 10 * 60_000,
+  resources: {
+    surfaces: ["desktop"], services: [],
+    nativeReason: "The Electron main process persists a local workspace path as added (unresolved while the folder does not exist yet) while its bundled engine serves and stamps sessions with the realpath; only the desktop reproduces that pairing.",
+  },
+});
+
+const archivedToast = { text: "Session archived" };
+const archiveFailedToast = { text: "Couldn't archive session" };
+
+test("archiving a split-pane session works when the desktop stores the workspace by a linked path", async ({ world, user, agent, probe, step }) => {
+  const candidate = world.candidate.sessionId;
+  const sibling = world.neighbor.sessionId;
+  const route = (sessionId: string | null) => `#/workspace/${world.workspace.workspaceId}/session${sessionId ? `/${sessionId}` : ""}`;
+  const openConversation = async (sessionId: string) => {
+    await agent.run("session.open", { sessionId });
+    await probe.eventually(() => probe.hash(), { within: 30_000, label: "conversation route opens", until: (hash) => hash === route(sessionId) });
+    await user.see("composer", { editable: true });
+  };
+
+  await step("the desktop addresses the workspace by its linked path while the engine stamps sessions with the real path", async () => {
+    expect(await world.storedWorkspacePath()).toBe(world.workspacePath);
+    const directories = await world.engineDirectories();
+    expect(directories[candidate]).toBe(world.realWorkspacePath);
+    expect(directories[sibling]).toBe(world.realWorkspacePath);
+    expect(directories[candidate]).not.toBe(world.workspacePath);
+    const stamps = await world.archivedAt();
+    expect(stamps[candidate]).toBe(0);
+    expect(stamps[sibling]).toBe(0);
+  });
+
+  let sideChat = "";
+  await step("a side chat opened beside the conversation is a new session the engine stamps the same way", async () => {
+    await openConversation(candidate);
+    const before = Object.keys(await world.archivedAt());
+    // The selected conversation's row offers its side chat directly.
+    await user.click({ role: "button", label: "Open side chat" });
+    const split = await probe.eventually(() => world.splitFacts(), {
+      within: 30_000, label: "the conversation owns a new side chat",
+      until: (value) => value.primarySessionId === candidate && value.secondaryPaneCount === 1
+        && Boolean(value.secondarySessionId) && !before.includes(value.secondarySessionId),
+    });
+    sideChat = split.secondarySessionId;
+    const directories = await probe.eventually(() => world.engineDirectories(), {
+      within: 30_000, label: "the side chat is stamped with the engine's real path", until: (value) => value[sideChat] === world.realWorkspacePath,
+    });
+    expect(directories[sideChat]).toBe(world.realWorkspacePath);
+    expect((await world.archivedAt())[sideChat]).toBe(0);
+  });
+
+  await step("archiving the side chat succeeds and leaves the conversation and its neighbor open", async () => {
+    expect(await agent.run("session.archive", { sessionId: sideChat, archived: true })).toEqual({ ok: true, sessionId: sideChat, archived: true });
+    await user.see(archivedToast, { timeoutMs: 30_000 });
+    await user.notSee(archiveFailedToast);
+    await user.notSee({ text: "Could not verify the conversation's workspace." });
+    const stamps = await probe.eventually(() => world.archivedAt(), {
+      within: 30_000, label: "only the side chat is archived on the engine", until: (value) => value[sideChat] > 0,
+    });
+    expect(stamps[sideChat]).toBeGreaterThan(0);
+    expect(stamps[candidate]).toBe(0);
+    expect(stamps[sibling]).toBe(0);
+    await probe.eventually(() => world.splitFacts(), {
+      within: 30_000, label: "the conversation stays open alone", until: (value) => value.primarySessionId === candidate && value.secondaryPaneCount === 0,
+    });
+    expect(await probe.hash()).toBe(route(candidate));
+    expect(await world.mutationRequests()).toEqual([expect.objectContaining({ method: "PATCH", path: expect.stringContaining(`/session/${sideChat}`) })]);
+  });
+
+  await step("archiving the conversation from the sidebar succeeds, keeps its neighbor, and Undo restores it", async () => {
+    const row = { testId: `sidebar-session-${candidate}` };
+    await user.hover(row);
+    await user.click({ role: "button", label: "Archive session", testId: `session-archive-${candidate}` });
+    await user.see(archivedToast, { timeoutMs: 30_000 });
+    await user.notSee(archiveFailedToast);
+    await user.notSee({ text: "This session is still working" });
+    const stamps = await probe.eventually(() => world.archivedAt(), {
+      within: 30_000, label: "the conversation is archived on the engine", until: (value) => value[candidate] > 0,
+    });
+    expect(stamps[candidate]).toBeGreaterThan(0);
+    expect(stamps[sibling]).toBe(0);
+    const sidebar = await probe.eventually(() => world.sidebar(), {
+      within: 30_000, label: "the conversation leaves the tree and its neighbor stays",
+      until: (value) => !value.active.includes(candidate) && value.active.includes(sibling) && value.archivedSection,
+    });
+    expect(sidebar.active).toContain(sibling);
+    await probe.eventually(() => probe.hash(), { within: 15_000, label: "archive returns to the workspace start", until: (hash) => hash === route(null) });
+    await user.screenshot();
+    await probe.eventually(() => world.undoToastSettled(), { within: 10_000, label: "undo pill settles", until: Boolean });
+    await user.click({ role: "button", label: "Undo" });
+    const restored = await probe.eventually(() => world.archivedAt(), {
+      within: 30_000, label: "Undo restores the conversation", until: (value) => value[candidate] === 0,
+    });
+    expect(restored[sibling]).toBe(0);
+    expect(restored[sideChat]).toBeGreaterThan(0);
+    await probe.eventually(() => probe.hash(), { within: 15_000, label: "Undo reopens the conversation", until: (hash) => hash === route(candidate) });
+  });
+});

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1,10 +1,10 @@
 import { allocateFreePort, browserScript, clickAt, evaluate, hoverAt, reload, type Point, type Surface, typeText, waitForLocated } from "@openwork/cdp";
 import { createServer, type Server, type ServerResponse } from "node:http";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, realpath, rm, symlink } from "node:fs/promises";
 import { engineSessionProbe, observeSidebarExpansion, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
 import { resolveEvalEngine, SkipError } from "@openwork/env";
 import type { Place, Seed } from "@openwork/env";
-import { daytonaSandbox, desktop as launchDesktop, startMockOnSandbox } from "@openwork/hosts";
+import { daytonaSandbox, defaultDaytonaExec, desktop as launchDesktop, execInSandbox, startMockOnSandbox } from "@openwork/hosts";
 import { startMockMcp } from "@openwork/labs";
 
 const stormProviderId = "active-session-storm-mock";
@@ -1817,11 +1817,81 @@ export async function archiveActiveSessions(seed: Seed, { place }: { place: Plac
 }
 
 export async function archiveSessions(seed: Seed) {
-  const engine = resolveEvalEngine();
   const app = await seed.desktop({ name: "session-archive-undo" });
-  const workspacePath = seed.tmpPath("session-archive-undo");
-  const workspace = await seed.workspace(app, workspacePath);
-  const [candidate, neighbor] = await seed.sessions(app, ["Archive candidate", "Archive neighbor"]);
+  return archiveWorld(seed, app, seed.tmpPath("session-archive-undo"), ["Archive candidate", "Archive neighbor"]);
+}
+
+/**
+ * Archive in a workspace the desktop stores by a linked path. The folder does
+ * not exist when the workspace is added, so the desktop keeps the path as
+ * given (`<root>/link/OpenWork Chat`) while the engine resolves it and stamps
+ * every session with the real path (`<root>/real/OpenWork Chat`) — the shape a
+ * fresh macOS profile has under `/var` -> `/private/var`.
+ */
+export async function archiveSessionsInLinkedWorkspace(seed: Seed) {
+  if (resolveEvalEngine() !== "v1") throw new SkipError("Archive is unavailable in the v2 preview; session-archive-undo covers that.");
+  const app = await seed.desktop({ name: "session-archive-linked-path" });
+  const root = seed.tmpPath("session-archive-linked");
+  const real = `${root}/real`;
+  const link = `${root}/link`;
+  // The real parent as the app host resolves it; `seed.tmpPath` itself may sit behind a symlink (macOS /tmp).
+  let resolvedReal: string;
+  if (app.handle.sandboxId) {
+    const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+    const script = `mkdir -p ${quote(real)} && ln -sfn ${quote(real)} ${quote(link)} && readlink -f ${quote(real)}`;
+    const result = await execInSandbox(defaultDaytonaExec, app.handle.sandboxId, `printf %s ${Buffer.from(script).toString("base64")} | base64 -d | bash`, { timeoutMs: 15_000, context: "Arrange the linked workspace parent" });
+    resolvedReal = result.stdout.trim();
+    if (result.code !== 0 || !resolvedReal.startsWith("/")) throw new Error(`Linked workspace parent arrangement failed: ${result.stderr || result.stdout}`);
+  } else {
+    await mkdir(real, { recursive: true });
+    await symlink(real, link);
+    resolvedReal = await realpath(real);
+  }
+  const world = await archiveWorld(seed, app, `${link}/OpenWork Chat`, ["Split pane conversation", "Other pane"], { create: true });
+  return {
+    ...world,
+    realWorkspacePath: `${resolvedReal}/OpenWork Chat`,
+    /** The path the desktop persisted for the workspace, exactly as it will address the engine. */
+    storedWorkspacePath: async () => {
+      const value = await seed.evalIn(app, browserScript((workspaceId) =>
+        window.__openwork?.slice?.("route")?.workspaces?.find(item => item.id === workspaceId)?.path ?? null, [world.workspace.workspaceId]));
+      if (typeof value !== "string") throw new Error(`Stored workspace path was malformed: ${JSON.stringify(value)}`);
+      return value;
+    },
+    /** The directory the engine stamped on each session, read through the workspace mount. */
+    engineDirectories: async (): Promise<Record<string, string>> => {
+      const value = await seed.evalIn(app, browserScript(async (workspaceId) => {
+        const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+        if (!info?.running || !info.baseUrl) throw new Error("OpenWork server is unavailable");
+        const response = await fetch(`${String(info.baseUrl).replace(/\/+$/, "")}/workspace/${encodeURIComponent(workspaceId)}/opencode/session?limit=200`, {
+          headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") }, signal: AbortSignal.timeout(15000),
+        });
+        if (!response.ok) throw new Error("Workspace session listing failed with HTTP " + response.status);
+        const sessions = await response.json();
+        if (!Array.isArray(sessions)) throw new Error("Workspace session listing was not an array");
+        return Object.fromEntries(sessions.filter((session) => typeof session?.id === "string" && typeof session?.directory === "string")
+          .map((session) => [session.id, session.directory]));
+      }, [world.workspace.workspaceId]), { awaitPromise: true, timeoutMs: 20_000 });
+      if (!isRecord(value) || !Object.values(value).every((directory) => typeof directory === "string")) {
+        throw new Error(`Engine directories were malformed: ${JSON.stringify(value)}`);
+      }
+      return Object.fromEntries(Object.entries(value).map(([id, directory]) => [id, String(directory)]));
+    },
+    splitFacts: () => seed.evalIn(app, () => {
+      const layout = window.__openworkControl?.context?.()?.conversations?.layout;
+      return {
+        primarySessionId: (layout?.kind === "split" ? layout.primarySessionId : undefined) ?? (layout?.kind === "single" ? layout.sessionId : undefined) ?? "",
+        secondarySessionId: (layout?.kind === "split" ? layout.secondarySessionId : undefined) ?? "",
+        secondaryPaneCount: document.querySelectorAll('[data-workbench-pane="secondary"]').length,
+      };
+    }),
+  };
+}
+
+async function archiveWorld(seed: Seed, app: Surface, workspacePath: string, titles: [string, string], options: { create?: boolean } = {}) {
+  const engine = resolveEvalEngine();
+  const workspace = await seed.workspace(app, workspacePath, options);
+  const [candidate, neighbor] = await seed.sessions(app, titles);
   if (!candidate || !neighbor) throw new Error("Archive world did not create both sessions.");
   await seed.evalIn(app, browserScript((workspaceId) => {
     const original = window.fetch.bind(window);


### PR DESCRIPTION
## Problem

In a freshly launched dev desktop (`pnpm dev:worktree --blank-slate`), creating a split session and archiving it failed with the toast **"Couldn't archive session" / "Could not verify the conversation's workspace."** Pressing Stop in the same profile fails the same way ("Stop was not confirmed.").

## Root cause

`useSessionArchive` (#4640) and `stopForegroundTree` (#4649) compare `session.directory` to the workspace path the desktop stored with `!==`.

- OpenCode resolves the directory it serves through `realpath` (`FSUtil.resolve` → `realpathSync`) and stamps that resolved path on every session it stores.
- The desktop persists a newly created workspace path exactly as added: `normalizeLocalWorkspacePath` does `realpath(...).catch(() => resolved)`, and the folder does not exist yet at first launch / `workspace.create`, so no resolution happens.

Any workspace whose path crosses a symlink therefore never matches: the blank-slate profile stores `/var/folders/.../OpenWork Chat` while the engine's SQLite rows carry `/private/var/folders/.../OpenWork Chat` (verified read-only in the affected profile's `opencode.db`; both sessions remained `time_archived = NULL`). The same applies to `/tmp` → `/private/tmp` on macOS and to any user folder behind a link. Split panes were only where it was first noticed; archiving *any* session in such a workspace fails.

## Fix

`apps/app/src/app/lib/session-ownership.ts` asks the same engine which directory it serves for the workspace path (`GET /path?directory=…`) and compares `session.directory` against that answer. Archive's tree read and Stop's root check both use it; child checks keep comparing against the verified root. Sessions from another workspace and subtasks stamped elsewhere are still refused with the existing errors, so the workspace safety check is not weakened. The v2 preview has no `/path` route and keeps its exact comparison.

## Proof

- `apps/app/tests/session-ownership.test.ts` (bun, runs in CI app tests): fake engine stamps sessions with `/private/var/...` while the client addresses `/var/...`; archive tree read and Stop succeed, `/path` is asked with the raw workspace path, and foreign sessions / foreign subtasks / cross-workspace reads are refused. Control with the pre-fix comparison fails with exactly the user's error.
- `evals/specs/session-archive-linked-workspace.e2e.test.ts` (desktop): creates a workspace under a symlinked parent that does not exist yet, asserts the desktop stored the linked path while the engine stamped the real one, opens a side chat, archives the side chat via the public action and the conversation via the sidebar button, asserts "Session archived", no "Couldn't archive session", the neighbor stays unarchived, and Undo restores. Control against the pre-fix comparison fails at the archive step.
- Existing `session-archive-undo.e2e.test.ts` now also passes locally on macOS (its `/tmp` workspace hits the same symlink).

Follow-up (not in this PR): `normalizeLocalWorkspacePath` could resolve the nearest existing ancestor so new workspace paths are persisted canonically; that would not help already-stored paths, which this fix covers.
