### PR TITLE
fix(chat): acknowledge conversation actions immediately

### DIFF
--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -27,7 +27,8 @@ interface MessageListContextValue {
   dispatchAction: (action: DispatchAction) => void
   setPrompt: (prompt: string) => void
   onRevertToUserMessage: (messageId: string) => void
-  onForkAtMessage: (messageId: string) => void
+  onForkAtMessage: (messageId: string) => void | Promise<void>
+  forkingMessageId?: string
   onEditUserMessage: (messageId: string, text: string) => void
   /** Open a sub-agent (child) session in the main chat surface. */
   onOpenSubagentSession?: (sessionId: string) => void
@@ -52,7 +53,8 @@ interface MessageListProviderProps {
   highlightQuery?: string
   developerMode: boolean
   onRevertToUserMessage: (messageId: string) => void
-  onForkAtMessage: (messageId: string) => void
+  onForkAtMessage: (messageId: string) => void | Promise<void>
+  forkingMessageId?: string
   onEditUserMessage: (messageId: string, text: string) => void
   onOpenSubagentSession?: (sessionId: string) => void
   onResumeInterrupted?: (recoveryPrompt: string) => void
@@ -92,6 +94,7 @@ export function MessageListProvider({
   setPrompt,
   onRevertToUserMessage,
   onForkAtMessage,
+  forkingMessageId,
   onEditUserMessage,
   onOpenSubagentSession,
   onResumeInterrupted,
@@ -162,6 +165,7 @@ export function MessageListProvider({
       sessionId,
       showThinking,
       highlightQuery,
+      forkingMessageId,
       developerMode,
       displaySuggestions,
       providerConnectedCount,
@@ -181,6 +185,7 @@ export function MessageListProvider({
       sessionId,
       showThinking,
       highlightQuery,
+      forkingMessageId,
       developerMode,
       displaySuggestions,
       providerConnectedCount,

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -684,7 +684,8 @@ function renderUserTextWithSkillChips(text: string, highlightQuery: string | und
 
 const UserMessage = React.memo(
   ({ message, isStreaming }: UserMessageProps) => {
-    const { onRevertToUserMessage, onForkAtMessage, onEditUserMessage, highlightQuery, readOnly } = useMessageList()
+    const { onRevertToUserMessage, onForkAtMessage, forkingMessageId, onEditUserMessage, highlightQuery, readOnly } = useMessageList()
+    const branching = forkingMessageId === message.id
     const { onOpenTarget } = useOpenTargets()
     const openLink = (event: React.MouseEvent) => {
       if (!onOpenTarget || !(event.target instanceof Element)) return
@@ -706,7 +707,7 @@ const UserMessage = React.memo(
       { type: "item", id: "copy", label: "Copy", icon: <Copy className="size-4" />, onSelect: () => navigator.clipboard.writeText(messageText) },
     )
     menuActions.push(
-      { type: "item", id: "branch", label: "Branch in new chat", icon: <Split className="size-4 rotate-90" />, onSelect: () => onForkAtMessage(message.id) },
+      { type: "item", id: "branch", label: branching ? "Branching..." : "Branch in new chat", icon: <Split className="size-4 rotate-90" />, disabled: Boolean(forkingMessageId), onSelect: () => onForkAtMessage(message.id) },
       { type: "item", id: "revert", label: "Revert", icon: <Undo2 className="size-4" />, disabled: readOnly, onSelect: () => onRevertToUserMessage(message.id) },
     )
 
@@ -758,7 +759,8 @@ const UserMessage = React.memo(
                 {!isStreaming && (
                   <MessageActions
                     className={cn(
-                      "flex items-center gap-0 opacity-0 transition-opacity duration-150 group-hover:opacity-100 max-lg:opacity-100 pointer-coarse:opacity-100"
+                      "flex items-center gap-0 transition-opacity duration-150 group-hover:opacity-100 max-lg:opacity-100 pointer-coarse:opacity-100",
+                      branching ? "opacity-100" : "opacity-0"
                     )}
                   >
                     <MessageTimestamp message={message} className="mr-1.5" />
@@ -776,16 +778,19 @@ const UserMessage = React.memo(
                         </Button>
                       </MessageAction>
                     ) : null}
-                    <MessageAction tooltip="Branch in new chat">
+                    <MessageAction tooltip={branching ? "Branching..." : "Branch in new chat"}>
                       <Button
                         variant="ghost"
                         size="icon"
-                        aria-label="Branch in new chat"
+                        aria-label={branching ? "Branching..." : "Branch in new chat"}
+                        aria-busy={branching || undefined}
+                        disabled={Boolean(forkingMessageId)}
                         onClick={() => onForkAtMessage(message.id)}
                       >
-                        <Split className="rotate-90" />
+                        {branching ? <LoaderCircle className="motion-safe:animate-spin" /> : <Split className="rotate-90" />}
                       </Button>
                     </MessageAction>
+                    {branching ? <span role="status" className="sr-only">Branching...</span> : null}
                     <MessageAction tooltip="Revert">
                       <Button
                         variant="ghost"
@@ -1206,7 +1211,7 @@ function MessageGroup({
   isLastGroup,
   isStreaming,
 }: AssistantMessageGroupProps) {
-  const { onRevertToUserMessage, onForkAtMessage, showThinking, readOnly } = useMessageList()
+  const { onRevertToUserMessage, onForkAtMessage, forkingMessageId, showThinking, readOnly } = useMessageList()
   const lastItem = items[items.length - 1]
   // Branch/revert must target a real server-side message id. Synthetic
   // client-side messages (e.g. session errors) don't exist on the server and
@@ -1373,21 +1378,24 @@ function MessageGroup({
       ))}
       {renderItems(proseItems, stepItems.length, collapseSteps)}
       {lastTextMessage && !isStreaming && (
-        <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 max-lg:opacity-100 pointer-coarse:opacity-100 md:px-8">
+        <div className={cn("mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 transition-opacity duration-150 group-hover/message-group:opacity-100 max-lg:opacity-100 pointer-coarse:opacity-100 md:px-8", forkingMessageId && forkingMessageId === lastRealItem?.message.id ? "opacity-100" : "opacity-0")}>
           <MessageActions className="flex gap-0">
             <CopyMessageButton messages={renderableItems.map((item) => item.message)} />
             {lastRealItem ? (
               <>
-                <MessageAction tooltip="Branch in new chat">
+                <MessageAction tooltip={forkingMessageId === lastRealItem.message.id ? "Branching..." : "Branch in new chat"}>
                   <Button
                     variant="ghost"
                     size="icon"
-                    aria-label="Branch in new chat"
+                    aria-label={forkingMessageId === lastRealItem.message.id ? "Branching..." : "Branch in new chat"}
+                    aria-busy={forkingMessageId === lastRealItem.message.id || undefined}
+                    disabled={Boolean(forkingMessageId)}
                     onClick={() => onForkAtMessage(lastRealItem.message.id)}
                   >
-                    <Split className="rotate-90" />
+                    {forkingMessageId === lastRealItem.message.id ? <LoaderCircle className="motion-safe:animate-spin" /> : <Split className="rotate-90" />}
                   </Button>
                 </MessageAction>
+                {forkingMessageId === lastRealItem.message.id ? <span role="status" className="sr-only">Branching...</span> : null}
                 <MessageAction tooltip="Revert">
                   <Button
                     variant="ghost"

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -417,7 +417,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
           : attachment.name}
       </span>)}
     </div> : null}
-    {pendingSubmission?.attachments.length ? <div role="status" className="mb-2 text-xs text-muted-foreground">Creating conversation...</div> : null}
+    {pendingSubmission ? <div role="status" className="mb-2 text-xs text-muted-foreground">Creating conversation...</div> : null}
     {submissionError ? <div role="alert" className="mb-2 text-sm text-red-11">{submissionError}</div> : null}
     {failedSubmission ? <button type="button" disabled={Boolean(props.draft || attachments.length)} className="mb-2 text-sm disabled:opacity-50" onClick={() => {
       restoreComposer(failedSubmission);
@@ -435,6 +435,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       busy={false}
       steering={false}
       submissionPreparing={props.busy || pendingSubmission !== null || failedSubmission !== null}
+      submissionPreparingLabel={failedSubmission ? "Restore the unsent message before sending" : "Creating conversation..."}
       queuedCount={0}
       disabled={Boolean(context?.modelUnavailable)}
       modelUnavailable={context?.modelUnavailable}

--- a/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
+++ b/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { ArrowUp, FileText, GripVertical, ListPlus, X } from "lucide-react";
+import { ArrowUp, FileText, GripVertical, ListPlus, LoaderCircle, X } from "lucide-react";
 import { Fragment, useRef, useState, type DragEvent, type ReactNode } from "react";
 
 import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge";
@@ -16,6 +16,7 @@ export type QueuedMessagesPanelProps = {
   onReorder: (ids: string[]) => void;
   onEdit: (id: string, text: string) => void;
   sending?: boolean;
+  sendingId?: string;
 };
 
 const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\])/;
@@ -147,6 +148,7 @@ function QueuedDraftRow(props: {
   item: QueuedComposerItem;
   ids: string[];
   sending?: boolean;
+  active?: boolean;
   onRemove: (id: string) => void;
   onSendNow: (id: string) => void;
   onReorder: (ids: string[]) => void;
@@ -191,6 +193,7 @@ function QueuedDraftRow(props: {
 
   const onDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
+    if (props.sending) return;
     const fromId = event.dataTransfer.getData("text/plain");
     draggingRef.current = false;
     if (fromId) moveId(fromId, props.item.id);
@@ -206,6 +209,7 @@ function QueuedDraftRow(props: {
         draggingRef.current = false;
       }}
       className="flex items-start gap-2 rounded-xl border border-gray-6 bg-gray-1 px-2 py-2.5"
+      aria-busy={props.active || undefined}
     >
       <span
         className="mt-0.5 flex size-5 shrink-0 cursor-grab items-center justify-center text-gray-9 active:cursor-grabbing"
@@ -218,6 +222,7 @@ function QueuedDraftRow(props: {
         {editing ? (
           <textarea
             autoFocus
+            disabled={props.sending}
             value={draftText}
             onChange={(event) => setDraftText(event.target.value)}
             onBlur={commitEdit}
@@ -251,6 +256,7 @@ function QueuedDraftRow(props: {
             <QueuedDraftContent draft={props.item.draft} />
           </button>
         )}
+        {props.active ? <span role="status" className="block px-0.5 text-xs text-gray-10">Sending...</span> : null}
       </div>
       <div className="mt-0.5 flex shrink-0 items-center gap-0.5">
         <button
@@ -258,10 +264,10 @@ function QueuedDraftRow(props: {
           onClick={() => props.onSendNow(props.item.id)}
           disabled={props.sending}
           className="flex size-5 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12 disabled:pointer-events-none disabled:opacity-40"
-          title={t("composer.queued_send_now")}
-          aria-label={t("composer.queued_send_now")}
+          title={props.active ? "Sending..." : t("composer.queued_send_now")}
+          aria-label={props.active ? "Sending..." : t("composer.queued_send_now")}
         >
-          <ArrowUp size={13} />
+          {props.active ? <LoaderCircle size={13} className="motion-safe:animate-spin" /> : <ArrowUp size={13} />}
         </button>
         <button
           type="button"
@@ -306,6 +312,7 @@ export function QueuedMessagesPanel(props: QueuedMessagesPanelProps) {
             item={item}
             ids={ids}
             sending={props.sending}
+            active={props.sendingId === item.id}
             onRemove={props.onRemove}
             onSendNow={props.onSendNow}
             onReorder={props.onReorder}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -60,6 +60,7 @@ type ComposerProps = {
   stopping?: boolean;
   steering: boolean;
   submissionPreparing: boolean;
+  submissionPreparingLabel?: string;
   queuedCount: number;
   disabled: boolean;
   modelUnavailable?: boolean;
@@ -1035,7 +1036,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
     // Escape-to-stop while the agent is busy. Only when no menu is open so
     // Escape can still close menus. First press arms a confirmation prompt
     // for 3s; a second Escape within that window stops the agent.
-    const anyMenuOpen = agentMenuOpen || toolMenuOpen || Boolean(activeMenu);
+    const anyMenuOpen = agentMenuOpen || toolMenuOpen || props.modelPickerOpen || Boolean(activeMenu);
     if (event.key === "Escape" && props.busy && !anyMenuOpen) {
       event.preventDefault();
       if (props.stopping) return;
@@ -1415,6 +1416,11 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
             />
 
             {/* Respond to the pane width, including desktop split views. */}
+            {props.busy && !props.stopping && escapeArmed ? (
+              <div data-composer-stop-confirmation role="status" className="mt-2 text-[12px] font-medium text-gray-10">
+                {t("composer.escape_to_stop")}
+              </div>
+            ) : null}
             <div data-composer-toolbar className="mt-2 grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-2 @min-[560px]/composer:flex">
               <div className="contents">
                 <div className="col-start-1 row-start-2 flex shrink-0 items-center gap-1.5">
@@ -1801,11 +1807,6 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                   Cmd/Ctrl+Enter still steers).
               */}
               <div data-composer-actions className="col-start-2 row-start-2 ml-auto flex shrink-0 items-center gap-1.5">
-                {props.busy && !props.stopping && escapeArmed ? (
-                  <span className="self-center pr-1 text-[12px] font-medium text-gray-10 hidden @min-[720px]/composer:inline">
-                    {t("composer.escape_to_stop")}
-                  </span>
-                ) : null}
                 <button
                   type="button"
                   onClick={
@@ -1826,10 +1827,10 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                       : props.busy
                         ? t("composer.stop")
                         : props.submissionPreparing
-                          ? "Preparing connected service tools…"
+                          ? props.submissionPreparingLabel ?? "Preparing connected service tools…"
                           : t("composer.run_task")
                   }
-                  aria-busy={props.stopping || undefined}
+                  aria-busy={props.stopping || props.submissionPreparing || undefined}
                   className={`inline-flex h-9 max-h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors ${
                     props.stopping
                       ? "cursor-wait bg-[var(--dls-accent)] text-[var(--dls-accent-fg)]"
@@ -1845,7 +1846,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                       : props.busy
                         ? t("composer.stop")
                         : props.submissionPreparing
-                          ? "Preparing connected service tools…"
+                          ? props.submissionPreparingLabel ?? "Preparing connected service tools…"
                           : t("composer.run_task")
                   }
                 >
@@ -1864,7 +1865,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                       : props.busy
                         ? t("composer.stop")
                         : props.submissionPreparing
-                          ? "Preparing connected service tools…"
+                          ? props.submissionPreparingLabel ?? "Preparing connected service tools…"
                           : t("composer.run_task")}
                   </span>
                 </button>

--- a/apps/app/src/react-app/domains/session/surface/session-branch-action.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-branch-action.ts
@@ -1,0 +1,47 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+type SessionBranchAction =
+  | { status: "pending"; messageId: string; promise: Promise<void> }
+  | { status: "failed"; error: unknown };
+
+// A surface owns navigation, but the request outlives that surface. Keep its
+// claim through both the history read and fork POST, including across remounts.
+const actions = new Map<string, SessionBranchAction>();
+const listeners = new Map<string, Set<() => void>>();
+
+function notify(owner: string) {
+  for (const listener of listeners.get(owner) ?? []) listener();
+}
+
+export function runSessionBranchAction(owner: string, messageId: string, run: () => Promise<void>): Promise<void> {
+  const existing = actions.get(owner);
+  if (existing?.status === "pending") return existing.promise;
+  const promise = Promise.resolve().then(run).catch((error: unknown) => {
+    // Only retain failure feedback for a mounted subscriber, never its request.
+    if (listeners.get(owner)?.size) actions.set(owner, { status: "failed", error });
+    throw error;
+  }).finally(() => {
+    if (actions.get(owner) === action) actions.delete(owner);
+    notify(owner);
+  });
+  const action: SessionBranchAction = { status: "pending", messageId, promise };
+  actions.set(owner, action);
+  notify(owner);
+  return promise;
+}
+
+export function useSessionBranchAction(owner: string) {
+  const subscribe = useCallback((listener: () => void) => {
+    const subscribers = listeners.get(owner) ?? new Set<() => void>();
+    subscribers.add(listener);
+    listeners.set(owner, subscribers);
+    return () => {
+      subscribers.delete(listener);
+      if (subscribers.size) return;
+      listeners.delete(owner);
+      if (actions.get(owner)?.status === "failed") actions.delete(owner);
+    };
+  }, [owner]);
+  const snapshot = useCallback(() => actions.get(owner), [owner]);
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -76,6 +76,7 @@ import { PaperGrainGradient } from "@openwork/ui/react";
 import { useShellConfig } from "@/react-app/shell/shell-config";
 import { useReactRenderWatchdog } from "@/react-app/shell/react-render-watchdog";
 import { SessionDebugPanel } from "./debug-panel";
+import { runSessionBranchAction, useSessionBranchAction } from "./session-branch-action";
 import { deriveComposerHistory, deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
 import { pendingMessageParts, useDisplayedMessages } from "./use-displayed-messages";
 import {
@@ -93,7 +94,6 @@ import { setQueuedSendContext } from "@/react-app/domains/session/sync/queued-se
 import { useSessionScrollController } from "./scroll-controller";
 import { getSessionScrollState, useSessionScrollStore } from "./scroll-store";
 import { SessionHistoryBoundary, useOpeningSessionHistory, type OpeningHistoryWindow } from "./session-history";
-import { runSessionBranchAction, useSessionBranchAction } from "./session-branch-action";
 import { SessionScrollOverlay } from "./scroll-overlay";
 import { SessionFindBar } from "./find-bar";
 import { useSessionFindStore } from "./find-store";

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -93,6 +93,7 @@ import { setQueuedSendContext } from "@/react-app/domains/session/sync/queued-se
 import { useSessionScrollController } from "./scroll-controller";
 import { getSessionScrollState, useSessionScrollStore } from "./scroll-store";
 import { SessionHistoryBoundary, useOpeningSessionHistory, type OpeningHistoryWindow } from "./session-history";
+import { runSessionBranchAction, useSessionBranchAction } from "./session-branch-action";
 import { SessionScrollOverlay } from "./scroll-overlay";
 import { SessionFindBar } from "./find-bar";
 import { useSessionFindStore } from "./find-store";
@@ -643,7 +644,7 @@ export type SessionSurfaceProps = {
   onOpenSettingsSection?: ((section: ComposerSettingsSection) => void) | undefined;
   onRevertToMessage?: (messageId: string, sessionId: string) => Promise<boolean>;
   onRestoreRevertedSession?: (sessionId: string) => Promise<boolean>;
-  onForkAtMessage?: (messageId: string | null, sessionId: string) => void;
+  onForkAtMessage?: (messageId: string | null, sessionId: string, isCurrent: () => boolean) => Promise<void>;
   /** Open a sub-agent (child) session in the main chat surface. */
   onOpenSubagentSession?: (sessionId: string) => void;
   onOpenTarget?: (target: OpenTarget, options?: OpenTargetOptions, sessionId?: string) => void;
@@ -2008,7 +2009,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   // Immediate sends interrupt foreground delegation, but otherwise steer the
   // running loop. Explicit queueing and automatic draining stay separate.
-  const sendDraft = useCallback(async (nextDraft: ComposerDraft, itemId: string, onPrepared?: (text?: string) => void): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
+  const sendDraft = useCallback(async (
+    nextDraft: ComposerDraft,
+    itemId: string,
+    onPrepared?: (text?: string) => void,
+    options: { consumeQueuedItem?: boolean } = {},
+  ): Promise<CloudMcpSubmissionResult | { outcome: "unknown" }> => {
     const messageId = nextDraft.messageId ?? createPromptMessageID();
     const generation = getQueuedSendGeneration(props.sessionId);
     const submissionId = Symbol();
@@ -2028,6 +2034,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
           }
           return props.onSendDraft({ ...nextDraft, messageId }, props.sessionId, onPrepared);
         }, { directory: props.workspaceRoot.trim() || undefined, messageID: messageId });
+      // Drain listeners can reconcile idle and claim another item synchronously.
+      // Consume the submitted row while its send slot is still held.
+      if (options.consumeQueuedItem && (result.outcome === "sent" || result.outcome === "accepted")) {
+        removeQueuedDraftFromStore(props.sessionId, itemId);
+      }
       dispatchQueuedDrain(props.sessionId, {
         type: "send_result", itemId, outcome: result.outcome, at: Date.now(),
         deferredMessageID: nextDraft.command ? messageId : undefined,
@@ -2044,6 +2055,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return result;
     } catch (nextError) {
       if (isPromptAdmissionUnknown(nextError)) {
+        if (options.consumeQueuedItem) removeQueuedDraftFromStore(props.sessionId, itemId);
         dispatchQueuedDrain(props.sessionId, { type: "send_unknown", itemId, messageID: messageId, at: Date.now(), deferred: Boolean(nextDraft.command) });
         if (activeSessionOwnerRef.current === sessionOwner) setAwaitingAssistantBaseline(null);
         return { outcome: "unknown" };
@@ -2065,7 +2077,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       pendingSendsRef.current.delete(submissionId);
       setPendingSendSessions([...pendingSendsRef.current.values()]);
     }
-  }, [archived, archiveStateKnown, opencodeClient, openingHistory.ensureFullSnapshot, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, props.workspaceRoot, renderedMessages.length, sessionOwner, setError]);
+  }, [archived, archiveStateKnown, opencodeClient, openingHistory.ensureFullSnapshot, props.onSendDraft, props.opencodeBaseUrl, props.sessionId, props.workspaceId, props.workspaceRoot, removeQueuedDraftFromStore, renderedMessages.length, sessionOwner, setError]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);
@@ -2232,7 +2244,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Promote a queued follow-up to an immediate send (steer-style), instead of
   // waiting for the idle drain. Guarded against the drain effect so the same
   // draft cannot be delivered twice.
-  const [sendingQueued, setSendingQueued] = useState(false);
+  const sendingQueuedId = queuedDrainState.phase.kind === "sending"
+    ? queuedDrainState.phase.itemId
+    : undefined;
+  const sendingQueued = Boolean(sendingQueuedId);
   const sendQueuedDraftNow = useCallback(async (id: string) => {
     if (archived || !archiveStateKnown || sessionWorkHeld(props.opencodeBaseUrl, props.sessionId)) return;
     if (drainingQueueRef.current || sendingQueued) return;
@@ -2241,34 +2256,23 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!item || !target) return;
     if (!claimQueuedSend(props.sessionId, item.id, true)) return;
     const generation = getQueuedSendGeneration(props.sessionId);
-    setSendingQueued(true);
-    removeQueuedDraftFromStore(props.sessionId, id);
     try {
-      const result = await sendDraft(target, item.id);
+      const result = await sendDraft(target, item.id, undefined, { consumeQueuedItem: true });
       if (result.outcome === "blocked" || result.outcome === "cancelled") {
-        if (getQueuedSendGeneration(props.sessionId) === generation) {
-          prependQueuedDrafts(props.sessionId, [{ id: item.id, draft: target }]);
-        } else {
-          target.attachments.forEach(revokeAttachmentPreview);
-        }
         return;
       }
       target.attachments.forEach(revokeAttachmentPreview);
     } catch {
-      if (getQueuedSendGeneration(props.sessionId) === generation) {
-        prependQueuedDrafts(props.sessionId, [{ id: item.id, draft: target }]);
-      }
+      // sendDraft owns the error and halts admission. Keep the row for an
+      // explicit retry without touching any newer composer input.
     } finally {
       if (getQueuedSendGeneration(props.sessionId) !== generation) target.attachments.forEach(revokeAttachmentPreview);
-      setSendingQueued(false);
     }
   }, [
     archived,
     archiveStateKnown,
-    prependQueuedDrafts,
     props.opencodeBaseUrl,
     props.sessionId,
-    removeQueuedDraftFromStore,
     sendDraft,
     sendingQueued,
   ]);
@@ -2995,14 +2999,34 @@ export function SessionSurface(props: SessionSurfaceProps) {
     void props.onRevertToMessage?.(messageId, props.sessionId);
   }, [archived, archiveStateKnown, props.onRevertToMessage, props.opencodeBaseUrl, props.sessionId]);
 
+  const branchAction = useSessionBranchAction(sessionOwner);
+  const forkingMessageId = branchAction?.status === "pending" ? branchAction.messageId : undefined;
+  useEffect(() => {
+    if (branchAction?.status === "failed") setError(parseSessionError(branchAction.error));
+  }, [branchAction, setError]);
+  const branchOwnerRef = useRef<{ owner: string; controlTarget: boolean } | null>(null);
+  if (branchOwnerRef.current?.owner !== sessionOwner || branchOwnerRef.current.controlTarget !== props.isControlTarget) {
+    branchOwnerRef.current = { owner: sessionOwner, controlTarget: props.isControlTarget };
+  }
+  useEffect(() => {
+    branchOwnerRef.current ??= { owner: sessionOwner, controlTarget: props.isControlTarget };
+    return () => { branchOwnerRef.current = null; };
+  }, []);
   const handleForkAtMessage = useCallback((messageId: string) => {
-    if (!props.onForkAtMessage) return;
-    void openingHistory.runWithFullSnapshot((full) => {
+    const fork = props.onForkAtMessage;
+    if (!fork) return;
+    setError(null);
+    const owner = branchOwnerRef.current;
+    const isCurrent = () => branchOwnerRef.current === owner;
+    return runSessionBranchAction(sessionOwner, messageId, () => openingHistory.runWithFullSnapshot((full) => {
       // Use the untruncated timeline: even a hidden next message is a boundary,
       // and a singleton preview never means "fork the entire conversation".
-      props.onForkAtMessage?.(resolveForkBoundaryId(full.messages.map(({ info }) => info), messageId), props.sessionId);
-    }, { fresh: true }).catch((error) => setError(parseSessionError(error)));
-  }, [openingHistory.runWithFullSnapshot, props.onForkAtMessage, props.sessionId, setError]);
+      if (!isCurrent()) return;
+      return fork(resolveForkBoundaryId(full.messages.map(({ info }) => info), messageId), props.sessionId, isCurrent);
+    }, { fresh: true })).catch(() => {
+      // The owner-scoped subscriber presents failure, including after remount.
+    });
+  }, [openingHistory.runWithFullSnapshot, props.onForkAtMessage, props.sessionId, sessionOwner, setError]);
 
   const handleEditUserMessage = useCallback((messageId: string, text: string) => {
     if (archived) return;
@@ -3227,6 +3251,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       setPrompt={handleMessageListSetPrompt}
                       onRevertToUserMessage={handleRevertToUserMessage}
                       onForkAtMessage={handleForkAtMessage}
+                      forkingMessageId={forkingMessageId}
                       onEditUserMessage={handleEditUserMessage}
                       onOpenSubagentSession={props.onOpenSubagentSession}
                       onResumeInterrupted={archived ? undefined : handleResumeInterrupted}
@@ -3410,6 +3435,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     onReorder={(ids) => reorderQueuedDrafts(props.sessionId, ids)}
                     onEdit={editQueuedDraft}
                     sending={sendingQueued}
+                    sendingId={sendingQueuedId}
                   />
                 ) : null}
                 {props.activeQuestion ? (

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1579,25 +1579,26 @@ export function SessionRoute() {
           return false;
         }
       },
-      onForkAtMessage: (messageId: string | null, sessionId: string) => {
-        void (async () => {
-          const targetSessionId = sessionId.trim() || selectedSessionId;
-          if (!targetSessionId) return;
-          try {
-            const forked = await forkSession(opencodeClient, targetSessionId, messageId ?? undefined);
-            writeLastSessionFor(selectedWorkspaceId, forked.id);
-            rememberPendingCreatedSession(selectedWorkspaceId, forked.id);
-            setSessionsByWorkspaceId((current) => ({
-              ...current,
-              [selectedWorkspaceId]: mergeWorkspaceRouteSession(current[selectedWorkspaceId] ?? [], forked),
-            }));
-            navigateToWorkspaceSession(selectedWorkspaceId, forked.id);
-            void refreshRouteState();
-          } catch (error) {
-            console.warn("[fork] failed", error);
-            toast.error(t("session.branch_failed"));
-          }
-        })();
+      onForkAtMessage: async (messageId: string | null, sessionId: string, isCurrent: () => boolean) => {
+        const targetSessionId = sessionId.trim() || selectedSessionId;
+        if (!targetSessionId) return;
+        const navigationOwner = selectedConversationRef.current;
+        const paneOwner = focusedWorkbenchPaneOwner();
+        const forked = await forkSession(opencodeClient, targetSessionId, messageId ?? undefined);
+        if (!isCurrent()
+          || selectedConversationRef.current.navigationGeneration !== navigationOwner.navigationGeneration
+          || selectedConversationRef.current.workspaceId !== navigationOwner.workspaceId
+          || selectedConversationRef.current.sessionId !== navigationOwner.sessionId
+          || selectedConversationRef.current.draftScope !== navigationOwner.draftScope
+          || focusedWorkbenchPaneOwner() !== paneOwner) return;
+        writeLastSessionFor(selectedWorkspaceId, forked.id);
+        rememberPendingCreatedSession(selectedWorkspaceId, forked.id);
+        setSessionsByWorkspaceId((current) => ({
+          ...current,
+          [selectedWorkspaceId]: mergeWorkspaceRouteSession(current[selectedWorkspaceId] ?? [], forked),
+        }));
+        navigateToWorkspaceSession(selectedWorkspaceId, forked.id);
+        void refreshRouteState();
       },
       onChangeModel: (model: { providerID: string; modelID: string }) => {
         local.setPrefs((previous) => ({
@@ -1879,24 +1880,25 @@ export function SessionRoute() {
           return false;
         }
       },
-      onForkAtMessage: (messageId: string | null, sessionId: string) => {
-        void (async () => {
-          const targetSessionId = sessionId.trim() || session.sessionId;
-          try {
-            const forked = await forkSession(workspaceOpencodeClient, targetSessionId, messageId ?? undefined);
-            writeLastSessionFor(workspace.id, forked.id);
-            rememberPendingCreatedSession(workspace.id, forked.id);
-            setSessionsByWorkspaceId((current) => ({
-              ...current,
-              [workspace.id]: mergeWorkspaceRouteSession(current[workspace.id] ?? [], forked),
-            }));
-            navigateToWorkspaceSession(workspace.id, forked.id);
-            void refreshRouteState();
-          } catch (error) {
-            console.warn("[fork] failed", error);
-            toast.error(t("session.branch_failed"));
-          }
-        })();
+      onForkAtMessage: async (messageId: string | null, sessionId: string, isCurrent: () => boolean) => {
+        const targetSessionId = sessionId.trim() || session.sessionId;
+        const navigationOwner = selectedConversationRef.current;
+        const paneOwner = focusedWorkbenchPaneOwner();
+        const forked = await forkSession(workspaceOpencodeClient, targetSessionId, messageId ?? undefined);
+        if (!isCurrent()
+          || selectedConversationRef.current.navigationGeneration !== navigationOwner.navigationGeneration
+          || selectedConversationRef.current.workspaceId !== navigationOwner.workspaceId
+          || selectedConversationRef.current.sessionId !== navigationOwner.sessionId
+          || selectedConversationRef.current.draftScope !== navigationOwner.draftScope
+          || focusedWorkbenchPaneOwner() !== paneOwner) return;
+        writeLastSessionFor(workspace.id, forked.id);
+        rememberPendingCreatedSession(workspace.id, forked.id);
+        setSessionsByWorkspaceId((current) => ({
+          ...current,
+          [workspace.id]: mergeWorkspaceRouteSession(current[workspace.id] ?? [], forked),
+        }));
+        navigateToWorkspaceSession(workspace.id, forked.id);
+        void refreshRouteState();
       },
     };
     return {

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -125,9 +125,15 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   const restoreRequests: Request[] = [];
   const nativePromptTexts: string[] = [];
   const nativeMessages: { id: string; role: "user"; text: string }[] = [];
+  const forkRequests: Request[] = [];
   const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = new Request(input, init);
     const path = new URL(request.url).pathname;
+    if (request.method === "POST" && path.endsWith("/fork")) {
+      forkRequests.push(request);
+      await forkCompletion;
+      return Response.json(createSnapshot({ type: "idle" }, 1, "created-branch").session);
+    }
     if (request.method === "PATCH" && path.endsWith(`/session/${sessionId}`)) restoreRequests.push(request);
     if (path === `/opencode2/api/session/${sessionId}/prompt`) {
       const body: unknown = await request.json();
@@ -160,13 +166,15 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   }));
   mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
   mock.module("@/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
+  const nativeSessionModule = await import("../src/app/lib/opencode-session-native");
   mock.module("@/app/lib/opencode-session-native", () => ({
+    ...nativeSessionModule,
     composeNativeSessionSnapshot: async (_target: unknown, id: string) => id === otherSessionId ? otherSnapshot : snapshotRead ?? fetchedSnapshot,
   }));
   const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
   const { snapshotKey, transcriptKey } = await import("../src/react-app/domains/session/sync/session-sync");
   const { useSessionArchive } = await import("../src/react-app/domains/session/sidebar/use-session-archive");
-  const { getQueuedDrainState, resetQueuedDrainForTests } = await import("../src/react-app/domains/session/surface/queued-drain-machine");
+  const { claimQueuedSend, dispatchQueuedDrain, getQueuedDrainState, resetQueuedDrainForTests, subscribeQueuedDrain } = await import("../src/react-app/domains/session/surface/queued-drain-machine");
   const queryClient = getReactQueryClient();
   queryClient.clear();
   queryClient.setQueryData(snapshotKey(workspaceId, sessionId), createSnapshot({ type: "busy" }, 1));
@@ -185,7 +193,15 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   let prepareSubmission: ((text?: string) => void) | undefined;
   const revokePreview = spyOn(URL, "revokeObjectURL");
   const copyText = spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
-  const forkAtMessage = mock(() => {});
+  let forkCompletion: Promise<void> = Promise.resolve();
+  const { forkSession } = await import("../src/app/lib/opencode-session");
+  const { createClient } = await import("../src/app/lib/opencode");
+  const forkClient = createClient("http://127.0.0.1:1/opencode", "/tmp/project-focus-continuity");
+  const forkNavigation = mock((_id: string) => {});
+  const forkAtMessage = mock(async (messageId: string | null, id: string, isCurrent: () => boolean) => {
+    await forkSession(forkClient, id, messageId ?? undefined);
+    if (isCurrent()) forkNavigation(id);
+  });
   const revertToMessage = mock(async () => {});
   const nativeMenuRequests: NativeContextMenuRequest[] = [];
   let nativeMenuSelection: string | null = null;
@@ -236,7 +252,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     return children(archived);
   }
 
-  const renderSurface = (opencodeBaseUrl = "http://127.0.0.1:1/opencode", activeSessionId = sessionId) => root.render(
+  const renderSurface = (opencodeBaseUrl = "http://127.0.0.1:1/opencode", activeSessionId = sessionId, isControlTarget = false) => root.render(
     <PlatformProvider value={platform}>
       <MemoryRouter>
         <QueryClientProvider client={queryClient}>
@@ -250,7 +266,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
                 workspaceRoot="/tmp/project-focus-continuity"
                 sessionId={activeSessionId}
                 draftScope="local"
-                isControlTarget={false}
+                isControlTarget={isControlTarget}
                 opencodeBaseUrl={opencodeBaseUrl}
                 openworkToken="test-token"
                 developerMode
@@ -374,9 +390,20 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Stop"]')?.disabled).toBe(false);
     expect(refetch).toHaveBeenCalledTimes(1);
     interruption = Promise.withResolvers<void>();
+    // Opening a menu gives Escape to that menu, not the stop confirmation.
+    const tools = container.querySelector<HTMLButtonElement>('button[title="Agents, commands, skills, plugins, and connections"]');
+    if (!tools) throw new Error("Expected the tools menu trigger");
+    await act(async () => tools.click());
+    await act(async () => { escape(); });
+    expect(container.textContent).not.toContain("Hit Escape again to stop the agent");
+    expect(interrupt).toHaveBeenCalledTimes(2);
     await act(async () => { escape(); });
     expect(interrupt).toHaveBeenCalledTimes(2);
     expect(container.textContent).toContain("Hit Escape again to stop the agent");
+    const confirmation = container.querySelector('[data-composer-stop-confirmation][role="status"]');
+    expect(confirmation?.textContent).toBe("Hit Escape again to stop the agent");
+    expect(confirmation?.classList.contains("hidden")).toBe(false);
+    expect(container.querySelector('button[aria-label="Stop"]')?.className).toContain("w-9");
     await act(async () => { escape(); });
     expect(interrupt).toHaveBeenCalledTimes(3);
     expect(container.textContent).not.toContain("Stop unavailable");
@@ -462,7 +489,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     await openMessageMenu("copy");
     expect(copyText).toHaveBeenCalledWith("Keep this session mounted.");
     await openMessageMenu("branch");
-    expect(forkAtMessage).toHaveBeenCalledWith(null, sessionId);
+    expect(forkAtMessage).toHaveBeenCalledWith(null, sessionId, expect.any(Function));
     const retainedMessages = queryClient.getQueryData<OpenworkSessionSnapshot>(key)?.messages;
     await act(async () => updateRouteArchived(true));
 
@@ -503,6 +530,138 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
       { type: "item", id: "branch", label: "Branch in new chat", enabled: true },
       { type: "item", id: "revert", label: "Revert", enabled: true },
     ]);
+
+    const branch = () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Branch in new chat"]');
+      if (!button || button.disabled) throw new Error("Expected an enabled Branch button");
+      button.click();
+      button.click();
+    };
+    const expectBranching = () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Branching..."]');
+      expect(button?.disabled).toBe(true);
+      expect(button?.getAttribute("aria-busy")).toBe("true");
+      expect(button?.querySelector("svg.lucide-loader-circle")).not.toBeNull();
+      expect(container.querySelector('[data-message-role="user"] [role="status"]')?.textContent).toBe("Branching...");
+    };
+    const branchHistory = Promise.withResolvers<OpenworkSessionSnapshot>();
+    const forkCreated = Promise.withResolvers<void>();
+    snapshotRead = branchHistory.promise;
+    forkCompletion = forkCreated.promise;
+    await act(async () => branch());
+    expectBranching();
+    expect(forkAtMessage).toHaveBeenCalledTimes(1);
+    await openMessageMenu("branch");
+    expectBranching();
+    expect(forkAtMessage).toHaveBeenCalledTimes(1);
+    const branchSnapshot = createSnapshot({ type: "idle" }, 5);
+    const boundaryMessage = branchSnapshot.messages[0];
+    if (!boundaryMessage) throw new Error("Expected the branch boundary fixture");
+    branchSnapshot.messages.push({ ...boundaryMessage, info: { ...boundaryMessage.info, id: "fresh-next-message" } });
+    await act(async () => branchHistory.resolve(branchSnapshot));
+    expect(forkAtMessage).toHaveBeenCalledTimes(2);
+    expect(forkAtMessage).toHaveBeenLastCalledWith("fresh-next-message", sessionId, expect.any(Function));
+    expect(forkRequests).toHaveLength(2);
+    expect(new URL(forkRequests[1]!.url).pathname).toBe(`/opencode/session/${sessionId}/fork`);
+    expect(await forkRequests[1]?.json()).toEqual({ messageID: "fresh-next-message" });
+    expectBranching();
+    await openMessageMenu("branch");
+    expect(forkAtMessage).toHaveBeenCalledTimes(2);
+    expect(forkRequests).toHaveLength(2);
+    expect(forkNavigation).toHaveBeenCalledTimes(1);
+    await act(async () => forkCreated.reject(new Error("Branch creation failed")));
+    snapshotRead = null;
+    expect(container.textContent).toContain("Branch creation failed");
+    expect(container.querySelector('button[aria-label="Branching..."]')).toBeNull();
+    expect(editor.textContent).toBe(draft);
+    forkCompletion = Promise.resolve();
+    await act(async () => branch());
+    expect(forkAtMessage).toHaveBeenCalledTimes(3);
+    expect(forkNavigation).toHaveBeenCalledTimes(2);
+    expect(container.textContent).not.toContain("Branch creation failed");
+    const failedHistory = Promise.withResolvers<OpenworkSessionSnapshot>();
+    snapshotRead = failedHistory.promise;
+    await act(async () => branch());
+    expectBranching();
+    await act(async () => failedHistory.reject(new Error("Branch history unavailable")));
+    expect(container.textContent).toContain("Branch history unavailable");
+    expect(container.querySelector('button[aria-label="Branching..."]')).toBeNull();
+    expect(forkRequests).toHaveLength(3);
+    expect(editor.textContent).toBe(draft);
+
+    // A late history read cannot fork a new owner; a late fork cannot navigate it.
+    const abandonedHistory = Promise.withResolvers<OpenworkSessionSnapshot>();
+    snapshotRead = abandonedHistory.promise;
+    await act(async () => branch());
+    await act(async () => renderSession(otherSessionId));
+    await act(async () => abandonedHistory.resolve(branchSnapshot));
+    expect(forkAtMessage).toHaveBeenCalledTimes(3);
+    snapshotRead = null;
+    await act(async () => renderSession());
+    const abandonedFork = Promise.withResolvers<void>();
+    forkCompletion = abandonedFork.promise;
+    await act(async () => branch());
+    expectBranching();
+    expect(forkAtMessage).toHaveBeenCalledTimes(4);
+    await act(async () => renderSession(otherSessionId));
+    expect(container.querySelector('button[aria-label="Branching..."]')).toBeNull();
+    await act(async () => abandonedFork.resolve());
+    expect(forkNavigation).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Other session draft");
+    await act(async () => renderSession());
+    const blurredFork = Promise.withResolvers<void>();
+    forkCompletion = blurredFork.promise;
+    await act(async () => renderSurface(undefined, sessionId, true));
+    await act(async () => branch());
+    expectBranching();
+    await act(async () => renderSurface(undefined, sessionId, false));
+    await act(async () => blurredFork.resolve());
+    expect(forkNavigation).toHaveBeenCalledTimes(2);
+    forkCompletion = Promise.resolve();
+
+    for (const outcome of ["success", "failure"]) {
+      const remountedFork = Promise.withResolvers<void>();
+      forkCompletion = remountedFork.promise;
+      const beforeForks = forkRequests.length;
+      await act(async () => branch());
+      expectBranching();
+      expect(forkRequests).toHaveLength(beforeForks + 1);
+      const previousEditor = editor;
+      try {
+        await act(async () => root.render(null));
+        expect(container.querySelector('[data-lexical-editor="true"]')).toBeNull();
+        await act(async () => renderSession());
+        editor = container.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]');
+        if (!editor) throw new Error("Expected the remounted session composer");
+        expect(editor).not.toBe(previousEditor);
+        await act(async () => {
+          const button = container.querySelector<HTMLButtonElement>('button[aria-label="Branch in new chat"], button[aria-label="Branching..."]');
+          if (!button) throw new Error("Expected the remounted Branch action");
+          button.click();
+          button.click();
+        });
+        expect(forkRequests).toHaveLength(beforeForks + 1);
+        expectBranching();
+        await openMessageMenu("branch");
+        expect(forkRequests).toHaveLength(beforeForks + 1);
+        if (outcome === "failure") {
+          await act(async () => remountedFork.reject(new Error("Remounted branch failed")));
+          expect(container.textContent).toContain("Remounted branch failed");
+        } else {
+          await act(async () => remountedFork.resolve());
+        }
+        expect(container.querySelector('button[aria-label="Branching..."]')).toBeNull();
+        expect(container.querySelector<HTMLButtonElement>('button[aria-label="Branch in new chat"]')?.disabled).toBe(false);
+        expect(forkNavigation).toHaveBeenCalledTimes(2);
+        expect(editor.textContent).toBe(draft);
+      } finally {
+        await act(async () => remountedFork.resolve());
+      }
+    }
+    forkCompletion = Promise.resolve();
+    await act(async () => branch());
+    expect(container.textContent).not.toContain("Remounted branch failed");
+    expect(forkNavigation).toHaveBeenCalledTimes(3);
 
     const send = () => {
       const button = container.querySelector<HTMLButtonElement>('button[aria-label="Run task"]');
@@ -908,6 +1067,139 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(nativePending().map((item) => item.serverMessageId)).toEqual(["native-first", "native-second"]);
     expect(sentDrafts).toHaveLength(8);
 
+    await act(async () => {
+      fetchedSnapshot = createSnapshot({ type: "busy" }, 30);
+      queryClient.setQueryData(snapshotKey(workspaceId, sessionId), fetchedSnapshot);
+      renderSession();
+    });
+    await waitFor(() => container.querySelector('button[aria-label="Stop"]') !== null, "busy session for queue promotion");
+    const queueDraft = (text: string): ComposerDraft => ({
+      mode: "prompt", text, resolvedText: text, parts: [{ type: "text", text }], attachments: [],
+    });
+    await act(async () => {
+      useComposerStateStore.getState().setDraft(sessionId, "Composer continuation beside queue");
+      useComposerStateStore.getState().appendQueuedDraft(sessionId, queueDraft("Promote this queued message"));
+      useComposerStateStore.getState().appendQueuedDraft(sessionId, queueDraft("Keep this queued follower"));
+    });
+    const selectedQueueId = useComposerStateStore.getState().queuedDrafts[sessionId]?.[0]?.id;
+    if (!selectedQueueId) throw new Error("Expected the selected queue row");
+    const sendNow = () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Send now"]');
+      if (!button || button.disabled) throw new Error("Expected an enabled Send now button");
+      button.click();
+      button.click();
+    };
+    const expectQueuedSending = () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Sending..."]');
+      expect(button?.disabled).toBe(true);
+      expect(button?.querySelector("svg.lucide-loader-circle")).not.toBeNull();
+      expect(button?.closest('[aria-busy="true"]')?.querySelector('[role="status"]')?.textContent).toBe("Sending...");
+      expect(container.textContent?.split("Promote this queued message")).toHaveLength(2);
+      expect(useComposerStateStore.getState().queuedDrafts[sessionId]?.map((item) => item.id)).toContain(selectedQueueId);
+      expect(container.querySelector<HTMLButtonElement>('button[aria-label="Send now"]')?.disabled).toBe(true);
+      expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Composer continuation beside queue");
+    };
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    const queuedHistory = Promise.withResolvers<OpenworkSessionSnapshot>();
+    const ensureSnapshot = spyOn(queryClient, "ensureQueryData").mockImplementation(() => queuedHistory.promise);
+    const sendsBeforeQueue = sentDrafts.length;
+    await act(async () => sendNow());
+    expectQueuedSending();
+    expect(sentDrafts).toHaveLength(sendsBeforeQueue);
+    await act(async () => renderSession(otherSessionId));
+    expect(container.querySelector('button[aria-label="Sending..."]')).toBeNull();
+    await act(async () => renderSession());
+    expectQueuedSending();
+    await act(async () => queuedHistory.resolve(fetchedSnapshot));
+    ensureSnapshot.mockRestore();
+    expectQueuedSending();
+    expect(sentDrafts).toHaveLength(sendsBeforeQueue + 1);
+    expect(sentDrafts.at(-1)?.text).toBe("Promote this queued message");
+    await act(async () => submission.reject(new Error("Queue submission failed")));
+    expect(container.textContent).toContain("Queue submission failed");
+    expect(container.querySelector('button[aria-label="Sending..."]')).toBeNull();
+    expect(container.textContent?.split("Promote this queued message")).toHaveLength(2);
+    expect(getQueuedDrainState(sessionId).phase).toMatchObject({ kind: "halted", itemId: selectedQueueId });
+    expect(sentDrafts).toHaveLength(sendsBeforeQueue + 1);
+
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => sendNow());
+    expectQueuedSending();
+    await act(async () => submission.resolve({ outcome: "blocked", issue: {
+      code: "needs_connection", stage: "engine_delivery", retryable: true,
+      message: "Connection is unavailable", recommendedAction: "Reconnect before retrying",
+    } }));
+    expect(container.textContent?.split("Promote this queued message")).toHaveLength(2);
+    expect(getQueuedDrainState(sessionId).phase.kind).toBe("halted");
+    expect(sentDrafts).toHaveLength(sendsBeforeQueue + 2);
+
+    const watchAdmissionRelease = (itemId: string) => {
+      const observation = { published: false, replayClaimed: false, queuedAtRelease: false };
+      const unsubscribe = subscribeQueuedDrain(sessionId, () => {
+        const phase = getQueuedDrainState(sessionId).phase;
+        if (observation.published || (phase.kind !== "running" && phase.kind !== "awaiting_observation") || phase.itemId !== itemId) return;
+        observation.published = true;
+        // Like the global drainer, reconcile idle synchronously when admission
+        // is published, then try to claim any still-deliverable copy of this row.
+        dispatchQueuedDrain(sessionId, { type: "idle_reconciled", observedAt: Date.now() + 1, terminalObserved: true });
+        observation.queuedAtRelease = Boolean(useComposerStateStore.getState().queuedDrafts[sessionId]?.some((item) => item.id === itemId));
+        if (observation.queuedAtRelease) observation.replayClaimed = claimQueuedSend(sessionId, itemId);
+      });
+      return { observation, unsubscribe };
+    };
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => sendNow());
+    expectQueuedSending();
+    const acceptedRelease = watchAdmissionRelease(selectedQueueId);
+    try {
+      await act(async () => {
+        useComposerStateStore.getState().setDraft(sessionId, "Newer composer edits during queue send");
+        submission.resolve({ outcome: "accepted" });
+      });
+      expect(acceptedRelease.observation).toEqual({ published: true, replayClaimed: false, queuedAtRelease: false });
+    } finally {
+      acceptedRelease.unsubscribe();
+    }
+    expect(container.textContent).not.toContain("Promote this queued message");
+    expect(useComposerStateStore.getState().queuedDrafts[sessionId]?.map((item) => item.draft.text)).toEqual(["Keep this queued follower"]);
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Newer composer edits during queue send");
+    expect(sentDrafts).toHaveLength(sendsBeforeQueue + 3);
+
+    const sentQueueId = useComposerStateStore.getState().queuedDrafts[sessionId]?.[0]?.id;
+    if (!sentQueueId) throw new Error("Expected the next queued row");
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => sendNow());
+    expect(container.querySelector('button[aria-label="Sending..."]')).not.toBeNull();
+    const sentRelease = watchAdmissionRelease(sentQueueId);
+    try {
+      await act(async () => submission.resolve({ outcome: "sent", bypassed: false }));
+      expect(sentRelease.observation).toEqual({ published: true, replayClaimed: false, queuedAtRelease: false });
+    } finally {
+      sentRelease.unsubscribe();
+    }
+    expect(useComposerStateStore.getState().queuedDrafts[sessionId]).toBeUndefined();
+    expect(sentDrafts).toHaveLength(sendsBeforeQueue + 4);
+    await act(async () => useComposerStateStore.getState().appendQueuedDraft(sessionId, queueDraft("Uncertain queued message")));
+
+    submission = Promise.withResolvers<CloudMcpSubmissionResult>();
+    await act(async () => sendNow());
+    const queuedUnknownId = sentDrafts.at(-1)?.messageId;
+    if (!queuedUnknownId) throw new Error("Expected a queued admission identity");
+    expect(container.querySelector('button[aria-label="Sending..."]')).not.toBeNull();
+    await act(async () => submission.reject(new PromptAdmissionUnknownError({ messageID: queuedUnknownId })));
+    expect(getQueuedDrainState(sessionId).phase).toMatchObject({ kind: "admission_unknown", messageID: queuedUnknownId });
+    expect(container.textContent).toContain("It may already be running");
+    expect(useComposerStateStore.getState().queuedDrafts[sessionId]).toBeUndefined();
+    expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("Newer composer edits during queue send");
+    await act(async () => {
+      useComposerStateStore.getState().appendQueuedDraft(sessionId, queueDraft("Do not retry uncertain admission"));
+      fetchedSnapshot = createSnapshot({ type: "idle" }, 31);
+      queryClient.setQueryData(snapshotKey(workspaceId, sessionId), fetchedSnapshot);
+    });
+    await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Send now"]')?.click());
+    expect(sentDrafts).toHaveLength(sendsBeforeQueue + 5);
+    expect(getQueuedDrainState(sessionId).phase.kind).toBe("admission_unknown");
+
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
     let creation = Promise.withResolvers<void>();
     let creations = 0;
@@ -930,6 +1222,9 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(creations).toBe(1);
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("");
     expect(container.querySelector('[data-message-role="user"]')?.textContent).toBe("First hero message");
+    expect(container.querySelector('[role="status"]')?.textContent).toBe("Creating conversation...");
+    expect(container.querySelector('button[aria-label="Creating conversation..."]')?.getAttribute("aria-busy")).toBe("true");
+    expect(container.querySelector('button[aria-label="Preparing connected service tools…"]')).toBeNull();
     await act(async () => updateHeroDraft("Newer hero draft"));
     expect(capturedHandoff?.getContinuation().draft).toBe("Newer hero draft");
     await act(async () => creation.reject(new Error("Session creation failed")));
@@ -951,6 +1246,9 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     });
     await act(async () => send());
     expect(creations).toBe(2);
+    expect(container.querySelector('[role="status"]')?.textContent).toBe("Creating conversation...");
+    expect(container.querySelector('button[aria-label="Creating conversation..."]')?.getAttribute("aria-busy")).toBe("true");
+    expect(container.querySelector('button[aria-label="Preparing connected service tools…"]')).toBeNull();
     expect(container.querySelector('[data-lexical-editor="true"]')?.textContent).toBe("");
     expect(container.querySelector('[data-message-role="user"]')?.textContent).toContain("First hero message");
     expect(container.querySelector('[data-message-role="user"] img[alt="photo.png"]')).not.toBeNull();


### PR DESCRIPTION
## Summary

Conversation actions should acknowledge input while their requests are still pending.

- Show Branch pending state through the fresh history read and actual fork creation. Owner-scoped singleflight survives surface remounts; repeated activation cannot issue another concurrent fork, and stale completions cannot navigate a replacement conversation.
- Keep queued Send now visible as Sending until it settles. Consume accepted/sent queue items before publishing admission results so the global drainer cannot reclaim the same row. Preserve blocked/cancelled rows, uncertain-admission holds, and newer composer edits.
- Label both text-only and attachment first sends as Creating conversation instead of connected-service preparation.
- Show accessible Escape-to-stop confirmation at narrow widths while retaining menu Escape precedence.

Stable action sizing, truthful failure feedback, and draft preservation remain. No cosmetic Cancel or routine success toast is introduced.

## Verification

Candidate: `c2f4095f5377c40ee33ed317f455e7173666c084`, based on `dev` at `0b219dc4e5f2868c258dbe960d58c657dbe8d99b`. Both commits have verified signatures.

From `apps/app`:

```sh
pnpm --config.verify-deps-before-run=never exec bun test --isolate ./tests/composer-focus-continuity.test.tsx ./tests/queued-drain-admission-wedge.test.ts
pnpm --config.verify-deps-before-run=never typecheck
```

**14 passed, 0 failed, 0 skipped**; typecheck and whitespace checks passed. Delayed-transport and queue-listener regressions caught repeat-fork and queue-reclaim ordering before their fixes.

An additional combined staged-tree check of the five experience changes passed 149 focused tests and typecheck. That is supplementary integration checking, not immutable-head real-app evidence. Non-failing fixture warnings remain in the combined run.

## Proof verdict: Incomplete

No exact-head real-app testkit run or interaction-latency measurement was performed. Component coverage does not establish a 100ms acknowledgment budget, native screen-reader behavior, or narrow/split geometry. Existing runtime owners include `streamed-markdown-answer` and the queue/first-send journeys.

The command-local dependency-verification flag avoids an automatic reinstall during checks; no package configuration or lockfile was changed. A small existing component-fixture repair overlaps #4841's mock setup; its composer-mode behavior is not copied. Upload/admission-recovery and engine queue changes from other PRs are outside this scope. Required CI is unchanged.
