### PR TITLE
fix(apps): bind actions to the originating conversation

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -457,6 +457,8 @@ export type OpenworkMcpItem = {
 };
 
 export type OpenworkMcpAppResource = {
+  /** Opaque, short-lived host context. Absent on generated previews and older servers. */
+  launchId?: string;
   serverName: string;
   toolName: string;
   resourceUri: string;
@@ -1991,6 +1993,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       workspaceId: string,
       projectedToolName: string,
       launch?: OpenworkMcpAppLaunchReference,
+      context?: { sessionId: string | null; readOnly: boolean; engine?: "v1" | "v2" },
     ) =>
       requestJson<{ app: OpenworkMcpAppResource | null }>(
         baseUrl,
@@ -1999,7 +2002,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
           token,
           hostToken,
           method: "POST",
-          body: { projectedToolName, ...(launch ? { launch } : {}) },
+          body: { projectedToolName, ...(launch ? { launch } : {}), ...(context ? { context: { sessionId: context.sessionId, readOnly: context.readOnly, engine: context.engine } } : {}) },
           timeoutMs: timeouts.config,
         },
       ),
@@ -2015,6 +2018,9 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     callMcpAppTool: (
       workspaceId: string,
       payload: {
+        launchId?: string;
+        sessionId?: string | null;
+        engine?: "v1" | "v2";
         serverName: string;
         name: string;
         resourceUri: string;
@@ -2031,6 +2037,10 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         body: payload,
         timeoutMs: timeouts.binary,
       },
+    ),
+    releaseMcpApp: (workspaceId: string, launchId: string) => requestJson<{ released: boolean }>(
+      baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp-apps/release`,
+      { token, hostToken, method: "POST", body: { launchId } },
     ),
     getOpenworkCloudMcpHealth: (
       workspaceId: string,

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type { DynamicToolUIPart } from "ai"
 import { AppBridge, PostMessageTransport } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { McpUiStyles, McpUiStyleVariableKey } from "@modelcontextprotocol/ext-apps"
@@ -18,7 +18,8 @@ import {
   type OpenworkMcpAppResource,
   type OpenworkMcpAppToolResult,
 } from "@/app/lib/openwork-server"
-import { useWorkspace } from "@/react-app/shell/workspace-provider"
+import { useMessageList } from "./message-list-provider"
+import { createMcpAppActions, type McpAppOrigin } from "./mcp-app-origin"
 import { cn } from "@/lib/utils"
 import {
   formatMcpAppDiagnostic,
@@ -246,6 +247,7 @@ export function McpAppDiagnosticNotice({ error, notice }: { error: McpAppDiagnos
 }
 
 export type McpAppSandboxViewProps = {
+  origin: McpAppOrigin
   app: OpenworkMcpAppResource
   /** Tool name used for host diagnostics and the iframe title. */
   toolName: string
@@ -260,8 +262,6 @@ export type McpAppSandboxViewProps = {
   initialHeight?: number
   /** Reports app-requested size changes so a host can persist them past this view's lifetime. */
   onHeightChange?: (height: number) => void
-  /** Generated result views cannot call tools or open links. */
-  readOnly?: boolean
 }
 
 /**
@@ -269,8 +269,10 @@ export type McpAppSandboxViewProps = {
  * bridges it to the workspace MCP App host. Chat messages and dashboard tiles
  * share this exact pipeline so rendering and diagnostics stay identical.
  */
-export function McpAppSandboxView({ app, toolName, inputArguments, result, unavailableNotice, onRequestTeardown, initialHeight, onHeightChange, readOnly = false }: McpAppSandboxViewProps) {
-  const { openworkServerClient, workspaceId } = useWorkspace()
+export function McpAppSandboxView({ origin, app, toolName, inputArguments, result, unavailableNotice, onRequestTeardown, initialHeight, onHeightChange }: McpAppSandboxViewProps) {
+  const openworkServerClient = origin.client
+  const workspaceId = origin.workspaceId
+  const readOnly = origin.readOnly
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [height, setHeightState] = useState(initialHeight ?? DEFAULT_HEIGHT)
   const [error, setError] = useState<McpAppDiagnostic | null>(null)
@@ -283,10 +285,11 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
     onHeightChangeRef.current?.(next)
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const iframe = iframeRef.current
     if (!iframe || !iframe.contentWindow || !openworkServerClient || !workspaceId) return
     let disposed = false
+    const actions = createMcpAppActions(origin, app, (message) => window.confirm(message))
     let lastSizeEventAt = 0
     const startedAt = performance.now()
     const checkpoints: string[] = []
@@ -302,6 +305,7 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
     ) => {
       if (disposed || failed) return
       failed = true
+      actions.dispose()
       const diagnostic: McpAppDiagnostic = {
         code,
         stage,
@@ -317,6 +321,11 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
       setError(diagnostic)
     }
     checkpoint("resource-resolved")
+    if (!readOnly && !app.launchId) {
+      fail("MCP_APP_LAUNCH_CONTEXT_MISSING", "resource-resolution", null,
+        "This App has no live launch context. Update OpenWork and reopen the App before using its actions.")
+      return
+    }
     const sandbox = openworkServerClient.mcpAppSandbox(app, window.location.origin)
     if (sandbox.expectedOrigin === window.location.origin) {
       fail(
@@ -341,8 +350,8 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
       },
     )
     bridge.onopenlink = async ({ url }) => {
-      if (readOnly) return { isError: true }
       try {
+        actions.assertActive()
         await openDesktopUrl(url)
         return {}
       } catch (cause) {
@@ -390,18 +399,17 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
       }, SIZE_EVENT_INTERVAL_MS)
     }
     bridge.onrequestteardown = () => {
+      actions.dispose()
       teardownRef.current?.()
     }
     bridge.oncalltool = async ({ name, arguments: args }) => {
-      if (readOnly) throw new Error("This app displays results and cannot call tools.")
-      const request = { serverName: app.serverName, name, resourceUri: app.resourceUri, arguments: args }
       try {
-        return mcpToolResult(await openworkServerClient.callMcpAppTool(workspaceId, request))
+        return mcpToolResult(await actions.callTool(name, args))
       } catch (cause) {
-        if (!(cause instanceof OpenworkServerError) || cause.code !== "tool_requires_approval") throw cause
-        const approved = window.confirm(`Allow this MCP App to call ${name} on ${app.serverName}?`)
-        if (!approved) throw new Error("The user declined the MCP App tool call.")
-        return mcpToolResult(await openworkServerClient.callMcpAppTool(workspaceId, { ...request, approved: true }))
+        if (cause instanceof OpenworkServerError && ["missing_launch_context", "stale_launch_context", "inactive_session"].includes(cause.code)) {
+          fail("MCP_APP_LAUNCH_CONTEXT_STALE", "resource-resolution", cause, "Reopen the App in its original conversation before trying again.")
+        }
+        throw cause
       }
     }
     bridge.oninitialized = () => {
@@ -543,6 +551,7 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
 
     return () => {
       disposed = true
+      actions.dispose()
       window.removeEventListener("message", handleSandboxDiagnosticMessage)
       window.removeEventListener("message", handleSandboxReady)
       window.clearTimeout(sandboxReadyTimer)
@@ -554,7 +563,7 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
         new Promise<void>((resolve) => window.setTimeout(resolve, 500)),
       ]).catch(() => undefined).finally(() => bridge.close().catch(() => undefined))
     }
-  }, [app, inputArguments, openworkServerClient, result, toolName, workspaceId, readOnly])
+  }, [app, inputArguments, openworkServerClient, result, toolName, workspaceId, readOnly, origin])
 
   if (error) return <McpAppDiagnosticNotice error={error} notice={unavailableNotice} />
   return (
@@ -593,7 +602,9 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
 }
 
 function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
-  const { openworkServerClient, workspaceId } = useWorkspace()
+  const { mcpAppOrigin: origin } = useMessageList()
+  const openworkServerClient = origin?.client
+  const workspaceId = origin?.workspaceId
   const nextResult = preservedResult(part)
   const nextResultSignature = JSON.stringify(nextResult)
   const resultCache = useRef<{ signature: string; value: PreservedMcpAppResult | null }>({
@@ -621,20 +632,31 @@ function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
     () => launch?.arguments ?? (isRecord(part.input) ? part.input : {}),
     [launch, part.input],
   )
+  // Retire the old view in the same commit, before the passive resolution effect runs.
+  const resolution = useMemo(() => ({}), [origin, part.toolName, part.toolCallId, result, inputArguments])
+  const resolvedFor = useRef<object | null>(null)
 
   useEffect(() => {
     let cancelled = false
+    let launchId: string | undefined
+    const release = () => {
+      if (launchId && openworkServerClient && workspaceId) {
+        void openworkServerClient.releaseMcpApp(workspaceId, launchId).catch(() => undefined)
+      }
+    }
     setApp(null)
     setError(null)
     if (draft || !result || !openworkServerClient || !workspaceId) return () => { cancelled = true }
     const startedAt = performance.now()
-    void openworkServerClient.resolveMcpApp(workspaceId, part.toolName, launch ?? undefined)
+    void openworkServerClient.resolveMcpApp(workspaceId, part.toolName, launch ?? undefined, origin ?? undefined)
       .then(({ app: resolved }) => {
-        if (cancelled) return
+        launchId = resolved?.launchId
+        if (cancelled) { release(); return }
         // A preserved MCP result is neutral transport data. A null resolution
         // means the current tool definition does not advertise an MCP App, so
         // ordinary tools such as save_artifact_view render only their normal
         // result without claiming an unavailable interactive view.
+        resolvedFor.current = resolution
         setApp(resolved)
       })
       .catch((cause) => {
@@ -652,8 +674,8 @@ function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
           setError(diagnostic)
         }
       })
-    return () => { cancelled = true }
-  }, [draft, launch, openworkServerClient, part.toolName, result, workspaceId])
+    return () => { cancelled = true; release() }
+  }, [draft, launch, openworkServerClient, part.toolName, result, workspaceId, origin, resolution])
 
   // A completed build opens a native artifact tab. Rendering still goes
   // through the authorized Apps API and the shared sandbox inside that tab.
@@ -666,17 +688,22 @@ function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
     const receiptId = isRecord(artifact) && typeof artifact.receiptId === "string" ? artifact.receiptId : undefined
     return <AppChatArtifact key={`${viewId}:${revisionId}:${receiptId}`} appId={viewId} revisionId={revisionId} title={title} receiptId={receiptId} />
   }
-  if (!result || (!app && !error)) return null
+  if (!result) return null
+  if (!origin) return <p role="status">This App is missing its conversation origin. Reopen the conversation to use it.</p>
   if (error) return <McpAppDiagnosticNotice error={error} notice={CHAT_MCP_APP_UNAVAILABLE_NOTICE} />
-  if (!app) return null
+  if (!app || resolvedFor.current !== resolution) return null
   return (
     <McpAppSandboxView
+      origin={origin}
       app={app}
       toolName={part.toolName}
       inputArguments={inputArguments}
       result={result}
       unavailableNotice={CHAT_MCP_APP_UNAVAILABLE_NOTICE}
-      onRequestTeardown={() => setApp(null)}
+      onRequestTeardown={() => {
+        if (app.launchId) void origin.client.releaseMcpApp(origin.workspaceId, app.launchId).catch(() => undefined)
+        setApp(null)
+      }}
       initialHeight={heightRef.current}
       onHeightChange={(next) => { heightRef.current = next }}
     />

--- a/apps/app/src/components/chat/mcp-app-origin.ts
+++ b/apps/app/src/components/chat/mcp-app-origin.ts
@@ -1,0 +1,50 @@
+import { OpenworkServerError, type OpenworkMcpAppResource, type OpenworkServerClient } from "@/app/lib/openwork-server";
+
+/** The host surface owns this value. Never derive it from the selected workspace or App HTML. */
+export type McpAppOrigin = {
+  client: OpenworkServerClient;
+  workspaceId: string;
+  sessionId: string | null;
+  engine?: "v1" | "v2";
+  readOnly: boolean;
+};
+
+/** One bridge lifetime, including any approval that is still waiting when it closes. */
+export function createMcpAppActions(origin: McpAppOrigin, app: OpenworkMcpAppResource, confirm: (message: string) => boolean | Promise<boolean>) {
+  let active = true;
+  const assertActive = () => {
+    if (!active) throw new Error("This App view has closed or changed. Reopen it before using its actions.");
+    if (origin.readOnly) throw new Error("This view is read-only and cannot perform App actions.");
+    if (!app.launchId) throw new Error("This App has no live launch context. Update OpenWork and reopen the App.");
+  };
+  return {
+    dispose: () => { active = false; },
+    assertActive,
+    callTool: async (name: string, args?: Record<string, unknown>) => {
+      assertActive();
+      const request = {
+        launchId: app.launchId,
+        sessionId: origin.sessionId,
+        ...(origin.engine ? { engine: origin.engine } : {}),
+        serverName: app.serverName,
+        resourceUri: app.resourceUri,
+        name,
+        arguments: args,
+      };
+      try {
+        const result = await origin.client.callMcpAppTool(origin.workspaceId, request);
+        assertActive();
+        return result;
+      } catch (cause) {
+        assertActive();
+        if (!(cause instanceof OpenworkServerError) || cause.code !== "tool_requires_approval") throw cause;
+        const approved = await confirm(`Allow this MCP App to call ${name} on ${app.serverName}?`);
+        assertActive();
+        if (!approved) throw new Error("The user declined the MCP App tool call.");
+        const result = await origin.client.callMcpAppTool(origin.workspaceId, { ...request, approved: true });
+        assertActive();
+        return result;
+      }
+    },
+  };
+}

--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -8,8 +8,11 @@ import type {
 } from "@/components/tools/error-attribution"
 import * as React from "react"
 import type { ConnectorToolIdentity } from "@/react-app/domains/connections/connector-tool-identity"
+import type { OpenworkServerClient } from "@/app/lib/openwork-server"
+import type { McpAppOrigin } from "./mcp-app-origin"
 
 interface MessageListContextValue {
+  mcpAppOrigin: McpAppOrigin | null
   readOnly: boolean
   workspaceId: string
   sessionId: string
@@ -47,6 +50,8 @@ interface MessageListContextValue {
 const MessageListContext = React.createContext<MessageListContextValue | null>(null)
 
 interface MessageListProviderProps {
+  client?: OpenworkServerClient
+  mcpAppEngine?: "v1" | "v2"
   readOnly?: boolean
   children: React.ReactNode
   workspaceId: string
@@ -82,6 +87,8 @@ export interface DispatchAction {
 }
 
 export function MessageListProvider({
+  client,
+  mcpAppEngine,
   readOnly = false,
   children,
   workspaceId,
@@ -162,8 +169,13 @@ export function MessageListProvider({
   }), [])
   const canOpenSubagentSession = Boolean(onOpenSubagentSession)
   const canResumeInterrupted = Boolean(onResumeInterrupted)
+  const mcpAppOrigin = React.useMemo<McpAppOrigin | null>(
+    () => client ? { client, workspaceId, sessionId, readOnly, ...(mcpAppEngine ? { engine: mcpAppEngine } : {}) } : null,
+    [client, workspaceId, sessionId, readOnly, mcpAppEngine],
+  )
   const value = React.useMemo(
     () => ({
+      mcpAppOrigin,
       readOnly,
       workspaceId,
       sessionId,
@@ -185,6 +197,7 @@ export function MessageListProvider({
         : undefined,
     }),
     [
+      mcpAppOrigin,
       readOnly,
       workspaceId,
       sessionId,

--- a/apps/app/src/react-app/domains/apps/generated-app-preview.tsx
+++ b/apps/app/src/react-app/domains/apps/generated-app-preview.tsx
@@ -22,10 +22,13 @@ export function GeneratedAppPreview({ html, payload, title, revision }: {
     prefersBorder: true,
   }), [html, revision]);
   const result = useMemo(() => ({ content: [], structuredContent: payload }), [payload]);
-  if (!openworkServerClient || !workspaceId) {
+  const origin = useMemo(() => openworkServerClient
+    ? { client: openworkServerClient, workspaceId, sessionId: null, readOnly: true }
+    : null, [openworkServerClient, workspaceId]);
+  if (!origin || !workspaceId) {
     return <p role="status" className="text-sm text-muted-foreground">Connect a workspace to open the preview.</p>;
   }
-  return <McpAppSandboxView app={resource} toolName={title} inputArguments={PREVIEW_ARGUMENTS}
+  return <McpAppSandboxView origin={origin} app={resource} toolName={title} inputArguments={PREVIEW_ARGUMENTS}
     result={result} unavailableNotice="This app could not open. Try reopening it, or ask OpenWork to fix the preview."
-    initialHeight={360} readOnly />;
+    initialHeight={360} />;
 }

--- a/apps/app/src/react-app/domains/dashboard/dashboard-tile-cache.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-tile-cache.ts
@@ -128,7 +128,8 @@ export function writeDashboardTileCache(
     const raw = window.localStorage.getItem(scopeKey);
     const parsed: unknown = raw === null ? {} : JSON.parse(raw);
     const next: Record<string, unknown> = isRecord(parsed) ? { ...parsed } : {};
-    next[entryId] = cache;
+    // A live host lease must not survive in persisted HTML/result caches.
+    next[entryId] = { ...cache, app: parseApp(cache.app) };
 
     const entries = Object.entries(next).sort((left, right) => {
       const leftAt = isRecord(left[1]) && typeof left[1].cachedAt === "number" ? left[1].cachedAt : 0;

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Play } from "lucide-react";
 
 import {
@@ -10,7 +10,7 @@ import {
 import { McpAppSandboxView, type PreservedMcpAppResult } from "@/components/chat/mcp-app-frame";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useWorkspace, WorkspaceProvider } from "@/react-app/shell/workspace-provider";
+import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { DashboardTileShell } from "./dashboard-tile-shell";
 import {
   DASHBOARD_AUTO_REFRESH_INTERVAL_MS,
@@ -120,7 +120,7 @@ export function McpAppTile({
     ...(openworkServerClient && workspaceId ? [{ client: openworkServerClient, workspaceId }] : []),
     ...(fallbackEndpoints ?? []),
   ].filter((endpoint, index, all) => (
-    all.findIndex((other) => other.workspaceId === endpoint.workspaceId) === index
+    all.findIndex((other) => other.workspaceId === endpoint.workspaceId && other.client === endpoint.client) === index
   )), [fallbackEndpoints, openworkServerClient, workspaceId]);
   // Cached app HTML is interactive, so it follows the same per-user launch
   // consent as a live call and never mounts on a first visit.
@@ -155,6 +155,16 @@ export function McpAppTile({
   // reuses the same in-flight promise; a null promise marks a settled nonce so
   // later re-renders cannot repeat an already-executed data-modifying call.
   const launchRef = useRef<{ nonce: number; promise: Promise<TileState> | null } | null>(null);
+  const lifetime = useMemo(() => ({ active: true }), [cacheScopeKey, entry.id, entry.projectedToolName, launchArguments, launchEndpoints]);
+  const ownedLaunches = useRef(new Map<string, DashboardLaunchEndpoint>());
+  const releaseLaunches = () => {
+    for (const [id, endpoint] of ownedLaunches.current) void endpoint.client.releaseMcpApp(endpoint.workspaceId, id).catch(() => undefined);
+    ownedLaunches.current.clear();
+  };
+  useLayoutEffect(() => {
+    lifetime.active = true;
+    return () => { lifetime.active = false; releaseLaunches(); };
+  }, [lifetime]);
 
   useEffect(() => {
     let cancelled = false;
@@ -180,6 +190,9 @@ export function McpAppTile({
       return;
     }
     const userInitiated = userInitiatedNonceRef.current === nonce;
+    const assertActive = () => {
+      if (!lifetime.active || launchRef.current?.nonce !== nonce) throw new Error("This App launch has closed or changed. Run the tile again.");
+    };
     const promise = currentLaunch?.promise ?? (async (): Promise<TileState> => {
       // Connect app-host apps resolve through their connection reference; the
       // host revalidates the live UI binding before returning the resource.
@@ -195,8 +208,13 @@ export function McpAppTile({
       let resolveFailure: unknown = null;
       for (const endpoint of candidates) {
         try {
-          const { app } = await endpoint.client.resolveMcpApp(endpoint.workspaceId, entry.projectedToolName, launch);
+          const { app } = await endpoint.client.resolveMcpApp(endpoint.workspaceId, entry.projectedToolName, launch, { sessionId: null, readOnly: false });
+          if (!lifetime.active || launchRef.current?.nonce !== nonce) {
+            if (app?.launchId) void endpoint.client.releaseMcpApp(endpoint.workspaceId, app.launchId).catch(() => undefined);
+            assertActive();
+          }
           if (app) {
+            if (app.launchId) ownedLaunches.current.set(app.launchId, endpoint);
             resolved = { endpoint, app };
             break;
           }
@@ -209,7 +227,11 @@ export function McpAppTile({
         return { phase: "error", message: "This tool no longer advertises an interactive app." };
       }
       const { endpoint, app } = resolved;
+      assertActive();
+      if (!app.launchId) throw new Error("This App has no live launch context. Update OpenWork and run the tile again.");
       const request = {
+        launchId: app.launchId,
+        sessionId: null,
         serverName: app.serverName,
         name: app.toolName,
         resourceUri: app.resourceUri,
@@ -224,6 +246,7 @@ export function McpAppTile({
       try {
         result = await endpoint.client.callMcpAppTool(endpoint.workspaceId, request);
       } catch (cause) {
+        assertActive();
         if (!(cause instanceof OpenworkServerError) || cause.code !== "tool_requires_approval") throw cause;
         approvalWasRequired = true;
         // A stored entry can go stale: a tool that was read-only at add time
@@ -234,6 +257,7 @@ export function McpAppTile({
           `Allow this MCP App to call ${app.toolName} on ${app.serverName}? `
           + "OpenWork remembers your choice for this tile until you remove it.",
         );
+        assertActive();
         if (!approved) return { phase: "error", message: "The app launch was declined." };
         result = await endpoint.client.callMcpAppTool(endpoint.workspaceId, { ...request, approved: true });
         launchApprovedRef.current = true;
@@ -278,6 +302,11 @@ export function McpAppTile({
       .then((next) => {
         if (cancelled) return;
         if (next.phase === "ready") {
+          for (const [id, endpoint] of ownedLaunches.current) {
+            if (id === next.app.launchId) continue;
+            void endpoint.client.releaseMcpApp(endpoint.workspaceId, id).catch(() => undefined);
+            ownedLaunches.current.delete(id);
+          }
           writeDashboardTileCache(cacheScopeKey, entry.id, {
             cachedAt: next.cachedAt,
             workspaceId: next.endpoint.workspaceId,
@@ -321,7 +350,7 @@ export function McpAppTile({
     return () => {
       cancelled = true;
     };
-  }, [cacheScopeKey, entry.connectionId, entry.id, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, launchEndpoints, manualLaunch, nonce, started]);
+  }, [cacheScopeKey, entry.connectionId, entry.id, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, launchEndpoints, manualLaunch, nonce, started, lifetime]);
 
   useEffect(() => {
     if (manualLaunch) return;
@@ -353,8 +382,11 @@ export function McpAppTile({
   };
 
   const interactiveEndpoint = state.phase === "ready"
-    ? launchEndpoints.find((endpoint) => endpoint.workspaceId === state.endpoint.workspaceId) ?? null
+    ? launchEndpoints.find((endpoint) => endpoint.workspaceId === state.endpoint.workspaceId && endpoint.client === state.endpoint.client) ?? null
     : null;
+  const origin = useMemo(() => interactiveEndpoint
+    ? { ...interactiveEndpoint, sessionId: null, readOnly: state.phase !== "ready" || !state.app.launchId }
+    : null, [interactiveEndpoint, state]);
   const badge = (() => {
     if (state.phase === "ready" && !interactiveEndpoint) return "Saved locally · workspace unavailable";
     if (state.phase === "ready" && refreshState === "refreshing") return "Saved locally · refreshing";
@@ -423,25 +455,18 @@ export function McpAppTile({
         </p>
       ) : null}
       {state.phase === "ready" ? (
-        // The sandbox bridge calls tools through the workspace context, so the
-        // view only runs while that exact workspace endpoint is connected.
-        interactiveEndpoint ? <WorkspaceProvider
-          client={workspace.client}
-          opencodeBaseUrl={workspace.opencodeBaseUrl}
-          openworkServerClient={interactiveEndpoint.client}
-          workspaceId={interactiveEndpoint.workspaceId}
-          selectedWorkspaceRoot={workspace.selectedWorkspaceRoot}
-        >
+        origin ?
           <McpAppSandboxView
+            origin={origin}
             key={nonce}
             app={state.app}
             toolName={entry.projectedToolName}
             inputArguments={launchArguments}
             result={state.result}
             unavailableNotice="This app view is unavailable."
-            onRequestTeardown={() => setState({ phase: "closed" })}
+            onRequestTeardown={() => { releaseLaunches(); setState({ phase: "closed" }); }}
           />
-        </WorkspaceProvider> : (
+        : (
           <p className="pt-3 text-xs text-muted-foreground" role="status">
             This saved app view is unavailable until its workspace reconnects.
           </p>

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -42,6 +42,7 @@ type TileState =
       app: OpenworkMcpAppResource;
       result: PreservedMcpAppResult;
       endpoint: DashboardLaunchEndpoint;
+      lifetime?: { active: boolean };
       cachedAt: number;
       /** True only when the successful call did not need an approval override. */
       autoLaunchEligible?: boolean;
@@ -155,7 +156,8 @@ export function McpAppTile({
   // reuses the same in-flight promise; a null promise marks a settled nonce so
   // later re-renders cannot repeat an already-executed data-modifying call.
   const launchRef = useRef<{ nonce: number; promise: Promise<TileState> | null } | null>(null);
-  const lifetime = useMemo(() => ({ active: true }), [cacheScopeKey, entry.id, entry.projectedToolName, launchArguments, launchEndpoints]);
+  const lifetime = useMemo(() => ({ active: true }), [cacheScopeKey, entry.id, entry.projectedToolName, launchArguments, nonce]);
+  const endpointsRef = useRef(launchEndpoints);
   const ownedLaunches = useRef(new Map<string, DashboardLaunchEndpoint>());
   const releaseLaunches = () => {
     for (const [id, endpoint] of ownedLaunches.current) void endpoint.client.releaseMcpApp(endpoint.workspaceId, id).catch(() => undefined);
@@ -165,6 +167,16 @@ export function McpAppTile({
     lifetime.active = true;
     return () => { lifetime.active = false; releaseLaunches(); };
   }, [lifetime]);
+  useLayoutEffect(() => {
+    endpointsRef.current = launchEndpoints;
+    for (const [id, owner] of ownedLaunches.current) {
+      if (launchEndpoints.some(endpoint => endpoint.client === owner.client && endpoint.workspaceId === owner.workspaceId)) continue;
+      lifetime.active = false;
+      void owner.client.releaseMcpApp(owner.workspaceId, id).catch(() => undefined);
+      ownedLaunches.current.delete(id);
+      setState(current => current.phase === "ready" ? { ...current, app: { ...current.app, launchId: undefined } } : current);
+    }
+  }, [launchEndpoints, lifetime]);
 
   useEffect(() => {
     let cancelled = false;
@@ -213,6 +225,10 @@ export function McpAppTile({
             if (app?.launchId) void endpoint.client.releaseMcpApp(endpoint.workspaceId, app.launchId).catch(() => undefined);
             assertActive();
           }
+          if (!endpointsRef.current.some(current => current.client === endpoint.client && current.workspaceId === endpoint.workspaceId)) {
+            if (app?.launchId) void endpoint.client.releaseMcpApp(endpoint.workspaceId, app.launchId).catch(() => undefined);
+            continue;
+          }
           if (app) {
             if (app.launchId) ownedLaunches.current.set(app.launchId, endpoint);
             resolved = { endpoint, app };
@@ -260,10 +276,12 @@ export function McpAppTile({
         assertActive();
         if (!approved) return { phase: "error", message: "The app launch was declined." };
         result = await endpoint.client.callMcpAppTool(endpoint.workspaceId, { ...request, approved: true });
+        assertActive();
         launchApprovedRef.current = true;
         onApprovedLaunchRef.current?.();
         onAutoLaunchDisabledRef.current?.();
       }
+      assertActive();
       if (result.isError) {
         return {
           phase: "error",
@@ -277,6 +295,7 @@ export function McpAppTile({
         phase: "ready",
         app,
         endpoint,
+        lifetime,
         cachedAt: Date.now(),
         result: {
           content: result.content,
@@ -382,13 +401,15 @@ export function McpAppTile({
   };
 
   const interactiveEndpoint = state.phase === "ready"
-    ? launchEndpoints.find((endpoint) => endpoint.workspaceId === state.endpoint.workspaceId && endpoint.client === state.endpoint.client) ?? null
+    && launchEndpoints.some((endpoint) => endpoint.workspaceId === state.endpoint.workspaceId && endpoint.client === state.endpoint.client)
+    ? state.endpoint
     : null;
   const origin = useMemo(() => interactiveEndpoint
-    ? { ...interactiveEndpoint, sessionId: null, readOnly: state.phase !== "ready" || !state.app.launchId }
-    : null, [interactiveEndpoint, state]);
+    ? { ...interactiveEndpoint, sessionId: null, readOnly: state.phase !== "ready" || !state.app.launchId || state.lifetime !== lifetime || !lifetime.active }
+    : null, [interactiveEndpoint, state, lifetime]);
   const badge = (() => {
     if (state.phase === "ready" && !interactiveEndpoint) return "Saved locally · workspace unavailable";
+    if (state.phase === "ready" && origin?.readOnly && refreshState !== "refreshing") return "Saved locally · run required";
     if (state.phase === "ready" && refreshState === "refreshing") return "Saved locally · refreshing";
     if (state.phase === "ready" && refreshState === "failed") return "Saved locally · refresh failed";
     if (state.phase === "ready" && refreshState === "approval-required") return "Saved locally · run required";

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -3213,6 +3213,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   >
                     <MessageListProvider
                       uiStateOwner={props.draftScope ? sessionOwner : null}
+                      client={props.client}
+                      mcpAppEngine={isOpencodeV2BaseUrl(props.opencodeBaseUrl) ? "v2" : "v1"}
                       readOnly={archived || !archiveStateKnown || archiveHeld}
                       workspaceId={props.workspaceId}
                       sessionId={props.sessionId}

--- a/apps/app/tests/dashboard-tile-cache.test.ts
+++ b/apps/app/tests/dashboard-tile-cache.test.ts
@@ -116,6 +116,14 @@ describe("dashboard tile cache", () => {
     expect(readDashboardTileCache(scope, "tile_report", cache.cachedAt)).toBeNull();
   });
 
+  test("persists preview data without persisting a live App launch", () => {
+    const storage = installWindow();
+    const scope = dashboardTileCacheScopeKey("fixture-user", "fixture-org");
+    writeDashboardTileCache(scope, "tile", { ...cache, app: { ...cache.app, launchId: "private-live-launch" } });
+    expect(readDashboardTileCache(scope, "tile", cache.cachedAt)).toEqual(cache);
+    expect(storage.getItem(scope)).not.toContain("private-live-launch");
+  });
+
   test("refreshes only visible, stale, non-refreshing tiles", () => {
     const dueAt = cache.cachedAt + DASHBOARD_AUTO_REFRESH_INTERVAL_MS;
     expect(shouldAutoRefreshDashboardTile({

--- a/apps/app/tests/mcp-app-origin.test.tsx
+++ b/apps/app/tests/mcp-app-origin.test.tsx
@@ -1,0 +1,114 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { createOpenworkServerClient, OpenworkServerError, type OpenworkMcpAppResource, type OpenworkServerClient } from "../src/app/lib/openwork-server";
+import { createMcpAppActions } from "../src/components/chat/mcp-app-origin";
+import { McpAppFrame } from "../src/components/chat/mcp-app-frame";
+import { MessageListProvider } from "../src/components/chat/message-list-provider";
+import { WorkspaceProvider } from "../src/react-app/shell/workspace-provider";
+
+const app: OpenworkMcpAppResource = {
+  launchId: "launch-a", serverName: "fixture", toolName: "render", resourceUri: "ui://fixture/view.html",
+  html: "<p>Fixture</p>", csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] }, prefersBorder: true,
+};
+const result = { content: [{ type: "text", text: "ok" }] };
+const needsApproval = () => new OpenworkServerError(422, "tool_requires_approval", "Approval required");
+
+describe("App conversation ownership", () => {
+  test("split message origin supplies endpoint, workspace, session and archive state instead of the root workspace", async () => {
+    GlobalRegistrator.register({ url: "http://localhost/" });
+    const previousAct = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    const requests: unknown[] = [];
+    const primary = { ...createOpenworkServerClient({ baseUrl: "http://primary.invalid" }),
+      resolveMcpApp: async () => { throw new Error("Must not use the primary endpoint"); } };
+    const secondary: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://secondary.invalid" }),
+      resolveMcpApp: async (workspaceId, name, launch, context) => { requests.push({ workspaceId, name, launch, context }); return { app: null }; } };
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const render = (readOnly: boolean) => <WorkspaceProvider client={null} openworkServerClient={primary} workspaceId="workspace-a" selectedWorkspaceRoot="/a">
+      <MessageListProvider client={secondary} workspaceId="workspace-b" sessionId="session-b" readOnly={readOnly}
+        showThinking={false} developerMode={false} displaySuggestions={false} providerConnectedCount={0}
+        dispatchAction={() => {}} setPrompt={() => {}} onRevertToUserMessage={() => {}} onForkAtMessage={() => {}}
+        onEditUserMessage={() => {}} onMcpReconnect={async () => { throw new Error("unused"); }}
+        onMcpReopenAuthorization={async () => {}} onMcpRetry={() => {}}>
+        <McpAppFrame part={{ type: "dynamic-tool", toolName: "fixture_render", toolCallId: "call-b", state: "output-available", input: {}, output: {},
+          callProviderMetadata: { openwork: { mcpResult: { content: [] } } } }} />
+      </MessageListProvider>
+    </WorkspaceProvider>;
+    try {
+      await act(async () => { root.render(render(false)); });
+      await act(async () => { root.render(render(true)); });
+      expect(requests).toEqual([
+        { workspaceId: "workspace-b", name: "fixture_render", launch: undefined, context: { client: secondary, workspaceId: "workspace-b", sessionId: "session-b", readOnly: false } },
+        { workspaceId: "workspace-b", name: "fixture_render", launch: undefined, context: { client: secondary, workspaceId: "workspace-b", sessionId: "session-b", readOnly: true } },
+      ]);
+    } finally {
+      await act(async () => { root.unmount(); });
+      Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousAct);
+      await GlobalRegistrator.unregister();
+    }
+  });
+
+  test("follow-up and approved calls retain the exact launch and originating endpoint", async () => {
+    const requests: unknown[] = [];
+    const client: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://secondary.invalid" }),
+      callMcpAppTool: async (workspaceId, payload) => {
+        requests.push({ workspaceId, payload });
+        if (!payload.approved) throw needsApproval();
+        return result;
+      } };
+    const actions = createMcpAppActions({ client, workspaceId: "workspace-b", sessionId: "session-b", readOnly: false }, app, () => true);
+    expect(await actions.callTool("write_detail", { id: "b" })).toEqual(result);
+    expect(requests).toEqual([false, true].map(approved => ({ workspaceId: "workspace-b", payload: {
+      launchId: "launch-a", sessionId: "session-b", serverName: "fixture", resourceUri: app.resourceUri,
+      name: "write_detail", arguments: { id: "b" }, ...(approved ? { approved: true } : {}),
+    } })));
+  });
+
+  test("unmount before an approval response neither prompts nor dispatches again", async () => {
+    let reject: (error: Error) => void = () => { throw new Error("Missing pending call"); };
+    let calls = 0;
+    let prompts = 0;
+    const client: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://fixture.invalid" }),
+      callMcpAppTool: async () => { calls++; return new Promise((_, fail) => { reject = fail; }); } };
+    const actions = createMcpAppActions({ client, workspaceId: "b", sessionId: "b", readOnly: false }, app, () => { prompts++; return true; });
+    const pending = actions.callTool("write_detail");
+    actions.dispose();
+    reject(needsApproval());
+    await expect(pending).rejects.toThrow("closed or changed");
+    expect(calls).toBe(1);
+    expect(prompts).toBe(0);
+  });
+
+  test("an approval that completes after disposal cannot dispatch", async () => {
+    let approve: (value: boolean) => void = () => { throw new Error("Missing approval"); };
+    let calls = 0;
+    const client: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://fixture.invalid" }),
+      callMcpAppTool: async () => { calls++; throw needsApproval(); } };
+    let prompted: () => void = () => {};
+    const shown = new Promise<void>(resolve => { prompted = resolve; });
+    const actions = createMcpAppActions({ client, workspaceId: "b", sessionId: "b", readOnly: false }, app,
+      () => new Promise<boolean>(resolve => { approve = resolve; prompted(); }));
+    const pending = actions.callTool("write_detail");
+    await shown;
+    actions.dispose();
+    approve(true);
+    await expect(pending).rejects.toThrow("closed or changed");
+    expect(calls).toBe(1);
+  });
+
+  test("read-only previews and missing leases cannot call tools or open links", async () => {
+    let calls = 0;
+    const client: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://fixture.invalid" }),
+      callMcpAppTool: async () => { calls++; return result; } };
+    for (const readOnly of [true, false]) {
+      const actions = createMcpAppActions({ client, workspaceId: "b", sessionId: "b", readOnly }, { ...app, launchId: undefined }, () => true);
+      expect(() => actions.assertActive()).toThrow(readOnly ? "read-only" : "no live launch context");
+      await expect(actions.callTool("read_detail")).rejects.toThrow(readOnly ? "read-only" : "no live launch context");
+    }
+    expect(calls).toBe(0);
+  });
+});

--- a/apps/app/tests/mcp-app-tile.test.tsx
+++ b/apps/app/tests/mcp-app-tile.test.tsx
@@ -1,0 +1,113 @@
+/** @jsxImportSource react */
+import { expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, useLayoutEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { createOpenworkServerClient, type OpenworkMcpAppResource, type OpenworkServerClient } from "../src/app/lib/openwork-server";
+import { createMcpAppActions } from "../src/components/chat/mcp-app-origin";
+import type { McpAppSandboxViewProps } from "../src/components/chat/mcp-app-frame";
+import { WorkspaceProvider } from "../src/react-app/shell/workspace-provider";
+import type { DashboardMcpAppEntry } from "../src/react-app/domains/dashboard/granted-dashboard-store";
+
+// Exercise the mounted tile and real action lifetime without starting an iframe or provider.
+mock.module("@/components/chat/mcp-app-frame", () => ({
+  McpAppSandboxView: ({ app, origin }: McpAppSandboxViewProps) => {
+    const actions = useMemo(() => createMcpAppActions(origin, app, () => true), [origin, app]);
+    const [message, setMessage] = useState("");
+    useLayoutEffect(() => () => actions.dispose(), [actions]);
+    return <div>
+      <button disabled={origin.readOnly} onClick={() => {
+        void actions.callTool("read_detail").then(() => setMessage("Lease usable"), error => setMessage(error.message));
+      }}>App action</button>
+      <span data-action-result>{message}</span>
+    </div>;
+  },
+}));
+
+const { McpAppTile } = await import("../src/react-app/domains/dashboard/mcp-app-tile");
+
+test("a mounted tile retains its lease across fallback refreshes, but releases on owner removal, refresh and unmount", async () => {
+  GlobalRegistrator.register({ url: "http://localhost/" });
+  const previousAct = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  const leases = new Set<string>();
+  const released: string[] = [];
+  const calls: string[] = [];
+  let resolutions = 0;
+  const resource: OpenworkMcpAppResource = {
+    serverName: "fixture", toolName: "render", resourceUri: "ui://fixture/view.html", html: "<p>Fixture</p>",
+    csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] }, prefersBorder: true,
+  };
+  const primary: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://primary.invalid" }),
+    resolveMcpApp: async () => ({ app: null }) };
+  const owner: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://owner.invalid" }),
+    resolveMcpApp: async () => {
+      const launchId = `launch-${++resolutions}`;
+      leases.add(launchId);
+      return { app: { ...resource, launchId } };
+    },
+    callMcpAppTool: async (workspaceId, request) => {
+      expect(workspaceId).toBe("owner-workspace");
+      if (!request.launchId || !leases.has(request.launchId)) throw new Error("Lease revoked");
+      calls.push(request.name);
+      return { content: [] };
+    },
+    releaseMcpApp: async (workspaceId, launchId) => {
+      expect(workspaceId).toBe("owner-workspace");
+      released.push(launchId);
+      return { released: leases.delete(launchId) };
+    },
+  };
+  const unrelated: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://unrelated.invalid" }),
+    resolveMcpApp: async () => { throw new Error("Must not relaunch through an unrelated workspace"); } };
+  const entry: DashboardMcpAppEntry = { kind: "mcp", id: "tile", serverName: "fixture", toolName: "render",
+    projectedToolName: "fixture_render", resourceUri: resource.resourceUri, title: "Fixture", autoLaunch: true };
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const render = async (includeOwner = true, includeUnrelated = false) => {
+    await act(async () => root.render(<WorkspaceProvider client={null} openworkServerClient={primary} workspaceId="primary" selectedWorkspaceRoot="/fixture">
+      <McpAppTile entry={entry} cacheScopeKey="fixture-cache" fallbackEndpoints={[
+        ...(includeOwner ? [{ client: owner, workspaceId: "owner-workspace" }] : []),
+        ...(includeUnrelated ? [{ client: unrelated, workspaceId: "unrelated-workspace" }] : []),
+      ]} />
+    </WorkspaceProvider>));
+  };
+  const button = (selector: string) => {
+    const found = container.querySelector<HTMLButtonElement>(selector);
+    if (!found) throw new Error(`Missing button ${selector}`);
+    return found;
+  };
+  try {
+    await render();
+    expect(resolutions).toBe(1);
+    const actionButton = button("button:not([aria-label])");
+    await render();
+    await render(true, true);
+    expect(button("button:not([aria-label])")).toBe(actionButton);
+    expect(released).toEqual([]);
+    expect(resolutions).toBe(1);
+    await act(async () => actionButton.click());
+    expect(container.querySelector("[data-action-result]")?.textContent).toBe("Lease usable");
+    expect(calls).toEqual(["render", "read_detail"]);
+
+    await render(false, true);
+    expect(released).toEqual(["launch-1"]);
+    await render(true, true);
+    expect(button("button:not([aria-label])").disabled).toBe(true);
+    expect(resolutions).toBe(1);
+    await act(async () => button('[aria-label="Refresh Fixture"]').click());
+    expect(resolutions).toBe(2);
+    expect(button("button:not([aria-label])").disabled).toBe(false);
+    await act(async () => button('[aria-label="Refresh Fixture"]').click());
+    expect(resolutions).toBe(3);
+    expect(released).toEqual(["launch-1", "launch-2"]);
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousAct);
+    await GlobalRegistrator.unregister();
+  }
+  expect(released).toEqual(["launch-1", "launch-2", "launch-3"]);
+  expect(leases.size).toBe(0);
+});

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -61,6 +61,55 @@ Desktop Automation and remote-command requests opt out with
 Runtime journey verification for actual Electron restarts on both engines remains
 separate from the focused coordinator and mocked-proxy tests.
 
+## MCP App launch ownership
+
+An interactive host sends `context: { sessionId, readOnly, engine? }` with
+`POST /workspace/:id/mcp-apps/resolve`. `sessionId` is the originating conversation
+or `null` for a dashboard; `engine` is `v1` (default) or `v2`, never a provider URL.
+An actionable response includes an opaque `app.launchId`. The host keeps the
+server endpoint and workspace that resolved it, rather than the currently
+selected workspace. No credential, configuration, or fingerprint is returned.
+
+`POST /workspace/:id/mcp-apps/call` requires that `launchId`, the same `sessionId`
+and `engine`, and the existing `serverName`, `resourceUri`, `name`, `arguments`,
+and optional `approved` fields. The server binds the lease to its own instance,
+workspace path, conversation, original native launch tool, resource URI, and
+private configuration fingerprint. It rechecks the original tool's App visibility,
+resource binding and availability, original and requested tool policy, current
+session ownership/archive state, and configuration before dispatch. Existing
+helper audience and approval rules are unchanged.
+
+Leases are process-local, expire after 30 minutes, and are capped at 256 per
+server (oldest first eviction). `POST /workspace/:id/mcp-apps/release` with
+`{ launchId }` closes one workspace-owned lease. Closing/replacing a conversation
+view releases it; the renderer also invalidates its bridge synchronously and
+checks liveness before and after approval. A release failure is bounded by lease
+expiry. Already-dispatched provider operations cannot be recalled.
+
+The private fingerprint includes effective configuration (including headers),
+workspace/global runtime storage generations, private Connect authorization
+generation, and local managed gateway connection/credential/registration
+revisions. Runtime changes conservatively require reopening Apps, including
+changes unrelated to that App. File-backed configuration is compared by its
+observed values; edits restored between observations are not observable history.
+Provider-side account changes that leave all host-visible credentials and
+configuration unchanged are not detectable by this contract.
+
+Compatibility is intentionally fail-closed: older clients may still resolve HTML,
+but calls without a lease return `missing_launch_context`; stale leases return
+`stale_launch_context` with reopening guidance. New clients on old servers do not
+dispatch unbound calls. Generated read-only previews and archived result views
+still render and support local interactions without acquiring a lease. Dashboard
+HTML/result caches never persist a launch ID and remain read-only until refreshed.
+
+The renderer contract is `McpAppOrigin` and `createMcpAppActions` in
+`apps/app/src/components/chat/mcp-app-origin.ts`; `MessageListProvider` receives
+it from the owning `SessionSurface`. `McpAppLaunchContext`, resolution, validation,
+and release are owned by `src/mcp-app-host.ts`, with HTTP/session checks in
+`src/server.ts`.
+Internal callers of `callMcpAppTool` must supply `assertSessionActive` for a
+conversation lease; omitting the guard fails closed.
+
 ## Config file
 
 Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CONFIG` or `--config`).

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -87,10 +87,13 @@ checks liveness before and after approval. A release failure is bounded by lease
 expiry. Already-dispatched provider operations cannot be recalled.
 
 The private fingerprint includes effective configuration (including headers),
-workspace/global runtime storage generations, private Connect authorization
+workspace/global runtime generations of the relevant MCP entry, private Connect authorization
 generation, and local managed gateway connection/credential/registration
-revisions. Runtime changes conservatively require reopening Apps, including
-changes unrelated to that App. File-backed configuration is compared by its
+revisions. Named-entry generations are process-local, like the leases, and track
+host runtime writes including removal/restoration. Unrelated provider, plugin,
+and other MCP edits do not invalidate a lease. Private Connect hosts track the
+`openwork-cloud` runtime entry as well as their private authorization generation.
+File-backed configuration is compared by its
 observed values; edits restored between observations are not observable history.
 Provider-side account changes that leave all host-visible credentials and
 configuration unchanged are not detectable by this contract.

--- a/apps/server/src/connect-mcp-server-catalog.ts
+++ b/apps/server/src/connect-mcp-server-catalog.ts
@@ -268,11 +268,19 @@ export async function writeOpenWorkConnectMcpAppHostAuthorization(
 ): Promise<void> {
   const authorization = privateAppHostAuthorization(value);
   const origin = endpointOrigin(sourceUrl);
+  const previous = await appHostAuthorizationStore.getRow(config, workspaceId);
+  if (authorization && origin && previous?.value?.authorization === authorization && previous.value.origin === origin) return;
   await appHostAuthorizationStore.set(
     config,
     workspaceId,
     authorization && origin ? { authorization, origin } : null,
+    Math.max(Date.now(), (previous?.updatedAt ?? 0) + 1),
   );
+}
+
+/** Private storage generation, including revoke/re-authorize cycles with the same bearer. */
+export async function readOpenWorkConnectMcpAppHostAuthorizationRevision(config: ServerConfig, workspaceId: string): Promise<number | null> {
+  return (await appHostAuthorizationStore.getRow(config, workspaceId))?.updatedAt ?? null;
 }
 
 export async function findOpenWorkConnectMcpAppHostServer(

--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -897,6 +897,21 @@ export async function getLocalManagedMcpConnection(config: ServerConfig, workspa
   return withVaultRead(config, (vault) => publicConnection(requireConnection(vault, workspaceId, name)));
 }
 
+/** Private App-host identity: a same-name gateway does not identify its current OAuth account. */
+export async function localManagedMcpAppIdentity(config: ServerConfig, workspaceId: string, name: string, url: unknown) {
+  if (url !== runtimeConfig(config, workspaceId, name, true).url) return null;
+  return withVaultRead(config, (vault) => {
+    const connection = requireConnection(vault, workspaceId, name);
+    return {
+      id: connection.id,
+      serverUrl: connection.serverUrl,
+      enabled: connection.enabled,
+      credentialRevision: connection.credential?.revision ?? null,
+      registrationRevision: connection.clientRegistration?.revision ?? null,
+    };
+  });
+}
+
 type AuthorizationStatePayload = {
   version: 1;
   workspaceId: string;

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { createCipheriv, randomBytes, randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -29,9 +29,11 @@ import {
   resolveConnectMcpAppResource,
   resolveMcpAppResource,
   resolveSameServerMcpAppResource,
+  releaseMcpAppLaunch,
   toolUiResourceUri,
 } from "./mcp-app-host.js";
 import type { ServerConfig } from "./types.js";
+import { localManagedMcpAppIdentity } from "./local-managed-mcp.js";
 
 const WORKSPACE_ID = "ws_mcp_apps_host";
 const RESOURCE_URI = "ui://fixture/v1/view.html";
@@ -70,6 +72,9 @@ async function startFixtureMcp(
 ) {
   let activeResourceUri = RESOURCE_URI;
   let catalogReads = 0;
+  const calls: Array<{ name: string; arguments?: Record<string, unknown> }> = [];
+  let launchVisible = true;
+  let launchPresent = true;
   const mcp = new Server(
     { name: "mcp-app-fixture", version: "1.0.0" },
     {
@@ -89,7 +94,7 @@ async function startFixtureMcp(
         description: "Render the fixture",
         inputSchema: { type: "object", properties: {} },
         annotations: { readOnlyHint: true, destructiveHint: false },
-        _meta: { ui: { resourceUri: activeResourceUri, visibility: ["model", "app"] } },
+        _meta: { ui: { resourceUri: activeResourceUri, visibility: launchVisible ? ["model", "app"] : ["model"] } },
       },
       {
         name: "render_missing",
@@ -145,7 +150,7 @@ async function startFixtureMcp(
         inputSchema: { type: "object", properties: {} },
         annotations: { readOnlyHint: false, destructiveHint: true },
       },
-    ],
+    ].filter(tool => launchPresent || tool.name !== "render_fixture"),
   }));
   mcp.setRequestHandler(ReadResourceRequestSchema, async ({ params }) => {
     if (params.uri !== RESOURCE_URI && params.uri !== UPDATED_RESOURCE_URI) throw new Error("not found");
@@ -165,6 +170,7 @@ async function startFixtureMcp(
     };
   });
   mcp.setRequestHandler(CallToolRequestSchema, async ({ params }) => {
+    calls.push(params);
     if (params.name === "render_report" && typeof params.arguments?.id !== "string") {
       // A control character and an oversized tail model a hostile provider;
       // the host must relay neither verbatim.
@@ -186,6 +192,10 @@ async function startFixtureMcp(
     port: 0,
     fetch: async (request): Promise<Response> => {
       if (new URL(request.url).pathname !== "/catalog" || !connectionId) {
+        if (request.method === "POST") {
+          const body = await request.clone().json();
+          if (body.method === "initialize") await reconnect();
+        }
         return await transport.handleRequest(request);
       }
       if (request.method !== "POST") return new Response(null, { status: 405 });
@@ -245,6 +255,9 @@ async function startFixtureMcp(
     url: `${serverOrigin}/provider`,
     catalogUrl: `${serverOrigin}/catalog`,
     catalogReads: () => catalogReads,
+    calls,
+    hideLaunch: () => { launchVisible = false; },
+    removeLaunch: () => { launchPresent = false; },
     activateUpdatedResource: async () => {
       activeResourceUri = UPDATED_RESOURCE_URI;
       // A stateful SDK server transport owns one initialized MCP session. The
@@ -265,10 +278,15 @@ async function configuredFixture(
   root: string;
   activateUpdatedResource: () => Promise<void>;
   catalogReads: () => number;
+  calls: Array<{ name: string; arguments?: Record<string, unknown> }>;
+  hideLaunch: () => void;
+  removeLaunch: () => void;
 }> {
   const root = await mkdtemp(join(tmpdir(), prefix));
   const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
   const previousDevMode = process.env.OPENWORK_DEV_MODE;
+  const previousConfigDir = process.env.OPENCODE_CONFIG_DIR;
+  process.env.OPENCODE_CONFIG_DIR = join(root, "isolated-opencode");
   process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
   process.env.OPENWORK_DEV_MODE = "1";
   stops.push(async () => {
@@ -276,6 +294,8 @@ async function configuredFixture(
     else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
     if (previousDevMode === undefined) delete process.env.OPENWORK_DEV_MODE;
     else process.env.OPENWORK_DEV_MODE = previousDevMode;
+    if (previousConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = previousConfigDir;
     await rm(root, { recursive: true, force: true });
   });
   await mkdir(join(root, ".git"), { recursive: true });
@@ -317,7 +337,19 @@ async function configuredFixture(
     root,
     activateUpdatedResource: fixture.activateUpdatedResource,
     catalogReads: fixture.catalogReads,
+    calls: fixture.calls,
+    hideLaunch: fixture.hideLaunch,
+    removeLaunch: fixture.removeLaunch,
   };
+}
+
+async function fixtureLaunch(config: ServerConfig, root: string) {
+  const app = await resolveMcpAppResource({
+    serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+    projectedToolName: "fixture_render_fixture", context: { sessionId: "session-a", readOnly: false },
+  });
+  if (!app?.launchId) throw new Error("Fixture launch missing");
+  return { launchId: app.launchId, sessionId: "session-a", resourceUri: app.resourceUri, assertSessionActive: async () => {} };
 }
 
 describe("MCP Apps host transport", () => {
@@ -552,6 +584,7 @@ describe("MCP Apps host transport", () => {
     const app = await resolveSameServerMcpAppResource({
       serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
       projectedToolName: "openwork-cloud_model_only_fixture",
+      context: { sessionId: null, readOnly: false },
       launch: { toolName: "read_bound_detail", resourceUri: RESOURCE_URI },
     });
     expect(app).toMatchObject({ serverName: "openwork-cloud", html: RESOURCE_HTML });
@@ -559,12 +592,14 @@ describe("MCP Apps host transport", () => {
     expect(await callMcpAppTool({
       serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
       serverName: app.serverName, name: app.toolName, resourceUri: app.resourceUri,
+      launchId: app.launchId, sessionId: null,
       arguments: { id: "account" },
     })).toMatchObject({ structuredContent: { id: "account" } });
     await writeGlobalRuntimeOpencodeConfig(config, () => ({}));
     await expect(callMcpAppTool({
       serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
       serverName: app.serverName, name: app.toolName, resourceUri: app.resourceUri,
+      launchId: app.launchId, sessionId: null,
     })).rejects.toMatchObject({ code: "server_unavailable" });
   });
 
@@ -675,6 +710,7 @@ describe("MCP Apps host transport", () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-call-");
 
     const result = await callMcpAppTool({
+      ...await fixtureLaunch(config, root),
       serverConfig: config,
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
@@ -697,6 +733,7 @@ describe("MCP Apps host transport", () => {
     let failure: unknown = null;
     try {
       await callMcpAppTool({
+        ...await fixtureLaunch(config, root),
         serverConfig: config,
         workspaceId: WORKSPACE_ID,
         workspaceRoot: root,
@@ -722,6 +759,7 @@ describe("MCP Apps host transport", () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-bound-call-");
 
     const result = await callMcpAppTool({
+      ...await fixtureLaunch(config, root),
       serverConfig: config,
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
@@ -740,18 +778,20 @@ describe("MCP Apps host transport", () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-cross-resource-");
 
     await expect(callMcpAppTool({
+      ...await fixtureLaunch(config, root),
       serverConfig: config,
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
       serverName: "fixture",
       name: "read_bound_detail",
       resourceUri: UPDATED_RESOURCE_URI,
-    })).rejects.toMatchObject({ code: "tool_resource_mismatch" });
+    })).rejects.toMatchObject({ code: "stale_launch_context" });
   });
 
   test("prevents sandboxed Apps from calling model-only tools", async () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-model-only-");
     await expect(callMcpAppTool({
+      ...await fixtureLaunch(config, root),
       serverConfig: config,
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
@@ -763,6 +803,7 @@ describe("MCP Apps host transport", () => {
   test("rejects same-server tools that require approval", async () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-write-");
     await expect(callMcpAppTool({
+      ...await fixtureLaunch(config, root),
       serverConfig: config,
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
@@ -774,6 +815,7 @@ describe("MCP Apps host transport", () => {
   test("calls an approved write tool on the exact originating server", async () => {
     const { config, root } = await configuredFixture("openwork-mcp-app-approved-write-");
     const result = await callMcpAppTool({
+      ...await fixtureLaunch(config, root),
       serverConfig: config,
       workspaceId: WORKSPACE_ID,
       workspaceRoot: root,
@@ -798,5 +840,117 @@ describe("MCP Apps host transport", () => {
       workspaceRoot: root,
       projectedToolName: "fixture_render_fixture",
     })).rejects.toMatchObject({ code: "unsafe_server_url" });
+  });
+
+  test("rejects missing, cross-workspace, cross-session, cross-host and released launch contexts without dispatch", async () => {
+    const { config, root, calls } = await configuredFixture("openwork-app-origin-");
+    const launch = await fixtureLaunch(config, root);
+    const request = { serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, serverName: "fixture", name: "read_detail", ...launch };
+    await expect(callMcpAppTool({ ...request, launchId: undefined })).rejects.toMatchObject({ code: "missing_launch_context" });
+    for (const override of [{ workspaceId: "workspace-b" }, { sessionId: "session-b" }, { engine: "v2" as const }, { serverConfig: { ...config } }, { serverName: "other" }]) {
+      await expect(callMcpAppTool({ ...request, ...override })).rejects.toMatchObject({ code: "stale_launch_context" });
+    }
+    expect(releaseMcpAppLaunch(config, "workspace-b", launch.launchId)).toBe(false);
+    expect(releaseMcpAppLaunch(config, WORKSPACE_ID, launch.launchId)).toBe(true);
+    await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "stale_launch_context" });
+    expect(calls).toEqual([]);
+  });
+
+  test("read-only and old-client resolutions render HTML but issue no actionable lease", async () => {
+    const { config, root, calls } = await configuredFixture("openwork-app-readonly-");
+    for (const context of [undefined, { sessionId: "archived", readOnly: true }]) {
+      const app = await resolveMcpAppResource({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, projectedToolName: "fixture_render_fixture", context });
+      expect(app?.html).toBe(RESOURCE_HTML);
+      expect(app?.launchId).toBeUndefined();
+    }
+    expect(calls).toEqual([]);
+  });
+
+  test("unbound helpers cannot outlive the original launch tool or resource binding", async () => {
+    for (const change of ["hideLaunch", "removeLaunch", "activateUpdatedResource"] as const) {
+      const current = await configuredFixture("openwork-app-original-binding-");
+      const launch = await fixtureLaunch(current.config, current.root);
+      await current[change]();
+      await expect(callMcpAppTool({ serverConfig: current.config, workspaceId: WORKSPACE_ID, workspaceRoot: current.root,
+        serverName: "fixture", name: "read_detail", ...launch })).rejects.toMatchObject({ code: "stale_launch_context" });
+      expect(current.calls).toEqual([]);
+    }
+  });
+
+  test("same-name configuration replacement and restoration cannot reuse an existing launch", async () => {
+    const { config, root, calls } = await configuredFixture("openwork-app-config-replaced-");
+    const launch = await fixtureLaunch(config, root);
+    const original = (await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).mcp?.fixture;
+    if (!original) throw new Error("Missing fixture config");
+    await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, () => ({ mcp: { fixture: { ...original, headers: { Authorization: "Bearer replacement-fixture" } } } }));
+    await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, () => ({ mcp: { fixture: original } }));
+    await expect(callMcpAppTool({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+      serverName: "fixture", name: "read_detail", ...launch })).rejects.toMatchObject({ code: "stale_launch_context" });
+    expect(calls).toEqual([]);
+  });
+
+  test("private App-host authorization rotation invalidates the old launch", async () => {
+    const connectionId = "emc_fixture_rotation";
+    const serverName = connectMcpAppHostName(connectionId);
+    const { config, root, calls } = await configuredFixture("openwork-app-private-rotation-", undefined, serverName, connectionId);
+    const app = await resolveConnectMcpAppResource({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+      context: { sessionId: "session-a", readOnly: false }, launch: { connectionId, toolName: "render_fixture", resourceUri: RESOURCE_URI } });
+    const runtime = await readRuntimeOpencodeConfig(config, WORKSPACE_ID);
+    const url = runtime.mcp?.["openwork-cloud"]?.url;
+    if (typeof url !== "string") throw new Error("Missing fixture URL");
+    await writeOpenWorkConnectMcpAppHostAuthorization(config, WORKSPACE_ID, "Bearer replacement-fixture", url);
+    await expect(callMcpAppTool({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+      serverName, name: "read_detail", resourceUri: RESOURCE_URI, launchId: app.launchId, sessionId: "session-a" })).rejects.toMatchObject({ code: "stale_launch_context" });
+    expect(calls).toEqual([]);
+  });
+
+  test("session validation and release during validation prevent the final provider dispatch", async () => {
+    const { config, root, calls } = await configuredFixture("openwork-app-dispatch-gate-");
+    const launch = await fixtureLaunch(config, root);
+    const request = { serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, serverName: "fixture", name: "write_detail", approved: true, ...launch };
+    await expect(callMcpAppTool({ ...request, assertSessionActive: undefined })).rejects.toMatchObject({ code: "inactive_session" });
+    await expect(callMcpAppTool({ ...request, assertSessionActive: async () => { throw new McpAppHostError("inactive_session", "Archived"); } })).rejects.toMatchObject({ code: "inactive_session" });
+    await expect(callMcpAppTool({ ...request, assertSessionActive: async () => { releaseMcpAppLaunch(config, WORKSPACE_ID, launch.launchId); } })).rejects.toMatchObject({ code: "stale_launch_context" });
+    expect(calls).toEqual([]);
+  });
+
+  test("launch leases expire without allowing an approved dispatch", async () => {
+    const { config, root, calls } = await configuredFixture("openwork-app-expired-");
+    const launch = await fixtureLaunch(config, root);
+    const now = Date.now();
+    const clock = spyOn(Date, "now").mockReturnValue(now + 30 * 60_000 + 1);
+    try {
+      await expect(callMcpAppTool({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+        serverName: "fixture", name: "write_detail", approved: true, ...launch })).rejects.toMatchObject({ code: "stale_launch_context" });
+      expect(calls).toEqual([]);
+    } finally { clock.mockRestore(); }
+  });
+
+  test("a stable local gateway name exposes changing private credential and connection generations only to the host", async () => {
+    const { config, root } = await configuredFixture("openwork-app-managed-identity-");
+    const key = randomBytes(32);
+    config.localManagedMcpVaultKey = async () => key;
+    const url = `http://127.0.0.1:${config.port}/mcp/managed/${WORKSPACE_ID}/fixture`;
+    const identities = [];
+    for (const [id, revision] of [["connection-a", "credential-a"], ["connection-a", "credential-b"], ["connection-b", "credential-b"]]) {
+      const iv = randomBytes(12);
+      const cipher = createCipheriv("aes-256-gcm", key, iv);
+      cipher.setAAD(Buffer.from("openwork-local-managed-mcp-v1", "utf8"));
+      const payload = JSON.stringify({ schemaVersion: 1, connections: {
+        [`${WORKSPACE_ID.length}:${WORKSPACE_ID}fixture`]: {
+          id, workspaceId: WORKSPACE_ID, name: "fixture", serverUrl: "https://fixture.invalid/mcp", enabled: true,
+          oauth: { applicationType: "native" }, status: "connected", createdAt: 1, updatedAt: 1, authorizations: {},
+          credential: { revision, accessToken: "synthetic-private-credential" },
+        },
+      } });
+      const data = Buffer.concat([cipher.update(payload, "utf8"), cipher.final()]);
+      await Bun.write(join(root, "local-managed-mcp-vault.json"), JSON.stringify({ schemaVersion: 1, algorithm: "aes-256-gcm",
+        iv: iv.toString("base64"), tag: cipher.getAuthTag().toString("base64"), data: data.toString("base64") }));
+      identities.push(await localManagedMcpAppIdentity(config, WORKSPACE_ID, "fixture", url));
+    }
+    expect(identities[0]).not.toEqual(identities[1]);
+    expect(identities[1]).not.toEqual(identities[2]);
+    expect(JSON.stringify(identities)).not.toContain("synthetic-private-credential");
+    expect(await localManagedMcpAppIdentity(config, WORKSPACE_ID, "fixture", "https://ordinary.invalid/mcp")).toBeNull();
   });
 });

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -20,7 +20,7 @@ import {
   writeOpenWorkConnectMcpAppHostAuthorization,
   writeOpenWorkConnectMcpAppHostCatalog,
 } from "./connect-mcp-server-catalog.js";
-import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig, writeGlobalRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { ENGINE_GLOBAL_RUNTIME_CONFIG_ID, readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig, writeGlobalRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import {
   callMcpAppTool,
   listMcpAppCatalog,
@@ -877,15 +877,46 @@ describe("MCP Apps host transport", () => {
     }
   });
 
-  test("same-name configuration replacement and restoration cannot reuse an existing launch", async () => {
-    const { config, root, calls } = await configuredFixture("openwork-app-config-replaced-");
+  test("unrelated provider, plugin and other MCP runtime edits preserve a live App lease", async () => {
+    const { config, root, calls } = await configuredFixture("openwork-app-unrelated-runtime-");
     const launch = await fixtureLaunch(config, root);
     const original = (await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).mcp?.fixture;
     if (!original) throw new Error("Missing fixture config");
-    await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, () => ({ mcp: { fixture: { ...original, headers: { Authorization: "Bearer replacement-fixture" } } } }));
-    await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, () => ({ mcp: { fixture: original } }));
-    await expect(callMcpAppTool({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
-      serverName: "fixture", name: "read_detail", ...launch })).rejects.toMatchObject({ code: "stale_launch_context" });
+    for (const workspaceId of [WORKSPACE_ID, ENGINE_GLOBAL_RUNTIME_CONFIG_ID]) {
+      await writeRuntimeOpencodeConfig(config, workspaceId, current => ({
+        ...current,
+        provider: { ...current.provider, unrelated: { options: { apiKey: "synthetic-provider-key" } } },
+        plugin: ["unrelated-fixture-plugin"],
+        mcp: { ...current.mcp, unrelated: original },
+      }));
+    }
+    expect(await callMcpAppTool({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+      serverName: "fixture", name: "read_detail", arguments: { id: "same-lease" }, ...launch })).toMatchObject({
+      structuredContent: { id: "same-lease" },
+    });
+    expect(calls).toEqual([{ name: "read_detail", arguments: { id: "same-lease" } }]);
+  });
+
+  test.each([WORKSPACE_ID, ENGINE_GLOBAL_RUNTIME_CONFIG_ID])("target MCP replacement/removal and restoration in %s invalidate its lease", async (scope) => {
+    const { config, root, calls } = await configuredFixture("openwork-app-config-replaced-");
+    const original = (await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).mcp?.fixture;
+    if (!original) throw new Error("Missing fixture config");
+    if (scope === ENGINE_GLOBAL_RUNTIME_CONFIG_ID) {
+      await writeGlobalRuntimeOpencodeConfig(config, () => ({ mcp: { fixture: original } }));
+      await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, () => ({}));
+    }
+    for (const remove of [false, true]) {
+      const launch = await fixtureLaunch(config, root);
+      await writeRuntimeOpencodeConfig(config, scope, current => {
+        if (!current.mcp) throw new Error("Missing runtime MCP map");
+        if (remove) delete current.mcp.fixture;
+        else current.mcp.fixture = { ...original, headers: { Authorization: "Bearer replacement-fixture" } };
+        return current;
+      });
+      await writeRuntimeOpencodeConfig(config, scope, () => ({ mcp: { fixture: original } }));
+      await expect(callMcpAppTool({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+        serverName: "fixture", name: "read_detail", ...launch })).rejects.toMatchObject({ code: "stale_launch_context" });
+    }
     expect(calls).toEqual([]);
   });
 

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -24,7 +24,7 @@ import {
   LocalManagedMcpPrivateUrlError,
 } from "./local-managed-mcp-url-guard.js";
 import { diagnoseMcpToolDenies, listMcpFromRuntimeSnapshot } from "./mcp.js";
-import { readEffectiveRuntimeOpencodeConfig, readRuntimeOpencodeConfigRevisions } from "./runtime-opencode-config-store.js";
+import { readEffectiveRuntimeOpencodeConfig, readRuntimeMcpConfigRevisions } from "./runtime-opencode-config-store.js";
 import { localManagedMcpAppIdentity } from "./local-managed-mcp.js";
 
 async function listMcp(serverConfig: ServerConfig, workspaceId: string, workspaceRoot: string) {
@@ -100,7 +100,8 @@ function staleLaunch(): McpAppHostError {
 /** Values and private credential revisions stay on the host, never in the resource response. */
 async function launchFingerprint(input: { serverConfig: ServerConfig; workspaceId: string }, serverName: string, config: Record<string, unknown>): Promise<string> {
   const managed = await localManagedMcpAppIdentity(input.serverConfig, input.workspaceId, serverName, config.url);
-  const runtimeRevisions = await readRuntimeOpencodeConfigRevisions(input.serverConfig, input.workspaceId);
+  const runtimeRevisions = readRuntimeMcpConfigRevisions(input.serverConfig, input.workspaceId,
+    serverName.startsWith(CONNECT_MCP_APP_HOST_NAME_PREFIX) ? "openwork-cloud" : serverName);
   const privateRevision = serverName.startsWith(CONNECT_MCP_APP_HOST_NAME_PREFIX)
     ? await readOpenWorkConnectMcpAppHostAuthorizationRevision(input.serverConfig, input.workspaceId) : null;
   return createHash("sha256").update(JSON.stringify({ config, managed, runtimeRevisions, privateRevision })).digest("hex");

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -1,4 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createHash, randomUUID } from "node:crypto";
 import { SSEClientTransport, SseError } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -11,6 +12,7 @@ import {
   connectMcpAppHostName,
   findOpenWorkConnectMcpAppHostServer,
   readOpenWorkConnectMcpAppHostAuthorization,
+  readOpenWorkConnectMcpAppHostAuthorizationRevision,
   readOpenWorkConnectMcpAppHostCatalog,
   refreshOpenWorkConnectMcpAppHostCatalog,
   type ConnectMcpCatalogDiagnostic,
@@ -22,7 +24,8 @@ import {
   LocalManagedMcpPrivateUrlError,
 } from "./local-managed-mcp-url-guard.js";
 import { diagnoseMcpToolDenies, listMcpFromRuntimeSnapshot } from "./mcp.js";
-import { readEffectiveRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { readEffectiveRuntimeOpencodeConfig, readRuntimeOpencodeConfigRevisions } from "./runtime-opencode-config-store.js";
+import { localManagedMcpAppIdentity } from "./local-managed-mcp.js";
 
 async function listMcp(serverConfig: ServerConfig, workspaceId: string, workspaceRoot: string) {
   // Account-scoped gateways live in the engine-global runtime layer. Resolve
@@ -48,6 +51,7 @@ type McpAppCsp = {
 };
 
 export type McpAppResource = {
+  launchId?: string;
   serverName: string;
   toolName: string;
   resourceUri: string;
@@ -55,6 +59,70 @@ export type McpAppResource = {
   csp: McpAppCsp;
   prefersBorder: boolean;
 };
+
+export type McpAppLaunchContext = { sessionId: string | null; readOnly: boolean; engine?: "v1" | "v2" };
+
+type McpAppLaunch = {
+  workspaceId: string;
+  workspaceRoot: string;
+  sessionId: string | null;
+  engine: "v1" | "v2";
+  serverName: string;
+  toolName: string;
+  resourceUri: string;
+  fingerprint: string;
+  expiresAt: number;
+};
+
+const MAX_LIVE_LAUNCHES = 256;
+const LAUNCH_TTL_MS = 30 * 60_000;
+const launchesByServer = new WeakMap<ServerConfig, Map<string, McpAppLaunch>>();
+
+function liveLaunches(config: ServerConfig) {
+  let launches = launchesByServer.get(config);
+  if (!launches) {
+    launches = new Map();
+    launchesByServer.set(config, launches);
+  }
+  for (const [id, launch] of launches) if (launch.expiresAt <= Date.now()) launches.delete(id);
+  return launches;
+}
+
+export function releaseMcpAppLaunch(serverConfig: ServerConfig, workspaceId: string, launchId: string): boolean {
+  const launches = liveLaunches(serverConfig);
+  return launches.get(launchId)?.workspaceId === workspaceId && launches.delete(launchId);
+}
+
+function staleLaunch(): McpAppHostError {
+  return new McpAppHostError("stale_launch_context", "This App launch has expired, closed, or changed. Reopen the App in its original conversation before trying again.");
+}
+
+/** Values and private credential revisions stay on the host, never in the resource response. */
+async function launchFingerprint(input: { serverConfig: ServerConfig; workspaceId: string }, serverName: string, config: Record<string, unknown>): Promise<string> {
+  const managed = await localManagedMcpAppIdentity(input.serverConfig, input.workspaceId, serverName, config.url);
+  const runtimeRevisions = await readRuntimeOpencodeConfigRevisions(input.serverConfig, input.workspaceId);
+  const privateRevision = serverName.startsWith(CONNECT_MCP_APP_HOST_NAME_PREFIX)
+    ? await readOpenWorkConnectMcpAppHostAuthorizationRevision(input.serverConfig, input.workspaceId) : null;
+  return createHash("sha256").update(JSON.stringify({ config, managed, runtimeRevisions, privateRevision })).digest("hex");
+}
+
+function bindLaunch(input: { serverConfig: ServerConfig; workspaceId: string; workspaceRoot: string; context?: McpAppLaunchContext }, app: McpAppResource, fingerprint: string): McpAppResource {
+  // Old clients can read HTML, but cannot manufacture an actionable launch from a server name.
+  if (!input.context || input.context.readOnly) return app;
+  const launches = liveLaunches(input.serverConfig);
+  while (launches.size >= MAX_LIVE_LAUNCHES) {
+    const oldest = launches.keys().next().value;
+    if (oldest) launches.delete(oldest);
+  }
+  const launchId = randomUUID();
+  launches.set(launchId, {
+    workspaceId: input.workspaceId, workspaceRoot: input.workspaceRoot, sessionId: input.context.sessionId,
+    engine: input.context.engine ?? "v1",
+    serverName: app.serverName, toolName: app.toolName, resourceUri: app.resourceUri,
+    fingerprint, expiresAt: Date.now() + LAUNCH_TTL_MS,
+  });
+  return { ...app, launchId };
+}
 
 export type ConnectMcpAppLaunchReference = {
   connectionId: string;
@@ -600,6 +668,7 @@ export async function listMcpAppCatalog(input: {
 }
 
 export async function resolveMcpAppResource(input: {
+  context?: McpAppLaunchContext;
   serverConfig: ServerConfig;
   workspaceId: string;
   workspaceRoot: string;
@@ -613,10 +682,11 @@ export async function resolveMcpAppResource(input: {
     item.config.enabled !== false
     && input.projectedToolName.startsWith(`${item.name.replace(/[^a-zA-Z0-9_-]/g, "_")}_`)
   ));
-  const matches: McpAppResource[] = [];
+  const matches: Array<{ app: McpAppResource; fingerprint: string }> = [];
   const resolutionErrors: McpAppHostError[] = [];
   for (const item of candidates) {
     if (!remoteUrl(item.config)) continue;
+    const fingerprint = await launchFingerprint(input, item.name, item.config);
     const match = await withRemoteClient(item.config, async (client) => {
       const tool = (await listTools(client)).find((candidate) => (
         projectedMcpToolName(item.name, candidate.name) === input.projectedToolName
@@ -650,13 +720,13 @@ export async function resolveMcpAppResource(input: {
         : new McpAppHostError("mcp_app_resolution_failed", "The MCP App resource could not be resolved."));
       return null;
     });
-    if (match) matches.push(match);
+    if (match) matches.push({ app: match, fingerprint });
   }
   if (matches.length > 1) {
     throw new McpAppHostError("ambiguous_tool", "More than one configured MCP App matches this projected tool name.");
   }
   if (matches.length === 0 && resolutionErrors[0]) throw resolutionErrors[0];
-  return matches[0] ?? null;
+  return matches[0] ? bindLaunch(input, matches[0].app, matches[0].fingerprint) : null;
 }
 
 /**
@@ -666,6 +736,7 @@ export async function resolveMcpAppResource(input: {
  * UI binding to match before reading or executing any resource.
  */
 export async function resolveConnectMcpAppResource(input: {
+  context?: McpAppLaunchContext;
   serverConfig: ServerConfig;
   workspaceId: string;
   workspaceRoot: string;
@@ -690,8 +761,9 @@ export async function resolveConnectMcpAppResource(input: {
     throw new McpAppHostError("server_unavailable", "The originating Connect MCP server is not available to this workspace.");
   }
   const { serverName } = item;
+  const fingerprint = await launchFingerprint(input, serverName, item.config);
 
-  return await withRemoteClient(item.config, async (client) => {
+  const app = await withRemoteClient(item.config, async (client) => {
     const tool = (await listTools(client)).find((candidate) => candidate.name === input.launch.toolName);
     if (!tool) {
       throw new McpAppHostError("tool_not_found", "The originating MCP App tool is no longer advertised.");
@@ -723,6 +795,7 @@ export async function resolveConnectMcpAppResource(input: {
       ...presentation,
     };
   });
+  return bindLaunch(input, app, fingerprint);
 }
 
 /** Resolve an indirect launch against the same MCP server that owns the
@@ -730,6 +803,7 @@ export async function resolveConnectMcpAppResource(input: {
  * app-visible, but its standard UI binding and resource are revalidated live.
  */
 export async function resolveSameServerMcpAppResource(input: {
+  context?: McpAppLaunchContext;
   serverConfig: ServerConfig;
   workspaceId: string;
   workspaceRoot: string;
@@ -752,8 +826,9 @@ export async function resolveSameServerMcpAppResource(input: {
     && remoteUrl(item.config)
     && input.projectedToolName.startsWith(`${item.name.replace(/[^a-zA-Z0-9_-]/g, "_")}_`)
   ));
-  const matches: McpAppResource[] = [];
+  const matches: Array<{ app: McpAppResource; fingerprint: string }> = [];
   for (const item of candidates) {
+    const fingerprint = await launchFingerprint(input, item.name, item.config);
     const match = await withRemoteClient(item.config, async (client) => {
       const tools = await listTools(client);
       const gatewayTool = tools.find((tool) => projectedMcpToolName(item.name, tool.name) === input.projectedToolName);
@@ -783,16 +858,19 @@ export async function resolveSameServerMcpAppResource(input: {
         ...resourcePresentationMeta(resource.meta),
       } satisfies McpAppResource;
     });
-    if (match) matches.push(match);
+    if (match) matches.push({ app: match, fingerprint });
   }
   if (matches.length > 1) {
     throw new McpAppHostError("ambiguous_tool", "More than one configured MCP server matches this capability gateway launch.");
   }
   if (!matches[0]) throw new McpAppHostError("server_unavailable", "The MCP server that produced this App launch is unavailable.");
-  return matches[0];
+  return bindLaunch(input, matches[0].app, matches[0].fingerprint);
 }
 
 export async function callMcpAppTool(input: {
+  launchId?: string;
+  sessionId?: string | null;
+  engine?: "v1" | "v2";
   serverConfig: ServerConfig;
   workspaceId: string;
   workspaceRoot: string;
@@ -801,19 +879,53 @@ export async function callMcpAppTool(input: {
   resourceUri?: string;
   arguments?: Record<string, unknown>;
   approved?: boolean;
+  /** Required for conversation leases; the HTTP host checks current ownership/archive state. */
+  assertSessionActive?: () => Promise<void>;
 }): Promise<CallToolResult> {
-  const privateItem = await privateConnectMcpConfig({
-    serverConfig: input.serverConfig,
-    workspaceId: input.workspaceId,
-    serverName: input.serverName,
-  });
-  const configured = privateItem ? [] : await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
-  const item = privateItem ?? configured.find((candidate) => candidate.name === input.serverName);
-  if (!item || item.config.enabled === false) {
-    throw new McpAppHostError("server_unavailable", "The originating MCP server is not available to this workspace.");
-  }
-  return await withRemoteClient(item.config, async (client) => {
-    const tool = (await listTools(client)).find((candidate) => candidate.name === input.name);
+  if (!input.launchId) throw new McpAppHostError("missing_launch_context", "This App has no live launch context. Update OpenWork and reopen the App before using its actions.");
+  const launchId = input.launchId;
+  const launch = liveLaunches(input.serverConfig).get(launchId);
+  const assertLive = () => {
+    if (!launch || liveLaunches(input.serverConfig).get(launchId) !== launch
+      || launch.workspaceId !== input.workspaceId || launch.workspaceRoot !== input.workspaceRoot
+      || launch.sessionId !== input.sessionId || launch.serverName !== input.serverName
+      || launch.engine !== (input.engine ?? "v1")
+      || launch.resourceUri !== input.resourceUri) throw staleLaunch();
+  };
+  assertLive();
+  if (!launch) throw staleLaunch();
+  const currentConfig = async () => {
+    const privateItem = await privateConnectMcpConfig({
+      serverConfig: input.serverConfig,
+      workspaceId: input.workspaceId,
+      serverName: input.serverName,
+    });
+    const configured = privateItem ? [] : await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
+    // A reserved private host must never fall back to a same-name workspace configuration.
+    const item = input.serverName.startsWith(CONNECT_MCP_APP_HOST_NAME_PREFIX)
+      ? privateItem : configured.find((candidate) => candidate.name === input.serverName);
+    if (!item || item.config.enabled === false) {
+      throw new McpAppHostError("server_unavailable", "The originating MCP server is not available to this workspace. Reopen the App after restoring the connection.");
+    }
+    if (await launchFingerprint(input, input.serverName, item.config) !== launch.fingerprint) {
+      releaseMcpAppLaunch(input.serverConfig, input.workspaceId, launchId);
+      throw staleLaunch();
+    }
+    assertLive();
+    return item.config;
+  };
+  const config = await currentConfig();
+  return await withRemoteClient(config, async (client) => {
+    const tools = await listTools(client);
+    const original = tools.find((candidate) => candidate.name === launch.toolName);
+    if (!original || !toolVisibility(original, "app") || toolUiResourceUri(original) !== launch.resourceUri) throw staleLaunch();
+    findHtmlResource(launch.resourceUri, await client.readResource({ uri: launch.resourceUri }).catch(() => {
+      throw new McpAppHostError("resource_read_failed", "The original App resource is no longer available. Reopen the App before using its actions.");
+    }));
+    if ((await diagnoseMcpToolDenies(input.workspaceRoot, input.serverName, [projectedMcpToolName(input.serverName, original.name)])).length > 0) {
+      throw new McpAppHostError("tool_denied", "The originating App tool is denied. Reopen it after reviewing the workspace tool policy.");
+    }
+    const tool = tools.find((candidate) => candidate.name === input.name);
     if (!tool) throw new McpAppHostError("tool_not_found", "The requested same-server MCP tool was not found.");
     if (!toolVisibility(tool, "app")) {
       throw new McpAppHostError("tool_not_visible", "The requested MCP tool is not visible to apps.");
@@ -829,12 +941,18 @@ export async function callMcpAppTool(input: {
     if ((await diagnoseMcpToolDenies(input.workspaceRoot, input.serverName, [projectedName])).length > 0) {
       throw new McpAppHostError("tool_denied", "This same-server MCP tool is denied by the workspace tool policy.");
     }
+    if (launch.sessionId !== null && !input.assertSessionActive) {
+      throw new McpAppHostError("inactive_session", "The original conversation cannot be verified. Reopen it before using App actions.");
+    }
+    await input.assertSessionActive?.();
     if (toolRequiresApproval(tool) && !input.approved) {
       throw new McpAppHostError(
         "tool_requires_approval",
         "This MCP App tool requires user approval before OpenWork can call it.",
       );
     }
+    await currentConfig();
+    assertLive();
     // A provider that rejects the call (for example JSON-RPC -32602 for a
     // missing required argument) must reach the member as that rejection,
     // not as an unhandled 500 "Unexpected server error". The text is

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -148,6 +148,12 @@ export async function readRuntimeOpencodeConfig(config: ServerConfig, workspaceI
   return await runtimeOpencodeConfigStore.get(config, workspaceId) ?? {};
 }
 
+/** Host-observable generations; never expose the rows' configuration or credentials. */
+export async function readRuntimeOpencodeConfigRevisions(config: ServerConfig, workspaceId: string): Promise<Array<number | null>> {
+  return Promise.all([ENGINE_GLOBAL_RUNTIME_CONFIG_ID, workspaceId].map(async (id) =>
+    (await runtimeOpencodeConfigStore.getRow(config, id))?.updatedAt ?? null));
+}
+
 export async function readGlobalRuntimeOpencodeConfig(config: ServerConfig): Promise<RuntimeOpencodeConfig> {
   return await readRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID);
 }
@@ -531,7 +537,7 @@ function updateRuntimeConfig(
     const next = normalizeRuntimeOpencodeConfig(updater(row?.value ?? {}));
     const configJson = runtimeOpencodeConfigStore.serialize(next);
     if (row?.valueJson === configJson) return { config: next, changed: false };
-    await runtimeOpencodeConfigStore.setSerialized(config, workspaceId, configJson, Date.now());
+    await runtimeOpencodeConfigStore.setSerialized(config, workspaceId, configJson, Math.max(Date.now(), (row?.updatedAt ?? 0) + 1));
     for (const listener of writeListeners) listener(config, workspaceId);
     return { config: next, changed: true };
   });

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -148,10 +148,14 @@ export async function readRuntimeOpencodeConfig(config: ServerConfig, workspaceI
   return await runtimeOpencodeConfigStore.get(config, workspaceId) ?? {};
 }
 
-/** Host-observable generations; never expose the rows' configuration or credentials. */
-export async function readRuntimeOpencodeConfigRevisions(config: ServerConfig, workspaceId: string): Promise<Array<number | null>> {
-  return Promise.all([ENGINE_GLOBAL_RUNTIME_CONFIG_ID, workspaceId].map(async (id) =>
-    (await runtimeOpencodeConfigStore.getRow(config, id))?.updatedAt ?? null));
+// App leases are process-local too. Retain entry tombstones so removal and
+// restoration cannot resurrect a lease; unrelated runtime writes do not touch it.
+const runtimeMcpRevisions = new WeakMap<ServerConfig, Map<string, Map<string, number>>>();
+
+/** Private generations for one named MCP's global and workspace runtime entries. */
+export function readRuntimeMcpConfigRevisions(config: ServerConfig, workspaceId: string, name: string): Array<number | null> {
+  const revisions = runtimeMcpRevisions.get(config);
+  return [ENGINE_GLOBAL_RUNTIME_CONFIG_ID, workspaceId].map(id => revisions?.get(id)?.get(name) ?? null);
 }
 
 export async function readGlobalRuntimeOpencodeConfig(config: ServerConfig): Promise<RuntimeOpencodeConfig> {
@@ -537,7 +541,26 @@ function updateRuntimeConfig(
     const next = normalizeRuntimeOpencodeConfig(updater(row?.value ?? {}));
     const configJson = runtimeOpencodeConfigStore.serialize(next);
     if (row?.valueJson === configJson) return { config: next, changed: false };
-    await runtimeOpencodeConfigStore.setSerialized(config, workspaceId, configJson, Math.max(Date.now(), (row?.updatedAt ?? 0) + 1));
+    const updatedAt = Math.max(Date.now(), (row?.updatedAt ?? 0) + 1);
+    await runtimeOpencodeConfigStore.setSerialized(config, workspaceId, configJson, updatedAt);
+    // Compare persisted bytes rather than row.value: an updater may mutate its input.
+    const previousMcp = runtimeMcpMap(parseRuntimeOpencodeConfig(row?.valueJson ?? "{}"));
+    const nextMcp = runtimeMcpMap(next);
+    const changedMcpNames = [...new Set([...Object.keys(previousMcp), ...Object.keys(nextMcp)])]
+      .filter(name => JSON.stringify(previousMcp[name]) !== JSON.stringify(nextMcp[name]));
+    if (changedMcpNames.length) {
+      let workspaces = runtimeMcpRevisions.get(config);
+      if (!workspaces) {
+        workspaces = new Map();
+        runtimeMcpRevisions.set(config, workspaces);
+      }
+      let revisions = workspaces.get(workspaceId);
+      if (!revisions) {
+        revisions = new Map();
+        workspaces.set(workspaceId, revisions);
+      }
+      for (const name of changedMcpNames) revisions.set(name, updatedAt);
+    }
     for (const listener of writeListeners) listener(config, workspaceId);
     return { config: next, changed: true };
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -42,6 +42,8 @@ import {
   resolveConnectMcpAppResource,
   resolveMcpAppResource,
   resolveSameServerMcpAppResource,
+  releaseMcpAppLaunch,
+  type McpAppLaunchContext,
 } from "./mcp-app-host.js";
 import { CONNECT_MCP_SERVER_NAME_PREFIX } from "./connect-mcp-server-catalog.js";
 import {
@@ -616,10 +618,14 @@ async function assertWorkspaceOwnsProxiedSessionRead(
   workspace: WorkspaceInfo,
   method: string,
   proxyPath: string,
+  requireActive = false,
 ): Promise<void> {
   const sessionId = proxiedSessionReadId(method, proxyPath);
   const directory = resolveOpencodeDirectory(workspace);
-  if (!sessionId || !directory) return;
+  if (!sessionId || !directory) {
+    if (requireActive) throw new McpAppHostError("inactive_session", "The original conversation cannot be verified. Reopen it before using App actions.");
+    return;
+  }
 
   const result = await createWorkspaceOpencodeClient(config, workspace, { sessionId }).session.get({ sessionID: sessionId });
   if (result.error !== undefined) {
@@ -642,6 +648,9 @@ async function assertWorkspaceOwnsProxiedSessionRead(
     : [directory, sessionDirectory];
   if (!actualDirectory || actualDirectory !== expectedDirectory) {
     throw new ApiError(404, "session_not_found", "Session not found");
+  }
+  if (requireActive && (result.data?.id !== sessionId || result.data.time.archived)) {
+    throw new McpAppHostError("inactive_session", "This conversation is archived or unavailable. Reopen an active conversation before using App actions.");
   }
 }
 
@@ -3455,6 +3464,17 @@ function createRoutes(
     requireClientScope(ctx, "viewer");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
+    let context: McpAppLaunchContext | undefined;
+    if (body.context !== undefined) {
+      const parsed = body.context;
+      if (!parsed || typeof parsed !== "object" || !("sessionId" in parsed) || !("readOnly" in parsed)
+        || (parsed.sessionId !== null && (typeof parsed.sessionId !== "string" || !parsed.sessionId.trim()))
+        || ("engine" in parsed && parsed.engine !== "v1" && parsed.engine !== "v2")
+        || typeof parsed.readOnly !== "boolean") {
+        throw new ApiError(400, "invalid_launch_context", "App context requires a sessionId (null for dashboard views) and readOnly flag.");
+      }
+      context = { sessionId: parsed.sessionId, readOnly: parsed.readOnly, engine: "engine" in parsed && parsed.engine === "v2" ? "v2" : "v1" };
+    }
     const projectedToolName = typeof body.projectedToolName === "string" ? body.projectedToolName.trim() : "";
     const launch = body.launch && typeof body.launch === "object" && !Array.isArray(body.launch)
       ? body.launch as Record<string, unknown>
@@ -3463,6 +3483,7 @@ function createRoutes(
       const app = launch && typeof launch.connectionId === "string"
         ? await resolveConnectMcpAppResource({
             serverConfig: config,
+            context,
             workspaceId: workspace.id,
             workspaceRoot: workspace.path,
             launch: {
@@ -3474,6 +3495,7 @@ function createRoutes(
         : launch
           ? await resolveSameServerMcpAppResource({
               serverConfig: config,
+              context,
               workspaceId: workspace.id,
               workspaceRoot: workspace.path,
               projectedToolName,
@@ -3484,6 +3506,7 @@ function createRoutes(
             })
         : await resolveMcpAppResource({
             serverConfig: config,
+            context,
             workspaceId: workspace.id,
             workspaceRoot: workspace.path,
             projectedToolName,
@@ -3505,11 +3528,18 @@ function createRoutes(
       ? body.arguments as Record<string, unknown>
       : {};
     const approved = body.approved === true;
+    const launchId = typeof body.launchId === "string" ? body.launchId : undefined;
+    const sessionId = typeof body.sessionId === "string" || body.sessionId === null ? body.sessionId : undefined;
+    if (body.engine !== undefined && body.engine !== "v1" && body.engine !== "v2") throw new ApiError(400, "invalid_launch_context", "Unknown App session engine.");
+    const engine = body.engine === "v2" ? "v2" : "v1";
     if (!serverName || !name) throw new ApiError(400, "invalid_payload", "serverName and name are required");
     if (approved) requireClientScope(ctx, "collaborator");
     try {
       return jsonResponse(await callMcpAppTool({
         serverConfig: config,
+        launchId,
+        sessionId,
+        engine,
         workspaceId: workspace.id,
         workspaceRoot: workspace.path,
         serverName,
@@ -3517,10 +3547,44 @@ function createRoutes(
         resourceUri,
         arguments: args,
         approved,
+        assertSessionActive: async () => {
+          if (!sessionId) return;
+          if (engine === "v2") {
+            const connection = engineV2Preview.connection();
+            if (!connection) throw new McpAppHostError("inactive_session", "The original conversation engine is unavailable. Reopen it before using App actions.");
+            const url = new URL(`/api/session/${encodeURIComponent(sessionId)}`, connection.url);
+            url.searchParams.set("location[directory]", workspace.path);
+            const response = await loopbackFetch(url.toString(), {
+              headers: { authorization: `Basic ${Buffer.from(`opencode:${connection.password}`).toString("base64")}` },
+              signal: AbortSignal.timeout(10_000),
+            });
+            const payload: unknown = response.ok ? await response.json() : null;
+            const data = isRecord(payload) && isRecord(payload.data) ? payload.data : payload;
+            const session = isRecord(data) && isRecord(data.info) ? data.info : data;
+            const location = isRecord(session) && isRecord(session.location) ? session.location : null;
+            const directory = location && typeof location.directory === "string" ? location.directory : null;
+            const [expected, actual] = await Promise.all([
+              realpath(workspace.path).catch(() => workspace.path),
+              directory ? realpath(directory).catch(() => directory) : null,
+            ]);
+            if (!isRecord(session) || (session.id ?? session.sessionID) !== sessionId || !actual || actual !== expected || (isRecord(session.time) && session.time.archived)) {
+              throw new McpAppHostError("inactive_session", "The original conversation is archived or unavailable. Reopen it before using App actions.");
+            }
+            return;
+          }
+          await assertWorkspaceOwnsProxiedSessionRead(config, workspace, "GET", `/session/${encodeURIComponent(sessionId)}`, true);
+        },
       }));
     } catch (error) {
       rethrowMcpAppHostError(error);
     }
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/mcp-apps/release", "client", async (ctx) => {
+    requireClientScope(ctx, "viewer");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    return jsonResponse({ released: typeof body.launchId === "string" && releaseMcpAppLaunch(config, workspace.id, body.launchId) });
   });
 
   addRoute(routes, "POST", "/workspace/:id/mcp/managed", "client", async (ctx) => {

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -35,6 +35,31 @@ isolationTest("APP-ISOLATION embedded MCP Apps isolate siblings while SDK initia
   evidence.recordAssertionEvidence("Opaque Apps retain the standard SDK round trip", "Both real SDK Apps initialized through the shared renderer, received their distinct launch input and result, and completed exactly one legitimate helper call on their own provider.", true);
 });
 
+// The v2 engine does not expose a native archive mutation yet.
+isolationTest.skipIf(process.env.OPENWORK_EVAL_ENGINE === "v2")("APP-ARCHIVE archived conversations render Apps without actions (needs v1 archive API)", async ({ world, agent, user, probe, evidence }) => {
+  const sinceIso = new Date().toISOString();
+  await agent.send(isolationPrompt);
+  await user.see({ text: isolationReply }, { timeoutMs: 120_000 });
+  await probe.eventually(() => world.reports(), {
+    within: 30_000, label: "active Apps complete their initial helper requests",
+    until: values => values.length === 2 && values.every(value => value.complete === true && value.helper !== null),
+  });
+  await agent.run("session.archive", { sessionId: world.session.sessionId, archived: true });
+  await agent.run("session.open", { sessionId: world.session.sessionId });
+  const archived = await probe.eventually(() => world.reports(), {
+    within: 30_000, label: "archived Apps render results but reject helper actions",
+    until: values => values.length === 2 && values.every(value => value.complete === true && typeof value.helperError === "string"),
+  });
+  for (const label of ["A", "B"]) {
+    expect(archived.find(value => value.label === label)).toMatchObject({
+      input: { marker: `input-${label}` }, result: [{ type: "text", text: `initial-${label}` }], helper: null,
+    });
+  }
+  expect((await world.first.toolCalls({ name: "read_detail", sinceIso, atLeast: 1 })).map(call => call.args)).toEqual([{ marker: "legitimate-A" }]);
+  expect((await world.second.toolCalls({ name: "read_detail", sinceIso, atLeast: 1 })).map(call => call.args)).toEqual([{ marker: "legitimate-B" }]);
+  evidence.recordAssertionEvidence("Archived conversations cannot dispatch App helper calls", "Reopened archived Apps received their original inputs and results, rejected helper requests, and neither provider recorded an additional call.", true);
+});
+
 test("create, preview, save and reopen an app without changing already-open results", async ({ world, user, probe, seed, step, evidence }) => {
   await step("advertise direct artifact creation guidance and prerequisites", async () => {
     const { tools } = await world.listTools();

--- a/evals/worlds/saved-apps.ts
+++ b/evals/worlds/saved-apps.ts
@@ -75,7 +75,7 @@ export async function isolatedMcpApps(seed: Seed) {
         import { App } from "@modelcontextprotocol/ext-apps";
         const label = ${JSON.stringify(label)};
         const app = new App({ name: "isolation-" + label, version: "1" }, {});
-        const report = { label, input: null, result: null, helper: null, siblingReads: 0, siblingInjections: 0, readDenied: 0, injectionDenied: 0, forgedMessages: 0, complete: false };
+        const report = { label, input: null, result: null, helper: null, helperError: null, siblingReads: 0, siblingInjections: 0, readDenied: 0, injectionDenied: 0, forgedMessages: 0, complete: false };
         const publish = () => { document.body.dataset.isolationReport = JSON.stringify(report); };
         app.ontoolinput = ({ arguments: args }) => { report.input = args; publish(); };
         let received = false;
@@ -100,8 +100,10 @@ export async function isolatedMcpApps(seed: Seed) {
               report.forgedMessages += 1;
             }
           }
-          const resultFromHelper = await app.callServerTool({ name: "read_detail", arguments: { marker: "legitimate-" + label } });
-          report.helper = resultFromHelper.content;
+          try {
+            const resultFromHelper = await app.callServerTool({ name: "read_detail", arguments: { marker: "legitimate-" + label } });
+            report.helper = resultFromHelper.content;
+          } catch (error) { report.helperError = error.message; }
           await app.sendSizeChanged({ height: 220 });
           report.complete = true;
           document.querySelector("p").textContent = "App " + label + " received its own result and helper reply";
@@ -137,8 +139,8 @@ export async function isolatedMcpApps(seed: Seed) {
       sample_b: { type: "remote", url: app.mocks.second.mcpUrl, enabled: true, oauth: false },
     },
   });
-  await seed.session(app, { title: "Independent embedded apps" });
-  return { app, first: app.mocks.first, second: app.mocks.second,
+  const session = await seed.session(app, { title: "Independent embedded apps" });
+  return { app, session, first: app.mocks.first, second: app.mocks.second,
     reports: async () => (await inAppDocuments(app, "isolation")).map(value => record(JSON.parse(value))),
   };
 }


### PR DESCRIPTION
## Summary

Keep MCP App actions attached to the conversation and connection that opened them, rather than the currently selected workspace.

- Pass the owning endpoint, workspace, session, engine and effective read-only state into App frames, including split conversations.
- Require a bounded server-issued launch ID for callbacks. Revalidate the original tool/resource, session ownership/archive state and host-observable configuration/credential identity before dispatch.
- Fence disposed views and late approval continuations. Keep generated previews and cached results read-only until they have a valid live launch.
- Preserve working dashboard leases across equivalent fallback lists and unrelated provider/plugin/MCP changes. Relevant MCP replacement or restoration invalidates old launches.

App callbacks now require the returned launch ID. Older clients must update and reopen the App; there is no unbound-call fallback. Leases expire after 30 minutes and are capped at 256 per server instance. This does not revoke already-dispatched operations or detect upstream account changes that leave host-visible identity unchanged.

## Verification

Signed head: `b067e9a174725085dbcebcf3c3ff963f0b597157`.
Base and merge-base: `f550d6ebfc9649d43acc4f790eb63251767cc8cb` (`dev`).

Passed on that exact head, all exit 0:

- `pnpm --filter @openwork/app exec bun test --isolate ./tests/mcp-app-frame.test.ts ./tests/mcp-app-origin.test.tsx ./tests/dashboard-tile-cache.test.ts ./tests/mcp-app-tile.test.tsx` — 26 passed, 0 failed/skipped.
- `pnpm --filter openwork-server exec bun --conditions=development test src/mcp-app-host.test.ts` — 35 passed, 0 failed/skipped.
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server typecheck`
- Diff whitespace check and signatures for both commits.

The tests cover explicit origin wiring, stale approvals, lease policy/configuration changes, unrelated-update preservation and dashboard lease ownership. They are focused feedback, not full desktop journey proof.

## Verdict and remaining coverage

**Incomplete.** The existing `saved-app-creation` journey was extended with `APP-ARCHIVE`, but not executed. Cross-workspace iframe behavior, native approval timing, generated previews and actual v1/v2 HTTP session guards still need runtime proof. The archive case explicitly skips v2 where its archive mutation API is unavailable. No live provider or enterprise deployment was exercised.

This is the foundation for #4864 (direct resources), #4865 (audiences) and #4866 (conversation handoff). It does not implement those child outcomes. #4294 retains dashboard retry ownership; #4297 retains saved-input editing. Independent #4862 changes frame fixtures; rebase and adapt those fixtures to this explicit-origin contract when combining the changes, then rerun affected checks. Current results do not certify the combined set.

The latest rebase resolved one `session-surface.tsx` conflict by retaining upstream `uiStateOwner` alongside the owning client and engine. Focused checks above were rerun on the new head; old-head results are not substituted.

Hosted CI/review are pending. No merge or deployment is included.
