### PR TITLE
fix(apps): isolate embedded MCP App documents

### DIFF
--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -493,7 +493,7 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
           await bridge.sendSandboxResourceReady({
             html: secureMcpAppHtml(app),
             csp: app.csp,
-            sandbox: "allow-scripts allow-same-origin",
+            sandbox: "allow-scripts",
           })
           checkpoint(resourceSendAttempts === 1 ? "resource-sent" : `resource-resent-${resourceSendAttempts}`)
           if (resourceAccepted || initialized) return

--- a/apps/server/src/mcp-app-sandbox.test.ts
+++ b/apps/server/src/mcp-app-sandbox.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runInNewContext } from "node:vm";
 import { buildMcpAppSandboxCsp, MCP_APP_SANDBOX_PROXY_SCRIPT, parseMcpAppSandboxCsp } from "./mcp-app-sandbox.js";
 import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
@@ -9,12 +10,106 @@ import type { ServerConfig } from "./types.js";
 const stops: Array<() => void | Promise<void>> = [];
 const roots: string[] = [];
 
+function sandboxProxy(hostOrigin: string) {
+  type Message = { source: object | null; origin: string; data: unknown };
+  const upstream: Array<{ data: unknown; target: string }> = [];
+  const downstream: Array<{ data: unknown; target: string }> = [];
+  const parent = { postMessage: (data: unknown, target: string) => upstream.push({ data, target }) };
+  const child = { postMessage: (data: unknown, target: string) => downstream.push({ data, target }) };
+  const listeners = new Map<string, () => void>();
+  const attributes = new Map<string, string>();
+  let messageListener: (event: Message) => void = () => { throw new Error("Proxy did not install its listener"); };
+  const inner = {
+    title: "", style: { cssText: "" }, srcdoc: "", contentWindow: child,
+    get contentDocument() { throw new Error("Opaque document must not be inspected"); },
+    setAttribute: (name: string, value: string) => attributes.set(name, value),
+    addEventListener: (name: string, listener: () => void) => listeners.set(name, listener),
+  };
+  runInNewContext(MCP_APP_SANDBOX_PROXY_SCRIPT, {
+    URL,
+    window: {
+      self: {}, top: parent, parent,
+      location: { href: `https://sandbox.example/mcp-apps/sandbox.html?hostOrigin=${encodeURIComponent(hostOrigin)}`, origin: "https://sandbox.example" },
+      addEventListener(name: string, listener: (event: Message) => void) {
+        expect(name).toBe("message");
+        messageListener = listener;
+      },
+    },
+    document: { referrer: "", createElement: () => inner, body: { appendChild() {} } },
+  });
+  return { parent, child, inner, attributes, upstream, downstream, listeners, message: (event: Message) => messageListener(event) };
+}
+
 afterEach(async () => {
   while (stops.length) await stops.pop()?.();
   while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
 });
 
 describe("MCP Apps sandbox proxy policy", () => {
+  test.each(["https://host.example", "null"])("relays only the assigned opaque child for host %s", (hostOrigin) => {
+    const app = sandboxProxy(hostOrigin);
+    const sibling = sandboxProxy(hostOrigin);
+    const target = hostOrigin === "null" ? "*" : hostOrigin;
+    const helper = { jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "read_detail", arguments: { marker: "own-app" } } };
+    expect(app.attributes.get("sandbox")).toBe("allow-scripts");
+    expect(app.upstream).toEqual([{ data: { jsonrpc: "2.0", method: "ui/notifications/sandbox-proxy-ready", params: {} }, target }]);
+    app.upstream.length = 0;
+
+    app.message({ source: app.child, origin: "null", data: helper });
+    const resource = (html: unknown, sandbox: string) => ({ method: "ui/notifications/sandbox-resource-ready", params: { html, sandbox } });
+    app.message({ source: app.parent, origin: "https://wrong-host.example", data: resource("wrong host", "allow-scripts") });
+    app.message({ source: sibling.child, origin: hostOrigin, data: resource("wrong window", "allow-scripts") });
+    expect(app.inner.srcdoc).toBe("");
+    expect(app.upstream).toEqual([]);
+    expect(app.downstream).toEqual([]);
+
+    app.message({ source: app.parent, origin: hostOrigin, data: resource(null, "allow-same-origin") });
+    expect(app.upstream.pop()).toMatchObject({ data: { method: "ui/notifications/sandbox-diagnostic", params: { code: "MCP_APP_SANDBOX_RESOURCE_INVALID" } } });
+    app.message({ source: app.child, origin: "null", data: helper });
+    expect(app.upstream).toEqual([]);
+
+    for (const sandbox of ["allow-scripts allow-same-origin", "allow-same-origin", "", "allow-scripts allow-popups"]) {
+      app.message({ source: app.parent, origin: hostOrigin, data: resource("<p>Own App</p>", sandbox) });
+      expect(app.inner.srcdoc).toBe("<p>Own App</p>");
+      expect(app.attributes.get("sandbox")).toBe("allow-scripts");
+      expect(app.upstream.pop()).toEqual({ data: { method: "ui/notifications/sandbox-resource-accepted", params: {} }, target });
+    }
+
+    for (const event of [
+      { source: sibling.child, origin: "null" },
+      { source: sibling.child, origin: "https://sandbox.example" },
+      { source: null, origin: "null" },
+      { source: app.child, origin: "https://sandbox.example" },
+      { source: app.child, origin: "https://other.example" },
+      { source: app.parent, origin: "https://wrong-host.example" },
+    ]) app.message({ ...event, data: helper });
+    expect(app.upstream).toEqual([]);
+    expect(app.downstream).toEqual([]);
+
+    const requests = [
+      { jsonrpc: "2.0", id: 1, method: "ui/initialize", params: {} },
+      { jsonrpc: "2.0", method: "ui/notifications/initialized", params: {} },
+      helper,
+      { jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 240 } },
+      { jsonrpc: "2.0", id: 3, result: {} },
+    ];
+    for (const data of requests) app.message({ source: app.child, origin: "null", data });
+    expect(app.upstream).toEqual(requests.map(data => ({ data, target })));
+    const responses = [
+      { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2026-01-26" } },
+      { jsonrpc: "2.0", method: "ui/notifications/tool-input", params: { arguments: { marker: "own-app" } } },
+      { jsonrpc: "2.0", method: "ui/notifications/tool-result", params: { content: [] } },
+      { jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: "detail" }] } },
+      { jsonrpc: "2.0", id: 3, method: "ui/resource-teardown", params: {} },
+    ];
+    for (const data of responses) app.message({ source: app.parent, origin: hostOrigin, data });
+    expect(app.downstream).toEqual(responses.map(data => ({ data, target: "*" })));
+    app.listeners.get("load")?.();
+    expect(app.upstream.at(-1)).toEqual({ data: { method: "ui/notifications/sandbox-resource-loaded", params: { readyState: null, hasHtmlRoot: null, scriptCount: null } }, target });
+    expect(sibling.inner.srcdoc).toBe("");
+    expect(sibling.downstream).toEqual([]);
+  });
+
   test("reports resource acceptance, document load, and safe sandbox failures", () => {
     expect(MCP_APP_SANDBOX_PROXY_SCRIPT).toContain("ui/notifications/sandbox-resource-accepted");
     expect(MCP_APP_SANDBOX_PROXY_SCRIPT).toContain("ui/notifications/sandbox-resource-loaded");

--- a/apps/server/src/mcp-app-sandbox.ts
+++ b/apps/server/src/mcp-app-sandbox.ts
@@ -73,26 +73,20 @@ export const MCP_APP_SANDBOX_PROXY_SCRIPT = String.raw`
   const hostOrigin = referrerOrigin || declaredHostOrigin;
   if (!hostOrigin) throw new Error("MCP App sandbox host origin is unavailable.");
   const hostTargetOrigin = hostOrigin === "null" ? "*" : hostOrigin;
-  const ownOrigin = window.location.origin;
   // OpenWork delivery diagnostics are deliberately outside JSON-RPC so the
   // stable MCP Apps transport never mistakes them for protocol messages.
   const notifyHost = (method, params = {}) => window.parent.postMessage({ method, params }, hostTargetOrigin);
   const inner = document.createElement("iframe");
   inner.title = "MCP App view";
   inner.style.cssText = "display:block;width:100%;height:100%;border:0;background:transparent";
-  inner.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  // Provider documents must not share this proxy's origin or another App's DOM.
+  // Resource payloads cannot relax this policy.
+  inner.setAttribute("sandbox", "allow-scripts");
   let resourceAssigned = false;
   inner.addEventListener("load", () => {
     if (!resourceAssigned) return;
-    let readyState = null;
-    let hasHtmlRoot = null;
-    let scriptCount = null;
-    try {
-      readyState = inner.contentDocument?.readyState || null;
-      hasHtmlRoot = Boolean(inner.contentDocument?.documentElement);
-      scriptCount = inner.contentDocument?.scripts.length ?? null;
-    } catch {}
-    notifyHost("ui/notifications/sandbox-resource-loaded", { readyState, hasHtmlRoot, scriptCount });
+    // An opaque document can report a load without exposing its DOM to the proxy.
+    notifyHost("ui/notifications/sandbox-resource-loaded", { readyState: null, hasHtmlRoot: null, scriptCount: null });
   });
   inner.addEventListener("error", () => {
     if (resourceAssigned) notifyHost("ui/notifications/sandbox-diagnostic", { code: "MCP_APP_SANDBOX_DOCUMENT_ERROR", message: "The sandbox iframe reported a document load error." });
@@ -103,15 +97,13 @@ export const MCP_APP_SANDBOX_PROXY_SCRIPT = String.raw`
       if (event.origin !== hostOrigin) return;
       if (event.data?.method === "ui/notifications/sandbox-resource-ready") {
         const html = event.data?.params?.html;
-        const sandbox = event.data?.params?.sandbox;
-        if (typeof sandbox === "string" && /^(?:allow-scripts|allow-same-origin|\s)+$/.test(sandbox)) inner.setAttribute("sandbox", sandbox);
         if (typeof html !== "string") {
           notifyHost("ui/notifications/sandbox-diagnostic", { code: "MCP_APP_SANDBOX_RESOURCE_INVALID", message: "The sandbox received an invalid HTML resource payload." });
           return;
         }
         try {
-          resourceAssigned = true;
           inner.srcdoc = html;
+          resourceAssigned = true;
           notifyHost("ui/notifications/sandbox-resource-accepted");
         } catch {
           notifyHost("ui/notifications/sandbox-diagnostic", { code: "MCP_APP_SANDBOX_RESOURCE_ASSIGNMENT_FAILED", message: "The sandbox could not assign the HTML resource to its isolated document." });
@@ -121,7 +113,7 @@ export const MCP_APP_SANDBOX_PROXY_SCRIPT = String.raw`
       inner.contentWindow?.postMessage(event.data, "*");
       return;
     }
-    if (event.source === inner.contentWindow && event.origin === ownOrigin) {
+    if (resourceAssigned && event.source === inner.contentWindow && event.origin === "null") {
       window.parent.postMessage(event.data, hostTargetOrigin);
     }
   });

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -37,6 +37,9 @@ const definitions = {
   'unfinished-tool-lifecycle.e2e.test.ts': {
     cases: [{ id: 'STOP-01', engines: ['v1', 'v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v1' } }],
   },
+  'saved-app-creation.e2e.test.ts': {
+    cases: [{ id: 'APP-ISOLATION', engines: ['v1', 'v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v1' } }],
+  },
 };
 
 export const registeredCases = Object.freeze(Object.entries(definitions).flatMap(([spec, definition]) =>

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -82,6 +82,11 @@ test('registered case metadata names exact files, supported execution axes, and 
       id: 'STOP-01',
       engines: ['v1', 'v2'],
     },
+    {
+      spec: 'saved-app-creation.e2e.test.ts',
+      id: 'APP-ISOLATION',
+      engines: ['v1', 'v2'],
+    },
   ]);
   for (const registered of registeredCases) {
     assert(entries.some(entry => entry.spec === registered.spec));

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -10,7 +10,7 @@ const isolationTest = spec.world(isolatedMcpApps, {
   needs: { commands: ["bun", "pnpm", "opencode"] }, timeout: 300_000,
 });
 
-isolationTest("embedded MCP Apps isolate siblings while SDK initialization and helper calls work", async ({ world, agent, user, probe, evidence }) => {
+isolationTest("APP-ISOLATION embedded MCP Apps isolate siblings while SDK initialization and helper calls work", async ({ world, agent, user, probe, evidence }) => {
   const sinceIso = new Date().toISOString();
   await agent.send(isolationPrompt);
   await user.see({ text: isolationReply }, { timeoutMs: 120_000 });

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -1,9 +1,39 @@
 import { expect } from "vitest";
 import { saveWorkflow, runWorkflow } from "@openwork/behaviors";
 import { spec } from "@openwork/testkit";
-import { creationPrompt, creationReply, field, record, savedAppCreation } from "../worlds/saved-apps.ts";
+import { creationPrompt, creationReply, field, record, savedAppCreation, isolatedMcpApps, isolationPrompt, isolationReply } from "../worlds/saved-apps.ts";
 
 const test = spec.world(savedAppCreation, { timeout: 900_000 });
+
+const isolationTest = spec.world(isolatedMcpApps, {
+  resources: { surfaces: ["appWeb"], services: ["mock"] },
+  needs: { commands: ["bun", "pnpm", "opencode"] }, timeout: 300_000,
+});
+
+isolationTest("embedded MCP Apps isolate siblings while SDK initialization and helper calls work", async ({ world, agent, user, probe, evidence }) => {
+  const sinceIso = new Date().toISOString();
+  await agent.send(isolationPrompt);
+  await user.see({ text: isolationReply }, { timeoutMs: 120_000 });
+  const reports = await probe.eventually(() => world.reports(), {
+    within: 30_000, label: "both SDK Apps received their own input, result, and helper reply",
+    until: values => values.length === 2 && values.every(value => value.complete === true),
+  });
+  for (const label of ["A", "B"]) {
+    expect(reports.find(value => value.label === label)).toMatchObject({
+      input: { marker: `input-${label}` }, result: [{ type: "text", text: `initial-${label}` }],
+      helper: [{ type: "text", text: `helper-${label}` }], complete: true,
+    });
+  }
+  expect(reports.find(value => value.label === "A")).toMatchObject({
+    siblingReads: 0, siblingInjections: 0, readDenied: 1, injectionDenied: 1, forgedMessages: 1,
+  });
+  const firstCalls = await world.first.toolCalls({ name: "read_detail", sinceIso, atLeast: 1 });
+  const secondCalls = await world.second.toolCalls({ name: "read_detail", sinceIso, atLeast: 1 });
+  expect(firstCalls.map(call => call.args)).toEqual([{ marker: "legitimate-A" }]);
+  expect(secondCalls.map(call => call.args)).toEqual([{ marker: "legitimate-B" }]);
+  evidence.recordAssertionEvidence("Sibling Apps cannot read or inject into each other", "App A attempted sibling DOM reads, proxy script injection, and a forged helper request; both DOM operations raised SecurityError and neither provider observed the forged call.", true);
+  evidence.recordAssertionEvidence("Opaque Apps retain the standard SDK round trip", "Both real SDK Apps initialized through the shared renderer, received their distinct launch input and result, and completed exactly one legitimate helper call on their own provider.", true);
+});
 
 test("create, preview, save and reopen an app without changing already-open results", async ({ world, user, probe, seed, step, evidence }) => {
   await step("advertise direct artifact creation guidance and prerequisites", async () => {

--- a/evals/worlds/saved-apps.ts
+++ b/evals/worlds/saved-apps.ts
@@ -1,4 +1,6 @@
-import { browserScript } from "@openwork/cdp";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { browserScript, type Surface } from "@openwork/cdp";
 import type { Seed } from "@openwork/env";
 import { go, runWorkflow, saveWorkflow } from "@openwork/behaviors";
 import { connect, debuggerUrlFor, evaluate, listTargets } from "@openwork/cdp";
@@ -7,6 +9,8 @@ import { defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
 
 export const creationPrompt = "Create a reusable app for my dashboard that shows a weekly briefing using my existing Weekly briefing workflow.";
 export const creationReply = "Your briefing app draft is ready. Try the preview, then choose Save.";
+export const isolationPrompt = "Open both independent sample apps, the second sample first.";
+export const isolationReply = "Both sample apps are open.";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -20,6 +24,123 @@ export function field(value: unknown, key: string): string {
   const found = record(value)[key];
   if (typeof found !== "string") throw new Error(`Expected ${key} in the response.`);
   return found;
+}
+
+async function inAppDocuments(app: Surface, action: "read" | "details" | "isolation") {
+  const values: string[] = [];
+  const seen = new Set<string>();
+  const targets = (await listTargets(app.handle.cdpUrl)).filter(entry => entry.type === "iframe"
+    && (entry.url === "about:srcdoc" || entry.url.includes("/mcp-apps/sandbox.html")))
+    .sort((left, right) => Number(right.url === "about:srcdoc") - Number(left.url === "about:srcdoc"));
+  for (const target of targets) {
+    const client = await connect(debuggerUrlFor(app.handle.cdpUrl, target));
+    try {
+      const tree = record(await client.send("Page.getFrameTree"));
+      const frames: string[] = [];
+      const visit = (value: unknown) => {
+        const node = record(value);
+        const frame = record(node.frame);
+        if (frame.url === "about:srcdoc") frames.push(field(frame, "id"));
+        if (Array.isArray(node.childFrames)) node.childFrames.forEach(visit);
+      };
+      visit(tree.frameTree);
+      for (const frameId of frames) {
+        if (seen.has(frameId)) continue;
+        // Observe the child itself, never read its DOM through the proxy's origin.
+        const context = record(await client.send("Page.createIsolatedWorld", { frameId, worldName: "mcp-app-observer" }));
+        if (typeof context.executionContextId !== "number") throw new Error("App frame context is unavailable");
+        const contextId = context.executionContextId;
+        const value = await evaluate({ ...client, send: (method, params, options) => client.send(method, { ...params, contextId }, options) }, browserScript((action) => {
+          if (action === "isolation") return document.body.dataset.isolationReport ?? "";
+          if (action === "read") return document.body.innerText;
+          document.querySelector<HTMLButtonElement>("button")?.click();
+          return "";
+        }, [action]));
+        seen.add(frameId);
+        if (value) values.push(value);
+        if (action !== "isolation") return values;
+      }
+    } finally { client.close(); }
+  }
+  return values;
+}
+
+/** Two real SDK Apps in the shared renderer, with no Den or live provider. */
+export async function isolatedMcpApps(seed: Seed) {
+  const appRequire = createRequire(new URL("../../apps/app/package.json", import.meta.url));
+  const { build } = await import(createRequire(appRequire.resolve("vite")).resolve("esbuild"));
+  const appHtml = async (label: string) => {
+    const bundle = await build({
+      stdin: { resolveDir: fileURLToPath(new URL("../../apps/app", import.meta.url)), contents: `
+        import { App } from "@modelcontextprotocol/ext-apps";
+        const label = ${JSON.stringify(label)};
+        const app = new App({ name: "isolation-" + label, version: "1" }, {});
+        const report = { label, input: null, result: null, helper: null, siblingReads: 0, siblingInjections: 0, readDenied: 0, injectionDenied: 0, forgedMessages: 0, complete: false };
+        const publish = () => { document.body.dataset.isolationReport = JSON.stringify(report); };
+        app.ontoolinput = ({ arguments: args }) => { report.input = args; publish(); };
+        let received = false;
+        app.ontoolresult = async (result) => {
+          if (received) return;
+          received = true;
+          report.result = result.content;
+          if (label === "A") {
+            for (let index = 0; index < window.top.length; index += 1) {
+              const sibling = window.top.frames[index];
+              if (sibling === window.parent) continue;
+              try { sibling.frames[0].document.body.innerText; report.siblingReads += 1; }
+              catch (error) { if (error.name === "SecurityError") report.readDenied += 1; else throw error; }
+              const forged = { jsonrpc: "2.0", id: "sibling-forgery", method: "tools/call", params: { name: "read_detail", arguments: { marker: "forged-by-A" } } };
+              try {
+                const script = sibling.document.createElement("script");
+                script.textContent = "window.parent.postMessage(" + JSON.stringify(forged) + ", '*')";
+                sibling.document.body.appendChild(script);
+                report.siblingInjections += 1;
+              } catch (error) { if (error.name === "SecurityError") report.injectionDenied += 1; else throw error; }
+              sibling.postMessage(forged, "*");
+              report.forgedMessages += 1;
+            }
+          }
+          const resultFromHelper = await app.callServerTool({ name: "read_detail", arguments: { marker: "legitimate-" + label } });
+          report.helper = resultFromHelper.content;
+          await app.sendSizeChanged({ height: 220 });
+          report.complete = true;
+          document.querySelector("p").textContent = "App " + label + " received its own result and helper reply";
+          publish();
+        };
+        app.connect().catch(error => { document.body.dataset.isolationReport = JSON.stringify({ label, error: error.message }); });
+      ` },
+      bundle: true, write: false, format: "iife", platform: "browser", minify: true,
+    });
+    return `<!doctype html><html><head><title>Sample ${label}</title></head><body><p>App ${label} waiting</p><span>private-${label}</span><script>${bundle.outputFiles[0].text.replaceAll("</script", "<\\/script")}</script></body></html>`;
+  };
+  const tools = async (label: string) => [
+    { name: `render_${label.toLowerCase()}`, description: `Open sample ${label}`, inputSchema: { type: "object", properties: { marker: { type: "string" } } },
+      annotations: { readOnlyHint: true, destructiveHint: false }, _meta: { ui: { resourceUri: `ui://sample-${label}/view.html` } },
+      appHtml: await appHtml(label), result: { content: [{ type: "text", text: `initial-${label}` }] } },
+    { name: "read_detail", description: "Read this sample's detail", inputSchema: { type: "object", properties: { marker: { type: "string" } } },
+      annotations: { readOnlyHint: true, destructiveHint: false }, _meta: { ui: { resourceUri: `ui://sample-${label}/view.html`, visibility: ["app"] } },
+      result: { content: [{ type: "text", text: `helper-${label}` }] } },
+  ];
+  const workspacePath = seed.tmpPath("embedded-app-isolation");
+  const app = await seed.appWeb({ name: "embedded-app-isolation", workspacePath, mocks: {
+    first: seed.mock({ isolatedProcessEnv: true, allowUnauthenticatedMcp: true, tools: await tools("A"), agentWorkloads: [{
+      promptMarker: isolationPrompt, finalReply: isolationReply,
+      steps: [{ tool: "render_b", arguments: { marker: "input-B" } }, { tool: "render_a", arguments: { marker: "input-A" } }],
+    }] }),
+    second: seed.mock({ isolatedProcessEnv: true, allowUnauthenticatedMcp: true, tools: await tools("B") }),
+  } });
+  const workspace = await seed.workspace(app, workspacePath);
+  await configureProvider(seed, app, workspace.workspaceId, "sample-model", "sample-model", {
+    provider: { "sample-model": { npm: "@ai-sdk/openai-compatible", name: "Sample model", options: { baseURL: `${app.mocks.first.url}/v1`, apiKey: "sk-sample-fixture" }, models: { "sample-model": { name: "Sample model" } } } },
+    mcp: {
+      sample_a: { type: "remote", url: app.mocks.first.mcpUrl, enabled: true, oauth: false },
+      sample_b: { type: "remote", url: app.mocks.second.mcpUrl, enabled: true, oauth: false },
+    },
+  });
+  await seed.session(app, { title: "Independent embedded apps" });
+  return { app, first: app.mocks.first, second: app.mocks.second,
+    reports: async () => (await inAppDocuments(app, "isolation")).map(value => record(JSON.parse(value))),
+  };
 }
 
 export async function savedAppCreation(seed: Seed) {
@@ -121,20 +242,7 @@ export async function savedAppCreation(seed: Seed) {
     } },
     mcp: { "openwork-cloud": { type: "remote", url: `${den.ref.apiUrl}/mcp/agent`, enabled: true, oauth: false, headers: { Authorization: `Bearer ${token}` } } },
   });
-  const inPreview = async (action: "read" | "details") => {
-    const targets = await listTargets(app.handle.cdpUrl);
-    const target = targets.find((entry) => entry.type === "iframe" && (entry.url === "about:srcdoc" || entry.url.includes("/mcp-apps/sandbox.html")));
-    if (!target) return "";
-    const client = await connect(debuggerUrlFor(app.handle.cdpUrl, target));
-    try {
-      return await evaluate(client, browserScript((action) => {
-        const appDocument = document.querySelector("iframe")?.contentDocument ?? document;
-        if (action === "read") return appDocument.body.innerText;
-        appDocument.querySelector("button")?.click();
-        return "";
-      }, [action]));
-    } finally { client.close(); }
-  };
+  const inPreview = async (action: "read" | "details") => (await inAppDocuments(app, action)).join("\n");
   return {
     app, web, den, proxy, resetProxy, workspace, configObjectId, dashboardId, rpc, run,
     async ageAdminSession() {


### PR DESCRIPTION
## Summary

Give every embedded MCP App an opaque inner origin so provider HTML cannot read a sibling App or execute inside its proxy.

- Keep the outer proxy and parent-origin checks unchanged.
- Enforce `allow-scripts` on the inner document regardless of resource payload overrides.
- Relay only the assigned inner window with an opaque origin.
- Preserve standard SDK initialization, inputs/results, helper replies, sizing, and safe load diagnostics.

## Verification

**Proof verdict: Passed for `APP-ISOLATION` at `ec1e5ab3c94ed9140d86644d617d0bcfb67b5fa8`.** Exact-head evidence is published in the test-evidence comment.

- Executed proxy-script tests: 6 passed, 75 assertions.
- Focused real app-web case: 1 passed, 2 assertion records, zero failures/skips; one unrelated case filtered out. Two SDK Apps received distinct inputs/results and one legitimate helper reply each; App A's sibling read, proxy injection, and forged helper call were blocked.
- Browser callback static check passed.
- Focused catalog expectation check passed all 13 tests after adding the new case.

Command: `pnpm evals:e2e saved-app-creation --local --engine v1 --case APP-ISOLATION`.

## Limits

The focused case does not certify the unrelated save/share journey, packaged Electron, all provider storage/CORS behavior, or the v2 engine. The sibling attack is exercised from App A toward App B; both legitimate SDK paths are exercised. App lifetime/revocation is separate.

No merge or deployment included.
