### PR TITLE
perf(chat): prioritize visible thread history and preserve scroll

### DIFF
--- a/apps/app/src/app/lib/opencode-session-native.ts
+++ b/apps/app/src/app/lib/opencode-session-native.ts
@@ -18,6 +18,7 @@ export type NativeSessionSnapshotTarget = {
 export type NativeSessionOperations = {
   get: (sessionId: string, options?: RequestOptions) => Promise<FieldsResult<Session>>;
   messages: (sessionId: string, limit: number | undefined, options?: RequestOptions) => Promise<FieldsResult<Array<{ info: Message; parts: Part[] }>>>;
+  message?: (sessionId: string, messageId: string, options?: RequestOptions) => Promise<FieldsResult<{ info: Message; parts: Part[] }>>;
   todo: (sessionId: string, options?: RequestOptions) => Promise<FieldsResult<Todo[]>>;
   status: (options?: RequestOptions) => Promise<FieldsResult<Record<string, SessionStatus>>>;
   delete: (sessionId: string, options?: RequestOptions) => Promise<FieldsResult<boolean>>;
@@ -63,6 +64,7 @@ function createNativeOperations(endpoint: NativeSessionEndpoint): NativeSessionO
   return {
     get: (sessionId, options) => client.session.get({ sessionID: sessionId }, options),
     messages: (sessionId, limit, options) => client.session.messages({ sessionID: sessionId, limit }, options),
+    message: (sessionId, messageId, options) => client.session.message({ sessionID: sessionId, messageID: messageId }, options),
     todo: (sessionId, options) => client.session.todo({ sessionID: sessionId }, options),
     status: (options) => client.session.status(undefined, options),
     delete: (sessionId, options) => client.session.delete({ sessionID: sessionId }, options),
@@ -113,18 +115,41 @@ export async function getNativeSessionMessages(
 export async function composeNativeSessionSnapshot(
   endpoint: NativeSessionEndpoint,
   sessionId: string,
-  options?: RequestOptions & { limit?: number },
+  options?: RequestOptions & { limit?: number; messageIds?: readonly string[] },
   dependencies?: NativeSessionDependencies,
 ): Promise<OpenworkSessionSnapshot> {
   const operations = sessionOperations(endpoint, dependencies);
-  const [sessionResult, messagesResult, todoResult, statusResult] = await Promise.all([
+  const readMessages = async () => {
+    if (options?.messageIds === undefined) {
+      return unwrapSessionResult(await operations.messages(sessionId, options?.limit, options), "session_not_found");
+    }
+    // Saved IDs already follow the visible timeline, not lexical ID order.
+    const ids = [...new Set(options.messageIds)].slice(0, 24);
+    const records = await Promise.all(ids.map(async (messageId) => {
+      options.signal?.throwIfAborted();
+      if (!messageId.trim() || messageId === "." || messageId === "..") {
+        throw new Error("Invalid saved session message ID.");
+      }
+      if (!operations.message) throw new Error("Native single-message reads are unavailable.");
+      const result = await operations.message(sessionId, messageId, options);
+      options.signal?.throwIfAborted();
+      if (result.response.status === 404) return [];
+      const record = unwrapSessionResult(result, "message_not_found");
+      if (record.info.id !== messageId || record.info.sessionID !== sessionId
+        || record.parts.some((part) => part.messageID !== messageId || part.sessionID !== sessionId)) {
+        throw new Error("Could not verify the saved session message owner.");
+      }
+      return [record];
+    }));
+    return records.flat();
+  };
+  const [sessionResult, messages, todoResult, statusResult] = await Promise.all([
     operations.get(sessionId, options),
-    operations.messages(sessionId, options?.limit, options),
+    readMessages(),
     operations.todo(sessionId, options),
     operations.status(options),
   ]);
   const session = unwrapSessionResult(sessionResult, "session_not_found");
-  const messages = unwrapSessionResult(messagesResult, "session_not_found");
   const todos = unwrapSessionResult(todoResult, "session_not_found");
   const statuses = unwrapSessionResult(statusResult);
   return { session, messages, todos, status: statuses[sessionId] ?? { type: "idle" } };
@@ -133,7 +158,7 @@ export async function composeNativeSessionSnapshot(
 export async function composeNativeSessionSnapshotWithRetry(
   expectedOwner: string,
   readCurrentTarget: () => NativeSessionSnapshotTarget,
-  options: RequestOptions & { limit?: number },
+  options: RequestOptions & { limit?: number; messageIds?: readonly string[] },
   dependencies?: NativeSessionDependencies,
 ): Promise<OpenworkSessionSnapshot> {
   const signal = options.signal ?? new AbortController().signal;

--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -1814,6 +1814,21 @@ export function createClientV2(
     },
     create: createSession,
     get: getSession,
+    message: async (
+      parameters: SessionParameters & { messageID: string },
+      options?: RequestOptions,
+    ): Promise<FieldsResult<V2MappedMessage>> => {
+      const result = await request(
+        "GET",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/message/${encodeURIComponent(parameters.messageID)}`,
+        undefined,
+        options?.signal,
+      );
+      if (!result.response.ok) return failedResult(result);
+      const mapped = mapV2Message(responseData(result.payload), parameters.sessionID, taskSessions);
+      if (mapped) return successfulResult(result, mapped);
+      return failedResult({ ...result, payload: { name: "InvalidV2MessageResponse" } });
+    },
     messages: async (
       parameters: SessionParameters & { limit?: number; before?: string },
       options?: RequestOptions,

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -53,6 +53,7 @@ import { WebfetchTool } from "@/components/tools/webfetch"
 import { WebsearchTool } from "@/components/tools/websearch"
 import { useMessageList, useSessionErrorMessage } from "@/components/chat/message-list-provider"
 import { TaskSuggestions } from "@/components/chat/task-suggestions"
+import { ProgressiveMessageList, type MessageListViewport } from "@/components/chat/progressive-message-list"
 import {
   DescriptiveButtonContent,
   DescriptiveButtonDescription,
@@ -1449,6 +1450,7 @@ interface MessageListProps {
   activityStatus: SessionActivityStatus
   retryStatus?: RetryStatus | null
   syncHealth?: RunSyncHealth
+  viewport?: MessageListViewport
 }
 
 export function shouldShowMessageListLoading(
@@ -1465,7 +1467,7 @@ export function shouldShowRunReconnecting(status: ThreadStatus, syncDegraded: bo
   return status === "submitted" || status === "streaming" || status === "retrying"
 }
 
-export function MessageList({ messages, status, activityStatus, retryStatus, syncHealth }: MessageListProps) {
+export function MessageList({ messages, status, activityStatus, retryStatus, syncHealth, viewport }: MessageListProps) {
   const { workspaceId, sessionId } = useMessageList()
   const workspace = useWorkspaceMaybe()
   const tasks = React.useMemo(() => activeDelegatedTasks(messages), [messages])
@@ -1553,10 +1555,14 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
       activityStatus={activityStatus}
       currentToolCallIds={currentToolCallIds}
     >
-      <div className={cn("flex flex-col gap-2 @container/message-list")}>
-        {messages.length === 0 && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
-
-        {items.map((item) => {
+      <ProgressiveMessageList
+        groups={items}
+        viewport={viewport}
+        className="@container/message-list"
+        getGroupKey={(item) => isMessageGroup(item) ? item.messages[0]?.message.id ?? "empty-assistant-group" : item.message.id}
+        getMessageIds={(item) => isMessageGroup(item) ? item.messages.flatMap(({ message }) => [message.id, `${message.id}:steps`]) : [item.message.id]}
+        header={messages.length === 0 && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
+        renderGroup={(item) => {
         if (isMessageGroup(item)) {
           return (
             <MemoizedMessageGroup
@@ -1581,13 +1587,13 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
             isLastStep={isLastStep}
           />
         )
-        })}
-
+        }}
+      >
         {showLoading && <LoadingMessage elapsedSeconds={runElapsedSeconds} />}
         {showReconnecting && <ReconnectingMessage lastConfirmedAt={syncHealth?.lastConfirmedAt ?? null} />}
         {retryStatus ? <RetryMessage status={retryStatus} /> : null}
         {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
-      </div>
+      </ProgressiveMessageList>
     </CurrentToolLifecycleProvider>
     </ParentRunActiveContext.Provider>
   )

--- a/apps/app/src/components/chat/progressive-message-list.tsx
+++ b/apps/app/src/components/chat/progressive-message-list.tsx
@@ -1,0 +1,381 @@
+import * as React from "react"
+
+export interface MessageListViewport {
+  sessionKey: string
+  scrollRef: React.RefObject<HTMLDivElement | null>
+  anchorMessageId?: string
+  scrollTop?: number
+  scrollHeight?: number
+  viewportWidth?: number
+  leadingHeight?: number
+  trailingHeight?: number
+  historyComplete: boolean
+  revealAll?: boolean
+  stickyBottom: () => boolean
+  /** Called after initial/structural commits, not after ordinary content reflow. */
+  onReady?: () => void
+}
+
+interface ProgressiveMessageListProps<T> {
+  groups: readonly T[]
+  getGroupKey: (group: T) => string
+  getMessageIds: (group: T) => readonly string[]
+  renderGroup: (group: T, index: number) => React.ReactNode
+  viewport?: MessageListViewport
+  className?: string
+  header?: React.ReactNode
+  children?: React.ReactNode
+}
+
+const BATCH_SIZE = 8
+const GROUP_GAP = 8
+const ESTIMATED_HEIGHT = 240
+const MAX_CACHED_VIEWPORTS = 12
+const MAX_CACHED_GROUPS = 2048
+// Only IDs and geometry, scoped by session and width. Nothing is persisted.
+const heightCache = new Map<string, Map<string, number>>()
+
+type MountState = {
+  mounted: ReadonlySet<string>
+  initialized: boolean
+  anchorPending: boolean
+  width: number
+}
+
+type Segment = { key: string; start: number; end: number; height: number; placeholder: boolean }
+type Plan = { keys: string[]; heights: number[]; segments: Segment[]; complete: boolean }
+type ReadingPosition = {
+  element: HTMLElement | null
+  messageId?: string
+  key: string | undefined
+  offset: number
+  fraction: number
+  sticky: boolean
+}
+
+function addNearby(keys: readonly string[], mounted: ReadonlySet<string>, center: number) {
+  const next = new Set(mounted)
+  let added = 0
+  for (let distance = 0; distance < keys.length && added < BATCH_SIZE; distance++) {
+    for (const index of distance === 0 ? [center] : [center - distance, center + distance]) {
+      const key = keys[index]
+      if (key !== undefined && !next.has(key)) {
+        next.add(key)
+        if (++added === BATCH_SIZE) break
+      }
+    }
+  }
+  return next
+}
+
+function sameStructure(a: Plan, b: Plan) {
+  return a.segments.length === b.segments.length
+    && a.segments.every((segment, index) => {
+      const other = b.segments[index]
+      return segment.key === other.key && (!segment.placeholder || segment.height === other.height)
+    })
+}
+
+/** Whole groups mount once, then stay mounted. The key cancels work on a session switch. */
+export function ProgressiveMessageList<T>(props: ProgressiveMessageListProps<T>) {
+  return <ProgressiveGroups key={props.viewport?.sessionKey ?? "eager"} {...props} />
+}
+
+// getSnapshotBeforeUpdate reads the actual pre-mutation DOM, including any scroll
+// since a batch was queued. An effect's previous-commit anchor would snap readers back.
+class ProgressiveGroups<T> extends React.Component<ProgressiveMessageListProps<T>, MountState> {
+  state: MountState = {
+    mounted: new Set(),
+    initialized: false,
+    anchorPending: Boolean(this.props.viewport?.anchorMessageId),
+    width: this.props.viewport?.viewportWidth ?? 0,
+  }
+
+  static getDerivedStateFromProps<T>(props: ProgressiveMessageListProps<T>, state: MountState): MountState | null {
+    const keys = props.groups.map(props.getGroupKey)
+    if (!keys.length) return null
+    const anchorMessageId = props.viewport?.anchorMessageId
+    const anchorIndex = anchorMessageId
+      ? props.groups.findIndex((group) => props.getMessageIds(group).includes(anchorMessageId))
+      : -1
+    let mounted = state.mounted
+    const last = keys[keys.length - 1]
+    if (!props.viewport || props.viewport.revealAll) {
+      if (keys.every((key) => mounted.has(key))) return null
+      mounted = new Set(keys)
+    } else if (!state.initialized || (anchorIndex >= 0 && (state.anchorPending || !mounted.has(keys[anchorIndex])))) {
+      // Include the live tail without allowing the first mount to exceed eight groups.
+      const estimatedIndex = props.viewport.scrollTop !== undefined && props.viewport.scrollHeight
+        ? Math.min(keys.length - 1, Math.floor(keys.length * props.viewport.scrollTop / props.viewport.scrollHeight)) : keys.length - 1
+      const nearby = addNearby(keys, mounted, anchorIndex >= 0 ? anchorIndex : estimatedIndex)
+      if (!nearby.has(last)) {
+        const furthest = [...nearby].at(-1)
+        if (furthest && !mounted.has(furthest)) nearby.delete(furthest)
+        nearby.add(last)
+      }
+      mounted = nearby
+    } else if (!mounted.has(last)) {
+      mounted = new Set([...mounted, last])
+    } else return null
+    return { ...state, mounted, initialized: true, anchorPending: state.anchorPending && anchorIndex < 0 && !props.viewport?.historyComplete }
+  }
+
+  private nodes = new Map<string, HTMLDivElement>()
+  private plan: Plan = { keys: [], heights: [], segments: [], complete: false }
+  private committed = this.plan
+  private container: HTMLDivElement | null = null
+  private observer: ResizeObserver | null = null
+  private frame: number | null = null
+  private active = false
+  private estimates = new Map<string, number>()
+  private estimateScope = ""
+
+  private cacheKey(width = this.state.width) {
+    return JSON.stringify([this.props.viewport?.sessionKey, width])
+  }
+
+  private measure = (node: HTMLElement) => {
+    const key = node.getAttribute("data-thread-group")
+    const height = node.getBoundingClientRect().height
+    const width = this.container?.clientWidth || this.state.width
+    if (key === null || height <= 0 || !this.props.viewport || width <= 0) return
+    const cacheKey = this.cacheKey(width)
+    const cache = heightCache.get(cacheKey) ?? new Map<string, number>()
+    heightCache.delete(cacheKey)
+    heightCache.set(cacheKey, cache)
+    cache.delete(key)
+    cache.set(key, height)
+    if (cache.size > MAX_CACHED_GROUPS) {
+      const oldest = cache.keys().next().value
+      if (oldest !== undefined) cache.delete(oldest)
+    }
+    if (heightCache.size > MAX_CACHED_VIEWPORTS) {
+      const oldest = heightCache.keys().next().value
+      if (oldest !== undefined) heightCache.delete(oldest)
+    }
+  }
+
+  private trackNode = (node: HTMLDivElement | null) => {
+    if (!node) return
+    const group = node.getAttribute("data-thread-group")
+    const key = group === null ? node.getAttribute("data-thread-placeholder") : `group:${group}`
+    if (key === null) return
+    this.nodes.set(key, node)
+    if (group !== null && this.observer) {
+      this.observer.observe(node)
+      this.measure(node)
+    }
+    return () => {
+      this.observer?.unobserve(node)
+      this.nodes.delete(key)
+    }
+  }
+
+  private connectViewport() {
+    const container = this.props.viewport?.scrollRef.current
+    if (!container || this.container === container) return
+    this.container?.removeEventListener("scroll", this.handleScroll)
+    this.observer?.disconnect()
+    this.container = container
+    container.addEventListener("scroll", this.handleScroll, { passive: true })
+    this.observer = new ResizeObserver((entries) => {
+      if (!this.active) return
+      const width = container.clientWidth
+      if (width > 0 && width !== this.state.width) {
+        this.setState({ width })
+        return
+      }
+      // Native browser anchoring owns image/markdown reflow. Only remember sizes.
+      for (const entry of entries) if (entry.target instanceof HTMLElement) this.measure(entry.target)
+    })
+    this.observer.observe(container)
+    for (const node of this.nodes.values()) {
+      if (node.hasAttribute("data-thread-group")) this.observer.observe(node)
+    }
+    if (container.clientWidth > 0 && container.clientWidth !== this.state.width) this.setState({ width: container.clientWidth })
+  }
+
+  private position(plan: Plan, index: number) {
+    const segment = plan.segments.find((part) => part.start <= index && part.end > index)
+    if (!segment) return null
+    const node = this.nodes.get(segment.key)
+    if (!node) return null
+    let top = node.getBoundingClientRect().top
+    if (segment.placeholder) {
+      for (let i = segment.start; i < index; i++) top += plan.heights[i] + GROUP_GAP
+    }
+    return { top, height: segment.placeholder ? plan.heights[index] : node.getBoundingClientRect().height }
+  }
+
+  private visibleIndex(plan: Plan) {
+    const top = this.container?.getBoundingClientRect().top ?? 0
+    for (const segment of plan.segments) {
+      const node = this.nodes.get(segment.key)
+      if (!node || segment.end <= segment.start) continue
+      const rect = node.getBoundingClientRect()
+      if (rect.bottom <= top) continue
+      let offset = rect.top
+      for (let i = segment.start; i < segment.end; i++) {
+        if (!segment.placeholder || offset + plan.heights[i] + GROUP_GAP > top) return i
+        offset += plan.heights[i] + GROUP_GAP
+      }
+    }
+    return Math.max(0, plan.keys.length - 1)
+  }
+
+  private handleScroll = () => {
+    if (!this.active || this.committed.complete) return
+    const index = this.visibleIndex(this.committed)
+    // Jumping into a spacer should not wait behind the history queue.
+    const nearby = this.committed.keys.slice(Math.max(0, index - 1), index + BATCH_SIZE - 1)
+    if (nearby.some((key) => !this.state.mounted.has(key))) {
+      this.setState((state) => ({ mounted: new Set([...state.mounted, ...nearby]) }))
+    }
+  }
+
+  private schedule() {
+    const pending = this.committed.keys.some((key) => !this.state.mounted.has(key))
+    if (!pending && this.frame !== null) {
+      window.cancelAnimationFrame(this.frame)
+      this.frame = null
+    }
+    if (!this.active || this.frame !== null || !this.props.viewport) return
+    if (!pending && this.container) return
+    // Two frames guarantee a paint opportunity between expensive group batches.
+    this.frame = window.requestAnimationFrame(() => {
+      this.frame = window.requestAnimationFrame(() => {
+        this.frame = null
+        if (!this.active) return
+        this.connectViewport()
+        const { keys } = this.committed
+        const index = this.visibleIndex(this.committed)
+        this.setState((state) => {
+          const next = addNearby(keys, state.mounted, index)
+          return next.size !== state.mounted.size ? { mounted: next } : null
+        })
+      })
+    })
+  }
+
+  componentDidMount() {
+    this.active = true
+    this.committed = this.plan
+    this.connectViewport()
+    for (const node of this.nodes.values()) this.measure(node)
+    this.props.viewport?.onReady?.()
+    this.schedule()
+  }
+
+  getSnapshotBeforeUpdate(): ReadingPosition | null {
+    const container = this.container
+    if (!container || sameStructure(this.committed, this.plan)) return null
+    const viewport = container.getBoundingClientRect()
+    const sticky = Boolean(this.props.viewport?.stickyBottom())
+      && container.scrollHeight - container.scrollTop - container.clientHeight <= 1
+    for (const node of this.nodes.values()) {
+      if (!node.hasAttribute("data-thread-group")) continue
+      const rect = node.getBoundingClientRect()
+      if (rect.height <= 0 || rect.bottom <= viewport.top || rect.top >= viewport.bottom) continue
+      const element = [...node.querySelectorAll<HTMLElement>("[data-message-id]")].find((message) => {
+        const bounds = message.getBoundingClientRect()
+        return bounds.height > 0 && bounds.bottom > viewport.top && bounds.top < viewport.bottom
+      }) ?? node
+      return { element, messageId: element.getAttribute("data-message-id") ?? undefined, key: node.getAttribute("data-thread-group") ?? undefined,
+        offset: element.getBoundingClientRect().top - viewport.top, fraction: 0, sticky }
+    }
+    const index = this.visibleIndex(this.committed)
+    const position = this.position(this.committed, index)
+    return { element: null, key: this.committed.keys[index], offset: (position?.top ?? viewport.top) - viewport.top,
+      fraction: position && position.height > 0 ? Math.max(0, (viewport.top - position.top) / position.height) : 0, sticky }
+  }
+
+  componentDidUpdate(_props: ProgressiveMessageListProps<T>, _state: MountState, snapshot: ReadingPosition | null) {
+    const changed = !sameStructure(this.committed, this.plan) || this.committed.complete !== this.plan.complete
+    this.committed = this.plan
+    this.connectViewport()
+    const container = this.container
+    if (container && snapshot) {
+      const element = snapshot.element?.isConnected ? snapshot.element
+        : snapshot.messageId ? [...container.querySelectorAll<HTMLElement>("[data-message-id]")]
+          .find((message) => message.getAttribute("data-message-id") === snapshot.messageId) : null
+      if (snapshot.sticky && this.props.viewport?.stickyBottom()) {
+        container.scrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
+      } else if (element) {
+        const delta = element.getBoundingClientRect().top - container.getBoundingClientRect().top - snapshot.offset
+        if (Math.abs(delta) > 0.5) container.scrollTop += delta
+      } else if (snapshot.key) {
+        const position = this.position(this.plan, this.plan.keys.indexOf(snapshot.key))
+        if (position) {
+          const offset = snapshot.fraction > 0 ? -snapshot.fraction * position.height : snapshot.offset
+          const delta = position.top - container.getBoundingClientRect().top - offset
+          if (Math.abs(delta) > 0.5) container.scrollTop += delta
+        }
+      }
+    }
+    if (changed) this.props.viewport?.onReady?.()
+    this.schedule()
+  }
+
+  componentWillUnmount() {
+    this.active = false
+    if (this.frame !== null) window.cancelAnimationFrame(this.frame)
+    this.frame = null
+    this.container?.removeEventListener("scroll", this.handleScroll)
+    this.container = null
+    this.observer?.disconnect()
+    this.observer = null
+  }
+
+  render() {
+    const { groups, getGroupKey, renderGroup, viewport, header, children, className } = this.props
+    const keys = groups.map(getGroupKey)
+    const cache = heightCache.get(this.cacheKey())
+    const estimateScope = JSON.stringify([this.state.width, viewport?.historyComplete])
+    if (estimateScope !== this.estimateScope) {
+      this.estimateScope = estimateScope
+      this.estimates = new Map()
+    }
+    const known = keys.reduce((sum, key) => sum + (this.estimates.get(key) ?? cache?.get(key) ?? 0), 0)
+    const unknown = keys.filter((key) => !this.estimates.has(key) && !cache?.has(key)).length
+    const estimate = viewport?.historyComplete && viewport.scrollHeight && unknown > 0
+      ? Math.max(32, (viewport.scrollHeight - known - GROUP_GAP * Math.max(0, keys.length - 1)) / unknown)
+      : ESTIMATED_HEIGHT
+    // Freeze skipped geometry for this data/width scope. Learning a mounted
+    // group's size must not redistribute every other spacer during live reflow.
+    const heights = keys.map((key) => {
+      const height = this.estimates.get(key) ?? cache?.get(key) ?? estimate
+      this.estimates.set(key, height)
+      return height
+    })
+    const segments: Segment[] = []
+    const reserved = viewport && !viewport.historyComplete
+      ? Math.max(0, (viewport.scrollHeight ?? 0) - heights.reduce((sum, height) => sum + height + GROUP_GAP, 0)) : 0
+    const leading = !viewport?.historyComplete ? viewport?.leadingHeight ?? reserved : 0
+    const trailing = !viewport?.historyComplete ? viewport?.trailingHeight ?? 0 : 0
+    if (leading > 0) segments.push({ key: "history-prefix", start: 0, end: 0, height: leading, placeholder: true })
+    for (let index = 0; index < keys.length; index++) {
+      const key = keys[index]
+      if (this.state.mounted.has(key)) {
+        segments.push({ key: `group:${key}`, start: index, end: index + 1, height: heights[index], placeholder: false })
+      } else {
+        const previous = segments.at(-1)
+        if (previous?.placeholder && previous.end > previous.start) {
+          previous.end = index + 1
+          previous.height += heights[index] + GROUP_GAP
+        } else segments.push({ key: `placeholder:${key}`, start: index, end: index + 1, height: heights[index], placeholder: true })
+      }
+    }
+    if (trailing > 0) segments.push({ key: "history-suffix", start: keys.length, end: keys.length, height: trailing, placeholder: true })
+    this.plan = { keys, heights, segments, complete: (viewport?.historyComplete ?? true) && segments.every((segment) => !segment.placeholder) }
+    return <div className={`flex flex-col gap-2 ${className ?? ""}`} data-thread-history-complete={this.plan.complete}>
+      {header}
+      {segments.map((segment) => segment.placeholder
+        ? <div key={segment.key} ref={this.trackNode} data-thread-placeholder={segment.key} aria-hidden="true"
+            style={{ height: segment.height, flexShrink: 0, overflowAnchor: "none" }} />
+        : <div key={segment.key} ref={this.trackNode} data-thread-group={keys[segment.start]} className="min-w-0 shrink-0 empty:hidden">
+            {renderGroup(groups[segment.start], segment.start)}
+          </div>)}
+      {children}
+    </div>
+  }
+}

--- a/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
@@ -7,6 +7,7 @@ const SCROLL_GESTURE_WINDOW_MS = 600;
 
 type SessionScrollControllerOptions = {
   selectedSessionId: string | null;
+  geometryOwner?: string;
   submittedMessageId: string | null;
   historyReady: boolean;
   renderedMessages: unknown;
@@ -64,7 +65,7 @@ type ScrollController = {
 };
 
 export function useSessionScrollController(options: SessionScrollControllerOptions) {
-  const { selectedSessionId, containerRef, contentRef } = options;
+  const { selectedSessionId, geometryOwner, containerRef, contentRef } = options;
   const controllerRef = useRef<ScrollController | null>(null);
   // Consumed (including cancelled) submissions survive session effect recreation.
   const submittedMessagesRef = useRef(new Set<string>());
@@ -77,7 +78,10 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
     if (!container || !content) return;
 
     const store = useSessionScrollStore.getState();
-    const readState = () => getSessionScrollState(useSessionScrollStore.getState().sessions, selectedSessionId);
+    const readState = () => {
+      const state = getSessionScrollState(useSessionScrollStore.getState().sessions, selectedSessionId);
+      return geometryOwner && state.geometry && state.geometry.owner !== geometryOwner ? getSessionScrollState({}, null) : state;
+    };
     let active = true;
     let historyReady = false;
     let pendingRestore = true;
@@ -101,6 +105,30 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
     const cancelFrames = () => {
       for (const id of frames) window.cancelAnimationFrame(id);
       frames.clear();
+    };
+    const rememberGeometry = () => {
+      if (!geometryOwner || !selectedSessionId || !historyReady || pendingRestore || cancelledWhileLoading
+        || container.clientWidth <= 0 || container.clientHeight <= 0
+        || !content.querySelector('[data-thread-history-complete="true"]')) return;
+      const viewport = container.getBoundingClientRect();
+      const messages = [...container.querySelectorAll<HTMLElement>("[data-message-id]")];
+      const firstVisible = messages.findIndex((message) => {
+        const rect = message.getBoundingClientRect();
+        return rect.height > 0 && rect.bottom > viewport.top && rect.top < viewport.bottom;
+      });
+      if (firstVisible < 0) return;
+      const nearby = messages.slice(Math.max(0, firstVisible - 4), firstVisible + 20);
+      const first = nearby[0];
+      const last = nearby.at(-1);
+      if (!first || !last) return;
+      store.setGeometry(selectedSessionId, {
+        owner: geometryOwner,
+        scrollHeight: container.scrollHeight,
+        viewportWidth: container.clientWidth,
+        before: Math.max(0, container.scrollTop + first.getBoundingClientRect().top - viewport.top),
+        after: Math.max(0, container.scrollHeight - container.scrollTop - last.getBoundingClientRect().bottom + viewport.top),
+        messageIds: nearby.flatMap((message) => { const id = messageIdForElement(message); return id ? [id] : []; }),
+      });
     };
     const refreshTopClippedMessage = () => {
       if (active && historyReady) store.setTopClippedMessageId(selectedSessionId, latestMessageTopClippedId(container));
@@ -152,14 +180,24 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
         else store.setManualScroll(selectedSessionId, container.scrollTop, clipped, readingAnchor(container));
         return;
       }
-      if (!historyReady) return;
+      if (!historyReady) {
+        // Reserve the last known extent while Suspense owns the transcript,
+        // without overwriting the real reading position with a loading clamp.
+        const saved = readState();
+        if (pendingRestore && saved.geometry && saved.geometry.owner === geometryOwner && content.querySelector("[data-thread-loading]")) {
+          container.scrollTop = saved.mode === "manual" ? saved.scrollTop : container.scrollHeight;
+          lastKnownScrollTop = container.scrollTop;
+        }
+        return;
+      }
       const saved = readState();
       if (pendingRestore) {
-        pendingRestore = false;
         if (saved.mode === "manual") {
-          // A bounded snapshot may not contain the old message. Fall back once,
-          // without persisting a clamped position or silently becoming sticky.
           const top = saved.anchor ? anchorTop(saved.anchor) : null;
+          // A live tail/partial preview is not proof the old anchor is gone.
+          const partial = content.querySelector('[data-thread-history-complete="false"]');
+          if (partial && (top === null || top < 0 || top > container.scrollHeight - container.clientHeight + EXACT_BOTTOM_GAP_PX)) return;
+          pendingRestore = false;
           container.scrollTop = top ?? saved.scrollTop;
           lastKnownScrollTop = container.scrollTop;
         } else {
@@ -171,6 +209,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
         }
       }
       refreshTopClippedMessage();
+      rememberGeometry();
     };
     const markScrollGesture = (target?: EventTarget | null) => {
       if (!active) return;
@@ -223,6 +262,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
         refreshTopClippedMessage();
       }
       lastKnownScrollTop = container.scrollTop;
+      rememberGeometry();
     };
     const jumpToStartOfMessage = (behavior: ScrollBehavior = "smooth") => {
       if (!active) return;
@@ -322,7 +362,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       controllerRef.current = null;
       flushSessionScrollState();
     };
-  }, [selectedSessionId, containerRef, contentRef]);
+  }, [selectedSessionId, geometryOwner, containerRef, contentRef]);
 
   useLayoutEffect(() => {
     controllerRef.current?.update(options.historyReady, options.submittedMessageId);
@@ -342,5 +382,11 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
     if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.jumpToStartOfMessage(behavior);
   }, [selectedSessionId]);
 
-  return { handleScroll, markScrollGesture, scrollToBottom, jumpToLatest, jumpToStartOfMessage };
+  const refresh = useCallback(() => {
+    if (controllerRef.current?.sessionId === selectedSessionId) {
+      controllerRef.current.update(options.historyReady, options.submittedMessageId);
+    }
+  }, [selectedSessionId, options.historyReady, options.submittedMessageId]);
+
+  return { handleScroll, markScrollGesture, scrollToBottom, jumpToLatest, jumpToStartOfMessage, refresh };
 }

--- a/apps/app/src/react-app/domains/session/surface/scroll-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-store.ts
@@ -5,9 +5,20 @@ const PERSIST_DELAY_MS = 250;
 
 export type SessionScrollAnchor = { messageId: string; offset: number };
 
+// Geometry and nearby IDs only: never persist transcript text or tool results.
+export type SessionScrollGeometry = {
+  owner: string;
+  scrollHeight: number;
+  viewportWidth: number;
+  before: number;
+  after: number;
+  messageIds: string[];
+};
+
 type StickyBottomSessionScrollState = {
   mode: "stickyBottom";
   topClippedMessageId: string | null;
+  geometry?: SessionScrollGeometry;
 };
 
 type ManualSessionScrollState = {
@@ -15,6 +26,7 @@ type ManualSessionScrollState = {
   scrollTop: number;
   anchor?: SessionScrollAnchor;
   topClippedMessageId: string | null;
+  geometry?: SessionScrollGeometry;
 };
 
 export type SessionScrollState = StickyBottomSessionScrollState | ManualSessionScrollState;
@@ -38,8 +50,9 @@ function normalizeSessionScrollState(value: unknown): SessionScrollState | null 
   if (!isRecord(value)) return null;
 
   const topClippedMessageId = normalizeTopClippedMessageId(value.topClippedMessageId);
+  const geometry = normalizeGeometry(value.geometry);
   if (value.mode === "stickyBottom") {
-    return { mode: "stickyBottom", topClippedMessageId };
+    return { mode: "stickyBottom", topClippedMessageId, ...(geometry ? { geometry } : {}) };
   }
 
   if (value.mode !== "manual" || typeof value.scrollTop !== "number" || !Number.isFinite(value.scrollTop)) {
@@ -54,7 +67,20 @@ function normalizeSessionScrollState(value: unknown): SessionScrollState | null 
       ? { anchor: { messageId: value.anchor.messageId, offset: value.anchor.offset } }
       : {}),
     topClippedMessageId,
+    ...(geometry ? { geometry } : {}),
   };
+}
+
+function normalizeGeometry(value: unknown): SessionScrollGeometry | undefined {
+  if (!isRecord(value) || typeof value.owner !== "string" || !value.owner || value.owner.length > 1024) return;
+  const { scrollHeight, viewportWidth, before, after, messageIds } = value;
+  if (typeof scrollHeight !== "number" || !Number.isFinite(scrollHeight) || scrollHeight <= 0 || scrollHeight > 30_000_000
+    || typeof viewportWidth !== "number" || !Number.isFinite(viewportWidth) || viewportWidth <= 0 || viewportWidth > 30_000
+    || typeof before !== "number" || !Number.isFinite(before) || before < 0 || before > scrollHeight
+    || typeof after !== "number" || !Number.isFinite(after) || after < 0 || after > scrollHeight
+    || !Array.isArray(messageIds)) return;
+  const ids = messageIds.filter((id): id is string => typeof id === "string" && id.length > 0 && id.length < 256).slice(0, 24);
+  return { owner: value.owner, scrollHeight, viewportWidth, before, after, messageIds: [...new Set(ids)] };
 }
 
 function readPersistedSessionScrollState(): SessionScrollStateById {
@@ -85,8 +111,8 @@ function persistSessionScrollState(sessions: SessionScrollStateById): void {
     // Clipped-message controls are presentation state, not a reading position.
     const positions = Object.fromEntries(Object.entries(sessions).map(([id, state]) => [id,
       state.mode === "manual"
-        ? { mode: state.mode, scrollTop: state.scrollTop, anchor: state.anchor }
-        : { mode: state.mode },
+        ? { mode: state.mode, scrollTop: state.scrollTop, anchor: state.anchor, geometry: state.geometry }
+        : { mode: state.mode, geometry: state.geometry },
     ]));
     window.localStorage.setItem(SESSION_SCROLL_STORAGE_KEY, JSON.stringify(positions));
   } catch {
@@ -130,7 +156,7 @@ function setSessionStickyBottom(
 
   return {
     ...sessions,
-    [sessionId]: { mode: "stickyBottom", topClippedMessageId },
+    [sessionId]: { mode: "stickyBottom", topClippedMessageId, ...(current.geometry ? { geometry: current.geometry } : {}) },
   };
 }
 
@@ -157,7 +183,7 @@ function setSessionManualScroll(
 
   return {
     ...sessions,
-    [sessionId]: { mode: "manual", scrollTop: nextScrollTop, topClippedMessageId, anchor },
+    [sessionId]: { mode: "manual", scrollTop: nextScrollTop, topClippedMessageId, anchor, ...(current.geometry ? { geometry: current.geometry } : {}) },
   };
 }
 
@@ -182,10 +208,26 @@ type SessionScrollStore = {
   setStickyBottom: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
   setManualScroll: (sessionId: string | null | undefined, scrollTop: number, topClippedMessageId: string | null, anchor?: SessionScrollAnchor) => void;
   setTopClippedMessageId: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
+  setGeometry: (sessionId: string, geometry: SessionScrollGeometry) => void;
 };
 
 export const useSessionScrollStore = create<SessionScrollStore>((set) => ({
   sessions: readPersistedSessionScrollState(),
+  setGeometry: (sessionId, geometry) => set((state) => {
+    const next = normalizeGeometry(geometry);
+    const current = getSessionScrollState(state.sessions, sessionId);
+    if (!next || JSON.stringify(current.geometry) === JSON.stringify(next)) return state;
+    const updated = { ...current, geometry: next };
+    schedulePersistence(current, updated);
+    const sessions = { ...state.sessions, [sessionId]: updated };
+    // Keep positions indefinitely, but bound the heavier geometry hints.
+    const older = Object.keys(sessions).filter((id) => id !== sessionId && sessions[id].geometry);
+    for (const id of older.slice(0, Math.max(0, older.length - 63))) {
+      const { geometry: _geometry, ...position } = sessions[id];
+      sessions[id] = position;
+    }
+    return { sessions };
+  }),
   setStickyBottom: (sessionId, topClippedMessageId) => set((state) => {
     const sessions = setSessionStickyBottom(state.sessions, sessionId, topClippedMessageId);
     schedulePersistence(getSessionScrollState(state.sessions, sessionId), getSessionScrollState(sessions, sessionId));
@@ -212,7 +254,7 @@ export function flushSessionScrollState() {
 }
 
 function schedulePersistence(before: SessionScrollState, next: SessionScrollState) {
-  const changed = before.mode !== next.mode || (next.mode === "manual" && before.mode === "manual" && (
+  const changed = before.geometry !== next.geometry || before.mode !== next.mode || (next.mode === "manual" && before.mode === "manual" && (
     next.scrollTop !== before.scrollTop || next.anchor?.messageId !== before.anchor?.messageId
     || next.anchor?.offset !== before.anchor?.offset
   ));

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { queryOptions, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { LoaderCircle } from "lucide-react";
 import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
@@ -53,6 +53,11 @@ export function useOpeningSessionHistory(input: {
     networkMode: "always",
   });
   const query = useQuery({ ...options, enabled: !hasFullSnapshot });
+  const ensureFullSnapshot = useCallback(() => client.ensureQueryData({
+    queryKey: input.snapshotQueryKey,
+    queryFn: ({ signal }) => input.readSnapshot(signal),
+    networkMode: "always",
+  }), [client, input.snapshotQueryKey, input.readSnapshot]);
   const [backgroundOwner, setBackgroundOwner] = useState<string | null>(null);
   useEffect(() => {
     if (!query.isSuccess || hasFullSnapshot) return;
@@ -71,6 +76,7 @@ export function useOpeningSessionHistory(input: {
     options,
     snapshot: hasFullSnapshot ? null : query.data?.snapshot ?? null,
     backgroundReady: hasFullSnapshot || backgroundOwner === input.owner,
+    ensureFullSnapshot,
   };
 }
 

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -1,0 +1,105 @@
+import { Suspense, useEffect, useMemo, useState, type ReactNode } from "react";
+import { queryOptions, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { LoaderCircle } from "lucide-react";
+import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
+import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types";
+import { getSessionScrollState, useSessionScrollStore, type SessionScrollState } from "./scroll-store";
+
+export type OpeningHistoryWindow = { limit?: number; messageIds?: readonly string[] };
+
+export function openingHistoryWindow(saved: SessionScrollState): OpeningHistoryWindow {
+  if (saved.mode !== "manual" || !saved.anchor) return { limit: 24 };
+  const nearby = saved.geometry?.messageIds ?? [];
+  // Old saved positions may have an anchor but predate nearby-ID persistence.
+  const ids = nearby.includes(saved.anchor.messageId) ? nearby : [saved.anchor.messageId];
+  // Rendering splits a native assistant turn into a steps row and can append a
+  // synthetic error row. Keep those DOM IDs for restoration, not native reads.
+  const nativeIds = ids.map((id) => {
+    const messageId = id.endsWith(":steps") ? id.slice(0, -":steps".length) : id;
+    return messageId.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX)
+      ? messageId.slice(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX.length) : messageId;
+  }).filter(Boolean);
+  return { messageIds: [...new Set(nativeIds)].slice(0, 24) };
+}
+
+export function useOpeningSessionHistory(input: {
+  owner: string;
+  sessionId: string;
+  snapshotQueryKey: readonly unknown[];
+  readSnapshot: (signal: AbortSignal, window?: OpeningHistoryWindow) => Promise<OpenworkSessionSnapshot>;
+}) {
+  const client = useQueryClient();
+  const saved = useMemo(() => {
+    const state = getSessionScrollState(useSessionScrollStore.getState().sessions, input.sessionId);
+    return state.geometry && state.geometry.owner !== input.owner
+      ? getSessionScrollState({}, null) : state;
+  }, [input.owner, input.sessionId]);
+  const hasFullSnapshot = client.getQueryData<OpenworkSessionSnapshot>(input.snapshotQueryKey)?.session.id === input.sessionId;
+  const options = queryOptions({
+    queryKey: ["react-session-opening", input.owner],
+    queryFn: async ({ signal }): Promise<{ snapshot: OpenworkSessionSnapshot | null }> => {
+      try {
+        return { snapshot: await input.readSnapshot(signal, openingHistoryWindow(saved)) };
+      } catch {
+        signal.throwIfAborted();
+        // A preview is optional (e.g. a deleted anchor or an older server).
+        // The uncapped authoritative query owns errors and the retry UI.
+        return { snapshot: null };
+      }
+    },
+    staleTime: Infinity,
+    gcTime: 15_000,
+    retry: false,
+    networkMode: "always",
+  });
+  const query = useQuery({ ...options, enabled: !hasFullSnapshot });
+  const [backgroundOwner, setBackgroundOwner] = useState<string | null>(null);
+  useEffect(() => {
+    if (!query.isSuccess || hasFullSnapshot) return;
+    // Let the relevant messages paint before full-history JSON/React work starts.
+    let second: number | undefined;
+    const first = window.requestAnimationFrame(() => {
+      second = window.requestAnimationFrame(() => setBackgroundOwner(input.owner));
+    });
+    return () => {
+      window.cancelAnimationFrame(first);
+      if (second !== undefined) window.cancelAnimationFrame(second);
+    };
+  }, [input.owner, query.isSuccess, hasFullSnapshot]);
+  return {
+    saved,
+    options,
+    snapshot: hasFullSnapshot ? null : query.data?.snapshot ?? null,
+    backgroundReady: hasFullSnapshot || backgroundOwner === input.owner,
+  };
+}
+
+type OpeningOptions = ReturnType<typeof useOpeningSessionHistory>["options"];
+
+function AwaitOpeningHistory({ options, saved }: { options: OpeningOptions; saved: SessionScrollState }) {
+  useSuspenseQuery(options);
+  return <SessionHistoryLoading saved={saved} />;
+}
+
+export function SessionHistoryLoading({ saved }: { saved: SessionScrollState }) {
+  const height = Math.max(200, (saved.geometry?.scrollHeight ?? 232) - 32);
+  const top = saved.mode === "manual" ? Math.min(saved.scrollTop + 64, height - 120) : Math.max(64, height - 200);
+  return <div data-thread-loading role="status" aria-live="polite" aria-label="Loading conversation" style={{ minHeight: height }}>
+    <div className="flex items-center justify-center gap-2 text-sm text-dls-secondary" style={{ paddingTop: Math.max(32, top) }}>
+      <LoaderCircle aria-hidden="true" className="size-4 motion-safe:animate-spin" />
+      <span>{saved.mode === "manual" ? "Returning to your reading position…" : "Loading latest messages…"}</span>
+    </div>
+  </div>;
+}
+
+export function SessionHistoryBoundary({ owner, pending, options, saved, children }: {
+  owner: string;
+  pending: boolean;
+  options: OpeningOptions;
+  saved: SessionScrollState;
+  children: ReactNode;
+}) {
+  return <Suspense key={owner} fallback={<SessionHistoryLoading saved={saved} />}>
+    {pending ? <AwaitOpeningHistory options={options} saved={saved} /> : children}
+  </Suspense>;
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2048,8 +2048,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setError(null);
     try {
       if (archived || !archiveStateKnown) throw new Error("This session is read-only. Restore it before sending.");
+      // The reading preview can omit the current delegated turn. Reuse or finish
+      // the uncapped read before deciding whether this follow-up must interrupt it.
+      const sendSnapshot = await openingHistory.ensureFullSnapshot();
+      if (getQueuedSendGeneration(props.sessionId) !== generation) throw new Error("Send cancelled by Stop.");
       const result = await submitImmediateSessionTurn<CloudMcpSubmissionResult>(props.opencodeBaseUrl, opencodeClient, props.sessionId,
-        snapshot?.messages ?? [], async () => {
+        sendSnapshot.messages, async () => {
           if (getQueuedSendGeneration(props.sessionId) !== generation) {
             return { outcome: "cancelled", reason: "context_changed" };
           }
@@ -2092,7 +2096,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       pendingSendsRef.current.delete(submissionId);
       setPendingSendSessions([...pendingSendsRef.current.values()]);
     }
-  }, [archived, archiveStateKnown, opencodeClient, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, props.workspaceRoot, renderedMessages.length, sessionOwner, setError, snapshot]);
+  }, [archived, archiveStateKnown, opencodeClient, openingHistory.ensureFullSnapshot, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, props.workspaceRoot, renderedMessages.length, sessionOwner, setError]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -90,6 +90,8 @@ import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/
 import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/transition-controller";
 import { setQueuedSendContext } from "@/react-app/domains/session/sync/queued-send-context";
 import { useSessionScrollController } from "./scroll-controller";
+import { getSessionScrollState, useSessionScrollStore } from "./scroll-store";
+import { SessionHistoryBoundary, useOpeningSessionHistory, type OpeningHistoryWindow } from "./session-history";
 import { SessionScrollOverlay } from "./scroll-overlay";
 import { SessionFindBar } from "./find-bar";
 import { useSessionFindStore } from "./find-store";
@@ -1198,14 +1200,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setOwnedError(nextError ? { owner: sessionOwner, error: nextError } : null);
   }, [sessionOwner]);
   const [restoringRevertedMessages, setRestoringRevertedMessages] = useState(false);
-  const [delayedLoadingTarget, setDelayedLoadingTarget] = useState<{ workspaceId: string; sessionId: string } | null>(null);
-  const showDelayedLoading = delayedLoadingTarget?.workspaceId === props.workspaceId &&
-    delayedLoadingTarget.sessionId === props.sessionId;
   const [awaitingAssistantBaseline, setAwaitingAssistantBaseline] = useState<number | null>(null);
   // Terminal invariant: an accepted admission that reached idle with no
   // assistant result surfaces a bounded recovery card instead of plain idle.
   const [admissionOutcomeUnresolved, setAdmissionOutcomeUnresolved] = useState(false);
-  const [rendered, setRendered] = useState<{ sessionId: string; snapshot: OpenworkSessionSnapshot } | null>(null);
+  const [rendered, setRendered] = useState<{ owner: string; sessionId: string; snapshot: OpenworkSessionSnapshot } | null>(null);
   const [toolSkills, setToolSkills] = useState<SkillCard[]>([]);
   const [toolMcpServers, setToolMcpServers] = useState<McpServerEntry[]>([]);
   const [toolMcpStatus, setToolMcpStatus] = useState<string | null>(null);
@@ -1270,30 +1269,32 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
   const useDesktopLoopbackSnapshotRetry = isDesktopRuntime()
     && isLoopbackOpenworkServerUrl(props.opencodeBaseUrl);
-  const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
-    queryKey: snapshotQueryKey,
-    queryFn: async ({ signal }) => {
+  const readSnapshot = useCallback(async (signal: AbortSignal, window?: OpeningHistoryWindow) => {
       if (evalSnapshotFailureRef.current) {
         throw new Error("eval: forced session snapshot failure");
       }
       const startedAt = Date.now();
-      // No `limit`: OpenCode pages `limit` as the NEWEST n messages and only
-      // signals older pages through a Link header nothing here follows, so a
-      // cap silently drops the start of any longer conversation.
+      // The preview is bounded; the second read MUST remain uncapped. A preview
+      // is never written to the authoritative snapshot cache as complete history.
       const item = useDesktopLoopbackSnapshotRetry
         ? await opencodeSessionNative.composeNativeSessionSnapshotWithRetry(
           sessionOwner,
           () => snapshotTargetRef.current,
-          { signal },
+          { ...window, signal },
         )
         : await opencodeSessionNative.composeNativeSessionSnapshot(
           { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
           props.sessionId,
-          { signal },
+          { ...window, signal },
         );
       markSessionSnapshotFetchStart(item, startedAt);
       return item;
-    },
+  }, [props.opencodeBaseUrl, props.openworkToken, props.sessionId, sessionOwner, useDesktopLoopbackSnapshotRetry]);
+  const openingHistory = useOpeningSessionHistory({ owner: sessionOwner, sessionId: props.sessionId, snapshotQueryKey, readSnapshot });
+  const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
+    queryKey: snapshotQueryKey,
+    queryFn: ({ signal }) => readSnapshot(signal),
+    enabled: openingHistory.backgroundReady,
     staleTime: 500,
     networkMode: useDesktopLoopbackSnapshotRetry ? "always" : undefined,
     retry: useDesktopLoopbackSnapshotRetry
@@ -1301,7 +1302,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
       : (failureCount) => !evalSnapshotFailureRef.current && failureCount < 3,
   });
 
-  const currentSnapshot = snapshotQuery.data?.session.id === props.sessionId ? snapshotQuery.data : null;
+  const fullSnapshot = snapshotQuery.data?.session.id === props.sessionId ? snapshotQuery.data : null;
+  const hasFullHistory = fullSnapshot !== null;
+  const currentSnapshot = fullSnapshot ?? openingHistory.snapshot;
   const archived = Boolean(props.archived || currentSnapshot?.session.time.archived);
   const archiveStateKnown = props.archived !== undefined || currentSnapshot !== null;
   const [restoringArchived, setRestoringArchived] = useState(false);
@@ -1329,8 +1332,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     if (!currentSnapshot) return;
-    setRendered({ sessionId: props.sessionId, snapshot: currentSnapshot });
-  }, [props.sessionId, currentSnapshot]);
+    setRendered({ owner: sessionOwner, sessionId: props.sessionId, snapshot: currentSnapshot });
+  }, [sessionOwner, props.sessionId, currentSnapshot]);
 
   useEffect(() => {
     evalSnapshotFailureRef.current = false;
@@ -1425,14 +1428,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId, props.workspaceId]);
 
   useEffect(() => {
-    if (!currentSnapshot) return;
-    seedSessionState(props.workspaceId, currentSnapshot);
-  }, [currentSnapshot, props.sessionId, props.workspaceId]);
+    if (!fullSnapshot) return;
+    seedSessionState(props.workspaceId, fullSnapshot);
+  }, [fullSnapshot, props.sessionId, props.workspaceId]);
 
   const snapshot = resolveRenderedSessionSnapshot({
     sessionId: props.sessionId,
     currentSnapshot,
-    cachedRendered: rendered,
+    cachedRendered: rendered?.owner === sessionOwner ? rendered : null,
   });
   const revertMessageId = snapshot?.session.revert?.messageID ?? null;
   const revertedMessageCount = snapshot && revertMessageId ? hiddenMessageCount(snapshot, revertMessageId) : 0;
@@ -1808,7 +1811,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const handleOpenTarget = useCallback((target: OpenTarget, options?: OpenTargetOptions) => {
     props.onOpenTarget?.(target, options, props.sessionId);
   }, [props.onOpenTarget, props.sessionId]);
-  const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
+  const pendingSessionLoad = !snapshot && !snapshotQuery.isError && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;
     return renderedMessages
@@ -1883,16 +1886,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
     usePanelTabStore.getState().syncTranscriptArtifacts(props.sessionId, verifiedOpenTargets);
   }, [props.sessionId, verifiedOpenTargets]);
 
-  useEffect(() => {
-    setDelayedLoadingTarget(null);
-    if (!pendingSessionLoad) return;
-    const id = window.setTimeout(() => setDelayedLoadingTarget({
-      workspaceId: props.workspaceId,
-      sessionId: props.sessionId,
-    }), 2000);
-    return () => window.clearTimeout(id);
-  }, [pendingSessionLoad, props.workspaceId, props.sessionId]);
-
   // Terminal invariant for accepted admissions: idle with no assistant result
   // must never silently clear the task. The transcript-length check alone is
   // not an outcome — the newly appended user message satisfies it even when no
@@ -1909,7 +1902,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }), [error, liveStatus.type, props.activePermission, props.activeQuestion, renderedMessages, sending]);
 
   useEffect(() => {
-    if (admissionOutcome !== "unresolved") {
+    if (!hasFullHistory || admissionOutcome !== "unresolved") {
       setAdmissionOutcomeUnresolved(false);
       return;
     }
@@ -1920,7 +1913,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       setAdmissionOutcomeUnresolved(true);
     }, ADMISSION_OUTCOME_GRACE_MS);
     return () => window.clearTimeout(id);
-  }, [admissionOutcome]);
+  }, [admissionOutcome, hasFullHistory]);
 
   const model = deriveSessionRenderModel({
     intendedSessionId: props.sessionId,
@@ -2789,12 +2782,28 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const sessionScroll = useSessionScrollController({
     selectedSessionId: props.sessionId,
+    geometryOwner: sessionOwner,
     submittedMessageId: submittedMessage?.owner === sessionOwner ? submittedMessage.id : null,
     historyReady: snapshot !== null,
     renderedMessages,
     containerRef: scrollRef,
     contentRef,
   });
+  const initialScroll = openingHistory.saved;
+  const messageViewport = {
+    sessionKey: sessionOwner,
+    scrollRef,
+    anchorMessageId: initialScroll.mode === "manual" ? initialScroll.anchor?.messageId : undefined,
+    scrollTop: initialScroll.mode === "manual" ? initialScroll.scrollTop : undefined,
+    scrollHeight: initialScroll.geometry?.scrollHeight,
+    viewportWidth: initialScroll.geometry?.viewportWidth,
+    leadingHeight: initialScroll.mode === "manual" ? initialScroll.geometry?.before : undefined,
+    trailingHeight: initialScroll.mode === "manual" ? initialScroll.geometry?.after : undefined,
+    historyComplete: hasFullHistory,
+    revealAll: findOwned,
+    stickyBottom: () => getSessionScrollState(useSessionScrollStore.getState().sessions, props.sessionId).mode === "stickyBottom",
+    onReady: sessionScroll.refresh,
+  };
 
   const handleFindBeforeJump = useCallback(() => {
     sessionScroll.markScrollGesture(scrollRef.current);
@@ -3123,17 +3132,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
       onFocusCapture={handleFindSurfaceInteraction}
       className="flex h-full min-h-0 flex-col"
     >
-      {model.transitionState === "switching" && showDelayedLoading ? (
-        <div className="flex justify-center px-6 pt-4">
-          <div className="rounded-full border border-dls-border bg-dls-hover/80 px-3 py-1 text-xs text-dls-secondary">
-            {model.renderSource === "cache" ? "Switching session from cache..." : "Switching session..."}
-          </div>
-        </div>
-      ) : null}
-
       <div className="relative min-h-0 flex-1">
         <div
           ref={scrollRef}
+          data-thread-scroll
           onWheel={(event) => {
             sessionScroll.markScrollGesture(event.target);
           }}
@@ -3181,13 +3183,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
                 onOpenModelPicker={handleOpenModelPicker}
               />
             ) : null}
-            {showDelayedLoading && pendingSessionLoad ? (
-              <div className="px-6 py-16">
-                <div className="mx-auto max-w-sm rounded-3xl border border-dls-border bg-dls-hover/60 px-8 py-10 text-center">
-                  <div className="text-sm text-dls-secondary">Opening session…</div>
-                </div>
-              </div>
-            ) : (snapshotQuery.isError || error) && !snapshot && renderedMessages.length === 0 ? (
+            <SessionHistoryBoundary owner={sessionOwner} pending={pendingSessionLoad}
+              options={openingHistory.options} saved={initialScroll}>
+            {(snapshotQuery.isError || error) && !snapshot && renderedMessages.length === 0 ? (
               <div className="px-6 py-8">
                 {error ? (
                   <SessionErrorCard
@@ -3256,6 +3254,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       onMcpRetry={handleMcpRetry}
                     >
                       <MessageList
+                        viewport={messageViewport}
                         messages={renderedMessages}
                         status={status}
                         activityStatus={effectiveActivityStatus}
@@ -3267,6 +3266,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
                 </OpenTargetProvider>
               </DevProfiler>
             )}
+            </SessionHistoryBoundary>
+            {snapshotQuery.isError && snapshot && !fullSnapshot ? (
+              <div role="alert" className="flex items-center justify-center gap-3 py-3 text-xs text-dls-secondary">
+                <span>The rest of this conversation could not be loaded.</span>
+                <button type="button" className="underline" onClick={() => void snapshotQuery.refetch()}>Retry</button>
+              </div>
+            ) : null}
             {!archived && admissionOutcomeUnresolved && queuedDrainState.phase.kind !== "admission_unknown" && renderedMessages.length > 0 ? (
               <AdmissionOutcomeUnknownCard
                 resuming={resuming}

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -154,7 +154,7 @@ describe("native OpenCode session operations", () => {
     const calls: string[] = [];
     const controller = new AbortController();
     const snapshotPromise = composeNativeSessionSnapshot(endpoint, session.id, {
-      limit: 140,
+      limit: 24,
       signal: controller.signal,
     }, {
       createOperations: () => operations({
@@ -163,7 +163,7 @@ describe("native OpenCode session operations", () => {
           return result(session);
         },
         messages: async (_sessionId, limit, options) => {
-          calls.push(limit === 140 && options?.signal === controller.signal ? "messages" : "bad-messages");
+          calls.push(limit === 24 && options?.signal === controller.signal ? "messages" : "bad-messages");
           return result(messages);
         },
         todo: async (_sessionId, options) => {
@@ -179,6 +179,130 @@ describe("native OpenCode session operations", () => {
 
     expect(calls).toEqual(["get", "messages", "todo", "status"]);
     expect(await snapshotPromise).toEqual({ session, messages, todos, status: { type: "idle" } });
+  });
+
+  test.each(["opencode", "opencode2"])("%s previews request the newest bounded messages and leave full reads uncapped", async (engine) => {
+    const target = { ...endpoint, opencodeBaseUrl: endpoint.opencodeBaseUrl.replace("opencode", engine) };
+    const history = Array.from({ length: 30 }, (_, index) => ({
+      info: { ...messages[0]!.info, id: `msg_${index}`, time: { created: index } },
+      parts: [],
+    }));
+    const limits: Array<string | null> = [];
+    await withSessionFetch((request) => {
+      const url = new URL(request.url);
+      if (url.pathname.endsWith(`/session/${session.id}`)) {
+        return Response.json(engine === "opencode2" ? { data: session } : session);
+      }
+      if (url.pathname.endsWith("/message")) {
+        const limit = url.searchParams.get("limit");
+        limits.push(limit);
+        const page = limit ? history.slice(-Number(limit)) : history;
+        return Response.json(engine === "opencode2" ? {
+          data: page.toReversed().map(({ info }) => ({ ...info, type: "user", content: [] })),
+        } : page);
+      }
+      if (url.pathname.endsWith("/todo")) return Response.json(todos);
+      if (url.pathname.endsWith("/status")) return Response.json({});
+      if (url.pathname.endsWith("/active")) return Response.json({ data: {} });
+      throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+    }, async () => {
+      const preview = await composeNativeSessionSnapshot(target, session.id, { limit: 24 });
+      const full = await composeNativeSessionSnapshot(target, session.id);
+      const newestIds = history.slice(-24).map(({ info }) => info.id);
+      const allIds = history.map(({ info }) => info.id);
+      expect(preview.messages.map(({ info }) => info.id)).toEqual(engine === "opencode2" ? newestIds.toReversed() : newestIds);
+      expect(full.messages.map(({ info }) => info.id)).toEqual(engine === "opencode2" ? allIds.toReversed() : allIds);
+      expect(limits).toEqual(["24", null]);
+    });
+  });
+
+  test.each(["opencode", "opencode2"])("%s reads only saved IDs in requested order and skips a deleted anchor", async (engine) => {
+    const target = { ...endpoint, opencodeBaseUrl: endpoint.opencodeBaseUrl.replace("opencode", engine) };
+    const controller = new AbortController();
+    const ids: readonly string[] = ["msg_z", "msg_a", "msg_m", "msg_z"];
+    await withSessionFetch((request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith(`/session/${session.id}`)) return Response.json(engine === "opencode2" ? { data: session } : session);
+      const id = path.match(/\/message\/([^/]+)$/)?.[1];
+      if (id) {
+        if (id === "msg_a") return Response.json({ message: "Message not found" }, { status: 404 });
+        const record = {
+          info: { ...messages[0]!.info, id, time: { created: ids.indexOf(id) } },
+          parts: messages[0]!.parts.map((part) => ({ ...part, messageID: id })),
+        };
+        return Response.json(engine === "opencode2"
+          ? { data: { ...record.info, type: "user", content: [{ type: "text", text: "hello" }] } }
+          : record);
+      }
+      if (path.endsWith("/todo")) return Response.json(todos);
+      if (path.endsWith("/status")) return Response.json({});
+      if (path.endsWith("/active")) return Response.json({ data: {} });
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    }, async (requests) => {
+      const snapshot = await composeNativeSessionSnapshot(target, session.id, { messageIds: ids, limit: 24, signal: controller.signal });
+      expect(snapshot.messages.map(({ info }) => info.id)).toEqual(["msg_z", "msg_m"]);
+      expect(snapshot.messages.every(({ info, parts }) => info.sessionID === session.id && parts.length === 1
+        && parts.every((part) => part.sessionID === session.id && part.messageID === info.id))).toBe(true);
+      const lookups = requests.filter((request) => new URL(request.url).pathname.includes("/message/"));
+      expect(lookups.map((request) => request.url)).toEqual(["msg_z", "msg_a", "msg_m"].map((id) =>
+        `${target.opencodeBaseUrl}${engine === "opencode2" ? "/api" : ""}/session/${session.id}/message/${id}`));
+      expect(requests.some((request) => new URL(request.url).pathname.endsWith("/message"))).toBe(false);
+      for (const request of requests) {
+        expect(request.method).toBe("GET");
+        expect(request.headers.get("Authorization")).toBe(`Bearer ${endpoint.token}`);
+      }
+    });
+  });
+
+  test("saved-region previews dedupe before capping at 24 IDs without listing messages", async () => {
+    const ids = Array.from({ length: 30 }, (_, index) => `msg_${30 - index}`);
+    const lookups: string[] = [];
+    const controller = new AbortController();
+    const dependencies = { createOperations: () => operations({
+      messages: async () => { throw new Error("Unexpected full message read"); },
+      message: async (sessionId, messageId, options) => {
+        expect(sessionId).toBe(session.id);
+        expect(options?.signal).toBe(controller.signal);
+        lookups.push(messageId);
+        return result({ info: { ...messages[0]!.info, id: messageId }, parts: [] });
+      },
+    }) };
+    const snapshot = await composeNativeSessionSnapshot(endpoint, session.id, {
+      messageIds: [ids[0]!, ids[0]!, ...ids], signal: controller.signal,
+    }, dependencies);
+    expect(lookups).toEqual(ids.slice(0, 24));
+    expect(snapshot.messages.map(({ info }) => info.id)).toEqual(lookups);
+    expect((await composeNativeSessionSnapshot(endpoint, session.id, { messageIds: [] }, dependencies)).messages).toEqual([]);
+    expect(lookups).toHaveLength(24);
+  });
+
+  test("saved-region previews preserve auth, permission, and transport errors instead of treating them as deletion", async () => {
+    for (const status of [401, 403, 503]) {
+      await expect(composeNativeSessionSnapshot(endpoint, session.id, { messageIds: ["msg_1"] }, {
+        createOperations: () => operations({ message: async () => failedResult({ code: "read_failed" }, status) }),
+      })).rejects.toMatchObject({ status, code: "read_failed" });
+    }
+    const transportError = new Error("Connection lost");
+    await expect(composeNativeSessionSnapshot(endpoint, session.id, { messageIds: ["msg_1"] }, {
+      createOperations: () => operations({ message: async () => { throw transportError; } }),
+    })).rejects.toBe(transportError);
+    await expect(composeNativeSessionSnapshot(endpoint, session.id, { messageIds: ["msg_1"] }, {
+      createOperations: () => operations(),
+    })).rejects.toThrow("single-message reads are unavailable");
+  });
+
+  test("saved-region previews reject mismatched message and part owners", async () => {
+    const record = messages[0]!;
+    for (const mismatched of [
+      { ...record, info: { ...record.info, id: "msg_other" } },
+      { ...record, info: { ...record.info, sessionID: "ses_other" } },
+      { ...record, parts: record.parts.map((part) => ({ ...part, messageID: "msg_other" })) },
+      { ...record, parts: record.parts.map((part) => ({ ...part, sessionID: "ses_other" })) },
+    ]) {
+      await expect(composeNativeSessionSnapshot(endpoint, session.id, { messageIds: [record.info.id] }, {
+        createOperations: () => operations({ message: async () => result(mismatched) }),
+      })).rejects.toThrow("verify the saved session message owner");
+    }
   });
 
   test("returns raw SDK shapes for get, messages, and delete", async () => {
@@ -213,7 +337,7 @@ describe("native OpenCode session operations", () => {
     })).rejects.toMatchObject({ status: 503, code: "engine_unavailable" });
   });
 
-  test("retries a failed local snapshot read without waiting for query focus or issuing writes", async () => {
+  test.each([false, true])("retries a failed local snapshot read without waiting for query focus or issuing writes (saved region: %s)", async (savedRegion) => {
     const calls: string[] = [];
     const endpointTokens: string[] = [];
     let currentEndpoint = endpoint;
@@ -224,7 +348,7 @@ describe("native OpenCode session operations", () => {
         owner: "owner-a",
         endpoint: currentEndpoint,
         sessionId: session.id,
-      }), { limit: 140 }, {
+      }), savedRegion ? { messageIds: ["msg_1"] } : { limit: 140 }, {
         createOperations: (target) => {
           attempt += 1;
           endpointTokens.push(target.token);
@@ -237,6 +361,7 @@ describe("native OpenCode session operations", () => {
               ? failedResult({ code: "engine_reloading" }, 503)
               : result(session)),
             messages: async () => track("messages", result(messages)),
+            message: async () => track("message", result(messages[0]!)),
             todo: async () => track("todo", result(todos)),
             status: async () => track("status", result<Record<string, SessionStatus>>({})),
             delete: async () => {
@@ -253,7 +378,8 @@ describe("native OpenCode session operations", () => {
       expect(snapshot.session.id).toBe(session.id);
       expect(attempt).toBe(2);
       expect(endpointTokens).toEqual([endpoint.token, "rotated-workspace-token"]);
-      expect(calls).toEqual(["get", "messages", "todo", "status", "get", "messages", "todo", "status"]);
+      const messageRead = savedRegion ? "message" : "messages";
+      expect(calls).toEqual(["get", messageRead, "todo", "status", "get", messageRead, "todo", "status"]);
       expect(calls).not.toContain("delete");
       expect(calls).not.toContain("prompt");
     } finally {
@@ -283,7 +409,7 @@ describe("native OpenCode session operations", () => {
     expect(delays).toEqual([100, 250, 500]);
   });
 
-  test("aborting a local snapshot retry prevents the next read attempt", async () => {
+  test.each([false, true])("aborting a local snapshot retry prevents the next read attempt (saved region: %s)", async (savedRegion) => {
     const controller = new AbortController();
     const aborted = new Error("snapshot read cancelled");
     let attempt = 0;
@@ -291,16 +417,40 @@ describe("native OpenCode session operations", () => {
       owner: "owner-a",
       endpoint,
       sessionId: session.id,
-    }), { signal: controller.signal }, {
+    }), { signal: controller.signal, ...(savedRegion ? { messageIds: ["msg_1"] } : {}) }, {
       createOperations: () => {
         attempt += 1;
-        return operations({ get: async () => failedResult({ code: "engine_reloading" }, 503) });
+        return operations({
+          get: async () => failedResult({ code: "engine_reloading" }, 503),
+          message: async () => result(messages[0]!),
+        });
       },
       waitForSnapshotRetry: async () => { controller.abort(aborted); },
     });
 
     await expect(promise).rejects.toBe(aborted);
     expect(attempt).toBe(1);
+  });
+
+  test.each(["abort", "owner"])("a saved-region lookup cannot publish or retry after its %s changes", async (change) => {
+    const pending = Promise.withResolvers<FieldsResult<{ info: Message; parts: Part[] }>>();
+    const controller = new AbortController();
+    const aborted = new Error("snapshot read cancelled");
+    let owner = "owner-a";
+    let reads = 0;
+    const promise = composeNativeSessionSnapshotWithRetry("owner-a", () => ({
+      owner, endpoint, sessionId: session.id,
+    }), { messageIds: ["msg_1"], signal: controller.signal }, {
+      createOperations: () => operations({ message: async () => { reads += 1; return pending.promise; } }),
+      waitForSnapshotRetry: async () => { throw new Error("Unexpected retry"); },
+    });
+    expect(reads).toBe(1);
+    if (change === "abort") controller.abort(aborted);
+    else owner = "owner-b";
+    pending.resolve(result(messages[0]!));
+    if (change === "abort") await expect(promise).rejects.toBe(aborted);
+    else await expect(promise).rejects.toThrow("Session snapshot owner changed");
+    expect(reads).toBe(1);
   });
 });
 

--- a/apps/app/tests/progressive-message-list.test.tsx
+++ b/apps/app/tests/progressive-message-list.test.tsx
@@ -1,0 +1,392 @@
+/** @jsxImportSource react */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+import { act, StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import { ProgressiveMessageList, type MessageListViewport } from "../src/components/chat/progressive-message-list"
+
+const ownedDom = typeof window === "undefined"
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" })
+const originalObserver = globalThis.ResizeObserver
+const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT")
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true)
+const frames = new Map<number, FrameRequestCallback>()
+const observers = new Set<() => void>()
+const cleanups: (() => Promise<void>)[] = []
+let frameId = 0
+let sessionId = 0
+
+beforeEach(() => {
+  spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    frames.set(++frameId, callback)
+    return frameId
+  })
+  spyOn(window, "cancelAnimationFrame").mockImplementation((id) => { frames.delete(id) })
+  Reflect.set(globalThis, "ResizeObserver", class {
+    private targets = new Set<Element>()
+    private emit: () => void
+    constructor(callback: ResizeObserverCallback) {
+      this.emit = () => callback([...this.targets].map((target) => ({
+        target, contentRect: target.getBoundingClientRect(), borderBoxSize: [], contentBoxSize: [], devicePixelContentBoxSize: [],
+      })), this)
+      observers.add(this.emit)
+    }
+    observe(target: Element) { this.targets.add(target) }
+    unobserve(target: Element) { this.targets.delete(target) }
+    disconnect() { this.targets.clear(); observers.delete(this.emit) }
+  })
+})
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup()
+  frames.clear()
+  observers.clear()
+  Reflect.set(globalThis, "ResizeObserver", originalObserver)
+  mock.restore()
+})
+
+afterAll(async () => {
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment)
+  if (ownedDom) await GlobalRegistrator.unregister()
+})
+
+function runFrame() {
+  const pending = [...frames.values()]
+  frames.clear()
+  for (const callback of pending) callback(0)
+}
+
+async function batch() {
+  await act(async () => runFrame())
+  await act(async () => runFrame())
+}
+
+type Group = { id: string; messages: { id: string; height: number }[] }
+function groups(count = 80): Group[] {
+  return Array.from({ length: count }, (_, index) => ({ id: `g${index}`, messages: [{ id: `m${index}`, height: 240 }] }))
+}
+
+function fixture(initial = groups(), options: Partial<MessageListViewport> = {}, strict = false) {
+  const container = document.createElement("div")
+  document.body.append(container)
+  const root = createRoot(container)
+  let data = initial
+  let top = 0
+  let width = options.viewportWidth ?? 600
+  let sticky = false
+  let unmounted = false
+  const writes: number[] = []
+  const ready = mock(() => {})
+  const rendered: number[] = []
+  let viewport: MessageListViewport = {
+    sessionKey: `progressive-${++sessionId}`, scrollRef: { current: container }, viewportWidth: width,
+    historyComplete: true, stickyBottom: () => sticky, onReady: ready, ...options,
+  }
+  const messageHeight = (node: Element) => {
+    const id = node.getAttribute("data-message-id")
+    return data.flatMap((group) => group.messages).find((message) => message.id === id)?.height ?? 0
+  }
+  const height = (node: Element): number => {
+    if (node instanceof HTMLElement && node.hasAttribute("data-thread-placeholder")) return Number.parseFloat(node.style.height) || 0
+    if (node.hasAttribute("data-message-id")) return messageHeight(node)
+    if (node.hasAttribute("data-thread-group")) return [...node.children].reduce((sum, child) => sum + height(child), 0)
+    const children = [...node.children]
+    return children.reduce((sum, child) => sum + height(child), 0) + Math.max(0, children.length - 1) * 8
+  }
+  const contentTop = (node: Element): number => {
+    if (node === container || node.parentElement === container) return 0
+    let offset = node.parentElement ? contentTop(node.parentElement) : 0
+    let sibling = node.previousElementSibling
+    while (sibling) {
+      offset += height(sibling) + (node.parentElement?.hasAttribute("data-thread-history-complete") ? 8 : 0)
+      sibling = sibling.previousElementSibling
+    }
+    return offset
+  }
+  const originalRect = HTMLElement.prototype.getBoundingClientRect
+  spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+    if (this === container) return new DOMRect(0, 40, width, 200)
+    if (container.contains(this)) return new DOMRect(0, 40 + contentTop(this) - container.scrollTop, width, height(this))
+    return originalRect.call(this)
+  })
+  Object.defineProperties(container, {
+    clientWidth: { get: () => width },
+    clientHeight: { get: () => 200 },
+    scrollHeight: { get: () => height(container) },
+    scrollTop: { get: () => Math.max(0, Math.min(top, height(container) - 200)), set: (value: number) => {
+      writes.push(value)
+      top = Math.max(0, Math.min(value, height(container) - 200))
+    } },
+  })
+  const unmount = async () => {
+    if (unmounted) return
+    await act(async () => root.unmount())
+    unmounted = true
+    container.remove()
+  }
+  cleanups.push(unmount)
+  return {
+    container, ready, writes, rendered, unmount,
+    async render(next = data, update: Partial<MessageListViewport> = {}) {
+      data = next
+      viewport = { ...viewport, ...update }
+      const list = <ProgressiveMessageList
+        groups={data} viewport={viewport} getGroupKey={(group) => group.id} getMessageIds={(group) => group.messages.map((message) => message.id)}
+        renderGroup={(group, index) => {
+          rendered.push(index)
+          return group.messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.id}</div>)
+        }}
+      />
+      await act(async () => root.render(strict ? <StrictMode>{list}</StrictMode> : list))
+    },
+    get mounted() { return [...container.querySelectorAll<HTMLElement>("[data-thread-group]")].map((node) => node.dataset.threadGroup) },
+    get placeholders() { return [...container.querySelectorAll<HTMLElement>("[data-thread-placeholder]")] },
+    get complete() { return container.firstElementChild?.getAttribute("data-thread-history-complete") },
+    message(id: string) {
+      const node = [...container.querySelectorAll<HTMLElement>("[data-message-id]")].find((message) => message.dataset.messageId === id)
+      if (!node) throw new Error(`Message ${id} is not mounted`)
+      return node
+    },
+    position(id: string) { return this.message(id).getBoundingClientRect().top - 40 },
+    read(id: string, offset = -25) {
+      top = contentTop(this.message(id)) - offset
+    },
+    scroll(value: number) { top = value; container.dispatchEvent(new Event("scroll")) },
+    setSticky(value: boolean) { sticky = value },
+    resize(nextWidth = width) { width = nextWidth; for (const emit of observers) emit() },
+  }
+}
+
+describe("progressive whole-group rendering", () => {
+  test("reserves both sides of a saved middle preview and keeps its anchor mounted when the full assistant group arrives", async () => {
+    const full = groups(80);
+    const reading = full[40];
+    const preview = [{ ...reading, id: "partial-assistant-group" }];
+    const view = fixture(preview, { anchorMessageId: "m40", historyComplete: false, scrollHeight: 19_832, leadingHeight: 9_920, trailingHeight: 9_664 });
+    await view.render();
+    expect(view.placeholders.map((node) => node.style.height)).toEqual(["9920px", "9664px"]);
+    view.read("m40");
+    const offset = view.position("m40");
+    await view.render(full, { historyComplete: true });
+    expect(view.mounted).toContain("g40");
+    expect(view.position("m40")).toBeCloseTo(offset, 1);
+  });
+
+  test("mounts eight latest groups, yields a paint between bounded batches, then keeps the entire DOM", async () => {
+    const view = fixture()
+    await view.render()
+    expect(view.mounted).toEqual(["g72", "g73", "g74", "g75", "g76", "g77", "g78", "g79"])
+    expect(view.rendered).toEqual([72, 73, 74, 75, 76, 77, 78, 79])
+    expect(view.complete).toBe("false")
+    expect(view.container.scrollHeight).toBe(80 * 240 + 79 * 8)
+    expect(view.placeholders.every((node) => node.getAttribute("aria-hidden") === "true")).toBe(true)
+    const tail = view.message("m79")
+    await act(async () => runFrame())
+    expect(view.mounted.length).toBe(8)
+    await act(async () => runFrame())
+    expect(view.mounted.length).toBe(16)
+    for (let i = 0; i < 8; i++) {
+      const before = view.mounted.length
+      await batch()
+      expect(view.mounted.length - before).toBeLessThanOrEqual(8)
+    }
+    expect(view.mounted.length).toBe(80)
+    expect(view.complete).toBe("true")
+    expect(view.placeholders.length).toBe(0)
+    expect(view.message("m79")).toBe(tail)
+    expect(frames.size).toBe(0)
+  })
+
+  test("prioritizes an anchor inside a whole group and renders live additions without waiting", async () => {
+    const data = groups()
+    data[40].messages.push({ id: "answer-40", height: 200 })
+    const view = fixture(data, { anchorMessageId: "answer-40" })
+    await view.render()
+    expect(view.mounted.length).toBe(8)
+    expect(view.mounted).toContain("g40")
+    expect(view.message("m40")).toBeDefined()
+    expect(view.message("answer-40")).toBeDefined()
+    const tail = view.message("m79")
+    const next = data.map((group) => group.id === "g79" ? { ...group, messages: [...group.messages, { id: "live-answer", height: 60 }] } : group)
+    await view.render(next)
+    expect(view.message("live-answer")).toBeDefined()
+    expect(view.message("m79")).toBe(tail)
+    await view.render([...next, { id: "new-user", messages: [{ id: "new-user", height: 60 }] }])
+    expect(view.message("new-user")).toBeDefined()
+    expect(view.message("m79")).toBe(tail)
+  })
+
+  test("keeps the exact visible message offset while estimates above it are replaced", async () => {
+    const data = groups()
+    for (const group of data) group.messages[0].height = 70
+    data[40].messages.push({ id: "reading-answer", height: 500 })
+    const view = fixture(data, { anchorMessageId: "reading-answer" })
+    await view.render()
+    view.read("reading-answer", -125)
+    const before = view.container.scrollTop
+    await batch()
+    expect(view.position("reading-answer")).toBe(-125)
+    expect(view.container.scrollTop).toBeLessThan(before)
+    await batch()
+    expect(view.position("reading-answer")).toBe(-125)
+  })
+
+  test("captures a user's latest position at commit, not when the background batch was queued", async () => {
+    const data = groups()
+    for (const group of data) group.messages[0].height = 400
+    const view = fixture(data, { anchorMessageId: "m40" })
+    await view.render()
+    view.read("m40")
+    await act(async () => runFrame())
+    await act(async () => {
+      runFrame()
+      view.read("m42", -90)
+    })
+    expect(view.position("m42")).toBe(-90)
+    expect(view.position("m40")).not.toBe(-25)
+  })
+
+  test("jump-to-top and scrolling into an unloaded range mount that range promptly", async () => {
+    const view = fixture()
+    await view.render()
+    await act(async () => view.scroll(20 * 248 + 25))
+    expect(view.mounted).toContain("g20")
+    expect(view.position("m20")).toBe(-25)
+    await act(async () => view.scroll(0))
+    expect(view.mounted).toContain("g0")
+    expect(view.position("m0")).toBe(0)
+  })
+
+  test("a queued background batch cannot discard groups requested by a simultaneous scroll", async () => {
+    const view = fixture()
+    await view.render()
+    await act(async () => runFrame())
+    await act(async () => {
+      view.scroll(20 * 248)
+      runFrame()
+    })
+    for (let index = 19; index < 27; index++) expect(view.mounted).toContain(`g${index}`)
+  })
+
+  test("fills at sticky bottom, but does not snap back after the user reads earlier content", async () => {
+    const data = groups()
+    for (const group of data) group.messages[0].height = 400
+    const view = fixture(data)
+    await view.render()
+    view.setSticky(true)
+    view.container.scrollTop = view.container.scrollHeight - 200
+    await batch()
+    expect(view.container.scrollTop).toBe(view.container.scrollHeight - 200)
+    view.setSticky(false)
+    view.read("m75", -100)
+    await batch()
+    expect(view.position("m75")).toBe(-100)
+    expect(view.container.scrollTop).toBeLessThan(view.container.scrollHeight - 200)
+  })
+
+  test("does not compensate native content reflow or redistribute spacers during a content-only commit", async () => {
+    const data = groups()
+    const view = fixture(data, { anchorMessageId: "m40" })
+    await view.render()
+    view.read("m40", -80)
+    const placeholderHeights = view.placeholders.map((node) => node.style.height)
+    data[39].messages[0].height += 130
+    // Model the browser's own anchor adjustment after an image expands.
+    view.read("m40", -80)
+    view.writes.length = 0
+    await act(async () => view.resize())
+    await view.render([...data])
+    expect(view.writes).toEqual([])
+    expect(view.position("m40")).toBe(-80)
+    expect(view.placeholders.map((node) => node.style.height)).toEqual(placeholderHeights)
+  })
+
+  test("Find mounts everything immediately and closing Find never removes it", async () => {
+    const view = fixture()
+    await view.render()
+    await view.render(undefined, { revealAll: true })
+    expect(view.mounted.length).toBe(80)
+    expect(view.complete).toBe("true")
+    expect(frames.size).toBe(0)
+    await view.render(undefined, { revealAll: false })
+    expect(view.mounted.length).toBe(80)
+  })
+
+  test("reserves the saved full extent for a partial tail and prioritizes its missing anchor when history arrives", async () => {
+    const data = groups(100)
+    const view = fixture(data.slice(90), { historyComplete: false, scrollHeight: 40_000, anchorMessageId: "m40" })
+    await view.render()
+    expect(view.container.scrollHeight).toBeCloseTo(40_000)
+    expect(view.complete).toBe("false")
+    expect(view.placeholders.some((node) => node.dataset.threadPlaceholder === "history-prefix")).toBe(true)
+    view.read("m95", -50)
+    await view.render(data, { historyComplete: true })
+    expect(view.message("m40")).toBeDefined()
+    expect(view.position("m95")).toBe(-50)
+    expect(view.placeholders.some((node) => node.dataset.threadPlaceholder === "history-prefix")).toBe(false)
+  })
+
+  test("preserves a reading message when a partial assistant group acquires its earlier messages", async () => {
+    const view = fixture([{ id: "tail", messages: [{ id: "reading", height: 500 }] }], { historyComplete: false, scrollHeight: 20_000 })
+    await view.render()
+    view.read("reading", -125)
+    await view.render([{ id: "start", messages: [{ id: "earlier", height: 300 }, { id: "reading", height: 500 }] }], { historyComplete: true })
+    expect(view.position("reading")).toBe(-125)
+  })
+
+  test("reuses measured geometry only for the same session and width, with bounded viewport retention", async () => {
+    const data = groups(20)
+    for (const group of data) group.messages[0].height = 100
+    const key = `cache-${++sessionId}`
+    const first = fixture(data, { sessionKey: key, revealAll: true })
+    await first.render()
+    await first.unmount()
+    const returning = fixture(data, { sessionKey: key })
+    await returning.render()
+    expect(returning.placeholders[0].style.height).toBe(`${12 * 100 + 11 * 8}px`)
+    await returning.unmount()
+    const resized = fixture(data, { sessionKey: key, viewportWidth: 900 })
+    await resized.render()
+    expect(resized.placeholders[0].style.height).toBe(`${12 * 240 + 11 * 8}px`)
+    await resized.unmount()
+    for (let index = 0; index < 12; index++) {
+      const other = fixture(groups(1))
+      await other.render()
+      await other.unmount()
+    }
+    const evicted = fixture(data, { sessionKey: key })
+    await evicted.render()
+    expect(evicted.placeholders[0].style.height).toBe(`${12 * 240 + 11 * 8}px`)
+  })
+
+  test("cancels pending work on a same-instance session switch and on unmount", async () => {
+    const view = fixture()
+    await view.render()
+    await act(async () => runFrame())
+    const pending = [...frames.keys()]
+    const newReady = mock(() => {})
+    await view.render(undefined, { sessionKey: `switch-${++sessionId}`, onReady: newReady })
+    expect(view.mounted.length).toBe(8)
+    expect(pending.every((id) => !frames.has(id))).toBe(true)
+    const oldCalls = view.ready.mock.calls.length
+    await batch()
+    expect(view.ready.mock.calls.length).toBe(oldCalls)
+    expect(newReady).toHaveBeenCalledTimes(2)
+    await view.unmount()
+    expect(frames.size).toBe(0)
+    expect(observers.size).toBe(0)
+  })
+
+  test("resumes background work and viewport listeners after Strict Mode's mount replay", async () => {
+    const view = fixture(groups(), {}, true)
+    await view.render()
+    expect(view.mounted.length).toBe(8)
+    await batch()
+    expect(view.mounted.length).toBe(16)
+    await act(async () => view.scroll(20 * 248))
+    expect(view.mounted).toContain("g20")
+    await view.unmount()
+    expect(frames.size).toBe(0)
+    expect(observers.size).toBe(0)
+  })
+})

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -1,0 +1,134 @@
+/** @jsxImportSource react */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import { openingHistoryWindow, SessionHistoryBoundary, useOpeningSessionHistory, type OpeningHistoryWindow } from "../src/react-app/domains/session/surface/session-history";
+import { flushSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
+
+const ownedDom = typeof window === "undefined";
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+const previousAct = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+const frames = new Map<number, FrameRequestCallback>();
+const cleanups: (() => Promise<void>)[] = [];
+let frameId = 0;
+
+beforeEach(() => {
+  useSessionScrollStore.setState({ sessions: {} });
+  spyOn(window, "requestAnimationFrame").mockImplementation((callback) => { frames.set(++frameId, callback); return frameId; });
+  spyOn(window, "cancelAnimationFrame").mockImplementation((id) => { frames.delete(id); });
+});
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+  frames.clear();
+  flushSessionScrollState();
+  mock.restore();
+});
+afterAll(async () => {
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousAct);
+  if (ownedDom) await GlobalRegistrator.unregister();
+});
+
+function snapshot(id: string, title: string): OpenworkSessionSnapshot {
+  return { session: { id, title, version: "1", time: { created: 1, updated: 1 } }, messages: [], todos: [], status: { type: "idle" } };
+}
+
+async function settle() {
+  // TanStack notifications use a task, and React may throttle a Suspense reveal.
+  await act(async () => { await Bun.sleep(350); });
+}
+
+async function paint() {
+  await act(async () => {
+    const pending = [...frames.values()];
+    frames.clear();
+    for (const frame of pending) frame(0);
+  });
+}
+
+function fixture() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const reads: { owner: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionSnapshot) => void }[] = [];
+  function Harness({ owner }: { owner: string }) {
+    const key = ["snapshot", owner];
+    const readSnapshot = (signal: AbortSignal, window?: OpeningHistoryWindow) => new Promise<OpenworkSessionSnapshot>((resolve) => {
+      reads.push({ owner, window, signal, resolve });
+    });
+    const opening = useOpeningSessionHistory({ owner, sessionId: owner, snapshotQueryKey: key, readSnapshot });
+    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => readSnapshot(signal), enabled: opening.backgroundReady });
+    const current = full.data ?? opening.snapshot;
+    return <><span>Composer {owner}</span><SessionHistoryBoundary owner={owner} pending={!current} saved={opening.saved} options={opening.options}>
+      <div>{current?.session.title}</div>
+    </SessionHistoryBoundary></>;
+  }
+  cleanups.push(async () => { await act(async () => root.unmount()); client.clear(); host.remove(); });
+  return {
+    reads, host, client,
+    async render(owner = "a") { await act(async () => root.render(<QueryClientProvider client={client}><Harness owner={owner} /></QueryClientProvider>)); },
+    async resolve(index: number, title: string) {
+      await act(async () => reads[index].resolve(snapshot(reads[index].owner, title)));
+      await settle();
+    },
+  };
+}
+
+describe("opening a thread", () => {
+  test("Suspense shows feedback immediately, paints the newest window before the uncapped read, and keeps the composer mounted", async () => {
+    const view = fixture();
+    await view.render();
+    expect(view.host.querySelector('[role="status"]')?.textContent).toContain("Loading latest messages");
+    expect(view.host.textContent).toContain("Composer a");
+    expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }]);
+    await view.resolve(0, "Latest messages");
+    expect(view.host.textContent).toContain("Latest messages");
+    expect(view.reads).toHaveLength(1);
+    await paint();
+    expect(view.reads).toHaveLength(1);
+    await paint();
+    expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }, undefined]);
+    expect(view.host.querySelector('[role="status"]')).toBeNull();
+    expect(view.host.textContent).toContain("Latest messages");
+    await view.resolve(1, "Complete history");
+    expect(view.host.textContent).toContain("Complete history");
+  });
+
+  test("saved positions request their own region, while a late previous-thread preview cannot render in the destination", async () => {
+    const store = useSessionScrollStore.getState();
+    store.setManualScroll("a", 800, null, { messageId: "reading", offset: -20 });
+    store.setGeometry("a", { owner: "a", scrollHeight: 4000, viewportWidth: 600, before: 600, after: 2200, messageIds: ["before", "reading", "after"] });
+    const view = fixture();
+    await view.render();
+    expect(view.reads[0].window).toEqual({ messageIds: ["before", "reading", "after"] });
+    expect(view.host.textContent).toContain("Returning to your reading position");
+    await view.render("b");
+    await view.resolve(0, "Foreign preview");
+    expect(view.host.textContent).not.toContain("Foreign preview");
+    expect(view.host.textContent).toContain("Composer b");
+    expect(view.reads[1].window).toEqual({ limit: 24 });
+    await view.resolve(1, "Destination preview");
+    await paint();
+    await paint();
+    expect(view.reads.filter((read) => read.window === undefined).map((read) => read.owner)).toEqual(["b"]);
+  });
+
+  test("warm full snapshots skip previews, and old anchors do not require persisted neighbors", async () => {
+    expect(openingHistoryWindow({ mode: "manual", scrollTop: 500, anchor: { messageId: "legacy", offset: 0 }, topClippedMessageId: null }))
+      .toEqual({ messageIds: ["legacy"] });
+    expect(openingHistoryWindow({ mode: "manual", scrollTop: 500, anchor: { messageId: "turn:steps", offset: -20 }, topClippedMessageId: null }))
+      .toEqual({ messageIds: ["turn"] });
+    expect(openingHistoryWindow({ mode: "manual", scrollTop: 500, anchor: { messageId: "session-error:turn", offset: -20 }, topClippedMessageId: null }))
+      .toEqual({ messageIds: ["turn"] });
+    const view = fixture();
+    view.client.setQueryData(["snapshot", "a"], snapshot("a", "Cached history"));
+    await view.render();
+    expect(view.host.textContent).toContain("Cached history");
+    expect(view.host.querySelector('[role="status"]')).toBeNull();
+    expect(view.reads.map((read) => read.window)).toEqual([undefined]);
+  });
+});

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -54,6 +54,7 @@ function fixture() {
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
+  let ensureFullSnapshot: (() => Promise<OpenworkSessionSnapshot>) | undefined;
   const reads: { owner: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionSnapshot) => void }[] = [];
   function Harness({ owner }: { owner: string }) {
     const key = ["snapshot", owner];
@@ -61,7 +62,8 @@ function fixture() {
       reads.push({ owner, window, signal, resolve });
     });
     const opening = useOpeningSessionHistory({ owner, sessionId: owner, snapshotQueryKey: key, readSnapshot });
-    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => readSnapshot(signal), enabled: opening.backgroundReady });
+    ensureFullSnapshot = opening.ensureFullSnapshot;
+    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => readSnapshot(signal), enabled: opening.backgroundReady, staleTime: 500 });
     const current = full.data ?? opening.snapshot;
     return <><span>Composer {owner}</span><SessionHistoryBoundary owner={owner} pending={!current} saved={opening.saved} options={opening.options}>
       <div>{current?.session.title}</div>
@@ -70,6 +72,10 @@ function fixture() {
   cleanups.push(async () => { await act(async () => root.unmount()); client.clear(); host.remove(); });
   return {
     reads, host, client,
+    ensureFullSnapshot() {
+      if (!ensureFullSnapshot) throw new Error("History is not mounted");
+      return ensureFullSnapshot();
+    },
     async render(owner = "a") { await act(async () => root.render(<QueryClientProvider client={client}><Harness owner={owner} /></QueryClientProvider>)); },
     async resolve(index: number, title: string) {
       await act(async () => reads[index].resolve(snapshot(reads[index].owner, title)));
@@ -79,6 +85,21 @@ function fixture() {
 }
 
 describe("opening a thread", () => {
+  test("explicit sends can finish the uncapped read without trusting or duplicating the preview", async () => {
+    const view = fixture();
+    await view.render();
+    await view.resolve(0, "Reading preview");
+    const pending = view.ensureFullSnapshot();
+    expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }, undefined]);
+    const sameRead = view.ensureFullSnapshot();
+    expect(view.reads).toHaveLength(2);
+    await view.resolve(1, "Full current turn");
+    expect((await pending).session.title).toBe("Full current turn");
+    expect((await sameRead).session.title).toBe("Full current turn");
+    expect((await view.ensureFullSnapshot()).session.title).toBe("Full current turn");
+    expect(view.reads).toHaveLength(2);
+  });
+
   test("Suspense shows feedback immediately, paints the newest window before the uncapped read, and keeps the composer mounted", async () => {
     const view = fixture();
     await view.render();
@@ -125,7 +146,7 @@ describe("opening a thread", () => {
     expect(openingHistoryWindow({ mode: "manual", scrollTop: 500, anchor: { messageId: "session-error:turn", offset: -20 }, topClippedMessageId: null }))
       .toEqual({ messageIds: ["turn"] });
     const view = fixture();
-    view.client.setQueryData(["snapshot", "a"], snapshot("a", "Cached history"));
+    view.client.setQueryData(["snapshot", "a"], snapshot("a", "Cached history"), { updatedAt: Date.now() - 1_000 });
     await view.render();
     expect(view.host.textContent).toContain("Cached history");
     expect(view.host.querySelector('[role="status"]')).toBeNull();

--- a/apps/app/tests/session-scroll.test.tsx
+++ b/apps/app/tests/session-scroll.test.tsx
@@ -76,13 +76,14 @@ function observeStorageWrites() {
   return writes;
 }
 
-function fixture() {
+function fixture(geometryOwner?: string) {
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
   const layout = {
     height: 1_000,
     viewportHeight: 200,
+    complete: true,
     messages: [
       { id: "first", top: 0, height: 300 },
       { id: "reading", top: 300, height: 300 },
@@ -102,6 +103,7 @@ function fixture() {
       Object.defineProperties(node, {
         scrollHeight: { configurable: true, get: () => layout.height },
         clientHeight: { configurable: true, get: () => layout.viewportHeight },
+        clientWidth: { configurable: true, get: () => 500 },
         scrollTop: { configurable: true, get: () => scrollTop, set: (top: number) => {
           scrollWrites.push(top);
           scrollTop = Math.max(0, Math.min(top, layout.height - layout.viewportHeight));
@@ -111,12 +113,13 @@ function fixture() {
       });
     }, []);
     const scroll = useSessionScrollController({
-      selectedSessionId: sessionId, submittedMessageId: null, historyReady: ready, renderedMessages: [...layout.messages], containerRef, contentRef,
+      selectedSessionId: sessionId, geometryOwner, submittedMessageId: null, historyReady: ready, renderedMessages: [...layout.messages], containerRef, contentRef,
     });
     controls = scroll;
     return <div ref={setContainer} onScroll={scroll.handleScroll} onWheel={(event) => scroll.markScrollGesture(event.target)}
       onPointerDown={(event) => { if (event.target === event.currentTarget) scroll.markScrollGesture(event.target); }}>
       <div ref={contentRef}>
+        <div data-thread-history-complete={layout.complete} data-thread-loading={!ready ? "" : undefined} />
         {layout.messages.map((message) => <div key={message.id} data-message-id={message.id} ref={(node) => {
           if (node) node.getBoundingClientRect = () => new DOMRect(0, 40 + message.top - scrollTop, 500, message.height);
         }}>{message.id}</div>)}
@@ -158,6 +161,58 @@ function fixture() {
 }
 
 describe("session reading position", () => {
+  test("restores estimated loading geometry without consuming an anchor absent from a partial preview", async () => {
+    const store = useSessionScrollStore.getState();
+    store.setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
+    store.setGeometry("a", { owner: "owner-a", scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["first", "reading", "latest"] });
+    const saved = state();
+    const view = fixture("owner-a");
+    view.layout.complete = false;
+    view.layout.messages = [];
+    await view.render("a", false);
+    expect(view.container.scrollTop).toBe(325);
+    view.layout.messages = [{ id: "latest", top: 600, height: 400 }];
+    await view.render();
+    expect(state()).toEqual(saved);
+    view.layout.messages.unshift({ id: "reading", top: 420, height: 180 });
+    await view.render();
+    expect(view.container.scrollTop).toBe(445);
+    expect(state()).toEqual(saved);
+  });
+
+  test("records complete geometry and nearby IDs without replacing it with partial or zero-sized layout", async () => {
+    const view = fixture("owner-a");
+    await view.render();
+    view.wheel(325);
+    expect(state().geometry).toEqual({ owner: "owner-a", scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["first", "reading", "latest"] });
+    const geometry = state().geometry;
+    view.layout.complete = false;
+    view.layout.height = 1200;
+    await view.render();
+    view.wheel(350);
+    expect(state().geometry).toEqual(geometry);
+    useSessionScrollStore.getState().setStickyBottom("a", null);
+    flushSessionScrollState();
+    expect(JSON.parse(localStorage.getItem(storageKey)!)).toMatchObject({ a: { mode: "stickyBottom", geometry } });
+  });
+
+  test("does not consume a legacy anchor against a too-short preview", async () => {
+    useSessionScrollStore.getState().setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
+    const saved = state();
+    const view = fixture();
+    view.layout.complete = false;
+    view.layout.height = 200;
+    view.layout.messages = [{ id: "reading", top: 0, height: 100 }];
+    await view.render();
+    view.scroll(0);
+    expect(state()).toEqual(saved);
+    view.layout.height = 1000;
+    view.layout.messages[0].top = 300;
+    await view.render();
+    expect(view.container.scrollTop).toBe(325);
+    expect(state()).toEqual(saved);
+  });
+
   test("remembers native reflow adjustments without applying a competing scroll", async () => {
     useSessionScrollStore.getState().setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
     const view = fixture();

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -32,8 +32,15 @@ function renderedCount(value: unknown): number {
   return value.messageCount;
 }
 
-test("opening a long conversation shows it from its first message", async ({ user, agent, probe, step, world }) => {
+test("opening a long conversation shows the latest first and preserves access to its entire history", async ({ user, agent, probe, step, world }) => {
   const messagesPath = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/opencode/session/${encodeURIComponent(world.session.sessionId)}/message`;
+  const surface = `[data-session-surface-id="${world.session.sessionId}"]`;
+  const latestVisible = async () => {
+    const { elements } = await probe.dom(`${surface} [data-thread-scroll], ${surface} [data-message-id]`);
+    const viewport = elements[0];
+    const latest = elements.slice(1).find((element) => element.text.includes(longHistoryLast));
+    return Boolean(viewport && latest && latest.rect.height > 0 && latest.rect.bottom > viewport.rect.top && latest.rect.top < viewport.rect.bottom);
+  };
 
   await step("the engine stores more messages than one newest-first page holds", async () => {
     const stored = await probe.desktopApi(messagesPath);
@@ -62,7 +69,9 @@ test("opening a long conversation shows it from its first message", async ({ use
 
   await step("clicking the long conversation renders every stored message", async () => {
     await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });
-    await user.see({ text: longHistoryLast }, { timeoutMs: 60_000 });
+    // Read-only geometry: `user.see` may scroll a target into view and would
+    // conceal a regression where opening incorrectly lands at the first row.
+    await probe.eventually(latestVisible, { within: 60_000, label: "latest message visible without scrolling", until: Boolean });
     const rendered = await probe.eventually(async () => renderedCount(await agent.run("session.read_transcript", { count: 1 })), {
       within: 60_000,
       label: "rendered transcript length",
@@ -70,6 +79,11 @@ test("opening a long conversation shows it from its first message", async ({ use
     });
     expect(rendered).toBe(longHistoryCount);
     expect(rendered).not.toBe(oldPageSize);
+    await probe.eventually(async () => {
+      expect(await latestVisible()).toBe(true);
+      return (await probe.dom(`${surface} [data-thread-history-complete="true"]`)).elements.length;
+    }, { within: 30_000, label: "background history mounting preserves the latest viewport", until: (count) => count === 1 });
+    expect((await probe.dom(`${surface} [data-thread-loading]`)).elements).toHaveLength(0);
   });
 
   await step("the first message is reachable at the top of the transcript", async () => {


### PR DESCRIPTION
## Summary

Opening a conversation currently waits for the entire transcript, mounts all message groups, and delays loading feedback for two seconds. This change prioritizes the part the person is reading while retaining access to the complete history.

- Add a transcript-scoped Suspense boundary with immediate, accessible loading feedback; keep the composer and surrounding pane mounted.
- Read the newest 24 messages first, or the saved reading message and nearby native message IDs. Start the uncapped full-history read after a paint opportunity; never treat the preview as complete history.
- Mount whole message groups near the reading anchor first, keep the latest group available, and fill remaining groups in bounded background batches. Preserve the visible anchor or bottom while replacing estimated spacers.
- Persist bounded scroll-height and nearby-ID hints, cache measured group heights by session and width, and retain legacy reading anchors without consuming missing or clamped positions prematurely. Find requests all groups; input takes precedence over restoration.
- Preserve the newly merged follow-up interruption behavior: explicit sends reuse or finish the complete history read rather than deciding what to interrupt from a partial preview.

No permanent history truncation or virtualized eviction. No message bodies or tool outputs are added to persisted scroll state. The independent PageUp and Find-clearance fixes in #4742 and #4780 are not included.

## Verification

**Verdict: Incomplete.** The selected component/native-adapter checks pass, but exact-head real-app evidence and latency measurements are still missing. No measured speedup is claimed.

Candidate: `d71c725fb7f043d52e1eb7583b2091af87475f46`, rebased on `dev` at `23143497940c871bda4a9aaebb82bd86c3f95530`. Both included commits are signed.

Passed, from `apps/app`:

```sh
bun test --isolate ./tests/session-history.test.tsx ./tests/session-scroll.test.tsx ./tests/progressive-message-list.test.tsx ./tests/opencode-session-native.test.ts ./tests/message-list-loading.test.tsx ./tests/chat-message-grouping.test.ts
./node_modules/.bin/tsc --noEmit
git diff --check
```

- Focused tests: **105 passed, 0 failed, 0 skipped**, 833 assertions; exit 0.
- App typecheck and whitespace check: exit 0.
- Tests cover staged reads, Suspense feedback, saved-region lookup, stale-owner exclusion, native read cancellation, progressive mounting, geometry retention, clamped anchors, and complete-history reuse for sends. DOM geometry in component tests is simulated, not browser-layout proof.

Deferred / not passing evidence:

- The existing `session-full-history-on-open` journey now checks the newest message is visible without scrolling and stays visible while the rest mounts, but has not been run on this candidate. Run from the repository root with the authorized placement:
  ```sh
  pnpm evals:e2e session-full-history-on-open
  ```
- Cold-load latency, native browser anchoring, rapid-switch/split-pane end-to-end behavior, and published exact-head evidence remain unverified.
- A separate earlier step-fold component probe reported missing `PlatformProvider` fixture setup. It was not revalidated and is not counted as passing or classified as pre-existing.

One unusually large assistant group still mounts as a unit. Required repository CI remains unchanged.
