### PR TITLE
fix(app): stop persisting hero keystrokes to the new-task draft slot once a send is in flight

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowRight, X, Zap } from "lucide-react";
 
 import { DEFAULT_MODEL } from "@/app/constants";
@@ -82,9 +82,17 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
   // draft owner, so the initial read is the only hydration needed.
   const persistedDraft = useNewTaskDraftState(props.composer?.draftScope, props.composer?.workspaceId);
   const [prompt, setPromptState] = useState(() => persistedDraft.snapshot?.text ?? "");
+  const promptRef = useRef(prompt);
+  // Once a send is in flight the composer has cleared the slot, and anything
+  // typed until its route lands is carried into the created session as the
+  // continuation. Persisting it here would pre-fill the next new task. On
+  // success this hero unmounts, so the flag only resets when the send fails.
+  const sendInFlightRef = useRef(false);
   const persistPrompt = persistedDraft.save;
   const setPrompt = useCallback((value: string) => {
     setPromptState(value);
+    promptRef.current = value;
+    if (sendInFlightRef.current) return;
     // Attachment chips only exist in memory (File objects); the stored text drops their tokens.
     persistPrompt({ text: persistableComposerDraftText(value), mode: "prompt" });
   }, [persistPrompt]);
@@ -138,14 +146,23 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     })
     : DEFAULT_SUGGESTIONS;
 
-  const submit = (
+  const submit = async (
     resolvedPrompt: string,
     attachments: ComposerAttachment[],
     handoff?: NewTaskComposerHandoff,
   ) => {
     const trimmedPrompt = resolvedPrompt.trim();
     if ((!trimmedPrompt && !attachments.length) || props.busy) return;
-    return props.onRunTask(trimmedPrompt, attachments, handoff);
+    sendInFlightRef.current = true;
+    try {
+      await props.onRunTask(trimmedPrompt, attachments, handoff);
+    } catch (error) {
+      // The composer stays on this route, so whatever it holds now is once
+      // again the unsent new-task prompt and must stay reachable.
+      sendInFlightRef.current = false;
+      persistPrompt({ text: persistableComposerDraftText(promptRef.current), mode: "prompt" });
+      throw error;
+    }
   };
 
   const fillPrompt = (value: string) => {

--- a/apps/app/tests/new-task-draft-send-in-flight.test.tsx
+++ b/apps/app/tests/new-task-draft-send-in-flight.test.tsx
@@ -1,0 +1,201 @@
+/** @jsxImportSource react */
+import { afterAll, beforeAll, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { NewTaskComposerContext } from "../src/react-app/domains/session/chat/new-task-composer";
+
+const registeredDom = typeof globalThis.window === "undefined" || typeof globalThis.document === "undefined";
+
+// The real hero and NewTaskComposer run; only the Lexical editor is replaced by
+// a textarea so keystrokes and Run task can be driven under happy-dom. The
+// stub calls the same `onDraftChange` / `onSend` props Lexical would.
+type EditorStubProps = {
+  draft: string;
+  onDraftChange: (value: string) => void;
+  onSend: () => void;
+  submissionPreparing: boolean;
+};
+function ReactSessionComposer(props: EditorStubProps) {
+  return (
+    <div>
+      <textarea
+        data-testid="composer"
+        value={props.draft}
+        // happy-dom never reaches React's onChange; onInput does.
+        onInput={(event) => props.onDraftChange(event.currentTarget.value)}
+        readOnly
+      />
+      <button type="button" aria-label="Run task" disabled={props.submissionPreparing} onClick={props.onSend}>
+        Run task
+      </button>
+    </div>
+  );
+}
+mock.module("../src/react-app/domains/session/surface/composer/composer", () => ({ ReactSessionComposer }));
+
+beforeAll(() => {
+  if (registeredDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+});
+
+afterAll(async () => {
+  mock.restore();
+  if (registeredDom) await GlobalRegistrator.unregister();
+});
+
+const workspaceId = "ws_alpha";
+const draftScope = "local";
+
+function composerContext(): NewTaskComposerContext {
+  return {
+    client: null,
+    workspaceId,
+    draftOwnerKey: `owner:${workspaceId}`,
+    draftScope,
+    selectedModel: { providerID: "test", modelID: "test-model" },
+    modelPickerOpen: false,
+    onModelPickerOpenChange: () => {},
+    onModelChange: () => {},
+    modelVariantLabel: "Default",
+    modelVariant: null,
+    onModelVariantChange: () => {},
+    agentLabel: "OpenWork",
+    selectedAgent: null,
+    listAgents: async () => [],
+    onSelectAgent: () => {},
+    listCommands: async () => [],
+    searchFiles: async () => [],
+    isRemoteWorkspace: false,
+    isSandboxWorkspace: false,
+  };
+}
+
+test("keystrokes typed while a new-task send is in flight do not pre-fill the next New task composer", async () => {
+  window.localStorage.clear();
+  const [
+    { SessionEmptyHero },
+    { NEW_TASK_DRAFT_SESSION_ID, getSessionDraft },
+    { DenAuthProvider },
+    { DesktopConfigProvider },
+    { LocalProvider },
+    { ShellConfigProvider },
+    { PlatformProvider, createDefaultPlatform },
+  ] = await Promise.all([
+    import("../src/react-app/domains/session/chat/session-empty-hero"),
+    import("../src/react-app/domains/session/sync/draft-store"),
+    import("../src/react-app/domains/cloud/den-auth-provider"),
+    import("../src/react-app/domains/cloud/desktop-config-provider"),
+    import("../src/react-app/kernel/local-provider"),
+    import("../src/react-app/shell/shell-config"),
+    import("../src/react-app/kernel/platform"),
+  ]);
+  const slot = () => getSessionDraft(draftScope, workspaceId, NEW_TASK_DRAFT_SESSION_ID)?.text ?? null;
+
+  // The route owns this: it shows the hero while there is no session and
+  // swaps to the created session's surface once its route lands.
+  let creation = Promise.withResolvers<void>();
+  let creations = 0;
+  let setRouteState = (_state: "hero" | "session") => {};
+  function Route() {
+    const [state, setState] = useState<"hero" | "session">("hero");
+    setRouteState = setState;
+    if (state === "session") return <div data-testid="session-surface" />;
+    return (
+      <SessionEmptyHero
+        key={composerContext().draftOwnerKey}
+        providerCount={1}
+        composer={composerContext()}
+        onRunTask={() => {
+          creations += 1;
+          return creation.promise;
+        }}
+      />
+    );
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  const tree = (
+    <PlatformProvider value={createDefaultPlatform()}>
+      <DenAuthProvider>
+        <DesktopConfigProvider>
+          <LocalProvider>
+            <ShellConfigProvider>
+              <Route />
+            </ShellConfigProvider>
+          </LocalProvider>
+        </DesktopConfigProvider>
+      </DenAuthProvider>
+    </PlatformProvider>
+  );
+  const composer = () => {
+    const node = container.querySelector<HTMLTextAreaElement>('[data-testid="composer"]');
+    if (!node) throw new Error("Expected the new-task composer");
+    return node;
+  };
+  const type = async (text: string) => {
+    await act(async () => {
+      const node = composer();
+      // React reads the DOM value on change; mirror what a keystroke leaves behind.
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set?.call(node, text);
+      node.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    });
+  };
+  const runTask = async () => {
+    await act(async () => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Run task"]');
+      if (!button || button.disabled) throw new Error("Expected an enabled Run task button");
+      button.click();
+    });
+  };
+
+  try {
+    await act(async () => root.render(tree));
+
+    // #4796: an unsent prompt is persisted so it survives navigation.
+    await type("Summarize the deploy checklist");
+    expect(composer().value).toBe("Summarize the deploy checklist");
+    expect(slot()).toBe("Summarize the deploy checklist");
+
+    // Send: the composer clears and session creation is pending.
+    await runTask();
+    expect(creations).toBe(1);
+    expect(composer().value).toBe("");
+    expect(slot()).toBeNull();
+
+    // Typing while creation is pending belongs to the created session (it is
+    // carried over as the continuation), not to the workspace's new-task slot.
+    await type("and also check the rollback plan");
+    expect(composer().value).toBe("and also check the rollback plan");
+
+    // The created session's route lands and the hero unmounts.
+    await act(async () => creation.resolve());
+    await act(async () => setRouteState("session"));
+    expect(container.querySelector('[data-testid="session-surface"]')).not.toBeNull();
+
+    // Opening New task again must show an empty composer; the slot that feeds
+    // the sidebar Draft row must be empty too.
+    await act(async () => setRouteState("hero"));
+    expect(composer().value).toBe("");
+    expect(slot()).toBeNull();
+
+    // A failed send keeps #4796's promise: whatever is in the composer is
+    // once again the unsent new-task prompt and stays reachable.
+    creation = Promise.withResolvers<void>();
+    await type("Retry this one");
+    expect(slot()).toBe("Retry this one");
+    await runTask();
+    expect(creations).toBe(2);
+    expect(slot()).toBeNull();
+    await type("typed during the failing send");
+    expect(slot()).toBeNull();
+    await act(async () => creation.reject(new Error("Session creation failed")));
+    expect(composer().value).toBe("typed during the failing send");
+    expect(slot()).toBe("typed during the failing send");
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+  }
+});


### PR DESCRIPTION
## Root cause

Regression from #4796 (`e925c7c99`), flagged by the E2E risk gate as a new class (c) product regression on `dev` (`workspace-new-task-hit-target` — "Keep new tasks and sends instantly responsive" — red vs the last 3 nightlies at `2fcbae60e` and `3f783066f`, run 34519630856; gate table: `/Users/guillaume/OpenWork Chat/reports/e2e-gate-baseline-2026-09-10.md`).

#4796 made `SessionEmptyHero` persist every `onDraftChange` into the per-workspace `__new-task__` draft slot so an unsent prompt survives opening another session. `NewTaskComposer.handleRunTask` clears the draft (`onDraftChange("")`, which empties the slot) and then `await`s session creation while the composer stays live. Anything typed during that pending window flows through the same `onDraftChange` → hero `setPrompt` → **persisted into `__new-task__`**, even though that text is already carried into the created session as the continuation. The next New task hero hydrates from the slot and comes up pre-filled.

Gate signature (run 34519630856 at `3f783066f`): sample 2 `insertFocusedText` → `Error: Focused composer did not retain native insertText` at `workspace-new-task-hit-target.e2e.test.ts:336` — the hero already contained `INSTANT-PENDING-DRAFT-B-…` from sample 1, so the caret sat before it.

## What changed

`apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx` (+20/−3):

- The hero tracks a send in flight (`sendInFlightRef`). While set, `setPrompt` still updates local state but **no longer persists** to the `__new-task__` slot — those keystrokes belong to the created session (continuation), not to the next new task.
- If the send **fails**, the flag resets and the hero re-persists whatever the composer currently holds, so #4796's promise (an unsent prompt stays reachable via the sidebar Draft row) still holds after a failed creation. On success the hero unmounts when the created session's route lands; the flag is intentionally left set so a keystroke in the frame before unmount cannot resurrect the slot.

The brief's step (2) — an explicit clear when the created session's route lands — turned out to be redundant: the composer already empties the slot synchronously at send time (`onDraftChange("")`) and, with (1), nothing writes it afterwards while the send is pending. I left it out to keep the diff minimal; happy to add it as belt-and-braces if preferred.

`apps/app/tests/new-task-draft-send-in-flight.test.tsx` (new): real `SessionEmptyHero` + real `NewTaskComposer` with only the Lexical editor stubbed by a textarea. Type → Run task (creation pending) → type while pending → resolve, route lands (hero unmounts) → reopen New task → composer and slot must be empty; then a failing send must re-persist the typed text.

## Proof

**Unit / types**
- New test on unmodified code: `Expected: "" / Received: "and also check the rollback plan"` (red, commit `5f2d534d7`); green with the fix (`69c17c524`).
- `bun test --isolate tests/new-task-draft-send-in-flight.test.tsx tests/new-task-draft-state.test.tsx` → 3 pass (#4796's own tests stay green).
- `pnpm --filter @openwork/app test:core` → 225 pass, 0 fail.
- `pnpm --filter @openwork/app typecheck` → clean.
- `pnpm --filter @openwork/app test` (full `bun test --isolate tests/`) **did not complete**: the runner stalls after `tests/opencode-session-native.test.ts` with no child process (reproduced twice, log silent >10 min) — unrelated to this diff, but I could not obtain a full-suite verdict. `tests/composer-focus-continuity.test.tsx` is red identically on unmodified code (`SyntaxError: Export named 'deleteNativeSession' not found` in bun's isolate loader) — pre-existing.

**E2E — `workspace-new-task-hit-target`**
This spec is a local-placement contract: `workspaceNewTask` throws `SkipError` unless `place.kind === "local"`, so `pnpm evals:e2e workspace-new-task-hit-target --daytona` skips by design (`skipped: 1`, `cli-run-1789074523605`). The gate runs it via the "Product journeys" workflow (`daytona-e2e.yml`, `--local` on a Linux runner), so I dispatched that workflow — the exact gate environment:

| ref | sha | run | result |
|---|---|---|---|
| `fix/new-task-draft-slot-leak` (this PR, on `origin/dev` @ `9a60a4b59`) | `69c17c524` | [34532482730](https://github.com/different-ai/openwork/actions/runs/34532482730) | **failed** at `:379` — `Timed out waiting for prompt request is held … held: 0` (auto-send of the first lazy send never fires; screenshot shows the created session with a `CancelledError` alert) |
| `proof/new-task-draft-slot-leak-on-3f78306` = gate sha `3f783066f` + these two commits (cherry-picked, signed) | `c29f789cf` | [34533114105](https://github.com/different-ai/openwork/actions/runs/34533114105) | **passed** |
| same | `c29f789cf` | [34535074872](https://github.com/different-ai/openwork/actions/runs/34535074872) | **passed** (2nd sequential run) |

The `:379` failure on this branch is **not** caused by this change: a clean control on my machine with source identical to `origin/dev` (`9a60a4b59`, fix reverted) fails identically at `:379`, and so does the fixed branch. Bisecting `3f783066f..9a60a4b59` with the same workflow (all failing at `:336` = the leak only, i.e. auto-send still fine, unless noted):

- `7f8008d58` (#4837) and its parent → `:336`
- `dd7fae8dd` (#4829) → `:336`
- `4462762b4` (#4838 `perf(chat): prioritize visible thread history and preserve scroll`) → **`:379`** ← first bad; the only commit in between (`e4e316d41`) is den-api docs
- `0d0b835ac`, `bf722d514` (#4777) → `:379`
- `505583fb7` (#4782) → `:455` (reload-transcript timeout, seen once — possibly flaky; not investigated)

So `dev` currently carries a **second, independent regression from #4838** that breaks the first lazy send's auto-send and masks this spec before it reaches the point this PR fixes. This PR fixes the #4796 leak (proven at the gate sha); the gate spec will stay red on `dev` until #4838's regression is addressed.

Local macOS runs of the spec (`--local`, both fixed and control) also fail at `:379`; evidence under `evals/results/test-runs/2026-09-10T21-11-34-087Z-…` (fixed), `…T21-22-08-292Z-…` (fixed, quiet machine) and `…T21-26-35-317Z-…` (control, unmodified source) (renderer diagnostic + screenshot with the `CancelledError`).

**E2E — #4796's behaviour** (`evals/specs/new-task-draft-return.e2e.test.ts`, appWeb)
- `OPENWORK_EVAL_REF=69c17c524 pnpm evals:e2e new-task-draft-return --daytona` → **2 passed, 0 skipped** (both sandboxes auto-deleted).

## Noticed but not touched

- **#4838 regression** (above): first lazy send in a fresh session never issues its prompt request (`CancelledError` in the session surface); breaks `workspace-new-task-hit-target` on `dev` independently of this PR. Likely interacts with #4837's new `submitImmediateSessionTurn(..., snapshot?.messages, …)` in `sendDraft`.
- `bun test --isolate tests/` stalls after `opencode-session-native.test.ts` on macOS (parent process idles with no child).
- `composer-focus-continuity.test.tsx` pre-existing red under bun isolate (`deleteNativeSession` export cycle).
- Throwaway branch `proof/new-task-draft-slot-leak-on-3f78306` is kept only as the referent of the two green runs; delete after review. Bisect branches were deleted.
