### PR TITLE
fix(chat): preserve reading navigation during history loading

### DIFF
--- a/apps/app/src/components/chat/progressive-message-list.tsx
+++ b/apps/app/src/components/chat/progressive-message-list.tsx
@@ -45,6 +45,7 @@ type MountState = {
 type Segment = { key: string; start: number; end: number; height: number; placeholder: boolean }
 type Plan = { keys: string[]; heights: number[]; segments: Segment[]; complete: boolean }
 type ReadingPosition = {
+  reservedTop?: number
   element: HTMLElement | null
   messageId?: string
   key: string | undefined
@@ -272,6 +273,16 @@ class ProgressiveGroups<T> extends React.Component<ProgressiveMessageListProps<T
     const viewport = container.getBoundingClientRect()
     const sticky = Boolean(this.props.viewport?.stickyBottom())
       && container.scrollHeight - container.scrollTop - container.clientHeight <= 1
+    // A reserved region has no message anchor yet. Do not anchor to an offscreen
+    // preview row: full history moving that row would undo Home/top navigation.
+    const reserved = this.committed.segments.some((segment) => {
+      if (segment.end !== segment.start) return false
+      const rect = this.nodes.get(segment.key)?.getBoundingClientRect()
+      return rect && rect.top <= viewport.top && rect.bottom > viewport.top
+    })
+    if (container.scrollTop === 0 || reserved) {
+      return { reservedTop: container.scrollTop, element: null, key: undefined, offset: 0, fraction: 0, sticky }
+    }
     for (const node of this.nodes.values()) {
       if (!node.hasAttribute("data-thread-group")) continue
       const rect = node.getBoundingClientRect()
@@ -300,6 +311,10 @@ class ProgressiveGroups<T> extends React.Component<ProgressiveMessageListProps<T
           .find((message) => message.getAttribute("data-message-id") === snapshot.messageId) : null
       if (snapshot.sticky && this.props.viewport?.stickyBottom()) {
         container.scrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
+      } else if (snapshot.reservedTop !== undefined) {
+        container.scrollTop = snapshot.reservedTop
+        // The destination's groups only became available in this commit.
+        this.handleScroll()
       } else if (element) {
         const delta = element.getBoundingClientRect().top - container.getBoundingClientRect().top - snapshot.offset
         if (Math.abs(delta) > 0.5) container.scrollTop += delta

--- a/apps/app/src/react-app/domains/session/surface/find-bar.tsx
+++ b/apps/app/src/react-app/domains/session/surface/find-bar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useEffectEvent, useRef, useState, type RefObject } from "react";
 import { ChevronDown, ChevronUp, Search, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 import { useSessionFindStore } from "./find-store";
 import { SEARCH_HIGHLIGHT_SELECTOR } from "./text-highlights";
+import { SESSION_SCROLL_NAVIGATION_EVENT } from "./scroll-controller";
 
 const MIN_QUERY_LENGTH = 2;
 const DEBOUNCE_MS = 150;
@@ -19,10 +20,9 @@ const SEARCH_HIGHLIGHT_ACTIVE_CLASSES = ["bg-amber-7", "ring-1", "ring-amber-9"]
 type SessionFindBarProps = {
   sessionId: string;
   scrollRef: RefObject<HTMLDivElement | null>;
+  historyComplete?: boolean;
   onBeforeJump?: () => void;
 };
-
-type CollectReason = "query" | "mutation";
 
 function collectHighlightMarks(container: HTMLDivElement): HTMLElement[] {
   const marks: HTMLElement[] = [];
@@ -83,6 +83,7 @@ function firstMatchInMessage(matches: HTMLElement[], messageId: string) {
 export function SessionFindBar({
   sessionId,
   scrollRef,
+  historyComplete = true,
   onBeforeJump,
 }: SessionFindBarProps) {
   const open = useSessionFindStore((state) => state.open);
@@ -100,6 +101,7 @@ export function SessionFindBar({
   const activeIndexRef = useRef(0);
   const activeElementRef = useRef<HTMLElement | null>(null);
   const targetStartedAtRef = useRef<number | null>(null);
+  const pendingQueryRef = useRef<string | null>(null);
   const [matches, setMatchesState] = useState<HTMLElement[]>([]);
   const [activeIndex, setActiveIndexState] = useState(0);
   const activeQuery = appliedQuery.trim();
@@ -117,6 +119,7 @@ export function SessionFindBar({
   }, []);
 
   const jumpToElement = useCallback((element: HTMLElement) => {
+    pendingQueryRef.current = null;
     onBeforeJump?.();
     element.scrollIntoView({ block: "center" });
   }, [onBeforeJump]);
@@ -146,14 +149,18 @@ export function SessionFindBar({
     activateMatchAtIndex(currentIndex - 1, true);
   }, [activateMatchAtIndex]);
 
-  const collectMatches = useCallback((reason: CollectReason) => {
+  const collectMatches = useEffectEvent(() => {
     const container = scrollRef.current;
-    if (!owned || activeQuery.length < MIN_QUERY_LENGTH || !container) {
+    const current = useSessionFindStore.getState();
+    if (!owned || !current.open || current.sessionId !== sessionId || activeQuery.length < MIN_QUERY_LENGTH || !container) {
       setMatches([]);
       setActiveIndex(0);
       setActiveHighlight(activeElementRef, null);
       return;
     }
+    // Query edits supersede the previous request immediately, before debounce
+    // changes the rendered highlights. Never jump to those stale marks.
+    if (current.query.trim() !== activeQuery || current.appliedQuery.trim() !== activeQuery) return;
 
     const nextMatches = collectHighlightMarks(container);
     const previousActive = activeElementRef.current;
@@ -193,7 +200,7 @@ export function SessionFindBar({
       }
     } else {
       targetStartedAtRef.current = null;
-      if (reason === "query" && nextMatches.length > 0) {
+      if (pendingQueryRef.current === activeQuery && nextMatches.length > 0) {
         nextIndex = 0;
         shouldScroll = true;
       }
@@ -206,7 +213,7 @@ export function SessionFindBar({
     if (shouldScroll && nextActive) {
       jumpToElement(nextActive);
     }
-  }, [activeQuery.length, jumpToElement, owned, scrollRef, sessionId, setActiveIndex, setMatches]);
+  });
 
   useEffect(() => {
     if (!owned) return;
@@ -232,13 +239,48 @@ export function SessionFindBar({
     }
 
     if (activeQuery.length < MIN_QUERY_LENGTH) {
-      collectMatches("query");
+      collectMatches();
       return;
     }
 
-    const timer = window.setTimeout(() => collectMatches("query"), COLLECT_AFTER_RENDER_MS);
+    const timer = window.setTimeout(() => collectMatches(), COLLECT_AFTER_RENDER_MS);
     return () => window.clearTimeout(timer);
-  }, [activeQuery, collectMatches, owned, setActiveIndex, setMatches]);
+  }, [activeQuery, focusNonce, owned, setActiveIndex, setMatches]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const armQuery = () => {
+      const current = useSessionFindStore.getState();
+      const rawQuery = current.query.trim();
+      pendingQueryRef.current = current.open && current.sessionId === sessionId && rawQuery.length >= MIN_QUERY_LENGTH ? rawQuery : null;
+    };
+    armQuery();
+    // Own the request from its raw edit, not its delayed highlight commit.
+    // Synchronous subscription also covers input before React renders the edit.
+    const unsubscribe = useSessionFindStore.subscribe((current, previous) => {
+      if (current.open !== previous.open || current.sessionId !== previous.sessionId
+        || current.query.trim() !== previous.query.trim() || current.focusNonce !== previous.focusNonce) armQuery();
+    });
+    const cancelNavigation = (event: Event) => {
+      const current = useSessionFindStore.getState();
+      if (!current.open || current.sessionId !== sessionId) return;
+      const nested = event.target instanceof Element ? event.target.closest("[data-scrollable]") : null;
+      if (nested && nested !== container) return;
+      if (event instanceof KeyboardEvent) {
+        if (event.defaultPrevented || event.target instanceof Element && event.target.closest("input, textarea, select, [contenteditable=true]")) return;
+        if (!["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key)) return;
+      }
+      pendingQueryRef.current = null;
+      if (useSessionFindStore.getState().target?.sessionId === sessionId) useSessionFindStore.setState({ target: null });
+    };
+    const events = ["wheel", "touchmove", "pointerdown", "keydown", SESSION_SCROLL_NAVIGATION_EVENT];
+    for (const event of events) container.addEventListener(event, cancelNavigation, { passive: true });
+    return () => {
+      unsubscribe();
+      for (const event of events) container.removeEventListener(event, cancelNavigation);
+    };
+  }, [scrollRef, sessionId]);
 
   useEffect(() => {
     if (!searchActive) return;
@@ -252,7 +294,7 @@ export function SessionFindBar({
       }
       timer = window.setTimeout(() => {
         timer = undefined;
-        collectMatches("mutation");
+        collectMatches();
       }, MUTATION_DEBOUNCE_MS);
     });
 
@@ -263,7 +305,7 @@ export function SessionFindBar({
         window.clearTimeout(timer);
       }
     };
-  }, [collectMatches, scrollRef, searchActive]);
+  }, [scrollRef, searchActive]);
 
   useEffect(() => {
     if (!searchActive || target?.sessionId !== sessionId) {
@@ -272,9 +314,9 @@ export function SessionFindBar({
     }
 
     targetStartedAtRef.current = performance.now();
-    const timer = window.setTimeout(() => collectMatches("mutation"), TARGET_RESOLVE_TIMEOUT_MS);
+    const timer = window.setTimeout(() => collectMatches(), TARGET_RESOLVE_TIMEOUT_MS);
     return () => window.clearTimeout(timer);
-  }, [collectMatches, searchActive, sessionId, target]);
+  }, [searchActive, sessionId, target]);
 
   useEffect(() => () => {
     setActiveHighlight(activeElementRef, null);
@@ -288,7 +330,7 @@ export function SessionFindBar({
   const counterText = activeQuery.length < MIN_QUERY_LENGTH
     ? ""
     : totalMatches === 0
-      ? "No matches"
+      ? historyComplete ? "No matches" : "Searching..."
       : `${activeIndex + 1}/${totalMatches}`;
 
   return (

--- a/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-controller.ts
@@ -1,9 +1,10 @@
 import { useCallback, useLayoutEffect, useRef, type RefObject, type UIEventHandler } from "react";
 
-import { flushSessionScrollState, getSessionScrollState, useSessionScrollStore, type SessionScrollAnchor } from "./scroll-store";
+import { flushSessionScrollState, getSessionScrollState, sessionScrollKey, useSessionScrollStore, type SessionScrollAnchor } from "./scroll-store";
 
 const EXACT_BOTTOM_GAP_PX = 1;
 const SCROLL_GESTURE_WINDOW_MS = 600;
+export const SESSION_SCROLL_NAVIGATION_EVENT = "session-scroll-navigation";
 
 type SessionScrollControllerOptions = {
   selectedSessionId: string | null;
@@ -66,6 +67,7 @@ type ScrollController = {
 
 export function useSessionScrollController(options: SessionScrollControllerOptions) {
   const { selectedSessionId, geometryOwner, containerRef, contentRef } = options;
+  const scrollKey = selectedSessionId ? sessionScrollKey(selectedSessionId, geometryOwner) : null;
   const controllerRef = useRef<ScrollController | null>(null);
   // Consumed (including cancelled) submissions survive session effect recreation.
   const submittedMessagesRef = useRef(new Set<string>());
@@ -78,10 +80,8 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
     if (!container || !content) return;
 
     const store = useSessionScrollStore.getState();
-    const readState = () => {
-      const state = getSessionScrollState(useSessionScrollStore.getState().sessions, selectedSessionId);
-      return geometryOwner && state.geometry && state.geometry.owner !== geometryOwner ? getSessionScrollState({}, null) : state;
-    };
+    if (selectedSessionId && geometryOwner) store.claimOwner(selectedSessionId, geometryOwner);
+    const readState = () => getSessionScrollState(useSessionScrollStore.getState().sessions, scrollKey);
     let active = true;
     let historyReady = false;
     let pendingRestore = true;
@@ -107,7 +107,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       frames.clear();
     };
     const rememberGeometry = () => {
-      if (!geometryOwner || !selectedSessionId || !historyReady || pendingRestore || cancelledWhileLoading
+      if (!geometryOwner || !scrollKey || !historyReady || pendingRestore || cancelledWhileLoading
         || container.clientWidth <= 0 || container.clientHeight <= 0
         || !content.querySelector('[data-thread-history-complete="true"]')) return;
       const viewport = container.getBoundingClientRect();
@@ -121,7 +121,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       const first = nearby[0];
       const last = nearby.at(-1);
       if (!first || !last) return;
-      store.setGeometry(selectedSessionId, {
+      store.setGeometry(scrollKey, {
         owner: geometryOwner,
         scrollHeight: container.scrollHeight,
         viewportWidth: container.clientWidth,
@@ -131,7 +131,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       });
     };
     const refreshTopClippedMessage = () => {
-      if (active && historyReady) store.setTopClippedMessageId(selectedSessionId, latestMessageTopClippedId(container));
+      if (active && historyReady) store.setTopClippedMessageId(scrollKey, latestMessageTopClippedId(container));
     };
     const scrollToBottom = (behavior: ScrollBehavior = "auto") => {
       if (!active) return;
@@ -140,7 +140,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       pendingSubmittedMessageId = null;
       cancelledWhileLoading = false;
       lastGestureAt = -Infinity;
-      store.setStickyBottom(selectedSessionId, null);
+      store.setStickyBottom(scrollKey, null);
       smoothJump = behavior === "smooth";
       container.scrollTo({ top: container.scrollHeight, behavior });
       lastKnownScrollTop = container.scrollTop;
@@ -176,8 +176,8 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
         container.scrollTop = top;
         lastKnownScrollTop = container.scrollTop;
         const clipped = latestMessageTopClippedId(container);
-        if (isExactlyAtBottom(container)) store.setStickyBottom(selectedSessionId, clipped);
-        else store.setManualScroll(selectedSessionId, container.scrollTop, clipped, readingAnchor(container));
+        if (isExactlyAtBottom(container)) store.setStickyBottom(scrollKey, clipped);
+        else store.setManualScroll(scrollKey, container.scrollTop, clipped, readingAnchor(container));
         return;
       }
       if (!historyReady) {
@@ -215,6 +215,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       if (!active) return;
       const nested = target instanceof Element ? target.closest("[data-scrollable]") : null;
       if (nested && nested !== container) return;
+      container.dispatchEvent(new Event(SESSION_SCROLL_NAVIGATION_EVENT));
       // Pointer presses may just be clicks. Defer cancelling restoration until
       // they actually scroll; release without scrolling resumes pending follow.
       if (activePointerId === null) {
@@ -246,9 +247,9 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
         cancelledWhileLoading = false;
         const clipped = latestMessageTopClippedId(container);
         if (isExactlyAtBottom(container)) {
-          store.setStickyBottom(selectedSessionId, clipped);
+          store.setStickyBottom(scrollKey, clipped);
         } else {
-          store.setManualScroll(selectedSessionId, container.scrollTop, clipped, readingAnchor(container));
+          store.setManualScroll(scrollKey, container.scrollTop, clipped, readingAnchor(container));
         }
       } else {
         const saved = readState();
@@ -257,7 +258,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
         // visit, but never persist the initial restore's clamp or missing anchor.
         if (!pendingRestore && historyReady && container.scrollTop !== lastKnownScrollTop
           && saved.mode === "manual" && saved.anchor && messageElementById(container, saved.anchor.messageId)) {
-          store.setManualScroll(selectedSessionId, container.scrollTop, latestMessageTopClippedId(container), readingAnchor(container));
+          store.setManualScroll(scrollKey, container.scrollTop, latestMessageTopClippedId(container), readingAnchor(container));
         }
         refreshTopClippedMessage();
       }
@@ -276,7 +277,7 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       pendingSubmittedMessageId = null;
       cancelledWhileLoading = false;
       lastGestureAt = -Infinity;
-      store.setManualScroll(selectedSessionId, top, messageId, anchor);
+      store.setManualScroll(scrollKey, top, messageId, anchor);
       smoothJump = behavior === "smooth";
       container.scrollTo({ top, behavior });
       lastKnownScrollTop = container.scrollTop;
@@ -326,12 +327,12 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
     window.addEventListener("pagehide", flushSessionScrollState);
     document.addEventListener("visibilitychange", handleVisibility);
     controllerRef.current = {
-      sessionId: selectedSessionId,
+      sessionId: scrollKey,
       update: (ready, messageId) => {
         historyReady = ready;
         if (!messageId) pendingSubmittedMessageId = null;
         else {
-          const key = JSON.stringify([selectedSessionId, messageId]);
+          const key = JSON.stringify([scrollKey, messageId]);
           if (!submittedMessagesRef.current.has(key)) {
             submittedMessagesRef.current.add(key);
             pendingSubmittedMessageId = messageId;
@@ -362,31 +363,37 @@ export function useSessionScrollController(options: SessionScrollControllerOptio
       controllerRef.current = null;
       flushSessionScrollState();
     };
-  }, [selectedSessionId, geometryOwner, containerRef, contentRef]);
+  }, [selectedSessionId, geometryOwner, scrollKey, containerRef, contentRef]);
 
   useLayoutEffect(() => {
     controllerRef.current?.update(options.historyReady, options.submittedMessageId);
-  }, [selectedSessionId, containerRef, contentRef, options.historyReady, options.submittedMessageId, options.renderedMessages]);
+  }, [scrollKey, containerRef, contentRef, options.historyReady, options.submittedMessageId, options.renderedMessages]);
 
   const handleScroll = useCallback<UIEventHandler<HTMLDivElement>>((event) => {
-    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.handleScroll(event);
-  }, [selectedSessionId]);
+    if (controllerRef.current?.sessionId === scrollKey) controllerRef.current.handleScroll(event);
+  }, [scrollKey]);
   const markScrollGesture = useCallback((target?: EventTarget | null) => {
-    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.markScrollGesture(target);
-  }, [selectedSessionId]);
+    if (controllerRef.current?.sessionId === scrollKey) controllerRef.current.markScrollGesture(target);
+  }, [scrollKey]);
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
-    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.scrollToBottom(behavior);
-  }, [selectedSessionId]);
+    if (controllerRef.current?.sessionId === scrollKey) {
+      containerRef.current?.dispatchEvent(new Event(SESSION_SCROLL_NAVIGATION_EVENT));
+      controllerRef.current.scrollToBottom(behavior);
+    }
+  }, [scrollKey, containerRef]);
   const jumpToLatest = useCallback((behavior: ScrollBehavior = "smooth") => scrollToBottom(behavior), [scrollToBottom]);
   const jumpToStartOfMessage = useCallback((behavior: ScrollBehavior = "smooth") => {
-    if (controllerRef.current?.sessionId === selectedSessionId) controllerRef.current.jumpToStartOfMessage(behavior);
-  }, [selectedSessionId]);
+    if (controllerRef.current?.sessionId === scrollKey) {
+      containerRef.current?.dispatchEvent(new Event(SESSION_SCROLL_NAVIGATION_EVENT));
+      controllerRef.current.jumpToStartOfMessage(behavior);
+    }
+  }, [scrollKey, containerRef]);
 
   const refresh = useCallback(() => {
-    if (controllerRef.current?.sessionId === selectedSessionId) {
+    if (controllerRef.current?.sessionId === scrollKey) {
       controllerRef.current.update(options.historyReady, options.submittedMessageId);
     }
-  }, [selectedSessionId, options.historyReady, options.submittedMessageId]);
+  }, [scrollKey, options.historyReady, options.submittedMessageId]);
 
   return { handleScroll, markScrollGesture, scrollToBottom, jumpToLatest, jumpToStartOfMessage, refresh };
 }

--- a/apps/app/src/react-app/domains/session/surface/scroll-overlay.tsx
+++ b/apps/app/src/react-app/domains/session/surface/scroll-overlay.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback } from "react";
 import {
   selectSessionIsStickyBottom,
   selectSessionTopClippedMessageId,
+  sessionScrollKey,
   useSessionScrollStore,
 } from "./scroll-store";
 
@@ -59,6 +60,7 @@ const JumpToLatestButton = memo(function JumpToLatestButton({
 
 type SessionScrollOverlayProps = {
   sessionId: string;
+  owner?: string;
   isStreaming: boolean;
   onJumpToLatest: (behavior?: ScrollBehavior) => void;
   onJumpToStartOfMessage: (behavior?: ScrollBehavior) => void;
@@ -66,11 +68,12 @@ type SessionScrollOverlayProps = {
 
 export const SessionScrollOverlay = memo(function SessionScrollOverlay({
   sessionId,
+  owner,
   isStreaming,
   onJumpToLatest,
   onJumpToStartOfMessage,
 }: SessionScrollOverlayProps) {
-  const { isAtBottom, topClippedMessageId } = useSessionScrollOverlayState(sessionId);
+  const { isAtBottom, topClippedMessageId } = useSessionScrollOverlayState(sessionScrollKey(sessionId, owner));
   const showJumpToStart = !isStreaming && Boolean(topClippedMessageId);
   const showJumpToLatest = !isAtBottom;
 

--- a/apps/app/src/react-app/domains/session/surface/scroll-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/scroll-store.ts
@@ -29,7 +29,11 @@ type ManualSessionScrollState = {
   geometry?: SessionScrollGeometry;
 };
 
-export type SessionScrollState = StickyBottomSessionScrollState | ManualSessionScrollState;
+export type SessionScrollState = (StickyBottomSessionScrollState | ManualSessionScrollState) & {
+  // Also retain ownership on legacy entries until claimed, even if their
+  // optional geometry is evicted before the conversation is reopened.
+  owner?: string;
+};
 
 type SessionScrollStateById = Record<string, SessionScrollState>;
 
@@ -51,8 +55,11 @@ function normalizeSessionScrollState(value: unknown): SessionScrollState | null 
 
   const topClippedMessageId = normalizeTopClippedMessageId(value.topClippedMessageId);
   const geometry = normalizeGeometry(value.geometry);
+  const owner = typeof value.owner === "string" && value.owner.length > 0 && value.owner.length <= 1024
+    ? value.owner : geometry?.owner;
+  const metadata = { ...(owner ? { owner } : {}), ...(geometry && geometry.owner === owner ? { geometry } : {}) };
   if (value.mode === "stickyBottom") {
-    return { mode: "stickyBottom", topClippedMessageId, ...(geometry ? { geometry } : {}) };
+    return { mode: "stickyBottom", topClippedMessageId, ...metadata };
   }
 
   if (value.mode !== "manual" || typeof value.scrollTop !== "number" || !Number.isFinite(value.scrollTop)) {
@@ -67,7 +74,7 @@ function normalizeSessionScrollState(value: unknown): SessionScrollState | null 
       ? { anchor: { messageId: value.anchor.messageId, offset: value.anchor.offset } }
       : {}),
     topClippedMessageId,
-    ...(geometry ? { geometry } : {}),
+    ...metadata,
   };
 }
 
@@ -83,7 +90,7 @@ function normalizeGeometry(value: unknown): SessionScrollGeometry | undefined {
   return { owner: value.owner, scrollHeight, viewportWidth, before, after, messageIds: [...new Set(ids)] };
 }
 
-function readPersistedSessionScrollState(): SessionScrollStateById {
+export function readPersistedSessionScrollState(): SessionScrollStateById {
   if (globalThis.window === undefined) return {};
 
   try {
@@ -111,8 +118,8 @@ function persistSessionScrollState(sessions: SessionScrollStateById): void {
     // Clipped-message controls are presentation state, not a reading position.
     const positions = Object.fromEntries(Object.entries(sessions).map(([id, state]) => [id,
       state.mode === "manual"
-        ? { mode: state.mode, scrollTop: state.scrollTop, anchor: state.anchor, geometry: state.geometry }
-        : { mode: state.mode, geometry: state.geometry },
+        ? { mode: state.mode, scrollTop: state.scrollTop, anchor: state.anchor, owner: state.owner, geometry: state.geometry }
+        : { mode: state.mode, owner: state.owner, geometry: state.geometry },
     ]));
     window.localStorage.setItem(SESSION_SCROLL_STORAGE_KEY, JSON.stringify(positions));
   } catch {
@@ -123,9 +130,21 @@ function persistSessionScrollState(sessions: SessionScrollStateById): void {
 export function getSessionScrollState(
   sessions: SessionScrollStateById,
   sessionId: string | null | undefined,
+  owner?: string,
 ): SessionScrollState {
   if (!sessionId) return INITIAL_SESSION_SCROLL_STATE;
+  if (owner) {
+    const owned = sessions[sessionScrollKey(sessionId, owner)];
+    if (owned) return owned;
+    const legacy = sessions[sessionId];
+    const legacyOwner = legacy?.owner ?? legacy?.geometry?.owner;
+    return legacy && (!legacyOwner || legacyOwner === owner) ? legacy : INITIAL_SESSION_SCROLL_STATE;
+  }
   return sessions[sessionId] ?? INITIAL_SESSION_SCROLL_STATE;
+}
+
+export function sessionScrollKey(sessionId: string, owner?: string): string {
+  return owner ? JSON.stringify(["session-scroll", owner, sessionId]) : sessionId;
 }
 
 export function selectSessionIsStickyBottom(
@@ -156,7 +175,7 @@ function setSessionStickyBottom(
 
   return {
     ...sessions,
-    [sessionId]: { mode: "stickyBottom", topClippedMessageId, ...(current.geometry ? { geometry: current.geometry } : {}) },
+    [sessionId]: { mode: "stickyBottom", topClippedMessageId, owner: current.owner, ...(current.geometry ? { geometry: current.geometry } : {}) },
   };
 }
 
@@ -183,7 +202,7 @@ function setSessionManualScroll(
 
   return {
     ...sessions,
-    [sessionId]: { mode: "manual", scrollTop: nextScrollTop, topClippedMessageId, anchor, ...(current.geometry ? { geometry: current.geometry } : {}) },
+    [sessionId]: { mode: "manual", scrollTop: nextScrollTop, topClippedMessageId, anchor, owner: current.owner, ...(current.geometry ? { geometry: current.geometry } : {}) },
   };
 }
 
@@ -205,6 +224,7 @@ function setSessionTopClippedMessageId(
 
 type SessionScrollStore = {
   sessions: SessionScrollStateById;
+  claimOwner: (sessionId: string, owner: string) => void;
   setStickyBottom: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
   setManualScroll: (sessionId: string | null | undefined, scrollTop: number, topClippedMessageId: string | null, anchor?: SessionScrollAnchor) => void;
   setTopClippedMessageId: (sessionId: string | null | undefined, topClippedMessageId: string | null) => void;
@@ -213,11 +233,24 @@ type SessionScrollStore = {
 
 export const useSessionScrollStore = create<SessionScrollStore>((set) => ({
   sessions: readPersistedSessionScrollState(),
+  claimOwner: (sessionId, owner) => set((state) => {
+    const legacy = state.sessions[sessionId];
+    const legacyOwner = legacy?.owner ?? legacy?.geometry?.owner;
+    if (!legacy || (legacyOwner && legacyOwner !== owner)) return state;
+    const key = sessionScrollKey(sessionId, owner);
+    const sessions = { ...state.sessions };
+    // Geometry-free v1 positions have no recoverable owner. Claim them once,
+    // never copy them into every workspace exposing the same session ID.
+    sessions[key] ??= { ...legacy, owner };
+    delete sessions[sessionId];
+    schedulePersistence(legacy, sessions[key], true);
+    return { sessions };
+  }),
   setGeometry: (sessionId, geometry) => set((state) => {
     const next = normalizeGeometry(geometry);
     const current = getSessionScrollState(state.sessions, sessionId);
-    if (!next || JSON.stringify(current.geometry) === JSON.stringify(next)) return state;
-    const updated = { ...current, geometry: next };
+    if (!next || (current.owner && current.owner !== next.owner) || JSON.stringify(current.geometry) === JSON.stringify(next)) return state;
+    const updated = { ...current, owner: next.owner, geometry: next };
     schedulePersistence(current, updated);
     const sessions = { ...state.sessions, [sessionId]: updated };
     // Keep positions indefinitely, but bound the heavier geometry hints.
@@ -253,12 +286,12 @@ export function flushSessionScrollState() {
   persistSessionScrollState(useSessionScrollStore.getState().sessions);
 }
 
-function schedulePersistence(before: SessionScrollState, next: SessionScrollState) {
+function schedulePersistence(before: SessionScrollState, next: SessionScrollState, force = false) {
   const changed = before.geometry !== next.geometry || before.mode !== next.mode || (next.mode === "manual" && before.mode === "manual" && (
     next.scrollTop !== before.scrollTop || next.anchor?.messageId !== before.anchor?.messageId
     || next.anchor?.offset !== before.anchor?.offset
   ));
-  if (!changed) return;
+  if (!changed && !force) return;
   clearTimeout(persistTimer);
   persistTimer = setTimeout(flushSessionScrollState, PERSIST_DELAY_MS);
 }

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -29,11 +29,10 @@ export function useOpeningSessionHistory(input: {
   readSnapshot: (signal: AbortSignal, window?: OpeningHistoryWindow) => Promise<OpenworkSessionSnapshot>;
 }) {
   const client = useQueryClient();
+  const hasLegacyPosition = useSessionScrollStore((state) => Boolean(state.sessions[input.sessionId]));
   const saved = useMemo(() => {
-    const state = getSessionScrollState(useSessionScrollStore.getState().sessions, input.sessionId);
-    return state.geometry && state.geometry.owner !== input.owner
-      ? getSessionScrollState({}, null) : state;
-  }, [input.owner, input.sessionId]);
+    return getSessionScrollState(useSessionScrollStore.getState().sessions, input.sessionId, input.owner);
+  }, [input.owner, input.sessionId, hasLegacyPosition]);
   const hasFullSnapshot = client.getQueryData<OpenworkSessionSnapshot>(input.snapshotQueryKey)?.session.id === input.sessionId;
   const options = queryOptions({
     queryKey: ["react-session-opening", input.owner],

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2805,7 +2805,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     trailingHeight: initialScroll.mode === "manual" ? initialScroll.geometry?.after : undefined,
     historyComplete: hasFullHistory,
     revealAll: findOwned,
-    stickyBottom: () => getSessionScrollState(useSessionScrollStore.getState().sessions, props.sessionId).mode === "stickyBottom",
+    stickyBottom: () => getSessionScrollState(useSessionScrollStore.getState().sessions, props.sessionId, sessionOwner).mode === "stickyBottom",
     onReady: sessionScroll.refresh,
   };
 
@@ -3287,13 +3287,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
         </div>
         <SessionScrollOverlay
           sessionId={props.sessionId}
+          owner={sessionOwner}
           isStreaming={chatStreaming}
           onJumpToLatest={sessionScroll.jumpToLatest}
           onJumpToStartOfMessage={sessionScroll.jumpToStartOfMessage}
         />
         <SessionFindBar
+          key={sessionOwner}
           sessionId={props.sessionId}
           scrollRef={scrollRef}
+          historyComplete={hasFullHistory}
           onBeforeJump={handleFindBeforeJump}
         />
       </div>

--- a/apps/app/tests/find-bar.test.tsx
+++ b/apps/app/tests/find-bar.test.tsx
@@ -1,0 +1,170 @@
+/** @jsxImportSource react */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { SessionFindBar } from "../src/react-app/domains/session/surface/find-bar";
+import { useSessionFindStore } from "../src/react-app/domains/session/surface/find-store";
+import { SESSION_SCROLL_NAVIGATION_EVENT } from "../src/react-app/domains/session/surface/scroll-controller";
+import { TooltipProvider } from "../src/components/ui/tooltip";
+
+const ownedDom = typeof window === "undefined";
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+const cleanups: (() => Promise<void>)[] = [];
+
+beforeEach(() => {
+  useSessionFindStore.setState({ open: false, sessionId: null, query: "", appliedQuery: "", target: null, focusNonce: 0 });
+});
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+});
+afterAll(async () => {
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+  if (ownedDom) await GlobalRegistrator.unregister();
+});
+
+async function collect() {
+  // Exercise the real mutation observer and the bounded collection debounce.
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 180)); });
+}
+
+async function fixture(query = "needle") {
+  const host = document.createElement("div");
+  const container = document.createElement("div");
+  document.body.append(host, container);
+  const root = createRoot(host);
+  const beforeJump = mock(() => {});
+  const scrollRef = { current: container };
+  const render = async (historyComplete = false) => {
+    await act(async () => root.render(<TooltipProvider>
+      <SessionFindBar sessionId="a" scrollRef={scrollRef} historyComplete={historyComplete} onBeforeJump={() => beforeJump()} />
+    </TooltipProvider>));
+  };
+  const addMatch = (text = "needle") => {
+    const message = document.createElement("div");
+    message.dataset.messageId = text;
+    const mark = document.createElement("mark");
+    mark.dataset.searchHighlight = "true";
+    mark.textContent = text;
+    const scroll = mock(() => {});
+    mark.scrollIntoView = scroll;
+    message.append(mark);
+    container.append(message);
+    return { mark, scroll };
+  };
+  cleanups.push(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+    container.remove();
+  });
+  useSessionFindStore.getState().openFind({ sessionId: "a", query });
+  await render();
+  await collect();
+  return { host, container, render, addMatch, beforeJump };
+}
+
+describe("Find during history loading", () => {
+  test.each([
+    { initial: "", cancel: true },
+    { initial: "needle", cancel: true },
+    { initial: "", cancel: false },
+    { initial: "needle", cancel: false },
+  ])("raw-query debounce preserves cancellation and explicit match navigation (%j)", async ({ initial, cancel }) => {
+    const view = await fixture(initial);
+    await act(async () => {
+      useSessionFindStore.getState().setQuery("different");
+      // Input can follow the raw store update before React commits it, and
+      // certainly before the 150ms timer applies the query.
+      if (cancel) view.container.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+    });
+    expect(useSessionFindStore.getState().appliedQuery).toBe(initial);
+    await collect();
+    expect(useSessionFindStore.getState().appliedQuery).toBe("different");
+    const first = view.addMatch("different first");
+    const second = view.addMatch("different second");
+    await view.render(true);
+    await collect();
+    expect(view.host.textContent).toContain("1/2");
+    expect(first.scroll).toHaveBeenCalledTimes(cancel ? 0 : 1);
+    expect(second.scroll).not.toHaveBeenCalled();
+    const next = view.host.querySelector<HTMLButtonElement>('button[aria-label="Next match"]');
+    const previous = view.host.querySelector<HTMLButtonElement>('button[aria-label="Previous match"]');
+    if (!next || !previous) throw new Error("Missing Find navigation buttons");
+    await act(async () => next.click());
+    expect(view.host.textContent).toContain("2/2");
+    expect(second.scroll).toHaveBeenCalledTimes(1);
+    await act(async () => previous.click());
+    expect(view.host.textContent).toContain("1/2");
+    expect(first.scroll).toHaveBeenCalledTimes(cancel ? 1 : 2);
+    view.addMatch("different streamed");
+    await collect();
+    expect(view.beforeJump).toHaveBeenCalledTimes(cancel ? 2 : 3);
+  });
+
+  test("navigates to the first late match once, not on later streaming mutations or rerenders", async () => {
+    const view = await fixture();
+    expect(view.host.textContent).toContain("Searching...");
+    expect(view.beforeJump).not.toHaveBeenCalled();
+    const first = view.addMatch();
+    await view.render(true);
+    await collect();
+    expect(view.host.textContent).toContain("1/1");
+    expect(first.mark.dataset.searchHighlightActive).toBe("true");
+    expect(first.scroll).toHaveBeenCalledTimes(1);
+    const second = view.addMatch("needle streamed");
+    await view.render(true);
+    await collect();
+    expect(view.host.textContent).toContain("1/2");
+    expect(view.beforeJump).toHaveBeenCalledTimes(1);
+    expect(second.scroll).not.toHaveBeenCalled();
+    const next = view.host.querySelector<HTMLButtonElement>('button[aria-label="Next match"]');
+    if (!next) throw new Error("Missing next match button");
+    await act(async () => next.click());
+    expect(second.scroll).toHaveBeenCalledTimes(1);
+    expect(view.host.textContent).toContain("2/2");
+  });
+
+  test.each(["wheel", "touchmove", "pointerdown", "Home", SESSION_SCROLL_NAVIGATION_EVENT])("reader %s cancels the pending jump without cancelling highlights", async (input) => {
+    const view = await fixture();
+    view.container.dispatchEvent(input === "Home" ? new KeyboardEvent("keydown", { key: "Home", bubbles: true }) : new Event(input));
+    const first = view.addMatch();
+    await collect();
+    expect(view.host.textContent).toContain("1/1");
+    expect(first.mark.dataset.searchHighlightActive).toBe("true");
+    expect(view.beforeJump).not.toHaveBeenCalled();
+  });
+
+  test.each(["close", "session", "query"])("%s supersedes a pending initial jump", async (action) => {
+    const view = await fixture();
+    await act(async () => {
+      const store = useSessionFindStore.getState();
+      if (action === "close") store.closeFind();
+      else if (action === "session") store.openFind({ sessionId: "b", query: "needle" });
+      else store.setQuery("different");
+    });
+    const stale = view.addMatch();
+    await collect();
+    expect(stale.scroll).not.toHaveBeenCalled();
+    if (action === "query") {
+      // The new applied query replaces old highlights before collection.
+      view.container.replaceChildren();
+      const replacement = view.addMatch("different");
+      await collect();
+      expect(replacement.scroll).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test("completed history reports no matches but still navigates once if streaming later creates a match", async () => {
+    const view = await fixture();
+    await view.render(true);
+    expect(view.host.textContent).toContain("No matches");
+    const match = view.addMatch();
+    await collect();
+    expect(match.scroll).toHaveBeenCalledTimes(1);
+    view.addMatch();
+    await collect();
+    expect(view.beforeJump).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/tests/progressive-message-list.test.tsx
+++ b/apps/app/tests/progressive-message-list.test.tsx
@@ -257,6 +257,35 @@ describe("progressive whole-group rendering", () => {
     expect(view.position("m0")).toBe(0)
   })
 
+  test.each([0, 1250, 30_050])("preserves navigation to reserved history at %s when full history arrives", async (top) => {
+    const full = groups(100)
+    for (const group of full) group.messages[0].height = 392
+    const view = fixture(full.slice(40, 44), {
+      anchorMessageId: "m40", historyComplete: false, scrollHeight: 39_992,
+      leadingHeight: 16_000, trailingHeight: 22_384,
+    })
+    await view.render()
+    view.read("m40")
+    // Home/scroll_top reaches a prefix with no message to anchor. Scrolling
+    // into either reserved side must not select an offscreen preview message.
+    await act(async () => view.scroll(top))
+    await view.render(full, { historyComplete: true })
+    expect(view.container.scrollTop).toBeCloseTo(top, 1)
+    const destination = view.mounted.find((id) => {
+      if (!id) return false
+      const position = view.position(`m${id.slice(1)}`)
+      return position <= 0 && position > -392
+    })
+    expect(destination).toBeDefined()
+    if (!destination) throw new Error("Reserved destination did not mount")
+    const messageId = `m${destination.slice(1)}`
+    const offset = view.position(messageId)
+    for (let i = 0; i < 20; i++) await batch()
+    expect(view.complete).toBe("true")
+    expect(view.position(messageId)).toBeCloseTo(offset, 1)
+    if (top === 0) expect(view.container.scrollTop).toBe(0)
+  })
+
   test("a queued background batch cannot discard groups requested by a simultaneous scroll", async () => {
     const view = fixture()
     await view.render()

--- a/apps/app/tests/session-scroll.test.tsx
+++ b/apps/app/tests/session-scroll.test.tsx
@@ -3,8 +3,8 @@ import { afterAll, afterEach, beforeEach, describe, expect, jest, mock, spyOn, t
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, useCallback, useRef } from "react";
 import { createRoot } from "react-dom/client";
-import { useSessionScrollController } from "../src/react-app/domains/session/surface/scroll-controller";
-import { flushSessionScrollState, getSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
+import { SESSION_SCROLL_NAVIGATION_EVENT, useSessionScrollController } from "../src/react-app/domains/session/surface/scroll-controller";
+import { flushSessionScrollState, getSessionScrollState, readPersistedSessionScrollState, sessionScrollKey, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
 
 const ownedDom = typeof window === "undefined";
 if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
@@ -53,8 +53,8 @@ afterAll(async () => {
   if (ownedDom) await GlobalRegistrator.unregister();
 });
 
-function state(id = "a") {
-  return getSessionScrollState(useSessionScrollStore.getState().sessions, id);
+function state(id = "a", owner?: string) {
+  return getSessionScrollState(useSessionScrollStore.getState().sessions, id, owner);
 }
 
 function runFrames() {
@@ -161,6 +161,25 @@ function fixture(geometryOwner?: string) {
 }
 
 describe("session reading position", () => {
+  test("signals explicit navigation for pending Find cancellation, not passive sticky reconciliation", async () => {
+    const view = fixture();
+    await view.render();
+    const navigation = mock(() => {});
+    view.container.addEventListener(SESSION_SCROLL_NAVIGATION_EVENT, navigation);
+    view.layout.height += 100;
+    view.resize();
+    runFrames();
+    expect(navigation).not.toHaveBeenCalled();
+    view.controls.markScrollGesture(view.container);
+    view.scroll(0);
+    expect(navigation).toHaveBeenCalledTimes(1);
+    view.controls.jumpToLatest("auto");
+    expect(navigation).toHaveBeenCalledTimes(2);
+    runFrames();
+    view.controls.jumpToStartOfMessage("auto");
+    expect(navigation).toHaveBeenCalledTimes(3);
+  });
+
   test("restores estimated loading geometry without consuming an anchor absent from a partial preview", async () => {
     const store = useSessionScrollStore.getState();
     store.setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
@@ -173,27 +192,49 @@ describe("session reading position", () => {
     expect(view.container.scrollTop).toBe(325);
     view.layout.messages = [{ id: "latest", top: 600, height: 400 }];
     await view.render();
-    expect(state()).toEqual(saved);
+    expect(state("a", "owner-a")).toEqual(saved);
     view.layout.messages.unshift({ id: "reading", top: 420, height: 180 });
     await view.render();
     expect(view.container.scrollTop).toBe(445);
-    expect(state()).toEqual(saved);
+    expect(state("a", "owner-a")).toEqual(saved);
   });
 
   test("records complete geometry and nearby IDs without replacing it with partial or zero-sized layout", async () => {
     const view = fixture("owner-a");
     await view.render();
     view.wheel(325);
-    expect(state().geometry).toEqual({ owner: "owner-a", scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["first", "reading", "latest"] });
-    const geometry = state().geometry;
+    expect(state("a", "owner-a").geometry).toEqual({ owner: "owner-a", scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["first", "reading", "latest"] });
+    const geometry = state("a", "owner-a").geometry;
     view.layout.complete = false;
     view.layout.height = 1200;
     await view.render();
     view.wheel(350);
-    expect(state().geometry).toEqual(geometry);
-    useSessionScrollStore.getState().setStickyBottom("a", null);
+    expect(state("a", "owner-a").geometry).toEqual(geometry);
+    useSessionScrollStore.getState().setStickyBottom(sessionScrollKey("a", "owner-a"), null);
     flushSessionScrollState();
-    expect(JSON.parse(localStorage.getItem(storageKey)!)).toMatchObject({ a: { mode: "stickyBottom", geometry } });
+    expect(JSON.parse(localStorage.getItem(storageKey)!)).toMatchObject({ [sessionScrollKey("a", "owner-a")]: { mode: "stickyBottom", geometry } });
+  });
+
+  test("two owners with the same session ID keep independent manual positions and geometry", async () => {
+    const first = fixture("owner-a");
+    const second = fixture("owner-b");
+    second.layout.viewportHeight = 320;
+    await first.render();
+    first.wheel(325);
+    const saved = state("a", "owner-a");
+    await second.render();
+    expect(state("a", "owner-b").mode).toBe("stickyBottom");
+    now += 1_000;
+    first.resize();
+    runFrames();
+    expect(first.container.scrollTop).toBe(325);
+    expect(state("a", "owner-a")).toEqual(saved);
+    second.wheel(120);
+    expect(state("a", "owner-b")).toMatchObject({ mode: "manual", scrollTop: 120, geometry: { owner: "owner-b" } });
+    first.controls.jumpToLatest("auto");
+    runFrames();
+    expect(second.container.scrollTop).toBe(120);
+    expect(state("a", "owner-b").mode).toBe("manual");
   });
 
   test("does not consume a legacy anchor against a too-short preview", async () => {
@@ -468,6 +509,86 @@ describe("session reading position", () => {
 });
 
 describe("scroll persistence", () => {
+  test("hydrates legacy pixels, legacy geometry and owner-keyed positions after geometry eviction", () => {
+    const geometry = { owner: "owner-a", scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["reading"] };
+    localStorage.setItem(storageKey, JSON.stringify({
+      pixels: { mode: "manual", scrollTop: 125 },
+      legacy: { mode: "manual", scrollTop: 325, anchor: { messageId: "reading", offset: -25 }, geometry },
+      [sessionScrollKey("a", "owner-a")]: { mode: "manual", scrollTop: 450, owner: "owner-a", anchor: { messageId: "reading", offset: -150 } },
+    }));
+    useSessionScrollStore.setState({ sessions: readPersistedSessionScrollState() });
+    const store = useSessionScrollStore.getState();
+    expect(store.sessions.pixels).toMatchObject({ mode: "manual", scrollTop: 125 });
+    expect(store.sessions.legacy).toMatchObject({ mode: "manual", owner: "owner-a", geometry });
+    store.claimOwner("legacy", "owner-b");
+    expect(state("legacy", "owner-b").mode).toBe("stickyBottom");
+    store.claimOwner("legacy", "owner-a");
+    expect(state("legacy", "owner-a")).toMatchObject({ mode: "manual", scrollTop: 325, anchor: { messageId: "reading", offset: -25 } });
+    expect(state("a", "owner-a")).toMatchObject({ mode: "manual", scrollTop: 450, owner: "owner-a" });
+    expect(state("a", "owner-b").mode).toBe("stickyBottom");
+    flushSessionScrollState();
+  });
+
+  test.each([undefined, { messageId: "reading", offset: -25 }])("claims a geometry-free legacy position once without losing its pixels or anchor (%j)", (anchor) => {
+    const store = useSessionScrollStore.getState();
+    store.setManualScroll("a", 325, null, anchor);
+    const saved = state();
+    expect(state("a", "owner-a")).toEqual(saved);
+    store.claimOwner("a", "owner-a");
+    store.claimOwner("a", "owner-b");
+    expect(state("a", "owner-a")).toEqual({ ...saved, owner: "owner-a" });
+    expect(state("a", "owner-b").mode).toBe("stickyBottom");
+    expect(useSessionScrollStore.getState().sessions.a).toBeUndefined();
+    flushSessionScrollState();
+    const persisted = JSON.parse(localStorage.getItem(storageKey)!);
+    expect(persisted[sessionScrollKey("a", "owner-a")]).toEqual({ mode: "manual", scrollTop: 325, owner: "owner-a", ...(anchor ? { anchor } : {}) });
+    expect(persisted.a).toBeUndefined();
+  });
+
+  test("legacy geometry can only migrate to its recorded owner and cannot overwrite a newer position", () => {
+    const store = useSessionScrollStore.getState();
+    store.setManualScroll("a", 325, null, { messageId: "reading", offset: -25 });
+    store.setGeometry("a", { owner: "owner-a", scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["reading"] });
+    expect(state("a", "owner-b").mode).toBe("stickyBottom");
+    store.claimOwner("a", "owner-b");
+    expect(useSessionScrollStore.getState().sessions.a).toBeDefined();
+    store.setManualScroll(sessionScrollKey("a", "owner-a"), 100, null);
+    store.claimOwner("a", "owner-a");
+    expect(state("a", "owner-a")).toMatchObject({ mode: "manual", scrollTop: 100 });
+    expect(useSessionScrollStore.getState().sessions.a).toBeUndefined();
+  });
+
+  test("geometry eviction retains position ownership across persistence and cannot leak to another owner", () => {
+    const store = useSessionScrollStore.getState();
+    const key = sessionScrollKey("a", "owner-a");
+    store.setManualScroll(key, 325, null, { messageId: "reading", offset: -25 });
+    for (let index = 0; index < 65; index++) {
+      const owner = index === 0 ? "owner-a" : `owner-${index}`;
+      store.setGeometry(sessionScrollKey("a", owner), { owner, scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["reading"] });
+    }
+    expect(Object.values(useSessionScrollStore.getState().sessions).filter((entry) => entry.geometry)).toHaveLength(64);
+    expect(state("a", "owner-a").geometry).toBeUndefined();
+    expect(state("a", "owner-a")).toMatchObject({ mode: "manual", scrollTop: 325, anchor: { messageId: "reading", offset: -25 } });
+    expect(state("a", "new-owner").mode).toBe("stickyBottom");
+    flushSessionScrollState();
+    expect(JSON.parse(localStorage.getItem(storageKey)!)[key]).toEqual({ mode: "manual", scrollTop: 325, owner: "owner-a", anchor: { messageId: "reading", offset: -25 } });
+  });
+
+  test("evicting unclaimed legacy geometry does not make its position ownerless", () => {
+    const store = useSessionScrollStore.getState();
+    store.setManualScroll("a", 325, null);
+    store.setGeometry("a", { owner: "owner-a", scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["reading"] });
+    for (let index = 0; index < 64; index++) {
+      const owner = `other-${index}`;
+      store.setGeometry(sessionScrollKey("a", owner), { owner, scrollHeight: 1000, viewportWidth: 500, before: 0, after: 0, messageIds: ["reading"] });
+    }
+    expect(state().geometry).toBeUndefined();
+    store.claimOwner("a", "owner-b");
+    expect(state("a", "owner-b").mode).toBe("stickyBottom");
+    store.claimOwner("a", "owner-a");
+    expect(state("a", "owner-a")).toMatchObject({ mode: "manual", scrollTop: 325, owner: "owner-a" });
+  });
+
   test("coalesces hot scroll writes, keeps memory immediate and does not persist clipped-message controls", () => {
     const writes = observeStorageWrites();
     const store = useSessionScrollStore.getState();

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -225,8 +225,22 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     }, { within: 5_000, label: "keyboard browsing settles above the latest turn", until: (value) => value.stable });
   };
   const scrollStorageKey = "openwork:session-scroll:v1";
-  const savedScroll = (sessionId: string): Promise<unknown> => probe.storage(scrollStorageKey, (value): unknown =>
-    value && typeof value === "object" ? Reflect.get(value, sessionId) ?? null : null);
+  const savedScroll = async (sessionId: string): Promise<unknown> => {
+    const organizationId = await probe.storage("openwork.den.activeOrgId");
+    const port = await probe.storage("openwork.server.port");
+    if (typeof organizationId !== "string" || !organizationId.trim()
+      || (typeof port !== "string" && typeof port !== "number") || !/^\d+$/.test(String(port))) {
+      throw new Error("Streamed history fixture is missing its organization or local server port");
+    }
+    // This world signs in as its admin and uses a local v1 workspace. Match
+    // every owner coordinate; a same-ID entry from another owner is not proof.
+    const draftScope = `cloud:${encodeURIComponent(world.principalId)}:${encodeURIComponent(organizationId.trim())}`;
+    const endpoint = `http://127.0.0.1:${port}/workspace/${encodeURIComponent(world.workspace.workspaceId)}/opencode`;
+    const owner = JSON.stringify([draftScope, endpoint, world.workspace.workspaceId, sessionId]);
+    const key = JSON.stringify(["session-scroll", owner, sessionId]);
+    return probe.storage(scrollStorageKey, (value): unknown =>
+      value && typeof value === "object" ? Reflect.get(value, key) ?? null : null);
+  };
   const readingGeometry = async (messageId: string) => {
     const { elements } = await probe.dom(`${viewportSelector}, ${surface} [data-message-id="${messageId}"]`);
     const [viewport, message] = elements;

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -818,6 +818,12 @@ export async function streamedToolHistory(seed: Seed) {
   const den = await seed.den({ mocks: { agent: mock } });
   const app = await seed.desktop({ name: "streamed-tool-history", den, as: "admin", model: `${providerId}/${modelId}` });
   const workspace = await seed.workspace(app, seed.tmpPath("streamed-tool-history"));
+  const profile = await seed.api(den.admin, "/v1/me");
+  if (!profile.response.ok || !isRecord(profile.body) || !isRecord(profile.body.user)
+    || typeof profile.body.user.id !== "string" || !profile.body.user.id.trim()) {
+    throw new Error("Streamed history fixture could not resolve its authenticated principal");
+  }
+  const principalId = profile.body.user.id.trim();
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
     permission: { bash: "allow" },
     provider: { [providerId]: {
@@ -862,7 +868,7 @@ export async function streamedToolHistory(seed: Seed) {
       }
     }
   }, [historyPath, history, toolNames.map(command), providerId, modelId]), { awaitPromise: true, timeoutMs: 185_000 });
-  return { app, workspace, session, neighbor, historyPath, history, toolNames, latestTool, prompt, opening, middle, closing };
+  return { app, workspace, session, neighbor, principalId, historyPath, history, toolNames, latestTool, prompt, opening, middle, closing };
 }
 
 export const streamedMarkdownMarker = "STREAM_MARKDOWN_ANSWER";


### PR DESCRIPTION
## Summary

Follow-up to #4838: loading older history must not override a newer reading destination.

- Preserve explicit top and reserved-history positions when full history arrives, and promptly mount the destination range.
- Navigate once to the first late-arriving Find result. Raw query changes, closure, reader input (including during debounce), and explicit navigation cancel or supersede that pending jump.
- Show “Searching...” while history is incomplete instead of prematurely reporting no matches.
- Isolate reading positions, geometry, controller callbacks, and submission tracking by session owner. Legacy positions remain readable and ownership survives geometry eviction.
- Update the existing streamed-history journey's persistence reader to use the exact owner-qualified key, retaining neighbor-isolation assertions.

Ownerless legacy positions are claimed once by the first committed owner; their original owner cannot be recovered. Known-owner legacy positions cannot migrate elsewhere or overwrite a newer owned position.

## Verification

Candidate: `e572778942ea0022dd2b37341f5d549c34b17dd2`, based on `dev` at `fb3bc5b219ec3904baeeefc9738930b2bcb7d096`. Commit signature verified.

Passed from `apps/app`:

```sh
pnpm exec bun test --isolate tests/find-bar.test.tsx tests/find-store.test.ts tests/session-scroll.test.tsx tests/progressive-message-list.test.tsx ./tests/session-history.test.tsx tests/live-step-scroll.test.ts
pnpm typecheck
```

- **75 passed, 0 failed, 0 skipped**, 402 assertions; exit 0.
- App typecheck and `git diff --check`: exit 0.
- The debounce cancellation regression was first reproduced as two failing cases with two passing controls, then corrected.
- Focused coverage includes delayed Find results, cancellation, partial-history top navigation, two owners sharing a session ID, geometry eviction, and persisted legacy decoding.
- The updated journey storage key was checked against production principal/organization/endpoint/workspace/session assembly; the journey itself was not executed.

## Proof verdict: Incomplete

Exact-head real-app journey evidence is missing. Scroll geometry in component checks is simulated; native anchoring and smooth scrolling are not established.

Existing runtime owners for follow-up proof:

```sh
pnpm evals:e2e session-full-history-on-open
pnpm evals:e2e new-split-session
```

The updated persistence reader also belongs to `streamed-markdown-answer`. No real-app responsiveness or memory improvement is claimed.

## Scope and overlap

Independent PR targeting `dev`. Does not change progressive batch scheduling, message history actions, or task execution.

The PageUp/focus-reveal fix in #4742, the Find-clearance change in #4780, and the full-history cold-reload claim in #4792 are not duplicated. The owner-key reader migration changes a different part of the existing journey. Those PRs retain their own proof and merge requirements. Required repository CI is unchanged.
