### PR TITLE
feat(landing): dithered hero, gateway endpoint section, responsive alignment

### DIFF
--- a/ee/apps/landing/app/globals.css
+++ b/ee/apps/landing/app/globals.css
@@ -197,6 +197,33 @@ body {
   margin-right: auto;
 }
 
+/* Hero dither mask. Desktop: clear behind the left headline column (anchored to the
+   centered container), fade in across the right half, clear behind the top wordmark,
+   fade out toward the bottom. Below lg the headline spans the full width, so the
+   dither is pushed to the right edge and softened. */
+.lp-hero-dither {
+  -webkit-mask-image:
+    linear-gradient(to right, transparent 0, transparent calc(50% + 10px), rgba(0, 0, 0, 0.2) calc(50% + 80px), rgba(0, 0, 0, 0.6) calc(50% + 170px), #000 calc(50% + 260px), #000 100%),
+    linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.15) 150px, rgba(0, 0, 0, 0.65) 250px, #000 310px, #000 480px, rgba(0, 0, 0, 0.5) 740px, transparent 1080px);
+  mask-image:
+    linear-gradient(to right, transparent 0, transparent calc(50% + 10px), rgba(0, 0, 0, 0.2) calc(50% + 80px), rgba(0, 0, 0, 0.6) calc(50% + 170px), #000 calc(50% + 260px), #000 100%),
+    linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.15) 150px, rgba(0, 0, 0, 0.65) 250px, #000 310px, #000 480px, rgba(0, 0, 0, 0.5) 740px, transparent 1080px);
+  -webkit-mask-composite: source-in;
+  mask-composite: intersect;
+}
+
+@media (max-width: 1023px) {
+  .lp-hero-dither {
+    opacity: 0.4;
+    -webkit-mask-image:
+      linear-gradient(to right, transparent 0, transparent 52%, rgba(0, 0, 0, 0.35) 70%, #000 88%, #000 100%),
+      linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.2) 110px, #000 200px, #000 420px, rgba(0, 0, 0, 0.5) 620px, transparent 860px);
+    mask-image:
+      linear-gradient(to right, transparent 0, transparent 52%, rgba(0, 0, 0, 0.35) 70%, #000 88%, #000 100%),
+      linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.2) 110px, #000 200px, #000 420px, rgba(0, 0, 0, 0.5) 620px, transparent 860px);
+  }
+}
+
 .landing-shell {
   background: rgba(255, 255, 255, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.8);

--- a/ee/apps/landing/components/landing-hero-prompt.tsx
+++ b/ee/apps/landing/components/landing-hero-prompt.tsx
@@ -4,8 +4,7 @@
  * Hero agent-install prompt with copied feedback states.
  */
 
-import { AnimatePresence, motion } from "framer-motion";
-import { Check, ChevronRight } from "lucide-react";
+import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { capturePosthogEvent } from "../lib/posthog-client";
@@ -21,12 +20,9 @@ type Props = {
   compact?: boolean;
 };
 
-const steps = ["Installs OpenWork", "Creates your workspace", "Opens ready to run"];
-
 export function LandingHeroPrompt({ className, compact = false }: Props) {
   const [feedback, setFeedback] = useState(false);
   const [copyError, setCopyError] = useState(false);
-  const [revealed, setRevealed] = useState(false);
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -57,7 +53,6 @@ export function LandingHeroPrompt({ className, compact = false }: Props) {
     }
     setCopyError(!copied);
     setFeedback(true);
-    if (copied) setRevealed(true);
     capturePosthogEvent("landing_copy_prompt_clicked", {
       copied,
       method,
@@ -128,60 +123,21 @@ export function LandingHeroPrompt({ className, compact = false }: Props) {
         }}
         className="group cursor-pointer rounded-2xl bg-white p-5 shadow-[0_8px_24px_rgba(1,22,39,0.05)] transition-shadow hover:shadow-[0_10px_28px_rgba(1,22,39,0.08)]"
       >
-        <div className="mb-2 text-[13px] text-[var(--lp-muted)]">
-          Already use an AI agent? Paste this prompt — it installs OpenWork for you.
+        <div className="text-[15px] leading-snug text-[#011627]">
+          Already use an AI agent?
         </div>
-        <p className="text-[15px] leading-relaxed text-[#011627]">
-          Install OpenWork on my computer, set up my first workspace, and open it
-          ready to use. Follow the steps in{" "}
-          <span className="text-[var(--lp-muted)]">
-            https://openworklabs.com/start.md?v={PROMPT_VARIANT}
-          </span>
-          <span
-            className="hero-prompt-caret ml-0.5 inline-block h-[1.1em] w-[2px] translate-y-[2px] bg-[#011627]"
-            aria-hidden="true"
-          />
-        </p>
-        <div className="mt-3 flex items-center justify-between gap-3">
+        <div className="mt-1 text-[13px] leading-relaxed text-[var(--lp-muted)]">
+          Paste one prompt. It installs and sets up OpenWork for you.
+        </div>
+        <div className="mt-4 flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2 text-[var(--lp-faint)]">
             <LandingAgentGlyphs />
             <span className="hidden text-xs text-[var(--lp-faint)] sm:inline">
-              Works with Claude Code, Cursor, Codex — any agent
+              Claude Code, Cursor, Codex, or any agent
             </span>
           </div>
           {copyButton}
         </div>
-        <AnimatePresence initial={false}>
-          {revealed ? (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.25 }}
-              className="overflow-hidden"
-            >
-              <div className="mt-3 border-t border-[#F1F5F9] pt-3">
-                <div className="flex items-center gap-2 text-[13px] font-medium text-[#011627]">
-                  <Check
-                    className="h-5 w-5 shrink-0 text-green-600"
-                    strokeWidth={1.75}
-                    aria-hidden="true"
-                  />
-                  Copied — now paste it into Claude Code, Cursor, or ChatGPT:
-                </div>
-                <div className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-2">
-                  {steps.map((label, index) => (
-                    <div key={label} className="flex items-center gap-2">
-                      {index > 0 ? <ChevronRight size={12} className="text-[var(--lp-faint)]" /> : null}
-                      <span className="step-circle">{index + 1}</span>
-                      <span className="text-[13px] text-[var(--lp-body)]">{label}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </motion.div>
-          ) : null}
-        </AnimatePresence>
       </div>
       <span aria-live="polite" className="sr-only">
         {feedback ? (copyError ? "Couldn't copy the prompt" : "Prompt copied to clipboard") : ""}

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -12,9 +12,8 @@ import {
 } from "./landing-demo-flows";
 import { LandingFaq } from "./landing-faq";
 import { LandingHeroPrompt } from "./landing-hero-prompt";
-import { LpCopyBar } from "./lp-copy-bar";
 import { LpCta } from "./lp-cta";
-import { LpGatewayDiagram } from "./lp-gateway-diagram";
+import { LpGatewayEndpoint } from "./lp-gateway-endpoint";
 import { LpHeroBackground } from "./lp-hero-background";
 import { LpParityTable } from "./lp-parity-table";
 import {
@@ -79,21 +78,22 @@ export function LandingHome(props: Props) {
           active="home"
         />
 
-        <main className="mx-auto w-full max-w-[1176px] px-6 pb-8">
-          <div
-            aria-hidden="true"
-            className="font-pixel flex justify-between pb-10 pt-6 text-[clamp(3rem,16vw,12rem)] leading-none tracking-[-0.06em] sm:pb-12 sm:pt-8 lg:pb-16"
-          >
-            {Array.from("OpenWork").map((letter, index) => (
-              <span key={index}>{letter}</span>
-            ))}
-          </div>
+        <div
+          aria-hidden="true"
+          className="font-pixel mx-auto flex w-full max-w-[1920px] justify-between pb-10 px-[clamp(1.5rem,calc((100%-1128px)/2),4.75rem)] pt-6 text-[clamp(3rem,16vw,12rem)] leading-none tracking-[-0.06em] sm:pb-12 sm:pt-8 lg:pb-16"
+        >
+          {Array.from("OpenWork").map((letter, index) => (
+            <span key={index}>{letter}</span>
+          ))}
+        </div>
 
+        <main className="mx-auto w-full max-w-[1176px] px-6 pb-8">
           <section
             aria-labelledby="sovereign-hero-heading"
-            className="grid items-start gap-10 lg:grid-cols-[minmax(0,1.08fr)_minmax(0,1fr)] lg:gap-12"
+            className="grid items-start gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.08fr)] lg:gap-12"
           >
-            <div className="min-w-0 lg:order-2 lg:pt-2">
+            <div className="relative min-w-0 lg:pt-2">
+              <div className="relative">
               <p className="mono mb-5 text-[11px] leading-relaxed tracking-[0.1em] text-[var(--lp-body)] sm:text-xs">
                 SOVEREIGN AI FOR KNOWLEDGE WORKERS
               </p>
@@ -123,11 +123,11 @@ export function LandingHome(props: Props) {
                     Get Started for Free <ArrowRight size={18} />
                   </a>
                 ) : (
-                  <DownloadLink className="doc-button inline-flex items-center gap-2">
-                    Download for free <ArrowRight size={18} />
+                  <DownloadLink className="doc-button inline-flex !h-[52px] items-center gap-2 !px-6 !text-[17px]">
+                    Download for free <ArrowRight size={20} />
                   </DownloadLink>
                 )}
-                <a href="/enterprise" className="secondary-button">
+                <a href="/enterprise" className="secondary-button !h-[52px] !px-6 !text-[17px]">
                   Explore enterprise
                 </a>
               </div>
@@ -142,65 +142,18 @@ export function LandingHome(props: Props) {
                 <a href={props.linuxDownloadHref} className="underline-offset-4 hover:underline">Linux</a>
               </div>
 
-              {props.isMobileVisitor ? null : (
-                <div className="mt-7 flex flex-wrap items-center gap-3 border-t border-[var(--lp-border)] pt-5">
-                  <p className="text-xs text-[var(--lp-muted)]">Already use an AI agent? Let it set up OpenWork.</p>
-                  <LandingHeroPrompt compact />
-                </div>
-              )}
-
               <div className="mt-7 flex items-center gap-2 text-xs text-[var(--lp-muted)]">
                 <span>Backed by</span>
                 <span className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] bg-[#ff6600] text-[11px] text-white">Y</span>
                 <span className="font-medium">Combinator</span>
               </div>
-            </div>
-
-            <div id="product" className="min-w-0 scroll-mt-24 lg:order-1" aria-label="OpenWork product demo">
-              <div className="landing-shell overflow-hidden rounded-2xl">
-                <div className="relative flex h-10 items-center border-b border-white/50 bg-gradient-to-b from-white/90 to-white/60 px-4">
-                  <div className="flex gap-1.5" aria-hidden="true">
-                    <div className="h-2.5 w-2.5 rounded-full border border-[#e0443e]/20 bg-[#ff5f56]/90" />
-                    <div className="h-2.5 w-2.5 rounded-full border border-[#dea123]/20 bg-[#ffbd2e]/90" />
-                    <div className="h-2.5 w-2.5 rounded-full border border-[#1aab29]/20 bg-[#27c93f]/90" />
-                  </div>
-                  <span className="absolute left-1/2 -translate-x-1/2 text-xs font-medium text-[var(--lp-muted)]">OpenWork</span>
-                </div>
-                <div className="p-3">
-                  <LandingAppDemoPanel
-                    flows={landingDemoFlows}
-                    activeFlowId={activeDemo.id}
-                    onSelectFlow={setActiveDemoId}
-                  />
-                </div>
-                <div className="flex flex-wrap gap-1 border-t border-[var(--lp-border)] px-3 py-3" aria-label="Example tasks">
-                  {landingDemoFlows.map((flow) => {
-                    const isActive = flow.id === activeDemo.id;
-                    return (
-                      <button
-                        key={flow.id}
-                        type="button"
-                        onClick={() => setActiveDemoId(flow.id)}
-                        aria-pressed={isActive}
-                        className={`relative cursor-pointer rounded-full px-3 py-2 text-xs transition-colors ${isActive ? "text-[var(--lp-ink)]" : "text-[var(--lp-muted)] hover:text-[var(--lp-ink)]"}`}
-                      >
-                        {isActive ? (
-                          <motion.div
-                            layoutId="active-pill"
-                            className="absolute inset-0 rounded-full border border-[var(--lp-border)] bg-white shadow-sm"
-                            transition={{ type: "spring", stiffness: 400, damping: 30 }}
-                          />
-                        ) : null}
-                        <span className="relative z-10">{flow.categoryLabel}</span>
-                      </button>
-                    );
-                  })}
-                </div>
               </div>
-              <p className="mt-4 text-[13px] leading-relaxed text-[var(--lp-muted)]" aria-live="polite">
-                {activeDemo.description}
-              </p>
             </div>
+            {props.isMobileVisitor ? null : (
+              <div className="flex min-w-0 self-stretch lg:items-end lg:justify-end">
+                <LandingHeroPrompt className="w-full lg:max-w-[440px]" />
+              </div>
+            )}
           </section>
 
           <div className="mt-12 grid gap-4 border-y border-[var(--lp-border)] py-6 text-[13px] text-[var(--lp-body)] sm:grid-cols-3 sm:gap-0 lg:mt-16">
@@ -218,7 +171,7 @@ export function LandingHome(props: Props) {
           <section className="mt-20 scroll-mt-24 lg:mt-[120px]" id="models">
             <div className="mb-8">
               <h2 className="max-w-[680px] text-[16px] font-normal text-[var(--lp-ink)]">
-                Bring any model — or provision centrally for your whole org
+                Bring any model, or provision centrally for your whole org
               </h2>
             </div>
             <div className="rounded-[24px] bg-[var(--lp-tonal)] px-6 py-7 md:px-10">
@@ -255,7 +208,7 @@ export function LandingHome(props: Props) {
               }
             />
             <p className="mt-6 max-w-[640px] text-[16px] leading-[25px] text-[var(--lp-body)]">
-              If your team runs on Claude Cowork today, everything keeps working —
+              If your team runs on Claude Cowork today, everything keeps working,
               and you stop being tied to one vendor, one model, and one deployment.
             </p>
             <a
@@ -269,7 +222,7 @@ export function LandingHome(props: Props) {
             </div>
           </section>
 
-          <section className="mt-[120px]" id="product">
+          <section className="mt-[120px]">
             <div className="grid gap-6 md:grid-cols-3">
               <LpTonalCard className="group flex min-h-[260px] flex-col justify-between p-6">
                 <div className="lp-icon-chip flex h-11 w-11 items-center justify-center rounded-full bg-white transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:rotate-[8deg]">
@@ -326,28 +279,21 @@ export function LandingHome(props: Props) {
             />
             <p className="mt-6 max-w-[640px] text-[16px] leading-[25px] text-[var(--lp-body)]">
               OpenWork Connect is our MCP gateway. Add a server or skill to your org
-              once — every teammate and agent gets it instantly, in OpenWork and in
-              any MCP-compatible client. Claude Cowork has no equivalent.
+              once and every teammate and agent gets it instantly, in OpenWork and in
+              any MCP client.
             </p>
             <a href="/connect" className="lp-pill-secondary lp-pill-sm mt-6 md:!hidden">
               Explore OpenWork Connect
             </a>
             <div className="mt-10">
-              <LpGatewayDiagram />
+              <LpGatewayEndpoint url={GATEWAY_URL} />
             </div>
-            <div className="mt-6">
-              <LpCopyBar value={GATEWAY_URL} />
-            </div>
-            <p className="mt-3 text-[13.5px] text-[var(--lp-muted)]">
-              One URL for your whole org — skills, MCPs, roles, and policies
-              included. Works with your OpenWork account.
-            </p>
           </section>
 
           <section className="mt-[120px]">
             <LpSectionHeader
               label="Get started"
-              heading="Use it today — your way."
+              heading="Use it today, your way."
               right={
                 <p className="max-w-[340px] text-left text-[14.5px] leading-[22px] text-[var(--lp-body)] md:text-right">
                   Three doors into the same workspace. Same skills, same gateway,
@@ -387,7 +333,7 @@ export function LandingHome(props: Props) {
                     In your browser <LpAlphaBadge />
                   </h3>
                   <p className="mt-2 max-w-[280px] text-[14px] leading-[22px] text-[var(--lp-body)] md:min-h-[66px]">
-                    OpenWork Web. Nothing to install — sign in and run your first
+                    OpenWork Web. Nothing to install. Sign in and run your first
                     task.
                   </p>
                   <a
@@ -455,7 +401,7 @@ export function LandingHome(props: Props) {
                 <div>
                   <h3 className="text-[19px] font-medium">Own your AI stack</h3>
                   <p className="mt-2 text-[14.5px] leading-[22px] text-[var(--lp-body)]">
-                    Self-sovereign AI — your models, your infrastructure. Managed or
+                    Self-sovereign AI: your models, your infrastructure. Managed or
                     self-hosted.
                   </p>
                   <div className="mt-4">
@@ -464,6 +410,56 @@ export function LandingHome(props: Props) {
                 </div>
               </LpTonalCard>
             </div>
+          </section>
+
+          <section
+            id="product"
+            className="mt-[120px] scroll-mt-24"
+            aria-label="OpenWork product demo"
+          >
+            <div className="landing-shell overflow-hidden rounded-2xl">
+              <div className="relative flex h-10 items-center border-b border-white/50 bg-gradient-to-b from-white/90 to-white/60 px-4">
+                <div className="flex gap-1.5" aria-hidden="true">
+                  <div className="h-2.5 w-2.5 rounded-full border border-[#e0443e]/20 bg-[#ff5f56]/90" />
+                  <div className="h-2.5 w-2.5 rounded-full border border-[#dea123]/20 bg-[#ffbd2e]/90" />
+                  <div className="h-2.5 w-2.5 rounded-full border border-[#1aab29]/20 bg-[#27c93f]/90" />
+                </div>
+                <span className="absolute left-1/2 -translate-x-1/2 text-xs font-medium text-[var(--lp-muted)]">OpenWork</span>
+              </div>
+              <div className="p-3">
+                <LandingAppDemoPanel
+                  flows={landingDemoFlows}
+                  activeFlowId={activeDemo.id}
+                  onSelectFlow={setActiveDemoId}
+                />
+              </div>
+              <div className="flex flex-wrap gap-1 border-t border-[var(--lp-border)] px-3 py-3" aria-label="Example tasks">
+                {landingDemoFlows.map((flow) => {
+                  const isActive = flow.id === activeDemo.id;
+                  return (
+                    <button
+                      key={flow.id}
+                      type="button"
+                      onClick={() => setActiveDemoId(flow.id)}
+                      aria-pressed={isActive}
+                      className={`relative cursor-pointer rounded-full px-3 py-2 text-xs transition-colors ${isActive ? "text-[var(--lp-ink)]" : "text-[var(--lp-muted)] hover:text-[var(--lp-ink)]"}`}
+                    >
+                      {isActive ? (
+                        <motion.div
+                          layoutId="active-pill"
+                          className="absolute inset-0 rounded-full border border-[var(--lp-border)] bg-white shadow-sm"
+                          transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                        />
+                      ) : null}
+                      <span className="relative z-10">{flow.categoryLabel}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <p className="mt-4 text-[13px] leading-relaxed text-[var(--lp-muted)]" aria-live="polite">
+              {activeDemo.description}
+            </p>
           </section>
 
           <div className="mt-[120px] [&_h2]:!text-[36px] [&_h2]:!leading-[42px]">

--- a/ee/apps/landing/components/lp-gateway-endpoint.tsx
+++ b/ee/apps/landing/components/lp-gateway-endpoint.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+import { BrandLogo } from "./lp-brand-logos";
+import { OpenWorkMark } from "./openwork-mark";
+
+type Props = {
+  url: string;
+};
+
+const clients: { label: string; logo: "openwork" | "claude" | "cursor" | "codex" | "openai" }[] = [
+  { label: "OpenWork", logo: "openwork" },
+  { label: "Claude Code", logo: "claude" },
+  { label: "Cursor", logo: "cursor" },
+  { label: "Codex", logo: "codex" },
+  { label: "ChatGPT", logo: "openai" }
+];
+
+const points = [
+  {
+    title: "Add once",
+    body: "Connect a server or skill to your org. Every teammate and agent gets it instantly."
+  },
+  {
+    title: "Sign in once",
+    body: "Members authenticate with their OpenWork account. Credentials stay in the gateway."
+  },
+  {
+    title: "Governed by default",
+    body: "Roles and policies apply to every call, in every client. Nothing to configure per seat."
+  }
+];
+
+function ClientGlyph({ logo }: { logo: (typeof clients)[number]["logo"] }) {
+  if (logo === "openwork") {
+    return <OpenWorkMark className="h-4 w-4 object-contain brightness-0 invert" />;
+  }
+  if (logo === "codex") {
+    return (
+      <Image
+        src="/connect-icons/codex.png"
+        width={16}
+        height={16}
+        alt=""
+        className="h-4 w-4 rounded-[3px]"
+      />
+    );
+  }
+  return <BrandLogo name={logo} className="h-4 w-4" />;
+}
+
+export function LpGatewayEndpoint({ url }: Props) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => {
+        setCopied(false);
+        timer.current = null;
+      }, 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="rounded-[20px] bg-[var(--lp-terminal)] p-6 text-white md:p-8">
+        <div className="flex items-center justify-between gap-4">
+          <span className="mono text-[11px] tracking-[0.1em] text-white/50">
+            GATEWAY ENDPOINT
+          </span>
+          <span className="mono hidden text-[11px] tracking-[0.06em] text-white/40 sm:inline">
+            MCP · Streamable HTTP
+          </span>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <code className="mono break-all text-[17px] leading-[26px] text-white sm:whitespace-nowrap md:text-[22px]">
+            {url}
+          </code>
+          <button
+            type="button"
+            onClick={() => {
+              void copy();
+            }}
+            aria-label={`Copy ${url}`}
+            className="inline-flex h-10 min-w-[104px] shrink-0 items-center justify-center gap-2 rounded-full bg-white px-4 text-[13px] font-medium text-[var(--lp-ink)] transition-opacity hover:opacity-90 active:scale-[0.97]"
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                Copy
+              </>
+            )}
+            <span className="sr-only" aria-live="polite">
+              {copied ? "Copied" : ""}
+            </span>
+          </button>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-2 border-t border-white/10 pt-5">
+          <span className="mr-1 text-[13px] text-white/50">Works in</span>
+          {clients.map((client) => (
+            <span
+              key={client.label}
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.06] px-3 py-1.5 text-[13px] text-white/90"
+            >
+              <ClientGlyph logo={client.logo} />
+              {client.label}
+            </span>
+          ))}
+          <span className="inline-flex items-center rounded-full px-2 py-1.5 text-[13px] text-white/50">
+            and any MCP client
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-8 grid gap-6 border-t border-[var(--lp-border)] pt-6 md:grid-cols-3 md:gap-0">
+        {points.map((point, index) => (
+          <div
+            key={point.title}
+            className={
+              index === 1
+                ? "md:border-x md:border-[var(--lp-border)] md:px-6"
+                : index === 0
+                  ? "md:pr-6"
+                  : "md:pl-6"
+            }
+          >
+            <div className="text-[15px] font-medium text-[var(--lp-ink)]">{point.title}</div>
+            <p className="mt-1.5 text-[14px] leading-[22px] text-[var(--lp-body)]">
+              {point.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ee/apps/landing/components/lp-hero-background.tsx
+++ b/ee/apps/landing/components/lp-hero-background.tsx
@@ -1,26 +1,44 @@
 "use client";
 
-import { PaperGrainGradient } from "@openwork/ui/react";
+import { Dithering } from "@paper-design/shaders-react";
+import { useEffect, useState } from "react";
+
+// The mask lives in globals.css (.lp-hero-dither) so it can change per breakpoint.
+function canCreateWebGlContext(): boolean {
+  if (typeof document === "undefined") return false;
+  const canvas = document.createElement("canvas");
+  return Boolean(
+    canvas.getContext("webgl") || canvas.getContext("experimental-webgl")
+  );
+}
 
 export function LpHeroBackground() {
+  const [supported, setSupported] = useState(false);
+
+  useEffect(() => {
+    setSupported(canCreateWebGlContext());
+  }, []);
+
   return (
     <div
       aria-hidden
-      className="pointer-events-none absolute inset-x-0 top-0 h-[980px] overflow-hidden"
+      className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[1200px] overflow-hidden bg-[#fcfcfc]"
     >
-      <div className="absolute inset-0 opacity-50">
-        <PaperGrainGradient
-          colors={["#f6f9fc", "#f6f9fc", "#1e293b", "#334155"]}
-          colorBack="#f6f9fc"
-          softness={1}
-          intensity={0.03}
-          noise={0.14}
-          shape="corners"
-          speed={0.2}
-          style={{ width: "100%", height: "100%" }}
-        />
-      </div>
-      <div className="absolute inset-x-0 bottom-0 h-[320px] bg-gradient-to-b from-transparent to-[var(--lp-page)]" />
+      {supported ? (
+        <div className="lp-hero-dither absolute inset-0">
+          <Dithering
+            speed={0}
+            shape="warp"
+            type="4x4"
+            size={2.5}
+            scale={1}
+            frame={30214.2}
+            colorBack="#fcfcfc"
+            colorFront="#171717"
+            style={{ width: "100%", height: "100%" }}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ee/apps/landing/components/lp-parity-table.tsx
+++ b/ee/apps/landing/components/lp-parity-table.tsx
@@ -1,4 +1,4 @@
-import { Check, CheckCircle2 } from "lucide-react";
+import { Check, CheckCircle2, Minus } from "lucide-react";
 
 import { LpAlphaBadge } from "./lp-primitives";
 import { OpenWorkMark } from "./openwork-mark";
@@ -21,12 +21,12 @@ const rows: ParityRow[] = [
   { capability: "GPT-5, Gemini, Mistral, and local models", cowork: "none" },
   { capability: "Scheduled tasks", cowork: "check", badge: "alpha" },
   {
-    capability: "Dispatch — assign tasks from your phone",
+    capability: "Dispatch: assign tasks from your phone",
     cowork: "check",
     openwork: "soon"
   },
   {
-    capability: "Live artifacts — auto-refreshing dashboards",
+    capability: "Live artifacts: auto-refreshing dashboards",
     cowork: "check",
     openwork: "soon"
   },
@@ -40,7 +40,7 @@ const rows: ParityRow[] = [
     highlighted: true
   },
   { capability: "Self-host or managed private instance", cowork: "none" },
-  { capability: "Open source — audit it, fork it, own it", cowork: "none" }
+  { capability: "Open source. Audit it, fork it, own it", cowork: "none" }
 ];
 
 function OpenWorkCheck() {
@@ -60,7 +60,11 @@ function CoworkCell({ support }: { support: CoworkSupport }) {
   }
 
   if (support === "none") {
-    return <span className="text-[15px] text-[var(--lp-faint)]">—</span>;
+    return (
+      <span className="text-[13px] text-[var(--lp-faint)]" aria-label="Not available">
+        <Minus className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+      </span>
+    );
   }
 
   return (

--- a/ee/apps/landing/components/site-footer.tsx
+++ b/ee/apps/landing/components/site-footer.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import { ShieldCheck } from "lucide-react";
 import { OpenCodeLogo } from "./opencode-logo";
+import { SocTypeIBadge } from "./soc-type-i-badge";
 
 export function SiteFooter() {
   return (
@@ -62,11 +62,11 @@ export function SiteFooter() {
           </div>
           <Link
             href="/trust"
-            aria-label="SOC 2 Type I — view Trust Center"
-            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[var(--lp-border)] px-2.5 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-800"
+            aria-label="SOC 2 Type I. View Trust Center"
+            className="inline-flex shrink-0 items-center text-gray-600 transition-opacity hover:opacity-80"
           >
-            <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
-            SOC 2 Type I
+            <SocTypeIBadge className="h-12 w-12" />
+            <span className="sr-only">SOC 2 Type I</span>
           </Link>
         </div>
       </div>

--- a/ee/apps/landing/components/site-nav.tsx
+++ b/ee/apps/landing/components/site-nav.tsx
@@ -67,17 +67,15 @@ export function SiteNav(props: Props) {
 
   return (
     <header className={`sticky top-0 z-20 w-full transition-all duration-300 ${scrolled ? "bg-white/80 shadow-sm backdrop-blur-md" : ""}`}>
-      <div className="mx-auto flex w-full max-w-[1176px] flex-col px-6">
-        <div className="grid grid-cols-[auto_1fr_auto] items-center py-4">
+      <div className="mx-auto flex w-full max-w-[1920px] flex-col px-[clamp(1.5rem,calc((100%-1128px)/2),4.75rem)]">
+        <div className="grid min-h-[97px] grid-cols-[auto_1fr_auto] items-center py-4">
           <Link
             href="/"
-            className="group inline-flex items-center gap-1.5"
+            aria-label="OpenWork"
+            className="group inline-flex items-center"
             onClick={() => setMobileOpen(false)}
           >
             <OpenWorkMark className="h-[30px] w-[38px] transition-opacity group-hover:opacity-80" />
-            <span className="text-[1.2rem] font-semibold tracking-tight text-[#011627] md:text-[1.3rem]">
-              OpenWork
-            </span>
           </Link>
 
           <nav className="hidden items-center justify-center gap-7 text-[14px] font-normal lg:flex">

--- a/ee/apps/landing/components/soc-type-i-badge.tsx
+++ b/ee/apps/landing/components/soc-type-i-badge.tsx
@@ -1,0 +1,58 @@
+type Props = {
+  className?: string;
+};
+
+export function SocTypeIBadge(props: Props) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      className={props.className}
+      role="img"
+      aria-hidden="true"
+    >
+      <circle cx="32" cy="32" r="31" fill="#011627" />
+      <circle
+        cx="32"
+        cy="32"
+        r="27.5"
+        fill="none"
+        stroke="#fcfdfe"
+        strokeWidth="1.25"
+      />
+      <circle
+        cx="32"
+        cy="32"
+        r="24"
+        fill="none"
+        stroke="#fcfdfe"
+        strokeOpacity="0.35"
+        strokeWidth="0.75"
+      />
+      <text
+        x="32"
+        y="27"
+        textAnchor="middle"
+        fill="#fcfdfe"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="13"
+        fontWeight="700"
+        letterSpacing="0.02em"
+      >
+        SOC 2
+      </text>
+      <rect x="14" y="33" width="36" height="13" rx="6.5" fill="#fcfdfe" />
+      <text
+        x="32"
+        y="42.5"
+        textAnchor="middle"
+        fill="#011627"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="8"
+        fontWeight="700"
+        letterSpacing="0.06em"
+      >
+        TYPE I
+      </text>
+    </svg>
+  );
+}

--- a/ee/apps/landing/package.json
+++ b/ee/apps/landing/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@openwork/email": "workspace:*",
     "@openwork/ui": "workspace:*",
+    "@paper-design/shaders-react": "0.0.72",
     "botid": "^1.5.11",
     "framer-motion": "^12.35.1",
     "lucide-react": "^0.577.0",

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -60,13 +60,11 @@ test("visitors can read the trust badge and access every footer link at responsi
       const footer = document.querySelector("footer");
       const badge = footer?.querySelector('a[aria-label^="SOC 2 Type I"]');
       const icon = badge?.querySelector("svg");
-      if (!footer || !badge || !icon) throw new Error("Footer trust badge or shield missing");
-      const text = [...badge.childNodes].find((node) => node.nodeType === Node.TEXT_NODE && node.textContent?.includes("SOC 2 Type I"));
-      if (!text || !text.textContent) throw new Error("Trust badge text missing");
-      const range = document.createRange();
-      range.setStart(text, text.textContent.indexOf("SOC 2 Type I"));
-      range.setEnd(text, text.textContent.indexOf("SOC 2 Type I") + "SOC 2 Type I".length);
-      const lines = [...range.getClientRects()];
+      if (!footer || !badge || !icon) throw new Error("Footer trust badge or seal missing");
+      const label = badge.getAttribute("aria-label") ?? "";
+      if (!label.includes("SOC 2 Type I") && !badge.textContent?.includes("SOC 2 Type I")) {
+        throw new Error("Trust badge text missing");
+      }
       const bounds = footer.getBoundingClientRect();
       const iconBounds = icon.getBoundingClientRect();
       const links = [...footer.querySelectorAll("a")];
@@ -80,8 +78,7 @@ test("visitors can read the trust badge and access every footer link at responsi
         .map((link) => link.getBoundingClientRect().bottom));
       return {
         viewport: window.innerWidth,
-        lines: lines.length,
-        textVisible: lines.every((rect) => rect.width > 0 && rect.height > 0),
+        textVisible: badge.textContent?.includes("SOC 2 Type I") === true,
         iconWidth: iconBounds.width,
         iconHeight: iconBounds.height,
         poweredBy: poweredBy.textContent,
@@ -103,7 +100,7 @@ test("visitors can read the trust badge and access every footer link at responsi
       };
     });
     expect(facts, `footer at ${width}px`).toMatchObject({
-      viewport: width, lines: 1, textVisible: true, iconWidth: 14, iconHeight: 14,
+      viewport: width, textVisible: true, iconWidth: 48, iconHeight: 48,
       footerFits: true, contentFits: true, linksVisible: true,
       poweredBy: "Powered by", brandInline: true, brandRowBelowLinks: true,
     });
@@ -113,7 +110,7 @@ test("visitors can read the trust badge and access every footer link at responsi
       ["/download", "Desktop"], ["https://app.openworklabs.com", "Cloud"],
       ["/dashboard", "Dashboard"], ["/enterprise", "Enterprise"], ["/contact", "Contact"],
       ["/trust", "Trust Center"], ["/privacy", "Privacy"], ["/terms", "Terms"],
-      ["https://opencode.ai", ""], ["/trust", "SOC 2 Type I — view Trust Center"],
+      ["https://opencode.ai", ""], ["/trust", "SOC 2 Type I. View Trust Center"],
     ]);
     evidence.recordAssertionEvidence(`Footer remains readable and complete at ${width}px`, JSON.stringify(facts), true);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1017,6 +1017,9 @@ importers:
       '@openwork/ui':
         specifier: workspace:*
         version: link:../../../packages/ui
+      '@paper-design/shaders-react':
+        specifier: 0.0.72
+        version: 0.0.72(@types/react@18.2.79)(react@18.2.0)
       botid:
         specifier: ^1.5.11
         version: 1.5.11(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.12.12)(babel-plugin-react-compiler@1.0.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
@@ -12404,6 +12407,13 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.42.0': {}
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
+
+  '@paper-design/shaders-react@0.0.72(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      '@paper-design/shaders': 0.0.72
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
 
   '@paper-design/shaders-react@0.0.72(@types/react@19.2.14)(react@19.2.8)':
     dependencies:


### PR DESCRIPTION
## Summary

Landing page (`ee/apps/landing`) refresh.

- **Hero**: Paper `Dithering` shader as the hero background, masked so it lives on the right half, stays clear behind the headline column and the pixel wordmark, and fades out toward the bottom. Below `lg` (where the headline spans the full width) the dither is softened and pushed to the right edge so copy stays readable on tablet and phone.
- **Alignment**: the wordmark and nav share a padding that tracks the 1176px content container exactly until it reaches the wide-header inset (`clamp(1.5rem, calc((100% - 1128px) / 2), 4.75rem)`). Verified at 390 / 768 / 1024 / 1280 / 1536 / 1920: no horizontal overflow, nav, wordmark, and content edges coincide up to 1280, wide header above.
- **Nav**: logo only, Blacksmith-style wide container.
- **Hero prompt card**: trimmed to title, blurb, agent glyphs, and copy button; moved to the right column.
- **OpenWork Connect**: replaced the boxes-and-arrows diagram with a single gateway endpoint card (URL, copy, supported clients) and three proof points, following how MCP gateway products present a governed endpoint.
- **Product demo** moved above the FAQ.
- **Footer**: custom SOC 2 Type I seal (`soc-type-i-badge.tsx`) instead of the AICPA-style pill.
- **Copy**: removed em dashes on the homepage and the "Claude Cowork has no equivalent" line.

## Notes

- Adds `@paper-design/shaders-react@0.0.72` to the landing app.
- `/connect` still uses `LpGatewayDiagram`; only the homepage was redesigned.
- `evals/specs/landing-pricing.test.ts` footer assertions updated for the new badge.
