### PR TITLE
fix(chat): restore running task title hover feedback

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -528,6 +528,15 @@ select:disabled {
   }
 }
 
+/* Let running task titles inherit the same hover color as completed ones. */
+@media (hover: hover) {
+  [data-subagent-run] > .group:hover .ow-text-shimmer {
+    background-image: none;
+    color: inherit;
+    animation: none;
+  }
+}
+
 /* Quiet, small dot ticker (`:: :: ::`). Each dot pulses briefly in sequence,
    illuminating left-to-right like a subtle running light. Used for boot,
    "awaiting first token", and any idle-but-alive hint. */

--- a/evals/specs/task-activity-shimmer.e2e.test.ts
+++ b/evals/specs/task-activity-shimmer.e2e.test.ts
@@ -21,17 +21,20 @@ test("ACT-01 delegated-task activity stays with its original message after a fol
   await user.press(world.app.handle.hostKind !== "daytona" && process.platform === "darwin" ? "Meta+Enter" : "Control+Enter");
   await user.see({ text: "Build isolated Azure repro" });
   await user.see({ text: "What is the update?" });
-  evidence.recordJsonArtifact("Delegated activity state", await probe.eval(() =>
-    [...document.querySelectorAll("[data-subagent-run]")].map((row) => ({
-      activity: row.getAttribute("data-subagent-activity"), text: row.textContent,
-    })),
-  ));
   // TODO(primitive): inspect the visual treatment classes on a delegated-task status row.
-  const rendered = await probe.eval(() => {
+  const readActivity = () => probe.eval(() => {
     const row = document.querySelector<HTMLElement>('[data-subagent-activity="shimmer"]');
     const original = row?.closest<HTMLElement>('[data-message-id]');
     const followup = [...document.querySelectorAll<HTMLElement>('[data-message-id]')]
       .find((message) => message.innerText.includes("What is the update?"));
+    const button = row?.querySelector<HTMLButtonElement>(":scope > button.group");
+    const title = button?.querySelector<HTMLElement>(".ow-text-shimmer");
+    const suffix = title?.querySelector<HTMLElement>(":scope > span");
+    const status = button?.querySelector<HTMLElement>(":scope > span:nth-child(2)");
+    if (!row || !button || !title || !suffix || !status) {
+      throw new Error("Missing running task title, agent label, or status");
+    }
+    const style = getComputedStyle(title);
     return {
       text: row instanceof HTMLElement ? row.innerText.replace(/\s+/g, " ").trim() : "",
       hasSpinner: Boolean(row?.querySelector<HTMLElement>(".animate-spin")),
@@ -43,8 +46,22 @@ test("ACT-01 delegated-task activity stays with its original message after a fol
       staysWithOriginalMessage: Boolean(row && original?.contains(row)),
       precedesFollowup: Boolean(row && followup && (row.compareDocumentPosition(followup) & Node.DOCUMENT_POSITION_FOLLOWING)),
       rawPromptVisible: document.body.innerText.includes("ACTIVITY_CHILD_HOLD"),
+      childId: row.getAttribute("data-subagent-session-id"),
+      callId: row.getAttribute("data-subagent-run"),
+      hovered: button.matches(":hover"),
+      colorSettled: button.getAnimations().every((animation) => animation.playState !== "running"),
+      buttonColor: getComputedStyle(button).color,
+      titleStyle: { color: style.color, backgroundImage: style.backgroundImage, animationName: style.animationName },
+      mutedColors: [getComputedStyle(suffix).color, getComputedStyle(status).color],
+      reducedMotion: matchMedia("(prefers-reduced-motion: reduce)").matches,
     };
   });
+  await user.hover("composer");
+  const rendered = await probe.eventually(readActivity, {
+    within: 5_000, intervalMs: 50, label: "running task is not hovered",
+    until: (value) => !value.hovered && value.colorSettled,
+  });
+  evidence.recordJsonArtifact("Delegated activity state", rendered);
   expect(rendered).toMatchObject({
     text: expect.stringMatching(/Build isolated Azure repro.*Working/),
     hasSpinner: false,
@@ -57,18 +74,41 @@ test("ACT-01 delegated-task activity stays with its original message after a fol
     rawPromptVisible: false,
     messageId: native.messageId,
   });
-  expect(await probe.eval(() => document.querySelector('[data-subagent-run]')
-    ?.getAttribute("data-subagent-session-id"))).toBe(native.childId);
-  expect(await probe.eval(() => document.querySelector('[data-subagent-run]')
-    ?.getAttribute("data-subagent-run"))).toBe(native.callId);
+  expect(rendered.childId).toBe(native.childId);
+  expect(rendered.callId).toBe(native.callId);
+  expect(rendered.titleStyle.animationName).toBe(rendered.reducedMotion ? "none" : "ow-text-shimmer");
+  if (!rendered.reducedMotion) expect(rendered.titleStyle.backgroundImage).toContain("linear-gradient");
+
+  await user.hover({ role: "button", label: /Build isolated Azure repro/ });
+  const hovered = await probe.eventually(readActivity, {
+    within: 5_000, intervalMs: 50, label: "hovered task title uses solid foreground",
+    until: (value) => value.hovered && value.colorSettled
+      && value.titleStyle.backgroundImage === "none" && value.titleStyle.animationName === "none"
+      && value.titleStyle.color === value.buttonColor,
+  });
+  expect(hovered.titleStyle.color).not.toBe(rendered.buttonColor);
+  expect(hovered.mutedColors).toEqual(rendered.mutedColors);
+  expect(hovered.text).toMatch(/Working/);
+
+  await user.hover("composer");
+  const restored = await probe.eventually(readActivity, {
+    within: 5_000, intervalMs: 50, label: "task shimmer returns after pointer leave",
+    until: (value) => !value.hovered && value.colorSettled
+      && value.titleStyle.backgroundImage === rendered.titleStyle.backgroundImage
+      && value.titleStyle.animationName === rendered.titleStyle.animationName,
+  });
+  expect(restored.titleStyle).toEqual(rendered.titleStyle);
+  expect(restored.mutedColors).toEqual(rendered.mutedColors);
+  evidence.recordJsonArtifact("Delegated task hover", { rendered, hovered, restored });
+  evidence.recordAssertionEvidence("Running task titles use the normal hover foreground",
+    "Hover replaces the title shimmer with solid inherited text; pointer leave restores its running treatment without recoloring the agent label or status.", true);
   await user.click({ role: "button", label: /Build isolated Azure repro/ });
   await user.see({ text: /ACTIVITY_CHILD_HOLD/ });
   await user.see({ text: /Working/ });
-  await probe.eval(() => { location.reload(); });
+  await user.reload();
   await user.see({ text: /ACTIVITY_CHILD_HOLD/ }, { timeoutMs: 30_000 });
   await user.see({ text: /Working/ });
-  expect(await probe.eval(() => document.querySelector("[data-session-surface-id]")
-    ?.getAttribute("data-session-surface-id"))).toBe(native.childId);
+  expect((await probe.dom(`[data-session-surface-id="${native.childId}"]`)).elements).toHaveLength(1);
   expect((await world.replyState()).deliveredChunks).toBe(1);
   await user.notSee({ text: "Activity child finished." });
   evidence.recordAssertionEvidence("Delegated activity opens the exact live child across reload",


### PR DESCRIPTION
## Summary
Running task titles paint their text with a shimmer gradient, which hides the existing link hover color. Completed titles already inherit that color.

- Suspend only the running title shimmer while its task button is hovered, and inherit the normal theme-aware foreground.
- Restore the shimmer on pointer leave; leave the muted label/status, completed rows, and task execution unchanged.
- Extend the existing ACT-01 journey with computed-style assertions for hover, pointer leave, and unchanged status/label colors. Reuse one read-only probe and the standard reload action.

## Verification
**Focused runtime proof: Passed** on `cd22e93e68b404b2ec05d28eb0c7c6f40fb4a5d4`.

```sh
pnpm evals:e2e task-activity-shimmer --local --engine v1 --case ACT-01
```

`selection: engine=v1 surface=web case=ACT-01; placement: local (--local)`

Exit 0: **1 passed, 0 failed, 0 skipped**. Cold-started app-web with a deterministic mock; the extended hover assertions and existing exact-child navigation/reload assertions passed. No Den boundary was exercised. Exact-head assertion evidence will be published below.

**Additional check — Failed, pre-existing:** `pnpm evals:check-browser` exits 1 for `library-mcp-servers-from-config.e2e.test.ts:21:50` (raw browser string / TS2345). The identical command reproduces the identical error in a clean control at `3b251c66ad0cb239d21ac9a94863d49404c5932e`; that file is unchanged through the final base `87f7c09e091a80e5037f749fad2a0e43933c1715`. It is outside this styling fix.

**Deferred:** v2, native desktop, dark-theme and reduced-motion matrix runs; no broad suite or visual judging. Required CI is unchanged.

## Scope
Two files; nine lines of production CSS. No task-state changes or dependency on the separate delegated-task setup work in #4723.