### PR TITLE
feat(landing): set Work in the body face and keep the dither clear of the wordmark

### DIFF
--- a/ee/apps/landing/app/globals.css
+++ b/ee/apps/landing/app/globals.css
@@ -197,30 +197,46 @@ body {
   margin-right: auto;
 }
 
-/* Hero dither mask. Desktop: clear behind the left headline column (anchored to the
-   centered container), fade in across the right half, clear behind the top wordmark,
-   fade out toward the bottom. Below lg the headline spans the full width, so the
-   dither is pushed to the right edge and softened. */
-.lp-hero-dither {
-  -webkit-mask-image:
-    linear-gradient(to right, transparent 0, transparent calc(50% + 10px), rgba(0, 0, 0, 0.2) calc(50% + 80px), rgba(0, 0, 0, 0.6) calc(50% + 170px), #000 calc(50% + 260px), #000 100%),
-    linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.15) 150px, rgba(0, 0, 0, 0.65) 250px, #000 310px, #000 480px, rgba(0, 0, 0, 0.5) 740px, transparent 1080px);
-  mask-image:
-    linear-gradient(to right, transparent 0, transparent calc(50% + 10px), rgba(0, 0, 0, 0.2) calc(50% + 80px), rgba(0, 0, 0, 0.6) calc(50% + 170px), #000 calc(50% + 260px), #000 100%),
-    linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.15) 150px, rgba(0, 0, 0, 0.65) 250px, #000 310px, #000 480px, rgba(0, 0, 0, 0.5) 740px, transparent 1080px);
-  -webkit-mask-composite: source-in;
-  mask-composite: intersect;
+/* Pixel wordmark with "Work" set in the body face. */
+.lp-wordmark-sans {
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  font-weight: 500;
+  letter-spacing: -0.05em;
 }
 
+/* Hero dither mask, in page coordinates (the nav is 97px tall, the wordmark band ends
+   around 400px). The visible region is the union of two areas:
+     1. a soft radial sweeping in from the top-right corner, outside the content column,
+        so the dither resumes past the "k" on a curved, fading edge;
+     2. the right half of the page below the wordmark band (clear behind the headline
+        column), fading out toward the bottom.
+   Layer order: radial, then (below-band  intersect  right-half). */
+.lp-hero-dither {
+  -webkit-mask-image:
+    radial-gradient(1100px 800px at calc(50% + 1000px) 157px, #000 0, #000 20%, rgba(0, 0, 0, 0.5) 32%, rgba(0, 0, 0, 0.15) 40%, transparent 46%),
+    linear-gradient(to bottom, transparent 0, transparent 395px, rgba(0, 0, 0, 0.45) 455px, #000 525px, #000 620px, rgba(0, 0, 0, 0.5) 820px, transparent 1080px),
+    linear-gradient(to right, transparent 0, transparent calc(50% + 10px), rgba(0, 0, 0, 0.6) calc(50% + 170px), #000 calc(50% + 260px), #000 100%);
+  mask-image:
+    radial-gradient(1100px 800px at calc(50% + 1000px) 157px, #000 0, #000 20%, rgba(0, 0, 0, 0.5) 32%, rgba(0, 0, 0, 0.15) 40%, transparent 46%),
+    linear-gradient(to bottom, transparent 0, transparent 395px, rgba(0, 0, 0, 0.45) 455px, #000 525px, #000 620px, rgba(0, 0, 0, 0.5) 820px, transparent 1080px),
+    linear-gradient(to right, transparent 0, transparent calc(50% + 10px), rgba(0, 0, 0, 0.6) calc(50% + 170px), #000 calc(50% + 260px), #000 100%);
+  -webkit-mask-composite: source-over, source-in, source-over;
+  mask-composite: add, intersect, add;
+}
+
+/* Below lg the headline spans the full width and the wordmark is short, so the dither
+   is kept clear of the wordmark band, pushed to the right edge, and softened. */
 @media (max-width: 1023px) {
   .lp-hero-dither {
     opacity: 0.4;
     -webkit-mask-image:
       linear-gradient(to right, transparent 0, transparent 52%, rgba(0, 0, 0, 0.35) 70%, #000 88%, #000 100%),
-      linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.2) 110px, #000 200px, #000 420px, rgba(0, 0, 0, 0.5) 620px, transparent 860px);
+      linear-gradient(to bottom, transparent 0, transparent 230px, rgba(0, 0, 0, 0.25) 290px, #000 360px, #000 520px, rgba(0, 0, 0, 0.5) 700px, transparent 900px);
     mask-image:
       linear-gradient(to right, transparent 0, transparent 52%, rgba(0, 0, 0, 0.35) 70%, #000 88%, #000 100%),
-      linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.2) 110px, #000 200px, #000 420px, rgba(0, 0, 0, 0.5) 620px, transparent 860px);
+      linear-gradient(to bottom, transparent 0, transparent 230px, rgba(0, 0, 0, 0.25) 290px, #000 360px, #000 520px, rgba(0, 0, 0, 0.5) 700px, transparent 900px);
+    -webkit-mask-composite: source-in;
+    mask-composite: intersect;
   }
 }
 

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -62,10 +62,15 @@ export function LandingHome(props: Props) {
 
         <div
           aria-hidden="true"
-          className="font-pixel mx-auto flex w-full max-w-[1176px] justify-between px-6 pb-10 pt-6 text-[clamp(3rem,calc(22vw_-_11px),14rem)] leading-none tracking-[-0.06em] sm:pb-12 sm:pt-8 lg:pb-16"
+          className="font-pixel mx-auto flex w-full max-w-[1176px] items-baseline justify-between px-6 pb-10 pt-6 text-[clamp(3rem,calc(21vw_-_11px),13.5rem)] leading-none tracking-[-0.06em] sm:pb-12 sm:pt-8 lg:pb-16"
         >
-          {Array.from("OpenWork").map((letter, index) => (
-            <span key={index}>{letter}</span>
+          {Array.from("Open").map((letter, index) => (
+            <span key={`open-${index}`}>{letter}</span>
+          ))}
+          {Array.from("Work").map((letter, index) => (
+            <span key={`work-${index}`} className="lp-wordmark-sans">
+              {letter}
+            </span>
           ))}
         </div>
 


### PR DESCRIPTION
## Summary

Picked from a set of wordmark variations.

- Wordmark: pixel `Open` plus `Work` in Inter medium (`.lp-wordmark-sans`), baseline aligned, font size `clamp(3rem, 21vw - 11px, 13.5rem)` so it still fills the content column edge to edge (gaps 2px at 390, 20px at 1440).
- Hero dither mask is now a union of two regions: a soft radial sweeping in from the top-right corner outside the content column (so the dither resumes past the `k` on a curved, fading edge, not a vertical cut), and the right half of the page below the wordmark band, fading toward the bottom. The whole wordmark band is clear.
- Mobile mask keeps the wordmark band clear as well.

Verified at 390 and 1440: no overflow, wordmark edges match the content column, band bottom sits above the mask start.

Made with [Cursor](https://cursor.com)