### PR TITLE
fix(mcp): enforce App tool audiences across Connect

### DIFF
--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -13,7 +13,7 @@ import {
   ReadResourceRequestSchema,
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import { addMcp, listMcp } from "./mcp.js";
+import { addMcp, listMcp, resolveGlobalOpenCodeConfigPath } from "./mcp.js";
 import {
   CONNECT_MCP_APP_HOST_CAPABILITY,
   CONNECT_MCP_APP_HOST_CAPABILITY_HEADER,
@@ -1166,6 +1166,61 @@ describe("MCP Apps host transport", () => {
     hideLaunch();
     await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "stale_launch_context" });
     expect(calls).toHaveLength(3);
+  });
+
+  test.each(["tool", "workspace", "global"])("private read-only helpers honor explicit %s ask before dispatch", async (scope) => {
+    const connectionId = "emc_01mcpappaskfixture";
+    const serverName = connectMcpAppHostName(connectionId);
+    const { config, root, calls } = await configuredFixture("openwork-mcp-app-ask-", undefined, serverName, connectionId);
+    await Bun.write(scope === "global" ? resolveGlobalOpenCodeConfigPath() : join(root, "opencode.json"), JSON.stringify({
+      permission: { [scope === "workspace" ? "*" : projectedMcpToolName(serverName, "read_detail")]: "ask" },
+    }));
+    const catalog = await listMcpAppCatalog({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root });
+    expect(catalog.find(server => server.serverName === serverName)?.apps.find(app => app.toolName === "render_fixture")?.requiresApproval)
+      .toBe(scope === "workspace");
+    const app = await resolveConnectMcpAppResource({
+      serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+      launch: { connectionId, toolName: "render_fixture", resourceUri: RESOURCE_URI },
+      context: { sessionId: "session-a", readOnly: false },
+    });
+    const request = {
+      serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, serverName,
+      launchId: app.launchId, sessionId: "session-a", resourceUri: RESOURCE_URI,
+      assertSessionActive: async () => {}, name: "read_detail", arguments: { id: "asked" },
+    };
+    await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "tool_requires_approval" });
+    expect(calls).toEqual([]);
+    await callMcpAppTool({ ...request, approved: true });
+    expect(calls).toEqual([{ name: "read_detail", arguments: { id: "asked" } }]);
+  });
+
+  test("private wrappers honor later allows and final denies for every App target", async () => {
+    const connectionId = "emc_01mcpapporderedfixture";
+    const serverName = connectMcpAppHostName(connectionId);
+    const { config, root, calls } = await configuredFixture("openwork-mcp-app-ordered-", undefined, serverName, connectionId);
+    const names = ["render_fixture", "execute_capability", "read_detail"].map(name => projectedMcpToolName(serverName, name));
+    const permission = { "*": "deny", ...Object.fromEntries(names.map(name => [name, "allow"])) };
+    await Bun.write(join(root, "opencode.json"), JSON.stringify({ permission }));
+    const catalog = await listMcpAppCatalog({ serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root });
+    expect(catalog.find(server => server.serverName === serverName)?.apps.map(app => app.toolName)).toEqual(["render_fixture"]);
+    const app = await resolveConnectMcpAppResource({
+      serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+      launch: { connectionId, toolName: "render_fixture", resourceUri: RESOURCE_URI },
+      context: { sessionId: "session-a", readOnly: false },
+    });
+    const request = {
+      serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, serverName,
+      launchId: app.launchId, sessionId: "session-a", resourceUri: RESOURCE_URI,
+      assertSessionActive: async () => {}, name: "execute_capability", approved: true,
+      arguments: { name: "read_detail", body: { id: "ordered" } },
+    };
+    await callMcpAppTool(request);
+    expect(calls).toEqual([{ name: "execute_capability", arguments: request.arguments }]);
+    for (const name of names) {
+      await Bun.write(join(root, "opencode.json"), JSON.stringify({ permission: { ...permission, [`${name}*`]: "deny" } }));
+      await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "tool_denied" });
+      expect(calls).toHaveLength(1);
+    }
   });
 
   test("rejects private MCP egress outside explicit development mode", async () => {

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -654,6 +654,91 @@ describe("MCP Apps host transport", () => {
     expect(fixture.requests.filter((request) => request.method === "tools/call")).toEqual([]);
   });
 
+  test.each(["direct", "private"])("direct App actions retain %s asks while honoring later same-namespace allows", async (identity) => {
+    const fixture = await directConnectFixture();
+    const app = await fixture.resolve();
+    if (!app?.launchId) throw new Error("Missing App lease");
+    const privateName = connectMcpAppHostName(fixture.descriptor.connectionId);
+    const restrictedName = identity === "direct" ? fixture.directName : privateName;
+    const otherName = identity === "direct" ? privateName : fixture.directName;
+    const request = {
+      serverConfig: fixture.config, workspaceId: WORKSPACE_ID, workspaceRoot: fixture.root,
+      serverName: app.serverName, resourceUri: app.resourceUri, launchId: app.launchId,
+      sessionId: "session-direct", engine: "v2" as const, name: "read_detail", assertSessionActive: async () => {},
+    };
+    for (const toolName of ["render.fixture", "read_detail"]) {
+      const restrictedTool = projectedMcpToolName(restrictedName, toolName);
+      const otherTool = projectedMcpToolName(otherName, toolName);
+      await writeJsoncFile(opencodeConfigPath(fixture.root), { permission: {
+        "*": "allow", [restrictedTool]: "ask", [otherTool]: "allow",
+      } });
+      fixture.requests.length = 0;
+      await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "tool_requires_approval" });
+      expect(fixture.requests.filter(request => request.method === "tools/call")).toEqual([]);
+      await callMcpAppTool({ ...request, approved: true });
+      expect(fixture.requests.filter(request => request.method === "tools/call")).toHaveLength(1);
+    }
+    await writeJsoncFile(opencodeConfigPath(fixture.root), { permission: {
+      "*": "ask",
+      ...Object.fromEntries([privateName, fixture.directName].flatMap(serverName =>
+        ["render.fixture", "read_detail"].map(toolName => [projectedMcpToolName(serverName, toolName), "allow"]))),
+    } });
+    fixture.requests.length = 0;
+    await callMcpAppTool(request);
+    expect(fixture.requests.filter(request => request.method === "tools/call")).toEqual([{
+      path: new URL(fixture.descriptor.url).pathname, method: "tools/call", privateAuth: true,
+      appHostCapability: true, params: { name: "read_detail", arguments: {} },
+    }]);
+  });
+
+  test.each(["direct", "private"])("wrapped helpers enforce every %s target policy without rebinding the private lease", async (identity) => {
+    const fixture = await directConnectFixture();
+    fixture.tools.private.push({
+      name: "execute_capability", inputSchema: { type: "object" }, annotations: { readOnlyHint: false },
+      _meta: { ui: { visibility: ["app"] } },
+    });
+    const privateName = connectMcpAppHostName(fixture.descriptor.connectionId);
+    const serverNames = [privateName, fixture.directName];
+    const toolNames = ["render.fixture", "execute_capability", "read_detail"];
+    const permission = {
+      "*": "deny",
+      ...Object.fromEntries(serverNames.flatMap(serverName =>
+        toolNames.map(toolName => [projectedMcpToolName(serverName, toolName), "allow"]))),
+    };
+    await writeJsoncFile(opencodeConfigPath(fixture.root), { permission });
+    const app = await fixture.resolve();
+    if (!app?.launchId) throw new Error("Missing App lease");
+    expect(app.serverName).toBe(privateName);
+    const request = {
+      serverConfig: fixture.config, workspaceId: WORKSPACE_ID, workspaceRoot: fixture.root,
+      serverName: app.serverName, resourceUri: app.resourceUri, launchId: app.launchId,
+      sessionId: "session-direct", engine: "v2" as const, name: "execute_capability", assertSessionActive: async () => {},
+      arguments: { name: "read_detail", body: { id: "wrapped" } },
+    };
+    fixture.requests.length = 0;
+    await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "tool_requires_approval" });
+    expect(fixture.requests.filter(request => request.method === "tools/call")).toEqual([]);
+    await callMcpAppTool({ ...request, approved: true });
+    expect(fixture.requests.filter(request => request.method === "tools/call")).toEqual([{
+      path: new URL(fixture.descriptor.url).pathname, method: "tools/call", privateAuth: true,
+      appHostCapability: true, params: { name: "execute_capability", arguments: request.arguments },
+    }]);
+    for (const toolName of toolNames) {
+      const serverName = identity === "direct" ? fixture.directName : privateName;
+      await writeJsoncFile(opencodeConfigPath(fixture.root), { permission: {
+        ...permission, [`${projectedMcpToolName(serverName, toolName)}*`]: "deny",
+      } });
+      fixture.requests.length = 0;
+      await expect(callMcpAppTool({ ...request, approved: true })).rejects.toMatchObject({ code: "tool_denied" });
+      expect(fixture.requests.filter(request => request.method === "tools/call")).toEqual([]);
+    }
+    await writeJsoncFile(opencodeConfigPath(fixture.root), { permission });
+    await writeOpenWorkConnectMcpAppHostAuthorization(fixture.config, WORKSPACE_ID, "Bearer rotated-fixture", fixture.descriptor.url);
+    fixture.requests.length = 0;
+    await expect(callMcpAppTool({ ...request, approved: true })).rejects.toMatchObject({ code: "stale_launch_context" });
+    expect(fixture.requests).toEqual([]);
+  });
+
   test("a read-only direct resolution forwards context without issuing an actionable lease", async () => {
     const fixture = await directConnectFixture();
     const app = await fixture.resolve({ sessionId: "session-direct", readOnly: true, engine: "v2" });

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -85,6 +85,7 @@ async function startFixtureMcp(
   const calls: Array<{ name: string; arguments?: Record<string, unknown> }> = [];
   let launchVisible = true;
   let launchPresent = true;
+  let detailUi: { resourceUri?: string; visibility?: unknown } = { visibility: ["app"] };
   const mcp = new Server(
     { name: "mcp-app-fixture", version: "1.0.0" },
     {
@@ -99,6 +100,17 @@ async function startFixtureMcp(
   );
   mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
+      ...(connectionId ? [{
+        name: "execute_capability",
+        inputSchema: { type: "object" as const, properties: { name: { type: "string" }, body: { type: "object" } }, required: ["name"] },
+        annotations: { readOnlyHint: false },
+        _meta: { ui: { visibility: ["app"] } },
+      }, {
+        name: "search_capabilities",
+        inputSchema: { type: "object" as const, properties: { query: { type: "string" } } },
+        annotations: { readOnlyHint: true },
+        _meta: { ui: { visibility: ["app"] } },
+      }] : []),
       {
         name: "render_fixture",
         description: "Render the fixture",
@@ -138,7 +150,7 @@ async function startFixtureMcp(
         description: "Read fixture detail",
         inputSchema: { type: "object", properties: { id: { type: "string" } } },
         annotations: { readOnlyHint: true, destructiveHint: false },
-        _meta: { ui: { visibility: ["app"] } },
+        _meta: { ui: detailUi },
       },
       {
         name: "read_bound_detail",
@@ -268,6 +280,7 @@ async function startFixtureMcp(
     calls,
     hideLaunch: () => { launchVisible = false; },
     removeLaunch: () => { launchPresent = false; },
+    setDetailUi: (ui: typeof detailUi) => { detailUi = ui; },
     activateUpdatedResource: async () => {
       activeResourceUri = UPDATED_RESOURCE_URI;
       // A stateful SDK server transport owns one initialized MCP session. The
@@ -291,6 +304,7 @@ async function configuredFixture(
   calls: Array<{ name: string; arguments?: Record<string, unknown> }>;
   hideLaunch: () => void;
   removeLaunch: () => void;
+  setDetailUi: (ui: { resourceUri?: string; visibility?: unknown }) => void;
 }> {
   const { config, root } = await fixtureWorkspace(prefix);
   const fixture = await startFixtureMcp(resourceContent, connectionId);
@@ -333,6 +347,7 @@ async function configuredFixture(
     calls: fixture.calls,
     hideLaunch: fixture.hideLaunch,
     removeLaunch: fixture.removeLaunch,
+    setDetailUi: fixture.setDetailUi,
   };
 }
 
@@ -706,6 +721,7 @@ describe("MCP Apps host transport", () => {
     expect(names).toContain("render_fixture");
     // Connect launches resolve by connection reference, so app-only tools qualify.
     expect(names).toContain("read_bound_detail");
+    expect(names).not.toContain("read_detail");
     expect(names).not.toContain("save_artifact_view");
     const renderFixture = connect?.apps.find((app) => app.toolName === "render_fixture");
     expect(renderFixture?.connectionId).toBe(connectionId);
@@ -1099,6 +1115,57 @@ describe("MCP Apps host transport", () => {
       content: [{ type: "text", text: "detail:approved" }],
       structuredContent: { id: "approved" },
     });
+  });
+
+  test("private Connect wrappers validate the inner helper against the trusted launch and workspace policy", async () => {
+    const connectionId = "emc_01mcpappwrapperfixture";
+    const serverName = connectMcpAppHostName(connectionId);
+    const { config, root, calls, setDetailUi, hideLaunch } = await configuredFixture(
+      "openwork-mcp-app-wrapper-", undefined, serverName, connectionId,
+    );
+    const app = await resolveConnectMcpAppResource({
+      serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root,
+      launch: { connectionId, toolName: "render_fixture", resourceUri: RESOURCE_URI },
+      context: { sessionId: "session-a", readOnly: false },
+    });
+    const request = {
+      serverConfig: config, workspaceId: WORKSPACE_ID, workspaceRoot: root, serverName,
+      launchId: app.launchId, sessionId: "session-a", resourceUri: RESOURCE_URI,
+      assertSessionActive: async () => {}, name: "execute_capability", approved: true,
+      arguments: { name: "read_detail", body: { id: "wrapper-detail" } },
+    };
+    await expect(callMcpAppTool({ ...request, approved: false })).rejects.toMatchObject({ code: "tool_requires_approval" });
+    expect(calls).toEqual([]);
+    for (const ui of [{ visibility: ["app"] }, {}, { visibility: ["app"], resourceUri: RESOURCE_URI }]) {
+      setDetailUi(ui);
+      await callMcpAppTool(request);
+      expect(calls.at(-1)).toEqual({ name: "execute_capability", arguments: request.arguments });
+    }
+    for (const [ui, code] of [
+      [{ visibility: ["model"] }, "tool_not_visible"],
+      [{ visibility: ["app", "invalid"] }, "tool_not_visible"],
+      [{ visibility: [] }, "tool_not_visible"],
+      [{ visibility: "app" }, "tool_not_visible"],
+      [{ visibility: ["app"], resourceUri: UPDATED_RESOURCE_URI }, "tool_resource_mismatch"],
+    ] satisfies Array<[{ visibility: unknown; resourceUri?: string }, string]>) {
+      setDetailUi(ui);
+      await expect(callMcpAppTool(request)).rejects.toMatchObject({ code });
+      await expect(callMcpAppTool({ ...request, name: "read_detail", arguments: {} })).rejects.toMatchObject({ code });
+    }
+    for (const name of ["unknown", "execute_capability", "search_capabilities", "mcp:another-connection:read_detail"]) {
+      await expect(callMcpAppTool({ ...request, arguments: { name, body: {} } })).rejects.toMatchObject({ code: "tool_not_found" });
+    }
+    expect(calls).toHaveLength(3);
+    setDetailUi({ visibility: ["app"] });
+    await Bun.write(join(root, "opencode.json"), JSON.stringify({
+      permission: { [projectedMcpToolName(serverName, "read_detail")]: "deny" },
+    }));
+    await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "tool_denied" });
+    await expect(callMcpAppTool({ ...request, name: "read_detail", arguments: {} })).rejects.toMatchObject({ code: "tool_denied" });
+    await Bun.write(join(root, "opencode.json"), "{}");
+    hideLaunch();
+    await expect(callMcpAppTool(request)).rejects.toMatchObject({ code: "stale_launch_context" });
+    expect(calls).toHaveLength(3);
   });
 
   test("rejects private MCP egress outside explicit development mode", async () => {

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -190,9 +190,15 @@ export function projectedMcpToolName(serverName: string, toolName: string): stri
 async function appToolPolicy(input: { serverConfig: ServerConfig; workspaceRoot: string }) {
   const rules = await readMcpToolPolicy(input.serverConfig, input.workspaceRoot);
   if (!rules) throw new McpAppHostError("tool_policy_unavailable", "The workspace tool policy could not be read safely.");
-  // With no configured rule the App host retains its annotation approval gate.
-  return (serverName: string, toolName: string) =>
-    winningRule(rules, projectedMcpToolName(serverName, toolName), "*")?.action ?? "allow";
+  return (policyServerNames: readonly string[], toolName: string) => {
+    // Rule order decides within each identity; one identity cannot relax another.
+    const actions = policyServerNames.map(serverName =>
+      winningRule(rules, projectedMcpToolName(serverName, toolName), "*")?.action);
+    if (actions.includes("deny")) return "deny";
+    if (actions.includes("ask")) return "ask";
+    // With no configured rule the App host retains its annotation approval gate.
+    return "allow";
+  };
 }
 
 export function toolUiResourceUri(tool: Partial<Tool>): string | null {
@@ -548,7 +554,7 @@ async function catalogAppsFromClient(client: Client, options: {
     }
     if (!resourceUri) continue;
     const projectedToolName = projectedMcpToolName(options.serverName, tool.name);
-    if (permission(options.serverName, tool.name) === "deny") continue;
+    if (permission([options.serverName], tool.name) === "deny") continue;
     catalog.push({
       serverName: options.serverName,
       ...(options.connectionId ? { connectionId: options.connectionId } : {}),
@@ -558,7 +564,7 @@ async function catalogAppsFromClient(client: Client, options: {
       title: toolDisplayTitle(tool),
       description: typeof tool.description === "string" ? tool.description : null,
       requiresInput: toolRequiresInput(tool),
-      requiresApproval: toolRequiresApproval(tool) || permission(options.serverName, tool.name) === "ask",
+      requiresApproval: toolRequiresApproval(tool) || permission([options.serverName], tool.name) === "ask",
     });
   }
   return catalog;
@@ -726,7 +732,7 @@ export async function resolveMcpAppResource(input: {
       if (!mcpToolVisibleTo(tool, "model")) return null;
       const resourceUri = toolUiResourceUri(tool);
       if (!resourceUri) return null;
-      if (permission(item.name, tool.name) === "deny") {
+      if (permission([item.name], tool.name) === "deny") {
         throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
       }
       if (directConnectionId) {
@@ -834,7 +840,7 @@ async function resolvePrivateConnectMcpAppResource(
     if (resourceUri !== input.launch.resourceUri) {
       throw new McpAppHostError("tool_resource_mismatch", "The originating MCP App tool now advertises a different resource.");
     }
-    if (policyServerNames.some(name => permission(name, tool.name) === "deny")) {
+    if (permission(policyServerNames, tool.name) === "deny") {
       throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
     }
     const read = await client.readResource({ uri: resourceUri }).catch(() => {
@@ -901,7 +907,7 @@ export async function resolveSameServerMcpAppResource(input: {
       if (resourceUri !== input.launch.resourceUri) {
         throw new McpAppHostError("tool_resource_mismatch", "The same-server MCP App tool now advertises a different resource.");
       }
-      if (permission(item.name, launchTool.name) === "deny") {
+      if (permission([item.name], launchTool.name) === "deny") {
         throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
       }
       const read = await client.readResource({ uri: resourceUri }).catch(() => {
@@ -1010,7 +1016,7 @@ export async function callMcpAppTool(input: {
     await input.assertSessionActive?.();
     await currentConfig();
     const permission = await appToolPolicy(input);
-    const decisions = [original, ...targets].flatMap(target => launch.policyServerNames.map(name => permission(name, target.name)));
+    const decisions = [original, ...targets].map(target => permission(launch.policyServerNames, target.name));
     if (decisions.includes("deny")) {
       throw new McpAppHostError("tool_denied", "This App tool is denied by the workspace tool policy.");
     }

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -28,7 +28,8 @@ import {
   createLocalManagedMcpGuardedFetch,
   LocalManagedMcpPrivateUrlError,
 } from "./local-managed-mcp-url-guard.js";
-import { diagnoseMcpToolDenies, listMcpFromRuntimeSnapshot } from "./mcp.js";
+import { listMcpFromRuntimeSnapshot, readMcpToolPolicy } from "./mcp.js";
+import { winningRule } from "./effective-permissions.js";
 import { readEffectiveRuntimeOpencodeConfig, readRuntimeMcpConfigRevisions } from "./runtime-opencode-config-store.js";
 import { localManagedMcpAppIdentity } from "./local-managed-mcp.js";
 
@@ -186,13 +187,12 @@ export function projectedMcpToolName(serverName: string, toolName: string): stri
   return `${sanitize(serverName)}_${sanitize(toolName)}`;
 }
 
-/** Apply every host-owned lease namespace to a native tool, including resolved inner targets. */
-export async function assertMcpAppToolPolicy(workspaceRoot: string, policyServerNames: readonly string[], toolName: string): Promise<void> {
-  for (const serverName of policyServerNames) {
-    if ((await diagnoseMcpToolDenies(workspaceRoot, serverName, [projectedMcpToolName(serverName, toolName)])).length > 0) {
-      throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
-    }
-  }
+async function appToolPolicy(input: { serverConfig: ServerConfig; workspaceRoot: string }) {
+  const rules = await readMcpToolPolicy(input.serverConfig, input.workspaceRoot);
+  if (!rules) throw new McpAppHostError("tool_policy_unavailable", "The workspace tool policy could not be read safely.");
+  // With no configured rule the App host retains its annotation approval gate.
+  return (serverName: string, toolName: string) =>
+    winningRule(rules, projectedMcpToolName(serverName, toolName), "*")?.action ?? "allow";
 }
 
 export function toolUiResourceUri(tool: Partial<Tool>): string | null {
@@ -528,6 +528,7 @@ async function withCatalogProbeTimeout<T>(work: Promise<T>): Promise<T> {
 }
 
 async function catalogAppsFromClient(client: Client, options: {
+  serverConfig: ServerConfig;
   serverName: string;
   workspaceRoot: string;
   connectionId?: string;
@@ -535,6 +536,7 @@ async function catalogAppsFromClient(client: Client, options: {
   requireModelVisibility: boolean;
 }): Promise<McpAppCatalogApp[]> {
   const catalog: McpAppCatalogApp[] = [];
+  const permission = await appToolPolicy(options);
   for (const tool of await listTools(client)) {
     if (options.requireModelVisibility && !mcpToolVisibleTo(tool, "model")) continue;
     if (!mcpToolVisibleTo(tool, "app")) continue;
@@ -546,7 +548,7 @@ async function catalogAppsFromClient(client: Client, options: {
     }
     if (!resourceUri) continue;
     const projectedToolName = projectedMcpToolName(options.serverName, tool.name);
-    if ((await diagnoseMcpToolDenies(options.workspaceRoot, options.serverName, [projectedToolName])).length > 0) continue;
+    if (permission(options.serverName, tool.name) === "deny") continue;
     catalog.push({
       serverName: options.serverName,
       ...(options.connectionId ? { connectionId: options.connectionId } : {}),
@@ -556,7 +558,7 @@ async function catalogAppsFromClient(client: Client, options: {
       title: toolDisplayTitle(tool),
       description: typeof tool.description === "string" ? tool.description : null,
       requiresInput: toolRequiresInput(tool),
-      requiresApproval: toolRequiresApproval(tool),
+      requiresApproval: toolRequiresApproval(tool) || permission(options.serverName, tool.name) === "ask",
     });
   }
   return catalog;
@@ -608,6 +610,7 @@ export async function listMcpAppCatalog(input: {
           // audience) and execute through the app-mediated call path, so a
           // listed app must stay visible to both.
           catalogAppsFromClient(client, {
+            serverConfig: input.serverConfig,
             serverName: item.name,
             workspaceRoot: input.workspaceRoot,
             requireModelVisibility: true,
@@ -655,6 +658,7 @@ export async function listMcpAppCatalog(input: {
     try {
       const apps = await withCatalogProbeTimeout(withRemoteClient(config, (client) =>
         catalogAppsFromClient(client, {
+          serverConfig: input.serverConfig,
           serverName: hostName,
           workspaceRoot: input.workspaceRoot,
           connectionId: descriptor.connectionId,
@@ -688,6 +692,7 @@ export async function resolveMcpAppResource(input: {
   }
   const runtime = await readEffectiveRuntimeOpencodeConfig(input.serverConfig, input.workspaceId);
   const configured = await listMcpFromRuntimeSnapshot(input.workspaceRoot, runtime);
+  const permission = await appToolPolicy(input);
   const candidates = configured.filter((item) => (
     item.config.enabled !== false
     && input.projectedToolName.startsWith(`${item.name.replace(/[^a-zA-Z0-9_-]/g, "_")}_`)
@@ -721,7 +726,7 @@ export async function resolveMcpAppResource(input: {
       if (!mcpToolVisibleTo(tool, "model")) return null;
       const resourceUri = toolUiResourceUri(tool);
       if (!resourceUri) return null;
-      if ((await diagnoseMcpToolDenies(input.workspaceRoot, item.name, [input.projectedToolName])).length > 0) {
+      if (permission(item.name, tool.name) === "deny") {
         throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
       }
       if (directConnectionId) {
@@ -815,6 +820,7 @@ async function resolvePrivateConnectMcpAppResource(
   const { serverName } = item;
   const policyServerNames = directPolicyServerName ? [serverName, directPolicyServerName] : [serverName];
   const fingerprint = await launchFingerprint(input, serverName, item.config);
+  const permission = await appToolPolicy(input);
 
   const app = await withRemoteClient(item.config, async (client) => {
     const tool = (await listTools(client)).find((candidate) => candidate.name === input.launch.toolName);
@@ -828,7 +834,9 @@ async function resolvePrivateConnectMcpAppResource(
     if (resourceUri !== input.launch.resourceUri) {
       throw new McpAppHostError("tool_resource_mismatch", "The originating MCP App tool now advertises a different resource.");
     }
-    await assertMcpAppToolPolicy(input.workspaceRoot, policyServerNames, tool.name);
+    if (policyServerNames.some(name => permission(name, tool.name) === "deny")) {
+      throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
+    }
     const read = await client.readResource({ uri: resourceUri }).catch(() => {
       throw new McpAppHostError(
         "resource_read_failed",
@@ -871,6 +879,7 @@ export async function resolveSameServerMcpAppResource(input: {
   }
 
   const configured = await listMcp(input.serverConfig, input.workspaceId, input.workspaceRoot);
+  const permission = await appToolPolicy(input);
   const candidates = configured.filter((item) => (
     item.config.enabled !== false
     && remoteUrl(item.config)
@@ -892,8 +901,7 @@ export async function resolveSameServerMcpAppResource(input: {
       if (resourceUri !== input.launch.resourceUri) {
         throw new McpAppHostError("tool_resource_mismatch", "The same-server MCP App tool now advertises a different resource.");
       }
-      const projectedLaunchName = projectedMcpToolName(item.name, launchTool.name);
-      if ((await diagnoseMcpToolDenies(input.workspaceRoot, item.name, [projectedLaunchName])).length > 0) {
+      if (permission(item.name, launchTool.name) === "deny") {
         throw new McpAppHostError("tool_denied", "This MCP App tool is denied by the workspace tool policy.");
       }
       const read = await client.readResource({ uri: resourceUri }).catch(() => {
@@ -972,7 +980,6 @@ export async function callMcpAppTool(input: {
     findHtmlResource(launch.resourceUri, await client.readResource({ uri: launch.resourceUri }).catch(() => {
       throw new McpAppHostError("resource_read_failed", "The original App resource is no longer available. Reopen the App before using its actions.");
     }));
-    await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, original.name);
     const tool = tools.find((candidate) => candidate.name === input.name);
     if (!tool) throw new McpAppHostError("tool_not_found", "The requested same-server MCP tool was not found.");
     const targets = [tool];
@@ -996,21 +1003,22 @@ export async function callMcpAppTool(input: {
           "The requested MCP tool is bound to a different MCP App resource.",
         );
       }
-      await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, target.name);
     }
     if (launch.sessionId !== null && !input.assertSessionActive) {
       throw new McpAppHostError("inactive_session", "The original conversation cannot be verified. Reopen it before using App actions.");
     }
     await input.assertSessionActive?.();
-    if (targets.some(toolRequiresApproval) && !input.approved) {
+    await currentConfig();
+    const permission = await appToolPolicy(input);
+    const decisions = [original, ...targets].flatMap(target => launch.policyServerNames.map(name => permission(name, target.name)));
+    if (decisions.includes("deny")) {
+      throw new McpAppHostError("tool_denied", "This App tool is denied by the workspace tool policy.");
+    }
+    if ((decisions.includes("ask") || targets.some(toolRequiresApproval)) && !input.approved) {
       throw new McpAppHostError(
         "tool_requires_approval",
         "This MCP App tool requires user approval before OpenWork can call it.",
       );
-    }
-    await currentConfig();
-    for (const target of [original, ...targets]) {
-      await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, target.name);
     }
     assertLive();
     // A provider that rejects the call (for example JSON-RPC -32602 for a

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -6,6 +6,7 @@ import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontex
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { mcpToolVisibleTo } from "@openwork/types/mcp-tool-visibility";
 import {
   CONNECT_DIRECT_MCP_SERVER_NAME_PREFIX,
   CONNECT_MCP_APP_HOST_CAPABILITY,
@@ -365,15 +366,6 @@ async function listTools(client: Client): Promise<Tool[]> {
   throw new McpAppHostError("tool_catalog_too_large", "MCP tool pagination exceeded the host limit.");
 }
 
-function toolVisibility(tool: Partial<Tool>, audience: "model" | "app"): boolean {
-  const meta = isRecord(tool._meta) ? tool._meta : {};
-  const ui = isRecord(meta.ui) ? meta.ui : {};
-  if (ui.visibility === undefined) return true;
-  return Array.isArray(ui.visibility)
-    && ui.visibility.every((entry) => entry === "model" || entry === "app")
-    && ui.visibility.includes(audience);
-}
-
 function strictBase64Bytes(value: string): Uint8Array {
   if (value.length > Math.ceil(MAX_RESOURCE_BYTES / 3) * 4) {
     throw new McpAppHostError("resource_too_large", "The MCP App resource exceeds the 768 KiB host limit.");
@@ -544,8 +536,8 @@ async function catalogAppsFromClient(client: Client, options: {
 }): Promise<McpAppCatalogApp[]> {
   const catalog: McpAppCatalogApp[] = [];
   for (const tool of await listTools(client)) {
-    if (options.requireModelVisibility && !toolVisibility(tool, "model")) continue;
-    if (!toolVisibility(tool, "app")) continue;
+    if (options.requireModelVisibility && !mcpToolVisibleTo(tool, "model")) continue;
+    if (!mcpToolVisibleTo(tool, "app")) continue;
     let resourceUri: string | null;
     try {
       resourceUri = toolUiResourceUri(tool);
@@ -726,7 +718,7 @@ export async function resolveMcpAppResource(input: {
       }
       const tool = tools[0];
       if (!tool) return null;
-      if (!toolVisibility(tool, "model")) return null;
+      if (!mcpToolVisibleTo(tool, "model")) return null;
       const resourceUri = toolUiResourceUri(tool);
       if (!resourceUri) return null;
       if ((await diagnoseMcpToolDenies(input.workspaceRoot, item.name, [input.projectedToolName])).length > 0) {
@@ -829,7 +821,7 @@ async function resolvePrivateConnectMcpAppResource(
     if (!tool) {
       throw new McpAppHostError("tool_not_found", "The originating MCP App tool is no longer advertised.");
     }
-    if (!toolVisibility(tool, "app")) {
+    if (!mcpToolVisibleTo(tool, "app")) {
       throw new McpAppHostError("tool_not_visible", "The originating MCP App tool is not visible to apps.");
     }
     const resourceUri = toolUiResourceUri(tool);
@@ -890,10 +882,10 @@ export async function resolveSameServerMcpAppResource(input: {
     const match = await withRemoteClient(item.config, async (client) => {
       const tools = await listTools(client);
       const gatewayTool = tools.find((tool) => projectedMcpToolName(item.name, tool.name) === input.projectedToolName);
-      if (!gatewayTool || !toolVisibility(gatewayTool, "model")) return null;
+      if (!gatewayTool || !mcpToolVisibleTo(gatewayTool, "model")) return null;
       const launchTool = tools.find((tool) => tool.name === input.launch.toolName);
       if (!launchTool) throw new McpAppHostError("tool_not_found", "The same-server MCP App tool is no longer advertised.");
-      if (!toolVisibility(launchTool, "app")) {
+      if (!mcpToolVisibleTo(launchTool, "app")) {
         throw new McpAppHostError("tool_not_visible", "The same-server MCP App tool is not visible to apps.");
       }
       const resourceUri = toolUiResourceUri(launchTool);
@@ -976,37 +968,50 @@ export async function callMcpAppTool(input: {
   return await withRemoteClient(config, async (client) => {
     const tools = await listTools(client);
     const original = tools.find((candidate) => candidate.name === launch.toolName);
-    if (!original || !toolVisibility(original, "app") || toolUiResourceUri(original) !== launch.resourceUri) throw staleLaunch();
+    if (!original || !mcpToolVisibleTo(original, "app") || toolUiResourceUri(original) !== launch.resourceUri) throw staleLaunch();
     findHtmlResource(launch.resourceUri, await client.readResource({ uri: launch.resourceUri }).catch(() => {
       throw new McpAppHostError("resource_read_failed", "The original App resource is no longer available. Reopen the App before using its actions.");
     }));
     await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, original.name);
     const tool = tools.find((candidate) => candidate.name === input.name);
     if (!tool) throw new McpAppHostError("tool_not_found", "The requested same-server MCP tool was not found.");
-    if (!toolVisibility(tool, "app")) {
-      throw new McpAppHostError("tool_not_visible", "The requested MCP tool is not visible to apps.");
+    const targets = [tool];
+    // Only the verified private Connect endpoint has this known wrapper contract.
+    // Its inner provider target must obey the original lease, not caller routing hints.
+    if (launch.serverName.startsWith(CONNECT_MCP_APP_HOST_NAME_PREFIX) && tool.name === "execute_capability") {
+      const name = typeof input.arguments?.name === "string" ? input.arguments.name.trim() : "";
+      const target = tools.find((candidate) => candidate.name === name
+        && candidate.name !== "execute_capability" && candidate.name !== "search_capabilities");
+      if (!target) throw new McpAppHostError("tool_not_found", "The requested same-server capability was not found.");
+      targets.push(target);
     }
-    const boundResourceUri = toolUiResourceUri(tool);
-    if (boundResourceUri && boundResourceUri !== input.resourceUri) {
-      throw new McpAppHostError(
-        "tool_resource_mismatch",
-        "The requested MCP tool is bound to a different MCP App resource.",
-      );
+    for (const target of targets) {
+      if (!mcpToolVisibleTo(target, "app")) {
+        throw new McpAppHostError("tool_not_visible", "The requested MCP tool is not visible to apps.");
+      }
+      const boundResourceUri = toolUiResourceUri(target);
+      if (boundResourceUri && boundResourceUri !== launch.resourceUri) {
+        throw new McpAppHostError(
+          "tool_resource_mismatch",
+          "The requested MCP tool is bound to a different MCP App resource.",
+        );
+      }
+      await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, target.name);
     }
-    await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, tool.name);
     if (launch.sessionId !== null && !input.assertSessionActive) {
       throw new McpAppHostError("inactive_session", "The original conversation cannot be verified. Reopen it before using App actions.");
     }
     await input.assertSessionActive?.();
-    if (toolRequiresApproval(tool) && !input.approved) {
+    if (targets.some(toolRequiresApproval) && !input.approved) {
       throw new McpAppHostError(
         "tool_requires_approval",
         "This MCP App tool requires user approval before OpenWork can call it.",
       );
     }
     await currentConfig();
-    await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, original.name);
-    await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, tool.name);
+    for (const target of [original, ...targets]) {
+      await assertMcpAppToolPolicy(input.workspaceRoot, launch.policyServerNames, target.name);
+    }
     assertLive();
     // A provider that rejects the call (for example JSON-RPC -32602 for a
     // missing required argument) must reach the member as that rejection,

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -4,6 +4,8 @@ import type { McpItem, ServerConfig } from "./types.js";
 import { sanitizeDiagnosticString } from "./diagnostic-sanitizer.js";
 import { readJsoncFile } from "./jsonc.js";
 import { opencodeConfigPath } from "./workspace-files.js";
+import { buildOpenworkRuntimeConfigObject } from "./openwork-runtime-config.js";
+import type { EffectiveEnginePermissionRule } from "./agent-context-engine-inspection.js";
 import { validateMcpConfig, validateMcpName, validateUserMcpName } from "./validators.js";
 import {
   readRuntimeOpencodeConfig,
@@ -437,11 +439,10 @@ function toolPolicyRules(policy: ToolPolicyMap): Array<{
   });
 }
 
-function deniedToolIds(
+function configuredToolPolicyRules(
   configs: Record<string, unknown>[],
   agentName: string,
-  toolIds: string[],
-): string[] {
+): EffectiveEnginePermissionRule[] {
   // OpenCode merges the deprecated top-level `tools` map and the current
   // `permission` map independently, then applies every permission key after
   // every tools key. A project `tools: { x: true }` therefore cannot undo a
@@ -456,7 +457,15 @@ function deniedToolIds(
     mergeConfiguredPolicies(configs, (config) => policyForAgentContainer(config, "agent", agentName)),
     mergeConfiguredPolicies(configs, (config) => policyForAgentContainer(config, "mode", agentName)),
   );
-  const rules = [...toolPolicyRules(topLevel), ...toolPolicyRules(agent)];
+  return [...toolPolicyRules(topLevel), ...toolPolicyRules(agent)];
+}
+
+function deniedToolIds(
+  configs: Record<string, unknown>[],
+  agentName: string,
+  toolIds: string[],
+): string[] {
+  const rules = configuredToolPolicyRules(configs, agentName);
   return toolIds.filter((toolId) => {
     const decision = rules.slice().reverse().find((rule) => (
       openCodeWildcardMatch(toolId, rule.permission)
@@ -526,6 +535,25 @@ async function inspectMcpConfigLayer(
     options.signal?.throwIfAborted();
     return { data: {}, status: "unreadable" };
   }
+}
+
+/** Current configured rules, in the same layer and agent order used by OpenCode. */
+export async function readMcpToolPolicy(
+  serverConfig: ServerConfig,
+  workspaceRoot: string,
+): Promise<EffectiveEnginePermissionRule[] | null> {
+  const options = { maxBytes: DIAGNOSTIC_STATIC_CONFIG_MAX_BYTES };
+  const [global, injected, project] = await Promise.all([
+    inspectMcpConfigLayer(resolveGlobalOpenCodeConfigPath(), options),
+    buildOpenworkRuntimeConfigObject(serverConfig),
+    inspectMcpConfigLayer(opencodeConfigPath(workspaceRoot), options),
+  ]);
+  if ([global, project].some(layer => layer.status === "invalid" || layer.status === "unreadable")) return null;
+  const agentName = project.data.default_agent ?? injected.default_agent ?? global.data.default_agent;
+  return configuredToolPolicyRules(
+    [global.data, injected, project.data],
+    typeof agentName === "string" ? agentName : "openwork",
+  );
 }
 
 export async function listMcpFromRuntimeSnapshot(

--- a/ee/apps/den-api/src/mcp/codemode-tools.ts
+++ b/ee/apps/den-api/src/mcp/codemode-tools.ts
@@ -1,4 +1,5 @@
 import { Tool, toolError } from "@openwork/codemode"
+import { mcpToolVisibleTo } from "@openwork/types/mcp-tool-visibility"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { Effect } from "effect"
 import type { Hono } from "hono"
@@ -323,7 +324,7 @@ export async function buildExternalMcpToolTree(input: {
         undefined,
         deadline,
       )
-      return { connection, tools }
+      return { connection, tools: tools.filter((tool) => mcpToolVisibleTo(tool, "model")) }
     } catch {
       return undefined
     }

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { mcpToolVisibleTo } from "@openwork/types/mcp-tool-visibility"
 import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import {
   OPENWORK_CLOUD_MCP_CONNECTION_ACTION_KIND,
@@ -791,7 +792,7 @@ async function probeExternalMcpConnection(input: {
   }
 
   for (const tool of tools) {
-    if (isToolDisabled(connection.toolPolicy, tool.name)) continue
+    if (!mcpToolVisibleTo(tool, "model") || isToolDisabled(connection.toolPolicy, tool.name)) continue
     const summary = tool.description ?? tool.title ?? tool.name
     const nameTokens = tokenize(`${connection.name} ${tool.name}`)
     const summaryTokens = tokenize(summary)
@@ -1216,7 +1217,7 @@ export async function executeExternalCapability(input: {
   try {
     const redirectUri = redirectUriFor(input.redirectUriBase, connection.id)
     const tools = await listExternalMcpTools(connection, redirectUri, member, undefined, deadline)
-    const tool = tools.find((candidate) => candidate.name === input.toolName)
+    const tool = tools.find((candidate) => candidate.name === input.toolName && mcpToolVisibleTo(candidate, "model"))
     if (!tool) {
       return {
         ok: false,

--- a/ee/apps/den-api/src/mcp/external-connection-proxy.ts
+++ b/ee/apps/den-api/src/mcp/external-connection-proxy.ts
@@ -12,6 +12,7 @@ import {
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable } from "@openwork-ee/den-db/schema"
+import { mcpToolVisibleTo } from "@openwork/types/mcp-tool-visibility"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Context, Hono } from "hono"
 import type { RequestIdVariables } from "hono/request-id"
@@ -116,29 +117,9 @@ const appGatewayTools: ExternalMcpProxyTool[] = boundedGatewayTools.map((tool) =
   _meta: { ui: { visibility: ["app"] } },
 }))
 
-/**
- * A provider tool the model may see on a directly exposed connection. Tools
- * that declare an app-only UI visibility stay private to the App host.
- */
-function toolVisibleToModel(tool: ExternalMcpProxyTool): boolean {
-  const meta = isRecord(tool._meta) ? tool._meta : {}
-  const ui = isRecord(meta.ui) ? meta.ui : {}
-  if (ui.visibility === undefined) return true
-  return Array.isArray(ui.visibility) && ui.visibility.includes("model")
-}
-
-function toolVisibleToApp(tool: ExternalMcpProxyTool): boolean {
-  const meta = isRecord(tool._meta) ? tool._meta : {}
-  const ui = isRecord(meta.ui) ? meta.ui : {}
-  if (ui.visibility === undefined) return true
-  return Array.isArray(ui.visibility)
-    && ui.visibility.every((entry) => entry === "model" || entry === "app")
-    && ui.visibility.includes("app")
-}
-
 function appOnlyProxyTool(tool: ExternalMcpProxyTool): ExternalMcpProxyTool | null {
+  if (!mcpToolVisibleTo(tool, "app")) return null
   const resourceUri = externalMcpAppResourceUri(tool)
-  if (!resourceUri || !toolVisibleToApp(tool)) return null
   const meta = isRecord(tool._meta) ? tool._meta : {}
   const ui = isRecord(meta.ui) ? meta.ui : {}
   return {
@@ -147,7 +128,7 @@ function appOnlyProxyTool(tool: ExternalMcpProxyTool): ExternalMcpProxyTool | nu
       ...meta,
       ui: {
         ...ui,
-        resourceUri,
+        ...(resourceUri ? { resourceUri } : {}),
         visibility: ["app"],
       },
     },
@@ -201,9 +182,9 @@ export function createExternalConnectionProxyServer(input: {
     )).filter((tool) => (
       !PROXY_GATEWAY_TOOL_NAMES.has(tool.name)
       && !evaluateToolPolicy(connection.toolPolicy, tool.name).blocked
+      && mcpToolVisibleTo(tool, input.appHostClient === true ? "app" : "model")
     ))
   }
-  const listDirectTools = async () => (await listProviderTools()).filter(toolVisibleToModel)
   const listAppTools = async () => (
     await listProviderTools()
   ).flatMap((tool) => {
@@ -223,7 +204,7 @@ export function createExternalConnectionProxyServer(input: {
       ...(downstreamUi ? { extensions: { [EXTENSION_ID]: downstreamUi } } : {}),
     },
     instructions: input.appHostClient
-      ? `This member-authorized OpenWork Connect endpoint exposes only app-visible MCP App tools and their bound resources for ${connection.name}. Ordinary provider capabilities remain available exclusively through search_capabilities and execute_capability.`
+      ? `This member-authorized OpenWork Connect endpoint exposes app-visible tools, including resource-less helpers, and their bound App resources for ${connection.name}. Search and execute use the same app-visible catalog.`
       : directClient
         ? `This member-authorized OpenWork Connect endpoint exposes the tools of ${connection.name} directly, subject to your organization's access grants and tool policy. Resources are not exposed.`
         : `This compatibility endpoint exposes only bounded search_capabilities and execute_capability for ${connection.name}. Direct provider tools, MCP App launch tools, and resources are not exposed.`,
@@ -234,13 +215,13 @@ export function createExternalConnectionProxyServer(input: {
       tools: input.appHostClient
         ? [...appGatewayTools, ...await listAppTools()]
         : directClient
-          ? await listDirectTools()
+          ? await listProviderTools()
           : boundedGatewayTools,
     }))
     server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const args = toolArguments(request.params.arguments)
       if (directClient) {
-        const tool = (await listDirectTools()).find((tool) => tool.name === request.params.name)
+        const tool = (await listProviderTools()).find((tool) => tool.name === request.params.name)
         if (!tool) {
           throw new McpError(ErrorCode.InvalidRequest, `Tool ${request.params.name} is not available on ${connection.name}.`)
         }

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto"
+import { mcpToolVisibleTo } from "@openwork/types/mcp-tool-visibility"
 import type { Context, Hono } from "hono"
 import { bodyLimit } from "hono/body-limit"
 import type { RequestIdVariables } from "hono/request-id"
@@ -158,14 +159,8 @@ export function projectedMcpToolName(serverName: string, toolName: string): stri
   return `${sanitize(serverName)}_${sanitize(toolName)}`
 }
 
-/** Mirrors the App-host proxy's app-audience visibility rule. */
 export function mcpToolVisibleToApp(tool: { _meta?: unknown }): boolean {
-  const meta = isRecord(tool._meta) ? tool._meta : {}
-  const ui = isRecord(meta.ui) ? meta.ui : {}
-  if (ui.visibility === undefined) return true
-  return Array.isArray(ui.visibility)
-    && ui.visibility.every((entry) => entry === "model" || entry === "app")
-    && ui.visibility.includes("app")
+  return mcpToolVisibleTo(tool, "app")
 }
 
 /** True when the launch tool declares required input, so a tile cannot start it with empty arguments. */

--- a/ee/apps/den-api/test/codemode-tools.test.ts
+++ b/ee/apps/den-api/test/codemode-tools.test.ts
@@ -229,12 +229,14 @@ test("native manifest capability names round-trip through the native parser", ()
   })
 })
 
-test("generic and Code Mode execution require write scope even for misleading read-only hints", async () => {
+test("generic search and Code Mode retain model audience, live policy and unconditional write scope", async () => {
   const connections = await import("../src/capability-sources/external-mcp-connections.js")
   const runtime = await import("../src/capability-sources/external-mcp-client-runtime.js")
   const { buildExternalMcpToolTree } = await import("../src/mcp/codemode-tools.js")
   const { createCapabilityRegistryContext, executeCapability } = await import("../src/mcp/capability-registry.js")
   const { runCodemodeScript } = await import("../src/mcp/codemode-run.js")
+  const { searchExternalCapabilities } = await import("../src/mcp/external-capabilities.js")
+  const { clearExternalToolsSearchCache, getExternalToolsSearchCache } = await import("../src/mcp/external-tools-search-cache.js")
   const organizationId = createDenTypeId("organization")
   const memberId = createDenTypeId("member")
   const connection: ExternalMcpConnectionRow = {
@@ -266,7 +268,7 @@ test("generic and Code Mode execution require write scope even for misleading re
       { annotations: { readOnlyHint: true }, requiredScope: "mcp:write" },
       { annotations: { readOnlyHint: true, destructiveHint: false }, requiredScope: "mcp:write" },
     ]
-    for (const scopes of [new Set(["mcp:read"]), new Set(["mcp:read", "mcp:write"]), new Set(["mcp:write"])]) {
+    for (const scopes of [new Set(["mcp:read"]), new Set(["mcp:read", "mcp:write"]), new Set(["mcp:write"]), new Set(["mcp:read", "mcp:write", "mcp:app-host"])]) {
       const member = { orgMembershipId: memberId, teamIds: [] }
       const context = createCapabilityRegistryContext({
         app: new Hono(), env: undefined, catalog: [], organizationId, member,
@@ -275,14 +277,18 @@ test("generic and Code Mode execution require write scope even for misleading re
         organizationMetadata: null, mcpConnectionsGatingEnabled: false,
       })
       liveTool = { ...liveTool, annotations: { readOnlyHint: true } }
-      const built = await buildExternalMcpToolTree({
-        organizationId, member, scopes, redirectUriBase: context.redirectUriBase,
-        namespaceContext: {
-          nativeProviderEntries: [], codemodeNativeProviderEntries: [],
-          externalMcpConnections: [connection], codemodeExternalMcpConnections: [connection],
-          namespaces: buildCodemodeConnectionNamespaceMaps({ native: [], externalMcp: [connection] }),
-        },
+      const namespaceContext = {
+        nativeProviderEntries: [], codemodeNativeProviderEntries: [],
+        externalMcpConnections: [connection], codemodeExternalMcpConnections: [connection],
+        namespaces: buildCodemodeConnectionNamespaceMaps({ native: [], externalMcp: [connection] }),
+      }
+      const build = () => buildExternalMcpToolTree({
+        organizationId, member, scopes, redirectUriBase: context.redirectUriBase, namespaceContext,
       })
+      const search = () => searchExternalCapabilities({
+        organizationId, member, redirectUriBase: context.redirectUriBase, namespaceContext, query: "scope",
+      })
+      const built = await build()
       const leaf = built.manifest[0]
       if (!leaf) throw new Error("Missing external Code Mode leaf")
       expect(leaf).toMatchObject({ readOnly: true, authority: "external" })
@@ -306,6 +312,49 @@ test("generic and Code Mode execution require write scope even for misleading re
           expect(calls).toBe(before)
         }
       }
+      for (const { visibility, visible } of [
+        { visibility: undefined, visible: true },
+        { visibility: ["model"], visible: true },
+        { visibility: ["model", "app"], visible: true },
+        { visibility: ["app"], visible: false },
+        { visibility: [], visible: false },
+        { visibility: ["model", "invalid"], visible: false },
+        { visibility: ["app", null], visible: false },
+        { visibility: "model", visible: false },
+        { visibility: null, visible: false },
+        { visibility: {}, visible: false },
+      ]) {
+        liveTool = { ...liveTool, _meta: { ui: { visibility } } }
+        clearExternalToolsSearchCache()
+        const names = visible ? [leaf.capabilityName] : []
+        expect((await search()).map(tool => tool.name)).toEqual(names)
+        expect((await search()).map(tool => tool.name)).toEqual(names)
+        // The cache retains provider bytes, not an audience-specific projection.
+        expect(getExternalToolsSearchCache({ organizationId, connectionId: connection.id,
+          credentialMode: "shared", updatedAt: connection.updatedAt })).toEqual({ outcome: "success", tools: [liveTool] })
+        const current = await build()
+        expect(current.manifest.map(tool => tool.capabilityName)).toEqual(names)
+        expect(Object.values(current.tools).flatMap(tools => Object.keys(tools))).toEqual(visible ? [liveTool.name] : [])
+        expect(restrictCodemodeToolTree({ built: current, requiredCapabilities: [leaf] }).missing).toEqual(visible ? [] : [leaf])
+        const before = calls
+        const generic = await executeCapability(context, { name: leaf.capabilityName, body: { audience: "app" } })
+        // Retained callbacks must re-read visibility even when the token also has App-host scope.
+        const script = await runCodemodeScript({ code: `return await ${leaf.scriptPath}({})`, tools: built.tools, timeoutMs: 1_000 })
+        const executable = visible && scopes.has("mcp:write")
+        expect(generic.isError === true).toBe(!executable)
+        expect(script.ok).toBe(executable)
+        expect(calls).toBe(before + (executable ? 2 : 0))
+      }
+      liveTool = { ...liveTool, _meta: undefined }
+      connection.toolPolicy = { version: 1, allDisabled: false, disabledTools: [liveTool.name] }
+      clearExternalToolsSearchCache()
+      expect(await search()).toEqual([])
+      expect((await build()).manifest).toEqual([])
+      const beforePolicy = calls
+      expect((await executeCapability(context, { name: leaf.capabilityName, body: {} })).isError).toBe(true)
+      expect((await runCodemodeScript({ code: `return await ${leaf.scriptPath}({})`, tools: built.tools, timeoutMs: 1_000 })).ok).toBe(false)
+      expect(calls).toBe(beforePolicy)
+      connection.toolPolicy = null
       allowed = false
       const before = calls
       expect((await executeCapability(context, { name: leaf.capabilityName, body: {} })).isError).toBe(true)
@@ -314,6 +363,7 @@ test("generic and Code Mode execution require write scope even for misleading re
       allowed = true
     }
   } finally {
+    clearExternalToolsSearchCache()
     mock.restore()
   }
 })

--- a/ee/apps/den-api/test/codemode-tools.test.ts
+++ b/ee/apps/den-api/test/codemode-tools.test.ts
@@ -7,6 +7,23 @@ import { Effect } from "effect"
 import { Hono } from "hono"
 import { buildMcpCatalog } from "../src/mcp/catalog.js"
 
+// These catalog tests supply principals directly; authentication must not seed a database at import time.
+mock.module("../src/auth.js", () => ({
+  auth: { handler: () => Promise.resolve(Response.json({ keys: [] })) },
+  DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX: "ow_mcp_at_",
+  DEN_MCP_FIRST_PARTY_CLIENT_ID: "openwork-desktop",
+  DEN_MCP_FIRST_PARTY_RESOURCES: [
+    "http://127.0.0.1:8790/mcp", "http://127.0.0.1:8790/mcp/agent", "http://127.0.0.1:8790/mcp/admin",
+  ],
+  DEN_MCP_GRANT_ID_CLAIM: "https://openworklabs.com/grant_id",
+  DEN_MCP_ORG_ID_CLAIM: "https://openworklabs.com/org_id",
+  DEN_MCP_OAUTH_RESOURCE: "http://127.0.0.1:8790/mcp/agent",
+  DEN_MCP_RESOURCE: "http://127.0.0.1:8790/mcp",
+  DEN_MCP_RESOURCE_CLAIM: "https://openworklabs.com/resource",
+  DEN_MCP_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+  DEN_MCP_TOKEN_USE_CLAIM: "https://openworklabs.com/token_use",
+}))
+
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)

--- a/ee/apps/den-api/test/external-connection-proxy.test.ts
+++ b/ee/apps/den-api/test/external-connection-proxy.test.ts
@@ -411,7 +411,7 @@ test("a healthy native MCP App preserves its resource and same-server app-visibl
   })
 })
 
-test("a regular MCP with an App keeps every model-visible tool behind search and execute", async () => {
+test("a private App surface includes unbound helpers but no model-only tools or unbound resources", async () => {
   let downstreamCalls = 0
   let downstreamReads = 0
   const privateResourceUri = "data://fixture/private.json"
@@ -422,6 +422,7 @@ test("a regular MCP with an App keeps every model-visible tool behind search and
       "search_capabilities",
       "execute_capability",
       "open_fixture",
+      "search_fixture",
     ])
     for (const tool of tools) expect(tool._meta).toMatchObject({ ui: { visibility: ["app"] } })
     expect(tools.find((tool) => tool.name === "open_fixture")?._meta).toMatchObject({
@@ -432,9 +433,6 @@ test("a regular MCP with an App keeps every model-visible tool behind search and
     expect(resources.map((resource) => resource.uri)).toEqual([resourceUri])
     expect((await client.listResourceTemplates()).resourceTemplates).toEqual([])
 
-    await expect(client.callTool({ name: "search_fixture", arguments: { query: "private" } })).rejects.toThrow(
-      "Use search_capabilities and execute_capability",
-    )
     await expect(client.callTool({ name: "model_only_fixture", arguments: {} })).rejects.toThrow(
       "Use search_capabilities and execute_capability",
     )
@@ -446,6 +444,8 @@ test("a regular MCP with an App keeps every model-visible tool behind search and
     )
     expect(downstreamCalls).toBe(0)
     expect(downstreamReads).toBe(0)
+    expect((await client.callTool({ name: "search_fixture", arguments: { query: "private" } })).structuredContent)
+      .toEqual({ status: "healthy" })
 
     const searched = await client.callTool({
       name: "search_capabilities",
@@ -461,11 +461,11 @@ test("a regular MCP with an App keeps every model-visible tool behind search and
       arguments: { name: "search_fixture", body: { query: "private" } },
     })
     expect(executed.structuredContent).toEqual({ status: "healthy" })
-    expect(downstreamCalls).toBe(1)
+    expect(downstreamCalls).toBe(2)
 
     const opened = await client.callTool({ name: "open_fixture", arguments: {} })
     expect(opened.structuredContent).toEqual({ status: "healthy" })
-    expect(downstreamCalls).toBe(2)
+    expect(downstreamCalls).toBe(3)
   }, {
     listTools: async () => [
       ...(await runtime().listTools()),
@@ -498,6 +498,68 @@ test("a regular MCP with an App keeps every model-visible tool behind search and
       return { contents: [] }
     },
   })
+})
+
+test.each(["direct", "compatibility", "app", "app-compatibility"])("%s filters live inner targets by strict audience and organization policy", async (mode) => {
+  const cases = [
+    { visibility: undefined, model: true, app: true },
+    { visibility: ["model"], model: true, app: false },
+    { visibility: ["app"], model: false, app: true },
+    { visibility: ["model", "app"], model: true, app: true },
+    { visibility: [], model: false, app: false },
+    { visibility: ["model", "invalid"], model: false, app: false },
+    { visibility: ["app", null], model: false, app: false },
+    { visibility: "model", model: false, app: false },
+    { visibility: null, model: false, app: false },
+    { visibility: {}, model: false, app: false },
+  ]
+  const policy = { allDisabled: false, disabledTools: ["blocked_fixture"] }
+  let liveTools: Tool[] = cases.map(({ visibility }, index) => ({
+    name: `audience_fixture_${index}`, inputSchema: { type: "object" },
+    _meta: { ui: { visibility } },
+  }))
+  let calls = 0
+  const isApp = mode.startsWith("app")
+  const names = cases.flatMap((entry, index) => entry[isApp ? "app" : "model"] ? [`audience_fixture_${index}`] : [])
+  await withClient({ tools: {}, resources: {} }, async (client) => {
+    const listed = (await client.listTools()).tools
+    expect(listed.map(tool => tool.name)).toEqual(mode === "direct" ? names
+      : ["search_capabilities", "execute_capability", ...(isApp ? names : [])])
+    if (isApp) for (const tool of listed) expect(tool._meta).toMatchObject({ ui: { visibility: ["app"] } })
+    if (mode !== "direct") {
+      const result = await client.callTool({ name: "search_capabilities", arguments: {
+        query: "audience fixture", limit: 20, audience: isApp ? "model" : "app",
+      } })
+      const matches = (result.structuredContent as { matches: Array<{ name: string; kind?: string }> }).matches
+      expect(matches.map(tool => tool.name).sort()).toEqual([...names].sort())
+      expect(matches.every(tool => tool.kind === undefined)).toBe(true)
+    }
+    const call = (name: string) => client.callTool(mode.endsWith("compatibility")
+      ? { name: "execute_capability", arguments: { name, body: {}, audience: "app", appHostClient: true } }
+      : { name, arguments: {} })
+    for (const [index, entry] of cases.entries()) {
+      const before = calls
+      if (entry[isApp ? "app" : "model"]) {
+        expect((await call(`audience_fixture_${index}`)).isError).not.toBe(true)
+        expect(calls).toBe(before + 1)
+      } else {
+        await expect(call(`audience_fixture_${index}`)).rejects.toThrow()
+        expect(calls).toBe(before)
+      }
+    }
+    const before = calls
+    await expect(call("blocked_fixture")).rejects.toThrow()
+    liveTools = liveTools.map(tool => ({ ...tool, _meta: { ui: { visibility: [] } } }))
+    await expect(call(names[0]!)).rejects.toThrow()
+    policy.allDisabled = true
+    await expect(call("audience_fixture_0")).rejects.toThrow()
+    expect(calls).toBe(before)
+    expect((await client.listResources()).resources).toEqual([])
+    await expect(client.readResource({ uri: resourceUri })).rejects.toThrow()
+  }, {
+    listTools: async () => [...liveTools, { name: "blocked_fixture", inputSchema: { type: "object" } }],
+    callTool: async () => { calls += 1; return { content: [] } },
+  }, isApp, { ...connection, exposeDirectly: mode === "direct", toolPolicy: policy })
 })
 
 test("OAuth registration and network failures become sanitized protocol errors", async () => {

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -128,7 +128,7 @@ export interface MockMcpTool {
   inputSchema: Record<string, unknown>;
   title?: string;
   annotations?: { readOnlyHint: boolean; destructiveHint: boolean };
-  _meta?: { ui: { resourceUri: string; visibility?: string[] } };
+  _meta?: { ui: { resourceUri?: string; visibility?: string[] } };
   /** Serve the HTML bound to this tool's _meta.ui.resourceUri. */
   appHtml?: string;
   /** Reject absent required input keys with JSON-RPC invalid params. */

--- a/evals/specs/connector-search-intent.test.ts
+++ b/evals/specs/connector-search-intent.test.ts
@@ -24,16 +24,27 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
     { name: "unknown_scope_fixture" },
     { name: "contradictory_scope_fixture", annotations: { readOnlyHint: true, destructiveHint: true } },
   ];
+  const audienceCases = [
+    { name: "audience_app_helper", visibility: ["app"], model: false, app: true },
+    { name: "audience_model_helper", visibility: ["model"], model: true, app: false },
+    { name: "audience_default_helper", visibility: undefined, model: true, app: true },
+    { name: "audience_hidden_helper", visibility: [], model: false, app: false },
+    { name: "audience_invalid_helper", visibility: ["model", "app", "invalid"], model: false, app: false },
+  ];
   const orgName = `Connector Search ${Date.now()}`;
   await using den = await server({
     place,
     web: false,
     org: { name: orgName, members: {} },
-    mocks: { connector: mcpMock({ port: 3986, allowUnauthenticatedMcp: true, tools: scopeCases.map(({ name, annotations }) => ({
+    mocks: { connector: mcpMock({ port: 3986, allowUnauthenticatedMcp: true, tools: [...scopeCases.map(({ name, annotations }) => ({
       name, annotations, description: `Scope fixture ${name}`, inputSchema: { type: "object" },
       _meta: { ui: { resourceUri: "ui://scope/fixture.html", visibility: ["model", "app"] } },
-      result: { content: [{ type: "text", text: "scope result" }] },
-    })) }) },
+      result: { content: [{ type: "text" as const, text: "scope result" }] },
+    })), ...audienceCases.map(({ name, visibility }) => ({
+      name, description: "Audience parity helper", inputSchema: { type: "object" },
+      _meta: { ui: { visibility } },
+      result: { content: [{ type: "text" as const, text: "audience result" }] },
+    }))] }) },
   });
   const database = den.database;
   if (!database) throw new Error("Scope authority fixtures require a cold-booted owned Den database");
@@ -148,19 +159,23 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
     [restrictedScopes, appTokenHash, String(orgId)]);
   expect(await queryDenDatabase(database.url, "SELECT scopes FROM oauthAccessToken WHERE token = ? AND reference_id = ?",
     [appTokenHash, String(orgId)])).toEqual([{ scopes: restrictedScopes }]);
-  async function call(bearer: string, name: string, args: Record<string, unknown>, endpoint = "/mcp/agent") {
+  async function rpc(bearer: string, method: string, params: Record<string, unknown>, endpoint = "/mcp/agent") {
     const response = await fetch(`${den.ref.apiUrl}${endpoint}`, {
       method: "POST",
-      headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method: "tools/call", params: { name, arguments: args } }),
+      headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json", accept: "application/json, text/event-stream",
+        "x-openwork-mcp-client-audience": "app-host" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method, params }),
       signal: AbortSignal.timeout(60_000),
     });
     const raw = await response.text();
     expect(response.status, raw).toBe(200);
     const line = raw.split("\n").find(value => value.startsWith("data:"));
-    const rpc = record(JSON.parse(line ? line.slice(5) : raw));
-    expect(rpc.error, JSON.stringify(rpc.error)).toBeUndefined();
-    return record(rpc.result);
+    return record(JSON.parse(line ? line.slice(5) : raw));
+  }
+  async function call(bearer: string, name: string, args: Record<string, unknown>, endpoint = "/mcp/agent") {
+    const response = await rpc(bearer, "tools/call", { name, arguments: args }, endpoint);
+    expect(response.error, JSON.stringify(response.error)).toBeUndefined();
+    return record(response.result);
   }
   const discovered = rows((await search({ query: "Scope Fixture false", type: "mcp", limit: 20 })).payload.matches);
   const beforeReadControls = await den.mocks.connector.toolCalls();
@@ -224,4 +239,44 @@ test("gateway discovery preserves setup intent and execution scopes", { timeout:
   expect(deniedCalls).toBe(24);
   expect(acceptedCalls).toBe(24);
   evidence.recordAssertionEvidence("Provider read-only hints never grant external execution authority", "Read-only tokens denied all four provider tools, including the misleading readOnlyHint:true tool, through generic, direct, compatibility, Code Mode and both App-host dispatch forms: 24 denials with zero provider calls. A genuinely minted App token was narrowed to mcp:read mcp:app-host in this owned database before first use, not issued by a changed production mint. Full-scope and unchanged App-host tokens produced exactly 24 expected calls.", true);
+  const compatibilityPath = `/mcp/agent/connections/${compatibilityId}`;
+  for (const bearer of [fullToken, appToken]) {
+    const isApp = bearer === appToken;
+    const expected = audienceCases.filter(entry => entry[isApp ? "app" : "model"]).map(entry => entry.name).sort();
+    const searched = await call(bearer, "search_capabilities", { query: "audience parity", limit: 20, audience: isApp ? "model" : "app" }, compatibilityPath);
+    const matches = rows(record(searched.structuredContent).matches);
+    expect(matches.map(entry => entry.name).sort()).toEqual(expected);
+    expect(matches.every(entry => entry.kind === undefined && entry.mcpApp === undefined)).toBe(true);
+    const listed = record((await rpc(bearer, "tools/list", {}, isApp ? compatibilityPath : `/mcp/agent/connections/${directId}`)).result);
+    expect(rows(listed.tools).filter(entry => String(entry.name).startsWith("audience_")).map(entry => entry.name).sort()).toEqual(expected);
+    // Even the private token must not turn the central registry or Code Mode into an App surface.
+    const central = await call(bearer, "search_capabilities", { query: "audience parity", type: "mcp", limit: 20 });
+    const centralMatches = rows(record(central.structuredContent).matches).filter(entry => String(entry.name).startsWith(`mcp:${compatibilityId}:`));
+    expect(centralMatches.map(entry => String(entry.name).split(":").at(-1)).sort()).toEqual(audienceCases.filter(entry => entry.model).map(entry => entry.name).sort());
+    for (const fixture of audienceCases) {
+      const before = await den.mocks.connector.toolCalls();
+      const result = await rpc(bearer, "tools/call", { name: "execute_capability", arguments: {
+        name: fixture.name, body: { marker: fixture.name }, audience: "app", appHostClient: true,
+      } }, compatibilityPath);
+      const after = await den.mocks.connector.toolCalls();
+      if (fixture[isApp ? "app" : "model"]) {
+        expect(result.error).toBeUndefined();
+        expect(record(result.result).isError).not.toBe(true);
+        expect(after.slice(before.length)).toEqual([expect.objectContaining({ name: fixture.name, args: { marker: fixture.name } })]);
+      } else {
+        expect(result.error).toBeDefined();
+        expect(after).toEqual(before);
+      }
+      if (!fixture.model) {
+        const beforeCentral = await den.mocks.connector.toolCalls();
+        expect((await call(bearer, "execute_capability", { name: `mcp:${compatibilityId}:${fixture.name}`, body: {} })).isError).toBe(true);
+        const modelPath = centralMatches[0]?.scriptPath;
+        if (typeof modelPath !== "string") throw new Error("Missing Code Mode namespace control");
+        const helperPath = `${modelPath.slice(0, modelPath.lastIndexOf("."))}.${fixture.name}`;
+        expect((await call(bearer, "execute_capability_script", { code: `return await ${helperPath}({})` })).isError).toBe(true);
+        expect(await den.mocks.connector.toolCalls()).toEqual(beforeCentral);
+      }
+    }
+  }
+  evidence.recordAssertionEvidence("Model and private App audiences remain separate, including resource-less helpers", "Authenticated private search, tools/list and wrapped execution included App-only and default helpers without launcher metadata. Ordinary compatibility and direct discovery stayed model-only despite forged audience headers and arguments. The central gateway and Code Mode rejected hidden helpers even with the private App token; rejected calls left the provider witness unchanged.", true);
 });

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -49,6 +49,11 @@
       "development": "./src/connection-action-app.ts",
       "default": "./src/connection-action-app.ts"
     },
+    "./mcp-tool-visibility": {
+      "types": "./src/mcp-tool-visibility.ts",
+      "development": "./src/mcp-tool-visibility.ts",
+      "default": "./src/mcp-tool-visibility.ts"
+    },
     "./plugin-flow-app": {
       "types": "./src/plugin-flow-app.ts",
       "development": "./src/plugin-flow-app.ts",

--- a/packages/types/src/mcp-tool-visibility.ts
+++ b/packages/types/src/mcp-tool-visibility.ts
@@ -1,0 +1,12 @@
+/** Missing visibility serves both audiences; malformed declarations serve neither. */
+export function mcpToolVisibleTo(tool: { _meta?: unknown }, audience: "model" | "app"): boolean {
+  const meta = tool._meta;
+  if (typeof meta !== "object" || meta === null || !("ui" in meta)) return true;
+  const ui = meta.ui;
+  if (typeof ui !== "object" || ui === null || !("visibility" in ui)) return true;
+  const visibility = ui.visibility;
+  if (visibility === undefined) return true;
+  return Array.isArray(visibility)
+    && visibility.every((entry) => entry === "model" || entry === "app")
+    && visibility.includes(audience);
+}


### PR DESCRIPTION
## Dependencies

Stacked on #4864 (`fix/direct-app-resources`), which builds on #4863. This delta consumes their trusted launch and authoritative policy-namespace contract. Merge/rebase and revalidate bottom-up.

## Summary

Apply MCP App tool audiences consistently across direct, compatibility and ordinary execution paths, while making valid App-only helpers callable through Connect.

- Share one strict audience predicate. Missing visibility defaults to both audiences; malformed or empty visibility exposes neither. Ordinary discovery, execution and Code Mode remain model-facing.
- Filter current execution targets, not just discovery. Retained Code Mode definitions cannot keep invoking a tool that becomes App-only.
- Expose resource-less App-visible helpers privately without turning them into dashboard launchers, model tools, or additional resource permissions.
- Validate the inner target of private Connect `execute_capability` against the trusted original lease, actual resource binding and effective ordered permissions.
- Evaluate private and original direct policy namespaces independently, then combine them as deny over ask over allow. Later rules win within each namespace. Any ask and annotation-based approval requirement remains effective.

Audience comes from the trusted private surface, not public arguments. Den write-scope requirements, grants, credential selection, ordinary resource denial and provider-specific routing remain unchanged.

## Verification

Signed head: `1b4207ef7d9f9bf6a96d3463a8850caffb679307`.
Exact parent-PR base and merge-base: `fe4e440cb398ec20d40df136051298c39164d61c`.

Passed on that exact head, exit 0:

- `pnpm --filter openwork-server exec bun --conditions=development test src/mcp-app-host.test.ts src/connect-mcp-server-catalog.test.ts src/mcp.passive-inventory.test.ts` — 93 passed.
- `DATABASE_URL=mysql://root:password@127.0.0.1:9/unused DATABASE_REDIS_URL=redis://127.0.0.1:9 pnpm --filter @openwork-ee/den-api exec bun --conditions=development test test/external-connection-proxy.test.ts` — 24 passed.
- `DATABASE_URL=mysql://root:password@127.0.0.1:9/unused DATABASE_REDIS_URL=redis://127.0.0.1:9 pnpm --filter @openwork-ee/den-api exec bun --conditions=development test test/codemode-tools.test.ts` — 11 passed.
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false`
- Delta whitespace and signatures for all three commits.

Total: 128 passed, zero failed. The database URLs above are deliberately unused local test settings; the focused tests use isolated mock authentication and provider boundaries. Only the local generated MCP dependency bundles were built for Den typechecking.

## Verdict and remaining coverage

**Incomplete.** The existing `connector-search-intent` journey and database-backed search-divergence assertions were extended but not executed. No full Den/Electron journey, live provider or enterprise deployment was exercised. These results do not establish universal MCP Apps conformance.

Hosted CI/review are pending. No merge or deployment is included.
