### PR TITLE
perf(chat): reuse settled groups during history backfill

### DIFF
--- a/apps/app/src/components/chat/progressive-message-list.tsx
+++ b/apps/app/src/components/chat/progressive-message-list.tsx
@@ -78,12 +78,32 @@ function sameStructure(a: Plan, b: Plan) {
 
 /** Whole groups mount once, then stay mounted. The key cancels work on a session switch. */
 export function ProgressiveMessageList<T>(props: ProgressiveMessageListProps<T>) {
-  return <ProgressiveGroups key={props.viewport?.sessionKey ?? "eager"} {...props} />
+  const { groups, getGroupKey, getMessageIds } = props
+  const keys = React.useMemo(() => groups.map(getGroupKey), [groups, getGroupKey])
+  const anchorMessageId = props.viewport?.anchorMessageId
+  const anchorIndex = React.useMemo(() => anchorMessageId
+    ? groups.findIndex((group) => getMessageIds(group).includes(anchorMessageId))
+    : -1, [groups, getMessageIds, anchorMessageId])
+  return <ProgressiveGroups key={props.viewport?.sessionKey ?? "eager"} {...props} keys={keys} anchorIndex={anchorIndex} />
+}
+
+type PreparedGroupsProps<T> = ProgressiveMessageListProps<T> & { keys: string[]; anchorIndex: number }
+
+// Internal mount batches reuse settled output. Parent callback changes must
+// invalidate it too: the callback captures streaming, last-step and other props.
+class RenderedGroup<T> extends React.PureComponent<{
+  group: T
+  index: number
+  renderGroup: ProgressiveMessageListProps<T>["renderGroup"]
+}> {
+  render() {
+    return this.props.renderGroup(this.props.group, this.props.index)
+  }
 }
 
 // getSnapshotBeforeUpdate reads the actual pre-mutation DOM, including any scroll
 // since a batch was queued. An effect's previous-commit anchor would snap readers back.
-class ProgressiveGroups<T> extends React.Component<ProgressiveMessageListProps<T>, MountState> {
+class ProgressiveGroups<T> extends React.Component<PreparedGroupsProps<T>, MountState> {
   state: MountState = {
     mounted: new Set(),
     initialized: false,
@@ -91,13 +111,9 @@ class ProgressiveGroups<T> extends React.Component<ProgressiveMessageListProps<T
     width: this.props.viewport?.viewportWidth ?? 0,
   }
 
-  static getDerivedStateFromProps<T>(props: ProgressiveMessageListProps<T>, state: MountState): MountState | null {
-    const keys = props.groups.map(props.getGroupKey)
+  static getDerivedStateFromProps<T>(props: PreparedGroupsProps<T>, state: MountState): MountState | null {
+    const { keys, anchorIndex } = props
     if (!keys.length) return null
-    const anchorMessageId = props.viewport?.anchorMessageId
-    const anchorIndex = anchorMessageId
-      ? props.groups.findIndex((group) => props.getMessageIds(group).includes(anchorMessageId))
-      : -1
     let mounted = state.mounted
     const last = keys[keys.length - 1]
     if (!props.viewport || props.viewport.revealAll) {
@@ -327,8 +343,7 @@ class ProgressiveGroups<T> extends React.Component<ProgressiveMessageListProps<T
   }
 
   render() {
-    const { groups, getGroupKey, renderGroup, viewport, header, children, className } = this.props
-    const keys = groups.map(getGroupKey)
+    const { groups, keys, renderGroup, viewport, header, children, className } = this.props
     const cache = heightCache.get(this.cacheKey())
     const estimateScope = JSON.stringify([this.state.width, viewport?.historyComplete])
     if (estimateScope !== this.estimateScope) {
@@ -373,7 +388,7 @@ class ProgressiveGroups<T> extends React.Component<ProgressiveMessageListProps<T
         ? <div key={segment.key} ref={this.trackNode} data-thread-placeholder={segment.key} aria-hidden="true"
             style={{ height: segment.height, flexShrink: 0, overflowAnchor: "none" }} />
         : <div key={segment.key} ref={this.trackNode} data-thread-group={keys[segment.start]} className="min-w-0 shrink-0 empty:hidden">
-            {renderGroup(groups[segment.start], segment.start)}
+            <RenderedGroup group={groups[segment.start]} index={segment.start} renderGroup={renderGroup} />
           </div>)}
       {children}
     </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -77,6 +77,7 @@ import { useShellConfig } from "@/react-app/shell/shell-config";
 import { useReactRenderWatchdog } from "@/react-app/shell/react-render-watchdog";
 import { SessionDebugPanel } from "./debug-panel";
 import { deriveComposerHistory, deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
+import { pendingMessageParts, useDisplayedMessages } from "./use-displayed-messages";
 import {
   ADMISSION_OUTCOME_GRACE_MS,
   createSingleFlight,
@@ -972,33 +973,6 @@ function revokeUnownedAttachmentPreviews(attachments: ComposerAttachment[]) {
   }
 }
 
-function pendingMessageParts(text: string, attachments: ComposerAttachment[], serverParts: UIMessage["parts"] = []) {
-  const parts = [...serverParts];
-  if (text && !parts.some((part) => part.type === "text" && part.text)) parts.unshift({ type: "text", text });
-  const matched = new Set<number>();
-  let attachmentsReady = true;
-  for (const attachment of attachments) {
-    const filename = resolveAttachmentFileMetadata(attachment.file).filename;
-    // Compression can change an image's extension, but never its submitted bytes here.
-    const compressedFilename = attachment.kind === "image"
-      ? resolveAttachmentFileMetadata({ name: `${attachment.file.name.replace(/\.[^.]+$/, "") || "image"}.jpg`, type: "image/jpeg" }).filename
-      : filename;
-    const index = serverParts.findIndex((part, index) => !matched.has(index) && part.type === "file"
-      && (part.filename === filename || part.filename === compressedFilename));
-    if (index >= 0) matched.add(index);
-    const part = serverParts[index];
-    const usable = part?.type === "file" && (attachment.kind === "image"
-      ? part.mediaType.startsWith("image/") && /^(data:image\/|https?:\/\/)/.test(part.url)
-      : /^(data:|file:\/\/|https?:\/\/)/.test(part.url));
-    if (usable) continue;
-    attachmentsReady = false;
-    const preview = { type: "file", filename: attachment.name, mediaType: attachment.mimeType, url: attachment.previewUrl ?? "" } satisfies UIMessage["parts"][number];
-    if (part) parts[parts.indexOf(part)] = preview;
-    else parts.push(preview);
-  }
-  return { parts, attachmentsReady };
-}
-
 function draftWithEditedText(draft: ComposerDraft, text: string): ComposerDraft {
   return {
     ...draft,
@@ -1547,20 +1521,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
       .filter((item) => !remainingPendingMessages.some((remaining) => remaining.draft === item.draft))
       .flatMap((item) => item.draft.attachments));
   }, [pendingMessages, sessionOwner, remainingPendingMessages]);
-  const renderedMessages = useMemo(() => {
-    const pending: UIMessage[] = [];
-    if (autoSending) {
-      const pendingComposer = autoSendPayload?.composer;
-      const pendingText = pendingComposer?.draft ?? draft;
-      const pendingPasteParts = pendingComposer?.pasteParts ?? pasteParts;
-      if (pendingText.trim() || (pendingComposer?.attachments.length ?? attachments.length)) pending.push({
-        id: `${props.sessionId}:first-send`,
-        role: "user",
-        parts: pendingMessageParts(resolvePastedTextPlaceholders(pendingText, pendingPasteParts).replace(/\[attachment [^\]]+\]/g, ""), pendingComposer?.attachments ?? attachments).parts,
-      });
-    }
-    return [...pendingReconciliation.messages, ...pending, ...evalMarkdownMessages];
-  }, [attachments, autoSendPayload, autoSending, draft, evalMarkdownMessages, pasteParts, pendingReconciliation.messages, props.sessionId]);
+  const renderedMessages = useDisplayedMessages({
+    messages: pendingReconciliation.messages,
+    extraMessages: evalMarkdownMessages,
+    sessionId: props.sessionId,
+    autoSending,
+    autoSendComposer: autoSendPayload?.composer,
+    composer: { draft, attachments, pasteParts },
+  });
   const renderedMessagesRef = useRef(renderedMessages);
   useEffect(() => {
     renderedMessagesRef.current = renderedMessages;

--- a/apps/app/src/react-app/domains/session/surface/use-displayed-messages.ts
+++ b/apps/app/src/react-app/domains/session/surface/use-displayed-messages.ts
@@ -1,0 +1,64 @@
+import { useMemo } from "react";
+import type { UIMessage } from "ai";
+import type { ComposerAttachment } from "../../../../app/types";
+import { resolveAttachmentFileMetadata } from "../sync/attachment-file-part";
+import type { ComposerSessionState } from "./composer-state-store";
+import { resolvePastedTextPlaceholders } from "./composer/pasted-text";
+
+export function pendingMessageParts(text: string, attachments: ComposerAttachment[], serverParts: UIMessage["parts"] = []) {
+  const parts = [...serverParts];
+  if (text && !parts.some((part) => part.type === "text" && part.text)) parts.unshift({ type: "text", text });
+  const matched = new Set<number>();
+  let attachmentsReady = true;
+  for (const attachment of attachments) {
+    const filename = resolveAttachmentFileMetadata(attachment.file).filename;
+    // Compression can change an image's extension, but never its submitted bytes here.
+    const compressedFilename = attachment.kind === "image"
+      ? resolveAttachmentFileMetadata({ name: `${attachment.file.name.replace(/\.[^.]+$/, "") || "image"}.jpg`, type: "image/jpeg" }).filename
+      : filename;
+    const index = serverParts.findIndex((part, index) => !matched.has(index) && part.type === "file"
+      && (part.filename === filename || part.filename === compressedFilename));
+    if (index >= 0) matched.add(index);
+    const part = serverParts[index];
+    const usable = part?.type === "file" && (attachment.kind === "image"
+      ? part.mediaType.startsWith("image/") && /^(data:image\/|https?:\/\/)/.test(part.url)
+      : /^(data:|file:\/\/|https?:\/\/)/.test(part.url));
+    if (usable) continue;
+    attachmentsReady = false;
+    const preview = { type: "file", filename: attachment.name, mediaType: attachment.mimeType, url: attachment.previewUrl ?? "" } satisfies UIMessage["parts"][number];
+    if (part) parts[parts.indexOf(part)] = preview;
+    else parts.push(preview);
+  }
+  return { parts, attachmentsReady };
+}
+
+type DisplayComposer = Pick<ComposerSessionState, "draft" | "attachments" | "pasteParts">;
+
+export function useDisplayedMessages(input: {
+  messages: UIMessage[];
+  extraMessages: UIMessage[];
+  sessionId: string;
+  autoSending: boolean;
+  composer: DisplayComposer;
+  autoSendComposer?: DisplayComposer;
+}) {
+  const { messages, extraMessages, sessionId } = input;
+  // Ordinary composer edits are not transcript inputs. A captured autosend
+  // likewise stays independent of the next draft being typed.
+  const composer = input.autoSending ? input.autoSendComposer ?? input.composer : undefined;
+  const draft = composer?.draft;
+  const attachments = composer?.attachments;
+  const pasteParts = composer?.pasteParts;
+  return useMemo(() => {
+    const pending: UIMessage[] = [];
+    if (draft !== undefined && attachments && pasteParts && (draft.trim() || attachments.length)) {
+      pending.push({
+        id: `${sessionId}:first-send`,
+        role: "user",
+        parts: pendingMessageParts(resolvePastedTextPlaceholders(draft, pasteParts).replace(/\[attachment [^\]]+\]/g, ""), attachments).parts,
+      });
+    }
+    if (!pending.length && !extraMessages.length) return messages;
+    return [...messages, ...pending, ...extraMessages];
+  }, [messages, extraMessages, sessionId, draft, attachments, pasteParts]);
+}

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -67,6 +67,50 @@ function renderList(messages: UIMessage[], status: ThreadStatus, syncHealth?: Ru
 }
 
 describe("message-list loading feedback", () => {
+  test("updates a live assistant group and its last-group props without resetting expanded tool details", async () => {
+    const ownedDom = typeof window === "undefined";
+    if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+    const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const tools: UIMessage["parts"] = [0, 1].map((index) => ({
+      type: "dynamic-tool", toolName: "bash", toolCallId: `render-state-${index}`,
+      state: "output-available", input: { command: `pwd ${index}` }, output: "done",
+    }));
+    const assistant: UIMessage = { id: "live-answer", role: "assistant", parts: [...tools, { type: "text", text: "First answer" }] };
+    try {
+      await act(async () => root.render(list([userMessage, assistant], "streaming")));
+      const aggregate = container.querySelector('[data-tool-aggregate="render-state-1"]');
+      const expand = aggregate?.querySelector<HTMLButtonElement>("button");
+      if (!expand) throw new Error("Missing aggregate expansion button");
+      await act(async () => expand.click());
+      const detail = aggregate?.querySelector<HTMLButtonElement>('[data-tool-aggregate-detail="command"]');
+      if (!detail) throw new Error("Missing command detail");
+      await act(async () => detail.click());
+      expect(detail.getAttribute("aria-expanded")).toBe("true");
+      const branchesWhileStreaming = container.querySelectorAll('[aria-label="Branch in new chat"]').length;
+      const live: UIMessage = { ...assistant, parts: [...tools, { type: "text", text: "First answer continues" }] };
+      await act(async () => root.render(list([userMessage, live], "streaming")));
+      expect(container.textContent).toContain("First answer continues");
+      await act(async () => root.render(list([userMessage, live], "ready")));
+      expect(container.querySelectorAll('[aria-label="Branch in new chat"]').length).toBeGreaterThan(branchesWhileStreaming);
+      const older: UIMessage = { ...userMessage, id: "older-user" };
+      const followup: UIMessage = { ...userMessage, id: "next-user" };
+      await act(async () => root.render(list([older, userMessage, live, followup], "streaming")));
+      expect(container.querySelector('[data-tool-aggregate="render-state-1"]')).toBe(aggregate);
+      expect(aggregate?.querySelector('[data-tool-aggregate-detail="command"]')).toBe(detail);
+      expect(detail.getAttribute("aria-expanded")).toBe("true");
+      expect(container.textContent).toContain("First answer continues");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+      Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+      if (ownedDom) await GlobalRegistrator.unregister();
+    }
+  });
+
   test("acknowledges a submitted message before streaming starts", () => {
     const markup = renderList([userMessage], "submitted");
 

--- a/apps/app/tests/progressive-message-list.test.tsx
+++ b/apps/app/tests/progressive-message-list.test.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { GlobalRegistrator } from "@happy-dom/global-registrator"
-import { act, StrictMode } from "react"
+import { act, createContext, StrictMode, useContext, useEffect, useState, type ReactNode } from "react"
 import { createRoot } from "react-dom/client"
 import { ProgressiveMessageList, type MessageListViewport } from "../src/components/chat/progressive-message-list"
 
@@ -66,7 +66,7 @@ function groups(count = 80): Group[] {
   return Array.from({ length: count }, (_, index) => ({ id: `g${index}`, messages: [{ id: `m${index}`, height: 240 }] }))
 }
 
-function fixture(initial = groups(), options: Partial<MessageListViewport> = {}, strict = false) {
+function fixture(initial = groups(), options: Partial<MessageListViewport> = {}, strict = false, fixedGeometry = false) {
   const container = document.createElement("div")
   document.body.append(container)
   const root = createRoot(container)
@@ -78,6 +78,8 @@ function fixture(initial = groups(), options: Partial<MessageListViewport> = {},
   const writes: number[] = []
   const ready = mock(() => {})
   const rendered: number[] = []
+  const key = mock((group: Group) => group.id)
+  const ids = mock((group: Group) => group.messages.map((message) => message.id))
   let viewport: MessageListViewport = {
     sessionKey: `progressive-${++sessionId}`, scrollRef: { current: container }, viewportWidth: width,
     historyComplete: true, stickyBottom: () => sticky, onReady: ready, ...options,
@@ -87,6 +89,7 @@ function fixture(initial = groups(), options: Partial<MessageListViewport> = {},
     return data.flatMap((group) => group.messages).find((message) => message.id === id)?.height ?? 0
   }
   const height = (node: Element): number => {
+    if (fixedGeometry) return node === container ? data.length * 248 : 240
     if (node instanceof HTMLElement && node.hasAttribute("data-thread-placeholder")) return Number.parseFloat(node.style.height) || 0
     if (node.hasAttribute("data-message-id")) return messageHeight(node)
     if (node.hasAttribute("data-thread-group")) return [...node.children].reduce((sum, child) => sum + height(child), 0)
@@ -106,6 +109,7 @@ function fixture(initial = groups(), options: Partial<MessageListViewport> = {},
   const originalRect = HTMLElement.prototype.getBoundingClientRect
   spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
     if (this === container) return new DOMRect(0, 40, width, 200)
+    if (fixedGeometry && container.contains(this)) return new DOMRect(0, 40, width, 240)
     if (container.contains(this)) return new DOMRect(0, 40 + contentTop(this) - container.scrollTop, width, height(this))
     return originalRect.call(this)
   })
@@ -126,14 +130,15 @@ function fixture(initial = groups(), options: Partial<MessageListViewport> = {},
   }
   cleanups.push(unmount)
   return {
-    container, ready, writes, rendered, unmount,
-    async render(next = data, update: Partial<MessageListViewport> = {}) {
+    container, ready, writes, rendered, key, ids, unmount,
+    async render(next = data, update: Partial<MessageListViewport> = {}, renderer?: (group: Group, index: number) => ReactNode) {
       data = next
       viewport = { ...viewport, ...update }
       const list = <ProgressiveMessageList
-        groups={data} viewport={viewport} getGroupKey={(group) => group.id} getMessageIds={(group) => group.messages.map((message) => message.id)}
+        groups={data} viewport={viewport} getGroupKey={key} getMessageIds={ids}
         renderGroup={(group, index) => {
           rendered.push(index)
+          if (renderer) return renderer(group, index)
           return group.messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.id}</div>)
         }}
       />
@@ -158,6 +163,95 @@ function fixture(initial = groups(), options: Partial<MessageListViewport> = {},
 }
 
 describe("progressive whole-group rendering", () => {
+  for (const count of [80, 800, 1600]) {
+    test(`invokes renderGroup only ${count} times while backfilling ${count} groups`, async () => {
+      const data = groups(count)
+      const view = fixture(data, { anchorMessageId: `m${count - 1}` }, false, true)
+      await view.render()
+      expect(view.rendered).toHaveLength(8)
+      for (let index = 8; index < count; index += 8) await batch()
+      expect(view.mounted).toHaveLength(count)
+      expect(view.rendered).toHaveLength(count)
+      expect(view.key).toHaveBeenCalledTimes(count)
+      expect(view.ids).toHaveBeenCalledTimes(count)
+      expect(frames.size).toBe(0)
+    })
+  }
+
+  test("invalidates parent render captures and preserves state across batches, live updates, index shifts and Find", async () => {
+    let mounts = 0
+    let unmounts = 0
+    function StatefulTool({ group, index, phase, last }: { group: Group; index: number; phase: string; last: boolean }) {
+      const [expanded, setExpanded] = useState(false)
+      useEffect(() => { mounts++; return () => { unmounts++ } }, [])
+      return <button data-message-id={group.messages[0].id} onClick={() => setExpanded(!expanded)}>
+        {`${group.messages.length}:${index}:${phase}:${last}:${expanded}`}
+      </button>
+    }
+    let data = groups()
+    const view = fixture(data)
+    const render = (phase: string) => view.render(data, {}, (group, index) =>
+      <StatefulTool group={group} index={index} phase={phase} last={index === data.length - 1} />)
+    await render("streaming")
+    const tail = view.message("m79")
+    await act(async () => tail.click())
+    await batch()
+    expect(view.rendered).toHaveLength(16)
+    expect(tail.textContent).toBe("1:79:streaming:true:true")
+    view.rendered.length = 0
+    await render("settled")
+    expect(view.rendered).toHaveLength(16)
+    expect(tail.textContent).toBe("1:79:settled:true:true")
+    data = data.map((group) => group.id === "g79" ? { ...group, messages: [...group.messages, { id: "delta", height: 40 }] } : group)
+    await render("streaming")
+    expect(tail.textContent).toBe("2:79:streaming:true:true")
+    data = [{ id: "prefix", messages: [{ id: "prefix", height: 40 }] }, ...data,
+      { id: "suffix", messages: [{ id: "suffix", height: 40 }] }]
+    await render("streaming")
+    expect(tail.textContent).toBe("2:80:streaming:false:true")
+    const renderer = (group: Group, index: number) => <StatefulTool group={group} index={index} phase="settled" last={index === data.length - 1} />
+    await view.render(data, { revealAll: true }, renderer)
+    expect(view.mounted).toHaveLength(82)
+    await view.render(data, { revealAll: false }, renderer)
+    expect(view.message("m79")).toBe(tail)
+    expect(tail.textContent).toBe("2:80:settled:false:true")
+    expect(mounts).toBe(82)
+    expect(unmounts).toBe(0)
+  })
+
+  test("stable callbacks still update changed groups and indexes, and descendants receive context without remounting", async () => {
+    const context = createContext("initial")
+    function Content({ group, index }: { group: Group; index: number }) {
+      const value = useContext(context)
+      return <div data-message-id={group.id}>{`${group.messages.length}:${index}:${value}`}</div>
+    }
+    const container = document.createElement("div")
+    document.body.append(container)
+    const root = createRoot(container)
+    cleanups.push(async () => { await act(async () => root.unmount()); container.remove() })
+    const renderGroup = mock((group: Group, index: number) => <Content group={group} index={index} />)
+    const getGroupKey = (group: Group) => group.id
+    const getMessageIds = (group: Group) => group.messages.map((message) => message.id)
+    let data = groups(2)
+    const render = async (value: string) => { await act(async () => root.render(<context.Provider value={value}>
+      <ProgressiveMessageList groups={data} getGroupKey={getGroupKey} getMessageIds={getMessageIds} renderGroup={renderGroup} />
+    </context.Provider>)) }
+    await render("initial")
+    const first = container.querySelector('[data-message-id="g0"]')
+    await render("updated")
+    expect(renderGroup).toHaveBeenCalledTimes(2)
+    expect(first?.textContent).toBe("1:0:updated")
+    data = [{ ...data[0], messages: [...data[0].messages, { id: "new", height: 40 }] }, data[1]]
+    await render("updated")
+    expect(renderGroup).toHaveBeenCalledTimes(3)
+    expect(first?.textContent).toBe("2:0:updated")
+    data = [data[1], data[0]]
+    await render("updated")
+    expect(renderGroup).toHaveBeenCalledTimes(5)
+    expect(first?.textContent).toBe("2:1:updated")
+    expect(container.querySelector('[data-message-id="g0"]')).toBe(first)
+  })
+
   test("reserves both sides of a saved middle preview and keeps its anchor mounted when the full assistant group arrives", async () => {
     const full = groups(80);
     const reading = full[40];
@@ -194,6 +288,7 @@ describe("progressive whole-group rendering", () => {
     expect(view.complete).toBe("true")
     expect(view.placeholders.length).toBe(0)
     expect(view.message("m79")).toBe(tail)
+    expect(view.rendered).toHaveLength(80)
     expect(frames.size).toBe(0)
   })
 

--- a/apps/app/tests/use-displayed-messages.test.tsx
+++ b/apps/app/tests/use-displayed-messages.test.tsx
@@ -1,0 +1,112 @@
+/** @jsxImportSource react */
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { UIMessage } from "ai";
+import type { ComposerAttachment } from "../src/app/types";
+import { pendingMessageParts, useDisplayedMessages } from "../src/react-app/domains/session/surface/use-displayed-messages";
+
+const ownedDom = typeof window === "undefined";
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+const cleanups: (() => Promise<void>)[] = [];
+afterEach(async () => { for (const cleanup of cleanups.splice(0)) await cleanup(); });
+afterAll(async () => {
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+  if (ownedDom) await GlobalRegistrator.unregister();
+});
+
+function fixture() {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  let output: UIMessage[] = [];
+  let input: Parameters<typeof useDisplayedMessages>[0] = {
+    messages: [{ id: "history", role: "assistant", parts: [{ type: "text", text: "Answer" }] }],
+    extraMessages: [], sessionId: "session", autoSending: false,
+    composer: { draft: "", attachments: [], pasteParts: [] },
+  };
+  function Harness() {
+    output = useDisplayedMessages(input);
+    return <div>{output.length}</div>;
+  }
+  cleanups.push(async () => { await act(async () => root.unmount()); container.remove(); });
+  return {
+    get input() { return input; },
+    async render(update: Partial<typeof input> = {}) {
+      input = { ...input, ...update };
+      await act(async () => root.render(<Harness />));
+      return output;
+    },
+  };
+}
+
+function attachment(): ComposerAttachment {
+  return {
+    id: "file", kind: "file", name: "notes.txt", mimeType: "text/plain", size: 5,
+    file: new File(["notes"], "notes.txt", { type: "text/plain" }), previewUrl: "blob:notes",
+  };
+}
+
+test("typing, attachment and paste edits retain the displayed transcript identity, including appended eval messages", async () => {
+  const view = fixture();
+  for (const extraMessages of [[], [{ id: "eval", role: "assistant", parts: [{ type: "text", text: "Example" }] }]] satisfies UIMessage[][]) {
+    const initial = await view.render({ extraMessages });
+    if (!extraMessages.length) expect(initial).toBe(view.input.messages);
+    for (const draft of ["H", "He", "Hello", ""]) {
+      expect(await view.render({ composer: { ...view.input.composer, draft } })).toBe(initial);
+    }
+    expect(await view.render({ composer: { ...view.input.composer, attachments: [attachment()] } })).toBe(initial);
+    expect(await view.render({ composer: { ...view.input.composer, pasteParts: [{ id: "paste", label: "Pasted text #1", text: "Full pasted text", lines: 1 }] } })).toBe(initial);
+    expect(await view.render({ composer: { draft: "", attachments: [], pasteParts: [] } })).toBe(initial);
+    expect(initial[0]).toBe(view.input.messages[0]);
+  }
+});
+
+test("autosend previews track their selected composer, and captured sends ignore the next draft", async () => {
+  const view = fixture();
+  const history = await view.render();
+  expect(await view.render({ autoSending: true })).toBe(history);
+  const first = await view.render({ composer: { draft: "First", attachments: [], pasteParts: [] } });
+  expect(first.map((message) => message.id)).toEqual(["history", "session:first-send"]);
+  expect(first[1].parts).toEqual([{ type: "text", text: "First" }]);
+  const updated = await view.render({ composer: { ...view.input.composer, draft: "First updated", attachments: [attachment()] } });
+  expect(updated).not.toBe(first);
+  expect(updated[1].parts).toEqual([{ type: "text", text: "First updated" }, {
+    type: "file", filename: "notes.txt", mediaType: "text/plain", url: "blob:notes",
+  }]);
+  const pasted = await view.render({ composer: {
+    draft: "[pasted text note]", attachments: [],
+    pasteParts: [{ id: "paste", label: "note", text: "Full pasted text", lines: 1 }],
+  } });
+  expect(pasted[1].parts).toEqual([{ type: "text", text: "Full pasted text" }]);
+  const revisedPaste = await view.render({ composer: {
+    ...view.input.composer, pasteParts: [{ id: "paste", label: "note", text: "Revised paste", lines: 1 }],
+  } });
+  expect(revisedPaste[1].parts).toEqual([{ type: "text", text: "Revised paste" }]);
+  const captured = await view.render({ autoSendComposer: view.input.composer });
+  expect(await view.render({ composer: { draft: "Next draft", attachments: [], pasteParts: [] } })).toBe(captured);
+  const otherSession = await view.render({ sessionId: "other" });
+  expect(otherSession[1].id).toBe("other:first-send");
+  expect(await view.render({ autoSending: false })).toBe(history);
+});
+
+test("live transcript and extra-message changes invalidate displayed output without mutating history", async () => {
+  const view = fixture();
+  const initial = await view.render();
+  const messages: UIMessage[] = [{ ...initial[0], parts: [{ type: "text", text: "Answer continues" }] }];
+  expect(await view.render({ messages })).toBe(messages);
+  const extra: UIMessage = { id: "eval", role: "assistant", parts: [{ type: "text", text: "Example" }] };
+  expect(await view.render({ extraMessages: [extra] })).toEqual([...messages, extra]);
+  expect(initial[0].parts).toEqual([{ type: "text", text: "Answer" }]);
+});
+
+test("pending attachment reconciliation still preserves usable server files", () => {
+  const serverParts: UIMessage["parts"] = [{ type: "file", filename: "notes.txt", mediaType: "text/plain", url: "file:///notes.txt" }];
+  expect(pendingMessageParts("Prompt", [attachment()], serverParts)).toEqual({
+    parts: [{ type: "text", text: "Prompt" }, ...serverParts], attachmentsReady: true,
+  });
+  expect(serverParts).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

Follow-up to #4838: progressive history loading should not repeatedly invoke settled group renderers, and ordinary composer edits should not create a new displayed transcript.

- Reuse settled group callback output during internal backfill batches.
- Invalidate reuse when group references, indexes, or parent render callbacks change; preserve context updates and stateful tool details.
- Compute group keys and anchor lookup outside internal mount updates.
- Keep displayed transcript-array identity stable across ordinary draft, attachment, and paste edits. Autosend previews still update, while captured sends remain independent of the next draft.

Existing scroll lifecycles, scheduling, full-history availability, owner checks, and background task behavior remain unchanged.

## Quantitative check

Actual component render callbacks during complete backfill, with fixed synthetic geometry:

| Groups | Before (#4838 review) | This candidate |
|---:|---:|---:|
| 80 | 440 | 80 |
| 800 | 40,400 | 800 |
| 1,600 | 160,800 | 1,600 |

Initial callbacks remain eight. These measure callback work, not full child renders, frame time, or wall-time speedups. Plan construction and reconciliation still revisit mounted history; this does not claim to eliminate all quadratic work or bound eventual DOM memory.

## Verification

Candidate: `046c4ab98aeb2738ffbcb9df018491af14664005`, based on `dev` at `fb3bc5b219ec3904baeeefc9738930b2bcb7d096`. Commit signature verified.

Passed from `apps/app`:

```sh
pnpm exec bun test --isolate ./tests/progressive-message-list.test.tsx ./tests/use-displayed-messages.test.tsx ./tests/message-list-loading.test.tsx ./tests/chat-message-grouping.test.ts
pnpm run typecheck
```

- **54 passed, 0 failed, 0 skipped**, 287 assertions; exit 0.
- App typecheck and `git diff --check`: exit 0.
- Tests assert callback counts at 80/800/1,600 groups, callback-capture invalidation, live updates, index shifts, context propagation, Find, actual message-list completion transitions, retained tool expansion state, and the production displayed-message hook.

## Proof verdict: Incomplete

Exact-head real-app evidence remains outstanding. Existing journey owners:

```sh
pnpm evals:e2e session-full-history-on-open
pnpm evals:e2e streamed-markdown-answer
```

No measured typing latency, native-scroll, sustained-memory, or end-to-end speedup claim is made. Large histories and concurrent streaming still need comparable base/candidate measurements.

## Scope

Independent PR targeting `dev`. Partial-history correctness and reading/Find continuity are separate follow-ups.

Deliberately deferred: input-aware scheduling, giant-turn inner chunking/aggregate construction, render eviction, background cache budgets, multiple-visible-session scheduling, offscreen app resource gating, and a new history API. These are separate architecture/performance decisions, not prerequisites for the bounded callback and composer-identity improvements. Required repository CI is unchanged.
