### PR TITLE
fix(app): interrupt delegated work before immediate follow-ups

### DIFF
--- a/apps/app/src/app/lib/opencode-interruption.ts
+++ b/apps/app/src/app/lib/opencode-interruption.ts
@@ -61,6 +61,32 @@ export async function submitAfterInterruption<T>(baseUrl: string, sessionID: str
   }
 }
 
+function foregroundDelegations(messages: readonly { info: Message; parts: Part[] }[]) {
+  const turnStart = messages.findLastIndex(({ info }) => info.role === "user");
+  return messages.slice(Math.max(0, turnStart)).flatMap(({ parts }) => parts.filter((part) =>
+    part.type === "tool" && ["task", "subagent"].includes(part.tool)
+    && part.state.status !== "completed" && part.state.input.background !== true
+    && !("metadata" in part.state && part.state.metadata?.background === true)));
+}
+
+/** Immediate follow-ups interrupt delegated work; ordinary steering and queued
+ * sends retain their existing behavior. Register before awaiting cancellation so
+ * another Stop can still cancel this successor. */
+export function submitImmediateSessionTurn<T>(
+  baseUrl: string,
+  client: Client,
+  sessionID: string,
+  messages: readonly { info: Message; parts: Part[] }[],
+  send: (afterStop: boolean) => Promise<T>,
+  options: { directory?: string; messageID?: string } = {},
+): Promise<T> {
+  if (!sessionWorkHeld(baseUrl, sessionID) && foregroundDelegations(messages).some((part) =>
+    part.type === "tool" && ["pending", "running"].includes(part.state.status))) {
+    void interruptSessionTurn(baseUrl, client, sessionID, options.directory);
+  }
+  return submitAfterInterruption(baseUrl, sessionID, send, options.messageID);
+}
+
 /** Commands can be acknowledged by the proxy before asynchronous dispatch.
  * Keep their exact admission in the shared Stop coordinator, even after HTTP settles. */
 export function sendSessionCommand(baseUrl: string, client: Client, parameters: Parameters<Client["session"]["command"]>[0]) {
@@ -173,15 +199,12 @@ async function stopForegroundTree(
 ) {
   const options = { signal };
   const childrenInMessages = (sessionID: string, messages: readonly { info: Message; parts: Part[] }[]) => {
-    const turnStart = messages.findLastIndex(({ info }) => info.role === "user");
-    return messages.slice(Math.max(0, turnStart)).flatMap(({ parts }) => parts.flatMap((part) => {
-      if (part.type !== "tool" || !["task", "subagent"].includes(part.tool)
-        || part.state.status === "completed" || part.state.input.background === true) return [];
+    return foregroundDelegations(messages).flatMap((part) => {
+      if (part.type !== "tool") return [];
       const metadata = "metadata" in part.state ? part.state.metadata : undefined;
-      if (metadata?.background === true) return [];
       const id = metadata?.sessionId ?? metadata?.sessionID;
       return typeof id === "string" && id !== sessionID ? [id] : [];
-    }));
+    });
   };
   const children = async (sessionID: string) => {
     signal.throwIfAborted();

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -9,7 +9,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
-import { hasTerminalSessionReply, interruptSessionTurn, sessionHasPendingSubmission, sessionNeedsStop, sessionWorkHeld, submitAfterInterruption, subscribeSessionInterruption } from "@/app/lib/opencode-interruption";
+import { hasTerminalSessionReply, interruptSessionTurn, sessionHasPendingSubmission, sessionNeedsStop, sessionWorkHeld, submitAfterInterruption, submitImmediateSessionTurn, subscribeSessionInterruption } from "@/app/lib/opencode-interruption";
 import { createClient, createPromptMessageID, hasAcceptedPromptMessage, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl, v2PromptText } from "@/app/lib/opencode-v2-adapter";
 import * as opencodeSessionNative from "@/app/lib/opencode-session-native";
@@ -2044,9 +2044,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
   };
 
-  // Core sender shared by initial send and steered follow-ups. OpenCode
-  // accepts follow-up user turns mid-run (steering) — the running loop picks
-  // up the new message — so this is safe to call while the agent is busy.
+  // Immediate sends interrupt foreground delegation, but otherwise steer the
+  // running loop. Explicit queueing and automatic draining stay separate.
   const sendDraft = useCallback(async (nextDraft: ComposerDraft, itemId: string, onPrepared?: (text?: string) => void): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
     const messageId = nextDraft.messageId ?? createPromptMessageID();
     const generation = getQueuedSendGeneration(props.sessionId);
@@ -2056,8 +2055,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setError(null);
     try {
       if (archived || !archiveStateKnown) throw new Error("This session is read-only. Restore it before sending.");
-      const result = await submitAfterInterruption(props.opencodeBaseUrl, props.sessionId,
-        () => props.onSendDraft({ ...nextDraft, messageId }, props.sessionId, onPrepared), messageId);
+      const result = await submitImmediateSessionTurn<CloudMcpSubmissionResult>(props.opencodeBaseUrl, opencodeClient, props.sessionId,
+        snapshot?.messages ?? [], async () => {
+          if (getQueuedSendGeneration(props.sessionId) !== generation) {
+            return { outcome: "cancelled", reason: "context_changed" };
+          }
+          return props.onSendDraft({ ...nextDraft, messageId }, props.sessionId, onPrepared);
+        }, { directory: props.workspaceRoot.trim() || undefined, messageID: messageId });
       dispatchQueuedDrain(props.sessionId, {
         type: "send_result", itemId, outcome: result.outcome, at: Date.now(),
         deferredMessageID: nextDraft.command ? messageId : undefined,
@@ -2095,7 +2099,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       pendingSendsRef.current.delete(submissionId);
       setPendingSendSessions([...pendingSendsRef.current.values()]);
     }
-  }, [archived, archiveStateKnown, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, renderedMessages.length, sessionOwner, setError]);
+  }, [archived, archiveStateKnown, opencodeClient, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, props.workspaceRoot, renderedMessages.length, sessionOwner, setError, snapshot]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -3,7 +3,7 @@ import { focusManager } from "@tanstack/react-query";
 import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, createPromptMessageID, hasAcceptedPromptMessage, unwrap, type FieldsResult } from "../src/app/lib/opencode";
-import { holdSessionWork, interruptSessionTurn, sendSessionCommand, sessionHasPendingSubmission, sessionNeedsStop, sessionWorkHeld, submitAfterInterruption } from "../src/app/lib/opencode-interruption";
+import { holdSessionWork, interruptSessionTurn, sendSessionCommand, sessionHasPendingSubmission, sessionNeedsStop, sessionWorkHeld, submitAfterInterruption, submitImmediateSessionTurn } from "../src/app/lib/opencode-interruption";
 import { createClientV2 } from "../src/app/lib/opencode-v2-adapter";
 import {
   composeNativeSessionSnapshot,
@@ -650,9 +650,9 @@ describe("native Stop and follow-up handoff", () => {
     }
   });
 
-  test("v2 interrupts the native subagent before admitting the next prompt", async () => {
+  test.each([false, true])("v2 interrupts the native subagent before admitting the next prompt (immediate: %s)", async (immediate) => {
     const baseUrl = endpoint.opencodeBaseUrl.replace("opencode", "opencode2");
-    const rootID = "ses_v2_stop";
+    const rootID = `ses_v2_stop_${immediate}`;
     const childID = "ses_v2_child";
     const events: string[] = [];
     await withSessionFetch((request) => {
@@ -676,13 +676,76 @@ describe("native Stop and follow-up handoff", () => {
       throw new Error(`Unexpected v2 request: ${request.method} ${path}`);
     }, async (requests) => {
       const client = createClientV2(baseUrl, session.directory, { token: endpoint.token, mode: "openwork" });
-      const stop = interruptSessionTurn(baseUrl, client, rootID, session.directory);
-      const next = submitAfterInterruption(baseUrl, rootID, async () => unwrap(await client.session.promptAsync({
+      const current = unwrap(await client.session.messages({ sessionID: rootID }));
+      const send = async () => unwrap(await client.session.promptAsync({
         sessionID: rootID, model: { providerID: "mock", modelID: "mock" }, parts: [{ type: "text", text: "new turn" }],
-      })));
+      }));
+      const stop = immediate ? undefined : interruptSessionTurn(baseUrl, client, rootID, session.directory);
+      const next = immediate
+        ? submitImmediateSessionTurn(baseUrl, client, rootID, current, send, { directory: session.directory })
+        : submitAfterInterruption(baseUrl, rootID, send);
       await Promise.all([stop, next]);
       expect(events).toEqual([`interrupt:${rootID}`, `interrupt:${rootID}`, `interrupt:${childID}`, `prompt:${rootID}`]);
       expect(requests.every((request) => new URL(request.url).pathname.includes("/opencode2/api/"))).toBe(true);
+    });
+  });
+
+  test("immediate follow-up preserves steering without current pending foreground delegation", async () => {
+    for (const variant of ["ordinary", "previous", "completed", "error", "background-input", "background-metadata"]) {
+      const rootID = `ses_steer_${variant}`;
+      const current = turnMessages(rootID, variant === "ordinary" ? [delegatedTool("ses_read", {}, "read")] :
+        variant === "previous" ? [] : [delegatedTool("ses_ignored", {
+          ...(variant === "completed" ? { status: "completed", output: "done" } : {}),
+          ...(variant === "error" ? { status: "error", error: "cancelled" } : {}),
+          ...(variant === "background-input" ? { input: { background: true } } : {}),
+          ...(variant === "background-metadata" ? { metadata: { sessionID: "ses_ignored", background: true } } : {}),
+        })]);
+      const sent: boolean[] = [];
+      await withSessionFetch((request) => {
+        if (request.method === "GET") return Response.json([
+          ...turnMessages(rootID, [delegatedTool("ses_old")], "msg_old"), ...current,
+        ]);
+        throw new Error("Ordinary steering must not abort");
+      }, async (requests) => {
+        const client = createClient(endpoint.opencodeBaseUrl);
+        const messages = unwrap(await client.session.messages({ sessionID: rootID }));
+        await submitImmediateSessionTurn(endpoint.opencodeBaseUrl, client, rootID, messages, async (afterStop) => { sent.push(afterStop); });
+        expect(sent).toEqual([false]);
+        expect(requests.filter((request) => request.method === "POST")).toEqual([]);
+      });
+    }
+  });
+
+  test("another Stop cancels an immediate successor while pending delegation is being interrupted", async () => {
+    const rootID = "ses_immediate_stop_race";
+    const idle = Promise.withResolvers<Response>();
+    const reached = Promise.withResolvers<void>();
+    let sends = 0;
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/message")) return Response.json(turnMessages(rootID, [
+        delegatedTool("ses_pending", { status: "pending", metadata: undefined }),
+      ]));
+      if (path.endsWith("/abort")) return Response.json(true);
+      if (path.endsWith("/status")) { reached.resolve(); return idle.promise; }
+      if (path.endsWith(`/session/${rootID}`)) return Response.json({ ...session, id: rootID });
+      throw new Error(`Unexpected request: ${path}`);
+    }, async () => {
+      const client = createClient(endpoint.opencodeBaseUrl);
+      const current = unwrap(await client.session.messages({ sessionID: rootID }));
+      const next = submitImmediateSessionTurn(endpoint.opencodeBaseUrl, client, rootID, current, async () => { sends += 1; });
+      const outcome = next.then(() => undefined, (error: unknown) => error);
+      try {
+        await reached.promise;
+        const stop = interruptSessionTurn(endpoint.opencodeBaseUrl, client, rootID);
+        idle.resolve(Response.json({}));
+        await stop;
+        expect(await outcome).toMatchObject({ message: "Send cancelled by Stop." });
+        expect(sends).toBe(0);
+      } finally {
+        idle.resolve(Response.json({}));
+        await outcome;
+      }
     });
   });
 
@@ -708,8 +771,8 @@ describe("native Stop and follow-up handoff", () => {
     });
   });
 
-  test("stops only the current foreground tree and holds follow-up through delayed child abort and authoritative idle", async () => {
-    const root = { ...session, id: "ses_tree" };
+  test.each([false, true])("stops only the current foreground tree through delayed child abort and authoritative idle (immediate: %s)", async (immediate) => {
+    const root = { ...session, id: `ses_tree_${immediate}` };
     const baseUrl = endpoint.opencodeBaseUrl;
     const childAbort = Promise.withResolvers<Response>();
     const childReached = Promise.withResolvers<void>();
@@ -759,14 +822,18 @@ describe("native Stop and follow-up handoff", () => {
       throw new Error(`Unexpected request: ${request.method} ${path}`);
     }, async (requests) => {
       const client = createClient(baseUrl, root.directory, { token: endpoint.token, mode: "openwork" });
-      const stop = interruptSessionTurn(baseUrl, client, root.id, root.directory, {
+      const current = unwrap(await client.session.messages({ sessionID: root.id, directory: root.directory }));
+      const stop = immediate ? undefined : interruptSessionTurn(baseUrl, client, root.id, root.directory, {
         timeoutMs: 1_000, onStopped: () => { admissionReconciled = true; },
       });
-      const followUp = submitAfterInterruption(baseUrl, root.id, async (afterStop) => {
-        expect(admissionReconciled).toBe(true);
+      const send = async (afterStop: boolean) => {
+        if (!immediate) expect(admissionReconciled).toBe(true);
         sent.push(afterStop);
         return unwrap(await client.session.promptAsync({ sessionID: root.id, parts: [{ type: "text", text: "follow-up" }] }));
-      });
+      };
+      const followUp = immediate
+        ? submitImmediateSessionTurn(baseUrl, client, root.id, current, send, { directory: root.directory })
+        : submitAfterInterruption(baseUrl, root.id, send);
       try {
         await childReached.promise;
         expect(sent).toEqual([]);


### PR DESCRIPTION
## Summary
Immediate follow-ups currently enter the running turn while foreground delegated work continues, leaving the new message waiting on that work. Interrupt the current foreground tree before admitting the successor.

- Reuse the existing scoped interruption coordinator for Steer and Send now.
- Preserve ordinary steering without active delegation, explicit queueing, automatic queue draining, background tasks, and unrelated conversations.
- Keep the successor fenced until cancellation completes; another Stop cancels the waiting successor.

## Verification
**Verdict: Incomplete** — focused regression checks passed; real-app runtime proof is not yet available.

Passed:
- `pnpm --filter @openwork/app exec bun test --isolate ./tests/opencode-session-native.test.ts` — 29 passed, 0 failed, exit 0.
- `git diff --check`.
- Signed commit; rebased onto freshly fetched `dev`.

Deferred:
- Exact-head real-app journey and published runtime evidence. The existing parent-child question journey hides the composer while the child question is pending; it needs a running-child fixture that permits the immediate follow-up gesture.
- Broader suites and manual UI verification.

Keyboard policy is unchanged: Enter while busy queues; the immediate-send action interrupts foreground delegation.