### PR TITLE
fix(den): add connectors from the catalog and search configured connections

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog-list.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog-list.tsx
@@ -344,8 +344,16 @@ export function ConnectorCatalog({
     connectorMatchesFilter(filter, preset.displayName, preset.description, preset.presetId));
   const microsoftVisible = connectorMatchesFilter(filter, "Microsoft 365", "Outlook Email", "Outlook", "OneDrive", "microsoft-365");
   const microsoftConnection = connections.find((connection) => connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365");
+  const representedConnectionIds = new Set([
+    ...popular.map((connector) => configuredConnectionForPopular(connector, connections, presets)?.id),
+    ...more.map((preset) => connectionForPresetUrl(connections, preset.url)?.id),
+    ...(microsoftVisible ? [microsoftConnection?.id] : []),
+  ]);
+  const configuredMatches = filtering ? connections.filter((connection) =>
+    !representedConnectionIds.has(connection.id)
+    && connectorMatchesFilter(filter, connection.name, connection.url)) : [];
   const showMore = filtering || moreOpen;
-  const nothingMatches = filtering && popular.length === 0 && more.length === 0 && !microsoftVisible;
+  const nothingMatches = filtering && popular.length === 0 && more.length === 0 && !microsoftVisible && configuredMatches.length === 0;
   const total = availablePopular.length + remainingPresets(presets).length + 1;
   const matching = popular.length + more.length + Number(microsoftVisible);
   const shown = popular.length + (showMore ? more.length + Number(microsoftVisible) : 0);
@@ -359,7 +367,35 @@ export function ConnectorCatalog({
 
       <p role="status" className="mb-4 text-[13px] text-gray-500" data-testid="connector-catalog-count">
         {filtering ? `${matching} of ${total} integrations match` : `Showing ${shown} of ${total} integrations`}
+        {configuredMatches.length > 0 ? `, plus ${configuredMatches.length} configured ${configuredMatches.length === 1 ? "connector" : "connectors"}` : ""}
       </p>
+
+      {configuredMatches.length > 0 ? (
+        <section className="mb-8" data-testid="configured-connector-matches">
+          <SectionTitle>Configured ({configuredMatches.length})</SectionTitle>
+          <div className="grid gap-x-8 sm:grid-cols-2">
+            {configuredMatches.map((connection) => (
+              <CatalogRow
+                key={connection.id}
+                id={connection.id}
+                name={connection.name}
+                description={connection.url}
+                icon={{ serviceUrl: connection.url }}
+                connection={connection}
+                href={configuredConnectionHref(connection.id)}
+                effort="guided"
+                adding={false}
+                setupRequired={setupRequired?.(connection)}
+                onRecover={onRecover}
+                recovering={recoveringConnectionId === connection.id}
+                onAdd={() => onManage(connection)}
+                onManage={onManage}
+                onRemove={onRemove}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {nothingMatches ? (
         <p className="text-[13px] text-gray-400">No connectors match &quot;{filter}&quot;. Paste an MCP server URL to add it directly.</p>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -905,10 +905,10 @@ export function McpConnectionsScreen({ view = "catalog", connectorId }: { view?:
               Add connector
             </Link>
           ) : (
-            <Link href={configuredRoute} className={buttonVariants({ variant: "secondary" })} data-testid="connectors-open-configured">
-              Configured
-              <ChevronRight className="h-4 w-4" aria-hidden="true" />
-            </Link>
+            <DenButton variant="primary" onClick={() => openAdvancedSetup()} data-testid="connectors-add-connector">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add connector
+            </DenButton>
           )}
         />
       )}

--- a/ee/apps/den-web/tests/connector-catalog-render.test.tsx
+++ b/ee/apps/den-web/tests/connector-catalog-render.test.tsx
@@ -115,6 +115,52 @@ describe("ConnectorCatalog", () => {
     expect(render({ filter: "zzzz" })).toContain("No connectors match");
   });
 
+  test("custom configured names match without changing the unfiltered catalog", () => {
+    const connections = [{ ...NOTION, id: "conn-custom", name: "Team Archive", url: "https://archive.example.com/mcp", connectedForMe: false }];
+    const markup = render({ connections, filter: "  TEAM archive  " });
+    expect(markup).toContain('data-testid="connector-row-conn-custom"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/configured?connectionId=conn-custom"');
+    expect(markup).toContain('data-testid="connector-options-conn-custom"');
+    expect(markup).toContain('data-testid="connector-recover-conn-custom"');
+    expect(markup).toContain('data-testid="connector-chat-conn-custom"');
+    expect(markup).toContain("Needs your account");
+    expect(markup).toContain("Configured (1)");
+    expect(markup).toContain("0 of 9 integrations match, plus 1 configured connector");
+    expect(markup).not.toContain("No connectors match");
+    expect(markup).not.toContain('data-testid="connector-add-conn-custom"');
+    expect(render({ connections })).not.toContain('data-testid="connector-row-conn-custom"');
+    const unrelated = render({ connections, filter: "unrelated" });
+    expect(unrelated).not.toContain('data-testid="configured-connector-matches"');
+    expect(unrelated).not.toContain("Team Archive");
+    expect(unrelated).toContain("No connectors match");
+  });
+
+  test("matching catalog rows do not duplicate their configured connections", () => {
+    for (const [presetId, name, url] of [
+      ["notion", "Notion", NOTION.url],
+      ["granola", "Granola", "https://mcp.granola.ai/mcp"],
+      ["microsoft-365", "Microsoft 365", "https://graph.microsoft.com"],
+    ]) {
+      const markup = render({ connections: [{ ...NOTION, id: presetId, name, url }], filter: name });
+      expect(markup.split(`data-testid="connector-row-${presetId}"`)).toHaveLength(2);
+      expect(markup).not.toContain('data-testid="configured-connector-matches"');
+      expect(markup).toContain("1 of 9 integrations match");
+    }
+  });
+
+  test("a renamed preset is searchable by its custom name and deduplicated by service", () => {
+    const connections = [{ ...NOTION, name: "Research Hub" }];
+    const markup = render({ connections, filter: "Research Hub" });
+    expect(markup).toContain('data-testid="connector-row-conn-notion"');
+    expect(markup).toContain("Research Hub");
+    expect(markup).toContain('href="/dashboard/mcp-connections/configured?connectionId=conn-notion"');
+    expect(markup).not.toContain('data-testid="connector-row-notion"');
+    const serviceMatch = render({ connections, filter: "notion" });
+    expect(serviceMatch).toContain('data-testid="connector-row-notion"');
+    expect(serviceMatch).not.toContain('data-testid="connector-row-conn-notion"');
+    expect(serviceMatch).not.toContain('data-testid="configured-connector-matches"');
+  });
+
   test("every row opens its detail page: stable catalog identity even when configured", () => {
     const markup = render({ filter: "o" });
 

--- a/evals/specs/den-connector-catalog.e2e.test.ts
+++ b/evals/specs/den-connector-catalog.e2e.test.ts
@@ -22,6 +22,20 @@ test("Den catalog shows its full inventory, preserves service identity, and keep
   expect(before.response.ok).toBe(true);
   const requestsBefore = (await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token");
 
+  await step("Add connector opens advanced setup and cancel leaves connections unchanged", async () => {
+    await admin.see({ testId: "connector-catalog-count" }, { timeoutMs: 90_000 });
+    await admin.click({ testId: "connectors-add-connector" });
+    await admin.see({ testId: "add-mcp-connection-dialog" });
+    await admin.see({ role: "heading", label: "Add a custom MCP server" });
+    await admin.see({ placeholder: "notion" }, { value: "" });
+    await admin.notSee({ testId: "smart-add-query-input" });
+    await admin.click({ role: "button", label: "Cancel" });
+    await admin.notSee({ testId: "add-mcp-connection-dialog" });
+    expect((await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable")).body).toEqual(before.body);
+    expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(requestsBefore);
+    expect(await probe.toolCalls(world.connector)).toEqual([]);
+  });
+
   await step("browse every integration with an accurate total and setup requirements", async () => {
     await admin.see({ testId: "connector-catalog-count" }, { text: `Showing 6 of ${expectedIds.length} integrations`, timeoutMs: 90_000 });
     await admin.see({ role: "button", label: "Set up Slack" });
@@ -57,6 +71,14 @@ test("Den catalog shows its full inventory, preserves service identity, and keep
   });
 
   await step("filter the full inventory and recover from an empty result", async () => {
+    await admin.type({ testId: "connector-smart-bar" }, "Catalog Notes", { replace: true });
+    await admin.see({ testId: "configured-connector-matches" }, { text: /Configured \(1\)/ });
+    expect((await catalog.connectorCatalog()).entries.map((entry) => entry.id)).toEqual([world.connection.id]);
+    await admin.click({ testId: `connector-open-${world.connection.id}` });
+    await admin.see({ testId: "connector-detail-title" }, { text: /^Catalog Notes\b/ });
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    await admin.notSee({ testId: "connector-detail-setup" });
+    await admin.navigate(catalogUrl);
     await admin.type({ testId: "connector-smart-bar" }, "granola", { replace: true });
     await admin.see({ testId: "connector-catalog-count" }, { text: `1 of ${expectedIds.length} integrations match` });
     expect((await catalog.connectorCatalog()).entries.map((entry) => entry.id)).toEqual(["granola"]);


### PR DESCRIPTION
## Summary
- Replace the catalog header’s Configured action with a primary Add connector button that opens the existing custom MCP setup dialog. The configured strip remains available.
- Include configured connectors in text search by name and URL, keeping their management, recovery, and chat actions. Avoid duplicate rows when the catalog already represents the matching connection.
- Preserve the unfiltered catalog and existing URL-discovery flow; show additional configured-result counts separately.

## Validation
**Verdict: Incomplete** — focused render coverage passes; exact-head browser journey evidence is not yet available.
- Passed: `bun test --conditions development tests/connector-catalog-render.test.tsx` in `ee/apps/den-web` — 10 passed, 0 failed, 79 assertions.
- Passed: `git diff --check`.
- Added assertions to the existing Den connector catalog journey for opening/cancelling Add connector and searching/opening a configured connector, with no-write checks.
- Not run: `pnpm evals:e2e den-connector-catalog`. Browser interaction and runtime no-write proof remain unverified; no broad suite was run.

This is a focused follow-up to the catalog implementation already on dev. No backend or connection authorization behavior changes.