### PR TITLE
fix(mcp): enforce external tool execution scopes

### DIFF
--- a/ee/apps/den-api/src/mcp/capability-registry.ts
+++ b/ee/apps/den-api/src/mcp/capability-registry.ts
@@ -231,6 +231,7 @@ const externalMcpProviderErrorOutputSchema = z.object({
 const externalCapabilityErrorPayloadSchema = z.object({
   error: z.string(),
   message: z.string(),
+  requiredScope: z.enum(["mcp:read", "mcp:write"]).optional(),
   referenceId: z.string().optional(),
   retryable: z.boolean().optional(),
   providerError: externalMcpProviderErrorOutputSchema.optional(),
@@ -260,6 +261,7 @@ export function externalCapabilityErrorToolResult(
   const payload = externalCapabilityErrorPayloadSchema.parse({
     error: result.error,
     message: result.message,
+    ...(result.requiredScope ? { requiredScope: result.requiredScope } : {}),
     ...(result.referenceId === undefined ? {} : { referenceId: result.referenceId }),
     ...(result.retryable === undefined ? {} : { retryable: result.retryable }),
     ...(result.providerError ? { providerError: result.providerError } : {}),
@@ -536,6 +538,7 @@ const externalMcpSource: CapabilitySource = {
     return leavesFromBuilt(await buildExternalMcpToolTree({
       organizationId: ctx.organizationId,
       member: ctx.member,
+      scopes: ctx.principal.scopes,
       redirectUriBase: ctx.redirectUriBase,
       namespaceContext: await ctx.resolveNamespaceContext(),
     }))
@@ -574,6 +577,7 @@ const externalMcpSource: CapabilitySource = {
     const result = await executeExternalCapability({
       organizationId: ctx.organizationId,
       member: ctx.member,
+      scopes: ctx.principal.scopes,
       connectionId: parsed.connectionId,
       toolName: parsed.toolName,
       args: normalizeToolBody(input.body),

--- a/ee/apps/den-api/src/mcp/codemode-tools.ts
+++ b/ee/apps/den-api/src/mcp/codemode-tools.ts
@@ -23,7 +23,6 @@ import {
   type McpMemberIdentity,
 } from "./external-capabilities.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
-import { requiredScopeForExternalTool } from "./policy.js"
 import {
   buildNativeCapabilityName,
   executeNativeCapability,
@@ -361,7 +360,8 @@ export async function buildExternalMcpToolTree(input: {
         .map((tool) => ({
           scriptPath: codemodeScriptPath(namespace, tool.name),
           capabilityName: buildExternalCapabilityName(connection.id, tool.name),
-          readOnly: requiredScopeForExternalTool(tool) === "mcp:read",
+          // Descriptive only: external dispatch always requires the caller's write scope.
+          readOnly: tool.annotations?.readOnlyHint === true && tool.annotations?.destructiveHint !== true,
           authority: "external" as const,
         }))
     }),

--- a/ee/apps/den-api/src/mcp/codemode-tools.ts
+++ b/ee/apps/den-api/src/mcp/codemode-tools.ts
@@ -23,6 +23,7 @@ import {
   type McpMemberIdentity,
 } from "./external-capabilities.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
+import { requiredScopeForExternalTool } from "./policy.js"
 import {
   buildNativeCapabilityName,
   executeNativeCapability,
@@ -299,6 +300,7 @@ function isListedExternalConnection(value: ListedExternalConnection | undefined)
 export async function buildExternalMcpToolTree(input: {
   organizationId: string
   member: McpMemberIdentity | null
+  scopes: ReadonlySet<string>
   redirectUriBase: string
   namespaceContext?: CodemodeConnectionNamespaceContext
 }): Promise<BuiltCodemodeTools> {
@@ -338,6 +340,7 @@ export async function buildExternalMcpToolTree(input: {
       run: (args) => Effect.promise(() => executeExternalCapability({
         organizationId: input.organizationId,
         member: memberIdentity,
+        scopes: input.scopes,
         connectionId: connection.id,
         toolName: tool.name,
         args: stripUndefinedEntries(args),
@@ -358,7 +361,7 @@ export async function buildExternalMcpToolTree(input: {
         .map((tool) => ({
           scriptPath: codemodeScriptPath(namespace, tool.name),
           capabilityName: buildExternalCapabilityName(connection.id, tool.name),
-          readOnly: tool.annotations?.readOnlyHint === true,
+          readOnly: requiredScopeForExternalTool(tool) === "mcp:read",
           authority: "external" as const,
         }))
     }),

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -41,7 +41,7 @@ import {
 } from "./external-mcp-tool-arguments.js"
 import { compareCapabilityMatches, tokenize } from "./search.js"
 import type { CapabilityMatch } from "./search.js"
-import { requiredScopeForExternalTool } from "./policy.js"
+import { DEN_MCP_WRITE_SCOPE } from "./scopes.js"
 import {
   codemodeScriptPath,
   resolveCodemodeConnectionNamespaceContext,
@@ -1101,7 +1101,7 @@ export async function executeExternalCapability(input: {
   args: unknown
   schemaDigest?: string
   redirectUriBase: string
-  /** Fail closed unless the live provider catalog still marks this exact tool read-only. */
+  /** Additional provider-hint restriction; never replaces write-scope authorization. */
   requireReadOnly?: boolean
   /** Fail closed when the live input schema no longer matches schemaDigest. */
   requireSchemaMatch?: boolean
@@ -1228,7 +1228,8 @@ export async function executeExternalCapability(input: {
       }
     }
 
-    const requiredScope = requiredScopeForExternalTool(tool)
+    // Provider-controlled hints cannot prove a tool will not mutate through its credential.
+    const requiredScope = DEN_MCP_WRITE_SCOPE
     if (!input.scopes.has(requiredScope)) {
       return {
         ok: false,
@@ -1238,7 +1239,7 @@ export async function executeExternalCapability(input: {
       }
     }
 
-    if (input.requireReadOnly && requiredScope !== "mcp:read") {
+    if (input.requireReadOnly && (tool.annotations?.readOnlyHint !== true || tool.annotations?.destructiveHint === true)) {
       return {
         ok: false,
         error: "policy_blocked",

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -41,6 +41,7 @@ import {
 } from "./external-mcp-tool-arguments.js"
 import { compareCapabilityMatches, tokenize } from "./search.js"
 import type { CapabilityMatch } from "./search.js"
+import { requiredScopeForExternalTool } from "./policy.js"
 import {
   codemodeScriptPath,
   resolveCodemodeConnectionNamespaceContext,
@@ -915,7 +916,9 @@ export type ExternalCapabilityExecuteResult =
         | "provider_error"
         | "invalid_capability_arguments"
         | "policy_blocked"
+        | "insufficient_mcp_scope"
       message: string
+      requiredScope?: "mcp:read" | "mcp:write"
       referenceId?: string
       retryable?: boolean
       providerError?: ExternalMcpProviderError
@@ -1092,6 +1095,7 @@ export async function probeExternalConnectionStatus(input: {
 export async function executeExternalCapability(input: {
   organizationId: string
   member: McpMemberIdentity | null
+  scopes: ReadonlySet<string>
   connectionId: string
   toolName: string
   args: unknown
@@ -1224,7 +1228,17 @@ export async function executeExternalCapability(input: {
       }
     }
 
-    if (input.requireReadOnly && (tool.annotations?.readOnlyHint !== true || tool.annotations?.destructiveHint === true)) {
+    const requiredScope = requiredScopeForExternalTool(tool)
+    if (!input.scopes.has(requiredScope)) {
+      return {
+        ok: false,
+        error: "insufficient_mcp_scope",
+        requiredScope,
+        message: `${input.toolName} requires the ${requiredScope} scope.`,
+      }
+    }
+
+    if (input.requireReadOnly && requiredScope !== "mcp:read") {
       return {
         ok: false,
         error: "policy_blocked",

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -41,6 +41,7 @@ import { externalMcpToolSchemaDigest } from "./external-mcp-tool-arguments.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
 import { EXECUTE_CAPABILITY_TOOL_NAME, scoreText, SEARCH_CAPABILITIES_TOOL_NAME, tokenize } from "./search.js"
 import { DEN_MCP_APP_HOST_SCOPE } from "./scopes.js"
+import { requiredScopeForExternalTool } from "./policy.js"
 
 function toolArguments(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {}
@@ -158,6 +159,7 @@ function appOnlyProxyTool(tool: ExternalMcpProxyTool): ExternalMcpProxyTool | nu
 export function createExternalConnectionProxyServer(input: {
   descriptor: ExternalMcpProxyDescriptor
   operation: ExternalMcpProxyOperation
+  scopes: ReadonlySet<string>
   runtime?: ExternalMcpProxyRuntime
   appHostClient?: boolean
   /**
@@ -169,6 +171,20 @@ export function createExternalConnectionProxyServer(input: {
 }) {
   const { connection } = input.operation
   const runtime = input.runtime ?? externalMcpProxyRuntime
+  const callTool = (tool: ExternalMcpProxyTool, args: Record<string, unknown>) => {
+    const requiredScope = requiredScopeForExternalTool(tool)
+    if (!input.scopes.has(requiredScope)) {
+      return {
+        isError: true,
+        content: [{ type: "text" as const, text: JSON.stringify({
+          error: "insufficient_mcp_scope",
+          requiredScope,
+          message: `${tool.name} requires the ${requiredScope} scope.`,
+        }) }],
+      }
+    }
+    return runtime.callTool({ ...input.operation, toolName: tool.name, args })
+  }
   // An administrator opted this connection into direct exposure: ordinary MCP
   // clients receive the provider's own catalog instead of the bounded
   // search/execute pair. The App host keeps its private app-only surface.
@@ -225,15 +241,11 @@ export function createExternalConnectionProxyServer(input: {
     server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const args = toolArguments(request.params.arguments)
       if (directClient) {
-        const allowed = (await listDirectTools()).some((tool) => tool.name === request.params.name)
-        if (!allowed) {
+        const tool = (await listDirectTools()).find((tool) => tool.name === request.params.name)
+        if (!tool) {
           throw new McpError(ErrorCode.InvalidRequest, `Tool ${request.params.name} is not available on ${connection.name}.`)
         }
-        return runtime.callTool({
-          ...input.operation,
-          toolName: request.params.name,
-          args,
-        })
+        return callTool(tool, args)
       }
       if (request.params.name === SEARCH_CAPABILITIES_TOOL_NAME) {
         const query = typeof args.query === "string" ? args.query.trim() : ""
@@ -270,11 +282,7 @@ export function createExternalConnectionProxyServer(input: {
         const toolName = typeof args.name === "string" ? args.name.trim() : ""
         const tool = (await listProviderTools()).find((candidate) => candidate.name === toolName)
         if (!tool) throw new McpError(ErrorCode.InvalidRequest, "The capability is unavailable. Call search_capabilities again.")
-        return runtime.callTool({
-          ...input.operation,
-          toolName,
-          args: toolArguments(args.body),
-        })
+        return callTool(tool, toolArguments(args.body))
       }
       if (!input.appHostClient) {
         throw new McpError(
@@ -282,18 +290,14 @@ export function createExternalConnectionProxyServer(input: {
           `Direct provider tool ${request.params.name} is unavailable. Use search_capabilities and execute_capability.`,
         )
       }
-      const allowed = (await listAppTools()).some((tool) => tool.name === request.params.name)
-      if (!allowed) {
+      const tool = (await listAppTools()).find((tool) => tool.name === request.params.name)
+      if (!tool) {
         throw new McpError(
           ErrorCode.InvalidRequest,
           `Tool ${request.params.name} is not available on the MCP Apps endpoint. Use search_capabilities and execute_capability.`,
         )
       }
-      return runtime.callTool({
-        ...input.operation,
-        toolName: request.params.name,
-        args,
-      })
+      return callTool(tool, args)
     })
   }
 
@@ -384,6 +388,7 @@ const externalMcpProxyRequestDependencies: ExternalMcpProxyRequestDependencies =
 export async function handleExternalConnectionProxyRequest(input: {
   context: Context
   operation: ExternalMcpProxyOperation
+  scopes: ReadonlySet<string>
   appHostClient?: boolean
   directExposureEnabled?: boolean
   runtime?: ExternalMcpProxyRuntime
@@ -398,6 +403,7 @@ export async function handleExternalConnectionProxyRequest(input: {
     const server = createExternalConnectionProxyServer({
       descriptor,
       operation: input.operation,
+      scopes: input.scopes,
       runtime: input.runtime,
       appHostClient: input.appHostClient === true,
       directExposureEnabled: input.directExposureEnabled === true,
@@ -480,6 +486,7 @@ export function registerExternalConnectionProxyRoutes<T extends { Variables: Req
     return handleExternalConnectionProxyRequest({
       context: c,
       operation,
+      scopes: principal.scopes,
       appHostClient: principal.scopes.has(DEN_MCP_APP_HOST_SCOPE),
       directExposureEnabled,
     })

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -40,8 +40,7 @@ import { externalMcpAppResourceUri, resolveMcpMemberIdentity } from "./external-
 import { externalMcpToolSchemaDigest } from "./external-mcp-tool-arguments.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
 import { EXECUTE_CAPABILITY_TOOL_NAME, scoreText, SEARCH_CAPABILITIES_TOOL_NAME, tokenize } from "./search.js"
-import { DEN_MCP_APP_HOST_SCOPE } from "./scopes.js"
-import { requiredScopeForExternalTool } from "./policy.js"
+import { DEN_MCP_APP_HOST_SCOPE, DEN_MCP_WRITE_SCOPE } from "./scopes.js"
 
 function toolArguments(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {}
@@ -172,7 +171,7 @@ export function createExternalConnectionProxyServer(input: {
   const { connection } = input.operation
   const runtime = input.runtime ?? externalMcpProxyRuntime
   const callTool = (tool: ExternalMcpProxyTool, args: Record<string, unknown>) => {
-    const requiredScope = requiredScopeForExternalTool(tool)
+    const requiredScope = DEN_MCP_WRITE_SCOPE
     if (!input.scopes.has(requiredScope)) {
       return {
         isError: true,

--- a/ee/apps/den-api/src/mcp/policy.ts
+++ b/ee/apps/den-api/src/mcp/policy.ts
@@ -84,3 +84,12 @@ export function isMcpOperationAllowed(input: {
 export function requiredScopeForMethod(method: string) {
   return method.toUpperCase() === "GET" ? "mcp:read" : "mcp:write"
 }
+
+export function requiredScopeForExternalTool(tool: {
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean }
+}) {
+  // Missing or contradictory provider hints never authorize a read-scoped call.
+  return tool.annotations?.readOnlyHint === true && tool.annotations?.destructiveHint !== true
+    ? "mcp:read"
+    : "mcp:write"
+}

--- a/ee/apps/den-api/src/mcp/policy.ts
+++ b/ee/apps/den-api/src/mcp/policy.ts
@@ -84,12 +84,3 @@ export function isMcpOperationAllowed(input: {
 export function requiredScopeForMethod(method: string) {
   return method.toUpperCase() === "GET" ? "mcp:read" : "mcp:write"
 }
-
-export function requiredScopeForExternalTool(tool: {
-  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean }
-}) {
-  // Missing or contradictory provider hints never authorize a read-scoped call.
-  return tool.annotations?.readOnlyHint === true && tool.annotations?.destructiveHint !== true
-    ? "mcp:read"
-    : "mcp:write"
-}

--- a/ee/apps/den-api/test/codemode-tools.test.ts
+++ b/ee/apps/den-api/test/codemode-tools.test.ts
@@ -1,4 +1,7 @@
-import { beforeAll, expect, test } from "bun:test"
+import { beforeAll, expect, mock, spyOn, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js"
+import type { ExternalMcpConnectionRow } from "../src/capability-sources/external-mcp-connections.js"
 import { Tool } from "@openwork/codemode"
 import { Effect } from "effect"
 import { Hono } from "hono"
@@ -224,4 +227,90 @@ test("native manifest capability names round-trip through the native parser", ()
     connectionId: "native-connection",
     toolName: "getCapabilitiesGoogleWorkspaceGmailMessages",
   })
+})
+
+test("generic and Code Mode execution check caller scopes against the live external tool", async () => {
+  const connections = await import("../src/capability-sources/external-mcp-connections.js")
+  const runtime = await import("../src/capability-sources/external-mcp-client-runtime.js")
+  const { buildExternalMcpToolTree } = await import("../src/mcp/codemode-tools.js")
+  const { createCapabilityRegistryContext, executeCapability } = await import("../src/mcp/capability-registry.js")
+  const { runCodemodeScript } = await import("../src/mcp/codemode-run.js")
+  const organizationId = createDenTypeId("organization")
+  const memberId = createDenTypeId("member")
+  const connection: ExternalMcpConnectionRow = {
+    id: createDenTypeId("externalMcpConnection"), organizationId,
+    name: "Scope fixture", url: "https://scope.example.test/mcp",
+    authType: "none", kind: "external_mcp", credentialMode: "shared",
+    externalKey: null, nativeProviderKey: null, oauthConfiguration: null,
+    toolPolicy: null, exposeDirectly: false, apiKey: null, accessToken: null,
+    refreshToken: null, tokenType: null, scope: null, expiresAt: null,
+    pendingCodeVerifier: null, credentialHealth: null, oauthIssuerReviewRequiredAt: null,
+    connectedAt: null, createdByOrgMembershipId: memberId, createdAt: new Date(), updatedAt: new Date(),
+  }
+  let allowed = true
+  let calls = 0
+  let liveTool: McpTool = { name: "scope_tool", inputSchema: { type: "object" }, annotations: { readOnlyHint: true } }
+  spyOn(connections, "getExternalMcpConnection").mockImplementation(async () => connection)
+  spyOn(connections, "memberCanUseExternalMcpConnection").mockImplementation(async () => allowed)
+  spyOn(runtime, "listExternalMcpTools").mockImplementation(async () => [liveTool])
+  spyOn(runtime, "callExternalMcpTool").mockImplementation(async () => {
+    calls += 1
+    return { content: [{ type: "text", text: "scope result" }] }
+  })
+  try {
+    const cases: Array<{ annotations?: McpTool["annotations"]; requiredScope: string }> = [
+      { requiredScope: "mcp:write" },
+      { annotations: { readOnlyHint: false }, requiredScope: "mcp:write" },
+      { annotations: { destructiveHint: false }, requiredScope: "mcp:write" },
+      { annotations: { readOnlyHint: true, destructiveHint: true }, requiredScope: "mcp:write" },
+      { annotations: { readOnlyHint: true }, requiredScope: "mcp:read" },
+    ]
+    for (const scopes of [new Set(["mcp:read"]), new Set(["mcp:read", "mcp:write"]), new Set(["mcp:write"])]) {
+      const member = { orgMembershipId: memberId, teamIds: [] }
+      const context = createCapabilityRegistryContext({
+        app: new Hono(), env: undefined, catalog: [], organizationId, member,
+        principal: { userId: createDenTypeId("user"), organizationId, scopes, payload: {} },
+        redirectUriBase: "https://openwork.example", generatedArtifactViewsEnabled: false,
+        organizationMetadata: null, mcpConnectionsGatingEnabled: false,
+      })
+      liveTool = { ...liveTool, annotations: { readOnlyHint: true } }
+      const built = await buildExternalMcpToolTree({
+        organizationId, member, scopes, redirectUriBase: context.redirectUriBase,
+        namespaceContext: {
+          nativeProviderEntries: [], codemodeNativeProviderEntries: [],
+          externalMcpConnections: [connection], codemodeExternalMcpConnections: [connection],
+          namespaces: buildCodemodeConnectionNamespaceMaps({ native: [], externalMcp: [connection] }),
+        },
+      })
+      const leaf = built.manifest[0]
+      if (!leaf) throw new Error("Missing external Code Mode leaf")
+      for (const entry of cases) {
+        // Keep the already-built tree: dispatch must not trust its read-only snapshot.
+        liveTool = { ...liveTool, annotations: entry.annotations }
+        const before = calls
+        const generic = await executeCapability(context, { name: leaf.capabilityName, body: {} })
+        const script = await runCodemodeScript({ code: `return await ${leaf.scriptPath}({})`, tools: built.tools, timeoutMs: 1_000 })
+        if (scopes.has(entry.requiredScope)) {
+          expect(generic.isError).not.toBe(true)
+          expect(script).toMatchObject({ ok: true, value: "scope result" })
+          expect(calls).toBe(before + 2)
+        } else {
+          expect(generic.isError).toBe(true)
+          const text = generic.content.find((part) => part.type === "text")
+          if (!text || text.type !== "text") throw new Error("Missing scope error")
+          expect(JSON.parse(text.text)).toMatchObject({ error: "insufficient_mcp_scope", requiredScope: entry.requiredScope })
+          expect(script).toMatchObject({ ok: false, error: { message: expect.stringContaining(entry.requiredScope) } })
+          expect(calls).toBe(before)
+        }
+      }
+      allowed = false
+      const before = calls
+      expect((await executeCapability(context, { name: leaf.capabilityName, body: {} })).isError).toBe(true)
+      expect((await runCodemodeScript({ code: `return await ${leaf.scriptPath}({})`, tools: built.tools, timeoutMs: 1_000 })).ok).toBe(false)
+      expect(calls).toBe(before)
+      allowed = true
+    }
+  } finally {
+    mock.restore()
+  }
 })

--- a/ee/apps/den-api/test/codemode-tools.test.ts
+++ b/ee/apps/den-api/test/codemode-tools.test.ts
@@ -229,7 +229,7 @@ test("native manifest capability names round-trip through the native parser", ()
   })
 })
 
-test("generic and Code Mode execution check caller scopes against the live external tool", async () => {
+test("generic and Code Mode execution require write scope even for misleading read-only hints", async () => {
   const connections = await import("../src/capability-sources/external-mcp-connections.js")
   const runtime = await import("../src/capability-sources/external-mcp-client-runtime.js")
   const { buildExternalMcpToolTree } = await import("../src/mcp/codemode-tools.js")
@@ -263,7 +263,8 @@ test("generic and Code Mode execution check caller scopes against the live exter
       { annotations: { readOnlyHint: false }, requiredScope: "mcp:write" },
       { annotations: { destructiveHint: false }, requiredScope: "mcp:write" },
       { annotations: { readOnlyHint: true, destructiveHint: true }, requiredScope: "mcp:write" },
-      { annotations: { readOnlyHint: true }, requiredScope: "mcp:read" },
+      { annotations: { readOnlyHint: true }, requiredScope: "mcp:write" },
+      { annotations: { readOnlyHint: true, destructiveHint: false }, requiredScope: "mcp:write" },
     ]
     for (const scopes of [new Set(["mcp:read"]), new Set(["mcp:read", "mcp:write"]), new Set(["mcp:write"])]) {
       const member = { orgMembershipId: memberId, teamIds: [] }
@@ -284,6 +285,8 @@ test("generic and Code Mode execution check caller scopes against the live exter
       })
       const leaf = built.manifest[0]
       if (!leaf) throw new Error("Missing external Code Mode leaf")
+      expect(leaf).toMatchObject({ readOnly: true, authority: "external" })
+      expect(firstUnattendedUnsafeCapability(built, [leaf])).toEqual(leaf)
       for (const entry of cases) {
         // Keep the already-built tree: dispatch must not trust its read-only snapshot.
         liveTool = { ...liveTool, annotations: entry.annotations }

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -548,6 +548,7 @@ test("MCP App launch metadata is published by default alongside regular search a
   })
 
   const executed = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -653,6 +654,7 @@ test("execute_capability shares one external MCP lifecycle budget across schema 
 
   try {
     const result = await executeExternalCapability({
+      scopes: new Set(["mcp:read", "mcp:write"]),
       organizationId: seed.organizationId,
       member: { orgMembershipId: seed.memberId, teamIds: [] },
       connectionId: connection.id,
@@ -701,6 +703,7 @@ test("external capability execution reports schema guidance but always attempts 
   })
 
   const providerAccepted = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -722,6 +725,7 @@ test("external capability execution reports schema guidance but always attempts 
   expect(mutableSchemaServer.toolCalls()).toBe(1)
 
   const providerRejected = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -744,6 +748,7 @@ test("external capability execution reports schema guidance but always attempts 
   expect(mutableSchemaServer.toolCalls()).toBe(2)
 
   const invalidShape = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -765,6 +770,7 @@ test("external capability execution reports schema guidance but always attempts 
   expect(mutableSchemaServer.toolCalls()).toBe(3)
 
   const valid = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -779,6 +785,7 @@ test("external capability execution reports schema guidance but always attempts 
 
   mutableSchemaServer.useSchema("incidentId")
   const stale = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -847,6 +854,7 @@ test("status-row execute returns a clean needs_connection error", async () => {
   })
 
   const result = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -892,6 +900,7 @@ test("dead-url execution returns a structured connection diagnostic instead of t
   })
 
   const result = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -1026,6 +1035,7 @@ test("MCP tool isError is surfaced as a provider failure, not transport success"
     url: providerErrorServer.url,
   })
   const result = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -1057,6 +1067,7 @@ test("provider-declared unknown JSON-RPC errors expose provider words without in
       url: providerDeclaredErrorServer.url,
     })
     const result = await executeExternalCapability({
+      scopes: new Set(["mcp:read", "mcp:write"]),
       organizationId: seed.organizationId,
       member: { orgMembershipId: seed.memberId, teamIds: [] },
       connectionId: connection.id,
@@ -1095,6 +1106,7 @@ test("standard MCP SDK invalid-argument tool errors become a corrective executio
     url: providerErrorServer.url,
   })
   const result = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -1131,6 +1143,7 @@ test("structured provider denial keeps connection health separate and names the 
     url: providerErrorServer.url,
   })
   const result = await executeExternalCapability({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -1168,6 +1181,7 @@ test("downstream provider authorization links are relayed as needs_connection", 
     })
 
     const result = await executeExternalCapability({
+      scopes: new Set(["mcp:read", "mcp:write"]),
       organizationId: seed.organizationId,
       member: { orgMembershipId: seed.memberId, teamIds: [] },
       connectionId: connection.id,
@@ -1226,6 +1240,7 @@ test("foreign-origin downstream authorization links are dropped but still surfac
     })
 
     const result = await executeExternalCapability({
+      scopes: new Set(["mcp:read", "mcp:write"]),
       organizationId: seed.organizationId,
       member: { orgMembershipId: seed.memberId, teamIds: [] },
       connectionId: connection.id,

--- a/ee/apps/den-api/test/external-connection-proxy.test.ts
+++ b/ee/apps/den-api/test/external-connection-proxy.test.ts
@@ -1,5 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import type { Tool } from "@modelcontextprotocol/sdk/types.js"
 import { expect, mock, test } from "bun:test"
 
 process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
@@ -97,8 +98,10 @@ async function withClient<T>(
   appHostClient = true,
   proxiedConnection: unknown = connection,
   directExposureEnabled = true,
+  scopes = new Set(["mcp:read", "mcp:write"]),
 ) {
   const server = createExternalConnectionProxyServer({
+    scopes,
     descriptor: {
       capabilities,
       serverInfo: { name: "fixture", version: "1.0.0" },
@@ -233,10 +236,66 @@ test("direct exposure stays closed while the organization has member-facing MCP 
   }, false, directConnection, false)
 })
 
+test.each(["direct", "compatibility", "app", "app-compatibility"])("%s execution enforces scopes against the fresh provider descriptor", async (mode) => {
+  const cases: Array<{ annotations?: Tool["annotations"]; requiredScope: string }> = [
+    { requiredScope: "mcp:write" },
+    { annotations: {}, requiredScope: "mcp:write" },
+    { annotations: { readOnlyHint: false }, requiredScope: "mcp:write" },
+    { annotations: { destructiveHint: false, idempotentHint: true }, requiredScope: "mcp:write" },
+    { annotations: { readOnlyHint: true, destructiveHint: true }, requiredScope: "mcp:write" },
+    { annotations: { readOnlyHint: true }, requiredScope: "mcp:read" },
+  ]
+  for (const scopes of [new Set(["mcp:read"]), new Set(["mcp:read", "mcp:write"]), new Set(["mcp:write"]), new Set(["mcp:app-host"])]) {
+    let downstreamCalls = 0
+    let liveTool: Tool | undefined = {
+      name: "scope_fixture",
+      inputSchema: { type: "object" },
+      annotations: { readOnlyHint: true },
+      _meta: { ui: { resourceUri, visibility: ["model", "app"] } },
+    }
+    await withClient({ tools: {} }, async (client) => {
+      await client.listTools()
+      const call = () => client.callTool(mode.endsWith("compatibility")
+        ? { name: "execute_capability", arguments: { name: "scope_fixture", body: { marker: "scoped" } } }
+        : { name: "scope_fixture", arguments: { marker: "scoped" } })
+      for (const entry of cases) {
+        if (!liveTool) throw new Error("Missing fixture descriptor")
+        liveTool = { ...liveTool, annotations: entry.annotations }
+        const before = downstreamCalls
+        const result = await call()
+        if (scopes.has(entry.requiredScope)) {
+          expect(result.isError).not.toBe(true)
+          expect(result.structuredContent).toEqual({ marker: "scoped" })
+          expect(downstreamCalls).toBe(before + 1)
+        } else {
+          expect(result.isError).toBe(true)
+          expect(result.content).toEqual([{ type: "text", text: JSON.stringify({
+            error: "insufficient_mcp_scope",
+            requiredScope: entry.requiredScope,
+            message: `scope_fixture requires the ${entry.requiredScope} scope.`,
+          }) }])
+          expect(downstreamCalls).toBe(before)
+        }
+      }
+      liveTool = undefined
+      const before = downstreamCalls
+      await expect(call()).rejects.toThrow()
+      expect(downstreamCalls).toBe(before)
+    }, {
+      listTools: async () => liveTool ? [liveTool] : [],
+      callTool: async (input: { args: Record<string, unknown> }) => {
+        downstreamCalls += 1
+        return { content: [], structuredContent: input.args }
+      },
+    }, mode.startsWith("app"), mode === "direct" ? directConnection : connection, true, scopes)
+  }
+})
+
 test("the request handler never enables direct exposure unless the route confirms the organization flag", async () => {
   let toolNames: string[] = []
   const request = new Request("https://openwork.example/mcp/agent/connections/fixture", { method: "POST" })
   await handleExternalConnectionProxyRequest({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     context: requestContext(request),
     operation: { ...(operation as Record<string, unknown>), connection: directConnection } as never,
     runtime: runtime(),
@@ -281,6 +340,7 @@ test("a forged App-host audience header cannot unlock the provider surface", asy
     headers: { "x-openwork-mcp-client-audience": "app-host" },
   })
   await handleExternalConnectionProxyRequest({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     context: requestContext(request),
     operation,
     runtime: runtime(),
@@ -457,6 +517,7 @@ test("OAuth registration and network failures become sanitized protocol errors",
     body: JSON.stringify({ jsonrpc: "2.0", id: 41, method: "initialize", params: {} }),
   })
   const oauthResponse = await handleExternalConnectionProxyRequest({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     context: requestContext(oauthRequest),
     operation,
     dependencies: { describe: async () => { throw oauthFailure } },
@@ -485,6 +546,7 @@ test("OAuth registration and network failures become sanitized protocol errors",
     body: JSON.stringify({ jsonrpc: "2.0", id: "network", method: "initialize", params: {} }),
   })
   const networkResponse = await handleExternalConnectionProxyRequest({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     context: requestContext(networkRequest),
     operation: { ...operation, diagnosticReferenceId: "req_network" },
     dependencies: {
@@ -503,6 +565,7 @@ test("unsupported GET requests never trigger downstream discovery", async () => 
   let discoveryCalls = 0
   const request = new Request("https://openwork.example/mcp", { method: "GET" })
   const response = await handleExternalConnectionProxyRequest({
+    scopes: new Set(["mcp:read", "mcp:write"]),
     context: requestContext(request),
     operation,
     dependencies: {

--- a/ee/apps/den-api/test/external-connection-proxy.test.ts
+++ b/ee/apps/den-api/test/external-connection-proxy.test.ts
@@ -236,14 +236,15 @@ test("direct exposure stays closed while the organization has member-facing MCP 
   }, false, directConnection, false)
 })
 
-test.each(["direct", "compatibility", "app", "app-compatibility"])("%s execution enforces scopes against the fresh provider descriptor", async (mode) => {
+test.each(["direct", "compatibility", "app", "app-compatibility"])("%s execution requires write scope even for misleading read-only hints", async (mode) => {
   const cases: Array<{ annotations?: Tool["annotations"]; requiredScope: string }> = [
     { requiredScope: "mcp:write" },
     { annotations: {}, requiredScope: "mcp:write" },
     { annotations: { readOnlyHint: false }, requiredScope: "mcp:write" },
     { annotations: { destructiveHint: false, idempotentHint: true }, requiredScope: "mcp:write" },
     { annotations: { readOnlyHint: true, destructiveHint: true }, requiredScope: "mcp:write" },
-    { annotations: { readOnlyHint: true }, requiredScope: "mcp:read" },
+    { annotations: { readOnlyHint: true }, requiredScope: "mcp:write" },
+    { annotations: { readOnlyHint: true, destructiveHint: false }, requiredScope: "mcp:write" },
   ]
   for (const scopes of [new Set(["mcp:read"]), new Set(["mcp:read", "mcp:write"]), new Set(["mcp:write"]), new Set(["mcp:app-host"])]) {
     let downstreamCalls = 0

--- a/ee/apps/den-api/test/marketplace-capabilities.test.ts
+++ b/ee/apps/den-api/test/marketplace-capabilities.test.ts
@@ -1233,6 +1233,7 @@ describe("marketplace capabilities source", () => {
 
     for (const connectionId of [directConnectionId, validConnectionId]) {
       const result = await externalCapabilities.executeExternalCapability({
+        scopes: new Set(["mcp:read"]),
         organizationId: owner.organizationId,
         member: owner.member,
         connectionId,
@@ -1247,6 +1248,7 @@ describe("marketplace capabilities source", () => {
 
     for (const connectionId of [staleConnectionId, orphanConnectionId]) {
       const result = await externalCapabilities.executeExternalCapability({
+        scopes: new Set(["mcp:read"]),
         organizationId: owner.organizationId,
         member: owner.member,
         connectionId,
@@ -1313,6 +1315,7 @@ describe("marketplace capabilities source", () => {
       return (await listUsableExternalMcpConnections({ organizationId: owner.organizationId, orgMembershipId: owner.memberId, teamIds: [] })).map((connection) => connection.id)
     }
     const execute = (connectionId: DenTypeId<"externalMcpConnection">) => externalCapabilities.executeExternalCapability({
+      scopes: new Set(["mcp:read"]),
       organizationId: owner.organizationId,
       member: owner.member,
       connectionId,
@@ -1383,6 +1386,7 @@ describe("marketplace capabilities source", () => {
     expectYourConnectionsUrl(matches[0]?.connectionStatus?.action.url, connectionId)
 
     const executeResult = await externalCapabilities.executeExternalCapability({
+      scopes: new Set(["mcp:read"]),
       organizationId: owner.organizationId,
       member: owner.member,
       connectionId,

--- a/evals/specs/connector-search-intent.test.ts
+++ b/evals/specs/connector-search-intent.test.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
+import { queryDenDatabase } from "@openwork/env";
 import { mcpMock, needs, server, test } from "@openwork/testkit";
 
 function record(value: unknown): Record<string, unknown> {
@@ -17,10 +19,10 @@ function rows(value: unknown): Record<string, unknown>[] {
 test("gateway discovery preserves setup intent and execution scopes", { timeout: 300_000 }, async ({ evidence, place }) => {
   needs({ commands: ["bun", "pnpm"] });
   const scopeCases = [
-    { name: "read_scope_fixture", annotations: { readOnlyHint: true, destructiveHint: false }, requiresWrite: false },
-    { name: "write_scope_fixture", annotations: { readOnlyHint: false, destructiveHint: false }, requiresWrite: true },
-    { name: "unknown_scope_fixture", requiresWrite: true },
-    { name: "contradictory_scope_fixture", annotations: { readOnlyHint: true, destructiveHint: true }, requiresWrite: true },
+    { name: "misleading_read_scope_fixture", annotations: { readOnlyHint: true, destructiveHint: false } },
+    { name: "write_scope_fixture", annotations: { readOnlyHint: false, destructiveHint: false } },
+    { name: "unknown_scope_fixture" },
+    { name: "contradictory_scope_fixture", annotations: { readOnlyHint: true, destructiveHint: true } },
   ];
   const orgName = `Connector Search ${Date.now()}`;
   await using den = await server({
@@ -33,6 +35,8 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
       result: { content: [{ type: "text", text: "scope result" }] },
     })) }) },
   });
+  const database = den.database;
+  if (!database) throw new Error("Scope authority fixtures require a cold-booted owned Den database");
   const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
   expect(orgs.response.status).toBe(200);
   const orgId = rows(record(orgs.body).orgs).find(org => org.name === orgName)?.id;
@@ -133,7 +137,17 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
   expect(record(granted.body).scopes).toEqual(["mcp:read", "mcp:write"]);
   const fullToken = record(granted.body).token;
   const appToken = record(minted.body).appHostToken;
-  if (typeof fullToken !== "string" || typeof appToken !== "string") throw new Error("Missing scoped control tokens");
+  const restrictedAppToken = record(granted.body).appHostToken;
+  if (typeof fullToken !== "string" || typeof appToken !== "string" || typeof restrictedAppToken !== "string") throw new Error("Missing scoped control tokens");
+  // The public mint cannot request a write-less App token. Narrow only this
+  // unused, genuinely minted token in the owned database; do not change mint policy.
+  if (!restrictedAppToken.startsWith("ow_mcp_at_")) throw new Error("Expected an opaque first-party App token");
+  const appTokenHash = createHash("sha256").update(restrictedAppToken.slice("ow_mcp_at_".length)).digest("base64url");
+  const restrictedScopes = JSON.stringify(["mcp:read", "mcp:app-host"]);
+  await queryDenDatabase(database.url, "UPDATE oauthAccessToken SET scopes = ? WHERE token = ? AND reference_id = ?",
+    [restrictedScopes, appTokenHash, String(orgId)]);
+  expect(await queryDenDatabase(database.url, "SELECT scopes FROM oauthAccessToken WHERE token = ? AND reference_id = ?",
+    [appTokenHash, String(orgId)])).toEqual([{ scopes: restrictedScopes }]);
   async function call(bearer: string, name: string, args: Record<string, unknown>, endpoint = "/mcp/agent") {
     const response = await fetch(`${den.ref.apiUrl}${endpoint}`, {
       method: "POST",
@@ -149,6 +163,27 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
     return record(rpc.result);
   }
   const discovered = rows((await search({ query: "Scope Fixture false", type: "mcp", limit: 20 })).payload.matches);
+  const beforeReadControls = await den.mocks.connector.toolCalls();
+  const status = await call(token, "execute_capability", { name: `mcp:${compatibilityId}:*` });
+  expect(status.isError).not.toBe(true);
+  expect(status.structuredContent).toMatchObject({ connectionId: compatibilityId, state: "connected" });
+  for (const bearer of [token, restrictedAppToken]) {
+    const discovery = await call(bearer, "search_capabilities", { query: "scope fixture", limit: 20 }, `/mcp/agent/connections/${compatibilityId}`);
+    expect(discovery.isError).not.toBe(true);
+    const matches = rows(record(discovery.structuredContent).matches);
+    expect(matches.map(entry => entry.name).sort()).toEqual(scopeCases.map(entry => entry.name).sort());
+    if (bearer === restrictedAppToken) {
+      for (const match of matches) expect(match.mcpApp).toMatchObject({ resourceUri: "ui://scope/fixture.html" });
+    }
+  }
+  const nativeRead = rows((await search({ query: "list workers", type: "api", limit: 20 })).payload.matches)
+    .find(entry => entry.method === "GET" && entry.path === "/v1/workers");
+  if (!nativeRead || typeof nativeRead.name !== "string" || typeof nativeRead.scriptPath !== "string") throw new Error("Missing native API read control");
+  expect((await call(token, "execute_capability", { name: nativeRead.name })).isError).not.toBe(true);
+  expect((await call(token, "execute_capability_script", { code: `return await ${nativeRead.scriptPath}({})` })).isError).not.toBe(true);
+  expect((await call(token, "execute_capability_script", { code: "return 1 + 1" })).content).toEqual([{ type: "text", text: "2" }]);
+  expect(await den.mocks.connector.toolCalls()).toEqual(beforeReadControls);
+  evidence.recordAssertionEvidence("Read scope still permits discovery, status, and native API reads", "The read-only token discovered external tools, read connected status, invoked GET /v1/workers directly and in Code Mode, and computed a pure script without any external provider tool call. The downscoped App token also discovered App bindings, proving the real authenticated App audience was reached.", true);
   let deniedCalls = 0;
   let acceptedCalls = 0;
   for (const fixture of scopeCases) {
@@ -157,19 +192,21 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
     const capabilityName = match.name;
     const scriptPath = match.scriptPath;
     const invoke = [
-      (bearer: string) => call(bearer, "execute_capability", { name: capabilityName, body: { marker: fixture.name } }),
-      (bearer: string) => call(bearer, "execute_capability", { name: fixture.name, body: { marker: fixture.name } }, `/mcp/agent/connections/${compatibilityId}`),
-      (bearer: string) => call(bearer, fixture.name, { marker: fixture.name }, `/mcp/agent/connections/${directId}`),
-      (bearer: string) => call(bearer, "execute_capability_script", { code: `return await ${scriptPath}({ marker: input.marker })`, input: { marker: fixture.name } }),
+      { tokens: [token, fullToken], execute: (bearer: string) => call(bearer, "execute_capability", { name: capabilityName, body: { marker: fixture.name } }) },
+      { tokens: [token, fullToken], execute: (bearer: string) => call(bearer, "execute_capability", { name: fixture.name, body: { marker: fixture.name } }, `/mcp/agent/connections/${compatibilityId}`) },
+      { tokens: [token, fullToken], execute: (bearer: string) => call(bearer, fixture.name, { marker: fixture.name }, `/mcp/agent/connections/${directId}`) },
+      { tokens: [token, fullToken], execute: (bearer: string) => call(bearer, "execute_capability_script", { code: `return await ${scriptPath}({ marker: input.marker })`, input: { marker: fixture.name } }) },
+      { tokens: [restrictedAppToken, appToken], execute: (bearer: string) => call(bearer, fixture.name, { marker: fixture.name }, `/mcp/agent/connections/${compatibilityId}`) },
+      { tokens: [restrictedAppToken, appToken], execute: (bearer: string) => call(bearer, "execute_capability", { name: fixture.name, body: { marker: fixture.name } }, `/mcp/agent/connections/${compatibilityId}`) },
     ];
-    for (const execute of invoke) {
-      for (const bearer of [token, fullToken]) {
+    for (const { execute, tokens } of invoke) {
+      for (const bearer of tokens) {
         const before = await den.mocks.connector.toolCalls();
         const result = await execute(bearer);
         const after = await den.mocks.connector.toolCalls();
         const text = rows(result.content).find(part => part.type === "text")?.text;
         if (typeof text !== "string") throw new Error("Missing execution result");
-        if (bearer === token && fixture.requiresWrite) {
+        if (bearer === token || bearer === restrictedAppToken) {
           expect(result.isError).toBe(true);
           expect(text).toContain("mcp:write");
           expect(["insufficient_mcp_scope", "script_failed"]).toContain(record(JSON.parse(text)).error);
@@ -183,16 +220,8 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
         }
       }
     }
-    // The separately minted first-party App token deliberately carries both
-    // scopes. App-host access must neither bypass scopes nor lose this authority.
-    const before = await den.mocks.connector.toolCalls();
-    const appResult = await call(appToken, fixture.name, { marker: "app" }, `/mcp/agent/connections/${compatibilityId}`);
-    expect(appResult.isError).not.toBe(true);
-    expect((await den.mocks.connector.toolCalls()).slice(before.length))
-      .toEqual([expect.objectContaining({ name: fixture.name, args: { marker: "app" } })]);
-    acceptedCalls += 1;
   }
-  expect(deniedCalls).toBe(12);
+  expect(deniedCalls).toBe(24);
   expect(acceptedCalls).toBe(24);
-  evidence.recordAssertionEvidence("Scoped external execution denies writes without invoking the provider", "A genuinely minted mcp:read token denied explicit, unclassified and contradictory writes through generic, direct, compatibility and Code Mode execution: 12 denials with zero provider calls. Read-only and full-scope controls plus the separately authorized App host produced exactly 24 expected calls.", true);
+  evidence.recordAssertionEvidence("Provider read-only hints never grant external execution authority", "Read-only tokens denied all four provider tools, including the misleading readOnlyHint:true tool, through generic, direct, compatibility, Code Mode and both App-host dispatch forms: 24 denials with zero provider calls. A genuinely minted App token was narrowed to mcp:read mcp:app-host in this owned database before first use, not issued by a changed production mint. Full-scope and unchanged App-host tokens produced exactly 24 expected calls.", true);
 });

--- a/evals/specs/connector-search-intent.test.ts
+++ b/evals/specs/connector-search-intent.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
-import { mcpMock, server, test } from "@openwork/testkit";
+import { mcpMock, needs, server, test } from "@openwork/testkit";
 
 function record(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected an object");
@@ -14,13 +14,24 @@ function rows(value: unknown): Record<string, unknown>[] {
 
 // This is a distinct gateway journey: discovering a blocked connection must be
 // informational until the caller explicitly requests connection setup.
-test("gateway discovery stays quiet until connection setup is explicitly requested", { timeout: 300_000 }, async ({ evidence, place }) => {
+test("gateway discovery preserves setup intent and execution scopes", { timeout: 300_000 }, async ({ evidence, place }) => {
+  needs({ commands: ["bun", "pnpm"] });
+  const scopeCases = [
+    { name: "read_scope_fixture", annotations: { readOnlyHint: true, destructiveHint: false }, requiresWrite: false },
+    { name: "write_scope_fixture", annotations: { readOnlyHint: false, destructiveHint: false }, requiresWrite: true },
+    { name: "unknown_scope_fixture", requiresWrite: true },
+    { name: "contradictory_scope_fixture", annotations: { readOnlyHint: true, destructiveHint: true }, requiresWrite: true },
+  ];
   const orgName = `Connector Search ${Date.now()}`;
   await using den = await server({
     place,
     web: false,
     org: { name: orgName, members: {} },
-    mocks: { connector: mcpMock({ port: 3986 }) },
+    mocks: { connector: mcpMock({ port: 3986, allowUnauthenticatedMcp: true, tools: scopeCases.map(({ name, annotations }) => ({
+      name, annotations, description: `Scope fixture ${name}`, inputSchema: { type: "object" },
+      _meta: { ui: { resourceUri: "ui://scope/fixture.html", visibility: ["model", "app"] } },
+      result: { content: [{ type: "text", text: "scope result" }] },
+    })) }) },
   });
   const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
   expect(orgs.response.status).toBe(200);
@@ -36,7 +47,8 @@ test("gateway discovery stays quiet until connection setup is explicitly request
   const minted = await denFetch(den.admin, "/v1/mcp/token", { method: "POST", headers, body: "{}" });
   expect(minted.response.status).toBe(200);
   const token = record(minted.body).token;
-  expect(typeof token).toBe("string");
+  if (typeof token !== "string") throw new Error("Missing read-scoped token");
+  expect(record(minted.body).scopes).toEqual(["mcp:read"]);
   let requestId = 0;
   async function search(args: Record<string, unknown>) {
     const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
@@ -80,8 +92,8 @@ test("gateway discovery stays quiet until connection setup is explicitly request
   expect(slack.payload.connectionAction).toBeUndefined();
   const entries = rows(catalog.entries);
   const ids = entries.map(entry => entry.id);
-  expect(ids).toHaveLength(12);
-  expect(new Set(ids).size).toBe(12);
+  expect(ids).toHaveLength(13);
+  expect(new Set(ids).size).toBe(13);
   expect(ids).toEqual(expect.arrayContaining(["slack", "google-workspace", "microsoft-365", "linear"]));
   for (const entry of entries) {
     expect(typeof entry.name).toBe("string");
@@ -89,7 +101,7 @@ test("gateway discovery stays quiet until connection setup is explicitly request
     expect(["http:", "https:"]).toContain(setupUrl.protocol);
     expect(setupUrl.searchParams.get("quickAdd")).toBe(entry.id);
   }
-  evidence.recordAssertionEvidence("Explicit named setup exposes the complete curated catalog without pretending a tool is connected", "Ordinary Slack search returned no setup UI. Explicit connect selected Slack in a versioned 12-entry catalog, including both suites and Linear, with a matching quickAdd setup URL for every entry and no connection action.", true);
+  evidence.recordAssertionEvidence("Explicit named setup exposes the complete curated catalog without pretending a tool is connected", "Ordinary Slack search returned no setup UI. Explicit connect selected Slack in a versioned 13-entry catalog, including both suites and Linear, with a matching quickAdd setup URL for every entry and no connection action.", true);
 
   const full = await search({ query: "available services", type: "connectors" });
   const fullCatalog = record(full.payload.connectorCatalog);
@@ -97,5 +109,90 @@ test("gateway discovery stays quiet until connection setup is explicitly request
   expect(fullCatalog.entries).toEqual(entries);
   expect(full.payload.matches).toEqual([]);
   expect(full.payload.connectionAction).toBeUndefined();
-  evidence.recordAssertionEvidence("Explicit catalog browsing returns all quick adds without selecting or authorizing an account", "type connectors returned all 12 entries, no selected IDs, no executable capability matches, and no connection action.", true);
+  evidence.recordAssertionEvidence("Explicit catalog browsing returns all quick adds without selecting or authorizing an account", "type connectors returned all 13 entries, no selected IDs, no executable capability matches, and no connection action.", true);
+
+  // Discovery does not grant mutation authority. Use the same read-scoped
+  // token against a healthy synthetic connector, not the private App token.
+  const connectionIds: string[] = [];
+  for (const exposeDirectly of [false, true]) {
+    const response = await denFetch(den.admin, `/v1/mcp-connections/by-key/scope-fixture-${exposeDirectly}`, {
+      method: "PUT", headers,
+      body: JSON.stringify({ name: `Scope Fixture ${exposeDirectly}`, url: den.mocks.connector.mcpUrl,
+        authType: "none", credentialMode: "shared", exposeDirectly, access: { orgWide: true } }),
+    });
+    expect(response.response.status, response.text).toBe(201);
+    const id = record(response.body).id;
+    if (typeof id !== "string") throw new Error("Missing scope fixture connection");
+    connectionIds.push(id);
+  }
+  const [compatibilityId, directId] = connectionIds;
+  const granted = await denFetch(den.admin, "/v1/mcp/token", {
+    method: "POST", headers, body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  expect(granted.response.status, granted.text).toBe(200);
+  expect(record(granted.body).scopes).toEqual(["mcp:read", "mcp:write"]);
+  const fullToken = record(granted.body).token;
+  const appToken = record(minted.body).appHostToken;
+  if (typeof fullToken !== "string" || typeof appToken !== "string") throw new Error("Missing scoped control tokens");
+  async function call(bearer: string, name: string, args: Record<string, unknown>, endpoint = "/mcp/agent") {
+    const response = await fetch(`${den.ref.apiUrl}${endpoint}`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method: "tools/call", params: { name, arguments: args } }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    const raw = await response.text();
+    expect(response.status, raw).toBe(200);
+    const line = raw.split("\n").find(value => value.startsWith("data:"));
+    const rpc = record(JSON.parse(line ? line.slice(5) : raw));
+    expect(rpc.error, JSON.stringify(rpc.error)).toBeUndefined();
+    return record(rpc.result);
+  }
+  const discovered = rows((await search({ query: "Scope Fixture false", type: "mcp", limit: 20 })).payload.matches);
+  let deniedCalls = 0;
+  let acceptedCalls = 0;
+  for (const fixture of scopeCases) {
+    const match = discovered.find(entry => entry.name === `mcp:${compatibilityId}:${fixture.name}`);
+    if (!match || typeof match.name !== "string" || typeof match.scriptPath !== "string") throw new Error(`Missing ${fixture.name}`);
+    const capabilityName = match.name;
+    const scriptPath = match.scriptPath;
+    const invoke = [
+      (bearer: string) => call(bearer, "execute_capability", { name: capabilityName, body: { marker: fixture.name } }),
+      (bearer: string) => call(bearer, "execute_capability", { name: fixture.name, body: { marker: fixture.name } }, `/mcp/agent/connections/${compatibilityId}`),
+      (bearer: string) => call(bearer, fixture.name, { marker: fixture.name }, `/mcp/agent/connections/${directId}`),
+      (bearer: string) => call(bearer, "execute_capability_script", { code: `return await ${scriptPath}({ marker: input.marker })`, input: { marker: fixture.name } }),
+    ];
+    for (const execute of invoke) {
+      for (const bearer of [token, fullToken]) {
+        const before = await den.mocks.connector.toolCalls();
+        const result = await execute(bearer);
+        const after = await den.mocks.connector.toolCalls();
+        const text = rows(result.content).find(part => part.type === "text")?.text;
+        if (typeof text !== "string") throw new Error("Missing execution result");
+        if (bearer === token && fixture.requiresWrite) {
+          expect(result.isError).toBe(true);
+          expect(text).toContain("mcp:write");
+          expect(["insufficient_mcp_scope", "script_failed"]).toContain(record(JSON.parse(text)).error);
+          expect(after).toEqual(before);
+          deniedCalls += 1;
+        } else {
+          expect(result.isError, text).not.toBe(true);
+          expect(text).toContain("scope result");
+          expect(after.slice(before.length)).toEqual([expect.objectContaining({ name: fixture.name, args: { marker: fixture.name } })]);
+          acceptedCalls += 1;
+        }
+      }
+    }
+    // The separately minted first-party App token deliberately carries both
+    // scopes. App-host access must neither bypass scopes nor lose this authority.
+    const before = await den.mocks.connector.toolCalls();
+    const appResult = await call(appToken, fixture.name, { marker: "app" }, `/mcp/agent/connections/${compatibilityId}`);
+    expect(appResult.isError).not.toBe(true);
+    expect((await den.mocks.connector.toolCalls()).slice(before.length))
+      .toEqual([expect.objectContaining({ name: fixture.name, args: { marker: "app" } })]);
+    acceptedCalls += 1;
+  }
+  expect(deniedCalls).toBe(12);
+  expect(acceptedCalls).toBe(24);
+  evidence.recordAssertionEvidence("Scoped external execution denies writes without invoking the provider", "A genuinely minted mcp:read token denied explicit, unclassified and contradictory writes through generic, direct, compatibility and Code Mode execution: 12 denials with zero provider calls. Read-only and full-scope controls plus the separately authorized App host produced exactly 24 expected calls.", true);
 });

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -196,6 +196,26 @@ Search can include OpenWork Cloud resources such as skills, plugins, connectors,
 
 Availability is governed by organization membership, role, policy, and exposure allowlists. It intentionally does not expose authentication internals, admin-only system routes, webhooks, API-key creation or deletion, or credential-returning endpoints.
 
+### MCP token scopes
+
+`mcp:read` permits discovery, connection-status probes, and read-only native API
+operations. **Every external MCP provider tool invocation requires `mcp:write`,
+including tools advertising `readOnlyHint: true`.** The provider controls those
+hints, and OpenWork has no trusted classification proving that a provider tool
+cannot modify data through the connected credential. Hints describe a tool;
+they do not grant execution authorization.
+
+This requirement applies to generic execution, direct connections, compatibility
+wrappers, Code Mode, and MCP App helper calls. The private `mcp:app-host` scope
+selects the App audience; it does not replace `mcp:write`. Scripts that only
+compute or call read-only native APIs do not require write scope.
+
+The desktop app already requests both read and write scopes, and its separately
+minted App-host token carries both. Existing read-only tokens are not upgraded:
+to invoke an external provider tool, explicitly authorize the OpenWork client
+for `mcp:write`. This is separate from reconnecting the provider account, and
+does not bypass connection grants or organization tool policy.
+
 ## MCP Apps
 
 Some gateway results come back as MCP Apps: rich, interactive UI rendered from a tool result instead of plain text — great for dynamic interfaces like a created-skill confirmation card or a workflow result view. OpenWork implements the standard [MCP Apps extension](https://modelcontextprotocol.io/docs/extensions/apps) (`ui://` resources declared on tools), so first-party OpenWork apps render in any MCP client that supports the extension, and fall back to readable text everywhere else.

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -207,6 +207,11 @@ What stays the same:
 
 Directly exposed connections appear in OpenCode as `openwork-direct-<name>-…`.
 
+External provider tool calls require the caller's `mcp:write` scope even when
+the provider advertises `readOnlyHint: true`. Provider hints do not grant
+execution authority; discovery and connection-status probes remain available
+with `mcp:read`. See [MCP token scopes](/cloud/run-in-the-cloud/cloud-mcp#mcp-token-scopes).
+
 ## Notes for admins
 
 - Members only see connections they've been granted — access is explicit


### PR DESCRIPTION
## Summary

Require authenticated `mcp:write` authority before invoking an external MCP provider tool through generic execution, direct connections, compatibility wrappers, Code Mode, or the private App host.

Provider-controlled `readOnlyHint` values cannot grant execution authority. Read-scoped discovery, connection status, native API reads, and compute-only scripts remain available. Desktop and App-host tokens already request both scopes; existing read-only tokens are not silently upgraded.

## Verification

**Proof verdict: Passed for the focused execution-scope journey at `cbe02e9814256d3887b2e54e9aa1136692876f47`.** Exact-head evidence is published in the test-evidence comment.

- Focused proxy and Code Mode tests: 31 passed.
- Existing `connector-search-intent` gateway journey: 1 passed, 5 assertion records, zero failures/skips; 24 denied external calls with zero provider invocations and 24 authorized controls. Includes a genuinely minted App token narrowed only in the owned test database.
- The journey preserves read-only discovery/status/native-read controls and exercises misleading provider annotations.

Command: `pnpm evals:pr specs/connector-search-intent.test.ts` with cold isolated local Den and synthetic providers.

## Compatibility

Read-only external clients must explicitly authorize `mcp:write` for provider tool execution. This is OpenWork-client authorization, not provider reconnection. Existing connection grants, tool policy, and native read/write classification are unchanged.

The affected Desktop path already requests both scopes: the default-scope change in #2280 also made Desktop requests explicit, before `/mcp/agent` and per-connection direct exposure were introduced. Published direct-exposure releases `v0.18.42` through `v0.18.46` retain that request. Older bare `/mcp` dispatch is separate and unchanged. This is not a claim about every custom client or manually issued token: intentionally read-only credentials must remain unable to execute an arbitrary external tool.

Packaged Desktop and every historical client version were not runtime-tested. The focused journey's catalog control checks uniqueness and key entries, not an exhaustive named connector-inventory audit.

No merge or deployment included.
