### PR TITLE
fix(app): clear stale waiting indicators when an aborted question never reports rejection

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/use-session-archive.tsx
@@ -24,6 +24,7 @@ import { getComposerQueuedDrafts, useComposerStateStore } from "../surface/compo
 import { composerAutoSendScopeKey, consumeComposerAutoSend, hasComposerAutoSend } from "../surface/composer-auto-send";
 import { dispatchQueuedDrain, getQueuedDrainState, hasPendingQueuedAdmission } from "../surface/queued-drain-machine";
 import { clearQueuedSendContext } from "../sync/queued-send-context";
+import { isOrphanedInteraction, terminalToolCallIds } from "../sync/orphaned-interactions";
 import { applySessionArchived } from "../sync/session-sync";
 
 type ArchiveTarget = { workspace: RouteWorkspace; endpoint: ResolvedWorkspaceEndpoint; sessionId: string; title: string; draftScope: string | null };
@@ -188,8 +189,12 @@ export function useSessionArchive(input: {
           }
           if (idle) dispatchQueuedDrain(id, { type: "idle_reconciled", observedAt, terminalObserved });
           else dispatchQueuedDrain(id, { type: "busy_observed" });
-          return !idle || permissionV2 || permissions.some(request => request.sessionID === id)
-            || questions.some(request => request.sessionID === id) || localWork(id)
+          // A request whose tool call already ended was abandoned by the engine
+          // without a rejection; nobody can answer it, so it is not open work.
+          const terminal = terminalToolCallIds(messages);
+          const unanswered = (request: { sessionID: string; tool?: { messageID: string; callID: string } }) =>
+            request.sessionID === id && !isOrphanedInteraction(request.tool, terminal);
+          return !idle || permissionV2 || permissions.some(unanswered) || questions.some(unanswered) || localWork(id)
             || sessionHasPendingSubmission(baseUrl, id, messages) || sessionNeedsStop(baseUrl, id)
             || hasPendingQueuedAdmission(getQueuedDrainState(id))
             || [workspace.id, endpoint.workspaceId].some(workspaceId =>

--- a/apps/app/src/react-app/domains/session/sync/orphaned-interactions.ts
+++ b/apps/app/src/react-app/domains/session/sync/orphaned-interactions.ts
@@ -1,0 +1,37 @@
+import { isToolUIPart, type UIMessage } from "ai";
+import type { Part } from "@opencode-ai/sdk/v2/client";
+
+// OpenCode asks questions and permissions from inside a tool call. When that
+// turn is aborted or superseded by a newer prompt, the engine marks the tool
+// part terminal and drops the request without publishing question.rejected /
+// permission.replied; an abandoned (not interrupted) ask even stays listed by
+// GET /question. A request whose tool call already ended can no longer be
+// answered by anyone, so the transcript is the authority that settles it.
+
+type ToolLink = { messageID: string; callID: string };
+
+export function isTerminalToolPart(part: Part): part is Extract<Part, { type: "tool" }> {
+  return part.type === "tool" && (part.state.status === "completed" || part.state.status === "error");
+}
+
+export function terminalToolCallIds(messages: ReadonlyArray<{ parts: ReadonlyArray<Part> }>): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    for (const part of message.parts) if (isTerminalToolPart(part)) ids.add(part.callID);
+  }
+  return ids;
+}
+
+export function terminalTranscriptToolCallIds(messages: ReadonlyArray<UIMessage>): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (isToolUIPart(part) && (part.state === "output-available" || part.state === "output-error")) ids.add(part.toolCallId);
+    }
+  }
+  return ids;
+}
+
+export function isOrphanedInteraction(tool: ToolLink | undefined, terminalCallIds: ReadonlySet<string>): boolean {
+  return tool !== undefined && terminalCallIds.has(tool.callID);
+}

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -30,6 +30,7 @@ import {
 } from "./parse-tool-parts";
 import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
 import { applyRevertCursor, reconcileTranscriptMessages } from "./transcript-reconcile";
+import { isOrphanedInteraction, isTerminalToolPart, terminalToolCallIds, terminalTranscriptToolCallIds } from "./orphaned-interactions";
 import {
   useSessionActivityStore,
 } from "../status/session-activity-store";
@@ -664,6 +665,27 @@ export function settleQuestionState(workspaceId: string, sessionId: string, requ
   useSessionActivityStore.getState().setWaitingRequest(workspaceId, sessionId, "question", requestId, false);
 }
 
+/**
+ * Settle every cached question/permission whose tool call is in
+ * `terminalCallIds`. OpenCode never publishes a rejection for a request whose
+ * turn was aborted or superseded, so the terminal tool part is the only
+ * signal; settling also keeps a later list read from resurrecting it.
+ */
+function settleOrphanedInteractions(workspaceId: string, sessionId: string, terminalCallIds: ReadonlySet<string>) {
+  if (terminalCallIds.size === 0) return;
+  const queryClient = getReactQueryClient();
+  for (const question of queryClient.getQueryData<PendingQuestion[]>(questionKey(workspaceId, sessionId)) ?? []) {
+    if (isOrphanedInteraction(question.tool, terminalCallIds)) settleQuestionState(workspaceId, sessionId, question.id);
+  }
+  for (const permission of queryClient.getQueryData<PendingPermission[]>(permissionKey(workspaceId, sessionId)) ?? []) {
+    if (isOrphanedInteraction(permission.tool, terminalCallIds)) settlePermissionState(workspaceId, sessionId, permission.id);
+  }
+}
+
+function terminalTranscriptCallIds(workspaceId: string, sessionId: string) {
+  return terminalTranscriptToolCallIds(getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId)) ?? []);
+}
+
 export function seedPermissionState(
   workspaceId: string,
   sessionId: string,
@@ -673,6 +695,10 @@ export function seedPermissionState(
   const queryClient = getReactQueryClient();
   const now = Date.now();
   const settled = new Set(queryClient.getQueryData<string[]>(settledPermissionsKey(workspaceId, sessionId)) ?? []);
+  const terminalCallIds = terminalTranscriptCallIds(workspaceId, sessionId);
+  for (const permission of permissions) {
+    if (!isV2PermissionRequest(permission) && isOrphanedInteraction(permission.tool, terminalCallIds)) settled.add(permission.id);
+  }
   const changedDuringRead = options.snapshotRevision === undefined
     || options.snapshotRevision !== (queryClient.getQueryState(permissionKey(workspaceId, sessionId))?.dataUpdateCount ?? 0);
   const snapshotKey = [...permissionKey(workspaceId, sessionId), "snapshot-started-at"];
@@ -722,6 +748,10 @@ export function seedQuestionState(
   const queryClient = getReactQueryClient();
   const now = Date.now();
   const settled = new Set(queryClient.getQueryData<string[]>(settledQuestionsKey(workspaceId, sessionId)) ?? []);
+  const terminalCallIds = terminalTranscriptCallIds(workspaceId, sessionId);
+  for (const question of questions) {
+    if (isOrphanedInteraction(question.tool, terminalCallIds)) settled.add(question.id);
+  }
   const nextQuestions = queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, sessionId), (current = []) => {
     const receivedAtById = new Map(current.map((question) => [question.id, question.receivedAt]));
     const seeded = questions.flatMap((question) =>
@@ -1210,6 +1240,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       clearSessionRetry(entry, workspaceId, part.sessionID);
       useSessionActivityStore.getState().markAssistantOutput(workspaceId, part.sessionID, part.messageID);
     }
+    if (isTerminalToolPart(part)) settleOrphanedInteractions(workspaceId, part.sessionID, new Set([part.callID]));
     if (!isTrackedSession(entry, part.sessionID)) return;
     const [mapped, ...attachments] = toUIParts(part);
     if (!mapped) return;
@@ -1897,6 +1928,7 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
     }),
     snapshot.session.revert?.messageID ?? null,
   ));
+  settleOrphanedInteractions(workspaceId, snapshot.session.id, terminalToolCallIds(snapshot.messages));
 
   const todosKey = todoKey(workspaceId, snapshot.session.id);
   // Remember first observation for unmarked snapshots too, so reselecting a

--- a/apps/app/tests/session-sync-orphaned-interactions.test.ts
+++ b/apps/app/tests/session-sync-orphaned-interactions.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client";
+import type { UIMessage } from "ai";
+
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import { getReactQueryClient } from "../src/react-app/infra/query-client";
+import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import { terminalToolCallIds } from "../src/react-app/domains/session/sync/orphaned-interactions";
+import {
+  __applySessionSyncEventForTest,
+  __createWorkspaceSessionSyncForTest,
+  permissionKey,
+  questionKey,
+  seedPermissionState,
+  seedQuestionState,
+  seedSessionState,
+  trackWorkspaceSessionSync,
+  transcriptKey,
+} from "../src/react-app/domains/session/sync/session-sync";
+
+// OpenCode 1.18 drops a question or permission whose turn was aborted or
+// superseded by a newer prompt without publishing `question.rejected` /
+// `permission.replied`; when the tool call is abandoned rather than
+// interrupted the request even stays in `GET /question`. The transcript's
+// terminal tool part is the only signal that nobody can answer it any more.
+
+const workspaceId = "workspace-a";
+const sessionId = "session-a";
+const syncInput = { workspaceId, baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+const toolLink = { messageID: "msg-assistant", callID: "call-question" };
+
+type ToolPart = Extract<Part, { type: "tool" }>;
+
+function toolPart(status: "running" | "completed" | "error", overrides: Partial<ToolPart> = {}): ToolPart {
+  const base = { id: "part-question", sessionID: sessionId, messageID: toolLink.messageID, type: "tool" as const,
+    callID: toolLink.callID, tool: "question" };
+  if (status === "running") return { ...base, ...overrides, state: { status: "running", input: {}, time: { start: 1 } } };
+  if (status === "completed") {
+    return { ...base, ...overrides, state: { status: "completed", input: {}, output: "ok", title: "Asked", metadata: {}, time: { start: 1, end: 2 } } };
+  }
+  return { ...base, ...overrides, state: { status: "error", input: {}, error: "Tool execution aborted", time: { start: 1, end: 2 } } };
+}
+
+function question(id: string): QuestionRequest {
+  return { id, sessionID: sessionId, tool: toolLink,
+    questions: [{ header: "Choice", question: "Pick one", options: [{ label: "Yes", description: "Proceed" }] }] };
+}
+
+function unlinkedQuestion(id: string): QuestionRequest {
+  const { tool: _tool, ...rest } = question(id);
+  return rest;
+}
+
+function permission(id: string): PermissionRequest {
+  return { id, sessionID: sessionId, permission: "bash", patterns: ["echo ok"], metadata: {}, always: [], tool: toolLink };
+}
+
+function snapshotWithParts(parts: Part[]): OpenworkSessionSnapshot {
+  return {
+    session: { id: sessionId, title: "Test session", time: { created: 1, updated: 2 }, version: "0" },
+    messages: [
+      { info: { id: "msg-user", role: "user", sessionID: sessionId, time: { created: 1 } }, parts: [] },
+      { info: { id: toolLink.messageID, role: "assistant", sessionID: sessionId, time: { created: 2 } }, parts },
+    ],
+    todos: [],
+    status: { type: "idle" },
+  } as unknown as OpenworkSessionSnapshot;
+}
+
+const status = () => useSessionActivityStore.getState().getStatus(workspaceId, sessionId);
+const questions = () => getReactQueryClient().getQueryData(questionKey(workspaceId, sessionId));
+const permissions = () => getReactQueryClient().getQueryData(permissionKey(workspaceId, sessionId));
+
+afterEach(() => {
+  getReactQueryClient().clear();
+  useSessionActivityStore.getState().removeSession(workspaceId, sessionId);
+});
+
+describe("orphaned interaction settlement", () => {
+  test("a live terminal tool part settles the question it asked without any rejected event", () => {
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    const release = trackWorkspaceSessionSync(syncInput, sessionId);
+    try {
+      __applySessionSyncEventForTest(syncInput, { type: "session.status", properties: { sessionID: sessionId, status: { type: "busy" } } });
+      __applySessionSyncEventForTest(syncInput, { type: "message.updated",
+        properties: { info: { id: toolLink.messageID, role: "assistant", sessionID: sessionId } } });
+      __applySessionSyncEventForTest(syncInput, { type: "question.asked", properties: question("que-1") });
+      __applySessionSyncEventForTest(syncInput, { type: "message.part.updated", properties: { part: toolPart("running") } });
+      expect(status()).toBe("waiting");
+
+      // A newer prompt supersedes the turn: OpenCode marks the tool call as
+      // errored and moves on, but never publishes question.rejected.
+      __applySessionSyncEventForTest(syncInput, { type: "message.part.updated", properties: { part: toolPart("error") } });
+      expect(questions()).toEqual([]);
+      expect(status()).toBe("responding");
+
+      __applySessionSyncEventForTest(syncInput, { type: "session.status", properties: { sessionID: sessionId, status: { type: "idle" } } });
+      expect(status()).toBe("idle");
+
+      // The engine still lists the abandoned request; a later list read must
+      // not resurrect it.
+      seedQuestionState(workspaceId, sessionId, [question("que-1")], { snapshotStartedAt: Date.now() });
+      expect(questions()).toEqual([]);
+      expect(status()).toBe("idle");
+    } finally {
+      release();
+      cleanup();
+    }
+  });
+
+  test("an abandoned question listed by the engine is not seeded for a transcript whose tool call ended", () => {
+    seedSessionState(workspaceId, snapshotWithParts([toolPart("error")]));
+    expect(status()).toBe("idle");
+
+    seedQuestionState(workspaceId, sessionId, [question("que-zombie")], { snapshotStartedAt: Date.now() });
+    expect(questions()).toEqual([]);
+    expect(status()).toBe("idle");
+  });
+
+  test("a transcript snapshot settles a question and permission that were listed before it loaded", () => {
+    seedQuestionState(workspaceId, sessionId, [question("que-zombie")], { snapshotStartedAt: Date.now() });
+    seedPermissionState(workspaceId, sessionId, [permission("perm-zombie")], { snapshotStartedAt: Date.now() });
+    expect(status()).toBe("waiting");
+
+    seedSessionState(workspaceId, snapshotWithParts([toolPart("completed")]));
+    expect(questions()).toEqual([]);
+    expect(permissions()).toEqual([]);
+    expect(status()).toBe("idle");
+  });
+
+  test("a running tool call or a request without a tool link keeps the waiting marker", () => {
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    const release = trackWorkspaceSessionSync(syncInput, sessionId);
+    try {
+      __applySessionSyncEventForTest(syncInput, { type: "session.status", properties: { sessionID: sessionId, status: { type: "busy" } } });
+      __applySessionSyncEventForTest(syncInput, { type: "question.asked", properties: question("que-live") });
+      __applySessionSyncEventForTest(syncInput, { type: "question.asked", properties: unlinkedQuestion("que-unlinked") });
+      __applySessionSyncEventForTest(syncInput, { type: "message.part.updated", properties: { part: toolPart("running") } });
+      expect(questions()).toMatchObject([{ id: "que-live" }, { id: "que-unlinked" }]);
+      expect(status()).toBe("waiting");
+
+      // Another tool call finishing must not settle this question.
+      __applySessionSyncEventForTest(syncInput, { type: "message.part.updated",
+        properties: { part: toolPart("completed", { id: "part-other", callID: "call-other", tool: "bash" }) } });
+      seedQuestionState(workspaceId, sessionId, [question("que-live"), unlinkedQuestion("que-unlinked")], { snapshotStartedAt: Date.now() });
+      expect(questions()).toMatchObject([{ id: "que-live" }, { id: "que-unlinked" }]);
+      expect(status()).toBe("waiting");
+
+      __applySessionSyncEventForTest(syncInput, { type: "message.part.updated", properties: { part: toolPart("error") } });
+      expect(questions()).toMatchObject([{ id: "que-unlinked" }]);
+      expect(status()).toBe("waiting");
+    } finally {
+      release();
+      cleanup();
+    }
+  });
+
+  test("a terminal part for an untracked session still clears its sidebar marker", () => {
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    try {
+      __applySessionSyncEventForTest(syncInput, { type: "permission.asked", properties: permission("perm-1") });
+      expect(status()).toBe("waiting");
+      __applySessionSyncEventForTest(syncInput, { type: "message.part.updated", properties: { part: toolPart("error", { tool: "bash" }) } });
+      expect(permissions()).toEqual([]);
+      expect(status()).toBe("idle");
+      expect(getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId))).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("terminalToolCallIds reads only completed and errored tool calls from raw messages", () => {
+    const ids = terminalToolCallIds([
+      { parts: [toolPart("running"), toolPart("completed", { callID: "call-done" }), toolPart("error", { callID: "call-failed" })] },
+      { parts: [{ id: "text", type: "text", text: "hi", sessionID: sessionId, messageID: "msg-user" }] },
+    ]);
+    expect([...ids].sort()).toEqual(["call-done", "call-failed"]);
+  });
+});

--- a/evals/specs/abandoned-question-waiting-indicator.e2e.test.ts
+++ b/evals/specs/abandoned-question-waiting-indicator.e2e.test.ts
@@ -1,0 +1,97 @@
+import { expect } from "vitest";
+import { browserScript } from "@openwork/cdp";
+import { spec } from "@openwork/testkit";
+import { abandonedQuestion } from "../worlds/chat.ts";
+
+// OpenCode 1.18 marks a stopped question tool call as errored but never
+// publishes question.rejected, and the abandoned request can stay listed by
+// GET /question. The app must stop asking the user for an answer nobody can
+// consume, and Archive must not treat that leftover as open work.
+
+const test = spec.world(abandonedQuestion, { timeout: 600_000 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected a native engine object");
+  return value;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) throw new Error("Expected a native engine list");
+  return value.map(record);
+}
+
+test("a question abandoned by a stopped, superseded turn stops needing the user and lets the session archive", async ({ world, user, agent, probe, step }) => {
+  const { sessionId } = world.session;
+  const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/opencode`;
+  const read = async (path: string): Promise<unknown> => {
+    const result = await probe.desktopApi(`${mount}${path}`);
+    expect(result.status, path).toBe(200);
+    return result.body;
+  };
+  const pendingQuestions = async () => records(await read("/question")).filter((request) => request.sessionID === sessionId);
+  const questionToolStates = async () => records(await read(`/session/${encodeURIComponent(sessionId)}/message?limit=50`))
+    .flatMap((message) => records(message.parts))
+    .filter((part) => part.type === "tool" && part.tool === "question")
+    .map((part) => record(part.state).status);
+  // TODO(primitive): read the sidebar row's attention indicator through a first-class primitive.
+  const attention = () => probe.eval(browserScript((id) => {
+    const row = document.querySelector<HTMLElement>('[data-sidebar-session-id="' + id + '"]');
+    const dot = row?.querySelector<HTMLElement>("[data-session-attention-indicator]");
+    return dot instanceof HTMLElement ? dot.title : null;
+  }, [sessionId]));
+
+  await step("a real question asks for the user's answer", async () => {
+    await user.click({ text: world.session.title });
+    await probe.eventually(() => probe.hash(), { within: 30_000, label: "the seeded conversation is selected",
+      until: (hash) => hash.includes(`/session/${sessionId}`) });
+    await user.type("composer", world.ask.prompt, { verify: true });
+    await user.press("Enter");
+    await user.see({ text: world.ask.question }, { timeoutMs: 45_000 });
+    await probe.eventually(attention, { within: 15_000, label: "the sidebar marks the conversation as waiting for the user",
+      until: (title) => title === "Waiting" });
+    expect(await pendingQuestions()).toHaveLength(1);
+    expect(await questionToolStates()).toEqual(["running"]);
+    await user.screenshot();
+  });
+
+  await step("stopping the turn and sending a follow-up abandon the question without any rejection event", async () => {
+    // The same engine calls another agent makes: stop, then prompt again.
+    const abort = await agent.desktopApi(`${mount}/session/${encodeURIComponent(sessionId)}/abort`, { method: "POST" });
+    expect(abort.status).toBe(200);
+    const prompt = await agent.desktopApi(`${mount}/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+      method: "POST", body: { parts: [{ type: "text", text: world.followup.prompt }] },
+    });
+    expect([200, 204]).toContain(prompt.status);
+    await user.see({ text: world.followup.reply }, { timeoutMs: 60_000 });
+    const states = await probe.eventually(questionToolStates, { within: 15_000, label: "the engine records the question tool call as ended",
+      until: (states) => states.length === 1 && states[0] !== "running" && states[0] !== "pending" });
+    expect(states).toEqual([expect.stringMatching(/^(error|completed)$/)]);
+    await probe.eventually(() => read("/session/status"), { within: 15_000, label: "the engine reports the conversation idle",
+      until: (statuses) => record(statuses)[sessionId] === undefined || record(record(statuses)[sessionId]).type === "idle" });
+    // Whether the engine still lists the request is the upstream defect under
+    // observation, not this claim; record it for the evidence.
+    console.info(`[abandoned-question] engine still lists the abandoned request: ${(await pendingQuestions()).length > 0}`);
+  });
+
+  await step("the conversation stops needing the user within seconds", async () => {
+    await user.notSee({ text: world.ask.question }, { timeoutMs: 15_000 });
+    await probe.eventually(attention, { within: 15_000, label: "the sidebar no longer marks the conversation as waiting",
+      until: (title) => title !== "Waiting" });
+    await user.see("composer", { editable: true });
+    await user.screenshot();
+  });
+
+  await step("archiving succeeds without the stop-and-archive confirmation", async () => {
+    await user.hover({ testId: `sidebar-session-${sessionId}` });
+    await user.click({ testId: `session-archive-${sessionId}` });
+    await user.see({ text: "Session archived" }, { timeoutMs: 30_000 });
+    await user.notSee({ text: "This session is still working" });
+    await probe.eventually(() => read(`/session/${encodeURIComponent(sessionId)}`), { within: 15_000, label: "the engine records the archive",
+      until: (session) => typeof record(record(session).time).archived === "number" });
+    await user.screenshot();
+  });
+});

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -352,6 +352,32 @@ export async function delegatedQuestionHandoff(seed: Seed) {
   return { ...base, engine, delegationTool, followup, root: { ...root, prompt: rootPrompt }, child, unrelated: { ...other, ...unrelated } };
 }
 
+/** A real native question whose turn is stopped and superseded by a follow-up prompt, as another agent's STOP does. */
+export async function abandonedQuestion(seed: Seed) {
+  const engine = resolveEvalEngine();
+  if (engine !== "v1") throw new SkipError("Abandoned-question archive requires v1; v2 has no session archive.");
+  const ask = {
+    prompt: "Help me choose the abandoned task format",
+    question: "Which format should the abandoned task use?",
+    answer: "Abandoned outline",
+    alternative: "Abandoned checklist",
+  };
+  const followup = { prompt: "Skip the format question and summarize instead", reply: "Summary finished without the format answer." };
+  const base = await splitPaneQuestions(seed, "abandoned-question", [
+    {
+      promptMarker: ask.prompt, latestUserTurn: true,
+      finalReply: "Unused: return the actual question result.", finalReplyFrom: "last-tool-text",
+      steps: [{ tool: "question", arguments: { questions: [{
+        header: "Task format", question: ask.question,
+        options: [{ label: ask.answer, description: "Use this format" }, { label: ask.alternative, description: "Use the other format" }],
+      }] } }],
+    },
+    { promptMarker: followup.prompt, latestUserTurn: true, finalReply: followup.reply, steps: [] },
+  ]);
+  const session = await seedSessionRetry(seed, base.app, { title: "Abandoned question task" });
+  return { ...base, engine, ask, followup, session };
+}
+
 /** Real native permissions and a provider retry, without synthetic UI events. */
 export async function permissionStopRecovery(seed: Seed) {
   const engine = resolveEvalEngine();


### PR DESCRIPTION
## Symptom

A session that finished hours ago still shows the orange "needs you" dot in the sidebar, and `session.archive` is refused ("could not be confirmed" → Stop-and-archive confirmation → "A task, approval, or message acceptance is still unresolved"). Found by the workspace audit on an "E2E fix" session: 12:02 the assistant calls `question`; 12:05 a superseding prompt (another agent's STOP) arrives while the question is pending; the question tool part ends with `state.status = "error"`; the follow-up turn finishes with `finish=stop`; engine idle for hours; app still says `waiting`.

## RCA (confirmed, with one correction)

**Engine (confirmed, not patchable here).** The engine is the upstream OpenCode binary (`constants.json` → `v1.18.18`, downloaded by `apps/desktop/scripts/prepare-sidecar.mjs`). In `packages/opencode/src/question/index.ts` (and identically `permission/index.ts`), `ask()` wraps `Deferred.await` in `Effect.ensuring(pending.delete(id))`; only an explicit `reply()`/`reject()` publishes `question.replied`/`question.rejected`. `SessionProcessor.cleanup()` waits 250 ms for open tool calls and then marks them `error: "Tool execution aborted"` **without interrupting the tool fiber**, so the question's deferred is never failed either. Read-only probe of the live engine while the affected session was idle:

- `GET /session/status` → the session is absent (idle)
- `GET /question` → **still lists** the session's request `que_…` with `tool: { messageID, callID }`
- DB: that `callID`'s tool part is `state.status = "error"`

So the RCA hypothesis 1 is confirmed *and stronger than stated*: not only is `question.rejected` never published, the abandoned request stays in the engine's pending list as a zombie. That rules out option (a) ("drop ids missing from the engine list") as a fix — the list is the source of the ghost.

**App (corrected).** Hypothesis 2 (a missed SSE idle plus the snapshot guards) is not what keeps the record waiting. `setRunStatus(idle)` does clear the ids, and `connect-reconcile` (`seedSessionRun` with `snapshotStartedAt`) heals a missed idle. The `record.status !== "idle"` guards in `seedWorkspaceSessions`/`seedSessionRun` are intentional: `waiting` + `runActive=false` is a legitimate state ("retains a pending question at the idle release deadline" test, v2 permissions), so they stay. What actually re-poisons the store is the zombie itself:

- `useSessionInteractions` reads `GET /question` whenever the session (or its parent) is open and `seedQuestionState` re-adds the zombie → `waiting` again with `runActive=false`; nothing ever settles it.
- `useSessionArchive.readWorking` reads the same list and counts the zombie as open work → archive refused forever.

## Fix (option (c): the transcript is authoritative)

A question/permission can only be answered while the tool call that asked it is still running. When that call's part is `completed`/`error`, nobody can consume an answer, so the request is settled:

- `sync/orphaned-interactions.ts` (new): `isTerminalToolPart`, `terminalToolCallIds` (raw parts), `terminalTranscriptToolCallIds` (UI transcript), `isOrphanedInteraction(tool, terminal)`.
- `session-sync.ts`: `settleOrphanedInteractions()` runs on live `message.part.updated` (before the tracked-session gate, so background sidebar rows heal too) and after each transcript snapshot; `seedQuestionState`/`seedPermissionState` treat orphaned requests as settled so a zombie list read cannot resurrect them. Settling goes through the existing `settle*State` path (settled set + waiting id removal), so the existing snapshot/live ordering guards are untouched.
- `use-session-archive.tsx`: `readWorking` ignores a pending request whose tool call already ended in the fetched messages.

Requests without a `tool` link and requests whose tool part is still `running` are never touched (covered by tests).

## Proof

- `apps/app`: `bun test --isolate tests/session-sync-orphaned-interactions.test.ts tests/session-sync-permissions.test.ts tests/session-sync-run-status.test.ts tests/session-sync-tool-parts.test.ts tests/session-sync-lifecycle.test.ts` → 107 pass / 0 fail (the 6 new tests were red before the fix: 5 fail / 1 pass; the existing "does not let an older idle snapshot stop a live run" guard stays green).
- `apps/app`: `pnpm typecheck` → clean.
- E2E: `evals/specs/abandoned-question-waiting-indicator.e2e.test.ts` (new world `abandonedQuestion` in `evals/worlds/chat.ts`): real question via mock model → `POST /session/:id/abort` + `prompt_async` follow-up (what another agent's STOP does) → asserts the engine tool part ended and the session is idle, the question panel closes, the sidebar dot stops saying "Waiting" within 15 s, and Archive succeeds with no Stop-and-archive confirmation. Lane and result: see the evidence comment below.

## Upstream engine item (not patchable in this repo)

Proposed issue for anomalyco/opencode:

> **Aborted/superseded question or permission is never rejected and stays in the pending list**
>
> When a session turn is aborted (`POST /session/:id/abort`) or superseded while a `question` (or permission) tool call is awaiting an answer, `SessionProcessor.cleanup()` marks the tool part `error: "Tool execution aborted"` but does not interrupt the tool fiber. `Question.ask`'s `Effect.ensuring(pending.delete(id))` therefore never runs: `GET /question` keeps listing the request after the session is idle, and no `question.rejected` event is published (only explicit `reject()` publishes one; the instance finalizer also fails deferreds silently). Clients cannot tell a live question from this leftover without cross-checking the tool part state. Same shape in `Permission.ask`. Suggested fix: on abort/supersede, interrupt or `reject()` the pending asks linked to the aborted tool calls so `question.rejected` / `permission.replied(reject)` is published and the pending map is cleaned. Observed on v1.18.18.

## Coordination

Sibling branch `fix/session-blocker-introspection` exposes pending question/permission state to agents. This PR does not touch `session-activity-store.ts`; it adds one helper module and small hooks in `session-sync.ts` (`settleOrphanedInteractions`, seed filters, `message.part.updated`, `seedSessionState`) and `use-session-archive.tsx`. If that branch reads the engine's pending lists, it should apply the same `isOrphanedInteraction` filter so agents do not see the zombie either.
