### PR TITLE
fix(connect): honor organization policy for native actions

### DIFF
--- a/apps/server/src/opencode-plugins/gmail-attachment-fulfillment.test.ts
+++ b/apps/server/src/opencode-plugins/gmail-attachment-fulfillment.test.ts
@@ -137,6 +137,8 @@ test("uncertain network or timeout failures surface unknown creation and are not
   for (const error of [new TypeError("fetch failed"), new DOMException("Timed out", "TimeoutError"),
     new ApiError(503, "file_not_found", "Unavailable"),
     new ApiError(502, "cloud_upload_failed", "Gmail create failed", { upstreamCode: "google_api_error" }),
+    new ApiError(502, "cloud_upload_failed", "Unconfirmed policy rejection", { upstreamCode: "policy_blocked" }),
+    new ApiError(403, "cloud_upload_failed", "Unknown rejection", { upstreamCode: "unrecognized_error" }),
     new ApiError(409, "cloud_upload_failed", "Unknown rejection", { upstreamCode: "unrecognized_error" }),
   ]) {
     let calls = 0;
@@ -205,7 +207,7 @@ test("disposal cancels a pending preflight and late success after cancellation i
   await expect(plugin["tool.execute.after"](queued, pending())).rejects.toThrow("no draft created");
 });
 
-test("definite file, size and missing connection rejections retain their actionable messages", async () => {
+test("definite file, size, connection and policy rejections retain their actionable messages", async () => {
   for (const error of [
     new ApiError(404, "file_not_found", "File was not found inside an authorized workspace root."),
     new ApiError(413, "file_too_large", "Direct uploads support files up to 4194304 bytes."),
@@ -213,6 +215,7 @@ test("definite file, size and missing connection rejections retain their actiona
     new ApiError(409, "cloud_not_connected", "Connect OpenWork Cloud before uploading files."),
     new ApiError(409, "cloud_upload_failed", "Connect the selected Google account in Settings > Connect.", { upstreamCode: "needs_connection" }),
     new ApiError(401, "cloud_upload_failed", "Sign in again to renew your token.", { upstreamCode: "invalid_mcp_token" }),
+    new ApiError(403, "cloud_upload_failed", "Connect is disabled for this organization. Ask your administrator to have it re-enabled.", { upstreamCode: "policy_blocked" }),
   ]) {
     let calls = 0;
     const fulfill = createGmailAttachmentFulfillment({ callExtension: async () => { calls++; throw error; } });
@@ -296,6 +299,7 @@ test.each([
   { status: 404, code: "file_not_found", message: "Choose a file inside an authorized workspace root.", details: undefined },
   { status: 409, code: "cloud_not_connected", message: "Connect OpenWork Cloud before uploading files.", details: undefined },
   { status: 409, code: "cloud_upload_failed", message: "Reconnect the selected account in Settings > Connect.", details: { upstreamCode: "needs_connection" } },
+  { status: 403, code: "cloud_upload_failed", message: "Connect is disabled for this organization. Ask your administrator to have it re-enabled.", details: { upstreamCode: "policy_blocked" } },
 ])("Gmail loopback adapter preserves structured rejection $code", async ({ status, ...payload }) => {
   const previousUrl = process.env.OPENWORK_SERVER_URL;
   const previousToken = process.env.OPENWORK_SERVER_TOKEN;

--- a/apps/server/src/opencode-plugins/gmail-attachment-fulfillment.ts
+++ b/apps/server/src/opencode-plugins/gmail-attachment-fulfillment.ts
@@ -75,7 +75,7 @@ const LOCAL_NO_WRITE = new Set([
 ]);
 const CLOUD_NO_WRITE = new Set([
   "invalid_request:400", "invalid_request:413", "missing_thread_id:400",
-  "needs_connection:409", "unauthorized:401", "forbidden:403",
+  "needs_connection:409", "unauthorized:401", "forbidden:403", "policy_blocked:403",
   "missing_mcp_token:401", "invalid_mcp_token:401", "wrong_token_use:401", "wrong_mcp_resource:401",
   "missing_mcp_principal:401", "mcp_grant_revoked:401", "mcp_session_required:401", "mcp_session_revoked:401",
   "insufficient_mcp_scope:403", "mcp_membership_revoked:403",

--- a/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
@@ -110,15 +110,23 @@ export function buildNativeProviderEntry(
   }
 }
 
-async function nativeProviderConnectionsEnabled(organizationId: DenTypeId<"organization">): Promise<boolean> {
+export type NativeProviderPolicyError = { kind: "policy_blocked"; message: string }
+
+export async function nativeProviderConnectionPolicyError(organizationId: DenTypeId<"organization">): Promise<NativeProviderPolicyError | null> {
   const [organization] = await db
     .select({ metadata: OrganizationTable.metadata })
     .from(OrganizationTable)
     .where(eq(OrganizationTable.id, organizationId))
     .limit(1)
-  return Boolean(organization) && memberFacingMcpConnectionsEnabled(organization?.metadata, {
+  if (organization && memberFacingMcpConnectionsEnabled(organization.metadata, {
     gatingEnabled: env.mcpConnectionsGatingEnabled,
-  })
+  })) return null
+  return {
+    kind: "policy_blocked",
+    message: organization
+      ? "Connect is disabled for this organization. Ask your administrator to have it re-enabled."
+      : "This organization is unavailable. Ask your administrator to check your organization access.",
+  }
 }
 
 export async function listNativeProviderUsableEntries(input: {
@@ -127,7 +135,7 @@ export async function listNativeProviderUsableEntries(input: {
   teamIds?: DenTypeId<"team">[]
 }): Promise<NativeProviderConnectionEntry[]> {
   // Recheck at resolution so retained capability names and Code Mode calls cannot bypass an org disable.
-  if (!await nativeProviderConnectionsEnabled(input.organizationId)) return []
+  if (await nativeProviderConnectionPolicyError(input.organizationId)) return []
   const entries: NativeProviderConnectionEntry[] = []
   const connections = await listUsableNativeProviderConnections({
     organizationId: input.organizationId,
@@ -198,7 +206,7 @@ export async function resolveDefaultNativeProviderCredentialId(input: {
   nativeProviderKey: string
   teamIds: DenTypeId<"team">[]
 }): Promise<string | null> {
-  if (!await nativeProviderConnectionsEnabled(input.organizationId)) return null
+  if (await nativeProviderConnectionPolicyError(input.organizationId)) return null
   // The literal registry key is the legacy alias: it has no connector row or
   // access grants, so it intentionally remains implicitly org-wide.
   if (await getOrgOAuthClient(input.organizationId, input.nativeProviderKey)) {

--- a/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/native-provider-connections.ts
@@ -1,7 +1,8 @@
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { and, eq } from "@openwork-ee/den-db/drizzle"
-import { ConnectedAccountTable } from "@openwork-ee/den-db/schema"
+import { ConnectedAccountTable, OrganizationTable } from "@openwork-ee/den-db/schema"
 import { db } from "../db.js"
+import { env } from "../env.js"
 import {
   clientSelectedFeatures,
   NATIVE_OAUTH_PROVIDERS,
@@ -12,6 +13,7 @@ import {
 import { getConnectedAccount, getOrgOAuthClient } from "./oauth-credentials.js"
 import { readProviderTenantId } from "./oauth-tenant.js"
 import { listExternalMcpConnections, listUsableNativeProviderConnections } from "./external-mcp-connections.js"
+import { memberFacingMcpConnectionsEnabled } from "./external-mcp-rollout.js"
 
 /**
  * Native providers (google-workspace, ...) surface in the SAME member-facing
@@ -108,11 +110,24 @@ export function buildNativeProviderEntry(
   }
 }
 
+async function nativeProviderConnectionsEnabled(organizationId: DenTypeId<"organization">): Promise<boolean> {
+  const [organization] = await db
+    .select({ metadata: OrganizationTable.metadata })
+    .from(OrganizationTable)
+    .where(eq(OrganizationTable.id, organizationId))
+    .limit(1)
+  return Boolean(organization) && memberFacingMcpConnectionsEnabled(organization?.metadata, {
+    gatingEnabled: env.mcpConnectionsGatingEnabled,
+  })
+}
+
 export async function listNativeProviderUsableEntries(input: {
   organizationId: DenTypeId<"organization">
   orgMembershipId: DenTypeId<"member">
   teamIds?: DenTypeId<"team">[]
 }): Promise<NativeProviderConnectionEntry[]> {
+  // Recheck at resolution so retained capability names and Code Mode calls cannot bypass an org disable.
+  if (!await nativeProviderConnectionsEnabled(input.organizationId)) return []
   const entries: NativeProviderConnectionEntry[] = []
   const connections = await listUsableNativeProviderConnections({
     organizationId: input.organizationId,
@@ -183,6 +198,7 @@ export async function resolveDefaultNativeProviderCredentialId(input: {
   nativeProviderKey: string
   teamIds: DenTypeId<"team">[]
 }): Promise<string | null> {
+  if (!await nativeProviderConnectionsEnabled(input.organizationId)) return null
   // The literal registry key is the legacy alias: it has no connector row or
   // access grants, so it intentionally remains implicitly org-wide.
   if (await getOrgOAuthClient(input.organizationId, input.nativeProviderKey)) {

--- a/ee/apps/den-api/src/mcp/native-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/native-capabilities.ts
@@ -1,6 +1,6 @@
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
-import { listNativeProviderUsableEntries, type NativeProviderConnectionEntry } from "../capability-sources/native-provider-connections.js"
+import { listNativeProviderUsableEntries, nativeProviderConnectionPolicyError, type NativeProviderConnectionEntry } from "../capability-sources/native-provider-connections.js"
 import type { McpPrincipal } from "./auth.js"
 import type { AgentToolContentPart } from "./tool-content.js"
 import {
@@ -205,6 +205,10 @@ export async function executeNativeCapability(input: {
     catalog: input.catalog,
   })
   if (!resolved) {
+    const policyError = await nativeProviderConnectionPolicyError(input.organizationId)
+    if (policyError) {
+      return { isError: true, content: [{ type: "text", text: JSON.stringify({ error: policyError.kind, message: policyError.message }) }] }
+    }
     return {
       isError: true,
       content: [{

--- a/ee/apps/den-api/src/routes/org/google-workspace-actions.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace-actions.ts
@@ -50,7 +50,7 @@ export async function requestGoogleAction(
   if (!context) return { ok: false, reply: c.json({ error: "unauthorized", message: "Sign in to an organization first." }, 401) }
   const token = await dependencies.token({ organizationId: context.organization.id, orgMembershipId: context.currentMember.id })
   if (token.kind !== "ok") {
-    return { ok: false, reply: c.json({ error: token.kind, message: token.message }, token.kind === "needs_connection" ? 409 : 502) }
+    return { ok: false, reply: c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : token.kind === "needs_connection" ? 409 : 502) }
   }
   if (requiredFeatures && !token.enabledFeatures?.some((feature) => requiredFeatures.includes(feature))) {
     return { ok: false, reply: c.json({ error: "needs_connection", message: "The administrator has not enabled this action for the selected Google connector. Enable it in connector setup before using it." }, 409) }

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -13,7 +13,7 @@ import { buildGmailDraftRaw, gmailDraftUrl, gmailThreadUrl, normalizeGmailHeader
 import type { GmailDraftAttachment, GmailDraftQuote } from "../../capability-sources/gmail.js"
 import { gmailFileInputPreflight, gmailFileInputPreflightSchema } from "../../capability-sources/gmail-file-input.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
-import { listNativeProviderUsableEntries, resolveDefaultNativeProviderCredentialId } from "../../capability-sources/native-provider-connections.js"
+import { listNativeProviderUsableEntries, nativeProviderConnectionPolicyError, resolveDefaultNativeProviderCredentialId, type NativeProviderPolicyError } from "../../capability-sources/native-provider-connections.js"
 import {
   buildDriveMultipartUpload,
   buildDriveSearchQuery,
@@ -305,6 +305,7 @@ export type GoogleWorkspaceAccessToken =
   | { kind: "ok"; accessToken: string; account: ConnectedAccountRow; enabledScopes: string[]; enabledFeatures?: string[] }
   | { kind: "needs_connection"; message: string }
   | { kind: "google_api_error"; message: string }
+  | NativeProviderPolicyError
 
 type CalendarConferenceData = {
   createRequest: {
@@ -409,7 +410,8 @@ async function googleWorkspaceToken(input: {
     })
   }
   if (!credentialProviderId) {
-    return { kind: "needs_connection", message: CONNECT_GOOGLE_ACCOUNT_MESSAGE }
+    return await nativeProviderConnectionPolicyError(input.organizationId)
+      ?? { kind: "needs_connection", message: CONNECT_GOOGLE_ACCOUNT_MESSAGE }
   }
 
   const token = await getValidAccessToken({
@@ -626,7 +628,7 @@ async function executeGmailDraft(
   payload: OrganizationContext,
   attachments: GmailDraftAttachment[],
   connectionId?: string | null,
-): Promise<{ status: 200 | 400 | 409 | 422 | 502; body: Record<string, unknown> }> {
+): Promise<{ status: 200 | 400 | 403 | 409 | 422 | 502; body: Record<string, unknown> }> {
   const { to, cc, bcc, subject, body, threadId } = input
   if (!threadId && GMAIL_REPLY_SUBJECT_RE.test(subject)) {
     return {
@@ -646,8 +648,8 @@ async function executeGmailDraft(
   if (token.kind === "google_api_error") {
     return { status: 502, body: { error: "google_api_error", message: token.message } }
   }
-  if (token.kind === "needs_connection") {
-    return { status: 409, body: { error: "needs_connection", message: token.message } }
+  if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+    return { status: token.kind === "policy_blocked" ? 403 : 409, body: { error: token.kind, message: token.message } }
   }
 
   if (threadId && missingScope(token.account, [GMAIL_READ_SCOPE])) {
@@ -783,8 +785,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [DRIVE_FILE_SCOPE, DRIVE_FULL_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive write") }, 409)
@@ -902,8 +904,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
@@ -971,8 +973,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
@@ -1016,8 +1018,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
@@ -1065,8 +1067,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Calendar read") }, 409)
@@ -1115,8 +1117,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [CALENDAR_EVENTS_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Calendar write") }, 409)
@@ -1184,8 +1186,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [CALENDAR_EVENTS_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Calendar write") }, 409)
@@ -1247,8 +1249,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       const permissionMessage = driveReadPermissionMessage(token.account)
       if (permissionMessage) {
@@ -1310,8 +1312,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       const permissionMessage = driveReadPermissionMessage(token.account)
       if (permissionMessage) {
@@ -1465,8 +1467,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "google_api_error") {
         return c.json({ error: "google_api_error", message: token.message }, 502)
       }
-      if (token.kind === "needs_connection") {
-        return c.json({ error: "needs_connection", message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") {
+        return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       }
       if (missingScope(token.account, [DRIVE_FILE_SCOPE, DRIVE_FULL_SCOPE])) {
         return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive write") }, 409)

--- a/ee/apps/den-api/src/routes/org/microsoft-365.ts
+++ b/ee/apps/den-api/src/routes/org/microsoft-365.ts
@@ -11,7 +11,7 @@ import { jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
 import { MicrosoftGraphClient, MicrosoftGraphMutationOutcomeUnknownError, MicrosoftGraphRequestError } from "../../capability-sources/microsoft-graph.js"
 import { getOrgOAuthClient } from "../../capability-sources/oauth-credentials.js"
-import { listNativeProviderUsableEntries, resolveDefaultNativeProviderCredentialId } from "../../capability-sources/native-provider-connections.js"
+import { listNativeProviderUsableEntries, nativeProviderConnectionPolicyError, resolveDefaultNativeProviderCredentialId, type NativeProviderPolicyError } from "../../capability-sources/native-provider-connections.js"
 import { clientSelectedFeatures, getNativeOAuthProvider, providerScopesSatisfy } from "../../capability-sources/provider-registry.js"
 import { listTeamsForMember } from "../../orgs.js"
 import { INTERNAL_CAPABILITY_CONNECTOR_HEADER, readInternalCapabilityConnectorId } from "../../session.js"
@@ -308,6 +308,7 @@ export type Microsoft365AccessToken =
   | { kind: "ok"; accessToken: string; scopes: string[] | null; enabledFeatures: string[] }
   | { kind: "needs_connection"; message: string }
   | { kind: "microsoft_graph_error"; message: string }
+  | NativeProviderPolicyError
 
 export type Microsoft365AccessTokenResolver = (input: {
   organizationId: DenTypeId<"organization">
@@ -345,7 +346,8 @@ async function defaultAccessTokenResolver(input: {
     credentialProviderId = await resolveDefaultNativeProviderCredentialId({ ...input, nativeProviderKey: provider.providerId, teamIds })
   }
   if (!credentialProviderId) {
-    return { kind: "needs_connection", message: CONNECT_MICROSOFT_ACCOUNT_MESSAGE }
+    return await nativeProviderConnectionPolicyError(input.organizationId)
+      ?? { kind: "needs_connection", message: CONNECT_MICROSOFT_ACCOUNT_MESSAGE }
   }
   const client = await getOrgOAuthClient(input.organizationId, credentialProviderId)
   if (!client) {
@@ -452,7 +454,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
     if (!payload) return Response.json({ error: "unauthorized" }, { status: 401 })
     const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
     if (token.kind === "microsoft_graph_error") return Response.json({ error: token.kind, message: token.message }, { status: 502 })
-    if (token.kind === "needs_connection") return Response.json({ error: token.kind, message: token.message }, { status: 409 })
+    if (token.kind === "needs_connection" || token.kind === "policy_blocked") return Response.json({ error: token.kind, message: token.message }, { status: token.kind === "policy_blocked" ? 403 : 409 })
     if (!featureEnabled(token, features)) return Response.json({ error: "needs_connection", message: disabledFeatureMessage(label) }, { status: 409 })
     if (!featureGranted(token, features)) return Response.json({ error: "needs_connection", message: missingPermissionMessage(label) }, { status: 409 })
     return graphClient(token.accessToken, signal)
@@ -597,7 +599,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
         orgMembershipId: payload.currentMember.id,
       })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["mailRead"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Outlook mail access") }, 409)
       }
@@ -637,7 +639,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["mailRead"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Outlook mail access") }, 409)
       }
@@ -673,7 +675,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["calendarRead"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Outlook calendar access") }, 409)
       }
@@ -714,7 +716,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["filesRead", "filesWrite", "filesReadAll", "filesFull"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("OneDrive access") }, 409)
       }
@@ -751,7 +753,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["filesRead", "filesWrite", "filesReadAll", "filesFull"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("OneDrive access") }, 409)
       }
@@ -787,7 +789,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["mailDraft"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Outlook draft creation") }, 409)
       }
@@ -824,7 +826,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["calendarWrite"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Outlook calendar event creation") }, 409)
       }
@@ -860,7 +862,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["filesWrite", "filesFull"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("OneDrive file writing") }, 409)
       }
@@ -896,7 +898,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["teamsChatRead", "teamsChatSend"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Teams chat reading") }, 409)
       }
@@ -933,7 +935,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["teamsChatRead", "teamsChatSend"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Teams chat reading") }, 409)
       }
@@ -973,7 +975,7 @@ export function registerMicrosoft365Routes<T extends { Variables: OrgRouteVariab
       const payload = c.get("organizationContext")
       const token = await resolveAccessToken({ organizationId: payload.organization.id, orgMembershipId: payload.currentMember.id })
       if (token.kind === "microsoft_graph_error") return c.json({ error: token.kind, message: token.message }, 502)
-      if (token.kind === "needs_connection") return c.json({ error: token.kind, message: token.message }, 409)
+      if (token.kind === "needs_connection" || token.kind === "policy_blocked") return c.json({ error: token.kind, message: token.message }, token.kind === "policy_blocked" ? 403 : 409)
       if (!featureEnabled(token, ["teamsChatSend"])) {
         return c.json({ error: "needs_connection", message: disabledFeatureMessage("Teams chat sending") }, 409)
       }

--- a/evals/specs/connected-service-actions.test.ts
+++ b/evals/specs/connected-service-actions.test.ts
@@ -442,7 +442,15 @@ test("connected service actions reach only the selected account and enforce writ
           expect(observed).toEqual([expect.objectContaining({ method: "POST", path: providerPath, email: selected, tokenId: selectedTokens.get(connection.id) })]);
         } else {
           expect(executed.result.isError).toBe(true);
-          expect(executed.payload).toMatchObject(executor === "execute_capability" ? policyDenial : { error: "script_failed" });
+          if (executor === "execute_capability") expect(executed.payload).toMatchObject(policyDenial);
+          else {
+            // Disabled native leaves are omitted before the script runs, not invoked and rejected by the provider.
+            expect(executed.payload).toMatchObject({
+              error: "script_failed", kind: "UnknownTool",
+              message: `Unknown tool '${text(match.scriptPath).replace(/^tools\./, "")}'.`,
+            });
+            expect(executed.payload.toolCalls).toEqual([]);
+          }
           expect(executed.payload.connectionStatus).toBeUndefined();
           expect(executed.payload.connectionAction).toBeUndefined();
           expect(JSON.stringify(executed.payload)).not.toMatch(/needs_connection|reauth_required|reconnect|connect your account/i);
@@ -499,7 +507,7 @@ test("connected service actions reach only the selected account and enforce writ
       : "Organization disable stops selected and legacy native execution while preserving admin management",
     enabled
       ? "The retained generic and Code Mode capabilities and default REST routes each made exactly one request with their original selected credential. Only the selected account gained ten folders; other accounts stayed unchanged."
-      : "The actual admin capability switch hid native search and usable connections. Generic execution and legacy REST reads/writes returned policy_blocked with administrator guidance, not reconnect instructions. Code Mode stayed blocked. No provider call or account change occurred; admins could still list and save client configuration.", true);
+      : "The actual admin capability switch hid native search and usable connections. Generic execution and legacy REST reads/writes returned policy_blocked with administrator guidance, not reconnect instructions. Code Mode omitted the native leaves and returned UnknownTool for each exact retained path with no tool calls. No provider call or account change occurred; admins could still list and save client configuration.", true);
   }
   const final = await snapshot(selected);
   for (const { providerKey } of legacyConnections) {

--- a/evals/specs/connected-service-actions.test.ts
+++ b/evals/specs/connected-service-actions.test.ts
@@ -385,6 +385,7 @@ test("connected service actions reach only the selected account and enforce writ
   const policyMatches = new Map<string, Record<string, unknown>>();
   const folderBody = { name: "Policy recovery", parentId: "parent-2" };
   const folderReceipt = { ok: true, file: { name: folderBody.name } };
+  const policyDenial = { error: "policy_blocked", message: "Connect is disabled for this organization. Ask your administrator to have it re-enabled." };
   for (const { connection, providerKey } of policyConnections) {
     const [match] = await discover(connection, providerKey, "drive-folders", ["POST"]);
     expect(match).toBeDefined();
@@ -441,7 +442,10 @@ test("connected service actions reach only the selected account and enforce writ
           expect(observed).toEqual([expect.objectContaining({ method: "POST", path: providerPath, email: selected, tokenId: selectedTokens.get(connection.id) })]);
         } else {
           expect(executed.result.isError).toBe(true);
-          expect(executed.payload).toMatchObject({ error: executor === "execute_capability" ? "unknown_capability" : "script_failed" });
+          expect(executed.payload).toMatchObject(executor === "execute_capability" ? policyDenial : { error: "script_failed" });
+          expect(executed.payload.connectionStatus).toBeUndefined();
+          expect(executed.payload.connectionAction).toBeUndefined();
+          expect(JSON.stringify(executed.payload)).not.toMatch(/needs_connection|reauth_required|reconnect|connect your account/i);
           expect(await snapshot(selected)).toEqual(before);
         }
       }
@@ -462,12 +466,20 @@ test("connected service actions reach only the selected account and enforce writ
       const executed = await denFetch(writer, `/v1/capabilities/${providerKey}/drive-folders`, {
         method: "POST", headers: { authorization: `Bearer ${writer.token}` }, body: JSON.stringify(folderBody),
       });
-      expect(executed.response.status, executed.text).toBe(enabled ? 200 : 409);
-      expect(executed.body).toMatchObject(enabled ? folderReceipt : { error: "needs_connection" });
+      expect(executed.response.status, executed.text).toBe(enabled ? 200 : 403);
+      expect(executed.body).toMatchObject(enabled ? folderReceipt : policyDenial);
       if (enabled) {
         const observed = rows((await snapshot(selected)).requests).slice(rows(before.requests).length);
         expect(observed).toEqual([expect.objectContaining({ method: "POST", path: providerPath, email: selected, tokenId: selectedTokens.get(connection.id) })]);
-      } else expect(await snapshot(selected)).toEqual(before);
+      } else {
+        expect(executed.text).not.toMatch(/needs_connection|reauth_required|reconnect|connect your account/i);
+        const read = await denFetch(writer, `/v1/capabilities/${providerKey}/${providerKey === "google-workspace" ? "gmail-messages" : "mail-messages"}`, {
+          headers: { authorization: `Bearer ${writer.token}` },
+        });
+        expect(read.response.status, read.text).toBe(403);
+        expect(read.body).toMatchObject(policyDenial);
+        expect(await snapshot(selected)).toEqual(before);
+      }
     }
     for (const { email, initial } of [{ email: primary, initial: untouched }, { email: readonly, initial: readerBefore }]) {
       const account = await snapshot(email);
@@ -487,9 +499,18 @@ test("connected service actions reach only the selected account and enforce writ
       : "Organization disable stops selected and legacy native execution while preserving admin management",
     enabled
       ? "The retained generic and Code Mode capabilities and default REST routes each made exactly one request with their original selected credential. Only the selected account gained ten folders; other accounts stayed unchanged."
-      : "The actual admin capability switch hid native search and usable connections. Generic, Code Mode, and legacy default REST writes were denied with zero provider calls or account changes; admins could still list and save the existing client configuration.", true);
+      : "The actual admin capability switch hid native search and usable connections. Generic execution and legacy REST reads/writes returned policy_blocked with administrator guidance, not reconnect instructions. Code Mode stayed blocked. No provider call or account change occurred; admins could still list and save client configuration.", true);
   }
   const final = await snapshot(selected);
+  for (const { providerKey } of legacyConnections) {
+    const disconnected = await denFetch(den.admin, `/v1/capabilities/${providerKey}/drive-folders`, {
+      method: "POST", headers: { authorization: `Bearer ${den.admin.token}` }, body: JSON.stringify(folderBody),
+    });
+    expect(disconnected.response.status, disconnected.text).toBe(409);
+    expect(disconnected.body).toMatchObject({ error: "needs_connection" });
+    expect(await snapshot(selected)).toEqual(final);
+  }
+  evidence.recordAssertionEvidence("Organization policy does not replace genuine native sign-in requirements", "With Connect enabled, the unconnected admin still receives needs_connection and HTTP 409 for both native providers, without reaching either provider.", true);
   for (const [connection, features, action] of [
     [google, ["gmailRead", "calendarRead", "sheetsRead"], cases[0]],
     [microsoft, ["mailRead"], cases[googleCases.length]],

--- a/evals/specs/connected-service-actions.test.ts
+++ b/evals/specs/connected-service-actions.test.ts
@@ -27,8 +27,9 @@ test("connected service actions reach only the selected account and enforce writ
   const selected = "selected@example.test";
   const readonly = "readonly@example.test";
   await using provider = await startMockGoogle({ accounts: [primary, selected, readonly], port: 0 });
+  const organizationName = `Service Actions ${Date.now()}`;
   await using den = await server({
-    place, web: false, org: { name: `Service Actions ${Date.now()}`, members: { writer: {}, reader: {} } },
+    place, web: false, org: { name: organizationName, members: { writer: {}, reader: {} } },
     env: {
       DEN_GOOGLE_OAUTH_AUTHORIZE_URL: provider.authorizeUrl,
       DEN_GOOGLE_OAUTH_TOKEN_URL: provider.tokenUrl,
@@ -43,16 +44,20 @@ test("connected service actions reach only the selected account and enforce writ
   const writer = den.members.writer;
   const reader = den.members.reader;
   const writeFeatures = ["gmailManage", "calendarWrite", "sheetsWrite", "driveFile"];
-  const connect = async (member: DenSession, providerKey: string, name: string, features: string[], email: string) => {
-    const connection = await createNativeConnector(den.admin, {
+  const connect = async (member: DenSession, providerKey: string, name: string, features: string[], email: string, legacy = false) => {
+    const connection = legacy ? { id: providerKey, name } : await createNativeConnector(den.admin, {
       providerKey, name, features, clientId: `synthetic-${name}`, clientSecret: "synthetic-service-actions-secret",
     });
-    if (providerKey === "microsoft-365") {
+    if (legacy || providerKey === "microsoft-365") {
       const configured = await denFetch(den.admin, `/v1/oauth-providers/${connection.id}/client`, {
         method: "POST", headers: { authorization: `Bearer ${den.admin.token}` },
-        body: JSON.stringify({ tenantId: "12345678-1234-1234-1234-123456789abc" }),
+        body: JSON.stringify({
+          ...(legacy ? { features, clientId: `synthetic-${name}`, clientSecret: "synthetic-service-actions-secret" } : {}),
+          ...(providerKey === "microsoft-365" ? { tenantId: "12345678-1234-1234-1234-123456789abc" } : {}),
+        }),
       });
       expect(configured.response.status, configured.text).toBe(200);
+      expect(configured.body).toMatchObject({ providerId: connection.id });
     }
     const started = await denFetch(member, `/v1/mcp-connections/${connection.id}/connect/start`, {
       headers: { authorization: `Bearer ${member.token}` },
@@ -367,6 +372,123 @@ test("connected service actions reach only the selected account and enforce writ
       email: selected, tokenId: selectedTokens.get(google.id) }]);
   }
   evidence.recordAssertionEvidence("Gmail system labels cannot be renamed or deleted", "Both operations read the selected label type and return protected_label. Only the authenticated GET reaches the provider; no mutation or state change occurs.", true);
+
+  // Legacy defaults and selected connectors must obey the same organization switch.
+  const legacyGoogle = await connect(writer, "google-workspace", "Google Workspace", writeFeatures, selected, true);
+  const legacyMicrosoft = await connect(writer, "microsoft-365", "Microsoft 365", ["filesWrite"], selected, true);
+  const policyConnections = [
+    { connection: google, providerKey: "google-workspace", providerPath: "/drive/v3/files" },
+    { connection: microsoft, providerKey: "microsoft-365", providerPath: "/v1.0/me/drive/items/parent-2/children" },
+    { connection: legacyGoogle, providerKey: "google-workspace", providerPath: "/drive/v3/files" },
+    { connection: legacyMicrosoft, providerKey: "microsoft-365", providerPath: "/v1.0/me/drive/items/parent-2/children" },
+  ];
+  const policyMatches = new Map<string, Record<string, unknown>>();
+  const folderBody = { name: "Policy recovery", parentId: "parent-2" };
+  const folderReceipt = { ok: true, file: { name: folderBody.name } };
+  for (const { connection, providerKey } of policyConnections) {
+    const [match] = await discover(connection, providerKey, "drive-folders", ["POST"]);
+    expect(match).toBeDefined();
+    expect(typeof match.scriptPath).toBe("string");
+    policyMatches.set(connection.id, match);
+  }
+  const legacyConnections = policyConnections.slice(2);
+  for (const { connection, providerKey, providerPath } of legacyConnections) {
+    const before = await snapshot(selected);
+    const executed = await denFetch(writer, `/v1/capabilities/${providerKey}/drive-folders`, {
+      method: "POST", headers: { authorization: `Bearer ${writer.token}` }, body: JSON.stringify(folderBody),
+    });
+    expect(executed.response.status, executed.text).toBe(200);
+    expect(executed.body).toMatchObject(folderReceipt);
+    const observed = rows((await snapshot(selected)).requests).slice(rows(before.requests).length);
+    expect(observed).toEqual([expect.objectContaining({ method: "POST", path: providerPath, email: selected })]);
+    selectedTokens.set(connection.id, text(observed[0].tokenId));
+  }
+  const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
+  expect(orgs.response.status, orgs.text).toBe(200);
+  const organizationId = text(rows(record(orgs.body).orgs).find((org) => org.name === organizationName)?.id);
+  const beforeDisable = await snapshot(selected);
+  for (const enabled of [false, true]) {
+    const switched = await denFetch(den.admin, `/v1/admin/organizations/${organizationId}/capabilities`, {
+      method: "PUT", headers: { authorization: `Bearer ${den.admin.token}` },
+      body: JSON.stringify({ capabilities: { mcpConnections: enabled } }),
+    });
+    expect(switched.response.status, switched.text).toBe(200);
+    expect(switched.body).toMatchObject({ capabilities: { mcpConnections: enabled } });
+    const usable = await denFetch(writer, "/v1/mcp-connections?scope=usable", { headers: { authorization: `Bearer ${writer.token}` } });
+    expect(usable.response.status, usable.text).toBe(200);
+    const usableIds = rows(record(usable.body).connections).map((entry) => entry.id);
+    if (enabled) expect(usableIds).toEqual(expect.arrayContaining(policyConnections.map(({ connection }) => connection.id)));
+    else expect(usableIds).toEqual([]);
+    const manageable = await denFetch(den.admin, "/v1/mcp-connections?scope=manageable", { headers: { authorization: `Bearer ${den.admin.token}` } });
+    expect(manageable.response.status, manageable.text).toBe(200);
+    expect(rows(record(manageable.body).connections).map((entry) => entry.id)).toEqual(expect.arrayContaining([google.id, microsoft.id]));
+    for (const { connection, providerPath } of policyConnections) {
+      const match = policyMatches.get(connection.id);
+      if (!match) throw new Error("Missing previously discovered policy action");
+      const search = await gateway(writerToken, "search_capabilities", { query: `${connection.name} drive-folders`, type: "api", limit: 20 });
+      const nativeNames = rows(search.payload.matches).map((entry) => text(entry.name)).filter((name) => name.startsWith("native:"));
+      if (enabled) expect(nativeNames).toContain(match.name);
+      else expect(nativeNames).toEqual([]);
+      for (const executor of ["execute_capability", "execute_capability_script"]) {
+        const before = await snapshot(selected);
+        const executed = await gateway(writerToken, executor, executor === "execute_capability"
+          ? { name: match.name, body: folderBody }
+          : { code: `return await ${text(match.scriptPath)}(input)`, input: { body: folderBody } });
+        if (enabled) {
+          expect(executed.result.isError, JSON.stringify(executed.payload)).not.toBe(true);
+          expect(executed.payload).toMatchObject(folderReceipt);
+          const observed = rows((await snapshot(selected)).requests).slice(rows(before.requests).length);
+          expect(observed).toEqual([expect.objectContaining({ method: "POST", path: providerPath, email: selected, tokenId: selectedTokens.get(connection.id) })]);
+        } else {
+          expect(executed.result.isError).toBe(true);
+          expect(executed.payload).toMatchObject({ error: executor === "execute_capability" ? "unknown_capability" : "script_failed" });
+          expect(await snapshot(selected)).toEqual(before);
+        }
+      }
+      const config = await denFetch(den.admin, `/v1/oauth-providers/${connection.id}/client`, { headers: { authorization: `Bearer ${den.admin.token}` } });
+      expect(config.response.status, config.text).toBe(200);
+      expect(config.body).toMatchObject({ configured: true, providerId: connection.id });
+      if (!enabled) {
+        const saved = await denFetch(den.admin, `/v1/oauth-providers/${connection.id}/client`, {
+          method: "POST", headers: { authorization: `Bearer ${den.admin.token}` },
+          body: JSON.stringify({ features: record(config.body).features }),
+        });
+        expect(saved.response.status, saved.text).toBe(200);
+        expect(saved.body).toMatchObject({ providerId: connection.id, features: record(config.body).features });
+      }
+    }
+    for (const { connection, providerKey, providerPath } of legacyConnections) {
+      const before = await snapshot(selected);
+      const executed = await denFetch(writer, `/v1/capabilities/${providerKey}/drive-folders`, {
+        method: "POST", headers: { authorization: `Bearer ${writer.token}` }, body: JSON.stringify(folderBody),
+      });
+      expect(executed.response.status, executed.text).toBe(enabled ? 200 : 409);
+      expect(executed.body).toMatchObject(enabled ? folderReceipt : { error: "needs_connection" });
+      if (enabled) {
+        const observed = rows((await snapshot(selected)).requests).slice(rows(before.requests).length);
+        expect(observed).toEqual([expect.objectContaining({ method: "POST", path: providerPath, email: selected, tokenId: selectedTokens.get(connection.id) })]);
+      } else expect(await snapshot(selected)).toEqual(before);
+    }
+    for (const { email, initial } of [{ email: primary, initial: untouched }, { email: readonly, initial: readerBefore }]) {
+      const account = await snapshot(email);
+      expect(account.state).toEqual(initial.state);
+      expect(account.requests).toEqual(initial.requests);
+    }
+    const after = await snapshot(selected);
+    if (!enabled) expect(after).toEqual(beforeDisable);
+    else {
+      expect(after.totalRequests).toBe(Number(beforeDisable.totalRequests) + 10);
+      for (const field of ["folders", "onedriveFolders"]) {
+        expect(rows(record(after.state)[field])).toHaveLength(rows(record(beforeDisable.state)[field]).length + 5);
+      }
+    }
+    evidence.recordAssertionEvidence(enabled
+      ? "Re-enabling native connections restores the same accounts without reconnecting"
+      : "Organization disable stops selected and legacy native execution while preserving admin management",
+    enabled
+      ? "The retained generic and Code Mode capabilities and default REST routes each made exactly one request with their original selected credential. Only the selected account gained ten folders; other accounts stayed unchanged."
+      : "The actual admin capability switch hid native search and usable connections. Generic, Code Mode, and legacy default REST writes were denied with zero provider calls or account changes; admins could still list and save the existing client configuration.", true);
+  }
   const final = await snapshot(selected);
   for (const [connection, features, action] of [
     [google, ["gmailRead", "calendarRead", "sheetsRead"], cases[0]],

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -47,6 +47,26 @@ one with form or JSON arguments, and inspect the request and response. The tool
 policy controls on this page choose which tools the organization can use.
 **Your Connections** also shows admins a wrench shortcut to the same tester.
 
+## Organization policy and native actions
+
+Connect is default-on. A platform administrator can disable member-facing
+connections with the organization's `capabilities.mcpConnections` setting.
+Native Google Workspace and Microsoft 365 actions honor that same policy,
+including existing clients using legacy/default accounts. Client version does
+not bypass a disabled organization's authorization policy.
+
+A disabled native action returns the existing `policy_blocked` error and an
+administrator-directed message; native REST routes use HTTP `403`. This is not
+a sign-in failure: reconnecting an account does not enable Connect. Missing
+credentials in an enabled organization still return `needs_connection` and HTTP
+`409`. Success payloads and saved credentials are unchanged. Administrators can
+still manage connection configuration, and re-enabling Connect restores access
+subject to the member's existing grants and credentials.
+
+For self-hosted deployments, `DEN_MCP_CONNECTIONS_GATING_ENABLED` is deprecated
+and inert. It does not override an explicit organization disable; the existing
+organization metadata policy remains authoritative.
+
 ## OAuth redirect URL
 
 An OAuth redirect URL, also called a callback URL, is the exact address where


### PR DESCRIPTION
## Summary

Make the organization Connect policy apply to native Google Workspace and Microsoft 365 discovery and execution, including retained capability names, Code Mode, and legacy/default account routes.

- Denied actions return `policy_blocked` with administrator guidance, not a request to reconnect.
- Administrative configuration and stored credentials remain intact; re-enabling restores the existing authorized accounts.
- Success payloads and genuine missing-credential responses remain unchanged.

## Verification

**Proof verdict: Passed for the focused native-policy journey at `60e7d837755169c9ed360b9de00e6d2fa32044a1`.** Exact-head evidence is published in the test-evidence comment.

The focused `connected-service-actions` gateway journey passed: 1 test, 39 assertion records, zero failures/skips. Synthetic Google/Microsoft providers confirm zero calls while disabled, unaffected accounts, legacy and selected credentials, and recovery without reconnecting. Code Mode must omit the exact retained tool with no calls. Genuine missing credentials still require sign-in.

The Gmail attachment fulfillment check passed 20 tests: a confirmed policy denial preserves administrator guidance and says no draft was created; uncertain responses remain uncertain.

Command: `pnpm evals:pr specs/connected-service-actions.test.ts` with cold isolated local Den and no attached services.

## Scope

This change covers native provider policy enforcement. External connection-proxy policy parity and already-dispatched provider operations are separate. Packaged Desktop and the live-provider matrix were not run. No schema migration or credential changes. No merge or deployment included.
