### PR TITLE
perf(chat): make conversation loading quiet and intentional

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -156,7 +156,7 @@ export type SessionPageSidebarProps = {
   startupPhase: BootPhase;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
-  onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
+  onPrefetchSession?: (workspaceId: string, sessionId: string) => void | (() => void);
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
   onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
   onCreateTaskWithPrompt?: (

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -16,7 +16,7 @@ export type SidebarContextValue = {
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
-  onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
+  onPrefetchSession?: (workspaceId: string, sessionId: string) => void | (() => void);
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
   onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import * as React from "react";
+import { useSessionPrefetchIntent } from "../surface/session-history";
 import {
   AlertCircle,
   AlertTriangle,
@@ -759,7 +760,7 @@ export type AppSidebarProps = {
   newTaskDraftScope?: string | null;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
-  onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
+  onPrefetchSession?: (workspaceId: string, sessionId: string) => void | (() => void);
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
   onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;
@@ -860,34 +861,6 @@ export function AppSidebar(props: AppSidebarProps) {
       [workspaceId]: Math.min((current[workspaceId] ?? MAX_SESSIONS_PREVIEW) + MAX_SESSIONS_PREVIEW, totalRoots),
     }));
   };
-
-  React.useEffect(() => {
-    const workspaceId = props.selectedWorkspaceId.trim();
-    if (!workspaceId) return;
-
-    const group = props.workspaceSessionGroups.find(
-      (entry) => entry.workspace.id === workspaceId,
-    );
-    if (!group?.sessions.length) return;
-
-    const selectedId = props.selectedSessionId?.trim() ?? "";
-    const selectedIndex = selectedId
-      ? group.sessions.findIndex((session) => session.id === selectedId)
-      : -1;
-    const start = selectedIndex >= 0 ? Math.max(0, selectedIndex - 2) : 0;
-    const end = selectedIndex >= 0
-      ? Math.min(group.sessions.length, selectedIndex + 3)
-      : Math.min(group.sessions.length, 4);
-
-    group.sessions.slice(start, end).forEach((session) => {
-      props.onPrefetchSession?.(workspaceId, session.id);
-    });
-  }, [
-    props.onPrefetchSession,
-    props.selectedSessionId,
-    props.selectedWorkspaceId,
-    props.workspaceSessionGroups,
-  ]);
 
   const contextValue: SidebarContextValue = {
     selectedWorkspaceId: props.selectedWorkspaceId,
@@ -2158,20 +2131,21 @@ function SessionMenuItem({
     : sessionNumberAriaKeyShortcut(ctx.sessionNumberShortcutOs, shortcutDigit);
 
   const openSession = () => {
+    commitPrefetch();
     useSessionManagementStore.getState().clearUnread(session.id);
     ctx.onOpenSession(workspaceId, session.id);
   };
 
-  const prefetchSession = () => {
+  const prefetchSession = React.useCallback(() => {
     if (workspaceId !== ctx.selectedWorkspaceId) {
       return;
     }
 
-    ctx.onPrefetchSession?.(workspaceId, session.id);
-  };
+    return ctx.onPrefetchSession?.(workspaceId, session.id);
+  }, [ctx.onPrefetchSession, ctx.selectedWorkspaceId, workspaceId, session.id]);
+  const commitPrefetch = useSessionPrefetchIntent(!isSelected && (isTitleHovered || isTitleFocused), prefetchSession);
 
   const handlePointerEnter = (event: React.PointerEvent) => {
-    prefetchSession();
     if (event.pointerType === "mouse") setIsTitleHovered(true);
   };
 
@@ -2247,7 +2221,6 @@ function SessionMenuItem({
             onPointerEnter={handlePointerEnter}
             onPointerLeave={() => setIsTitleHovered(false)}
             onFocus={() => {
-              prefetchSession();
               setIsTitleFocused(true);
             }}
             onBlur={() => setIsTitleFocused(false)}

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -1,11 +1,26 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { queryOptions, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { LoaderCircle } from "lucide-react";
 import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types";
+import { snapshotKey } from "../sync/session-sync";
+import { composerAutoSendScopeKey } from "./composer-auto-send";
 import { getSessionScrollState, useSessionScrollStore, type SessionScrollState } from "./scroll-store";
 
 export type OpeningHistoryWindow = { limit?: number; messageIds?: readonly string[] };
+
+export function sessionHistoryIdentity(input: {
+  draftScope: string | null;
+  opencodeBaseUrl: string;
+  runtimeWorkspaceId: string;
+  sessionId: string;
+}) {
+  // Sidebar aliases (rem_*) are navigation identities, not runtime cache owners.
+  return {
+    owner: composerAutoSendScopeKey({ ...input, workspaceId: input.runtimeWorkspaceId }),
+    snapshotQueryKey: snapshotKey(input.runtimeWorkspaceId, input.sessionId),
+  };
+}
 
 export function openingHistoryWindow(saved: SessionScrollState): OpeningHistoryWindow {
   if (saved.mode !== "manual" || !saved.anchor) return { limit: 24 };
@@ -22,23 +37,37 @@ export function openingHistoryWindow(saved: SessionScrollState): OpeningHistoryW
   return { messageIds: [...new Set(nativeIds)].slice(0, 24) };
 }
 
-export function useOpeningSessionHistory(input: {
+type OpeningHistoryInput = {
   owner: string;
   sessionId: string;
+  authToken?: string | null;
   snapshotQueryKey: readonly unknown[];
   readSnapshot: (signal: AbortSignal, window?: OpeningHistoryWindow) => Promise<OpenworkSessionSnapshot>;
-}) {
-  const client = useQueryClient();
-  const hasLegacyPosition = useSessionScrollStore((state) => Boolean(state.sessions[input.sessionId]));
-  const saved = useMemo(() => {
-    return getSessionScrollState(useSessionScrollStore.getState().sessions, input.sessionId, input.owner);
-  }, [input.owner, input.sessionId, hasLegacyPosition]);
-  const hasFullSnapshot = client.getQueryData<OpenworkSessionSnapshot>(input.snapshotQueryKey)?.session.id === input.sessionId;
-  const options = queryOptions({
-    queryKey: ["react-session-opening", input.owner],
+};
+
+// Opaque, bounded credential identities keep secrets out of query keys and
+// prevent an in-flight speculative read surviving a credential change as a hit.
+const openingCredentials = new Map<string | null, number>();
+let nextOpeningCredential = 0;
+
+export function openingSessionHistoryOptions(input: OpeningHistoryInput, saved = getSessionScrollState(
+  useSessionScrollStore.getState().sessions, input.sessionId, input.owner,
+)) {
+  const token = input.authToken ?? null;
+  let credential = openingCredentials.get(token);
+  if (credential === undefined) {
+    credential = ++nextOpeningCredential;
+    openingCredentials.set(token, credential);
+    if (openingCredentials.size > 32) openingCredentials.delete(openingCredentials.keys().next().value ?? null);
+  }
+  return queryOptions({
+    queryKey: ["react-session-opening", input.owner, credential],
     queryFn: async ({ signal }): Promise<{ snapshot: OpenworkSessionSnapshot | null }> => {
       try {
-        return { snapshot: await input.readSnapshot(signal, openingHistoryWindow(saved)) };
+        const snapshot = await input.readSnapshot(signal, openingHistoryWindow(saved));
+        signal.throwIfAborted();
+        if (snapshot.session.id !== input.sessionId) throw new Error("Conversation history belongs to another session.");
+        return { snapshot };
       } catch {
         signal.throwIfAborted();
         // A preview is optional (e.g. a deleted anchor or an older server).
@@ -46,11 +75,51 @@ export function useOpeningSessionHistory(input: {
         return { snapshot: null };
       }
     },
-    staleTime: Infinity,
+    staleTime: (query) => query.state.data?.snapshot ? Infinity : 0,
     gcTime: 15_000,
     retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
     networkMode: "always",
   });
+}
+
+export function prefetchOpeningSessionHistory(client: QueryClient, input: OpeningHistoryInput) {
+  if (client.getQueryData<OpenworkSessionSnapshot>(input.snapshotQueryKey)?.session.id === input.sessionId) return;
+  // No queue and no neighboring reads: only one speculative opening at a time.
+  if (client.isFetching({ queryKey: ["react-session-opening"] })) return;
+  const options = openingSessionHistoryOptions(input);
+  void client.prefetchQuery(options);
+  return () => {
+    const query = client.getQueryCache().find({ queryKey: options.queryKey, exact: true });
+    // Click may already have adopted this exact query. Never cancel its read.
+    if (query?.getObserversCount() === 0) void client.cancelQueries({ queryKey: options.queryKey, exact: true });
+  };
+}
+
+export function useSessionPrefetchIntent(intent: boolean, prefetch: () => void | (() => void)) {
+  const committed = useRef(false);
+  useEffect(() => {
+    committed.current = false;
+    if (!intent) return;
+    let cancel: void | (() => void);
+    const timer = setTimeout(() => { cancel = prefetch(); }, 250);
+    return () => {
+      clearTimeout(timer);
+      if (!committed.current) cancel?.();
+    };
+  }, [intent, prefetch]);
+  return () => { committed.current = true; };
+}
+
+export function useOpeningSessionHistory(input: OpeningHistoryInput) {
+  const client = useQueryClient();
+  const hasLegacyPosition = useSessionScrollStore((state) => Boolean(state.sessions[input.sessionId]));
+  const saved = useMemo(() => {
+    return getSessionScrollState(useSessionScrollStore.getState().sessions, input.sessionId, input.owner);
+  }, [input.owner, input.sessionId, hasLegacyPosition]);
+  const hasFullSnapshot = client.getQueryData<OpenworkSessionSnapshot>(input.snapshotQueryKey)?.session.id === input.sessionId;
+  const options = openingSessionHistoryOptions(input, saved);
   const query = useQuery({ ...options, enabled: !hasFullSnapshot });
   const activeOwner = useRef<string | null>(input.owner);
   activeOwner.current = input.owner;
@@ -104,37 +173,61 @@ export function useOpeningSessionHistory(input: {
   };
 }
 
-type OpeningOptions = ReturnType<typeof useOpeningSessionHistory>["options"];
-
-function AwaitOpeningHistory({ options, saved }: { options: OpeningOptions; saved: SessionScrollState }) {
-  useSuspenseQuery(options);
-  return <SessionHistoryLoading saved={saved} />;
-}
-
-export function SessionHistoryLoading({ saved }: { saved: SessionScrollState }) {
+export function SessionHistoryLoading({ saved, failed = false }: { saved: SessionScrollState; failed?: boolean }) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), 150);
+    return () => clearTimeout(timer);
+  }, []);
   const height = Math.max(200, (saved.geometry?.scrollHeight ?? 232) - 32);
   const top = saved.mode === "manual" ? Math.min(saved.scrollTop + 64, height - 120) : Math.max(64, height - 200);
+  if (failed) return <div data-thread-placeholder style={{ minHeight: height }} />;
   return <div data-thread-loading role="status" aria-live="polite" aria-label="Loading conversation" style={{ minHeight: height }}>
-    <div className="flex items-center justify-center gap-2 text-sm text-dls-secondary" style={{ paddingTop: Math.max(32, top) }}>
+    <span className="sr-only">Loading conversation</span>
+    {visible ? <div aria-hidden="true" data-thread-loading-visual className="flex items-center justify-center gap-2 text-sm text-dls-secondary" style={{ paddingTop: Math.max(32, top) }}>
       <LoaderCircle aria-hidden="true" className="size-4 motion-safe:animate-spin" />
       <span>{saved.mode === "manual" ? "Returning to your reading position…" : "Loading latest messages…"}</span>
+    </div> : null}
+  </div>;
+}
+
+export function SessionHistoryStatus({ complete, pending, failed, onRetry }: {
+  complete: boolean;
+  pending: boolean;
+  failed: boolean;
+  onRetry: () => Promise<unknown>;
+}) {
+  const [retrying, setRetrying] = useState(false);
+  const retryPending = useRef(false);
+  if (complete || (pending && !failed && !retrying)) return null;
+  return <div data-thread-history-status className="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
+    <div role={failed && !retrying ? "alert" : "status"} aria-live="polite" className="pointer-events-auto flex items-center gap-2 rounded-md bg-dls-surface/95 px-3 py-1 text-xs text-dls-secondary shadow-sm">
+      <span>{retrying ? pending ? "Loading conversation…" : "Loading earlier messages…" : failed
+        ? pending ? "This conversation could not be loaded." : "The rest of this conversation could not be loaded."
+        : "Loading earlier messages…"}</span>
+      {failed || retrying ? <button type="button" disabled={retrying} className="underline disabled:no-underline" onClick={() => {
+        if (retryPending.current) return;
+        retryPending.current = true;
+        setRetrying(true);
+        void onRetry().catch(() => undefined).finally(() => {
+          retryPending.current = false;
+          setRetrying(false);
+        });
+      }}>{retrying ? "Retrying…" : "Retry"}</button> : null}
     </div>
   </div>;
 }
 
-export function SessionHistoryBoundary({ owner, pending, options, saved, onRetry, children }: {
+export function SessionHistoryBoundary({ owner, pending, saved, failed, children }: {
   owner: string;
   pending: boolean;
-  options: OpeningOptions;
   saved: SessionScrollState;
-  onRetry?: () => void;
+  failed?: boolean;
   children: ReactNode;
 }) {
+  // useQuery owns the opening read without suspending its reveal behind React's
+  // fallback throttle. Keep descendant suspensions isolated from the composer.
   return <Suspense key={owner} fallback={<SessionHistoryLoading saved={saved} />}>
-    {onRetry ? <div role="alert" className="flex items-center justify-center gap-3 py-3 text-xs text-dls-secondary">
-      <span>The rest of this conversation could not be loaded.</span>
-      <button type="button" className="underline" onClick={onRetry}>Retry</button>
-    </div> : null}
-    {pending ? (onRetry ? null : <AwaitOpeningHistory options={options} saved={saved} />) : children}
+    {pending ? <SessionHistoryLoading saved={saved} failed={failed} /> : children}
   </Suspense>;
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -92,7 +92,7 @@ import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/trans
 import { setQueuedSendContext } from "@/react-app/domains/session/sync/queued-send-context";
 import { useSessionScrollController } from "./scroll-controller";
 import { getSessionScrollState, useSessionScrollStore } from "./scroll-store";
-import { SessionHistoryBoundary, useOpeningSessionHistory, type OpeningHistoryWindow } from "./session-history";
+import { sessionHistoryIdentity, SessionHistoryBoundary, SessionHistoryStatus, useOpeningSessionHistory, type OpeningHistoryWindow } from "./session-history";
 import { SessionScrollOverlay } from "./scroll-overlay";
 import { SessionFindBar } from "./find-bar";
 import { useSessionFindStore } from "./find-store";
@@ -106,7 +106,6 @@ import {
   markSessionSnapshotFetchStart,
   reconcileFailureDegradedThreshold,
   seedSessionState,
-  snapshotKey as reactSnapshotKey,
   statusKey as reactStatusKey,
   transcriptKey as reactTranscriptKey,
   useWorkspaceSyncStreamStore,
@@ -157,7 +156,6 @@ import {
 } from "@/react-app/domains/connections/cloud-inventory-cache";
 import { connectPluginsForComposer, EMPTY_CONNECT_CAPABILITY_INVENTORY } from "@/react-app/domains/session/surface/connect-capability-inventory";
 import {
-  composerAutoSendScopeKey,
   consumeComposerAutoSend,
   consumeComposerAutoSendPayload,
   getComposerAutoSendPayload,
@@ -1149,12 +1147,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
     : Boolean(props.modelUnavailable);
   // This surface is retained across navigation. Async completions must keep
   // their original owner, including when different servers reuse session IDs.
-  const sessionOwner = composerAutoSendScopeKey({
+  const { owner: sessionOwner, snapshotQueryKey } = useMemo(() => sessionHistoryIdentity({
     draftScope: props.draftScope,
     opencodeBaseUrl: props.opencodeBaseUrl,
-    workspaceId: props.workspaceId,
+    runtimeWorkspaceId: props.workspaceId,
     sessionId: props.sessionId,
-  });
+  }), [props.draftScope, props.opencodeBaseUrl, props.workspaceId, props.sessionId]);
   const activeSessionOwnerRef = useRef(sessionOwner);
   activeSessionOwnerRef.current = sessionOwner;
   const snapshotTargetRef = useRef<NativeSessionSnapshotTarget>({
@@ -1229,10 +1227,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
     [props.opencodeBaseUrl, props.openworkToken, props.workspaceRoot],
   );
 
-  const snapshotQueryKey = useMemo(
-    () => reactSnapshotKey(props.workspaceId, props.sessionId),
-    [props.workspaceId, props.sessionId],
-  );
   const transcriptQueryKey = useMemo(
     () => reactTranscriptKey(props.workspaceId, props.sessionId),
     [props.workspaceId, props.sessionId],
@@ -1264,7 +1258,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       markSessionSnapshotFetchStart(item, startedAt);
       return item;
   }, [props.opencodeBaseUrl, props.openworkToken, props.sessionId, sessionOwner, useDesktopLoopbackSnapshotRetry]);
-  const openingHistory = useOpeningSessionHistory({ owner: sessionOwner, sessionId: props.sessionId, snapshotQueryKey, readSnapshot });
+  const openingHistory = useOpeningSessionHistory({ owner: sessionOwner, sessionId: props.sessionId, authToken: props.openworkToken, snapshotQueryKey, readSnapshot });
   const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
     queryKey: snapshotQueryKey,
     queryFn: ({ signal }) => readSnapshot(signal),
@@ -1780,7 +1774,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     props.onOpenTarget?.(target, options, props.sessionId);
   }, [props.onOpenTarget, props.sessionId]);
   const pendingSessionLoad = (!hasFullHistory && Boolean(revertMessageId))
-    || (!snapshot && !snapshotQuery.isError && renderedMessages.length === 0);
+    || (!snapshot && renderedMessages.length === 0);
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;
     return renderedMessages
@@ -3164,27 +3158,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
               />
             ) : null}
             <SessionHistoryBoundary owner={sessionOwner} pending={pendingSessionLoad}
-              onRetry={snapshotQuery.isError && !snapshotQuery.isFetching && snapshot && !fullSnapshot ? () => { void snapshotQuery.refetch(); } : undefined}
-              options={openingHistory.options} saved={initialScroll}>
-            {(snapshotQuery.isError || error) && !snapshot && renderedMessages.length === 0 ? (
-              <div className="px-6 py-8">
-                {error ? (
-                  <SessionErrorCard
-                    developerMode={props.developerMode}
-                    error={error}
-                    onDismiss={handleDismissError}
-                    onChangeModel={handleModelChange}
-                    onOpenModelPicker={handleOpenModelPicker}
-                  />
-                ) : (
-                  <div className="mx-auto max-w-xl rounded-3xl border border-red-6/40 bg-red-3/20 px-6 py-5 text-sm text-red-11">
-                    {props.developerMode && snapshotQuery.error instanceof Error
-                      ? snapshotQuery.error.message
-                      : describeOpencodeSessionError(snapshotQuery.error, "Failed to load session.")}
-                  </div>
-                )}
-              </div>
-            ) : renderedMessages.length === 0 && effectiveActivityStatus !== "idle" && !error ? (
+              failed={snapshotQuery.isError && !snapshotQuery.isFetching} saved={initialScroll}>
+            {renderedMessages.length === 0 && effectiveActivityStatus !== "idle" && !error ? (
               <div className="px-6 py-12">
                 <AssistantWaitingCard label={getSessionActivityStatusLabel(effectiveActivityStatus)} />
               </div>
@@ -3256,6 +3231,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
             ) : null}
           </div>
         </div>
+        <SessionHistoryStatus key={sessionOwner} complete={hasFullHistory} pending={pendingSessionLoad}
+          failed={snapshotQuery.isError && !snapshotQuery.isFetching} onRetry={() => snapshotQuery.refetch()} />
         <SessionScrollOverlay
           sessionId={props.sessionId}
           owner={sessionOwner}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -19,7 +19,8 @@ import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
 import { createClient, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl, v2PromptText, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe, forkSession, listCommands, revertSession, shellInSession, unrevertSession } from "@/app/lib/opencode-session";
-import { getNativeSessionMessages } from "@/app/lib/opencode-session-native";
+import { composeNativeSessionSnapshot, getNativeSessionMessages } from "@/app/lib/opencode-session-native";
+import { prefetchOpeningSessionHistory, sessionHistoryIdentity } from "@/react-app/domains/session/surface/session-history";
 import { sendSessionCommand, sessionWorkHeld } from "@/app/lib/opencode-interruption";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
 import { getSessionDescendantIds } from "@/react-app/domains/session/sidebar/utils";
@@ -541,6 +542,28 @@ export function SessionRoute() {
     navigationGeneration: routeNavigationRef.current.generation,
   };
   const archiveDisabledReason = isOpencodeV2BaseUrl(opencodeBaseUrl) ? V2_SESSION_ARCHIVE_UNAVAILABLE : undefined;
+  const canPrefetchSelectedWorkspace = Boolean(opencodeClient && selectedWorkspaceEndpoint && !selectedWorkspaceError);
+  const prefetchRuntimeWorkspaceId = selectedWorkspaceEndpoint?.workspaceId;
+  const cancelOpeningPrefetchRef = useRef<(() => void) | undefined>(undefined);
+  const handlePrefetchSession = useCallback((workspaceId: string, sessionId: string) => {
+    // Only the selected workspace has a confirmed runtime here. Never infer an
+    // endpoint for a pinned/other-workspace row just to warm its transcript.
+    if (workspaceId !== selectedWorkspaceId || !canPrefetchSelectedWorkspace || !prefetchRuntimeWorkspaceId || !selectedWorkspaceServerToken
+      || !sessionsByWorkspaceIdRef.current[workspaceId]?.some((session) => session.id === sessionId)) return;
+    const endpoint = { opencodeBaseUrl: opencodeBaseUrl.trim(), token: selectedWorkspaceServerToken.trim() };
+    const cancel = prefetchOpeningSessionHistory(getReactQueryClient(), {
+      ...sessionHistoryIdentity({ draftScope: sessionDraftScope, opencodeBaseUrl: endpoint.opencodeBaseUrl, runtimeWorkspaceId: prefetchRuntimeWorkspaceId, sessionId }),
+      sessionId,
+      authToken: endpoint.token,
+      readSnapshot: (signal, window) => composeNativeSessionSnapshot(endpoint, sessionId, { ...window, signal }),
+    });
+    if (cancel) cancelOpeningPrefetchRef.current = cancel;
+    return cancel;
+  }, [selectedWorkspaceId, canPrefetchSelectedWorkspace, prefetchRuntimeWorkspaceId, opencodeBaseUrl, selectedWorkspaceServerToken, sessionDraftScope, sessionsByWorkspaceIdRef]);
+  useEffect(() => () => {
+    cancelOpeningPrefetchRef.current?.();
+    cancelOpeningPrefetchRef.current = undefined;
+  }, [handlePrefetchSession]);
   // The dashboard is user-scoped while MCP servers are workspace-scoped: the
   // selected workspace's runtime is primary, and every other available one is
   // a per-tile fallback so tiles keep working when the selected workspace does
@@ -3464,7 +3487,7 @@ export function SessionRoute() {
           writeLastSessionFor(workspaceId, sessionId);
           navigateToWorkspaceSession(workspaceId, sessionId);
         },
-        onPrefetchSession: () => {},
+        onPrefetchSession: handlePrefetchSession,
         onCreateTaskInWorkspace: (workspaceId, groupId) => {
           const { focusedPane, secondary } = useWorkbenchStore.getState();
           const hasWorkspaceError = Boolean(errorsByWorkspaceId[workspaceId]?.trim())

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -1,12 +1,13 @@
 /** @jsxImportSource react */
-import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, jest, mock, spyOn, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, useEffect } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
-import { openingHistoryWindow, SessionHistoryBoundary, useOpeningSessionHistory, type OpeningHistoryWindow } from "../src/react-app/domains/session/surface/session-history";
+import { openingHistoryWindow, openingSessionHistoryOptions, prefetchOpeningSessionHistory, sessionHistoryIdentity, SessionHistoryBoundary, SessionHistoryStatus, useOpeningSessionHistory, useSessionPrefetchIntent, type OpeningHistoryWindow } from "../src/react-app/domains/session/surface/session-history";
+import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
 import { flushSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import { applySessionUnrevert, seedSessionState, snapshotKey, transcriptKey } from "../src/react-app/domains/session/sync/session-sync";
@@ -22,6 +23,7 @@ const cleanups: (() => Promise<void>)[] = [];
 let frameId = 0;
 
 beforeEach(() => {
+  jest.useFakeTimers();
   useSessionScrollStore.setState({ sessions: {} });
   spyOn(window, "requestAnimationFrame").mockImplementation((callback) => { frames.set(++frameId, callback); return frameId; });
   spyOn(window, "cancelAnimationFrame").mockImplementation((id) => { frames.delete(id); });
@@ -30,6 +32,7 @@ afterEach(async () => {
   for (const cleanup of cleanups.splice(0)) await cleanup();
   frames.clear();
   flushSessionScrollState();
+  jest.useRealTimers();
   mock.restore();
 });
 afterAll(async () => {
@@ -49,8 +52,8 @@ function snapshot(id: string, title: string, ids: string[] = [], revert?: string
 }
 
 async function settle() {
-  // TanStack notifications use a task, and React may throttle a Suspense reveal.
-  await act(async () => { await Bun.sleep(350); });
+  // Flush TanStack's notification task, not the visual loading grace period.
+  await act(async () => { jest.advanceTimersByTime(1); });
 }
 
 async function paint() {
@@ -68,29 +71,38 @@ function fixture() {
   const root = createRoot(host);
   let ensureFullSnapshot: (() => Promise<OpenworkSessionSnapshot>) | undefined;
   let runWithFullSnapshot: ReturnType<typeof useOpeningSessionHistory>["runWithFullSnapshot"] | undefined;
-  const reads: { owner: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionSnapshot) => void; reject: (error: Error) => void }[] = [];
-  function Harness({ owner }: { owner: string }) {
-    const key = snapshotKey("workspace", owner);
+  const reads: { owner: string; authToken?: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionSnapshot) => void; reject: (error: Error) => void }[] = [];
+  function input(owner = "a", authToken?: string, cacheOwner = owner) {
     const readSnapshot = (signal: AbortSignal, window?: OpeningHistoryWindow) => new Promise<OpenworkSessionSnapshot>((resolve, reject) => {
-      reads.push({ owner, window, signal, resolve, reject });
+      reads.push({ owner, authToken, window, signal, resolve, reject });
     });
-    const opening = useOpeningSessionHistory({ owner, sessionId: owner, snapshotQueryKey: key, readSnapshot });
+    return { owner: cacheOwner, sessionId: owner, authToken, snapshotQueryKey: snapshotKey("workspace", owner), readSnapshot };
+  }
+  function Harness({ options }: { options: ReturnType<typeof input> }) {
+    const { sessionId: owner, owner: cacheOwner } = options;
+    const key = options.snapshotQueryKey;
+    const workspaceId = key[1];
+    const opening = useOpeningSessionHistory(options);
     ensureFullSnapshot = opening.ensureFullSnapshot;
     runWithFullSnapshot = opening.runWithFullSnapshot;
-    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => readSnapshot(signal), enabled: opening.backgroundReady, staleTime: 500, retry: false });
+    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => options.readSnapshot(signal), enabled: opening.backgroundReady, staleTime: 500, retry: false });
     const current = full.data ?? opening.snapshot;
     useEffect(() => {
-      if (current) seedSessionState("workspace", current, { preview: !full.data });
-    }, [current, full.data]);
-    const messages = deriveRenderedSessionMessages({ snapshot: current, transcriptState: client.getQueryData(transcriptKey("workspace", owner)), historyComplete: Boolean(full.data) });
-    return <><span>Composer {owner}</span><input aria-label="Draft" /><SessionHistoryBoundary owner={owner} pending={!current || (!full.data && Boolean(current.session.revert))} saved={opening.saved} options={opening.options}
-      onRetry={full.isError && !full.isFetching && current && !full.data ? () => { void full.refetch(); } : undefined}>
+      if (current) seedSessionState(workspaceId, current, { preview: !full.data });
+    }, [workspaceId, current, full.data]);
+    const messages = deriveRenderedSessionMessages({ snapshot: current, transcriptState: client.getQueryData(transcriptKey(workspaceId, owner)), historyComplete: Boolean(full.data) });
+    const pending = !current || (!full.data && Boolean(current.session.revert));
+    const failed = full.isError && !full.isFetching;
+    return <><span>Composer {owner}</span><input aria-label="Draft" /><div className="relative"><div data-thread-scroll><SessionHistoryBoundary owner={cacheOwner} pending={pending} saved={opening.saved} failed={failed}>
       <div>{current?.session.title}</div>{messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.id}</div>)}
-    </SessionHistoryBoundary></>;
+    </SessionHistoryBoundary></div><SessionHistoryStatus key={cacheOwner} complete={Boolean(full.data)} pending={pending} failed={failed} onRetry={() => full.refetch()} /></div></>;
+  }
+  async function renderInput(options: ReturnType<typeof input>) {
+    await act(async () => flushSync(() => root.render(<QueryClientProvider client={client}><Harness options={options} /></QueryClientProvider>)));
   }
   cleanups.push(async () => { await act(async () => root.unmount()); client.clear(); host.remove(); });
   return {
-    reads, host, client,
+    reads, host, client, input, renderInput,
     get runWithFullSnapshot() {
       if (!runWithFullSnapshot) throw new Error("History is not mounted");
       return runWithFullSnapshot;
@@ -99,7 +111,7 @@ function fixture() {
       if (!ensureFullSnapshot) throw new Error("History is not mounted");
       return ensureFullSnapshot();
     },
-    async render(owner = "a") { await act(async () => flushSync(() => root.render(<QueryClientProvider client={client}><Harness owner={owner} /></QueryClientProvider>))); },
+    render(owner = "a", authToken?: string, cacheOwner = owner) { return renderInput(input(owner, authToken, cacheOwner)); },
     async resolve(index: number, title: string | OpenworkSessionSnapshot) {
       await act(async () => reads[index].resolve(typeof title === "string" ? snapshot(reads[index].owner, title) : title));
       await settle();
@@ -108,6 +120,248 @@ function fixture() {
 }
 
 describe("opening a thread", () => {
+  for (const openworkWorkspaceId of [undefined, "runtime-x"]) test(`remote sidebar alias shares runtime preview/full keys with click (explicit runtime ID=${Boolean(openworkWorkspaceId)})`, async () => {
+    const sidebarWorkspaceId = "rem_x";
+    const endpoint = resolveWorkspaceEndpoint({ id: sidebarWorkspaceId, workspaceType: "remote", baseUrl: "https://worker.example", openworkToken: "remote-token", openworkWorkspaceId }, { baseUrl: "http://localhost:7777", token: "local-token" });
+    if (!endpoint) throw new Error("Missing remote endpoint");
+    const runtimeWorkspaceId = openworkWorkspaceId ?? "x";
+    expect(endpoint.workspaceId).toBe(runtimeWorkspaceId);
+    // The route's resolved engine can be v2 even though endpoint.opencodeBaseUrl
+    // is v1. Both prefetch and the mounted primary surface use this resolved URL.
+    const opencodeBaseUrl = `${endpoint.mountedBaseUrl}/opencode2`;
+    const draftScope = "org-a/member-a";
+    const prefetchIdentity = sessionHistoryIdentity({ draftScope, opencodeBaseUrl, runtimeWorkspaceId: endpoint.workspaceId, sessionId: "a" });
+    const surfaceIdentity = sessionHistoryIdentity({ draftScope, opencodeBaseUrl, runtimeWorkspaceId, sessionId: "a" });
+    expect(prefetchIdentity).toEqual(surfaceIdentity);
+    expect(prefetchIdentity.owner).toBe(JSON.stringify([draftScope, opencodeBaseUrl, runtimeWorkspaceId, "a"]));
+    expect(prefetchIdentity.snapshotQueryKey).toEqual(snapshotKey(runtimeWorkspaceId, "a"));
+    expect(prefetchIdentity.snapshotQueryKey).not.toEqual(snapshotKey(sidebarWorkspaceId, "a"));
+    const view = fixture();
+    view.client.setQueryData(snapshotKey(sidebarWorkspaceId, "a"), snapshot("a", "Wrong alias cache"));
+    const warmed = { ...view.input("a", endpoint.token), ...prefetchIdentity };
+    const clicked = { ...view.input("a", endpoint.token), ...surfaceIdentity };
+    const cancel = prefetchOpeningSessionHistory(view.client, warmed);
+    expect(view.reads.map((read) => [read.authToken, read.window])).toEqual([["remote-token", { limit: 24 }]]);
+    await view.renderInput(clicked);
+    cancel?.();
+    expect(view.reads).toHaveLength(1);
+    expect(view.reads[0].signal.aborted).toBe(false);
+    expect(view.host.textContent).not.toContain("Wrong alias cache");
+    await view.resolve(0, "Shared remote preview");
+    expect(view.host.textContent).toContain("Shared remote preview");
+    expect(view.reads).toHaveLength(1);
+
+    const openingKey = openingSessionHistoryOptions(clicked).queryKey;
+    for (const identity of [
+      sessionHistoryIdentity({ draftScope: "org-a/member-b", opencodeBaseUrl, runtimeWorkspaceId, sessionId: "a" }),
+      sessionHistoryIdentity({ draftScope, opencodeBaseUrl: endpoint.opencodeBaseUrl, runtimeWorkspaceId, sessionId: "a" }),
+      sessionHistoryIdentity({ draftScope, opencodeBaseUrl, runtimeWorkspaceId: sidebarWorkspaceId, sessionId: "a" }),
+    ]) expect(openingSessionHistoryOptions({ ...clicked, ...identity }).queryKey).not.toEqual(openingKey);
+    const rotated = { ...view.input("a", "rotated-token"), ...surfaceIdentity };
+    expect(openingSessionHistoryOptions(rotated).queryKey).not.toEqual(openingKey);
+    await view.renderInput(rotated);
+    expect(view.reads).toHaveLength(2);
+    expect(view.host.textContent).not.toContain("Shared remote preview");
+    const nextPrincipal = {
+      ...rotated,
+      ...sessionHistoryIdentity({ draftScope: "org-b/member-c", opencodeBaseUrl, runtimeWorkspaceId, sessionId: "a" }),
+    };
+    await view.renderInput(nextPrincipal);
+    expect(view.reads[1].signal.aborted).toBe(true);
+    await view.resolve(1, "Old principal preview");
+    expect(view.host.textContent).not.toContain("Old principal preview");
+    await view.resolve(2, "Current principal preview");
+    expect(view.host.textContent).toContain("Current principal preview");
+
+    // A complete runtime snapshot, not the sidebar alias entry, skips warming.
+    await act(async () => view.client.setQueryData(surfaceIdentity.snapshotQueryKey, snapshot("a", "Complete runtime history")));
+    await settle();
+    prefetchOpeningSessionHistory(view.client, nextPrincipal);
+    expect(view.reads).toHaveLength(3);
+    expect(view.reads.map((read) => read.authToken)).toEqual(["remote-token", "rotated-token", "rotated-token"]);
+    expect(view.reads.every((read) => read.window?.limit === 24)).toBe(true);
+  });
+
+  test("a cold failure offers Retry and immediate Retrying without replacing the draft or reserved geometry", async () => {
+    const view = fixture();
+    await view.render();
+    const composer = view.host.querySelector("input");
+    if (!composer) throw new Error("Missing composer");
+    composer.value = "Keep this draft";
+    const geometry = view.host.querySelector("[data-thread-loading]")?.getAttribute("style");
+    await act(async () => view.reads[0].reject(new Error("Preview unavailable")));
+    await settle();
+    expect(view.host.querySelector('[role="alert"]')).toBeNull();
+    await paint();
+    await paint();
+    await act(async () => view.reads[1].reject(new Error("Full read unavailable")));
+    await settle();
+    expect(view.host.querySelector('[role="alert"]')?.textContent).toContain("This conversation could not be loaded.");
+    expect(view.host.querySelector("[data-thread-placeholder]")?.getAttribute("style")).toBe(geometry);
+    const retry = view.host.querySelector("button");
+    expect(retry?.type).toBe("button");
+    expect(retry?.disabled).toBe(false);
+    retry?.focus();
+    expect(document.activeElement).toBe(retry);
+    await act(async () => { retry?.click(); retry?.click(); });
+    expect(view.host.querySelector("button")?.disabled).toBe(true);
+    expect(view.host.querySelector('[data-thread-history-status] [role="status"]')?.textContent).toContain("Retrying");
+    expect(view.reads).toHaveLength(3);
+    expect(view.reads[2].window).toBeUndefined();
+    await act(async () => view.reads[2].reject(new Error("Still unavailable")));
+    await settle();
+    expect(view.host.querySelector("button")?.textContent).toBe("Retry");
+    await act(async () => view.host.querySelector("button")?.click());
+    await view.resolve(3, "Recovered history");
+    expect(view.host.textContent).toContain("Recovered history");
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.host.querySelector("input")).toBe(composer);
+    expect(composer.value).toBe("Keep this draft");
+  });
+
+  for (const resolved of [false, true]) test(`deliberate prefetch shares the opening query on click (resolved=${resolved})`, async () => {
+    const view = fixture();
+    const cancel = prefetchOpeningSessionHistory(view.client, view.input());
+    expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }]);
+    if (resolved) await view.resolve(0, "Warmed preview");
+    await view.render();
+    cancel?.(); // Release after click must not cancel the new observer's read.
+    expect(view.reads[0].signal.aborted).toBe(false);
+    expect(view.reads).toHaveLength(1);
+    if (!resolved) await view.resolve(0, "Warmed preview");
+    expect(view.host.textContent).toContain("Warmed preview");
+    expect(view.client.getQueryData(snapshotKey("workspace", "a"))).toBeUndefined();
+    await paint();
+    await paint();
+    expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }, undefined]);
+  });
+
+  test("speculation has no queue or parallel neighbor reads, cancels abandoned intent, and never reports optional errors", async () => {
+    const view = fixture();
+    const cancel = prefetchOpeningSessionHistory(view.client, view.input());
+    for (const id of ["a", "b", "c", "d"]) prefetchOpeningSessionHistory(view.client, view.input(id));
+    expect(view.reads).toHaveLength(1);
+    cancel?.();
+    expect(view.reads[0].signal.aborted).toBe(true);
+    await view.resolve(0, "Abandoned preview");
+    expect(view.client.getQueryData(openingSessionHistoryOptions(view.input()).queryKey)).toBeUndefined();
+    prefetchOpeningSessionHistory(view.client, view.input());
+    expect(view.reads).toHaveLength(2);
+    await act(async () => view.reads[1].reject(new Error("Optional preview failed")));
+    await settle();
+    expect(view.client.getQueryState(openingSessionHistoryOptions(view.input()).queryKey)?.status).toBe("success");
+    await view.render();
+    // A failed optional warmup is stale, not an infinite null cache hit.
+    expect(view.reads).toHaveLength(3);
+    expect(view.host.querySelector('[role="alert"]')).toBeNull();
+    await view.resolve(2, "Fresh preview");
+    expect(view.host.textContent).toContain("Fresh preview");
+  });
+
+  test("prefetch and click fence credentials and owners without putting credentials in keys", async () => {
+    const view = fixture();
+    const original = view.input("a", "credential-old");
+    const rotated = view.input("a", "credential-new");
+    expect(openingSessionHistoryOptions(original).queryKey).not.toEqual(openingSessionHistoryOptions(rotated).queryKey);
+    expect(JSON.stringify(openingSessionHistoryOptions(original).queryKey)).not.toContain("credential-old");
+    expect(openingSessionHistoryOptions({ ...original, owner: "other-endpoint/workspace/a" }).queryKey)
+      .not.toEqual(openingSessionHistoryOptions(original).queryKey);
+    const cancel = prefetchOpeningSessionHistory(view.client, original);
+    cancel?.(); // Route releases its warmup when endpoint/auth ownership changes.
+    await view.render("a", "credential-new");
+    expect(view.reads.map((read) => read.authToken)).toEqual(["credential-old", "credential-new"]);
+    await view.resolve(0, "Old credential data");
+    expect(view.host.textContent).not.toContain("Old credential data");
+    // Also exercise a credential change while the actual opening hook is mounted.
+    await view.render("a", "credential-newest");
+    expect(view.reads[1].signal.aborted).toBe(true);
+    await view.resolve(1, "Superseded data");
+    expect(view.host.textContent).not.toContain("Superseded data");
+    await view.render("a", "credential-newest", "other-endpoint/workspace/a");
+    expect(view.reads[2].signal.aborted).toBe(true);
+    await view.resolve(2, "Previous endpoint data");
+    expect(view.host.textContent).not.toContain("Previous endpoint data");
+    await view.resolve(3, "Current credential data");
+    expect(view.host.textContent).toContain("Current credential data");
+  });
+
+  test("dwell intent cancels on leave, blur, callback ownership change, and unmount but transfers a clicked read", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    const cancel = mock();
+    const prefetch = mock(() => cancel);
+    const replacement = mock(() => cancel);
+    let commit = () => {};
+    function Intent({ hover, focus, callback }: { hover: boolean; focus: boolean; callback: typeof prefetch }) {
+      commit = useSessionPrefetchIntent(hover || focus, callback);
+      return null;
+    }
+    const render = async (hover: boolean, focus = false, callback = prefetch) => {
+      await act(async () => root.render(<Intent hover={hover} focus={focus} callback={callback} />));
+    };
+    const advance = async (ms: number) => { await act(async () => { jest.advanceTimersByTime(ms); }); };
+    cleanups.push(async () => { await act(async () => root.unmount()); host.remove(); });
+    await render(false);
+    for (let row = 0; row < 5; row++) {
+      await render(true);
+      await advance(249);
+      await render(false);
+    }
+    expect(prefetch).not.toHaveBeenCalled();
+    await render(false, true);
+    await advance(250);
+    expect(prefetch).toHaveBeenCalledTimes(1);
+    await render(true, true);
+    await render(true, false);
+    expect(cancel).not.toHaveBeenCalled(); // Pointer intent still owns the read.
+    await render(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    await render(true);
+    await advance(100);
+    await render(true, false, replacement);
+    await advance(150);
+    expect(replacement).not.toHaveBeenCalled();
+    await advance(100);
+    expect(replacement).toHaveBeenCalledTimes(1);
+    commit();
+    await render(false, false, replacement);
+    expect(cancel).toHaveBeenCalledTimes(1); // Click owns the in-flight query now.
+    await render(false, true, replacement);
+    await advance(250);
+    await cleanups.pop()?.();
+    expect(cancel).toHaveBeenCalledTimes(2);
+  });
+
+  test("partial, failed, retrying, and complete history status stays outside the reader's scroll geometry", async () => {
+    const view = fixture();
+    await view.render();
+    await view.resolve(0, snapshot("a", "Reading preview", ["anchor"]));
+    const scroller = view.host.querySelector<HTMLDivElement>("[data-thread-scroll]");
+    if (!scroller) throw new Error("Missing scroll viewport");
+    scroller.scrollTop = 800;
+    const anchor = scroller.querySelector('[data-message-id="anchor"]');
+    const checkGeometry = () => {
+      expect(view.host.querySelector("[data-thread-scroll]")).toBe(scroller);
+      expect(scroller.scrollTop).toBe(800);
+      expect(scroller.querySelector('[data-message-id="anchor"]')).toBe(anchor);
+      expect(scroller.querySelector("[data-thread-history-status]")).toBeNull();
+      expect(view.host.querySelector("[data-thread-history-status]")?.className).toContain("absolute");
+    };
+    checkGeometry();
+    await paint();
+    await paint();
+    await act(async () => view.reads[1].reject(new Error("Full read unavailable")));
+    await settle();
+    checkGeometry();
+    await act(async () => view.host.querySelector("button")?.click());
+    checkGeometry();
+    await view.resolve(2, snapshot("a", "Full history", ["before", "anchor", "after"]));
+    expect(scroller.scrollTop).toBe(800);
+    expect(scroller.querySelector('[data-message-id="anchor"]')).toBe(anchor);
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+  });
+
   test("branching at a singleton preview waits for the next native message in complete history", async () => {
     const view = fixture();
     await view.render();
@@ -280,23 +534,30 @@ describe("opening a thread", () => {
     expect(view.reads).toHaveLength(2);
   });
 
-  test("Suspense shows feedback immediately, paints the newest window before the uncapped read, and keeps the composer mounted", async () => {
+  test("announces immediately, reveals fast content without a spinner, and stages the uncapped read", async () => {
     const view = fixture();
     await view.render();
-    expect(view.host.querySelector('[role="status"]')?.textContent).toContain("Loading latest messages");
+    expect(view.host.querySelector('[role="status"]')?.textContent).toContain("Loading conversation");
+    expect(view.host.querySelector('[data-thread-loading-visual]')).toBeNull();
     expect(view.host.textContent).toContain("Composer a");
     expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }]);
     await view.resolve(0, "Latest messages");
+    expect(view.host.querySelector('[data-thread-loading-visual]')).toBeNull();
     expect(view.host.textContent).toContain("Latest messages");
     expect(view.reads).toHaveLength(1);
     await paint();
     expect(view.reads).toHaveLength(1);
     await paint();
     expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }, undefined]);
-    expect(view.host.querySelector('[role="status"]')).toBeNull();
+    expect(view.host.querySelector('[role="status"]')?.textContent).toBe("Loading earlier messages…");
+    expect(view.host.querySelector('[data-thread-scroll] [data-thread-history-status]')).toBeNull();
+    expect(view.host.querySelector('[data-thread-history-status]')?.className).toContain("absolute");
     expect(view.host.textContent).toContain("Latest messages");
     await view.resolve(1, "Complete history");
     expect(view.host.textContent).toContain("Complete history");
+    expect(view.host.querySelector('[role="status"]')).toBeNull();
+    await act(async () => { jest.advanceTimersByTime(150); });
+    expect(view.host.querySelector('[data-thread-loading-visual]')).toBeNull();
   });
 
   test("saved positions request their own region, while a late previous-thread preview cannot render in the destination", async () => {
@@ -306,7 +567,12 @@ describe("opening a thread", () => {
     const view = fixture();
     await view.render();
     expect(view.reads[0].window).toEqual({ messageIds: ["before", "reading", "after"] });
+    expect(view.host.querySelector('[data-thread-loading]')?.getAttribute("style")).toContain("3968px");
+    await act(async () => { jest.advanceTimersByTime(149); });
+    expect(view.host.querySelector('[data-thread-loading-visual]')).toBeNull();
+    await act(async () => { jest.advanceTimersByTime(1); });
     expect(view.host.textContent).toContain("Returning to your reading position");
+    expect(view.host.querySelector('[data-thread-loading]')?.getAttribute("style")).toContain("3968px");
     await view.render("b");
     await view.resolve(0, "Foreign preview");
     expect(view.host.textContent).not.toContain("Foreign preview");
@@ -327,6 +593,8 @@ describe("opening a thread", () => {
       .toEqual({ messageIds: ["turn"] });
     const view = fixture();
     view.client.setQueryData(snapshotKey("workspace", "a"), snapshot("a", "Cached history"), { updatedAt: Date.now() - 1_000 });
+    prefetchOpeningSessionHistory(view.client, view.input());
+    expect(view.reads).toHaveLength(0);
     await view.render();
     expect(view.host.textContent).toContain("Cached history");
     expect(view.host.querySelector('[role="status"]')).toBeNull();


### PR DESCRIPTION
## Summary

Fast conversation opens should avoid spinner flashes; slower opens should explain the wait without blocking the composer.

- Reserve saved geometry and announce loading accessibly immediately, while delaying the visual spinner by 150ms. Content is never deliberately delayed.
- Show a quiet incomplete-history status outside transcript scroll flow.
- Give failed cold reads explicit Retry/Retrying feedback without replacing the composer.
- Warm the existing bounded opening query after 250ms of deliberate sidebar hover/focus. Cancel abandoned intent, remove neighbor-prefetch loops, and limit speculative reads.
- Reuse the exact runtime owner/query identity on click, including remote sidebar aliases, resolved engine URLs, principal scope, and opaque credential fencing. Failed optional previews do not become permanent successful cache entries.

No uncapped history reads on hover, new server API, or background-task suspension.

## Verification

Candidate: `b98fd9e1223d98e1e8686a28eda83b0b948330a9`, based on `dev` at `0b219dc4e5f2868c258dbe960d58c657dbe8d99b`. Commit signature verified.

From `apps/app`:

```sh
pnpm --config.verify-deps-before-run=never exec bun test --isolate ./tests/session-history.test.tsx ./tests/opencode-session-native.test.ts ./tests/progressive-message-list.test.tsx ./tests/session-scroll.test.tsx ./tests/message-list-loading.test.tsx
pnpm --config.verify-deps-before-run=never typecheck
```

**129 passed, 0 failed, 0 skipped**; typecheck and whitespace checks passed. Coverage includes grace timing, retry, intent abandonment, bounded speculation, consumer reuse, remote/runtime ID differences, and credential/principal changes.

Supplementary combined five-change checking passed 149 focused tests and typecheck. That staged-tree result is not exact-head runtime evidence.

## Proof verdict: Incomplete

No real-app journey or latency benchmark was run. Native layout/anchoring, actual sidebar pointer/focus interaction, and end-to-end speedup remain unverified. Existing owners: `session-full-history-on-open` and `live-tool-visible-after-session-switch` / `SWITCH-10`.

The command-local dependency flag avoided automatic reinstall; manifests and lockfile remain unchanged. Does not duplicate snapshot-owner-flip recovery from #4811, sidebar geometry from #4737, or change Branch/queue actions. Required CI is unchanged.
