### PR TITLE
fix(chat): preserve split layout and disclosure continuity

### DIFF
--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -13,6 +13,8 @@ interface MessageListContextValue {
   readOnly: boolean
   workspaceId: string
   sessionId: string
+  /** Verified principal/org, endpoint, workspace and session; absent means no retention. */
+  uiStateOwner?: string | null
   showThinking: boolean
   highlightQuery?: string
   developerMode: boolean
@@ -48,6 +50,7 @@ interface MessageListProviderProps {
   children: React.ReactNode
   workspaceId: string
   sessionId: string
+  uiStateOwner?: string | null
   showThinking: boolean
   highlightQuery?: string
   developerMode: boolean
@@ -81,6 +84,7 @@ export function MessageListProvider({
   children,
   workspaceId,
   sessionId,
+  uiStateOwner,
   showThinking,
   highlightQuery,
   developerMode,
@@ -160,6 +164,7 @@ export function MessageListProvider({
       readOnly,
       workspaceId,
       sessionId,
+      uiStateOwner,
       showThinking,
       highlightQuery,
       developerMode,
@@ -179,6 +184,7 @@ export function MessageListProvider({
       readOnly,
       workspaceId,
       sessionId,
+      uiStateOwner,
       showThinking,
       highlightQuery,
       developerMode,

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -532,6 +532,7 @@ const AssistantMessage = React.memo(
               return (
                 <ReasoningBlock
                   key={`reasoning-${index}`}
+                  disclosureKey={JSON.stringify(["reasoning", message.id, index])}
                   text={group.text}
                   isStreaming={group.isStreaming}
                 />
@@ -549,7 +550,7 @@ const AssistantMessage = React.memo(
             if (group.kind === "tool-aggregate") {
               return (
                 <div key={`tool-aggregate-${index}`} className="w-full">
-                  <ToolAggregateGroup parts={group.parts} thoughts={group.thoughts} />
+                  <ToolAggregateGroup messageId={message.id} parts={group.parts} thoughts={group.thoughts} />
                 </div>
               )
             }
@@ -1254,7 +1255,7 @@ function MessageGroup({
     item.message.role === "assistant" && !isSessionErrorMessage(item.message)
       ? getAssistantRenderGroups(item.message.parts, showThinking).flatMap((group, groupIndex) =>
         group.kind === "reasoning"
-          ? [{ key: `${item.message.id}-${groupIndex}`, text: group.text, isStreaming: group.isStreaming }]
+          ? [{ key: JSON.stringify(["reasoning", item.message.id, groupIndex]), text: group.text, isStreaming: group.isStreaming }]
           : []
       )
       : []
@@ -1288,7 +1289,7 @@ function MessageGroup({
         key={`folded-reasoning-${reasoning.key}`}
         className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10"
       >
-        <ReasoningBlock text={reasoning.text} isStreaming={reasoning.isStreaming} />
+        <ReasoningBlock disclosureKey={reasoning.key} text={reasoning.text} isStreaming={reasoning.isStreaming} />
       </Message>
     ))
     : []
@@ -1320,7 +1321,7 @@ function MessageGroup({
       nodes.push(
         <div key={`aggregate-${run.key}`}>
           <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
-            <ToolAggregateGroup parts={run.parts} className="w-full" />
+            <ToolAggregateGroup messageId={run.key} parts={run.parts} className="w-full" />
           </Message>
         </div>
       )

--- a/apps/app/src/components/chat/reasoning-block.tsx
+++ b/apps/app/src/components/chat/reasoning-block.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useWorkbenchDisclosure } from "@/react-app/domains/session/chat/workbench-ui-state"
 import { ChevronDown } from "lucide-react"
 
 import {
@@ -15,6 +15,7 @@ type ReasoningBlockProps = {
   text: string
   isStreaming: boolean
   className?: string
+  disclosureKey?: string
 }
 
 /**
@@ -22,8 +23,8 @@ type ReasoningBlockProps = {
  * line with a chevron; the full reasoning renders as markdown only
  * when the user opens it.
  */
-export function ReasoningBlock({ text, isStreaming, className }: ReasoningBlockProps) {
-  const [open, setOpen] = useState(false)
+export function ReasoningBlock({ text, isStreaming, className, disclosureKey }: ReasoningBlockProps) {
+  const [open, setOpen] = useWorkbenchDisclosure(disclosureKey)
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} className={cn("w-full", className)} data-reasoning-block="">

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, Check, ChevronUp, CircleHelp, CirclePause, Copy, MoreHor
 import { FileChip } from "@/components/chat/file-chip"
 import { ShellCommandText } from "@/components/chat/shell-command-text"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
+import { useWorkbenchDisclosure } from "@/react-app/domains/session/chat/workbench-ui-state"
 import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-lifecycle-context"
 import { Button } from "@/components/ui/button"
 import {
@@ -27,12 +28,9 @@ import { cn } from "@/lib/utils"
 
 const ROW_CAP = 8
 
-/** Expansion persists per group while the session stays mounted (Paper rule). */
-const expandedByGroupKey = new Map<string, boolean>()
-const showAllByGroupKey = new Map<string, boolean>()
-
 type ToolAggregateGroupProps = {
   parts: AnyToolPart[]
+  messageId?: string
   /** Thoughts that happened inside the run, anchored by afterIndex. */
   thoughts?: AggregateThought[]
   className?: string
@@ -138,6 +136,11 @@ export function DetailBox({ kind, text, expanded, onToggle }: DetailBoxProps) {
   )
 }
 
+function RetainedDetailBox({ disclosureKey, ...props }: Pick<DetailBoxProps, "kind" | "text"> & { disclosureKey?: string }) {
+  const [expanded, setExpanded] = useWorkbenchDisclosure(disclosureKey)
+  return <DetailBox {...props} expanded={expanded} onToggle={() => setExpanded(!expanded)} />
+}
+
 type AggregateRow = {
   /** The most recent call in the row (drives status, label, key). */
   part: AnyToolPart
@@ -189,42 +192,22 @@ export function buildAggregateRows(parts: AnyToolPart[], thoughts: AggregateThou
  * current action; past-tense summary when done. Chevron expands the chronological list — status
  * dot, monospace action, per-item duration — capped with "Show N more".
  */
-export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggregateGroupProps) {
+export function ToolAggregateGroup({ parts, messageId, thoughts = [], className }: ToolAggregateGroupProps) {
   const groupKey = parts[0]?.toolCallId ?? "aggregate"
   const latestToolCallId = parts.at(-1)?.toolCallId ?? groupKey
-  const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
-  const [showAll, setShowAllState] = useState(() => showAllByGroupKey.get(groupKey) ?? false)
-  // Which detail boxes (command / pattern / error, per call) show full text.
-  const [fullDetailKeys, setFullDetailKeys] = useState<ReadonlySet<string>>(() => new Set())
+  const keyFor = (id: string, detail: string) => messageId ? JSON.stringify(["tool", messageId, id, detail]) : undefined
+  const [expanded, setExpanded] = useWorkbenchDisclosure(keyFor(groupKey, "expanded"))
+  const [showAll, setShowAll] = useWorkbenchDisclosure(keyFor(groupKey, "show-all"))
   const resolveLifecycle = useCurrentToolLifecycleResolver()
 
-  const detailKey = (toolCallId: string, kind: DetailBoxProps["kind"]) => `${toolCallId}:${kind}`
   const detailBox = (kind: DetailBoxProps["kind"], toolCallId: string, text: string) => {
-    const key = detailKey(toolCallId, kind)
     return (
-      <DetailBox
+      <RetainedDetailBox
+        disclosureKey={keyFor(toolCallId, kind)}
         kind={kind}
         text={text}
-        expanded={fullDetailKeys.has(key)}
-        onToggle={() =>
-          setFullDetailKeys((current) => {
-            const next = new Set(current)
-            if (next.has(key)) next.delete(key)
-            else next.add(key)
-            return next
-          })
-        }
       />
     )
-  }
-
-  const setExpanded = (value: boolean) => {
-    expandedByGroupKey.set(groupKey, value)
-    setExpandedState(value)
-  }
-  const setShowAll = (value: boolean) => {
-    showAllByGroupKey.set(groupKey, value)
-    setShowAllState(value)
   }
 
   const inFlightPart = parts.find((part) => isToolPartInFlight(part))
@@ -247,7 +230,8 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
   // line for the same scrollable, copyable box the history uses, so the
   // whole command is readable while it is still running.
   const nowCommand = nowPart && isBashToolPart(nowPart) ? nowPart.input?.command?.trim() ?? "" : ""
-  const nowCommandShown = Boolean(nowPart && nowCommand && fullDetailKeys.has(detailKey(nowPart.toolCallId, "command")))
+  const [fullNowCommand, setFullNowCommand] = useWorkbenchDisclosure(keyFor(nowPart?.toolCallId ?? "", "command"))
+  const nowCommandShown = Boolean(nowPart && nowCommand && fullNowCommand)
   // The model is thinking mid-run: no tool is in flight but the run's
   // latest thought is still streaming. Show that instead of dead air.
   const lastThought = thoughts.at(-1)
@@ -360,7 +344,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
 
       {nowPart && nowCommandShown ? (
         <div data-tool-aggregate-now className="mt-1.5 min-w-0">
-          {detailBox("command", nowPart.toolCallId, nowCommand)}
+          <DetailBox kind="command" text={nowCommand} expanded={fullNowCommand} onToggle={() => setFullNowCommand(false)} />
         </div>
       ) : nowLabel ? (
         <div
@@ -369,10 +353,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
           title={nowCommand ? "Double-click to show the full command" : undefined}
           onDoubleClick={
             nowPart && nowCommand
-              ? () =>
-                  setFullDetailKeys((current) =>
-                    new Set(current).add(detailKey(nowPart.toolCallId, "command")),
-                  )
+              ? () => setFullNowCommand(true)
               : undefined
           }
         >
@@ -409,7 +390,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
               <Fragment key={part.toolCallId}>
               {thoughtsAt(row.index).map((thought) => (
                 <div key={`thought-${row.index}-${thought.afterIndex}`} data-tool-aggregate-thought className="py-1">
-                  <ReasoningBlock text={thought.text} isStreaming={thought.isStreaming} />
+                  <ReasoningBlock disclosureKey={keyFor(groupKey, `thought-${thought.afterIndex}`)} text={thought.text} isStreaming={thought.isStreaming} />
                 </div>
               ))}
               <div data-tool-aggregate-row className="flex min-w-0 flex-col gap-1.5 py-1">
@@ -483,7 +464,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
           })}
           {trailingThoughts.map((thought) => (
             <div key={`thought-trailing-${thought.afterIndex}`} data-tool-aggregate-thought className="py-1">
-              <ReasoningBlock text={thought.text} isStreaming={thought.isStreaming} />
+              <ReasoningBlock disclosureKey={keyFor(groupKey, `thought-${thought.afterIndex}`)} text={thought.text} isStreaming={thought.isStreaming} />
             </div>
           ))}
           {hiddenCount > 0 ? (

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -44,6 +44,7 @@ import { Input } from "@/components/ui/input";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import { usePlatform } from "../../../kernel/platform";
 import { useDenAuth } from "../../cloud/den-auth-provider";
+import { WorkbenchPanelGroup, PRIMARY_PANEL_ID, SECONDARY_PANEL_ID } from "./workbench-panel-group";
 import ProviderAuthModal, { type ProviderAuthModalProps } from "../../connections/provider-auth/provider-auth-modal";
 import { RenameSessionModal } from "../modals/rename-session-modal";
 import { AppSidebar } from "../sidebar/app-sidebar";
@@ -1728,13 +1729,16 @@ export function SessionPage(props: SessionPageProps) {
 
               {!props.primarySlot && !hasMainContentTakeover && !showDelayedSessionLoadingState && canRenderReactSurface ? (
                 <div className="flex h-full min-h-0 flex-col">
-                  <ResizablePanelGroup
-                    key={canRenderSplitSurface ? "workbench-split" : "workbench-single"}
-                    orientation="horizontal"
-                    className="min-h-0 flex-1"
+                  <WorkbenchPanelGroup
+                    owner={props.surface?.draftScope ? JSON.stringify([
+                      props.surface.draftScope, reactSessionBaseUrl, props.runtimeWorkspaceId,
+                    ]) : null}
+                    primaryVisible={!isMobile || narrowPane === "chat"}
+                    secondaryVisible={Boolean(canRenderSplitSurface && splitSession && splitPaneRuntime && (!isMobile || narrowPane === "split"))}
                   >
                     {!isMobile || narrowPane === "chat" ? (
                       <ResizablePanel
+                        id={PRIMARY_PANEL_ID}
                         minSize={isMobile ? "0px" : "320px"}
                         className="min-h-0 min-w-0"
                         data-workbench-pane="primary"
@@ -1794,6 +1798,7 @@ export function SessionPage(props: SessionPageProps) {
                       <>
                         {!isMobile ? <ResizableHandle /> : null}
                         <ResizablePanel
+                          id={SECONDARY_PANEL_ID}
                           minSize={isMobile ? "0px" : "320px"}
                           className="min-h-0 min-w-0"
                           data-workbench-pane="secondary"
@@ -1851,7 +1856,7 @@ export function SessionPage(props: SessionPageProps) {
                         </ResizablePanel>
                       </>
                     ) : null}
-                  </ResizablePanelGroup>
+                  </WorkbenchPanelGroup>
                 </div>
               ) : null}
 

--- a/apps/app/src/react-app/domains/session/chat/workbench-panel-group.tsx
+++ b/apps/app/src/react-app/domains/session/chat/workbench-panel-group.tsx
@@ -1,0 +1,89 @@
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { useGroupRef, type Layout } from "react-resizable-panels";
+import { ResizablePanelGroup } from "@/components/ui/resizable";
+import { useWorkbenchUiState } from "./workbench-ui-state";
+
+export const PRIMARY_PANEL_ID = "workbench-primary";
+export const SECONDARY_PANEL_ID = "workbench-secondary";
+
+export function WorkbenchPanelGroup({ owner, primaryVisible, secondaryVisible, children }: {
+  owner: string | null;
+  primaryVisible: boolean;
+  secondaryVisible: boolean;
+  children: ReactNode;
+}) {
+  const groupRef = useGroupRef();
+  const elementRef = useRef<HTMLDivElement>(null);
+  const coordinate = JSON.stringify([owner, primaryVisible, secondaryVisible]);
+  const restoration = useRef<{ coordinate: string; layout: Layout; applied: boolean } | null>(null);
+  if (restoration.current?.coordinate !== coordinate) {
+    const ratio = owner ? useWorkbenchUiState.getState().splitRatios.get(owner) ?? 50 : 50;
+    restoration.current = {
+      coordinate,
+      applied: false,
+      layout: {
+        ...(primaryVisible ? { [PRIMARY_PANEL_ID]: secondaryVisible ? ratio : 100 } : {}),
+        ...(secondaryVisible ? { [SECONDARY_PANEL_ID]: primaryVisible ? 100 - ratio : 100 } : {}),
+      },
+    };
+  }
+  const restore = (layout: Layout) => {
+    const pending = restoration.current;
+    if (!pending || pending.applied || !groupRef.current) return false;
+    // Panel registration is a separate layout pass. Never apply a two-panel
+    // layout to the one-panel registry (or persist that transitional layout).
+    const ids = Object.keys(pending.layout);
+    if (ids.length !== Object.keys(layout).length || ids.some((id) => !(id in layout))) return true;
+    pending.applied = true;
+    groupRef.current.setLayout(pending.layout);
+    return true;
+  };
+  useLayoutEffect(() => {
+    if (groupRef.current) restore(groupRef.current.getLayout());
+  }, [coordinate]);
+
+  useLayoutEffect(() => {
+    const element = elementRef.current;
+    const view = element?.ownerDocument.defaultView;
+    if (!element || !view) return;
+    let focused: HTMLElement | null = null;
+    const down = () => {
+      const active = element.ownerDocument.activeElement;
+      focused = active instanceof HTMLElement && element.contains(active) && !active.hasAttribute("data-separator")
+        ? active : null;
+    };
+    const up = () => {
+      // The library focuses separators on pointer resize. Return only that
+      // incidental focus; keyboard divider navigation and deliberate focus stay.
+      const active = element.ownerDocument.activeElement;
+      if (focused?.isConnected && element.contains(focused) && active && element.contains(active)
+        && active.hasAttribute("data-separator")) {
+        focused.focus({ preventScroll: true });
+      }
+      focused = null;
+    };
+    view.addEventListener("pointerdown", down, true);
+    view.addEventListener("pointerup", up);
+    view.addEventListener("pointercancel", up);
+    return () => {
+      view.removeEventListener("pointerdown", down, true);
+      view.removeEventListener("pointerup", up);
+      view.removeEventListener("pointercancel", up);
+    };
+  }, []);
+
+  return <ResizablePanelGroup
+    groupRef={groupRef}
+    elementRef={elementRef}
+    defaultLayout={restoration.current.layout}
+    orientation="horizontal"
+    className="min-h-0 flex-1"
+    onLayoutChange={(layout) => {
+      if (restore(layout)) return;
+      if (owner && primaryVisible && secondaryVisible
+        && Object.keys(layout).length === 2 && SECONDARY_PANEL_ID in layout) {
+        useWorkbenchUiState.getState().setSplitRatio(owner, layout[PRIMARY_PANEL_ID]);
+      }
+    }}
+  >{children}</ResizablePanelGroup>;
+}

--- a/apps/app/src/react-app/domains/session/chat/workbench-ui-state.ts
+++ b/apps/app/src/react-app/domains/session/chat/workbench-ui-state.ts
@@ -1,0 +1,68 @@
+import { useLayoutEffect, useState } from "react";
+import { create } from "zustand";
+import { useOptionalMessageList } from "@/components/chat/message-list-provider";
+
+export const MAX_WORKBENCH_DISCLOSURES = 2048;
+export const MAX_WORKBENCH_SPLIT_RATIOS = 32;
+
+function boundedEntry<T>(entries: ReadonlyMap<string, T>, key: string, value: T, limit: number) {
+  const next = new Map(entries);
+  next.delete(key);
+  next.set(key, value);
+  while (next.size > limit) {
+    const oldest = next.keys().next().value;
+    if (oldest === undefined) break;
+    next.delete(oldest);
+  }
+  return next;
+}
+
+// Only interaction metadata, never transcript bodies, credentials, or retained DOM.
+// These bounded, last-written caches deliberately do not survive an app restart.
+export const useWorkbenchUiState = create<{
+  disclosures: ReadonlyMap<string, boolean>;
+  splitRatios: ReadonlyMap<string, number>;
+  setDisclosure: (key: string, open: boolean) => void;
+  setSplitRatio: (owner: string, ratio: number) => void;
+}>((set) => ({
+  disclosures: new Map(),
+  splitRatios: new Map(),
+  setDisclosure: (key, open) => set((state) => ({
+    disclosures: boundedEntry(state.disclosures, key, open, MAX_WORKBENCH_DISCLOSURES),
+  })),
+  setSplitRatio: (owner, ratio) => {
+    if (!Number.isFinite(ratio) || ratio <= 0 || ratio >= 100) return;
+    set((state) => ({
+      splitRatios: boundedEntry(state.splitRatios, owner, ratio, MAX_WORKBENCH_SPLIT_RATIOS),
+    }));
+  },
+}));
+
+export function useWorkbenchDisclosure(detail: string | undefined): [boolean, (open: boolean) => void] {
+  const context = useOptionalMessageList();
+  const owner = context?.uiStateOwner;
+  const key = owner && detail ? JSON.stringify([owner, detail]) : null;
+  const localKey = JSON.stringify([context?.workspaceId, context?.sessionId, owner, detail]);
+  const saved = key ? useWorkbenchUiState.getState().disclosures.get(key) ?? false : false;
+  const [local, setLocal] = useState({ key: localKey, open: saved });
+  if (local.key !== localKey) setLocal({ key: localKey, open: saved });
+  useLayoutEffect(() => {
+    if (!key) return;
+    const update = (open: boolean | undefined) => {
+      // Eviction forgets restoration metadata, not the mounted reader's choice.
+      if (open === undefined) return;
+      setLocal((current) => current.key === localKey && current.open !== open
+        ? { key: localKey, open } : current);
+    };
+    const unsubscribe = useWorkbenchUiState.subscribe((state, previous) => {
+      const open = state.disclosures.get(key);
+      if (open !== previous.disclosures.get(key)) update(open);
+    });
+    update(useWorkbenchUiState.getState().disclosures.get(key));
+    return unsubscribe;
+  }, [key, localKey]);
+  return [local.key === localKey ? local.open : saved, (open) => {
+    setLocal({ key: localKey, open });
+    if (key) useWorkbenchUiState.getState().setDisclosure(key, open);
+  }];
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -3213,6 +3213,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     onApplyChanges={props.onApplyEnvironmentChanges}
                   >
                     <MessageListProvider
+                      uiStateOwner={props.draftScope ? sessionOwner : null}
                       readOnly={archived || !archiveStateKnown || archiveHeld}
                       workspaceId={props.workspaceId}
                       sessionId={props.sessionId}

--- a/apps/app/tests/message-list-step-fold.test.tsx
+++ b/apps/app/tests/message-list-step-fold.test.tsx
@@ -5,6 +5,7 @@ import type { DynamicToolUIPart, UIMessage } from "ai";
 
 import { MessageList } from "../src/components/chat/message-list";
 import { MessageListProvider } from "../src/components/chat/message-list-provider";
+import { createDefaultPlatform, PlatformProvider } from "../src/react-app/kernel/platform";
 
 function bashPart(id: string): DynamicToolUIPart {
   return {
@@ -49,6 +50,7 @@ function withoutWindow<T>(run: () => T): T {
 
 function renderList(messages: UIMessage[]) {
   return withoutWindow(() => renderToStaticMarkup(
+    <PlatformProvider value={createDefaultPlatform()}>
     <MessageListProvider
       workspaceId="ws"
       sessionId="session"
@@ -67,6 +69,7 @@ function renderList(messages: UIMessage[]) {
     >
       <MessageList messages={messages} status="ready" />
     </MessageListProvider>
+    </PlatformProvider>
   ));
 }
 

--- a/apps/app/tests/workbench-continuity.test.tsx
+++ b/apps/app/tests/workbench-continuity.test.tsx
@@ -1,0 +1,342 @@
+/** @jsxImportSource react */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, useEffect, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import type { DynamicToolUIPart } from "ai";
+
+GlobalRegistrator.register();
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+// The actual panel library needs nonzero geometry. This is a component test,
+// not a browser layout/anchoring measurement.
+Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+  configurable: true,
+  get(this: HTMLElement) {
+    if (this.hasAttribute("data-panel")) return 1200 * Number(this.style.flexGrow || 100) / 100;
+    return this.hasAttribute("data-separator") ? 1 : 1200;
+  },
+});
+Object.defineProperty(HTMLElement.prototype, "offsetHeight", { configurable: true, get: () => 800 });
+// Happy DOM does not implement this ARIA reflection used by the panel library.
+Object.defineProperty(HTMLElement.prototype, "ariaDisabled", {
+  configurable: true, get(this: HTMLElement) { return this.getAttribute("aria-disabled"); },
+});
+Object.defineProperty(HTMLElement.prototype, "offsetLeft", {
+  configurable: true,
+  get(this: HTMLElement) {
+    if (this.hasAttribute("data-separator") || this.id === "workbench-secondary") {
+      return document.getElementById("workbench-primary")?.offsetWidth ?? 600;
+    }
+    return 0;
+  },
+});
+Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+  configurable: true,
+  value(this: HTMLElement) { return new DOMRect(this.offsetLeft, 0, this.offsetWidth, this.offsetHeight); },
+});
+
+const { WorkbenchPanelGroup, PRIMARY_PANEL_ID, SECONDARY_PANEL_ID } = await import("../src/react-app/domains/session/chat/workbench-panel-group");
+const { ResizablePanel, ResizableHandle } = await import("../src/components/ui/resizable");
+const { MessageListProvider } = await import("../src/components/chat/message-list-provider");
+const { PlatformProvider, createDefaultPlatform } = await import("../src/react-app/kernel/platform");
+const { ReasoningBlock } = await import("../src/components/chat/reasoning-block");
+const { ToolAggregateGroup } = await import("../src/components/chat/tool-aggregate-group");
+const { useWorkbenchUiState, MAX_WORKBENCH_DISCLOSURES, MAX_WORKBENCH_SPLIT_RATIOS } = await import("../src/react-app/domains/session/chat/workbench-ui-state");
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+beforeEach(() => {
+  useWorkbenchUiState.setState({ disclosures: new Map(), splitRatios: new Map() });
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+function element(selector: string) {
+  const node = container.querySelector<HTMLElement>(selector);
+  if (!node) throw new Error(`Missing ${selector}`);
+  return node;
+}
+const click = async (selector: string) => act(async () => element(selector).click());
+
+function panels(owner: string | null, split: boolean, primary: ReactNode, primaryVisible = true) {
+  return <WorkbenchPanelGroup owner={owner} primaryVisible={primaryVisible} secondaryVisible={split}>
+    {primaryVisible ? <ResizablePanel id={PRIMARY_PANEL_ID} minSize="320px">{primary}</ResizablePanel> : null}
+    {split ? <>
+      {primaryVisible ? <ResizableHandle /> : null}
+      <ResizablePanel id={SECONDARY_PANEL_ID} minSize="320px"><div>Secondary</div></ResizablePanel>
+    </> : null}
+  </WorkbenchPanelGroup>;
+}
+
+test("the mounted primary survives split toggles with its draft, focus, selection and scroll; divider returns", async () => {
+  let mounts = 0;
+  let unmounts = 0;
+  function Primary() {
+    useEffect(() => { mounts++; return () => { unmounts++; }; }, []);
+    return <div data-primary-scroll><textarea defaultValue="unsent primary draft" /><p>Selected answer text</p></div>;
+  }
+  const render = async (split: boolean) => act(async () => root.render(panels("owner-a", split, <Primary />)));
+  await render(false);
+  const primary = element("[data-primary-scroll]");
+  const input = container.querySelector("textarea")!;
+  input.focus();
+  input.setSelectionRange(2, 8);
+  primary.scrollTop = 247;
+  await render(true);
+  expect(element("[data-primary-scroll]")).toBe(primary);
+  expect(document.activeElement).toBe(input);
+  expect(input.selectionStart).toBe(2);
+  expect(input.selectionEnd).toBe(8);
+  expect(primary.scrollTop).toBe(247);
+  expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBe(50);
+  await act(async () => element("[data-separator]").dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+  const resized = Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow);
+  expect(resized).toBeGreaterThan(50);
+  for (let i = 0; i < 3; i++) {
+    await render(false);
+    expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBe(100);
+    expect(container.querySelector(`#${SECONDARY_PANEL_ID}`)).toBeNull();
+    await render(true);
+    expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBe(resized);
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe("unsent primary draft");
+    expect(input.selectionStart).toBe(2);
+    expect(input.selectionEnd).toBe(8);
+    expect(primary.scrollTop).toBe(247);
+  }
+  expect(mounts).toBe(1);
+  expect(unmounts).toBe(0);
+  const answer = element("p").firstChild!;
+  const selection = window.getSelection()!;
+  const range = document.createRange();
+  range.setStart(answer, 0);
+  range.setEnd(answer, 8);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  await render(false);
+  await render(true);
+  expect(selection.toString()).toBe("Selected");
+  expect(selection.anchorNode).toBe(answer);
+  expect(element("[data-primary-scroll]")).toBe(primary);
+});
+
+test("pointer divider resize returns incidental focus without stealing keyboard divider focus", async () => {
+  await act(async () => root.render(panels("owner", true, <textarea defaultValue="draft" />)));
+  const input = container.querySelector("textarea")!;
+  input.focus();
+  input.setSelectionRange(1, 3);
+  const separator = element("[data-separator]");
+  await act(async () => {
+    separator.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerType: "mouse", clientX: 600, clientY: 100, button: 0, buttons: 1 }));
+    document.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerType: "mouse", clientX: 700, clientY: 100, buttons: 1 }));
+    document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerType: "mouse", clientX: 700, clientY: 100 }));
+  });
+  expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBeGreaterThan(50);
+  expect(document.activeElement).toBe(input);
+  expect(input.selectionStart).toBe(1);
+  expect(input.selectionEnd).toBe(3);
+  await act(async () => {
+    separator.focus();
+    separator.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+  });
+  expect(document.activeElement).toBe(separator);
+  const outside = document.createElement("div");
+  outside.tabIndex = 0;
+  outside.setAttribute("data-separator", "");
+  document.body.append(outside);
+  await act(async () => {
+    input.focus();
+    outside.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 1400 }));
+    outside.focus();
+    outside.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, clientX: 1400 }));
+  });
+  expect(document.activeElement).toBe(outside);
+  outside.remove();
+});
+
+test("split ratio is owner-isolated, bounded and restored after unmount, including single-pane mobile transitions", async () => {
+  const render = async (owner: string | null, split = true, primaryVisible = true) => act(async () => root.render(panels(owner, split, <div>Primary</div>, primaryVisible)));
+  await render("principal-a/org-a/endpoint-a/workspace-a");
+  await act(async () => element("[data-separator]").dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+  const ratio = Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow);
+  for (const foreign of ["principal-b/org-a/endpoint-a/workspace-a", "principal-a/org-b/endpoint-a/workspace-a", "principal-a/org-a/endpoint-b/workspace-a", "principal-a/org-a/endpoint-a/workspace-b", null]) {
+    await render(foreign);
+    expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBe(50);
+  }
+  await render("principal-a/org-a/endpoint-a/workspace-a", true, false);
+  expect(Number(element(`#${SECONDARY_PANEL_ID}`).style.flexGrow)).toBe(100);
+  await render("principal-a/org-a/endpoint-a/workspace-a");
+  expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBe(ratio);
+  await act(async () => root.render(null));
+  await render("principal-a/org-a/endpoint-a/workspace-a");
+  expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBe(ratio);
+  await act(async () => {
+    for (let i = 0; i < MAX_WORKBENCH_SPLIT_RATIOS; i++) useWorkbenchUiState.getState().setSplitRatio(`other-${i}`, 65);
+  });
+  expect(useWorkbenchUiState.getState().splitRatios.size).toBe(MAX_WORKBENCH_SPLIT_RATIOS);
+  await act(async () => root.render(null));
+  await render("principal-a/org-a/endpoint-a/workspace-a");
+  expect(Number(element(`#${PRIMARY_PANEL_ID}`).style.flexGrow)).toBe(50);
+});
+
+function Provider({ owner, children }: { owner: string | null; children: ReactNode }) {
+  return <PlatformProvider value={createDefaultPlatform()}><MessageListProvider uiStateOwner={owner} workspaceId="workspace" sessionId="session"
+    showThinking developerMode={false} displaySuggestions={false} providerConnectedCount={1}
+    dispatchAction={() => {}} setPrompt={() => {}} onRevertToUserMessage={() => {}} onForkAtMessage={() => {}}
+    onEditUserMessage={() => {}} onMcpReconnect={async () => { throw new Error("unused"); }}
+    onMcpReopenAuthorization={async () => {}} onMcpRetry={() => {}}>{children}</MessageListProvider></PlatformProvider>;
+}
+const command: DynamicToolUIPart = {
+  type: "dynamic-tool", toolName: "bash", toolCallId: "call", state: "output-error",
+  input: { command: "git status", description: "Inspect files" }, errorText: "Command failed",
+};
+function disclosures(owner: string | null, message = "message-a") {
+  return <Provider owner={owner}>
+    <ReasoningBlock disclosureKey={JSON.stringify(["reasoning", message, 0])} text="Reasoning body not stored" isStreaming={false} />
+    <ToolAggregateGroup messageId={message} parts={[command]} thoughts={[{ afterIndex: 1, text: "Nested thought", isStreaming: false }]} />
+  </Provider>;
+}
+
+test("reasoning and nested command/error/thought disclosures return on A-B-A without leaking owner, message or detail", async () => {
+  const render = async (owner: string | null, message = "message-a") => act(async () => root.render(disclosures(owner, message)));
+  await render("owner-a/session-a");
+  await click("[data-reasoning-block] button");
+  await click("[data-tool-aggregate] > button");
+  await click('[data-tool-aggregate-detail="command"]');
+  expect(element('[data-tool-aggregate-detail="error"]').getAttribute("aria-expanded")).toBe("false");
+  await click('[data-tool-aggregate-detail="error"]');
+  await click("[data-tool-aggregate-thought] button");
+  // An owner change without remount must not show the previous owner's state.
+  await render("owner-b/session-a");
+  expect(element("[data-reasoning-block] button").getAttribute("aria-expanded")).toBe("false");
+  expect(element("[data-tool-aggregate] > button").getAttribute("aria-expanded")).toBe("false");
+  await act(async () => root.render(null));
+  await render("owner-a/session-a");
+  for (const selector of ["[data-reasoning-block] button", "[data-tool-aggregate] > button", '[data-tool-aggregate-detail="command"]', '[data-tool-aggregate-detail="error"]', "[data-tool-aggregate-thought] button"]) {
+    expect(element(selector).getAttribute("aria-expanded")).toBe("true");
+  }
+  for (const [owner, message] of [["owner-a/session-a", "message-b"], ["owner-a/session-b", "message-a"]]) {
+    await render(owner, message);
+    expect(element("[data-reasoning-block] button").getAttribute("aria-expanded")).toBe("false");
+    expect(element("[data-tool-aggregate] > button").getAttribute("aria-expanded")).toBe("false");
+    await click("[data-tool-aggregate] > button");
+    expect(element('[data-tool-aggregate-detail="command"]').getAttribute("aria-expanded")).toBe("false");
+  }
+  await render("owner-a/session-a");
+  await click("[data-reasoning-block] button");
+  await act(async () => root.render(null));
+  await render("owner-a/session-a");
+  expect(element("[data-reasoning-block] button").getAttribute("aria-expanded")).toBe("false");
+  expect([...useWorkbenchUiState.getState().disclosures.values()].every((value) => typeof value === "boolean")).toBe(true);
+});
+
+test("cache eviction preserves mounted reasoning, aggregate details and focus but forgets an unmounted return", async () => {
+  await act(async () => root.render(disclosures("owner-a")));
+  await click("[data-reasoning-block] button");
+  await click("[data-tool-aggregate] > button");
+  await click('[data-tool-aggregate-detail="command"]');
+  const reasoning = element("[data-reasoning-block] button");
+  const aggregate = element("[data-tool-aggregate] > button");
+  const detail = element('[data-tool-aggregate-detail="command"]');
+  const retainedKeys = [...useWorkbenchUiState.getState().disclosures.keys()];
+  for (const focused of [reasoning, detail]) {
+    await act(async () => {
+      focused.focus();
+      for (let i = 0; i < MAX_WORKBENCH_DISCLOSURES; i++) {
+        useWorkbenchUiState.getState().setDisclosure(`other-${i}`, true);
+      }
+    });
+    expect(useWorkbenchUiState.getState().disclosures.size).toBe(MAX_WORKBENCH_DISCLOSURES);
+    expect(retainedKeys.every((key) => !useWorkbenchUiState.getState().disclosures.has(key))).toBe(true);
+    for (const node of [reasoning, aggregate, detail]) {
+      expect(node.isConnected).toBe(true);
+      expect(node.getAttribute("aria-expanded")).toBe("true");
+    }
+    expect(document.activeElement).toBe(focused);
+    // An unrelated render must not turn a cache miss into an explicit close.
+    await act(async () => root.render(disclosures("owner-a")));
+    expect(element('[data-tool-aggregate-detail="command"]')).toBe(detail);
+    expect(reasoning.getAttribute("aria-expanded")).toBe("true");
+    expect(document.activeElement).toBe(focused);
+  }
+  await act(async () => root.render(null));
+  await act(async () => root.render(disclosures("owner-a")));
+  expect(element("[data-reasoning-block] button").getAttribute("aria-expanded")).toBe("false");
+  expect(element("[data-tool-aggregate] > button").getAttribute("aria-expanded")).toBe("false");
+  await click("[data-tool-aggregate] > button");
+  expect(element('[data-tool-aggregate-detail="command"]').getAttribute("aria-expanded")).toBe("false");
+});
+
+test("mounted copies synchronize explicit choices even when the restoration entry is evicted in the same batch", async () => {
+  await act(async () => root.render(<>
+    <div data-copy="first">{disclosures("owner-shared")}</div>
+    <div data-copy="second">{disclosures("owner-shared")}</div>
+    <div data-copy="foreign">{disclosures("owner-foreign")}</div>
+  </>));
+  for (const selector of ["[data-reasoning-block] button", "[data-tool-aggregate] > button"]) {
+    await click(`[data-copy="first"] ${selector}`);
+    expect(element(`[data-copy="second"] ${selector}`).getAttribute("aria-expanded")).toBe("true");
+    await act(async () => {
+      element(`[data-copy="second"] ${selector}`).click();
+      for (let i = 0; i < MAX_WORKBENCH_DISCLOSURES; i++) {
+        useWorkbenchUiState.getState().setDisclosure(`other-${i}`, true);
+      }
+    });
+    for (const copy of ["first", "second", "foreign"]) {
+      expect(element(`[data-copy="${copy}"] ${selector}`).getAttribute("aria-expanded")).toBe("false");
+    }
+    await click(`[data-copy="second"] ${selector}`);
+    expect(element(`[data-copy="first"] ${selector}`).getAttribute("aria-expanded")).toBe("true");
+    expect(element(`[data-copy="foreign"] ${selector}`).getAttribute("aria-expanded")).toBe("false");
+  }
+});
+
+test("disclosure eviction and unverified ownership fall back closed on return", async () => {
+  await act(async () => root.render(disclosures("owner-a")));
+  await click("[data-reasoning-block] button");
+  await click("[data-tool-aggregate] > button");
+  await click('[data-tool-aggregate-detail="command"]');
+  await act(async () => root.render(null));
+  await act(async () => {
+    for (let i = 0; i < MAX_WORKBENCH_DISCLOSURES; i++) useWorkbenchUiState.getState().setDisclosure(`other-${i}`, true);
+  });
+  expect(useWorkbenchUiState.getState().disclosures.size).toBe(MAX_WORKBENCH_DISCLOSURES);
+  await act(async () => root.render(disclosures("owner-a")));
+  expect(element("[data-reasoning-block] button").getAttribute("aria-expanded")).toBe("false");
+  expect(element("[data-tool-aggregate] > button").getAttribute("aria-expanded")).toBe("false");
+  await click("[data-tool-aggregate] > button");
+  expect(element('[data-tool-aggregate-detail="command"]').getAttribute("aria-expanded")).toBe("false");
+  await act(async () => root.render(disclosures(null)));
+  await click("[data-reasoning-block] button");
+  const entries = useWorkbenchUiState.getState().disclosures;
+  await act(async () => root.render(null));
+  await act(async () => root.render(disclosures(null)));
+  expect(element("[data-reasoning-block] button").getAttribute("aria-expanded")).toBe("false");
+  expect(useWorkbenchUiState.getState().disclosures).toBe(entries);
+});
+
+test("show-more and a later call's details return without expanding sibling calls", async () => {
+  const parts = Array.from({ length: 10 }, (_, index): DynamicToolUIPart => ({ ...command, toolCallId: `call-${index}` }));
+  const render = async () => act(async () => root.render(<Provider owner="owner-many">
+    <ToolAggregateGroup messageId="message-many" parts={parts} />
+  </Provider>));
+  await render();
+  await click("[data-tool-aggregate] > button");
+  expect(container.querySelectorAll("[data-tool-aggregate-row]").length).toBe(8);
+  const more = [...container.querySelectorAll("button")].find((button) => button.textContent === "Show 2 more");
+  if (!more) throw new Error("Missing show-more control");
+  await act(async () => more.click());
+  const lastCommand = container.querySelectorAll<HTMLElement>('[data-tool-aggregate-detail="command"]')[9]!;
+  await act(async () => lastCommand.click());
+  await act(async () => root.render(null));
+  await render();
+  expect(container.querySelectorAll("[data-tool-aggregate-row]").length).toBe(10);
+  const commands = container.querySelectorAll('[data-tool-aggregate-detail="command"]');
+  expect(commands[9]!.getAttribute("aria-expanded")).toBe("true");
+  expect(commands[0]!.getAttribute("aria-expanded")).toBe("false");
+});

--- a/apps/app/tests/workbench-continuity.test.tsx
+++ b/apps/app/tests/workbench-continuity.test.tsx
@@ -1,12 +1,31 @@
 /** @jsxImportSource react */
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, useEffect, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import type { DynamicToolUIPart } from "ai";
 
-GlobalRegistrator.register();
-Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+const ownedDom = typeof globalThis.window === "undefined";
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+const elementPrototype = HTMLElement.prototype;
+const originalDescriptors = new Map<string, PropertyDescriptor | undefined>(
+  ["offsetWidth", "offsetHeight", "ariaDisabled", "offsetLeft", "getBoundingClientRect"]
+    .map((name) => [name, Object.getOwnPropertyDescriptor(elementPrototype, name)]),
+);
+const actEnvironment = Object.getOwnPropertyDescriptor(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+afterAll(async () => {
+  try {
+    for (const [name, descriptor] of originalDescriptors) {
+      if (descriptor) Object.defineProperty(elementPrototype, name, descriptor);
+      else Reflect.deleteProperty(elementPrototype, name);
+    }
+    if (actEnvironment) Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+    else Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  } finally {
+    if (ownedDom) await GlobalRegistrator.unregister();
+  }
+});
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, writable: true, value: true });
 // The actual panel library needs nonzero geometry. This is a component test,
 // not a browser layout/anchoring measurement.
 Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
@@ -32,6 +51,7 @@ Object.defineProperty(HTMLElement.prototype, "offsetLeft", {
 });
 Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
   configurable: true,
+  writable: true,
   value(this: HTMLElement) { return new DOMRect(this.offsetLeft, 0, this.offsetWidth, this.offsetHeight); },
 });
 
@@ -52,8 +72,11 @@ beforeEach(() => {
   root = createRoot(container);
 });
 afterEach(async () => {
-  await act(async () => root.unmount());
-  container.remove();
+  try {
+    await act(async () => root.unmount());
+  } finally {
+    container.remove();
+  }
 });
 
 function element(selector: string) {


### PR DESCRIPTION
## Summary

Opening a second pane should rearrange the workspace, not reopen the primary conversation.

- Keep primary panel identity stable across split toggles using the actual resizable-panel registration lifecycle.
- Retain split ratios in a memory-only cache bounded to 32 principal/organization/endpoint/workspace scopes.
- Retain reasoning, aggregate, show-more, and nested detail choices using 2,048 bounded owner/message/detail-scoped booleans.
- Keep mounted disclosure state independent of retention-cache eviction, so unrelated activity cannot close a detail currently being read.
- Return incidental pointer-resize focus without overriding keyboard divider navigation or deliberate focus elsewhere.

No message bodies, credentials, hidden conversation DOM, or native selections are persisted. The metadata caches do not survive an app restart.

## Verification

Candidate: `457793018133b785a097a2e8be4b90fd53fa4b76`, based on `dev` at `0b219dc4e5f2868c258dbe960d58c657dbe8d99b`. Both commits have verified signatures.

From `apps/app`:

```sh
pnpm --config.verify-deps-before-run=never exec bun test --isolate ./tests/workbench-continuity.test.tsx ./tests/tool-aggregate-group.test.tsx ./tests/message-list-step-fold.test.tsx ./tests/message-list-loading.test.tsx
pnpm --config.verify-deps-before-run=never typecheck
```

**45 passed, 0 failed, 0 skipped**, 297 assertions. Typecheck and whitespace checks passed. Tests use the production panel library and disclosure components, with simulated geometry, and cover primary mount count, ratio restoration, focus/selection, owner isolation, and mounted eviction.

An initial combined test run exposed prototype/DOM fixture contamination. This PR restores full descriptors, keeps the geometry method writable, and unregisters only its owned DOM. The repaired combined five-change check passed 149 tests and typecheck; no earlier failure is counted as passing evidence. Non-failing KaTeX fixture warnings remain.

## Proof verdict: Incomplete

Real-app testkit proof has not run. Native editor selection, browser anchoring, actual split geometry, and perceived responsiveness remain unverified. Extend/run the existing `new-split-session` journey for final runtime proof. No measured speedup is claimed.

## Dependency

This is the shared disclosure-state foundation for `fix/long-task-reading-continuity`. Merge this PR before that dependent PR, then refresh the dependent base and proof. Action feedback, loading/prefetch, and multi-thread orientation remain separate. Required CI is unchanged.
