### PR TITLE
fix(landing): align nav and wordmark to the content container at every width

### DIFF
--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -80,7 +80,7 @@ export function LandingHome(props: Props) {
 
         <div
           aria-hidden="true"
-          className="font-pixel mx-auto flex w-full max-w-[1920px] justify-between pb-10 px-[clamp(1.5rem,calc((100%-1128px)/2),4.75rem)] pt-6 text-[clamp(3rem,16vw,12rem)] leading-none tracking-[-0.06em] sm:pb-12 sm:pt-8 lg:pb-16"
+          className="font-pixel mx-auto flex w-full max-w-[1176px] justify-between px-6 pb-10 pt-6 text-[clamp(3rem,calc(22vw_-_11px),14rem)] leading-none tracking-[-0.06em] sm:pb-12 sm:pt-8 lg:pb-16"
         >
           {Array.from("OpenWork").map((letter, index) => (
             <span key={index}>{letter}</span>

--- a/ee/apps/landing/components/site-nav.tsx
+++ b/ee/apps/landing/components/site-nav.tsx
@@ -67,7 +67,7 @@ export function SiteNav(props: Props) {
 
   return (
     <header className={`sticky top-0 z-20 w-full transition-all duration-300 ${scrolled ? "bg-white/80 shadow-sm backdrop-blur-md" : ""}`}>
-      <div className="mx-auto flex w-full max-w-[1920px] flex-col px-[clamp(1.5rem,calc((100%-1128px)/2),4.75rem)]">
+      <div className="mx-auto flex w-full max-w-[1176px] flex-col px-6">
         <div className="grid min-h-[97px] grid-cols-[auto_1fr_auto] items-center py-4">
           <Link
             href="/"


### PR DESCRIPTION
## Summary

On wide screens the header container kept growing while the pixel wordmark font capped at 12rem, so `justify-between` spread the letters with large gaps and the nav sat far outside the content edges (see the production screenshot that prompted this).

- Nav and wordmark now use the same `max-w-[1176px] px-6` container as the page content.
- Wordmark font is `clamp(3rem, 22vw - 11px, 14rem)`, derived from the measured glyph width ratio (~4.45x font size), so the word fills the container with small, uniform gaps.

Measured left/right edges of nav logo, first and last wordmark letter, headline, and prompt card at 390 / 1024 / 1280 / 1800: all coincide, letter gaps 1 to 19px, no horizontal overflow.

Made with [Cursor](https://cursor.com)