### PR TITLE
feat(landing): hero buttons match the 43px pill with trailing glyph

### DIFF
--- a/ee/apps/landing/app/globals.css
+++ b/ee/apps/landing/app/globals.css
@@ -247,6 +247,64 @@ body {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
 }
 
+/* Hero buttons: 43px pill, 16px regular text, trailing glyph icon. */
+.lp-btn {
+  display: inline-flex;
+  align-items: center;
+  height: 43px;
+  padding: 0 22px;
+  border-radius: 9999px;
+  background-color: var(--lp-ink);
+  color: #f7f7f4;
+  border: 1px solid var(--lp-ink);
+  font-size: 16px;
+  line-height: 16px;
+  font-weight: 400;
+  white-space: nowrap;
+  text-decoration: none;
+  transition:
+    color 150ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 150ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 150ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 100ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.lp-btn:hover {
+  background-color: #102638;
+  border-color: #102638;
+}
+
+.lp-btn:active {
+  transform: scale(0.98);
+}
+
+.lp-btn-icon {
+  display: flex;
+  padding-left: 4px;
+  font-size: 16px;
+  line-height: 16px;
+  transition: transform 150ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.lp-btn:hover .lp-btn-icon {
+  transform: translateY(1px);
+}
+
+.lp-btn--secondary {
+  background-color: #e9edf2;
+  color: var(--lp-ink);
+  border-color: rgba(1, 22, 39, 0.04);
+}
+
+.lp-btn--secondary:hover {
+  background-color: #dfe5ec;
+  border-color: rgba(1, 22, 39, 0.06);
+}
+
+.lp-btn--secondary:hover .lp-btn-icon {
+  transform: translateX(2px);
+}
+
 .doc-button {
   background-color: var(--lp-ink);
   color: #ffffff;

--- a/ee/apps/landing/components/hero-download-button.tsx
+++ b/ee/apps/landing/components/hero-download-button.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { detectPlatform, type DetectedOS } from "@openwork/ui/react";
+import { useEffect, useState } from "react";
+
+import { DownloadLink } from "./download-link";
+
+const osLabel: Record<DetectedOS, string> = {
+  macos: "macOS",
+  windows: "Windows",
+  linux: "Linux"
+};
+
+export function HeroDownloadButton() {
+  const [os, setOs] = useState<DetectedOS | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectPlatform().then((detected) => {
+      if (!cancelled && detected) setOs(detected.os);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <DownloadLink className="lp-btn">
+      {os ? `Download for ${osLabel[os]}` : "Download for free"}
+      <span className="lp-btn-icon" aria-hidden="true">
+        ⤓
+      </span>
+    </DownloadLink>
+  );
+}

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -24,7 +24,7 @@ import {
 } from "./lp-primitives";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
-import { DownloadLink } from "./download-link";
+import { HeroDownloadButton } from "./hero-download-button";
 
 type Props = {
   stars: string;
@@ -123,12 +123,13 @@ export function LandingHome(props: Props) {
                     Get Started for Free <ArrowRight size={18} />
                   </a>
                 ) : (
-                  <DownloadLink className="doc-button inline-flex !h-[52px] items-center gap-2 !px-6 !text-[17px]">
-                    Download for free <ArrowRight size={20} />
-                  </DownloadLink>
+                  <HeroDownloadButton />
                 )}
-                <a href="/enterprise" className="secondary-button !h-[52px] !px-6 !text-[17px]">
+                <a href="/enterprise" className="lp-btn lp-btn--secondary">
                   Explore enterprise
+                  <span className="lp-btn-icon" aria-hidden="true">
+                    →
+                  </span>
                 </a>
               </div>
 


### PR DESCRIPTION
## Summary

Restyle the two hero CTAs to the compact pill pattern (43px tall, 16px regular text, 22px side padding, pill radius, trailing text glyph).

- New `hero-download-button.tsx`: `Download for macOS / Windows / Linux` once `detectPlatform` resolves (falls back to `Download for free`), trailing `⤓` glyph, wraps the existing `DownloadLink` so the auto-download flow is unchanged.
- Secondary `Explore enterprise` becomes a filled light pill with a trailing `→`.
- New `.lp-btn`, `.lp-btn--secondary`, `.lp-btn-icon` classes in `globals.css`. Brand ink is kept for the primary background.

Made with [Cursor](https://cursor.com)