### PR TITLE
fix(connect): keep authorization clear and one-step

### DIFF
--- a/ee/apps/den-web/app/mcp/consent-permissions.tsx
+++ b/ee/apps/den-web/app/mcp/consent-permissions.tsx
@@ -1,0 +1,29 @@
+export function McpConsentPermissions({ scope }: { scope: string }) {
+  const scopes = new Set(scope.split(/\s+/).filter(Boolean));
+  const canRead = scopes.has("mcp:read");
+  const canAct = scopes.has("mcp:write");
+  const permissions = [
+    ...(scopes.has("openid") || scopes.has("profile") || scopes.has("email")
+      ? ["Access the basic profile information requested by this client."] : []),
+    ...(canRead ? ["Read information and discover available tools."] : []),
+    ...(canAct ? ["Use connected tools and take actions that may create, change, or delete data."] : []),
+    ...(scopes.has("offline_access") ? ["Keep this connection available between visits."] : []),
+  ];
+
+  return (
+    <section aria-label="Requested access" className="grid gap-3 rounded-2xl border border-current/15 p-4 text-sm">
+      <h3 className="font-semibold">Requested access</h3>
+      {permissions.length > 0 ? (
+        <ul className="list-disc space-y-2 pl-5">
+          {permissions.map((permission) => <li key={permission}>{permission}</li>)}
+        </ul>
+      ) : <p>This client is requesting the permissions listed in Connection details.</p>}
+      {canRead && !canAct ? <p>This client cannot run external tools or make changes.</p> : null}
+      <p>Choosing Authorize grants the access shown here for this connection. Your organization's rules and existing service permissions still apply.</p>
+      <details className="text-xs">
+        <summary className="cursor-pointer">Connection details</summary>
+        <p className="mt-2 break-words font-mono">{scope || "No permissions requested"}</p>
+      </details>
+    </section>
+  );
+}

--- a/ee/apps/den-web/app/mcp/consent/page.tsx
+++ b/ee/apps/den-web/app/mcp/consent/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { TemporaryAuthNotice } from "../../(den)/_components/temporary-auth-notice";
 import { denApiCredentials, denApiEndpoint } from "../../(den)/_lib/den-api-origin";
+import { McpConsentPermissions } from "../consent-permissions";
 
 function getErrorMessage(payload: unknown, fallback: string) {
   if (payload && typeof payload === "object" && "message" in payload && typeof payload.message === "string") return payload.message;
@@ -61,9 +62,8 @@ export default function McpConsentPage() {
         <div className="mt-6">
           <TemporaryAuthNotice />
         </div>
-        <div className="mt-6 rounded-2xl border border-white/10 bg-slate-900/70 p-4">
-          <p className="text-sm font-medium text-slate-200">Requested scopes</p>
-          <p className="mt-2 break-words font-mono text-xs text-cyan-100">{scope}</p>
+        <div className="mt-6">
+          <McpConsentPermissions scope={scope} />
         </div>
         {status ? <p className="mt-4 text-sm text-slate-300">{status}</p> : null}
         <div className="mt-6 grid gap-3 sm:grid-cols-2">

--- a/ee/apps/den-web/app/mcp/select-organization/page.tsx
+++ b/ee/apps/den-web/app/mcp/select-organization/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { TemporaryAuthNotice } from "../../(den)/_components/temporary-auth-notice";
 import { denApiCredentials, denApiEndpoint } from "../../(den)/_lib/den-api-origin";
 import { useOrgListWindow } from "../../(den)/_lib/use-org-list-window";
+import { McpConsentPermissions } from "../consent-permissions";
 
 type Organization = {
   id: string;
@@ -229,7 +230,7 @@ export default function McpSelectOrganizationPage() {
           ? "Finishing authorization and sending you back to the MCP client now."
           : flowState === "submitting"
             ? "Authorizing the MCP client..."
-            : "The MCP client will only see data for the workspace you choose.";
+            : "Choose the workspace for this connection, then review the access you're authorizing below.";
 
   const primaryLabel =
     flowState === "submitting"
@@ -270,8 +271,8 @@ export default function McpSelectOrganizationPage() {
                   Pick the workspace this client can use.
                 </h1>
                 <p className="max-w-[34rem] text-[14px] leading-7 text-white/80">
-                  The MCP client only sees data and tools for the workspace you
-                  select here.
+                  This connection can only use the access you authorize for the
+                  workspace you select here.
                 </p>
               </div>
             </div>
@@ -399,6 +400,10 @@ export default function McpSelectOrganizationPage() {
                   </div>
                 ) : null}
               </div>
+            ) : null}
+
+            {orgs.length > 0 && flowState !== "loading" && flowState !== "error" ? (
+              <McpConsentPermissions scope={requestedScope} />
             ) : null}
 
             {errorMessage ? (

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -3,6 +3,8 @@ import { readdir, readFile } from 'node:fs/promises';
 // One home for CI grouping, readable names, and execution requirements.
 // Unlisted specs are discovered automatically as full-regression journeys.
 const definitions = {
+  // Its registered OAuth callback and synthetic client exchange run on owned loopback services.
+  'mcp-connection-consent.e2e.test.ts': { name: 'Authorize a connected client once', placement: 'local' },
   'task-activity-shimmer.e2e.test.ts': {
     cases: [{ id: 'ACT-01', engines: ['v1', 'v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v1' } }],
   },

--- a/evals/specs/mcp-connection-consent.e2e.test.ts
+++ b/evals/specs/mcp-connection-consent.e2e.test.ts
@@ -1,0 +1,81 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { consentCases, mcpConnectionConsent } from "../worlds/mcp-connection-consent.ts";
+
+const test = spec.world(mcpConnectionConsent, {
+  timeout: 300_000,
+  needs: { commands: ["bun", "pnpm"], placement: "local" },
+  resources: { surfaces: ["web"], services: ["den", "mock"] },
+});
+
+test("browser MCP consent preserves write, read-only and cancelled decisions without another gate", async ({ world, user, probe, step, evidence }) => {
+  for (const entry of consentCases) {
+    const flow = world.flows.find(flow => flow.id === entry.id);
+    if (!flow) throw new Error(`Missing ${entry.id} client fixture`);
+    const person = user.on(flow.web);
+    const browser = probe.on(flow.web);
+    await step(`${entry.id}: the OAuth endpoint leads through browser sign-in to consent`, async () => {
+      await person.navigate(flow.authorizeUrl);
+      await person.see({ role: "textbox", label: /email/i }, { timeoutMs: 90_000 });
+      await person.type({ role: "textbox", label: /email/i }, world.den.admin.email);
+      await person.click({ role: "button", text: /^next$/i });
+      await person.see({ role: "textbox", label: /password/i }, { timeoutMs: 30_000 });
+      await person.type({ role: "textbox", label: /password/i }, world.den.admin.password, { sensitive: true });
+      await person.click({ role: "button", text: /^sign in$/i });
+      await person.see({ role: "button", text: "Authorize and continue" }, { timeoutMs: 90_000 });
+    });
+
+    await step(`${entry.id}: requested access is understandable without another permission gate`, async () => {
+      await person.see({ text: "Requested access" });
+      if (entry.scope.includes("mcp:write")) {
+        await person.see({ text: "Use connected tools and take actions that may create, change, or delete data." });
+        await person.notSee({ text: "This client cannot run external tools or make changes." });
+      } else {
+        await person.see({ text: "Read information and discover available tools." });
+        await person.see({ text: "This client cannot run external tools or make changes." });
+        await person.notSee({ text: "Use connected tools and take actions that may create, change, or delete data." });
+      }
+      expect((await browser.dom('input[type="checkbox"], [role="checkbox"]')).elements).toHaveLength(0);
+      await person.notSee({ text: "Requested scopes" });
+      await person.notSee({ text: entry.scope });
+      expect(world.callbacks(entry.id)).toHaveLength(0);
+      expect((await browser.dom('input[name="mcp-organization"]')).elements).toHaveLength(2);
+      await person.click({ text: world.selectedOrgName });
+      await person.screenshot();
+    });
+
+    await step(`${entry.id}: one decision returns directly to the registered client`, async () => {
+      await person.click({ role: "button", text: entry.accept ? /^Authorize and continue$/ : /^Cancel$/ });
+      await person.see({ text: "Authorization returned to client" }, { timeoutMs: 30_000 });
+      const callbacks = world.callbacks(entry.id);
+      expect(callbacks).toHaveLength(1);
+      const returned = callbacks[0];
+      expect(returned.state).toBe(flow.state);
+      if (!entry.accept) {
+        expect(returned.hasCode).toBe(false);
+        expect(returned.error).toBe("access_denied");
+        expect(returned.exchange).toBeNull();
+        evidence.recordAssertionEvidence("Cancel grants no authorization code", "One trusted Cancel click returned access_denied with the original state and no code; no token exchange was attempted.", true);
+        return;
+      }
+      expect(returned.error).toBeNull();
+      expect(returned.hasCode).toBe(true);
+      const exchange = returned.exchange;
+      if (!exchange) throw new Error("The browser callback did not trigger its client's token exchange");
+      expect(exchange.status).toBe(200);
+      const granted = exchange.scope.split(/\s+/).sort();
+      expect(granted).toEqual(entry.scope.split(" ").sort());
+      expect(exchange.jwt).toBe(true);
+      expect(exchange.tokenScope.split(/\s+/).sort()).toEqual(granted);
+      expect(exchange.organizationId).toBe(world.selectedOrgId);
+      expect(world.selectedOrgId).not.toBe(world.originalOrgId);
+      expect(granted).not.toContain("mcp:app-host");
+      if (entry.id === "read") expect(granted).not.toContain("mcp:write");
+      evidence.recordAssertionEvidence(
+        "One browser consent preserves requested access and workspace identity",
+        `One trusted Authorize and continue click delivered one callback; PKCE exchange and JWT retained exactly ${granted.join(" ")} and the selected, not original, workspace. No additional approval or first-party scope was granted.`,
+        true,
+      );
+    });
+  }
+});

--- a/evals/worlds/mcp-connection-consent.ts
+++ b/evals/worlds/mcp-connection-consent.ts
@@ -1,0 +1,111 @@
+import { createHash, randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+import { denFetch } from "@openwork/behaviors";
+import type { Seed } from "@openwork/env";
+import { close, isRecord, listen } from "./openwork-server-cli.ts";
+
+export const consentCases = [
+  { id: "write", scope: "mcp:read mcp:write offline_access", accept: true },
+  { id: "read", scope: "mcp:read", accept: true },
+  { id: "cancel", scope: "mcp:read mcp:write offline_access", accept: false },
+];
+
+export function requiredString(value: unknown, key: string): string {
+  const field = isRecord(value) ? value[key] : undefined;
+  if (typeof field !== "string" || !field) throw new Error(`Missing ${key}`);
+  return field;
+}
+
+export async function mcpConnectionConsent(seed: Seed) {
+  const den = await seed.den({
+    org: { name: "Consent original workspace", members: {} },
+    env: { DEN_MCP_CLAIM_NAMESPACE: "https://consent.example.test" },
+  });
+  if (!den.database) throw new Error("Browser consent requires an owned isolated Den, not an attached service.");
+  const original = await seed.api(den.admin, "/v1/me/orgs");
+  const orgs = isRecord(original.body) && Array.isArray(original.body.orgs) ? original.body.orgs : [];
+  const originalOrgId = requiredString(orgs.find(org => isRecord(org) && org.name === "Consent original workspace"), "id");
+  const selectedOrgName = "Consent selected workspace";
+  const created = await seed.api(den.admin, "/v1/org", {
+    method: "POST", body: JSON.stringify({ name: selectedOrgName }),
+  });
+  if (!created.response.ok || !isRecord(created.body)) throw new Error(`Organization setup failed: HTTP ${created.response.status}`);
+  const selectedOrgId = requiredString(created.body.organization, "id");
+
+  const clients = new Map<string, { clientId: string; verifier: string; redirectUri: string; resource: string; state: string }>();
+  const callbacks: Array<{
+    path: string; hasCode: boolean; error: string | null; state: string | null;
+    exchange: { status: number; scope: string; tokenScope: string; organizationId: string; jwt: boolean } | null;
+  }> = [];
+  const callback = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method !== "GET" || !consentCases.some(entry => url.pathname === `/callback/${entry.id}`)) {
+      response.writeHead(404).end();
+      return;
+    }
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const client = clients.get(url.pathname);
+    const received: (typeof callbacks)[number] = { path: url.pathname, hasCode: Boolean(code), error: url.searchParams.get("error"), state, exchange: null };
+    try {
+      // The synthetic client exchanges only the code delivered to its registered
+      // callback, with its original state and PKCE verifier. No admin bearer is used.
+      if (code && client && state === client.state) {
+        const result = await denFetch(den.ref, "/api/auth/oauth2/token", {
+          method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ grant_type: "authorization_code", client_id: client.clientId, code,
+            code_verifier: client.verifier, redirect_uri: client.redirectUri, resource: client.resource }),
+        });
+        const token = isRecord(result.body) && typeof result.body.access_token === "string" ? result.body.access_token : "";
+        const parts = token.split(".");
+        const claims: unknown = parts.length === 3 ? JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) : null;
+        received.exchange = { status: result.response.status, jwt: parts.length === 3,
+          scope: isRecord(result.body) && typeof result.body.scope === "string" ? result.body.scope : "",
+          tokenScope: isRecord(claims) && typeof claims.scope === "string" ? claims.scope : "",
+          organizationId: isRecord(claims) && typeof claims["https://consent.example.test/org_id"] === "string" ? claims["https://consent.example.test/org_id"] : "" };
+      }
+    } catch {
+      received.exchange = { status: 0, scope: "", tokenScope: "", organizationId: "", jwt: false };
+    }
+    callbacks.push(received);
+    response.writeHead(200, { "content-type": "text/html", "cache-control": "no-store" });
+    response.end("<!doctype html><title>Consent callback</title><h1>Authorization returned to client</h1>");
+  });
+  const callbackOrigin = await listen(callback);
+  try {
+    const flows = [];
+    for (const entry of consentCases) {
+      const redirectUri = `${callbackOrigin}/callback/${entry.id}`;
+      const registered = await denFetch(den.ref, "/register", {
+        method: "POST",
+        body: JSON.stringify({
+          client_name: `Consent ${entry.id} client`, redirect_uris: [redirectUri],
+          token_endpoint_auth_method: "none", grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"], scope: entry.scope,
+        }),
+      });
+      if (registered.response.status !== 201) throw new Error(`Client registration failed: HTTP ${registered.response.status}`);
+      const clientId = requiredString(registered.body, "client_id");
+      const verifier = randomBytes(32).toString("base64url");
+      const state = randomBytes(16).toString("hex");
+      const resource = `${den.ref.apiUrl}/mcp/agent`;
+      clients.set(`/callback/${entry.id}`, { clientId, verifier, redirectUri, resource, state });
+      const query = new URLSearchParams({
+        client_id: clientId, redirect_uri: redirectUri, response_type: "code", scope: entry.scope,
+        resource, state, prompt: "consent", code_challenge_method: "S256",
+        code_challenge: createHash("sha256").update(verifier).digest("base64url"),
+      });
+      const web = await seed.web({ den, headless: true, viewport: { width: 1440, height: 1100 } });
+      flows.push({ ...entry, web, state,
+        authorizeUrl: `${den.ref.apiUrl}/api/auth/oauth2/authorize?${query}` });
+    }
+    return {
+      den, flows, originalOrgId, selectedOrgId, selectedOrgName,
+      callbacks: (id: string) => callbacks.filter(entry => entry.path === `/callback/${id}`).map(entry => ({ ...entry })),
+      async [Symbol.asyncDispose]() { await close(callback); },
+    };
+  } catch (error) {
+    await close(callback);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Make the existing connection authorization understandable without asking people to configure OAuth scopes or approve the same connection twice.

- Explain in plain language when authorization permits reading information versus using connected tools and changing data.
- Keep the existing **Authorize and continue** action; no extra checkbox, approval screen, or per-tool setup.
- Put protocol scope strings in an optional **Connection details** disclosure on both consent pages.
- Leave token minting, scope requests, organization policies, and provider permissions unchanged. Explicitly read-only access is never silently upgraded.

The existing consent already preserves requested permissions. This fixes misleading read-only copy and proves the one-click authorization behavior; it does not remove the execution checks added in #4831.

## Verification

**Proof verdict: Passed at `e31e58b9d3380f37984bd23c0e8c4386ddd7077b`.** Exact-head evidence is published in the test-evidence comment.

The isolated browser journey passed: 1 test covering three decisions, zero failures/skips, exit 0. It exercises real sign-in, workspace selection, one consent click, the registered callback, and PKCE exchange for write-authorized, read-only, and cancelled requests. It checks the exact granted scopes and selected workspace, no additional checkbox, hidden-by-default scope strings, and no authorization code after cancellation.

Command: `pnpm evals:e2e mcp-connection-consent --local`.

The journey is new because the existing OAuth recovery test exercises consent through HTTP, not the browser screen. Its loopback client callback requires local placement. The case-catalog check passed 13 tests.

## Scope

The normal workspace-selection consent page is browser-tested. The older consent page uses the same permission summary but is not a separately driven journey. No production credentials, real provider actions, merge, or deployment.
