### PR TITLE
fix(chat): keep staged conversation history consistent

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -427,8 +427,8 @@ describe("resolveForkBoundaryId", () => {
     expect(resolveForkBoundaryId(transcript, "msg_4")).toBeNull();
   });
 
-  it("returns null for unknown ids instead of corrupting the boundary", () => {
-    expect(resolveForkBoundaryId(transcript, "msg_missing")).toBeNull();
+  it("rejects unknown ids instead of forking the entire conversation", () => {
+    expect(() => resolveForkBoundaryId(transcript, "msg_missing")).toThrow("no longer in this conversation");
   });
 
   it("skips synthetic session-error messages when picking the boundary", () => {

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { queryOptions, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { LoaderCircle } from "lucide-react";
 import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
@@ -53,11 +53,35 @@ export function useOpeningSessionHistory(input: {
     networkMode: "always",
   });
   const query = useQuery({ ...options, enabled: !hasFullSnapshot });
+  const activeOwner = useRef<string | null>(input.owner);
+  activeOwner.current = input.owner;
+  useEffect(() => {
+    activeOwner.current = input.owner;
+    return () => { activeOwner.current = null; };
+  }, [input.owner]);
   const ensureFullSnapshot = useCallback(() => client.ensureQueryData({
     queryKey: input.snapshotQueryKey,
     queryFn: ({ signal }) => input.readSnapshot(signal),
     networkMode: "always",
   }), [client, input.snapshotQueryKey, input.readSnapshot]);
+  const runWithFullSnapshot = useCallback(async (
+    action: (snapshot: OpenworkSessionSnapshot) => void | Promise<unknown>,
+    options: { fresh?: boolean } = {},
+  ) => {
+    if (activeOwner.current !== input.owner) return;
+    const snapshot = await (options.fresh ? client.fetchQuery({
+      // Branch must not join an older opening/send read or trust cached history.
+      // Concurrent branches share this uncapped read and its response boundary.
+      queryKey: ["react-session-branch-history", input.owner],
+      queryFn: ({ signal }) => input.readSnapshot(signal),
+      staleTime: 0,
+      gcTime: 15_000,
+      networkMode: "always",
+    }) : ensureFullSnapshot());
+    if (activeOwner.current !== input.owner) return;
+    if (snapshot.session.id !== input.sessionId) throw new Error("Conversation history belongs to another session.");
+    await action(snapshot);
+  }, [client, ensureFullSnapshot, input.owner, input.sessionId, input.readSnapshot]);
   const [backgroundOwner, setBackgroundOwner] = useState<string | null>(null);
   useEffect(() => {
     if (!query.isSuccess || hasFullSnapshot) return;
@@ -77,6 +101,7 @@ export function useOpeningSessionHistory(input: {
     snapshot: hasFullSnapshot ? null : query.data?.snapshot ?? null,
     backgroundReady: hasFullSnapshot || backgroundOwner === input.owner,
     ensureFullSnapshot,
+    runWithFullSnapshot,
   };
 }
 
@@ -98,14 +123,19 @@ export function SessionHistoryLoading({ saved }: { saved: SessionScrollState }) 
   </div>;
 }
 
-export function SessionHistoryBoundary({ owner, pending, options, saved, children }: {
+export function SessionHistoryBoundary({ owner, pending, options, saved, onRetry, children }: {
   owner: string;
   pending: boolean;
   options: OpeningOptions;
   saved: SessionScrollState;
+  onRetry?: () => void;
   children: ReactNode;
 }) {
   return <Suspense key={owner} fallback={<SessionHistoryLoading saved={saved} />}>
-    {pending ? <AwaitOpeningHistory options={options} saved={saved} /> : children}
+    {onRetry ? <div role="alert" className="flex items-center justify-center gap-3 py-3 text-xs text-dls-secondary">
+      <span>The rest of this conversation could not be loaded.</span>
+      <button type="button" className="underline" onClick={onRetry}>Retry</button>
+    </div> : null}
+    {pending ? (onRetry ? null : <AwaitOpeningHistory options={options} saved={saved} />) : children}
   </Suspense>;
 }

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -27,8 +27,12 @@ export function resolveRenderedSessionSnapshot(input: {
 export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
   snapshot: OpenworkSessionSnapshot | null | undefined;
+  historyComplete?: boolean;
 }) {
   const revertMessageId = input.snapshot?.session.revert?.messageID ?? null;
+  // Neither a newest window nor saved neighbors prove their position relative
+  // to a revert cursor. Withhold them until the ordered full history arrives.
+  if (input.historyComplete === false && revertMessageId) return [];
   const liveMessages = input.transcriptState ?? [];
 
   const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1428,9 +1428,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId, props.workspaceId]);
 
   useEffect(() => {
-    if (!fullSnapshot) return;
-    seedSessionState(props.workspaceId, fullSnapshot);
-  }, [fullSnapshot, props.sessionId, props.workspaceId]);
+    if (!currentSnapshot) return;
+    seedSessionState(props.workspaceId, currentSnapshot, { preview: !hasFullHistory });
+  }, [currentSnapshot, hasFullHistory, props.sessionId, props.workspaceId]);
 
   const snapshot = resolveRenderedSessionSnapshot({
     sessionId: props.sessionId,
@@ -1491,8 +1491,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId]);
 
   const baseRenderedMessages = useMemo(
-    () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
-    [snapshot, transcriptState],
+    () => deriveRenderedSessionMessages({ transcriptState, snapshot, historyComplete: hasFullHistory }),
+    [snapshot, transcriptState, hasFullHistory],
   );
   const pendingMessages = useComposerStateStore((state) => state.pendingMessages[sessionOwner]);
   const [submittedMessage, setSubmittedMessage] = useState<{ owner: string; id: string } | null>(null);
@@ -1811,7 +1811,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const handleOpenTarget = useCallback((target: OpenTarget, options?: OpenTargetOptions) => {
     props.onOpenTarget?.(target, options, props.sessionId);
   }, [props.onOpenTarget, props.sessionId]);
-  const pendingSessionLoad = !snapshot && !snapshotQuery.isError && renderedMessages.length === 0;
+  const pendingSessionLoad = (!hasFullHistory && Boolean(revertMessageId))
+    || (!snapshot && !snapshotQuery.isError && renderedMessages.length === 0);
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;
     return renderedMessages
@@ -3027,10 +3028,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [archived, archiveStateKnown, props.onRevertToMessage, props.opencodeBaseUrl, props.sessionId]);
 
   const handleForkAtMessage = useCallback((messageId: string) => {
-    // OpenCode's fork copies messages strictly before the given id, so pass
-    // the next real message to make the branch include the clicked message.
-    props.onForkAtMessage?.(resolveForkBoundaryId(renderedMessagesRef.current, messageId), props.sessionId);
-  }, [props.onForkAtMessage, props.sessionId]);
+    if (!props.onForkAtMessage) return;
+    void openingHistory.runWithFullSnapshot((full) => {
+      // Use the untruncated timeline: even a hidden next message is a boundary,
+      // and a singleton preview never means "fork the entire conversation".
+      props.onForkAtMessage?.(resolveForkBoundaryId(full.messages.map(({ info }) => info), messageId), props.sessionId);
+    }, { fresh: true }).catch((error) => setError(parseSessionError(error)));
+  }, [openingHistory.runWithFullSnapshot, props.onForkAtMessage, props.sessionId, setError]);
 
   const handleEditUserMessage = useCallback((messageId: string, text: string) => {
     if (archived) return;
@@ -3043,9 +3047,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (archived || !archiveStateKnown || sessionWorkHeld(props.opencodeBaseUrl, props.sessionId)) return;
     if (!props.onRestoreRevertedSession || restoringRevertedMessages) return;
     setRestoringRevertedMessages(true);
-    void props.onRestoreRevertedSession(props.sessionId)
-      .finally(() => setRestoringRevertedMessages(false));
-  }, [archived, archiveStateKnown, props.onRestoreRevertedSession, props.opencodeBaseUrl, props.sessionId, restoringRevertedMessages]);
+    // The cache-only unrevert operation must not cancel the only full read.
+    void openingHistory.runWithFullSnapshot(() => props.onRestoreRevertedSession?.(props.sessionId))
+      .catch((error) => setError(parseSessionError(error)))
+      .finally(() => {
+        if (activeSessionOwnerRef.current === sessionOwner) setRestoringRevertedMessages(false);
+      });
+  }, [archived, archiveStateKnown, openingHistory.runWithFullSnapshot, props.onRestoreRevertedSession, props.opencodeBaseUrl, props.sessionId, restoringRevertedMessages, sessionOwner, setError]);
 
   const sessionScrollTopControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.scroll_top",
@@ -3188,6 +3196,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
               />
             ) : null}
             <SessionHistoryBoundary owner={sessionOwner} pending={pendingSessionLoad}
+              onRetry={snapshotQuery.isError && !snapshotQuery.isFetching && snapshot && !fullSnapshot ? () => { void snapshotQuery.refetch(); } : undefined}
               options={openingHistory.options} saved={initialScroll}>
             {(snapshotQuery.isError || error) && !snapshot && renderedMessages.length === 0 ? (
               <div className="px-6 py-8">
@@ -3271,12 +3280,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
               </DevProfiler>
             )}
             </SessionHistoryBoundary>
-            {snapshotQuery.isError && snapshot && !fullSnapshot ? (
-              <div role="alert" className="flex items-center justify-center gap-3 py-3 text-xs text-dls-secondary">
-                <span>The rest of this conversation could not be loaded.</span>
-                <button type="button" className="underline" onClick={() => void snapshotQuery.refetch()}>Retry</button>
-              </div>
-            ) : null}
             {!archived && admissionOutcomeUnresolved && queuedDrainState.phase.kind !== "admission_unknown" && renderedMessages.length > 0 ? (
               <AdmissionOutcomeUnknownCard
                 resuming={resuming}

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1823,7 +1823,9 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   }, workspaceSyncDisposeGraceMs);
 }
 
-export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionSnapshot) {
+export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionSnapshot, options: { preview?: boolean } = {}) {
+  // A reverted window cannot establish which messages are still visible.
+  if (options.preview && snapshot.session.revert?.messageID) return;
   const queryClient = getReactQueryClient();
   const key = transcriptKey(workspaceId, snapshot.session.id);
   const projected = snapshotToUIMessages(snapshot);
@@ -1858,6 +1860,16 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
     }
   }
   const existing = queryClient.getQueryData<UIMessage[]>(key);
+
+  if (options.preview) {
+    // Supply declaration baselines for live deltas, not whole-session truth.
+    // In particular, a partial turn must not settle admission or seed idle.
+    queryClient.setQueryData(key, reconcileTranscriptMessages({
+      currentMessages: existing ?? [],
+      snapshotMessages: incoming,
+    }));
+    return;
+  }
 
   const snapshotStartedAt = sessionSnapshotFetchStarts.get(snapshot);
   if (typeof snapshotStartedAt === "number") {

--- a/apps/app/src/react-app/domains/session/sync/transcript-reconcile.ts
+++ b/apps/app/src/react-app/domains/session/sync/transcript-reconcile.ts
@@ -63,9 +63,13 @@ function isSyntheticMessageId(id: string) {
  * do not exist server-side and would corrupt the fork boundary. Returns null
  * when the branch point is the last message, meaning "fork the full session".
  */
-export function resolveForkBoundaryId(messages: UIMessage[], messageId: string): string | null {
-  const idx = messages.findIndex((message) => message.id === messageId);
-  if (idx < 0) return null;
+export function resolveForkBoundaryId(messages: readonly Pick<UIMessage, "id">[], messageId: string): string | null {
+  const nativeId = isSyntheticMessageId(messageId)
+    ? messageId.slice(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX.length)
+    : messageId.endsWith(":steps") ? messageId.slice(0, -":steps".length) : messageId;
+  const exact = messages.findIndex((message) => message.id === messageId);
+  const idx = exact < 0 ? messages.findIndex((message) => message.id === nativeId) : exact;
+  if (idx < 0) throw new Error("The branch message is no longer in this conversation.");
   for (let index = idx + 1; index < messages.length; index += 1) {
     const candidate = messages[index];
     if (candidate && !isSyntheticMessageId(candidate.id)) return candidate.id;

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -1,12 +1,17 @@
 /** @jsxImportSource react */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
-import { act } from "react";
+import { act, useEffect } from "react";
+import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { openingHistoryWindow, SessionHistoryBoundary, useOpeningSessionHistory, type OpeningHistoryWindow } from "../src/react-app/domains/session/surface/session-history";
 import { flushSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
+import { getReactQueryClient } from "../src/react-app/infra/query-client";
+import { applySessionUnrevert, seedSessionState, snapshotKey, transcriptKey } from "../src/react-app/domains/session/sync/session-sync";
+import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+import { resolveForkBoundaryId } from "../src/react-app/domains/session/sync/transcript-reconcile";
 
 const ownedDom = typeof window === "undefined";
 if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
@@ -32,8 +37,15 @@ afterAll(async () => {
   if (ownedDom) await GlobalRegistrator.unregister();
 });
 
-function snapshot(id: string, title: string): OpenworkSessionSnapshot {
-  return { session: { id, title, version: "1", time: { created: 1, updated: 1 } }, messages: [], todos: [], status: { type: "idle" } };
+function snapshot(id: string, title: string, ids: string[] = [], revert?: string): OpenworkSessionSnapshot {
+  return {
+    session: { id, title, version: "1", time: { created: 1, updated: 1 }, revert: revert ? { messageID: revert } : undefined },
+    messages: ids.map((messageId, index) => ({
+      info: { id: messageId, sessionID: id, role: "user", time: { created: index + 1 } },
+      parts: [{ id: `part-${messageId}`, sessionID: id, messageID: messageId, type: "text", text: messageId }],
+    })),
+    todos: [], status: { type: "idle" },
+  };
 }
 
 async function settle() {
@@ -50,41 +62,209 @@ async function paint() {
 }
 
 function fixture() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = getReactQueryClient();
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
   let ensureFullSnapshot: (() => Promise<OpenworkSessionSnapshot>) | undefined;
-  const reads: { owner: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionSnapshot) => void }[] = [];
+  let runWithFullSnapshot: ReturnType<typeof useOpeningSessionHistory>["runWithFullSnapshot"] | undefined;
+  const reads: { owner: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionSnapshot) => void; reject: (error: Error) => void }[] = [];
   function Harness({ owner }: { owner: string }) {
-    const key = ["snapshot", owner];
-    const readSnapshot = (signal: AbortSignal, window?: OpeningHistoryWindow) => new Promise<OpenworkSessionSnapshot>((resolve) => {
-      reads.push({ owner, window, signal, resolve });
+    const key = snapshotKey("workspace", owner);
+    const readSnapshot = (signal: AbortSignal, window?: OpeningHistoryWindow) => new Promise<OpenworkSessionSnapshot>((resolve, reject) => {
+      reads.push({ owner, window, signal, resolve, reject });
     });
     const opening = useOpeningSessionHistory({ owner, sessionId: owner, snapshotQueryKey: key, readSnapshot });
     ensureFullSnapshot = opening.ensureFullSnapshot;
-    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => readSnapshot(signal), enabled: opening.backgroundReady, staleTime: 500 });
+    runWithFullSnapshot = opening.runWithFullSnapshot;
+    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => readSnapshot(signal), enabled: opening.backgroundReady, staleTime: 500, retry: false });
     const current = full.data ?? opening.snapshot;
-    return <><span>Composer {owner}</span><SessionHistoryBoundary owner={owner} pending={!current} saved={opening.saved} options={opening.options}>
-      <div>{current?.session.title}</div>
+    useEffect(() => {
+      if (current) seedSessionState("workspace", current, { preview: !full.data });
+    }, [current, full.data]);
+    const messages = deriveRenderedSessionMessages({ snapshot: current, transcriptState: client.getQueryData(transcriptKey("workspace", owner)), historyComplete: Boolean(full.data) });
+    return <><span>Composer {owner}</span><input aria-label="Draft" /><SessionHistoryBoundary owner={owner} pending={!current || (!full.data && Boolean(current.session.revert))} saved={opening.saved} options={opening.options}
+      onRetry={full.isError && !full.isFetching && current && !full.data ? () => { void full.refetch(); } : undefined}>
+      <div>{current?.session.title}</div>{messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.id}</div>)}
     </SessionHistoryBoundary></>;
   }
   cleanups.push(async () => { await act(async () => root.unmount()); client.clear(); host.remove(); });
   return {
     reads, host, client,
+    get runWithFullSnapshot() {
+      if (!runWithFullSnapshot) throw new Error("History is not mounted");
+      return runWithFullSnapshot;
+    },
     ensureFullSnapshot() {
       if (!ensureFullSnapshot) throw new Error("History is not mounted");
       return ensureFullSnapshot();
     },
-    async render(owner = "a") { await act(async () => root.render(<QueryClientProvider client={client}><Harness owner={owner} /></QueryClientProvider>)); },
-    async resolve(index: number, title: string) {
-      await act(async () => reads[index].resolve(snapshot(reads[index].owner, title)));
+    async render(owner = "a") { await act(async () => flushSync(() => root.render(<QueryClientProvider client={client}><Harness owner={owner} /></QueryClientProvider>))); },
+    async resolve(index: number, title: string | OpenworkSessionSnapshot) {
+      await act(async () => reads[index].resolve(typeof title === "string" ? snapshot(reads[index].owner, title) : title));
       await settle();
     },
   };
 }
 
 describe("opening a thread", () => {
+  test("branching at a singleton preview waits for the next native message in complete history", async () => {
+    const view = fixture();
+    await view.render();
+    await view.resolve(0, snapshot("a", "Older preview", ["z-earlier"]));
+    const fork = mock();
+    const pending = view.runWithFullSnapshot((full) => {
+      fork(resolveForkBoundaryId(full.messages.map(({ info }) => info), "z-earlier"), full.session.id);
+    }, { fresh: true });
+    expect(fork).not.toHaveBeenCalled();
+    expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }, undefined]);
+    await view.resolve(1, snapshot("a", "Complete", ["z-earlier", "a-next", "m-last"]));
+    await pending;
+    expect(fork.mock.calls).toEqual([["a-next", "a"]]);
+    expect(fork).toHaveBeenCalledTimes(1);
+  });
+
+  for (const backgroundRead of [false, true]) test(`Branch refreshes cached history and shares only the fresh read (older read in flight=${backgroundRead})`, async () => {
+    const view = fixture();
+    const cached = snapshot("a", "Cached through B", ["A", "B"]);
+    view.client.setQueryData(snapshotKey("workspace", "a"), cached, { updatedAt: Date.now() - (backgroundRead ? 1_000 : 0) });
+    await view.render();
+    const precedingReads = backgroundRead ? 1 : 0;
+    expect(view.reads).toHaveLength(precedingReads);
+    view.client.setQueryData(transcriptKey("workspace", "a"), ["A", "B", "C", "D"].map((id) => ({ id, role: "assistant", parts: [] })));
+    // Sends retain their original cache-hit behavior, even during a full read.
+    expect((await view.ensureFullSnapshot()).messages.map(({ info }) => info.id)).toEqual(["A", "B"]);
+    expect(view.reads).toHaveLength(precedingReads);
+    const fork = mock();
+    const branchAt = (id: string) => view.runWithFullSnapshot((full) => {
+      fork(id, resolveForkBoundaryId(full.messages.map(({ info }) => info), id), full.session.id);
+    }, { fresh: true });
+    const atB = branchAt("B");
+    const atC = branchAt("C");
+    expect(fork).not.toHaveBeenCalled();
+    expect(view.reads).toHaveLength(precedingReads + 1);
+    expect(view.reads[precedingReads].window).toBeUndefined();
+    if (backgroundRead) {
+      expect(view.reads[0].signal.aborted).toBe(false);
+      await view.resolve(0, cached);
+      expect(fork).not.toHaveBeenCalled();
+    }
+    await view.resolve(precedingReads, snapshot("a", "Fresh through D", ["A", "B", "C", "D"]));
+    await Promise.all([atB, atC]);
+    expect(fork.mock.calls).toEqual([["B", "C", "a"], ["C", "D", "a"]]);
+    // A subsequent branch must also refresh, not reuse the just-cached branch read.
+    const atD = branchAt("D");
+    expect(fork).toHaveBeenCalledTimes(2);
+    expect(view.reads).toHaveLength(precedingReads + 2);
+    expect(view.reads[precedingReads + 1].window).toBeUndefined();
+    await view.resolve(precedingReads + 1, snapshot("a", "Fresh through E", ["A", "B", "C", "D", "E"]));
+    await atD;
+    expect(fork.mock.calls).toEqual([["B", "C", "a"], ["C", "D", "a"], ["D", "E", "a"]]);
+  });
+
+  for (const fresh of [false, true]) test(`history actions cannot run against a destination owner or after unmount (fresh=${fresh})`, async () => {
+    const view = fixture();
+    await view.render();
+    await view.resolve(0, "Preview a");
+    const runForA = view.runWithFullSnapshot;
+    const action = mock();
+    // A query aborted by navigation is not an action failure in the destination.
+    const pending = runForA(action, { fresh }).catch(() => undefined);
+    await view.render("b");
+    await view.resolve(1, snapshot("a", "Late full a", ["a-message"]));
+    await pending;
+    await runForA(action, { fresh });
+    expect(action).not.toHaveBeenCalled();
+    expect(view.host.textContent).not.toContain("Late full a");
+    expect(view.host.textContent).toContain("Composer b");
+    const runForB = view.runWithFullSnapshot;
+    await cleanups.pop()?.();
+    const readCount = view.reads.length;
+    await runForB(action, { fresh });
+    expect(view.reads).toHaveLength(readCount);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  test("Restore waits for full history before clearing its cursor and never strands the read", async () => {
+    const view = fixture();
+    const neighbor = snapshot("b", "Neighbor", ["neighbor"]);
+    view.client.setQueryData(snapshotKey("workspace", "b"), neighbor);
+    await view.render();
+    const composer = view.host.querySelector("input");
+    await view.resolve(0, snapshot("a", "Reverted preview", ["hidden"], "cursor"));
+    await paint();
+    await paint();
+    const restore = mock(() => applySessionUnrevert("workspace", "a"));
+    const pending = view.runWithFullSnapshot(restore);
+    expect(restore).not.toHaveBeenCalled();
+    expect(view.reads).toHaveLength(2);
+    expect(view.reads[1].signal.aborted).toBe(false);
+    await view.resolve(1, snapshot("a", "Complete restored history", ["before", "cursor", "hidden"], "cursor"));
+    await pending;
+    await settle();
+    expect(restore).toHaveBeenCalledTimes(1);
+    expect(view.client.getQueryState(snapshotKey("workspace", "a"))).toMatchObject({ status: "success", fetchStatus: "idle" });
+    expect(view.client.getQueryData<OpenworkSessionSnapshot>(snapshotKey("workspace", "a"))?.session.revert).toBeUndefined();
+    expect(view.host.querySelectorAll("[data-message-id]").length).toBe(3);
+    expect(view.host.querySelector('[role="status"]')).toBeNull();
+    expect(view.host.querySelector("input")).toBe(composer);
+    expect(view.client.getQueryData(snapshotKey("workspace", "b"))).toEqual(neighbor);
+  });
+
+  test("a cache-hit history action is cancelled if ownership changes before its callback", async () => {
+    const view = fixture();
+    view.client.setQueryData(snapshotKey("workspace", "a"), snapshot("a", "Cached a", ["a-message"]));
+    await view.render();
+    const action = mock();
+    const pending = view.runWithFullSnapshot(action);
+    await view.render("b");
+    await pending;
+    expect(action).not.toHaveBeenCalled();
+    expect(view.host.textContent).not.toContain("Cached a");
+  });
+
+  test("a failed full read reports the error without invoking a history mutation", async () => {
+    const view = fixture();
+    view.client.setQueryDefaults(snapshotKey("workspace", "a"), { retry: false });
+    await view.render();
+    await view.resolve(0, "Preview");
+    const action = mock();
+    const pending = view.runWithFullSnapshot(action).catch((error: unknown) => error);
+    await act(async () => view.reads[1].reject(new Error("Full read failed")));
+    await settle();
+    expect(await pending).toMatchObject({ message: "Full read failed" });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  test("a reverted full-read failure replaces loading with Retry without revealing hidden messages", async () => {
+    const view = fixture();
+    await view.render();
+    view.client.setQueryData(transcriptKey("workspace", "a"), [{ id: "live-suffix", role: "assistant", parts: [] }]);
+    await view.resolve(0, snapshot("a", "Unsafe newest preview", ["a-suffix", "z-suffix"], "m-cursor"));
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(0);
+    expect(view.client.getQueryData(snapshotKey("workspace", "a"))).toBeUndefined();
+    await paint();
+    await paint();
+    await act(async () => view.reads[1].reject(new Error("Full history unavailable")));
+    await settle();
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(0);
+    expect(view.host.querySelector('[role="alert"]')?.textContent).toContain("could not be loaded");
+    expect(view.host.querySelector('[data-thread-loading]')).toBeNull();
+    expect(view.host.textContent).toContain("Composer a");
+    const retry = view.host.querySelector("button");
+    expect(retry?.textContent).toBe("Retry");
+    await act(async () => retry?.click());
+    await settle();
+    expect(view.host.querySelector('[data-thread-loading]')).not.toBeNull();
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(0);
+    expect(view.reads).toHaveLength(3);
+    expect(view.reads[2].window).toBeUndefined();
+    await view.resolve(2, snapshot("a", "Recovered full history", ["before", "m-cursor", "a-suffix", "z-suffix"], "m-cursor"));
+    expect([...view.host.querySelectorAll("[data-message-id]")].map((element) => element.getAttribute("data-message-id"))).toEqual(["before"]);
+    expect(view.host.querySelector('[data-thread-loading]')).toBeNull();
+    expect(view.host.querySelector('[role="alert"]')).toBeNull();
+  });
+
   test("explicit sends can finish the uncapped read without trusting or duplicating the preview", async () => {
     const view = fixture();
     await view.render();
@@ -146,7 +326,7 @@ describe("opening a thread", () => {
     expect(openingHistoryWindow({ mode: "manual", scrollTop: 500, anchor: { messageId: "session-error:turn", offset: -20 }, topClippedMessageId: null }))
       .toEqual({ messageIds: ["turn"] });
     const view = fixture();
-    view.client.setQueryData(["snapshot", "a"], snapshot("a", "Cached history"), { updatedAt: Date.now() - 1_000 });
+    view.client.setQueryData(snapshotKey("workspace", "a"), snapshot("a", "Cached history"), { updatedAt: Date.now() - 1_000 });
     await view.render();
     expect(view.host.textContent).toContain("Cached history");
     expect(view.host.querySelector('[role="status"]')).toBeNull();

--- a/apps/app/tests/session-render-state.test.ts
+++ b/apps/app/tests/session-render-state.test.ts
@@ -3,6 +3,7 @@ import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+import { resolveForkBoundaryId } from "../src/react-app/domains/session/sync/transcript-reconcile";
 import {
   mergeSnapshotAndLiveMessages,
   mergeSnapshotIntoCachedMessages,
@@ -253,6 +254,29 @@ describe("message merge duplicate and inclusion semantics", () => {
       expect(result[1]?.parts).toEqual(liveLast.parts);
       expect(result[2]).toBe(tail);
     }
+  });
+});
+
+describe("fork boundaries in complete history", () => {
+  const history = [{ id: "z-first" }, { id: "a-answer" }, { id: "m-next" }];
+
+  test("includes the clicked message using native history order and reserves null for the last message", () => {
+    expect(resolveForkBoundaryId(history, "z-first")).toBe("a-answer");
+    expect(resolveForkBoundaryId(history, "a-answer")).toBe("m-next");
+    expect(resolveForkBoundaryId(history, "m-next")).toBeNull();
+  });
+
+  test("rejects missing messages rather than forking the whole conversation", () => {
+    expect(() => resolveForkBoundaryId(history, "missing")).toThrow("no longer in this conversation");
+    expect(() => resolveForkBoundaryId([], "missing")).toThrow("no longer in this conversation");
+  });
+
+  test("resolves display-only rows and skips synthetic error boundaries", () => {
+    expect(resolveForkBoundaryId(history, "a-answer:steps")).toBe("m-next");
+    expect(resolveForkBoundaryId(history, "session-error:a-answer")).toBe("m-next");
+    const withError = [...history.slice(0, 2), { id: "session-error:a-answer" }, history[2]];
+    expect(resolveForkBoundaryId(withError, "a-answer")).toBe("m-next");
+    expect(resolveForkBoundaryId(withError, "session-error:a-answer")).toBe("m-next");
   });
 });
 

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -28,6 +28,8 @@ import {
   ensureWorkspaceSessionSync,
   permissionKey,
   markSessionSnapshotFetchStart,
+  snapshotKey,
+  statusKey,
   todoKey,
   questionKey,
   seedPermissionState,
@@ -784,8 +786,8 @@ describe("session transcript sync", () => {
     } finally { release(); cleanup(); }
   });
 
-  for (const declared of [true, false]) {
-    test(`snapshot reconciles buffered deltas exactly once (declared=${declared})`, () => {
+  for (const preview of [true, false]) for (const declared of [true, false]) {
+    test(`snapshot reconciles buffered deltas exactly once (declared=${declared}, preview=${preview})`, () => {
       const scheduled: Array<() => void> = [];
       __setSessionSyncDeltaFlushSchedulerForTest((_lane, run) => {
         scheduled.push(run);
@@ -825,7 +827,7 @@ describe("session transcript sync", () => {
           Object.freeze(message);
         }
         Object.freeze(projected);
-        seedSessionState("workspace-a", snapshot);
+        seedSessionState("workspace-a", snapshot, { preview });
         expect(projected[1]?.parts[0]).toMatchObject({ text: declared ? "hello world" : "hello" });
         expect(snapshotToUIMessages(snapshot)).toBe(projected);
         expect(queryClient.getQueryData<UIMessage[]>(key)?.find((message) => message.id === "history")).toEqual(projected[0]);
@@ -868,6 +870,51 @@ describe("session transcript sync", () => {
       } finally { releaseNeighbor(); release(); cleanup(); __setSessionSyncDeltaFlushSchedulerForTest(null); }
     });
   }
+
+  test("a preview supplies live part baselines without seeding status, todos, admission, or complete history", () => {
+    const scheduled: Array<() => void> = [];
+    __setSessionSyncDeltaFlushSchedulerForTest((_lane, run) => { scheduled.push(run); return () => {}; });
+    const input = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const release = trackWorkspaceSessionSync(input, "session-a");
+    const queryClient = getReactQueryClient();
+    const key = transcriptKey("workspace-a", "session-a");
+    try {
+      const preview = snapshotWithMessages([{ id: "answer", role: "assistant", text: "Existing answer" }]);
+      markSessionSnapshotFetchStart(preview, Date.now());
+      const activity = useSessionActivityStore.getState().recordsByWorkspaceId;
+      seedSessionState("workspace-a", preview, { preview: true });
+      expect(queryClient.getQueryData(snapshotKey("workspace-a", "session-a"))).toBeUndefined();
+      expect(queryClient.getQueryData(statusKey("workspace-a", "session-a"))).toBeUndefined();
+      expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toBeUndefined();
+      expect(useSessionActivityStore.getState().recordsByWorkspaceId).toBe(activity);
+      __applySessionSyncEventForTest(input, { type: "message.part.delta", properties: {
+        sessionID: "session-a", messageID: "answer", partID: "part_answer", delta: " continues",
+      } });
+      for (const run of scheduled.splice(0)) run();
+      expect(deriveRenderedSessionMessages({ snapshot: preview, transcriptState: queryClient.getQueryData(key), historyComplete: false })[0]?.parts[0])
+        .toMatchObject({ text: "Existing answer continues" });
+      seedSessionState("workspace-a", snapshotWithMessages([
+        { id: "earlier", role: "user", text: "Earlier prompt" },
+        { id: "answer", role: "assistant", text: "Existing answer" },
+      ]));
+      for (const run of scheduled.splice(0)) run();
+      expect(queryClient.getQueryData<UIMessage[]>(key)?.map((message) => message.id)).toEqual(["earlier", "answer"]);
+      expect(queryClient.getQueryData<UIMessage[]>(key)?.[1]?.parts[0]).toMatchObject({ text: "Existing answer continues" });
+    } finally { release(); cleanup(); __setSessionSyncDeltaFlushSchedulerForTest(null); }
+  });
+
+  test("a reverted preview neither seeds its suffix nor truncates a known live transcript", () => {
+    const queryClient = getReactQueryClient();
+    const key = transcriptKey("workspace-a", "session-a");
+    const current = [uiMessage("before", "user", "Kept")];
+    queryClient.setQueryData(key, current);
+    const preview = snapshotWithMessages([{ id: "hidden", role: "assistant", text: "Reverted away" }]);
+    preview.session.revert = { messageID: "missing-cursor" };
+    seedSessionState("workspace-a", preview, { preview: true });
+    expect(queryClient.getQueryData(key)).toEqual(current);
+    expect(queryClient.getQueryData(snapshotKey("workspace-a", "session-a"))).toBeUndefined();
+  });
 
   test("keeps longer live text when an idle snapshot lags the event stream", () => {
     getReactQueryClient().setQueryData(transcriptKey("workspace-a", "session-a"), [

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -94,4 +94,20 @@ test("opening a long conversation shows the latest first and preserves access to
       "The transcript shows no loading indicator, error card, or empty-conversation placeholder",
     ]);
   });
+
+  // Baseline branch coverage after full loading, not the delayed-preview race.
+  await step("after full loading, branching at the first message excludes later history and leaves the source unchanged", async () => {
+    await user.click({ role: "button", label: "Branch in new chat", nth: 0 });
+    // count limits returned messages; messageCount is the entire rendered transcript.
+    await probe.eventually(async () => renderedCount(await agent.run("session.read_transcript", { count: 1 })), {
+      within: 30_000,
+      label: "branch contains only the clicked message",
+      until: (count) => count === 1,
+    });
+    await user.see({ text: longHistoryFirst });
+    await user.notSee({ text: longHistoryLast });
+    const source = await probe.desktopApi(messagesPath);
+    expect(source.status).toBe(200);
+    expect(messageTexts(source.body)).toHaveLength(longHistoryCount);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #4838: partial conversation history must not be mistaken for a complete timeline.

- Seed preview message/part baselines so live deltas advance immediately, without seeding authoritative status, todos, admission, or full history.
- Wait for complete, owner-bound history before restoring reverted messages, avoiding cancellation of the only full read.
- Resolve Branch boundaries against a fresh uncapped snapshot, not a singleton preview or stale cached tail. Ignore callbacks after navigation; reject missing branch messages rather than copying the entire session.
- Withhold reverted preview content until full history establishes the visible timeline. Failed loads show an actionable Retry instead of an indefinite spinner.

The composer remains mounted and usable. Full history, newer live output, and neighboring session state remain intact. Reverted conversations deliberately wait for full history rather than guessing message ordering.

## Verification

Candidate: `4b5f5e496885272196bec1492f44831cbff99782`, based on `dev` at `fb3bc5b219ec3904baeeefc9738930b2bcb7d096`. Commit signature verified.

Passed from `apps/app`:

```sh
pnpm exec bun test --isolate ./tests/session-history.test.tsx ./tests/session-sync-permissions.test.ts ./tests/session-render-state.test.ts
pnpm typecheck
```

- **81 passed, 0 failed, 0 skipped**, 6,013 assertions; exit 0.
- App typecheck and `git diff --check`: exit 0.
- Coverage includes pending/full/failed reads, stale-cache Branch, buffered and subsequent deltas, Restore, owner changes, and reverted suffixes.
- The existing `session-full-history-on-open` journey gains a baseline branch-boundary/source-preservation assertion after complete loading. This does not claim to exercise the partial-window race.

## Proof verdict: Incomplete

Exact-head real-app evidence has not been run or published. The authored journey still needs:

```sh
pnpm evals:e2e session-full-history-on-open
```

Delayed preview/Restore/Branch races across both engines have focused hook/sync coverage, not real-app proof. No latency improvement is claimed.

An earlier diagnostic invocation of the legacy `scripts/session-render-state.test.ts` encountered a stale formatter import and unresolved formatter expectations. That invocation is not counted as passing or classified as pre-existing; the unrelated import was left unchanged. Primary verification uses the active tests above.

## Scope

Independent correctness PR targeting `dev`. Reading-position/Find changes and backfill/composer performance are separate follow-ups. No permanent history truncation, render eviction, provider behavior changes, or background-task suspension. Required repository CI is unchanged.
