### PR TITLE
fix(chat): preserve reading context through task completion

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -21,6 +21,7 @@ import {
 import {
   DynamicToolUIPart,
   isFileUIPart,
+  isToolUIPart,
   ToolUIPart,
   type FileUIPart,
   type UIMessage,
@@ -124,8 +125,8 @@ import { faviconUrlForHref } from "@/lib/favicon"
 import { useOpenArtifactPath } from "@/lib/artifacts"
 import { cn } from "@/lib/utils"
 import { DevProfiler } from "@/react-app/shell/dev-profiler"
-import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
-import type { AnyToolPart } from "@/lib/tool-aggregate"
+import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
+import { isAggregatableToolPart, type AnyToolPart } from "@/lib/tool-aggregate"
 import { resolveConnectorToolIdentity } from "@/react-app/domains/connections/connector-tool-identity"
 
 const SEARCH_HIGHLIGHT_MARK_CLASS = "rounded px-0.5 bg-amber-4/70 text-current"
@@ -1146,33 +1147,42 @@ function getRenderableMessage(message: UIMessage) {
   return parts.length > 0 ? { ...message, parts } : null;
 }
 
-/**
- * A finished turn's steps collapse to a single "Worked for 1m 19s" line
- * that expands back into the full run. Only live turns show their steps
- * unprompted; once the answer is in, the reasoning is available but out
- * of the way.
- */
-function CompletedStepRun({ label, children }: { label: string; children: React.ReactNode }) {
-  const [open, setOpen] = React.useState(false)
+/** Completion changes the summary, never the identity or the reader's choice. */
+function CompletedStepRun({ label, live, rowCount, mustShow, children }: {
+  label: string
+  live: boolean
+  rowCount: number
+  mustShow: boolean
+  children: React.ReactNode
+}) {
+  const { highlightQuery } = useMessageList()
+  const [open, setOpen] = React.useState(() => live || mustShow || rowCount <= COLLAPSED_STEP_RUN_MIN_ROWS)
+  // Reveal requests/errors without reparenting them, and do not fold them again
+  // when they settle: the reader may have started inspecting the revealed detail.
+  if (mustShow && !open) setOpen(true)
+  const searching = Boolean(highlightQuery?.trim())
+  const expanded = open || mustShow || searching
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className="flex w-full flex-col gap-2">
+    <Collapsible data-step-run="" open={expanded} onOpenChange={setOpen} className="flex w-full flex-col gap-2">
       <div className="mx-auto flex w-full max-w-3xl px-2 md:px-10">
         <CollapsibleTrigger
-          className="group flex cursor-pointer items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          aria-label={open ? `${label}. Hide steps` : `${label}. Show steps`}
+          disabled={mustShow || searching}
+          title={mustShow ? "Active steps, errors, and interactive tools stay visible" : searching ? "Steps are visible while searching" : undefined}
+          className="group flex min-h-6 cursor-pointer items-center gap-1 text-sm text-muted-foreground hover:text-foreground aria-disabled:cursor-default"
+          aria-label={expanded ? `${label}. Hide steps` : `${label}. Show steps`}
         >
           <span>{label}</span>
           <ChevronRight
             aria-hidden="true"
             className={cn(
-              "size-3.5 text-muted-foreground/70 transition-transform duration-150",
-              open && "rotate-90"
+              "size-3.5 text-muted-foreground/70",
+              expanded && "rotate-90"
             )}
           />
         </CollapsibleTrigger>
       </div>
-      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+      <CollapsibleContent hiddenUntilFound className="[&[hidden]:not([hidden='until-found'])]:hidden">
         {children}
       </CollapsibleContent>
     </Collapsible>
@@ -1214,6 +1224,7 @@ function MessageGroup({
   // silently corrupt fork/revert boundaries.
   const lastRealItem = items.findLast((item) => !isSessionErrorMessage(item.message))
   const isLiveGroup = isStreaming && isLastGroup
+  const { syncDegraded } = useMessageList()
 
   if (!lastItem || isMessageEmptyGroup(items)) {
     return null;
@@ -1232,15 +1243,16 @@ function MessageGroup({
   }
   let stepItems = items.slice(0, stepCount)
   let proseItems = items.slice(stepCount)
-  // OpenCode delivers a whole turn as one assistant message with steps and
-  // the answer interleaved in its parts. Split the first prose message so
-  // its leading steps fold with the rest instead of pinning the run open.
+  // Split at the FIRST prose boundary, not the changing last answer. Later
+  // narration/tools stay in place instead of moving under the fold on every
+  // new text part. A moving live tail would reset those stateful tool bodies.
   const firstProse = proseItems[0]
   if (firstProse && firstProse.message.role === "assistant" && !isSessionErrorMessage(firstProse.message)) {
-    const split = splitTurnAtAnswer(firstProse.message)
-    if (split) {
-      stepItems = [...stepItems, { index: firstProse.index, message: split.steps }]
-      proseItems = [{ index: firstProse.index, message: split.answer }, ...proseItems.slice(1)]
+    const parts = firstProse.message.parts
+    const boundary = parts.findIndex((part) => part.type === "text" || part.type === "file")
+    if (boundary > 0 && parts.slice(0, boundary).some((part) => isToolUIPart(part) || part.type === "reasoning")) {
+      stepItems = [...stepItems, { ...firstProse, message: { ...firstProse.message, id: `${firstProse.message.id}:steps`, parts: parts.slice(0, boundary) } }]
+      proseItems = [{ ...firstProse, message: { ...firstProse.message, parts: parts.slice(boundary) } }, ...proseItems.slice(1)]
     }
   }
   // How long the turn spent working, from the first step to when the answer
@@ -1249,17 +1261,6 @@ function MessageGroup({
   const stepsStartedAt = stepItems.length > 0 ? getMessageCreated(stepItems[0].message) : null
   const stepsEndedAt = getMessageCompleted(lastItem.message) ?? getMessageCreated(lastItem.message)
 
-  // The answer message's own thinking belongs to the work, not the answer, so
-  // a collapsed run shows it and the message below renders text only.
-  const proseReasoning = proseItems.flatMap((item) =>
-    item.message.role === "assistant" && !isSessionErrorMessage(item.message)
-      ? getAssistantRenderGroups(item.message.parts, showThinking).flatMap((group, groupIndex) =>
-        group.kind === "reasoning"
-          ? [{ key: JSON.stringify(["reasoning", item.message.id, groupIndex]), text: group.text, isStreaming: group.isStreaming }]
-          : []
-      )
-      : []
-  )
   // An aggregate line counts each call it absorbed: it reads as one row but
   // stands for that much work, and folding should key off the work done.
   const stepRowCount =
@@ -1273,32 +1274,29 @@ function MessageGroup({
           )
           : 1),
       0
-    ) + proseReasoning.length
+    )
   const stepRunLabel =
-    stepsStartedAt !== null && stepsEndedAt !== null && stepsEndedAt > stepsStartedAt
+    isLiveGroup
+      ? `${syncDegraded ? "Status unknown" : "Live activity"} · ${stepRowCount} ${stepRowCount === 1 ? "step" : "steps"}`
+      : stepRowCount > COLLAPSED_STEP_RUN_MIN_ROWS && stepsStartedAt !== null && stepsEndedAt !== null && stepsEndedAt > stepsStartedAt
       ? `Worked for ${formatToolCallDuration(stepsEndedAt - stepsStartedAt)}`
       : stepRowCount === 1
         ? "1 step"
         : `${stepRowCount} steps`
-  // A short finished run reads fine as a list, so only long ones fold away.
-  const collapseSteps =
-    !isLiveGroup && stepItems.length > 0 && stepRowCount > COLLAPSED_STEP_RUN_MIN_ROWS
-  const foldedReasoning = collapseSteps
-    ? proseReasoning.map((reasoning) => (
-      <Message
-        key={`folded-reasoning-${reasoning.key}`}
-        className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10"
-      >
-        <ReasoningBlock disclosureKey={reasoning.key} text={reasoning.text} isStreaming={reasoning.isStreaming} />
-      </Message>
-    ))
-    : []
+  // Only known, successful passive steps may be hidden. Unknown tools can own
+  // approvals or interactive frames even after returning a result.
+  const mustShowSteps = stepItems.some(({ message }) => isSessionErrorMessage(message)
+    || message.parts.some((part) => isToolUIPart(part)
+      && (part.state !== "output-available" || !isAggregatableToolPart(part))))
 
   const renderItem = (item: UIMessageWithIndex, groupIndex: number, hideReasoning?: boolean) => {
     const isLastMessage = isLastGroup && item.index === lastItem.index
+    // The synthetic DOM id remains useful to scroll/Find; it must not change
+    // the React identity when a tool-only message gains its first prose part.
+    const key = item.message.id.endsWith(":steps") ? item.message.id.slice(0, -6) : item.message.id
 
     return (
-      <div key={item.message.id}>
+      <div key={key}>
         <MessageComponent
           message={item.message}
           isLastMessage={isLastMessage}
@@ -1333,7 +1331,7 @@ function MessageGroup({
           ? getAggregateOnlyParts(item.message, showThinking)
           : null
       if (aggregateParts) {
-        if (!run) run = { parts: [], key: item.message.id }
+        if (!run) run = { parts: [], key: aggregateParts[0].toolCallId }
         run.parts.push(...aggregateParts)
         return
       }
@@ -1351,18 +1349,11 @@ function MessageGroup({
           message use, so a step row is spaced identically whether or not a
           message boundary happens to fall between it and the previous row. */}
       {stepItems.length > 0 ? (
-        collapseSteps ? (
-          <CompletedStepRun label={stepRunLabel}>
-            <div className="flex flex-col gap-2">
-              {renderItems(stepItems, 0)}
-              {foldedReasoning}
-            </div>
-          </CompletedStepRun>
-        ) : (
-          <div data-live-steps="" className="flex flex-col gap-2">
+        <CompletedStepRun label={stepRunLabel} live={isLiveGroup} rowCount={stepRowCount} mustShow={mustShowSteps}>
+          <div className="flex flex-col gap-2">
             {renderItems(stepItems, 0)}
           </div>
-        )
+        </CompletedStepRun>
       ) : null}
       {mcpAppParts.map((part) => (
         <Message
@@ -1372,7 +1363,7 @@ function MessageGroup({
           <McpAppFrame part={part} />
         </Message>
       ))}
-      {renderItems(proseItems, stepItems.length, collapseSteps)}
+      {renderItems(proseItems, stepItems.length)}
       {lastTextMessage && !isStreaming && (
         <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 max-lg:opacity-100 pointer-coarse:opacity-100 md:px-8">
           <MessageActions className="flex gap-0">

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -125,6 +125,7 @@ import { faviconUrlForHref } from "@/lib/favicon"
 import { useOpenArtifactPath } from "@/lib/artifacts"
 import { cn } from "@/lib/utils"
 import { DevProfiler } from "@/react-app/shell/dev-profiler"
+import { useWorkbenchDisclosure } from "@/react-app/domains/session/chat/workbench-ui-state"
 import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
 import { isAggregatableToolPart, type AnyToolPart } from "@/lib/tool-aggregate"
 import { resolveConnectorToolIdentity } from "@/react-app/domains/connections/connector-tool-identity"
@@ -496,9 +497,18 @@ type AssistantMessageProps = {
   hideReasoning?: boolean
 }
 
+// Leading work keeps its disclosure identity when the first prose part arrives;
+// the prose section has its own index space and must not inherit those choices.
+function messageDisclosureId(message: UIMessage) {
+  const id = message.id.endsWith(":steps") ? message.id.slice(0, -6) : message.id
+  const section = message.parts.some((part) => part.type === "text" || part.type === "file") ? "prose" : "steps"
+  return JSON.stringify([id, section])
+}
+
 const AssistantMessage = React.memo(
   ({ message, isStreaming, hideReasoning }: AssistantMessageProps) => {
     const { showThinking, highlightQuery } = useMessageList()
+    const disclosureMessageId = messageDisclosureId(message)
     const assistantRenderGroups = React.useMemo(
       () => {
         const groups = getAssistantRenderGroups(message.parts, showThinking)
@@ -533,7 +543,7 @@ const AssistantMessage = React.memo(
               return (
                 <ReasoningBlock
                   key={`reasoning-${index}`}
-                  disclosureKey={JSON.stringify(["reasoning", message.id, index])}
+                  disclosureKey={JSON.stringify(["reasoning", disclosureMessageId, index])}
                   text={group.text}
                   isStreaming={group.isStreaming}
                 />
@@ -551,7 +561,7 @@ const AssistantMessage = React.memo(
             if (group.kind === "tool-aggregate") {
               return (
                 <div key={`tool-aggregate-${index}`} className="w-full">
-                  <ToolAggregateGroup messageId={message.id} parts={group.parts} thoughts={group.thoughts} />
+                  <ToolAggregateGroup messageId={disclosureMessageId} parts={group.parts} thoughts={group.thoughts} />
                 </div>
               )
             }
@@ -1148,7 +1158,8 @@ function getRenderableMessage(message: UIMessage) {
 }
 
 /** Completion changes the summary, never the identity or the reader's choice. */
-function CompletedStepRun({ label, live, rowCount, mustShow, children }: {
+function CompletedStepRun({ disclosureKey, label, live, rowCount, mustShow, children }: {
+  disclosureKey: string
   label: string
   live: boolean
   rowCount: number
@@ -1156,10 +1167,12 @@ function CompletedStepRun({ label, live, rowCount, mustShow, children }: {
   children: React.ReactNode
 }) {
   const { highlightQuery } = useMessageList()
-  const [open, setOpen] = React.useState(() => live || mustShow || rowCount <= COLLAPSED_STEP_RUN_MIN_ROWS)
+  const [open, setOpen] = useWorkbenchDisclosure(disclosureKey, live || mustShow || rowCount <= COLLAPSED_STEP_RUN_MIN_ROWS)
   // Reveal requests/errors without reparenting them, and do not fold them again
   // when they settle: the reader may have started inspecting the revealed detail.
-  if (mustShow && !open) setOpen(true)
+  React.useLayoutEffect(() => {
+    if (mustShow && !open) setOpen(true)
+  }, [mustShow, open, setOpen])
   const searching = Boolean(highlightQuery?.trim())
   const expanded = open || mustShow || searching
 
@@ -1313,13 +1326,13 @@ function MessageGroup({
   // actions"); any prose, reasoning, or other tool breaks the run.
   const renderItems = (slice: UIMessageWithIndex[], offset: number, hideReasoning?: boolean) => {
     const nodes: React.ReactNode[] = []
-    let run: { parts: AnyToolPart[]; key: string } | null = null
+    let run: { parts: AnyToolPart[]; key: string; messageId: string } | null = null
     const flush = () => {
       if (!run) return
       nodes.push(
         <div key={`aggregate-${run.key}`}>
           <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
-            <ToolAggregateGroup messageId={run.key} parts={run.parts} className="w-full" />
+            <ToolAggregateGroup messageId={run.messageId} parts={run.parts} className="w-full" />
           </Message>
         </div>
       )
@@ -1331,7 +1344,7 @@ function MessageGroup({
           ? getAggregateOnlyParts(item.message, showThinking)
           : null
       if (aggregateParts) {
-        if (!run) run = { parts: [], key: aggregateParts[0].toolCallId }
+        if (!run) run = { parts: [], key: aggregateParts[0].toolCallId, messageId: messageDisclosureId(item.message) }
         run.parts.push(...aggregateParts)
         return
       }
@@ -1349,7 +1362,7 @@ function MessageGroup({
           message use, so a step row is spaced identically whether or not a
           message boundary happens to fall between it and the previous row. */}
       {stepItems.length > 0 ? (
-        <CompletedStepRun label={stepRunLabel} live={isLiveGroup} rowCount={stepRowCount} mustShow={mustShowSteps}>
+        <CompletedStepRun disclosureKey={JSON.stringify(["step-run", items[0].message.id])} label={stepRunLabel} live={isLiveGroup} rowCount={stepRowCount} mustShow={mustShowSteps}>
           <div className="flex flex-col gap-2">
             {renderItems(stepItems, 0)}
           </div>

--- a/apps/app/src/react-app/domains/session/chat/workbench-ui-state.ts
+++ b/apps/app/src/react-app/domains/session/chat/workbench-ui-state.ts
@@ -38,12 +38,13 @@ export const useWorkbenchUiState = create<{
   },
 }));
 
-export function useWorkbenchDisclosure(detail: string | undefined): [boolean, (open: boolean) => void] {
+export function useWorkbenchDisclosure(detail: string | undefined, defaultOpen = false): [boolean, (open: boolean) => void] {
   const context = useOptionalMessageList();
   const owner = context?.uiStateOwner;
   const key = owner && detail ? JSON.stringify([owner, detail]) : null;
   const localKey = JSON.stringify([context?.workspaceId, context?.sessionId, owner, detail]);
-  const saved = key ? useWorkbenchUiState.getState().disclosures.get(key) ?? false : false;
+  // Defaults initialize a new identity only; saved false is an explicit choice.
+  const saved = key ? useWorkbenchUiState.getState().disclosures.get(key) ?? defaultOpen : defaultOpen;
   const [local, setLocal] = useState({ key: localKey, open: saved });
   if (local.key !== localKey) setLocal({ key: localKey, open: saved });
   useLayoutEffect(() => {

--- a/apps/app/src/react-app/domains/session/surface/scroll-overlay.tsx
+++ b/apps/app/src/react-app/domains/session/surface/scroll-overlay.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { useSessionActivityStore } from "../status/session-activity-store";
 
 import {
   selectSessionIsStickyBottom,
@@ -22,7 +23,7 @@ const JumpToStartButton = memo(function JumpToStartButton({
   onJumpToStartOfMessage,
 }: JumpToStartButtonProps) {
   const handleClick = useCallback(() => {
-    onJumpToStartOfMessage("smooth");
+    onJumpToStartOfMessage(window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth");
   }, [onJumpToStartOfMessage]);
 
   return (
@@ -38,13 +39,15 @@ const JumpToStartButton = memo(function JumpToStartButton({
 
 type JumpToLatestButtonProps = {
   onJumpToLatest: (behavior?: ScrollBehavior) => void;
+  newOutput: boolean;
 };
 
 const JumpToLatestButton = memo(function JumpToLatestButton({
   onJumpToLatest,
+  newOutput,
 }: JumpToLatestButtonProps) {
   const handleClick = useCallback(() => {
-    onJumpToLatest("smooth");
+    onJumpToLatest(window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth");
   }, [onJumpToLatest]);
 
   return (
@@ -54,11 +57,13 @@ const JumpToLatestButton = memo(function JumpToLatestButton({
       onClick={handleClick}
     >
       Jump to latest
+      {newOutput ? <span className="ml-1.5 rounded-full bg-dls-hover px-1.5 py-0.5" role="status">New output</span> : null}
     </button>
   );
 });
 
 type SessionScrollOverlayProps = {
+  workspaceId: string;
   sessionId: string;
   owner?: string;
   isStreaming: boolean;
@@ -67,6 +72,7 @@ type SessionScrollOverlayProps = {
 };
 
 export const SessionScrollOverlay = memo(function SessionScrollOverlay({
+  workspaceId,
   sessionId,
   owner,
   isStreaming,
@@ -74,6 +80,21 @@ export const SessionScrollOverlay = memo(function SessionScrollOverlay({
   onJumpToStartOfMessage,
 }: SessionScrollOverlayProps) {
   const { isAtBottom, topClippedMessageId } = useSessionScrollOverlayState(sessionScrollKey(sessionId, owner));
+  const progressAt = useSessionActivityStore((state) => state.recordsByWorkspaceId[workspaceId]?.[sessionId]?.lastProgressAt ?? 0);
+  const key = JSON.stringify([workspaceId, owner, sessionId]);
+  const previous = useRef({ key, progressAt, isAtBottom, isStreaming });
+  const [unseenOwner, setUnseenOwner] = useState<string | null>(null);
+  useEffect(() => {
+    const last = previous.current;
+    if (last.key !== key || isAtBottom) {
+      setUnseenOwner(null);
+    } else if (!last.isAtBottom && (isStreaming || last.isStreaming) && progressAt > last.progressAt) {
+      // Observe validated transcript progress, not render/mutation counts or
+      // animation ticks. This affordance never changes the reader's position.
+      setUnseenOwner(key);
+    }
+    previous.current = { key, progressAt, isAtBottom, isStreaming };
+  }, [key, progressAt, isAtBottom, isStreaming]);
   const showJumpToStart = !isStreaming && Boolean(topClippedMessageId);
   const showJumpToLatest = !isAtBottom;
 
@@ -88,7 +109,7 @@ export const SessionScrollOverlay = memo(function SessionScrollOverlay({
           <JumpToStartButton onJumpToStartOfMessage={onJumpToStartOfMessage} />
         ) : null}
         {showJumpToLatest ? (
-          <JumpToLatestButton onJumpToLatest={onJumpToLatest} />
+          <JumpToLatestButton onJumpToLatest={onJumpToLatest} newOutput={unseenOwner === key} />
         ) : null}
       </div>
     </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -3258,6 +3258,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
           </div>
         </div>
         <SessionScrollOverlay
+          workspaceId={props.workspaceId}
           sessionId={props.sessionId}
           owner={sessionOwner}
           isStreaming={chatStreaming}

--- a/apps/app/tests/message-list-step-fold.test.tsx
+++ b/apps/app/tests/message-list-step-fold.test.tsx
@@ -1,11 +1,21 @@
 /** @jsxImportSource react */
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, useEffect } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { DynamicToolUIPart, UIMessage } from "ai";
 
-import { MessageList } from "../src/components/chat/message-list";
-import { MessageListProvider } from "../src/components/chat/message-list-provider";
 import { createDefaultPlatform, PlatformProvider } from "../src/react-app/kernel/platform";
+import type { ThreadStatus } from "../src/lib/messages";
+
+const ownedDom = typeof window === "undefined";
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+// Base UI chooses its layout-effect implementation at module initialization.
+const { MessageList } = await import("../src/components/chat/message-list");
+const { MessageListProvider } = await import("../src/components/chat/message-list-provider");
+const mcpAppFrame = await import("../src/components/chat/mcp-app-frame");
+afterAll(async () => { if (ownedDom) await GlobalRegistrator.unregister(); });
 
 function bashPart(id: string): DynamicToolUIPart {
   return {
@@ -48,13 +58,14 @@ function withoutWindow<T>(run: () => T): T {
   }
 }
 
-function renderList(messages: UIMessage[]) {
-  return withoutWindow(() => renderToStaticMarkup(
+function list(messages: UIMessage[], status: ThreadStatus = "ready", highlightQuery = "") {
+  return (
     <PlatformProvider value={createDefaultPlatform()}>
     <MessageListProvider
       workspaceId="ws"
       sessionId="session"
       showThinking={true}
+      highlightQuery={highlightQuery}
       developerMode={false}
       displaySuggestions={false}
       providerConnectedCount={1}
@@ -67,10 +78,14 @@ function renderList(messages: UIMessage[]) {
       onMcpReopenAuthorization={() => Promise.resolve()}
       onMcpRetry={() => {}}
     >
-      <MessageList messages={messages} status="ready" />
+      <MessageList messages={messages} status={status} activityStatus={status === "streaming" ? "thinking" : "idle"} />
     </MessageListProvider>
     </PlatformProvider>
-  ));
+  );
+}
+
+function renderList(messages: UIMessage[]) {
+  return withoutWindow(() => renderToStaticMarkup(list(messages)));
 }
 
 const userMessage: UIMessage = {
@@ -91,6 +106,8 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
         { type: "reasoning", text: "planning the change", state: "done" },
         bashPart("c1"),
         editPart("c2", "/repo/src/a.ts"),
+        bashPart("prefix-3"),
+        bashPart("prefix-4"),
         { type: "text", text: "Now checking the result:", state: "done" },
         bashPart("c3"),
         bashPart("c4"),
@@ -155,5 +172,234 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
     const run = markup.indexOf("Ran 2 commands");
     expect(openingThought).toBeGreaterThan(-1);
     expect(run).toBeGreaterThan(openingThought);
+  });
+});
+
+async function mounted(run: (container: HTMLDivElement, render: (messages: UIMessage[], status?: ThreadStatus, query?: string) => Promise<void>) => Promise<void>) {
+  const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  try {
+    await run(container, async (messages, status = "streaming", query = "") => {
+      await act(async () => root.render(list([userMessage, ...messages], status, query)));
+    });
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+  }
+}
+
+function longRun(id: string, count = 6): UIMessage {
+  return {
+    id, role: "assistant",
+    metadata: { opencode: { created: 1_000, completed: 80_000 } },
+    parts: Array.from({ length: count }, (_, index) => bashPart(`${id}-${index}`)),
+  };
+}
+
+function stepToggle(container: HTMLElement) {
+  const toggle = container.querySelector<HTMLButtonElement>('[data-step-run] > div > button');
+  if (!toggle) throw new Error("Missing step disclosure");
+  return toggle;
+}
+
+describe("long-task reading continuity", () => {
+  test("keeps actual expanded tool/detail nodes and focus through the first answer, more events, and completion", async () => {
+    await mounted(async (container, render) => {
+      const completed = longRun("continuity");
+      const initial: UIMessage = {
+        ...completed,
+        metadata: { opencode: { created: 1_000 } },
+        parts: [...completed.parts.slice(0, -1), { ...bashPart("continuity-5"), state: "input-available" }],
+      };
+      await render([initial]);
+      const shell = container.querySelector("[data-step-run]");
+      const aggregate = container.querySelector("[data-tool-aggregate]");
+      const expand = aggregate?.querySelector<HTMLButtonElement>("button");
+      if (!expand) throw new Error("Missing aggregate");
+      await act(async () => expand.click());
+      const detail = [...aggregate?.querySelectorAll<HTMLButtonElement>('[data-tool-aggregate-detail="command"]') ?? []].at(-1);
+      if (!detail) throw new Error("Missing command detail");
+      await act(async () => detail.click());
+      detail.focus();
+      const text: UIMessage["parts"][number] = { type: "text", text: "First narrative needle", state: "done" };
+      const answer: UIMessage = { ...completed, parts: [...completed.parts, text] };
+      await render([answer]);
+      const proseRoot = container.querySelector('[data-message-id="continuity"]');
+      expect(proseRoot).not.toBeNull();
+      const later: UIMessage = { ...answer, parts: [...answer.parts, bashPart("later-tool"), { type: "text", text: "Final answer", state: "done" }] };
+      await render([later]);
+      expect(container.querySelector('[data-message-id="continuity"]')).toBe(proseRoot);
+      await render([later], "ready");
+      expect(container.querySelector("[data-step-run]")).toBe(shell);
+      expect(container.querySelector("[data-tool-aggregate]")).toBe(aggregate);
+      expect([...aggregate?.querySelectorAll('[data-tool-aggregate-detail="command"]') ?? []].at(-1)).toBe(detail);
+      expect(detail.getAttribute("aria-expanded")).toBe("true");
+      expect(document.activeElement).toBe(detail);
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe("true");
+      expect(proseRoot?.isConnected).toBe(true);
+      expect(proseRoot?.closest("[data-step-run]")).toBeNull();
+      expect(container.textContent).toContain("Final answer");
+    });
+  });
+
+  test("keeps opened reasoning in its original section instead of relocating it on completion", async () => {
+    await mounted(async (container, render) => {
+      const initial = longRun("reasoning-continuity");
+      const message: UIMessage = { ...initial, parts: [
+        { type: "reasoning", text: "Planning detail", state: "done" },
+        ...initial.parts,
+        { type: "text", text: "Narrative", state: "done" },
+        { type: "reasoning", text: "Checking detail", state: "streaming" },
+      ] };
+      await render([{ ...message, parts: message.parts.slice(0, -2) }]);
+      const leading = container.querySelector("[data-reasoning-block]");
+      const leadingToggle = leading?.querySelector<HTMLButtonElement>("button");
+      if (!leadingToggle) throw new Error("Missing leading thought");
+      await act(async () => leadingToggle.click());
+      await render([message]);
+      const blocks = [...container.querySelectorAll("[data-reasoning-block]")];
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0]).toBe(leading);
+      for (const block of blocks) {
+        const button = block.querySelector<HTMLButtonElement>("button");
+        if (!button) throw new Error("Missing reasoning disclosure");
+        if (button.getAttribute("aria-expanded") !== "true") await act(async () => button.click());
+      }
+      const settled: UIMessage = { ...message, parts: message.parts.map((part) => part.type === "reasoning" ? { ...part, state: "done" } : part) };
+      await render([settled], "ready");
+      expect([...container.querySelectorAll("[data-reasoning-block]")]).toEqual(blocks);
+      for (const block of blocks) expect(block.querySelector("button")?.getAttribute("aria-expanded")).toBe("true");
+      expect(blocks[0].closest("[data-step-run]")).not.toBeNull();
+      expect(blocks[1].closest("[data-step-run]")).toBeNull();
+    });
+  });
+
+  test("honors a manual fold across hundreds of steps and completion; Find reveals without erasing the choice", async () => {
+    await mounted(async (container, render) => {
+      const initial = longRun("fold-choice");
+      await render([initial]);
+      const toggle = stepToggle(container);
+      await act(async () => toggle.click());
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      const large = longRun("fold-choice", 200);
+      await render([large]);
+      expect(stepToggle(container)).toBe(toggle);
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      expect(toggle.textContent).toContain("Live activity");
+      expect(toggle.textContent).toContain("200 steps");
+      expect(toggle.querySelector(".ow-text-shimmer, .animate-pulse, .animate-spin")).toBeNull();
+      await render([large], "ready");
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      const panel = container.querySelector('[data-step-run] > [data-slot="collapsible-content"]');
+      expect(panel?.getAttribute("hidden")).toBe("until-found");
+      await render([large], "ready", "fold-choice");
+      expect(toggle.getAttribute("aria-expanded")).toBe("true");
+      await render([large], "ready");
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      await act(async () => panel?.dispatchEvent(new Event("beforematch")));
+      expect(toggle.getAttribute("aria-expanded")).toBe("true");
+      const aggregateToggle = panel?.querySelector<HTMLButtonElement>("[data-tool-aggregate] > button");
+      if (!aggregateToggle) throw new Error("Missing full history disclosure");
+      await act(async () => aggregateToggle.click());
+      const showAll = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Show 192 more"));
+      if (!showAll) throw new Error("Missing bounded aggregate history control");
+      await act(async () => showAll.click());
+      expect(container.textContent).toContain("fold-choice-199");
+    });
+  });
+
+  test("never folds a short live run automatically when it crosses the historical fold threshold", async () => {
+    await mounted(async (container, render) => {
+      await render([longRun("threshold", 2)]);
+      const shell = container.querySelector("[data-step-run]");
+      await render([longRun("threshold", 8)]);
+      await render([longRun("threshold", 8)], "ready");
+      expect(container.querySelector("[data-step-run]")).toBe(shell);
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe("true");
+    });
+  });
+
+  test.each(["input-available", "approval-requested", "output-error"] as const)("reveals %s and keeps the revealed detail open after settlement", async (state) => {
+    await mounted(async (container, render) => {
+      const initial = longRun(`critical-${state}`);
+      await render([initial]);
+      await act(async () => stepToggle(container).click());
+      const part: DynamicToolUIPart = state === "output-error"
+        ? { ...bashPart("critical"), state, errorText: "Could not complete the command" }
+        : state === "approval-requested"
+          ? { ...bashPart("critical"), state, approval: { id: "approval-1" } }
+          : { ...bashPart("critical"), state };
+      const next: UIMessage = { ...initial, parts: [...initial.parts, part] };
+      await render([next]);
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe("true");
+      expect(stepToggle(container).getAttribute("aria-disabled")).toBe("true");
+      await act(async () => stepToggle(container).click());
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe("true");
+      await render([{ ...initial, parts: [...initial.parts, bashPart("critical")] }], "ready");
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe("true");
+      expect(stepToggle(container).getAttribute("aria-disabled")).not.toBe("true");
+    });
+  });
+
+  test("keeps interactive connection results outside the fold across completion", async () => {
+    await mounted(async (container, render) => {
+      const app: DynamicToolUIPart = {
+        type: "dynamic-tool", toolName: "openwork-cloud_execute_capability", toolCallId: "connection-app",
+        state: "output-available", input: { name: "mcp:fixture:*" },
+        output: { schemaVersion: "1", connectionId: "fixture", connectionName: "Notes", state: "needs_connection",
+          actor: "member", message: "Connect Notes to continue.",
+          action: { type: "connect", label: "Connect Notes", surface: "openwork_your_connections" } },
+      };
+      const initial = longRun("interactive");
+      const next = { ...initial, parts: [...initial.parts, app] };
+      await render([next]);
+      const button = container.querySelector('button[aria-label="Connect Notes"]');
+      if (!button) throw new Error("Missing interactive app control");
+      expect(button.closest("[data-step-run]")).toBeNull();
+      await render([next], "ready");
+      expect(button.isConnected).toBe(true);
+      expect(stepToggle(container).getAttribute("aria-disabled")).toBe("true");
+    });
+  });
+
+  test("does not remount or hide an interactive iframe when its surrounding run settles", async () => {
+    let mounts = 0;
+    let unmounts = 0;
+    // Isolate the transport leaf: no resource resolution, sandbox or network.
+    // The real MessageList/MessageGroup still own this component's lifecycle.
+    function InteractiveFixture() {
+      useEffect(() => { mounts += 1; return () => { unmounts += 1; }; }, []);
+      return <iframe title="Fixture interactive view" />;
+    }
+    const frame = spyOn(mcpAppFrame, "McpAppFrame").mockImplementation(InteractiveFixture);
+    try {
+      await mounted(async (container, render) => {
+        const initial = longRun("frame-continuity");
+        const app: DynamicToolUIPart = {
+          type: "dynamic-tool", toolName: "fixture_render", toolCallId: "fixture-app",
+          state: "output-available", input: {}, output: {},
+          callProviderMetadata: { openwork: { mcpResult: { content: [], _meta: { "openwork/mcpApp": {
+            toolName: "fixture_render", resourceUri: "ui://fixture/view.html", arguments: {},
+          } } } } },
+        };
+        await render([{ ...initial, parts: [...initial.parts, app] }]);
+        const iframe = container.querySelector("iframe");
+        expect(iframe).not.toBeNull();
+        const next = { ...initial, parts: [...initial.parts, app, bashPart("after-app")] };
+        await render([next]);
+        await render([next], "ready");
+        expect(container.querySelector("iframe")).toBe(iframe);
+        expect(iframe?.closest("[data-step-run], [hidden]")).toBeNull();
+        expect(mounts).toBe(1);
+        expect(unmounts).toBe(0);
+      });
+      expect(unmounts).toBe(1);
+    } finally {
+      frame.mockRestore();
+    }
   });
 });

--- a/apps/app/tests/message-list-step-fold.test.tsx
+++ b/apps/app/tests/message-list-step-fold.test.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { afterAll, describe, expect, spyOn, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, useEffect } from "react";
 import { createRoot } from "react-dom/client";
@@ -15,6 +15,8 @@ if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
 const { MessageList } = await import("../src/components/chat/message-list");
 const { MessageListProvider } = await import("../src/components/chat/message-list-provider");
 const mcpAppFrame = await import("../src/components/chat/mcp-app-frame");
+const { useWorkbenchUiState, MAX_WORKBENCH_DISCLOSURES } = await import("../src/react-app/domains/session/chat/workbench-ui-state");
+beforeEach(() => useWorkbenchUiState.setState({ disclosures: new Map() }));
 afterAll(async () => { if (ownedDom) await GlobalRegistrator.unregister(); });
 
 function bashPart(id: string): DynamicToolUIPart {
@@ -58,12 +60,16 @@ function withoutWindow<T>(run: () => T): T {
   }
 }
 
-function list(messages: UIMessage[], status: ThreadStatus = "ready", highlightQuery = "") {
+type Owner = { workspaceId: string; sessionId: string; uiStateOwner: string };
+
+function list(messages: UIMessage[], status: ThreadStatus = "ready", highlightQuery = "", owner?: Owner) {
   return (
     <PlatformProvider value={createDefaultPlatform()}>
     <MessageListProvider
-      workspaceId="ws"
-      sessionId="session"
+      key={owner?.uiStateOwner}
+      workspaceId={owner?.workspaceId ?? "ws"}
+      sessionId={owner?.sessionId ?? "session"}
+      uiStateOwner={owner?.uiStateOwner}
       showThinking={true}
       highlightQuery={highlightQuery}
       developerMode={false}
@@ -175,15 +181,15 @@ describe("finished turn step fold (single OpenCode message per turn)", () => {
   });
 });
 
-async function mounted(run: (container: HTMLDivElement, render: (messages: UIMessage[], status?: ThreadStatus, query?: string) => Promise<void>) => Promise<void>) {
+async function mounted(run: (container: HTMLDivElement, render: (messages: UIMessage[], status?: ThreadStatus, query?: string, owner?: Owner) => Promise<void>) => Promise<void>) {
   const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
   Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
   try {
-    await run(container, async (messages, status = "streaming", query = "") => {
-      await act(async () => root.render(list([userMessage, ...messages], status, query)));
+    await run(container, async (messages, status = "streaming", query = "", owner) => {
+      await act(async () => root.render(list([userMessage, ...messages], status, query, owner)));
     });
   } finally {
     await act(async () => root.unmount());
@@ -207,6 +213,40 @@ function stepToggle(container: HTMLElement) {
 }
 
 describe("long-task reading continuity", () => {
+  test.each([false, true])("restores explicit shell choice %s after A-B-A, isolates owners, and survives mounted cache eviction", async (open) => {
+    await mounted(async (container, render) => {
+      const a = { workspaceId: "ws-a", sessionId: "shared", uiStateOwner: "server-a/ws-a/shared" };
+      const b = { workspaceId: "ws-b", sessionId: "shared", uiStateOwner: "server-b/ws-b/shared" };
+      const c = { workspaceId: "ws-a", sessionId: "other", uiStateOwner: "server-a/ws-a/other" };
+      const run = longRun("same-message-id");
+      const status = open ? "ready" : "streaming";
+      await render([run], status, "", a);
+      const firstShell = container.querySelector("[data-step-run]");
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe(String(!open));
+      await act(async () => stepToggle(container).click());
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe(String(open));
+      for (const other of [b, c]) {
+        await render([run], status, "", other);
+        expect(firstShell?.isConnected).toBe(false);
+        expect(stepToggle(container).getAttribute("aria-expanded")).toBe(String(!open));
+        await render([run], status, "", a);
+        expect(container.querySelector("[data-step-run]")).not.toBe(firstShell);
+        expect(stepToggle(container).getAttribute("aria-expanded")).toBe(String(open));
+      }
+      await render([longRun("same-message-id", 12)], "ready", "", a);
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe(String(open));
+      const currentShell = container.querySelector("[data-step-run]");
+      await act(async () => {
+        for (let index = 0; index <= MAX_WORKBENCH_DISCLOSURES; index++) {
+          useWorkbenchUiState.getState().setDisclosure(`eviction-${index}`, false);
+        }
+      });
+      expect(useWorkbenchUiState.getState().disclosures.size).toBe(MAX_WORKBENCH_DISCLOSURES);
+      expect(container.querySelector("[data-step-run]")).toBe(currentShell);
+      expect(stepToggle(container).getAttribute("aria-expanded")).toBe(String(open));
+    });
+  });
+
   test("keeps actual expanded tool/detail nodes and focus through the first answer, more events, and completion", async () => {
     await mounted(async (container, render) => {
       const completed = longRun("continuity");

--- a/apps/app/tests/session-scroll.test.tsx
+++ b/apps/app/tests/session-scroll.test.tsx
@@ -5,6 +5,9 @@ import { act, useCallback, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { SESSION_SCROLL_NAVIGATION_EVENT, useSessionScrollController } from "../src/react-app/domains/session/surface/scroll-controller";
 import { flushSessionScrollState, getSessionScrollState, readPersistedSessionScrollState, sessionScrollKey, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
+import { SessionScrollOverlay } from "../src/react-app/domains/session/surface/scroll-overlay";
+import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import { WorkspaceProvider } from "../src/react-app/shell/workspace-provider";
 
 const ownedDom = typeof window === "undefined";
 if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
@@ -33,6 +36,7 @@ beforeEach(() => {
     disconnect() {}
   });
   useSessionScrollStore.setState({ sessions: {} });
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
   flushSessionScrollState();
   localStorage.clear();
 });
@@ -62,6 +66,108 @@ function runFrames() {
   frames.clear();
   for (const callback of pending) callback(now);
 }
+
+describe("new output while reading", () => {
+  test("uses the secondary surface workspace despite a primary ancestor and resets unseen output on owner changes", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    cleanups.push(async () => { await act(async () => root.unmount()); host.remove(); });
+    const latest = mock(() => {});
+    const start = mock(() => {});
+    const render = async (owner = "secondary-owner") => {
+      await act(async () => root.render(
+        <WorkspaceProvider workspaceId="primary" client={null} selectedWorkspaceRoot="/primary">
+          <SessionScrollOverlay workspaceId="secondary" sessionId="shared-session" owner={owner} isStreaming onJumpToLatest={latest} onJumpToStartOfMessage={start} />
+        </WorkspaceProvider>,
+      ));
+    };
+    const progress = async (workspaceId: string, text: string) => {
+      now += 10;
+      await act(async () => useSessionActivityStore.getState().observeTranscript(workspaceId, "shared-session", [
+        { id: "answer", role: "assistant", parts: [{ type: "text", text, state: "streaming" }] },
+      ]));
+    };
+    for (const owner of ["secondary-owner", "replacement-owner"]) {
+      useSessionScrollStore.getState().setManualScroll(sessionScrollKey("shared-session", owner), 325, "reading");
+    }
+    await progress("secondary", "Initial secondary output");
+    await render();
+    const positions = useSessionScrollStore.getState().sessions;
+    expect(host.textContent).toContain("Jump to latest");
+    expect(host.textContent).not.toContain("New output");
+    await progress("primary", "Primary output with the same session ID");
+    expect(host.textContent).not.toContain("New output");
+    await progress("secondary", "Secondary output continues");
+    expect(host.querySelector('[role="status"]')?.textContent).toBe("New output");
+    await render("replacement-owner");
+    expect(host.textContent).not.toContain("New output");
+    await progress("primary", "More primary output");
+    expect(host.textContent).not.toContain("New output");
+    await progress("secondary", "More secondary output");
+    expect(host.querySelector('[role="status"]')?.textContent).toBe("New output");
+    expect(useSessionScrollStore.getState().sessions).toBe(positions);
+    expect(latest).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  test.each([false, true])("badges real progress without scrolling; explicit navigation respects reduced motion (%s)", async (reducedMotion) => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    cleanups.push(async () => { await act(async () => root.unmount()); host.remove(); });
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    spyOn(window, "matchMedia").mockImplementation(() => ({ ...media, matches: reducedMotion }));
+    const latest = mock((_behavior?: ScrollBehavior) => {});
+    const start = mock((_behavior?: ScrollBehavior) => {});
+    const key = sessionScrollKey("a", "owner-a");
+    const render = async (streaming = true, owner = "owner-a", workspaceId = "ws") => {
+      await act(async () => root.render(
+        <WorkspaceProvider workspaceId={workspaceId} client={null} selectedWorkspaceRoot="/fixture">
+          <SessionScrollOverlay workspaceId={workspaceId} sessionId="a" owner={owner} isStreaming={streaming} onJumpToLatest={latest} onJumpToStartOfMessage={start} />
+        </WorkspaceProvider>,
+      ));
+    };
+    const progress = (text: string, workspace = "ws") => {
+      now += 10;
+      useSessionActivityStore.getState().observeTranscript(workspace, "a", [
+        { id: "answer", role: "assistant", parts: [{ type: "text", text, state: "streaming" }] },
+      ]);
+    };
+    progress("Initial output");
+    await render();
+    expect(host.textContent).not.toContain("New output");
+    await act(async () => useSessionScrollStore.getState().setManualScroll(key, 325, "reading", { messageId: "reading", offset: 25 }));
+    const position = state("a", "owner-a");
+    expect(host.textContent).toContain("Jump to latest");
+    expect(host.textContent).not.toContain("New output");
+    await act(async () => progress("Foreign output", "other-workspace"));
+    expect(host.textContent).not.toContain("New output");
+    await act(async () => progress("Initial output continues"));
+    expect(host.querySelector('[role="status"]')?.textContent).toBe("New output");
+    expect(latest).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+    expect(state("a", "owner-a")).toBe(position);
+    await render(false);
+    expect(host.textContent).toContain("New output");
+    const buttons = [...host.querySelectorAll("button")];
+    const latestButton = buttons.find((button) => button.textContent?.startsWith("Jump to latest"));
+    const startButton = buttons.find((button) => button.textContent === "Jump to start");
+    if (!latestButton || !startButton) throw new Error("Missing explicit scroll controls");
+    await act(async () => { latestButton.click(); startButton.click(); });
+    expect(latest).toHaveBeenCalledWith(reducedMotion ? "instant" : "smooth");
+    expect(start).toHaveBeenCalledWith(reducedMotion ? "instant" : "smooth");
+    await act(async () => useSessionScrollStore.getState().setStickyBottom(key, null));
+    await act(async () => useSessionScrollStore.getState().setManualScroll(key, 325, "reading"));
+    expect(host.textContent).not.toContain("New output");
+    await render(true);
+    await act(async () => progress("Another output"));
+    expect(host.textContent).toContain("New output");
+    await render(true, "owner-b", "other-workspace");
+    expect(host.textContent).not.toContain("New output");
+    expect(latest).toHaveBeenCalledTimes(1);
+  });
+});
 
 function observeStorageWrites() {
   const storage = window.localStorage;


### PR DESCRIPTION
## Dependency and merge order

**Stacked on #4856 (`fix/conversation-layout-continuity`).** This PR consumes its bounded owner-scoped disclosure hook; merge #4856 first. This diff contains only the long-task increment. After the base lands, refresh this branch/base and obtain new exact-head proof.

## Summary

Task completion should not collapse a detail being read or reset stateful tool content.

- Keep a stable step shell through live updates and completion, with an honest activity/step summary and user-controlled disclosure.
- Split at the stable first-prose boundary rather than moving existing tools when later narration arrives.
- Retain explicit step-shell choices across visits through the shared disclosure hook; preserve stable reasoning/tool keys and owner isolation.
- Keep active tools, errors, and potentially interactive unknown tools visible. Native and in-app Find can reveal folded content without erasing the reader's preference.
- Add New output beside Jump to latest for a manual reader, without automatic navigation. Use the pane's explicit workspace identity and respect reduced motion for explicit jumps.

The full history remains available and folded content remains mounted. This is not moving-tail virtualization or a DOM/memory bound. Existing aggregate row limits remain; no fabricated progress percentage or time remaining is shown.

## Verification

Candidate: `de6bc5d7229a4436f9aea01fef5142ecd61487ae`, based on disclosure foundation `457793018133b785a097a2e8be4b90fd53fa4b76`. Both incremental commits have verified signatures.

From `apps/app`:

```sh
pnpm --config.verify-deps-before-run=never exec bun test --isolate ./tests/message-list-step-fold.test.tsx ./tests/session-scroll.test.tsx ./tests/message-list-loading.test.tsx ./tests/chat-message-grouping.test.ts ./tests/find-bar.test.tsx ./tests/workbench-continuity.test.tsx ./tests/workbench-store.test.ts
pnpm --config.verify-deps-before-run=never typecheck
```

**105 passed, 0 failed, 0 skipped**, 637 assertions; typecheck and whitespace checks passed.

Coverage includes mounted detail/focus continuity, first-answer/later-prose transitions, explicit open/closed restoration, owner isolation/eviction, Find, critical tool visibility, cross-workspace badge isolation, and reduced-motion behavior.

Supplementary combined five-change checking passed 149 tests and typecheck. It is not an immutable-head runtime result.

## Proof verdict: Incomplete

No exact-head real-app testkit evidence, native anchoring, input latency, live sandbox, or sustained-memory measurements. Runtime owner: `streamed-markdown-answer`, with the split journey for cross-workspace behavior. Component iframe coverage isolates the transport leaf; it does not validate a live sandbox. Non-failing fixture warnings remain.

Markdown finalization and internal tool-detail transitions remain outside this shell fix. Required CI is unchanged.
