### PR TITLE
fix(dashboard): repair missing private App authorization

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -734,6 +734,8 @@ export type OpenworkCloudMcpHealth = {
   usable: boolean;
   usableByCurrentModel: boolean | null;
   connectCatalogEnabled: boolean;
+  /** Local private credential readiness, not provider health. Older servers omit it. */
+  appHostAuthorizationReady?: boolean | null;
   workspace: {
     id: string;
     type: string;

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -14,13 +14,16 @@ import type {
 import {
   CLOUD_MCP_SERVER_NAME,
   clearCloudMcpScopedMetadata,
+  clearCloudMcpUnhealthyRemintAttempt,
   clearCloudMcpUserState,
   getCloudMcpScopeKey,
   isCloudMcpSyncMarkerFresh,
   normalizeCloudMcpScope,
   readCloudMcpSyncMarker,
+  readCloudMcpUnhealthyRemintAttempt,
   readCloudMcpUserState,
   writeCloudMcpSyncMarker,
+  writeCloudMcpUnhealthyRemintAttempt,
   writeCloudMcpUserState,
   type CloudMcpScope,
   type CloudMcpUserState,
@@ -110,6 +113,10 @@ type CleanupClient = {
 };
 
 const repairInFlight = new Map<string, Promise<CloudMcpOperationResult>>();
+// Older Den releases may not issue a private App-host token. Keep ordinary
+// Connect working without reminting on every focus/maintenance tick. Explicit
+// Repair bypasses this cooldown; sign-out clears the scoped attempt marker.
+const APP_HOST_AUTHORIZATION_RETRY_MS = 60 * 60 * 1_000;
 
 const APP_VERSION = String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
 const APP_BUILD_SHA = String(import.meta.env.VITE_OPENWORK_BUILD_SHA ?? import.meta.env.VITE_OPENWORK_GIT_SHA ?? "").trim();
@@ -306,24 +313,54 @@ async function mintAndPost(input: CloudMcpReconcilerInput, scope: CloudMcpScope)
   };
 }
 
+function needsAppHostAuthorizationRepair(health: OpenworkCloudMcpHealth, scope: CloudMcpScope, now: number): boolean {
+  if (health.appHostAuthorizationReady !== false) return false;
+  const attempt = readCloudMcpUnhealthyRemintAttempt(scope);
+  if (!attempt) return true;
+  const elapsed = now - attempt.attemptedAt;
+  return elapsed < 0 || elapsed >= APP_HOST_AUTHORIZATION_RETRY_MS;
+}
+
 async function repairCloudMcp(input: CloudMcpReconcilerInput, scope: CloudMcpScope): Promise<CloudMcpOperationResult> {
+  const now = input.now ?? Date.now();
+  let appHostOnlyHealth: OpenworkCloudMcpHealth | null = null;
   if (!input.force) {
     const healthResult = await probeHealth(input, scope, { writeFreshnessMarker: true });
-    if (healthResult.health?.usable) return { ...healthResult, status: "unchanged" };
+    if (healthResult.health?.appHostAuthorizationReady === true) clearCloudMcpUnhealthyRemintAttempt(scope);
+    if (healthResult.health?.usable && !needsAppHostAuthorizationRepair(healthResult.health, scope, now)) {
+      return { ...healthResult, status: "unchanged" };
+    }
+    if (healthResult.health?.usable) appHostOnlyHealth = healthResult.health;
   }
 
   const marker = readCloudMcpSyncMarker(scope);
   if (!input.force && marker && isCloudMcpSyncMarkerFresh({
     expiresAt: marker.expiresAt,
-    now: input.now ?? Date.now(),
+    now,
     refreshMarginMs: input.refreshMarginMs,
   })) {
     const health = await input.client.getOpenworkCloudMcpHealth(scope.workspaceId, input.context.providerModel);
-    if (health.usable) return { status: "unchanged", health, attempts: 0, markerWritten: false, reminted: false };
+    if (health.usable && !needsAppHostAuthorizationRepair(health, scope, now)) {
+      return { status: "unchanged", health, attempts: 0, markerWritten: false, reminted: false };
+    }
+    appHostOnlyHealth = health.usable ? health : null;
   }
 
-  const first = await mintAndPost(input, scope);
+  const deferAppHostRepair = (): CloudMcpOperationResult => {
+    writeCloudMcpUnhealthyRemintAttempt({ ...scope, attemptedAt: now });
+    // Preserve the last observed ordinary health, not a claim that private
+    // authorization was repaired. A supplemental failure must not block chat.
+    return { status: "failed", health: appHostOnlyHealth, attempts: 1, markerWritten: false, reminted: false };
+  };
+  let first: Awaited<ReturnType<typeof mintAndPost>>;
+  try {
+    first = await mintAndPost(input, scope);
+  } catch (error) {
+    if (!appHostOnlyHealth) throw error;
+    return deferAppHostRepair();
+  }
   if (!first.token) {
+    if (appHostOnlyHealth) return deferAppHostRepair();
     return { status: "skipped", health: null, skippedReason: "mint_failed", attempts: 1, markerWritten: false, reminted: false };
   }
 
@@ -339,9 +376,14 @@ async function repairCloudMcp(input: CloudMcpReconcilerInput, scope: CloudMcpSco
     if (second.health) health = second.health;
   }
 
+  if (health?.appHostAuthorizationReady === false) {
+    writeCloudMcpUnhealthyRemintAttempt({ ...scope, attemptedAt: now });
+  } else if (health?.appHostAuthorizationReady === true) {
+    clearCloudMcpUnhealthyRemintAttempt(scope);
+  }
   const markerWritten = writeUsableMarker({ health, scope, expiresAt: token.expiresAt });
   return {
-    status: health?.usable ? "repaired" : "failed",
+    status: health?.usable && health.appHostAuthorizationReady !== false ? "repaired" : "failed",
     health,
     attempts,
     markerWritten,

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -310,7 +310,7 @@ export async function syncCloudControlMcpInBackground(input: {
   if (result.health?.usable) {
     return {
       outcome: "ready",
-      status: result.status === "unchanged" || result.status === "ready" ? "unchanged" : "synced",
+      status: result.status === "repaired" ? "synced" : "unchanged",
       health: result.health,
     };
   }

--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -6,6 +6,7 @@ import {
   __setCloudMcpUserStateStorageForTest,
   getCloudMcpScopeKey,
   readCloudMcpSyncMarker,
+  readCloudMcpUnhealthyRemintAttempt,
   writeCloudMcpSyncMarker,
 } from "../src/react-app/domains/connections/cloud-mcp-user-state";
 import {
@@ -190,7 +191,7 @@ describe("OpenWork Cloud MCP reconciler", () => {
         baseUrl: scope.serverBaseUrl,
         getOpenworkCloudMcpHealth: async () => {
           getCount += 1;
-          return health({ usable: true });
+          return { ...health({ usable: true }), appHostAuthorizationReady: false };
         },
         reconcileOpenworkCloudMcp: async () => {
           postCount += 1;
@@ -244,6 +245,112 @@ describe("OpenWork Cloud MCP reconciler", () => {
     });
 
     expect(probeOptionsSeen).toEqual([{ probe: true }, undefined]);
+  });
+
+  test("healthy Cloud and a fresh marker still repair missing workspace App-host authorization once", async () => {
+    writeCloudMcpSyncMarker({ ...scope, expiresAt: token.expiresAt });
+    const missing = { ...health({ usable: true }), appHostAuthorizationReady: false };
+    let currentHealth = missing;
+    let mintCount = 0;
+    const posts: Array<{ workspaceId: string; payload: OpenworkCloudMcpReconcilePayload }> = [];
+    const client = {
+      baseUrl: scope.serverBaseUrl,
+      getOpenworkCloudMcpHealth: async () => currentHealth,
+      reconcileOpenworkCloudMcp: async (workspaceId: string, payload: OpenworkCloudMcpReconcilePayload) => {
+        posts.push({ workspaceId, payload });
+        currentHealth = { ...missing, appHostAuthorizationReady: true };
+        return currentHealth;
+      },
+    };
+    const input: Parameters<typeof runOpenworkCloudMcpReconciler>[0] = {
+      mode: "repair", client, context, now: NOW, refreshMarginMs: 1,
+      mintToken: async () => { mintCount += 1; return token; },
+    };
+    expect(await runOpenworkCloudMcpReconciler(input)).toMatchObject({
+      status: "repaired", attempts: 1, health: { usable: true, appHostAuthorizationReady: true },
+    });
+    expect(await runOpenworkCloudMcpReconciler(input)).toMatchObject({ status: "unchanged", attempts: 0 });
+    expect(mintCount).toBe(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.workspaceId).toBe(scope.workspaceId);
+    expect(posts[0]?.payload.appHostAuthorization).toBe(`Bearer ${token.appHostToken}`);
+    expect(posts[0]?.payload.config.headers).toEqual({ Authorization: `Bearer ${token.token}` });
+    expect(JSON.stringify(posts[0]?.payload.config)).not.toContain(token.appHostToken!);
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)).toBeNull();
+  });
+
+  test("unknown, ineligible and already-provisioned App hosts do not remint healthy Cloud", async () => {
+    for (const appHostAuthorizationReady of [undefined, null, true]) {
+      let mintCount = 0;
+      let postCount = 0;
+      const result = await runOpenworkCloudMcpReconciler({
+        mode: "repair", context, now: NOW, refreshMarginMs: 1,
+        client: {
+          baseUrl: scope.serverBaseUrl,
+          getOpenworkCloudMcpHealth: async () => ({ ...health({ usable: true }), appHostAuthorizationReady }),
+          reconcileOpenworkCloudMcp: async () => { postCount += 1; return health({ usable: true }); },
+        },
+        mintToken: async () => { mintCount += 1; return token; },
+      });
+      expect(result.status).toBe("unchanged");
+      expect(mintCount).toBe(0);
+      expect(postCount).toBe(0);
+    }
+  });
+
+  test("an unavailable private token has a scoped cooldown without blocking core repair or explicit retry", async () => {
+    let mintCount = 0;
+    let ordinaryUsable = true;
+    const client = {
+      baseUrl: scope.serverBaseUrl,
+      getOpenworkCloudMcpHealth: async () => ({ ...health({ usable: ordinaryUsable }), appHostAuthorizationReady: false }),
+      reconcileOpenworkCloudMcp: async () => ({ ...health({ usable: true }), appHostAuthorizationReady: false }),
+    };
+    const input: Parameters<typeof runOpenworkCloudMcpReconciler>[0] = {
+      mode: "repair", client, context, now: NOW, refreshMarginMs: 1,
+      mintToken: async () => {
+        mintCount += 1;
+        return { ...token, appHostToken: undefined, appHostExpiresAt: undefined };
+      },
+    };
+    const first = await runOpenworkCloudMcpReconciler(input);
+    expect(first).toMatchObject({ attempts: 1, health: { usable: true, appHostAuthorizationReady: false } });
+    expect(await runOpenworkCloudMcpReconciler(input)).toMatchObject({ status: "unchanged", attempts: 0 });
+    expect(mintCount).toBe(1);
+    expect(await runOpenworkCloudMcpReconciler({ ...input, context: { ...context, workspaceId: "ws_other" } })).toMatchObject({ attempts: 1 });
+    expect(await runOpenworkCloudMcpReconciler({ ...input, force: true })).toMatchObject({ attempts: 1 });
+    ordinaryUsable = false;
+    expect(await runOpenworkCloudMcpReconciler(input)).toMatchObject({ attempts: 1 });
+    ordinaryUsable = true;
+    expect(await runOpenworkCloudMcpReconciler({ ...input, now: NOW + 60 * 60 * 1_000 })).toMatchObject({ attempts: 1 });
+    expect(mintCount).toBe(5);
+  });
+
+  test("failed App-only mint/reconcile attempts retain ordinary health and respect the cooldown", async () => {
+    for (const failingStep of ["mint", "reconcile", "empty-token"]) {
+      installStorageStub();
+      let mintCount = 0;
+      const observed = { ...health({ usable: true }), appHostAuthorizationReady: false };
+      const input: Parameters<typeof runOpenworkCloudMcpReconciler>[0] = {
+        mode: "repair", context, now: NOW, refreshMarginMs: 1,
+        client: {
+          baseUrl: scope.serverBaseUrl,
+          getOpenworkCloudMcpHealth: async () => observed,
+          reconcileOpenworkCloudMcp: async () => { throw new Error("Synthetic reconcile unavailable"); },
+        },
+        mintToken: async () => {
+          mintCount += 1;
+          if (failingStep === "mint") throw new Error("Synthetic mint unavailable");
+          return failingStep === "empty-token" ? null : token;
+        },
+      };
+      const failed = await runOpenworkCloudMcpReconciler(input);
+      expect(failed).toMatchObject({ status: "failed", attempts: 1 });
+      expect(failed.health).toBe(observed);
+      expect(await runOpenworkCloudMcpReconciler(input)).toMatchObject({ status: "unchanged", attempts: 0 });
+      expect(mintCount).toBe(1);
+      expect(readCloudMcpUnhealthyRemintAttempt(scope)?.attemptedAt).toBe(NOW);
+    }
   });
 
   test("engine refresh maps the endpoint result and skips unsupported servers", async () => {

--- a/apps/app/tests/cloud-mcp-maintenance-gate.test.ts
+++ b/apps/app/tests/cloud-mcp-maintenance-gate.test.ts
@@ -164,6 +164,45 @@ function configuredItem(): OpenworkMcpItem {
 describe("cloud MCP maintenance user-state gate", () => {
   beforeEach(() => installStorageStub());
 
+  test("background maintenance provisions private authorization even when ordinary Cloud is healthy", async () => {
+    let mintCount = 0;
+    let reconcileCount = 0;
+    const result = await syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        listMcp: async () => ({ items: [configuredItem()] }),
+        getOpenworkCloudMcpHealth: async () => ({ ...health({ usable: true }), appHostAuthorizationReady: false }),
+        reconcileOpenworkCloudMcp: async (workspaceId, payload) => {
+          reconcileCount += 1;
+          expect(workspaceId).toBe(scope.workspaceId);
+          expect(payload.appHostAuthorization).toBe(`Bearer ${token.appHostToken}`);
+          return { ...health({ usable: true }), appHostAuthorizationReady: true };
+        },
+      },
+      workspaceId: scope.workspaceId,
+      settings,
+      now: NOW,
+      mintToken: async () => { mintCount += 1; return token; },
+    });
+    expect(result).toMatchObject({ outcome: "ready", status: "synced", health: { appHostAuthorizationReady: true } });
+    expect(mintCount).toBe(1);
+    expect(reconcileCount).toBe(1);
+  });
+
+  test("an App-only failure does not block ordinary Connect or claim a successful sync", async () => {
+    const result = await syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        listMcp: async () => ({ items: [configuredItem()] }),
+        getOpenworkCloudMcpHealth: async () => ({ ...health({ usable: true }), appHostAuthorizationReady: false }),
+        reconcileOpenworkCloudMcp: async () => { throw new Error("Must not reconcile after mint failure"); },
+      },
+      workspaceId: scope.workspaceId, settings, now: NOW,
+      mintToken: async () => { throw new Error("Synthetic mint unavailable"); },
+    });
+    expect(result).toMatchObject({ outcome: "ready", status: "unchanged", health: { usable: true, appHostAuthorizationReady: false } });
+  });
+
   test("field repro: legacy 'removed' intent must not block token maintenance of an existing enabled entry", async () => {
     // The affected machine had the legacy raw-string value from an old manual
     // toggle. Its 7-day token expired with maintenance permanently skipped.

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -217,6 +217,12 @@ export type CloudMcpHealth = {
   usable: boolean;
   usableByCurrentModel: boolean | null;
   connectCatalogEnabled: boolean;
+  /**
+   * Workspace-private auth is locally provisioned for the effective trusted origin.
+   * False means missing, malformed, or origin-mismatched auth; null means ineligible or unreadable.
+   * This does not establish token validity, provider availability, or access.
+   */
+  appHostAuthorizationReady: boolean | null;
   /** Result of this reconciliation's private catalog discovery; absent when not attempted. */
   connectCatalogDiagnostic?: ConnectMcpCatalogDiagnostic;
   workspace: {
@@ -2192,6 +2198,15 @@ async function readOpenworkCloudMcpHealthInternal(
   const checkedAt = new Date().toISOString();
   const startedAtMs = Date.now();
   const desired = await readDesiredState({ config: input.config, workspace: input.workspace, directory: input.directory });
+  let appHostAuthorizationReady: boolean | null = null;
+  if (desired.config && !desired.validationProblem) {
+    try {
+      const { readOpenWorkConnectMcpAppHostAuthorizationReady } = await import("./connect-mcp-server-catalog.js");
+      appHostAuthorizationReady = await readOpenWorkConnectMcpAppHostAuthorizationReady(input.config, input.workspace.id, desired.config);
+    } catch {
+      appHostAuthorizationReady = null;
+    }
+  }
   let delivery = cloudMcpDeliveryState.snapshot(input.workspace, input.directory, desired.revision);
   const toolDenies = desired.present
     ? await diagnoseMcpToolDenies(input.workspace.path, OPENWORK_CLOUD_MCP_NAME, expectedTools())
@@ -2284,6 +2299,7 @@ async function readOpenworkCloudMcpHealthInternal(
     usable: firstFailure === null,
     usableByCurrentModel: usableByModel(inspection.providerProjection, firstFailure),
     connectCatalogEnabled: desired.metadata.connectCatalogEnabled,
+    appHostAuthorizationReady,
     workspace: {
       id: input.workspace.id,
       type: input.workspace.workspaceType,

--- a/apps/server/src/connect-mcp-server-catalog.test.ts
+++ b/apps/server/src/connect-mcp-server-catalog.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,6 +12,7 @@ import {
   connectDirectMcpRuntimeName,
   connectMcpAppHostName,
   type OpenWorkConnectMcpServerIndex,
+  readOpenWorkConnectMcpAppHostAuthorizationReady,
   readOpenWorkConnectMcpAppHostCatalog,
   readOpenWorkConnectMcpServerIndex,
   readOpenWorkConnectMcpServerIndexWithDiagnostics,
@@ -18,22 +21,28 @@ import {
   writeOpenWorkConnectMcpAppHostAuthorization,
   writeOpenWorkConnectMcpAppHostCatalog,
 } from "./connect-mcp-server-catalog.js";
+import { runtimeDbPath } from "./runtime-db.js";
 import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
+import { createWorkspaceKvStore } from "./workspace-kv-store.js";
 
 const roots: string[] = [];
 const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+const previousBootstrapPath = process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH;
 
 afterEach(async () => {
   while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
   if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
   else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+  if (previousBootstrapPath === undefined) delete process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH;
+  else process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH = previousBootstrapPath;
 });
 
 async function fixtureConfig(): Promise<ServerConfig> {
   const root = await mkdtemp(join(tmpdir(), "openwork-connect-mcp-servers-"));
   roots.push(root);
   process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH = join(root, "desktop-bootstrap.json");
   return {
     host: "127.0.0.1",
     port: 0,
@@ -87,6 +96,66 @@ function indexFetcher(
 }
 
 describe("OpenWork Connect MCP server catalog", () => {
+  test("reports workspace- and origin-bound private authorization readiness without initializing storage", async () => {
+    const config = await fixtureConfig();
+    config.workspaces.push({ ...config.workspaces[0]!, id: "ws_2", name: "Two" });
+    const readOnlyConfig = { ...config, readOnly: true };
+    const dbPath = runtimeDbPath(config);
+    const cloudMcp = {
+      type: "remote", enabled: true, url: "https://api.openworklabs.com/mcp/agent",
+      headers: { Authorization: "Bearer member-token" },
+    };
+    expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(readOnlyConfig, "ws_1", cloudMcp)).toBe(false);
+    expect(existsSync(dbPath)).toBe(false);
+    await writeRuntimeOpencodeConfig(config, "ws_1", () => ({ mcp: { "openwork-cloud": cloudMcp } }));
+    const sqlite = new Database(dbPath, { readonly: true, create: false });
+    try {
+      const schema = sqlite.query("SELECT type, name, sql FROM sqlite_master ORDER BY name").all();
+      expect(sqlite.query("SELECT name FROM sqlite_master WHERE name = ?").get("connect_mcp_app_host_authorizations")).toBeNull();
+      expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(readOnlyConfig, "ws_1", cloudMcp)).toBe(false);
+      expect(sqlite.query("SELECT type, name, sql FROM sqlite_master ORDER BY name").all()).toEqual(schema);
+    } finally {
+      sqlite.close();
+    }
+    await writeOpenWorkConnectMcpAppHostAuthorization(config, "ws_1", "Bearer private-app-host-token", cloudMcp.url);
+    expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(readOnlyConfig, "ws_1", cloudMcp)).toBe(true);
+    expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(readOnlyConfig, "ws_2", cloudMcp)).toBe(false);
+    expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(readOnlyConfig, "ws_1", {
+      ...cloudMcp, url: "https://api.openwork.software/mcp/agent",
+    })).toBe(false);
+    expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(readOnlyConfig, "ws_1", cloudMcp)).toBe(true);
+  });
+
+  test("reports malformed stored private authorization as not provisioned", async () => {
+    const config = await fixtureConfig();
+    const cloudMcp = { type: "remote", enabled: true, url: "https://api.openworklabs.com/mcp/agent" };
+    const authorizations = createWorkspaceKvStore<string>({
+      tableName: "connect_mcp_app_host_authorizations", valueColumn: "authorization_json",
+      parse: (json) => json, serialize: (json) => json,
+    });
+    for (const value of [
+      "not-json",
+      JSON.stringify({ authorization: 123, origin: "https://api.openworklabs.com" }),
+      JSON.stringify({ authorization: "Bearer token with spaces", origin: "https://api.openworklabs.com" }),
+      JSON.stringify({ authorization: "Bearer private-app-host-token", origin: "not-an-origin" }),
+    ]) {
+      await authorizations.set(config, "ws_1", value);
+      expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(config, "ws_1", cloudMcp)).toBe(false);
+    }
+  });
+
+  test("leaves private authorization readiness unknown for ineligible endpoints", async () => {
+    const config = await fixtureConfig();
+    const cloudMcp = { type: "remote", enabled: true, url: "https://api.openworklabs.com/mcp/agent" };
+    await writeOpenWorkConnectMcpAppHostAuthorization(config, "ws_1", "Bearer private-app-host-token", cloudMcp.url);
+    for (const endpoint of [null, { ...cloudMcp, enabled: false }, { ...cloudMcp, type: "local" }, { ...cloudMcp, url: "not-a-url" }]) {
+      expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(config, "ws_1", endpoint)).toBeNull();
+    }
+    const untrusted = { ...cloudMcp, url: "https://untrusted.invalid/mcp/agent" };
+    await writeOpenWorkConnectMcpAppHostAuthorization(config, "ws_1", "Bearer private-app-host-token", untrusted.url);
+    expect(await readOpenWorkConnectMcpAppHostAuthorizationReady(config, "ws_1", untrusted)).toBeNull();
+  });
+
   test("reads the member catalog through an authenticated MCP resource", async () => {
     const requests: Array<{ url: string; headers: Headers; body: Record<string, unknown> }> = [];
     const index = await readOpenWorkConnectMcpServerIndex({

--- a/apps/server/src/connect-mcp-server-catalog.ts
+++ b/apps/server/src/connect-mcp-server-catalog.ts
@@ -253,11 +253,28 @@ export async function readOpenWorkConnectMcpAppHostAuthorization(
   config: ServerConfig,
   workspaceId: string,
   endpointUrl: string,
+  options?: { readOnly?: boolean },
 ): Promise<string | null> {
-  const credential = await appHostAuthorizationStore.get(config, workspaceId);
+  const credential = options?.readOnly
+    ? await appHostAuthorizationStore.getExisting(config, workspaceId)
+    : await appHostAuthorizationStore.get(config, workspaceId);
   const expectedOrigin = endpointOrigin(endpointUrl);
   if (!credential || !expectedOrigin || credential.origin !== expectedOrigin) return null;
   return privateAppHostAuthorization(credential.authorization);
+}
+
+/**
+ * Local provisioning for the caller's validated effective Cloud config only;
+ * never validates tokens or proves provider availability or access.
+ */
+export async function readOpenWorkConnectMcpAppHostAuthorizationReady(
+  config: ServerConfig,
+  workspaceId: string,
+  cloudMcp: Record<string, unknown> | null,
+): Promise<boolean | null> {
+  if (!cloudMcp || cloudMcp.type !== "remote" || cloudMcp.enabled !== true || typeof cloudMcp.url !== "string"
+    || !await trustedAppHostCloudEndpoint(cloudMcp)) return null;
+  return await readOpenWorkConnectMcpAppHostAuthorization(config, workspaceId, cloudMcp.url, { readOnly: true }) !== null;
 }
 
 export async function writeOpenWorkConnectMcpAppHostAuthorization(

--- a/apps/server/src/workspace-kv-store.node.test.ts
+++ b/apps/server/src/workspace-kv-store.node.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -70,6 +71,45 @@ async function setSessionGroupSchemaVersion(dbPath: string, schemaVersion: numbe
 }
 
 if (typeof process.versions.bun !== "string") {
+  test("workspace kv getExisting uses Node SQLite without initializing storage or shared connections", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-workspace-kv-node-existing-"));
+    const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+    const dbPath = join(root, "runtime.sqlite");
+    process.env.OPENWORK_RUNTIME_DB = dbPath;
+    try {
+      const config = { ...serverConfig(root), readOnly: true };
+      const store = recordStore("workspace_kv_node_existing");
+      assert.equal(await store.getExisting(config, WORKSPACE_ID), undefined);
+      assert.equal(existsSync(dbPath), false);
+
+      const { DatabaseSync } = await import("node:sqlite");
+      const sqlite = new DatabaseSync(dbPath);
+      try {
+        sqlite.exec("CREATE TABLE unrelated (value TEXT)");
+        const schema = sqlite.prepare("SELECT type, name, sql FROM sqlite_master ORDER BY name").all();
+        assert.equal(await store.getExisting(config, WORKSPACE_ID), undefined);
+        assert.deepEqual(sqlite.prepare("SELECT type, name, sql FROM sqlite_master ORDER BY name").all(), schema);
+        assert.deepEqual(workspaceKvStoreCacheStatsForTests(dbPath), { connectionEntries: 0, tableEntries: 0 });
+
+        sqlite.exec("CREATE TABLE workspace_kv_node_existing (workspace_id TEXT PRIMARY KEY, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
+        sqlite.prepare("INSERT INTO workspace_kv_node_existing VALUES (?, ?, ?)").run(WORKSPACE_ID, JSON.stringify({ enabled: true }), 1);
+        const populatedSchema = sqlite.prepare("SELECT type, name, sql FROM sqlite_master ORDER BY name").all();
+        assert.deepEqual(await store.getExisting(config, WORKSPACE_ID), { enabled: true });
+        assert.equal(await store.getExisting(config, "missing"), undefined);
+        sqlite.prepare("UPDATE workspace_kv_node_existing SET config_json = ? WHERE workspace_id = ?").run("{", WORKSPACE_ID);
+        assert.deepEqual(await store.getExisting(config, WORKSPACE_ID), {});
+        assert.deepEqual(sqlite.prepare("SELECT type, name, sql FROM sqlite_master ORDER BY name").all(), populatedSchema);
+        assert.deepEqual(workspaceKvStoreCacheStatsForTests(dbPath), { connectionEntries: 0, tableEntries: 0 });
+      } finally {
+        sqlite.close();
+      }
+    } finally {
+      if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("workspace kv store uses Node SQLite with one shared connection per runtime DB", async () => {
     const root = await mkdtemp(join(tmpdir(), "openwork-workspace-kv-node-"));
     const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;

--- a/apps/server/src/workspace-kv-store.test.ts
+++ b/apps/server/src/workspace-kv-store.test.ts
@@ -139,6 +139,35 @@ describe("workspace kv store", () => {
     expect(await store.get(config, WORKSPACE_ID)).toEqual({ enabled: true });
   });
 
+  test("getExisting reads and parses rows without initializing storage or shared connections", async () => {
+    const { config, dbPath } = await tempWorkspace();
+    const readOnlyConfig = { ...config, readOnly: true };
+    const store = recordStore("workspace_kv_existing");
+
+    expect(await store.getExisting(readOnlyConfig, WORKSPACE_ID)).toBeUndefined();
+    expect(existsSync(dbPath)).toBe(false);
+    const sqlite = new Database(dbPath, { create: true });
+    try {
+      sqlite.run("CREATE TABLE unrelated (value TEXT)");
+      const schema = sqlite.query("SELECT type, name, sql FROM sqlite_master ORDER BY name").all();
+      expect(await store.getExisting(readOnlyConfig, WORKSPACE_ID)).toBeUndefined();
+      expect(sqlite.query("SELECT type, name, sql FROM sqlite_master ORDER BY name").all()).toEqual(schema);
+      expect(workspaceKvStoreCacheStatsForTests(dbPath)).toEqual({ connectionEntries: 0, tableEntries: 0 });
+
+      sqlite.run("CREATE TABLE workspace_kv_existing (workspace_id TEXT PRIMARY KEY, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
+      sqlite.query("INSERT INTO workspace_kv_existing VALUES (?, ?, ?)").run(WORKSPACE_ID, JSON.stringify({ enabled: true }), 1);
+      const populatedSchema = sqlite.query("SELECT type, name, sql FROM sqlite_master ORDER BY name").all();
+      expect(await store.getExisting(readOnlyConfig, WORKSPACE_ID)).toEqual({ enabled: true });
+      expect(await store.getExisting(readOnlyConfig, "missing")).toBeUndefined();
+      sqlite.query("UPDATE workspace_kv_existing SET config_json = ? WHERE workspace_id = ?").run("{", WORKSPACE_ID);
+      expect(await store.getExisting(readOnlyConfig, WORKSPACE_ID)).toEqual({});
+      expect(sqlite.query("SELECT type, name, sql FROM sqlite_master ORDER BY name").all()).toEqual(populatedSchema);
+      expect(workspaceKvStoreCacheStatsForTests(dbPath)).toEqual({ connectionEntries: 0, tableEntries: 0 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("returns each migrated store's documented defaults for missing and malformed rows", async () => {
     const { root, config, dbPath } = await tempWorkspace();
 

--- a/apps/server/src/workspace-kv-store.ts
+++ b/apps/server/src/workspace-kv-store.ts
@@ -1,7 +1,8 @@
 import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { existsSync } from "node:fs";
-import { openRuntimeSqliteDatabase, runtimeDbPath, type RuntimeSqliteDatabase } from "./runtime-db.js";
+import { stat } from "node:fs/promises";
+import { importNodeSqlite, openRuntimeSqliteDatabase, runtimeDbPath, type RuntimeSqliteDatabase } from "./runtime-db.js";
 import type { ServerConfig } from "./types.js";
 
 type WorkspaceKvSchemaVersionColumn = {
@@ -242,6 +243,27 @@ export function createWorkspaceKvStore<T>(options: WorkspaceKvStoreOptions<T>) {
     getRow,
     get: async (serverConfig: ServerConfig, workspaceId: string): Promise<T | undefined> => {
       return (await getRow(serverConfig, workspaceId))?.value;
+    },
+    /** Reads existing state without initializing the DB, table, or shared write cache. */
+    getExisting: async (serverConfig: ServerConfig, workspaceId: string): Promise<T | undefined> => {
+      const path = runtimeDbPath(serverConfig);
+      try {
+        await stat(path);
+      } catch (error) {
+        if (isRecord(error) && error.code === "ENOENT") return undefined;
+        throw error;
+      }
+      const sqlite = typeof process.versions.bun === "string"
+        ? new (await import("bun:sqlite")).Database(path, { readonly: true, create: false })
+        : new (await importNodeSqlite()).DatabaseSync(path, { readOnly: true });
+      try {
+        const table = sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? COLLATE NOCASE").get(config.tableName);
+        if (!table) return undefined;
+        const row = rowFromUnknown(sqlite.prepare(config.selectSql).get(workspaceId));
+        return row ? options.parse(row.valueJson) : undefined;
+      } finally {
+        sqlite.close();
+      }
     },
     has: async (serverConfig: ServerConfig, workspaceId: string): Promise<boolean> => {
       const db = await readableWorkspaceKvDb(runtimeDbPath(serverConfig), config);

--- a/evals/packages/labs/src/mock-mcp-catalog.ts
+++ b/evals/packages/labs/src/mock-mcp-catalog.ts
@@ -45,7 +45,7 @@ export async function startCatalogWitness(privateAuthorization: string) {
     }
     if (path === "/mcp") return sendJson(response, 200, Object.fromEntries([...connected].map((name) => [name, { status: "connected" }])));
     if (path === "/global/health") return sendJson(response, 200, { healthy: true, version: "1.17.11" });
-    if (path === "/experimental/tool/ids") return sendJson(response, 200, ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"]);
+    if (path === "/experimental/tool/ids") return sendJson(response, 200, ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability", "openwork_docs_search", "openwork_query"]);
     if (path === "/provider") return sendJson(response, 200, { all: [], default: {}, connected: [] });
     if (path === "/session" || path === "/experimental/tool") return sendJson(response, 200, []);
     return sendJson(response, 200, {});

--- a/evals/specs/mcp-catalog-diagnostics.test.ts
+++ b/evals/specs/mcp-catalog-diagnostics.test.ts
@@ -6,8 +6,8 @@ import { needs, test } from "@openwork/testkit";
 import { startCatalogWitness } from "../packages/labs/src/mock-mcp-catalog.ts";
 import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
 
-// New journey: operators can distinguish catalog failures in the real server's
-// reconciliation response. Quick-add catalog specs exercise Den/UI, not this API.
+// Operators can distinguish catalog failures and local App-host provisioning in
+// the real server's responses. Quick-add catalog specs exercise Den/UI, not this API.
 test("catalog reconciliation attributes failures without leaking private auth or retaining revoked direct servers", async ({ evidence }) => {
   needs({ commands: ["bun"] });
   const root = await mkdtemp(join(tmpdir(), "mcp-catalog-diagnostics-"));
@@ -51,6 +51,23 @@ test("catalog reconciliation attributes failures without leaking private auth or
     if (!isRecord(body)) throw new Error("Missing reconciliation result");
     return body;
   }
+  async function health(endpoint: string) {
+    const requestCount = witness.requests.length;
+    const registrationCount = witness.registrations.length;
+    const disconnectCount = witness.disconnects.length;
+    const response = await fetch(endpoint.replace("/reconcile", "/health"), { headers, signal: AbortSignal.timeout(10_000) });
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).not.toContain(privateAuthorization.slice("Bearer ".length));
+    expect(text).not.toContain(memberAuthorization.slice("Bearer ".length));
+    expect(witness.requests).toHaveLength(requestCount);
+    expect(witness.registrations).toHaveLength(registrationCount);
+    expect(witness.disconnects).toHaveLength(disconnectCount);
+    const body: unknown = JSON.parse(text);
+    if (!isRecord(body)) throw new Error("Missing health result");
+    expect(body.tools).toMatchObject({ direct: { checked: false } });
+    return body;
+  }
   async function expectResolveError(endpoint: string, code: string) {
     const response = await fetch(endpoint.replace("/mcp/openwork-cloud/reconcile", "/mcp-apps/resolve"), {
       method: "POST", headers, signal: AbortSignal.timeout(20_000),
@@ -64,15 +81,26 @@ test("catalog reconciliation attributes failures without leaking private auth or
   }
   try {
     const endpoint = await boot("trusted-dev", "1");
+    expect((await health(endpoint)).appHostAuthorizationReady).toBeNull();
     const disabled = await reconcile(endpoint, undefined, false);
     expect(disabled.connectCatalogDiagnostic).toBeUndefined();
     expect(disabled.firstFailure).toMatchObject({ code: "cloud_mcp_disabled" });
-    expect((await reconcile(endpoint)).connectCatalogDiagnostic).toBe("missing_app_host_auth");
+    expect(disabled.appHostAuthorizationReady).toBeNull();
+    const missingAuth = await reconcile(endpoint);
+    expect(missingAuth).toMatchObject({ usable: true, phase: "ready", firstFailure: null, appHostAuthorizationReady: false, connectCatalogDiagnostic: "missing_app_host_auth" });
+    const missingAuthHealth = await health(endpoint);
+    expect(missingAuthHealth).toMatchObject({ usable: true, phase: "ready", firstFailure: null, appHostAuthorizationReady: false });
+    if (!isRecord(missingAuthHealth.desired) || typeof missingAuthHealth.desired.revision !== "string") throw new Error("Missing desired revision");
+    const desiredRevision = missingAuthHealth.desired.revision;
+    expect(missingAuth.desired).toMatchObject({ revision: desiredRevision });
     await expectResolveError(endpoint, "connect_catalog_missing_app_host_auth");
     expect(witness.requests.filter((entry) => entry.privateAuth || entry.method === "resources/read")).toEqual([]);
 
     witness.catalog(index([]));
-    expect((await reconcile(endpoint, privateAuthorization)).connectCatalogDiagnostic).toBe("empty");
+    const authorized = await reconcile(endpoint, privateAuthorization);
+    expect(authorized).toMatchObject({ usable: true, appHostAuthorizationReady: true, connectCatalogDiagnostic: "empty", desired: { revision: desiredRevision } });
+    expect(await health(endpoint)).toMatchObject({ usable: true, phase: "ready", firstFailure: null, appHostAuthorizationReady: true, desired: { revision: desiredRevision } });
+    evidence.recordAssertionEvidence("App-host provisioning is independent of ordinary Cloud health", "Ordinary health GET remains usable after global reconciliation without private auth, reports false then true after private authorization, and retains the same desired revision. GET makes no direct probe or catalog requests and leaks neither credential.", true);
     await expectResolveError(endpoint, "server_unavailable");
     expect(witness.requests.some((entry) => entry.method === "resources/read" && entry.privateAuth && entry.appHostCapability)).toBe(true);
     expect(witness.registrations.some((entry) => entry.name.startsWith("openwork-direct-"))).toBe(false);
@@ -106,7 +134,8 @@ test("catalog reconciliation attributes failures without leaking private auth or
     witness.catalog(index([]));
     const untrustedEndpoint = await boot("unactivated", "0");
     const privateRequestsBefore = witness.requests.filter((entry) => entry.privateAuth).length;
-    expect((await reconcile(untrustedEndpoint, privateAuthorization)).connectCatalogDiagnostic).toBe("untrusted_origin");
+    expect(await reconcile(untrustedEndpoint, privateAuthorization)).toMatchObject({ connectCatalogDiagnostic: "untrusted_origin", appHostAuthorizationReady: null });
+    expect(await health(untrustedEndpoint)).toMatchObject({ usable: true, firstFailure: null, appHostAuthorizationReady: null });
     await expectResolveError(untrustedEndpoint, "connect_catalog_untrusted_origin");
     expect(witness.requests.filter((entry) => entry.privateAuth)).toHaveLength(privateRequestsBefore);
     evidence.recordAssertionEvidence("Unactivated origin cannot receive private App-host credentials", "An isolated non-development server reports untrusted_origin for the same unactivated origin; private request count does not increase. Reconciliation responses omit both bearer credentials.", true);


### PR DESCRIPTION
## Summary

Dashboard Apps can fail to resolve even when ordinary Connect health is ready: the globally configured Cloud connection does not prove that the current workspace has its separate private App-host authorization. The healthy short circuit previously skipped the repair that supplies it.

- Report workspace- and origin-bound private authorization readiness independently of ordinary Cloud usability. Unknown or ineligible endpoints do not trigger App-only repair.
- Repair explicitly missing private authorization despite healthy Cloud or a fresh sync marker. Keep ordinary access usable when an optional repair fails, without claiming that synchronization succeeded.
- Bound unsuccessful App-only repairs with a scoped one-hour cooldown. Explicit Repair and core Cloud failures bypass it; successful provisioning clears it.
- Inspect existing SQLite state read-only without initializing a database, table, or shared write cache. Preserve origin trust, connector permissions, and private-token isolation.

Builds on the merged catalog transport and diagnostics changes in #4773, #4774, and #4776. Dashboard UI retries remain outside this change; #4294 owns that separate work.

## Verification

Exact signed head: `6cfcb1ae9de9eff46422b28d61b061a474fcbd87`.
Rebased onto `dev` at `4462762b4f47eb4dd9752b3f6d682eb9773279a4`; merge-base matches that revision.

All commands below exited 0 on this head:

- `pnpm --config.verify-deps-before-run=false --filter @openwork/app exec bun test --isolate tests/cloud-mcp-health.test.ts tests/cloud-mcp-maintenance-gate.test.ts` — 23 passed, 0 failed.
- `pnpm --config.verify-deps-before-run=false --filter openwork-server test ./src/workspace-kv-store.test.ts ./src/connect-mcp-server-catalog.test.ts` — 24 passed, 0 failed.
- `pnpm --config.verify-deps-before-run=false evals:pr specs/mcp-catalog-diagnostics.test.ts` — 1 passed, 0 failed, 0 skipped; cold isolated local server and synthetic HTTP witnesses. Four passing assertion records, no pending judgments. This direct PR command emitted no placement line.
- `pnpm --config.verify-deps-before-run=false --filter @openwork/app typecheck`
- `pnpm --config.verify-deps-before-run=false --filter openwork-server typecheck`
- `git diff --check 4462762b4f47eb4dd9752b3f6d682eb9773279a4...HEAD`

The pnpm flag prevents automatic dependency installation before execution; it does not disable test checks. Exact-head assertion evidence will be attached below.

## Verdict and remaining coverage

**Incomplete overall.** Focused unit checks and the server-boundary journey passed. The complete desktop provisioning-to-dashboard journey, Node-specific storage test execution, and enterprise deployment retest remain unrun. Hosted CI and review are pending; no clearance is claimed here.

The readiness field establishes local credential provisioning, not token validity, expiry, revocation, provider availability, or connector access. These checks do not establish incident resolution or authorize merge/deployment.