### PR TITLE
fix(chat): preserve conversation history across engine switches

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -988,11 +988,8 @@ export function SessionPage(props: SessionPageProps) {
       workspaceTitle: workspaceName,
       primarySessionId: props.selectedSessionId,
       sessionsKnown: workspaceGroup?.status === "ready",
-      sessions: (workspaceGroup?.sessions ?? []).filter((session) => (
-        !session.time?.archived
-        || session.id === props.selectedSessionId
-        || (splitSession?.workspaceId === props.selectedWorkspaceId && splitSession.sessionId === session.id)
-      )).map((session) => ({
+      archivedSessionIds: (workspaceGroup?.sessions ?? []).filter((session) => session.time?.archived).map((session) => session.id),
+      sessions: (workspaceGroup?.sessions ?? []).map((session) => ({
         workspaceId: props.selectedWorkspaceId,
         sessionId: session.id,
         title: getDisplaySessionTitle(session.title),
@@ -1004,7 +1001,6 @@ export function SessionPage(props: SessionPageProps) {
     props.selectedWorkspaceId,
     props.sidebar.workspaceSessionGroups,
     syncWorkbench,
-    splitSession,
     workspaceName,
   ]);
   useEffect(() => {

--- a/apps/app/src/react-app/domains/session/chat/workbench-store.ts
+++ b/apps/app/src/react-app/domains/session/chat/workbench-store.ts
@@ -22,6 +22,8 @@ export type SyncWorkbenchInput = {
   primarySessionId: string | null;
   sessions: OpenworkSessionRef[];
   sessionsKnown: boolean;
+  /** Explicit archive metadata for this workspace, not sessions missing from its engine index. */
+  archivedSessionIds?: string[];
 };
 
 const initialWorkbenchSnapshot: WorkbenchSnapshot = {
@@ -97,17 +99,15 @@ export function syncWorkbenchSnapshot(
 ): WorkbenchSnapshot {
   const workspaceTitle = input.workspaceTitle?.trim() || input.workspaceId;
   const available = input.sessions.map((session) => ({ ...session, workspaceTitle }));
-  // The index can be partial, or briefly show the previous engine during boot.
-  // Saved pairs are durable navigation state; only an explicit close removes them.
-  const pairedSessions = new Set(Object.entries(current.sideChats).flatMap(([owner, chat]) =>
-    [owner, workbenchSessionKey(chat)]));
+  const archivedSessionIds = new Set(input.archivedSessionIds);
+  // An index only covers one engine. Absence is not evidence of deletion:
+  // retained tabs, like saved pairs, require an explicit close or archive.
   let tabs = current.tabs
     .filter((tab) => (
       tab.workspaceId !== input.workspaceId
-      || !input.sessionsKnown
-      || available.some((session) => isSameWorkbenchSession(session, tab))
+      || !archivedSessionIds.has(tab.sessionId)
+      // Keep the routed archived primary viewable until navigation leaves it.
       || tab.sessionId === input.primarySessionId
-      || pairedSessions.has(workbenchSessionKey(tab))
     ))
     .map((tab) => {
       const fresh = available.find((session) => isSameWorkbenchSession(session, tab));

--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -1,6 +1,8 @@
 // Concurrency and degraded-state policy for the session route's
 // refreshRouteState. Extracted as pure helpers so the desktop restart
 // recovery contract is unit-testable without rendering the route.
+import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
+import type { RouteWorkspace } from "./route-workspaces";
 
 export type RouteRefreshAttempt = {
   readonly generation: number;
@@ -31,12 +33,12 @@ export type RouteRefreshLifecycle = {
 
 export type RouteWorkspaceLoadCoalescer = {
   /**
-   * Run at most one session-list request chain per workspace. Concurrent
-   * callers share the active chain until it settles, including its backoff
-   * waits and retries.
+   * Share a workspace's active chain only within the same engine/endpoint.
+   * A changed scope starts immediately and makes the old chain stale.
    */
-  run(workspaceId: string, load: () => Promise<void>): Promise<void>;
+  run(workspaceId: string, scope: string, load: (isCurrent: () => boolean) => Promise<void>): Promise<void>;
   isInFlight(workspaceId: string): boolean;
+  invalidate(workspaceId: string): void;
 };
 
 export type LatestWorkspaceCommitter = {
@@ -167,24 +169,52 @@ export async function mapRouteWorkspaceLoads<T, R>(
  * Keeping ownership until the promise settles prevents route, settings, and
  * visibility refreshes from starting overlapping retries for the same
  * workspace while still allowing different workspaces to load concurrently.
+ * Changed engines/endpoints must not wait for an obsolete, possibly hung read.
  */
 export function createRouteWorkspaceLoadCoalescer(): RouteWorkspaceLoadCoalescer {
-  const inFlight = new Map<string, Promise<void>>();
+  const current = new Map<string, { scope: string; promise: Promise<void> | null }>();
 
   return {
-    run(workspaceId, load) {
-      const existing = inFlight.get(workspaceId);
-      if (existing) return existing;
+    run(workspaceId, scope, load) {
+      const existing = current.get(workspaceId);
+      if (existing?.scope === scope && existing.promise) return existing.promise;
 
-      const request = Promise.resolve().then(load);
-      const tracked = request.finally(() => {
-        if (inFlight.get(workspaceId) === tracked) inFlight.delete(workspaceId);
+      const entry: { scope: string; promise: Promise<void> | null } = { scope, promise: null };
+      const isCurrent = () => current.get(workspaceId) === entry;
+      const request = Promise.resolve().then(() => {
+        if (isCurrent()) return load(isCurrent);
       });
-      inFlight.set(workspaceId, tracked);
+      const tracked = request.finally(() => {
+        entry.promise = null;
+      });
+      entry.promise = tracked;
+      current.set(workspaceId, entry);
       return tracked;
     },
-    isInFlight: (workspaceId) => inFlight.has(workspaceId),
+    isInFlight: (workspaceId) => Boolean(current.get(workspaceId)?.promise),
+    invalidate: (workspaceId) => { current.delete(workspaceId); },
   };
+}
+
+/** Unknown local routing is not v1. Remote inventories retain their native transport. */
+export function routeWorkspaceSessionLoadScope(
+  workspace: RouteWorkspace,
+  endpoint: ResolvedWorkspaceEndpoint | null,
+  engineV2ChatRouting: boolean | undefined,
+): string | null {
+  const remote = workspace.workspaceType === "remote";
+  if (!remote && (!endpoint || engineV2ChatRouting === undefined)) return null;
+  return JSON.stringify([
+    workspace.workspaceType,
+    workspace.remoteType,
+    workspace.path,
+    endpoint?.baseUrl,
+    endpoint?.workspaceId,
+    endpoint?.mountedBaseUrl,
+    endpoint?.opencodeBaseUrl,
+    endpoint?.token,
+    remote ? false : engineV2ChatRouting,
+  ]);
 }
 
 /**

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -55,6 +55,7 @@ import {
   mapRouteWorkspaceLoads,
   planRouteConnectionGap,
   planRouteWorkspaceLoads,
+  routeWorkspaceSessionLoadScope,
   routeWorkspaceSelectionCommitter,
 } from "./route-refresh-control";
 import {
@@ -62,6 +63,7 @@ import {
   describeRouteError,
   listRouteSessions,
   mapDesktopWorkspace,
+  orderRouteWorkspaces,
   refreshRouteWorkspaceListState,
   stabilizeRouteWorkspaceOrder,
   type RouteSession,
@@ -186,11 +188,8 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const [client, setClient] = useState<OpenworkServerClient | null>(null);
   const [baseUrl, setBaseUrl] = useState("");
   const [token, setToken] = useState("");
-  const [engineV2ChatRouting, setEngineV2ChatRouting] = useState(false);
-  const [engineRoutingReady, setEngineRoutingReady] = useState(false);
-  const engineV2ChatRoutingRef = useRef(engineV2ChatRouting);
-  engineV2ChatRoutingRef.current = engineV2ChatRouting;
-  const previousEngineV2ChatRoutingRef = useRef<boolean | null>(null);
+  const [engineRoutingByServer, setEngineRoutingByServer] = useState<Record<string, boolean>>({});
+  const engineRoutingByServerRef = useRef(engineRoutingByServer);
   const [workspaces, setWorkspaces] = useState<RouteWorkspace[]>([]);
   const [workspaceOrderIds, setWorkspaceOrderIds] = useState<string[]>(() => readWorkspaceOrderIds());
   const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, RouteSession[]>>({});
@@ -213,17 +212,16 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   // hit the worker that owns the workspace, not the user's local server. The
   // single source of truth for that routing is `resolveWorkspaceEndpoint`.
   //
-  // We refresh the memoized endpoint resolver behind a ref so the
+  // We refresh the endpoint resolver behind a ref so the
   // `endpointForWorkspace` callback stays permanently stable. Otherwise it
   // would change on every `setBaseUrl`/`setToken`, which used to cascade up
   // through `loadWorkspaceSessionsInBackground` and `refreshRouteState` and
-  // produce a tight render-refresh-setWorkspaces loop.
-  const currentWorkspaceServerClientResolver = useMemo(
-    () => createWorkspaceServerClientResolver({ baseUrl, token }),
-    [baseUrl, token],
+  // produce a tight render-refresh-setWorkspaces loop. Only connection
+  // resolution updates this ref: a render during refresh must not restore
+  // the old endpoint while the new workspace list is still being awaited.
+  const workspaceServerClientResolverRef = useRef(
+    createWorkspaceServerClientResolver({ baseUrl: "", token: "" }),
   );
-  const workspaceServerClientResolverRef = useRef(currentWorkspaceServerClientResolver);
-  workspaceServerClientResolverRef.current = currentWorkspaceServerClientResolver;
   const updateLocalServer = useCallback((next: { baseUrl: string; token: string }) => {
     const resolver = createWorkspaceServerClientResolver(next);
     workspaceServerClientResolverRef.current = resolver;
@@ -236,6 +234,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   );
   const refreshLifecycleRef = useRef(createRouteRefreshLifecycle());
   const workspacesRef = useRef<RouteWorkspace[]>([]);
+  workspacesRef.current = workspaces;
   const workspaceOrderIdsRef = useRef(workspaceOrderIds);
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
   const remoteWorkspaceCheckRunCounterRef = useRef(0);
@@ -246,6 +245,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const [retryingWorkspaceIds, setRetryingWorkspaceIds] = useState<string[]>([]);
   const reconnectAttemptedWorkspaceIdRef = useRef("");
   const backgroundSessionLoadCoalescerRef = useRef(createRouteWorkspaceLoadCoalescer());
+  const workspaceSessionLoadScopesRef = useRef(new Map<string, string | null>());
   const loadedWorkspaceIdsRef = useRef(new Set<string>());
   const serverActiveWorkspaceIdRef = useRef("");
   const workspaceSelectionCommitTimerRef = useRef<number | null>(null);
@@ -315,136 +315,142 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       hydratedSessionId,
     );
   }, []);
+  const sessionLoadScopeForWorkspace = useCallback((workspace: RouteWorkspace) => {
+    const endpoint = endpointForWorkspace(workspace);
+    return routeWorkspaceSessionLoadScope(
+      workspace,
+      endpoint,
+      engineRoutingByServerRef.current[JSON.stringify([endpoint?.baseUrl, endpoint?.token])],
+    );
+  }, [endpointForWorkspace]);
   const loadWorkspaceSessionsInBackground = useCallback(
     async (workspaces: RouteWorkspace[]) => {
       const MAX_ATTEMPTS = 6;
       const backoffMs = (attempt: number) => Math.min(500 * Math.pow(2, attempt), 4_000);
 
-      const fetchWithRetries = async (workspace: RouteWorkspace, attempt: number): Promise<void> => {
-        const isRemoteOpenworkWorkspace = workspace.workspaceType === "remote" && workspace.remoteType !== "opencode";
+      const loadWorkspace = async (requestedWorkspace: RouteWorkspace, initialAttempt = 0): Promise<void> => {
+        const workspace = workspacesRef.current.find((item) => item.id === requestedWorkspace.id);
+        if (!workspace) return;
+        const scope = sessionLoadScopeForWorkspace(workspace);
+        if (scope === null) return;
         const endpoint = endpointForWorkspace(workspace);
-        if (!endpoint) {
-          if (workspace.workspaceType === "remote") {
-            const message = "Remote worker URL is missing. Edit connection and add a server URL.";
-            setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: message }));
-            setWorkspaceConnectionOverrides((current) => ({
-              ...current,
-              [workspace.id]: {
-                status: "error",
-                message,
-                checkedAt: Date.now(),
-              },
-            }));
-            setRetryingWorkspaceIds((current) =>
-              current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
-            );
-          }
-          return;
-        }
-        if (isRemoteOpenworkWorkspace) {
-          setWorkspaceConnectionOverrides((current) => ({
-            ...current,
-            [workspace.id]: {
-              status: "connecting",
-              message: t("workspace_list.loading_remote_tasks"),
-              checkedAt: null,
-            },
-          }));
-        }
-        try {
-          // The sidebar lists from whichever engine chat is routed to.
-          const fetchedItems = workspace.workspaceType !== "remote" && engineV2ChatRoutingRef.current
-            ? await listRouteSessions(endpoint, v2RouteSessionList)
-            : await listRouteSessions(endpoint);
-          const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
-          const items = workspaceRoot && !isRemoteOpenworkWorkspace
-            ? fetchedItems.filter((session) =>
-                normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
-              )
-            : fetchedItems;
-          const current = sessionsByWorkspaceIdRef.current;
-          const nextItems = mergeFetchedSessionsWithPending(workspace.id, items, current[workspace.id] ?? []);
-          const next = { ...current, [workspace.id]: nextItems };
-          sessionsByWorkspaceIdRef.current = next;
-          setSessionsByWorkspaceId(next);
-          loadedWorkspaceIdsRef.current = new Set([...loadedWorkspaceIdsRef.current, workspace.id]);
-          setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: null }));
-          setWorkspaceConnectionOverrides((current) => {
+        const engineV2ChatRouting = workspace.workspaceType !== "remote"
+          && engineRoutingByServerRef.current[JSON.stringify([endpoint?.baseUrl, endpoint?.token])] === true;
+        await backgroundSessionLoadCoalescerRef.current.run(workspace.id, scope, async (isLoadCurrent) => {
+          const isCurrent = () => {
+            const currentWorkspace = workspacesRef.current.find((item) => item.id === workspace.id);
+            return isLoadCurrent() && Boolean(currentWorkspace && sessionLoadScopeForWorkspace(currentWorkspace) === scope);
+          };
+          const fetchWithRetries = async (attempt: number): Promise<void> => {
+            if (!isCurrent()) return;
+            const isRemoteOpenworkWorkspace = workspace.workspaceType === "remote" && workspace.remoteType !== "opencode";
+            if (!endpoint) {
+              if (workspace.workspaceType === "remote") {
+                const message = "Remote worker URL is missing. Edit connection and add a server URL.";
+                setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: message }));
+                setWorkspaceConnectionOverrides((current) => ({
+                  ...current,
+                  [workspace.id]: {
+                    status: "error",
+                    message,
+                    checkedAt: Date.now(),
+                  },
+                }));
+                setRetryingWorkspaceIds((current) =>
+                  current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
+                );
+              }
+              return;
+            }
             if (isRemoteOpenworkWorkspace) {
-              return {
+              setWorkspaceConnectionOverrides((current) => ({
                 ...current,
                 [workspace.id]: {
-                  status: "connected",
-                  message: items.length > 0
-                    ? t("workspace_list.connected_loaded_tasks", { count: items.length })
-                    : t("workspace.connected_no_tasks"),
-                  checkedAt: Date.now(),
+                  status: "connecting",
+                  message: t("workspace_list.loading_remote_tasks"),
+                  checkedAt: null,
                 },
-              };
+              }));
             }
-            if (current[workspace.id]?.status !== "error") return current;
-            const next = { ...current };
-            delete next[workspace.id];
-            return next;
-          });
-          setRetryingWorkspaceIds((current) =>
-            current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
-          );
-          // When a workspace returns zero sessions during the initial batch
-          // load, OpenCode may still be warming up its index.  Schedule a
-          // single delayed retry so the sidebar doesn't stay permanently
-          // empty while the managed engine finishes starting.
-          if (items.length === 0 && attempt === 0) {
-            window.setTimeout(() => {
-              if (backgroundSessionLoadCoalescerRef.current.isInFlight(workspace.id)) return;
-              void backgroundSessionLoadCoalescerRef.current.run(
-                workspace.id,
-                () => fetchWithRetries(workspace, 1),
+            try {
+              // The sidebar lists from whichever engine chat is routed to.
+              const fetchedItems = engineV2ChatRouting
+                ? await listRouteSessions(endpoint, v2RouteSessionList)
+                : await listRouteSessions(endpoint);
+              if (!isCurrent()) return;
+              const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
+              const items = workspaceRoot && !isRemoteOpenworkWorkspace
+                ? fetchedItems.filter((session) =>
+                    normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
+                  )
+                : fetchedItems;
+              const current = sessionsByWorkspaceIdRef.current;
+              const nextItems = mergeFetchedSessionsWithPending(workspace.id, items, current[workspace.id] ?? []);
+              const next = { ...current, [workspace.id]: nextItems };
+              sessionsByWorkspaceIdRef.current = next;
+              setSessionsByWorkspaceId(next);
+              loadedWorkspaceIdsRef.current = new Set([...loadedWorkspaceIdsRef.current, workspace.id]);
+              setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: null }));
+              setWorkspaceConnectionOverrides((current) => {
+                if (isRemoteOpenworkWorkspace) {
+                  return {
+                    ...current,
+                    [workspace.id]: {
+                      status: "connected",
+                      message: items.length > 0
+                        ? t("workspace_list.connected_loaded_tasks", { count: items.length })
+                        : t("workspace.connected_no_tasks"),
+                      checkedAt: Date.now(),
+                    },
+                  };
+                }
+                if (current[workspace.id]?.status !== "error") return current;
+                const next = { ...current };
+                delete next[workspace.id];
+                return next;
+              });
+              setRetryingWorkspaceIds((current) =>
+                current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
               );
-            }, 3_000);
-          }
-        } catch (error) {
-          const message = error instanceof Error ? error.message : t("app.unknown_error");
-          // The first cold call to OpenCode's /session endpoint often hits
-          // the 12s server timeout while the daemon finishes warming up
-          // its index. Retry silently with backoff until we get a response
-          // or run out of attempts — the sidebar keeps its "loading" state
-          // in the meantime instead of flashing "error" next to the
-          // workspace name.
-          if (attempt + 1 < MAX_ATTEMPTS && classifyRouteSessionReadError(error) === "retryable") {
-            await new Promise((r) => window.setTimeout(r, backoffMs(attempt)));
-            await fetchWithRetries(workspace, attempt + 1);
-            return;
-          }
-          // Final failure: keep local workspace startup quiet, but give
-          // remote workers a precise endpoint/token/workspace diagnostic.
-          if (workspace.workspaceType === "remote") {
-            const connectionState = await diagnoseRemoteWorkspaceTaskLoadFailure(workspace, message);
-            setErrorsByWorkspaceId((current) => ({
-              ...current,
-              [workspace.id]: connectionState.message ?? "Remote worker connection failed.",
-            }));
-            setWorkspaceConnectionOverrides((current) => {
-              return {
-                ...current,
-                [workspace.id]: connectionState,
-              };
-            });
-          }
-          setRetryingWorkspaceIds((current) =>
-            current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
-          );
-        }
+              // Retry an initially empty index once while the managed engine warms up.
+              if (items.length === 0 && attempt === 0) {
+                window.setTimeout(() => {
+                  if (!isCurrent()) return;
+                  if (backgroundSessionLoadCoalescerRef.current.isInFlight(workspace.id)) return;
+                  void loadWorkspace(workspace, 1);
+                }, 3_000);
+              }
+            } catch (error) {
+              if (!isCurrent()) return;
+              const message = error instanceof Error ? error.message : t("app.unknown_error");
+              // Cold index reads can time out. Keep startup quiet through backoff.
+              if (attempt + 1 < MAX_ATTEMPTS && classifyRouteSessionReadError(error) === "retryable") {
+                await new Promise((r) => window.setTimeout(r, backoffMs(attempt)));
+                await fetchWithRetries(attempt + 1);
+                return;
+              }
+              // Remote failures need a precise endpoint/token/workspace diagnostic.
+              if (workspace.workspaceType === "remote") {
+                const connectionState = await diagnoseRemoteWorkspaceTaskLoadFailure(workspace, message);
+                if (!isCurrent()) return;
+                setErrorsByWorkspaceId((current) => ({
+                  ...current,
+                  [workspace.id]: connectionState.message ?? "Remote worker connection failed.",
+                }));
+                setWorkspaceConnectionOverrides((current) => ({ ...current, [workspace.id]: connectionState }));
+              }
+              setRetryingWorkspaceIds((current) =>
+                current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
+              );
+            }
+          };
+          await fetchWithRetries(initialAttempt);
+        });
       };
 
-      await mapRouteWorkspaceLoads(workspaces, (workspace) =>
-        backgroundSessionLoadCoalescerRef.current.run(
-          workspace.id,
-          () => fetchWithRetries(workspace, 0),
-        ),
-      );
+      await mapRouteWorkspaceLoads(workspaces, (workspace) => loadWorkspace(workspace));
     },
-    [endpointForWorkspace, mergeFetchedSessionsWithPending],
+    [endpointForWorkspace, mergeFetchedSessionsWithPending, sessionLoadScopeForWorkspace],
   );
   const reloadWorkspaceSessions = useCallback(async (workspaceId: string): Promise<void> => {
     const workspace = workspacesRef.current.find((item) => item.id === workspaceId);
@@ -556,11 +562,8 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       }
       // Update the local-server resolver synchronously, BEFORE we kick off any
       // workspace-scoped requests below. `endpointForWorkspace` reads from
-      // this resolver synchronously; the render that mirrors `[baseUrl,
-      // token]` into the resolver doesn't run until after the next React commit,
-      // which is too late for the `loadWorkspaceSessionsInBackground` call
-      // later in this function. Stale ref => `resolveWorkspaceEndpoint` returns null for
-      // local workspaces => sidebar gets stuck in "loading" forever.
+      // this resolver synchronously, including while the workspace list below
+      // is awaited. Old inventory reads must immediately become stale.
       updateLocalServer({ baseUrl: normalizedBaseUrl, token: resolvedToken });
 
       const openworkClient = createOpenworkServerClient({
@@ -634,6 +637,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // Publish host credentials/generation with their endpoint, never before
       // the awaited workspace refresh while React still holds the old port.
       onHostInfo(hostInfo);
+      workspacesRef.current = nextWorkspaces;
       setWorkspaces(nextWorkspaces);
       const nextSessionsByWorkspaceId = Object.fromEntries(cachedEntries.map((entry) => [entry.workspaceId, entry.sessions]));
       sessionsByWorkspaceIdRef.current = nextSessionsByWorkspaceId;
@@ -782,10 +786,6 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   }, [selectedWorkspaceId]);
 
   useEffect(() => {
-    workspacesRef.current = workspaces;
-  }, [workspaces]);
-
-  useEffect(() => {
     workspaceOrderIdsRef.current = workspaceOrderIds;
   }, [workspaceOrderIds]);
 
@@ -859,6 +859,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
 
     return () => {
       cancelled = true;
+      for (const workspace of workspacesRef.current) {
+        backgroundSessionLoadCoalescerRef.current.invalidate(workspace.id);
+      }
       if (startupRetryTimerRef.current !== null) {
         window.clearTimeout(startupRetryTimerRef.current);
         startupRetryTimerRef.current = null;
@@ -1017,30 +1020,54 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const opencode2BaseUrl = selectedWorkspaceEndpoint ? `${selectedWorkspaceEndpoint.mountedBaseUrl}/opencode2` : "";
   const routingServerUrl = selectedWorkspaceEndpoint?.baseUrl ?? "";
   const routingServerToken = selectedWorkspaceEndpoint?.token ?? "";
+  const selectedEngineRouting = engineRoutingByServer[JSON.stringify([routingServerUrl, routingServerToken])];
+  const engineRoutingReady = Boolean(routingServerUrl) && selectedEngineRouting !== undefined;
+  const engineV2ChatRouting = selectedEngineRouting === true;
   useEffect(() => {
-    if (!routingServerUrl || !routingServerToken) {
-      setEngineV2ChatRouting(false);
-      return;
-    }
-    const openworkClient = createOpenworkServerClient({ baseUrl: routingServerUrl, token: routingServerToken });
     let cancelled = false;
-    const refresh = async () => {
-      try {
-        const status = await openworkClient.getEngineV2PreviewStatus();
-        if (!cancelled) {
-          setEngineV2ChatRouting(status.enabled && status.chatRouting);
-          setEngineRoutingReady(true);
+    const refreshers: Array<() => Promise<void>> = [];
+    const serverKeys = new Set<string>();
+    // Local inventories must not borrow the selected remote worker's routing
+    // or wait for that worker to connect. The selected client still uses its owner.
+    for (const server of [{ baseUrl, token }, { baseUrl: routingServerUrl, token: routingServerToken }]) {
+      const key = JSON.stringify([server.baseUrl, server.token]);
+      if (!server.baseUrl || serverKeys.has(key)) continue;
+      serverKeys.add(key);
+      const openworkClient = createOpenworkServerClient(server);
+      let requestVersion = 0;
+      refreshers.push(async () => {
+        const version = ++requestVersion;
+        let routing: boolean;
+        try {
+          const status = await withRouteRefreshTimeout(openworkClient.getEngineV2PreviewStatus(), "Engine routing status");
+          routing = status.enabled && status.chatRouting;
+        } catch (error) {
+          if (cancelled || version !== requestVersion) return;
+          // Only a legacy server's 404 establishes v1; transient failures stay unknown.
+          if (!(error instanceof OpenworkServerError && error.status === 404)) {
+            console.warn("[opencode-v2] failed to read chat routing status; retaining the current engine", error);
+            return;
+          }
+          routing = false;
         }
-      } catch (error) {
-        if (cancelled) return;
-        // Older servers do not expose the preview endpoint and use v1.
-        if (error instanceof OpenworkServerError && error.status === 404) setEngineRoutingReady(true);
-        console.warn("[opencode-v2] failed to read chat routing status; retaining the current engine", error);
-      }
+        if (cancelled || version !== requestVersion || engineRoutingByServerRef.current[key] === routing) return;
+        const next = { ...engineRoutingByServerRef.current, [key]: routing };
+        engineRoutingByServerRef.current = next;
+        setEngineRoutingByServer(next);
+      });
+    }
+    // A server that stopped being polled must revalidate when selected again.
+    // Keep the local server's readiness while it remains in the polling set.
+    const knownRouting = Object.entries(engineRoutingByServerRef.current);
+    if (knownRouting.some(([key]) => !serverKeys.has(key))) {
+      const next = Object.fromEntries(knownRouting.filter(([key]) => serverKeys.has(key)));
+      engineRoutingByServerRef.current = next;
+      setEngineRoutingByServer(next);
+    }
+    const refresh = () => {
+      for (const refreshRouting of refreshers) void refreshRouting();
     };
-    setEngineV2ChatRouting(false);
-    setEngineRoutingReady(false);
-    void refresh();
+    refresh();
     window.addEventListener("openwork-server-settings-changed", refresh);
     const interval = window.setInterval(() => { void refresh(); }, 15_000);
     return () => {
@@ -1048,13 +1075,34 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       window.clearInterval(interval);
       window.removeEventListener("openwork-server-settings-changed", refresh);
     };
-  }, [routingServerUrl, routingServerToken]);
+  }, [baseUrl, token, routingServerUrl, routingServerToken]);
   useEffect(() => {
-    const previous = previousEngineV2ChatRoutingRef.current;
-    previousEngineV2ChatRoutingRef.current = engineV2ChatRouting;
-    if (previous === null || previous === engineV2ChatRouting || !selectedWorkspaceId) return;
-    void reloadWorkspaceSessions(selectedWorkspaceId);
-  }, [engineV2ChatRouting, reloadWorkspaceSessions, selectedWorkspaceId]);
+    const scopes = workspaceSessionLoadScopesRef.current;
+    const changed: RouteWorkspace[] = [];
+    for (const workspace of workspaces) {
+      const scope = sessionLoadScopeForWorkspace(workspace);
+      if (scopes.get(workspace.id) === scope) continue;
+      if (scopes.has(workspace.id)) {
+        // A ready scope supersedes through run(), preserving any fresh load
+        // already started by a concurrent route refresh. Unknown scopes cannot run.
+        if (scope === null) backgroundSessionLoadCoalescerRef.current.invalidate(workspace.id);
+        delete pendingCreatedSessionIdsRef.current[workspace.id];
+        delete hydratedRouteSessionIdsRef.current[workspace.id];
+      }
+      scopes.set(workspace.id, scope);
+      loadedWorkspaceIdsRef.current.delete(workspace.id);
+      changed.push(workspace);
+    }
+    for (const id of scopes.keys()) {
+      if (workspaces.some((workspace) => workspace.id === id)) continue;
+      backgroundSessionLoadCoalescerRef.current.invalidate(id);
+      scopes.delete(id);
+      loadedWorkspaceIdsRef.current.delete(id);
+    }
+    if (changed.length === 0) return;
+    setRetryingWorkspaceIds((current) => Array.from(new Set([...current, ...changed.map((workspace) => workspace.id)])));
+    void loadWorkspaceSessionsInBackground(orderRouteWorkspaces(changed, [selectedWorkspaceId]));
+  }, [baseUrl, token, engineRoutingByServer, workspaces, selectedWorkspaceId, loadWorkspaceSessionsInBackground, sessionLoadScopeForWorkspace]);
   const opencodeBaseUrl = engineV2ChatRouting ? opencode2BaseUrl : defaultOpencodeBaseUrl;
   const selectedWorkspaceError = errorsByWorkspaceId[selectedWorkspaceId] ?? null;
   const selectedSessionKnown = Boolean(

--- a/apps/app/tests/route-refresh-control.test.ts
+++ b/apps/app/tests/route-refresh-control.test.ts
@@ -3,11 +3,123 @@ import { describe, expect, test } from "bun:test";
 import {
   commitRouteWorkspaceSelection,
   createLatestWorkspaceCommitter,
+  createRouteWorkspaceLoadCoalescer,
   createRouteWorkspaceSelectionCommitter,
   createRouteRefreshLifecycle,
   planRouteConnectionGap,
   planRouteWorkspaceLoads,
+  routeWorkspaceSessionLoadScope,
 } from "../src/react-app/shell/route-refresh-control";
+import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
+import type { RouteWorkspace } from "../src/react-app/shell/route-workspaces";
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason: Error) => void = () => undefined;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("workspace inventory scope", () => {
+  const workspace: RouteWorkspace = {
+    id: "ws_1", name: "One", displayNameResolved: "One", path: "/tmp/one", workspaceType: "local",
+  };
+  const endpoint = resolveWorkspaceEndpoint(workspace, { baseUrl: "http://localhost:4100", token: "token-1" });
+
+  test("unknown local routing is not v1, but remote inventory does not wait for it", () => {
+    expect(routeWorkspaceSessionLoadScope(workspace, endpoint, undefined)).toBeNull();
+    expect(routeWorkspaceSessionLoadScope(workspace, null, false)).toBeNull();
+    expect(routeWorkspaceSessionLoadScope(workspace, endpoint, false)).not.toBeNull();
+    const remote: RouteWorkspace = { ...workspace, workspaceType: "remote" };
+    expect(routeWorkspaceSessionLoadScope(remote, endpoint, undefined)).toBe(routeWorkspaceSessionLoadScope(remote, endpoint, true));
+    // A missing remote URL still reaches the loader's connection diagnostic.
+    expect(routeWorkspaceSessionLoadScope(remote, null, undefined)).not.toBeNull();
+  });
+
+  test("engine, endpoint, credentials, mount and directory changes produce a fresh scope", () => {
+    if (!endpoint) throw new Error("Expected a local endpoint");
+    const scope = routeWorkspaceSessionLoadScope(workspace, endpoint, false);
+    expect(routeWorkspaceSessionLoadScope(workspace, endpoint, true)).not.toBe(scope);
+    expect(routeWorkspaceSessionLoadScope(workspace, { ...endpoint, token: "token-2" }, false)).not.toBe(scope);
+    expect(routeWorkspaceSessionLoadScope(workspace, { ...endpoint, mountedBaseUrl: "http://localhost:4200/workspace/ws_1" }, false)).not.toBe(scope);
+    expect(routeWorkspaceSessionLoadScope(workspace, { ...endpoint, mountedBaseUrl: "http://localhost:4100/workspace/ws_2" }, false)).not.toBe(scope);
+    expect(routeWorkspaceSessionLoadScope({ ...workspace, path: "/tmp/two" }, endpoint, false)).not.toBe(scope);
+  });
+});
+
+describe("workspace inventory switching", () => {
+  for (const staleCompletesFirst of [true, false]) {
+    test(`a delayed v1 list cannot commit or swallow v2 (stale completes ${staleCompletesFirst ? "first" : "last"})`, async () => {
+      const coalescer = createRouteWorkspaceLoadCoalescer();
+      const v1 = deferred<string[]>();
+      const v2 = deferred<string[]>();
+      const starts: string[] = [];
+      let inventory = ["cached"];
+      const load = (engine: string, response: Promise<string[]>) => coalescer.run("ws_1", engine, async (isCurrent) => {
+        starts.push(engine);
+        const items = await response;
+        if (isCurrent()) inventory = items;
+      });
+      const oldLoad = load("v1", v1.promise);
+      await Promise.resolve();
+      const freshLoad = load("v2", v2.promise);
+      expect(load("v2", v2.promise)).toBe(freshLoad);
+      expect(freshLoad).not.toBe(oldLoad);
+      await Promise.resolve();
+      expect(starts).toEqual(["v1", "v2"]);
+
+      if (staleCompletesFirst) {
+        v1.resolve(["obsolete"]);
+        await oldLoad;
+        expect(inventory).toEqual(["cached"]);
+        expect(coalescer.isInFlight("ws_1")).toBe(true);
+        expect(load("v2", v2.promise)).toBe(freshLoad);
+      }
+      v2.resolve(["fresh"]);
+      await freshLoad;
+      v1.resolve(["obsolete"]);
+      await oldLoad;
+      expect(inventory).toEqual(["fresh"]);
+      expect(coalescer.isInFlight("ws_1")).toBe(false);
+    });
+  }
+
+  test("an invalidated failed chain cannot diagnose, retry, or release a fresh chain", async () => {
+    const coalescer = createRouteWorkspaceLoadCoalescer();
+    const old = deferred<void>();
+    const fresh = deferred<void>();
+    const effects: string[] = [];
+    const oldLoad = coalescer.run("ws_1", "endpoint-1", async (isCurrent) => {
+      try {
+        await old.promise;
+      } catch {
+        if (isCurrent()) effects.push("diagnose or retry");
+      }
+    });
+    await Promise.resolve();
+    coalescer.invalidate("ws_1");
+    // Even returning to the same endpoint cannot resurrect its old chain.
+    const freshLoad = coalescer.run("ws_1", "endpoint-1", () => fresh.promise);
+    old.reject(new Error("obsolete connection failed"));
+    await oldLoad;
+    expect(effects).toEqual([]);
+    expect(coalescer.isInFlight("ws_1")).toBe(true);
+    fresh.resolve();
+    await freshLoad;
+  });
+
+  test("delayed warm-up retries lose ownership when the inventory is replaced", async () => {
+    const coalescer = createRouteWorkspaceLoadCoalescer();
+    let mayRetry = () => false;
+    await coalescer.run("ws_1", "v1", async (isCurrent) => { mayRetry = isCurrent; });
+    expect(mayRetry()).toBe(true);
+    await coalescer.run("ws_1", "v2", async () => undefined);
+    expect(mayRetry()).toBe(false);
+  });
+});
 
 describe("createLatestWorkspaceCommitter", () => {
   test("coalesces an in-flight switching burst to the last route", async () => {

--- a/apps/app/tests/use-workspace-route-state.test.tsx
+++ b/apps/app/tests/use-workspace-route-state.test.tsx
@@ -1,0 +1,320 @@
+/** @jsxImportSource react */
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router";
+import type { ResolvedWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
+import type { RouteSession, RouteSessionListTransport, RouteWorkspace } from "../src/react-app/shell/route-workspaces";
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((onResolve) => { resolve = onResolve; });
+  return { promise, resolve };
+}
+
+const ownedDom = typeof window === "undefined";
+if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+
+const defaultWorkspaces: RouteWorkspace[] = [
+  { id: "ws_1", name: "One", displayNameResolved: "One", workspaceType: "local", path: "/tmp/ws_1" },
+  { id: "ws_2", name: "Two", displayNameResolved: "Two", workspaceType: "local", path: "/tmp/ws_2" },
+  {
+    id: "rem_remote", name: "Remote", displayNameResolved: "Remote", workspaceType: "remote",
+    remoteType: "openwork", path: "/tmp/remote", baseUrl: "http://remote.invalid", openworkToken: "remote-token",
+  },
+];
+let workspaces = defaultWorkspaces;
+let connection = { baseUrl: "http://localhost:4100", token: "token-1" };
+let localStatus = deferred<{ enabled: boolean; chatRouting: boolean }>();
+const remoteStatuses = new Map<string, ReturnType<typeof deferred<{ enabled: boolean; chatRouting: boolean }>>>();
+let bootReadyCalls = 0;
+const markRouteReady = () => { bootReadyCalls += 1; };
+const requests: Array<{
+  workspaceId: string;
+  engine: "v1" | "v2";
+  endpoint: ResolvedWorkspaceEndpoint;
+  response: ReturnType<typeof deferred<RouteSession[]>>;
+}> = [];
+
+const serverModule = await import("../src/app/lib/openwork-server");
+const createServerClient = serverModule.createOpenworkServerClient;
+mock.module("@/app/lib/openwork-server", () => ({
+  ...serverModule,
+  createOpenworkServerClient: (options: Parameters<typeof createServerClient>[0]) => ({
+    ...createServerClient(options),
+    listWorkspaces: async () => ({ items: workspaces, activeId: "ws_1" }),
+    activateWorkspace: async () => undefined,
+    getEngineV2PreviewStatus: async () => {
+      const remoteStatus = remoteStatuses.get(options.baseUrl);
+      if (remoteStatus) return remoteStatus.promise;
+      if (options.baseUrl === "http://remote.invalid") {
+        throw new serverModule.OpenworkServerError(404, "not_found", "Legacy worker");
+      }
+      return localStatus.promise;
+    },
+  }),
+}));
+const routeWorkspaces = await import("../src/react-app/shell/route-workspaces");
+const v2Transport = routeWorkspaces.v2RouteSessionList;
+mock.module("@/react-app/shell/route-workspaces", () => ({
+  ...routeWorkspaces,
+  listRouteSessions: (endpoint: ResolvedWorkspaceEndpoint, transport?: RouteSessionListTransport) => {
+    const response = deferred<RouteSession[]>();
+    requests.push({ workspaceId: endpoint.workspaceId, engine: transport === v2Transport ? "v2" : "v1", endpoint, response });
+    return response.promise;
+  },
+}));
+mock.module("@/react-app/shell/openwork-connection", () => ({
+  resolveOpenworkConnection: async () => ({
+    normalizedBaseUrl: connection.baseUrl, resolvedToken: connection.token, resolvedHostToken: "", hostInfo: null,
+  }),
+}));
+mock.module("@/react-app/kernel/local-provider", () => ({ useLocal: () => ({ prefs: { hasCompletedOnboarding: true } }) }));
+mock.module("@/react-app/domains/cloud/den-auth-provider", () => ({ useDenAuth: () => ({ status: "signed-out", isSignedIn: false }) }));
+mock.module("@/react-app/shell/boot-state", () => ({ useBootState: () => ({ markRouteReady, phase: "ready", routeReady: true }) }));
+mock.module("@/app/lib/app-inspector", () => ({
+  publishInspectorOpencodeClient: () => () => undefined,
+  publishInspectorSlice: () => () => undefined,
+  recordInspectorEvent: () => undefined,
+}));
+
+const { useWorkspaceRouteState } = await import("../src/react-app/shell/use-workspace-route-state");
+const handle: { current: ReturnType<typeof useWorkspaceRouteState> | null } = { current: null };
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+const input = { developerMode: false, onServerSettingsChanged: () => undefined, onHostInfo: () => undefined };
+
+function Probe() {
+  handle.current = useWorkspaceRouteState(input);
+  return null;
+}
+
+function route() {
+  if (!handle.current) throw new Error("Route is not mounted");
+  return handle.current;
+}
+
+async function mount(workspaceId = "ws_1") {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  const mountedRoot = createRoot(container);
+  root = mountedRoot;
+  await act(async () => {
+    mountedRoot.render(
+      <MemoryRouter initialEntries={[`/workspace/${workspaceId}/session`]}>
+        <Routes><Route path="/workspace/:workspaceId/session" element={<Probe />} /></Routes>
+      </MemoryRouter>,
+    );
+  });
+}
+
+function session(workspaceId: string, id: string): RouteSession {
+  return { id, title: id, slug: id, projectID: "project", directory: `/tmp/${workspaceId}`, version: "1", time: { created: 1, updated: 1 } };
+}
+
+async function publishRouting(v2: boolean) {
+  await act(async () => { localStatus.resolve({ enabled: v2, chatRouting: v2 }); });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  workspaces = defaultWorkspaces;
+  requests.length = 0;
+  remoteStatuses.clear();
+  bootReadyCalls = 0;
+  connection = { baseUrl: "http://localhost:4100", token: "token-1" };
+  localStatus = deferred();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+    for (const request of requests) request.response.resolve([]);
+    localStatus.resolve({ enabled: false, chatRouting: false });
+    for (const status of remoteStatuses.values()) status.resolve({ enabled: false, chatRouting: false });
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  handle.current = null;
+});
+
+afterAll(async () => { if (ownedDom) await GlobalRegistrator.unregister(); });
+
+test("routing readiness starts the fifth selected local workspace before slow background lists finish", async () => {
+  workspaces = Array.from({ length: 5 }, (_, index): RouteWorkspace => ({
+    id: `ws_${index + 1}`, name: `Workspace ${index + 1}`, displayNameResolved: `Workspace ${index + 1}`,
+    workspaceType: "local", path: `/tmp/ws_${index + 1}`,
+  }));
+  await mount("ws_5");
+  expect(route().selectedWorkspaceId).toBe("ws_5");
+  expect(requests).toHaveLength(0);
+
+  await publishRouting(true);
+  // No background response has resolved: the selected workspace must be in the first batch.
+  expect(requests.map((request) => request.workspaceId)).toEqual(["ws_5", "ws_1", "ws_2", "ws_3"]);
+  const selected = requests.find((request) => request.workspaceId === "ws_5");
+  if (!selected) throw new Error("Expected selected workspace inventory load");
+  await act(async () => { selected.response.resolve([session("ws_5", "selected")]); });
+  expect(route().sessionsByWorkspaceId.ws_5.map((item) => item.id)).toEqual(["selected"]);
+  expect(route().retryingWorkspaceIds).not.toContain("ws_5");
+  expect(requests).toHaveLength(4);
+
+  await act(async () => {
+    for (const request of requests) request.response.resolve([session(request.workspaceId, "background")]);
+  });
+  expect(requests).toHaveLength(5);
+  await act(async () => {
+    requests.find((request) => request.workspaceId === "ws_4")?.response.resolve([session("ws_4", "background")]);
+  });
+});
+
+for (const staleCompletesFirst of [true, false]) {
+  test(`refreshes every local inventory after switching to v2; stale v1 completes ${staleCompletesFirst ? "first" : "last"}`, async () => {
+    await mount();
+    // Routing discovery must not gate workspace bootstrap or remote inventory.
+    expect(route().loading).toBe(false);
+    expect(bootReadyCalls).toBeGreaterThan(0);
+    expect(route().opencodeClient).toBeNull();
+    expect(requests.map((request) => request.workspaceId)).toEqual(["remote"]);
+
+    await publishRouting(false);
+    const initial = requests.filter((request) => request.workspaceId !== "remote");
+    expect(initial.map((request) => request.workspaceId).sort()).toEqual(["ws_1", "ws_2"]);
+    expect(initial.every((request) => request.engine === "v1")).toBe(true);
+    await act(async () => {
+      initial.find((request) => request.workspaceId === "ws_2")?.response.resolve([session("ws_2", "cached-v1")]);
+    });
+    expect(route().loadedWorkspaceIds.has("ws_2")).toBe(true);
+    const stale = initial.filter((request) => request.workspaceId === "ws_1");
+
+    localStatus = deferred();
+    await act(async () => { window.dispatchEvent(new Event("openwork-server-settings-changed")); });
+    await publishRouting(true);
+    const fresh = requests.filter((request) => request.engine === "v2");
+    // The delayed list cannot block v2, and the already-loaded, unselected inventory refreshes too.
+    expect(fresh.map((request) => request.workspaceId).sort()).toEqual(["ws_1", "ws_2"]);
+    expect(requests.filter((request) => request.workspaceId === "remote")).toHaveLength(1);
+
+    const finishStale = async () => {
+      await act(async () => {
+        for (const request of stale) request.response.resolve([session(request.workspaceId, "obsolete")]);
+      });
+    };
+    if (staleCompletesFirst) {
+      await finishStale();
+      expect(route().sessionsByWorkspaceId.ws_1).toEqual([]);
+      expect(route().sessionsByWorkspaceId.ws_2.map((item) => item.id)).toEqual(["cached-v1"]);
+      expect(route().loadedWorkspaceIds.has("ws_1")).toBe(false);
+      expect(route().loadedWorkspaceIds.has("ws_2")).toBe(false);
+      expect(route().retryingWorkspaceIds).toContain("ws_1");
+    }
+    await act(async () => {
+      for (const request of fresh) request.response.resolve([session(request.workspaceId, "fresh")]);
+    });
+    if (!staleCompletesFirst) await finishStale();
+    expect(route().sessionsByWorkspaceId.ws_1.map((item) => item.id)).toEqual(["fresh"]);
+    expect(route().sessionsByWorkspaceId.ws_2.map((item) => item.id)).toEqual(["fresh"]);
+    expect(route().retryingWorkspaceIds).not.toContain("ws_1");
+    expect(route().loadedWorkspaceIds.has("ws_2")).toBe(true);
+  });
+}
+
+test("a rotated endpoint waits for its own routing and rejects the old endpoint's late inventory", async () => {
+  await mount();
+  await publishRouting(false);
+  const stale = requests.filter((request) => request.workspaceId !== "remote");
+  connection = { baseUrl: "http://localhost:4200", token: "token-2" };
+  localStatus = deferred();
+  await act(async () => { await route().refreshRouteState({ supersede: true }); });
+  expect(route().opencodeClient).toBeNull();
+  expect(requests.filter((request) => request.endpoint.baseUrl === connection.baseUrl)).toEqual([]);
+  await act(async () => {
+    for (const request of stale) request.response.resolve([session(request.workspaceId, "obsolete")]);
+  });
+  expect(route().sessionsByWorkspaceId.ws_1).toEqual([]);
+  await publishRouting(true);
+  const fresh = requests.filter((request) => request.endpoint.baseUrl === connection.baseUrl);
+  expect(fresh).toHaveLength(2);
+  expect(fresh.every((request) => request.engine === "v2" && request.endpoint.token === "token-2")).toBe(true);
+});
+
+test("selecting a legacy remote worker neither blocks nor selects the engine for local inventories", async () => {
+  await mount("rem_remote");
+  expect(route().loading).toBe(false);
+  expect(route().opencodeClient).not.toBeNull();
+  expect(requests.map((request) => request.workspaceId)).toEqual(["remote"]);
+  await publishRouting(true);
+  expect(route().opencodeBaseUrl).toBe("http://remote.invalid/workspace/remote/opencode");
+  expect(requests.filter((request) => request.engine === "v2").map((request) => request.workspaceId).sort()).toEqual(["ws_1", "ws_2"]);
+});
+
+test("a late routing-status response cannot switch inventories back to the old engine", async () => {
+  await mount();
+  const staleStatus = localStatus;
+  localStatus = deferred();
+  await act(async () => { window.dispatchEvent(new Event("openwork-server-settings-changed")); });
+  await publishRouting(true);
+  await act(async () => { staleStatus.resolve({ enabled: false, chatRouting: false }); });
+  expect(route().opencodeBaseUrl.endsWith("/opencode2")).toBe(true);
+  expect(requests.filter((request) => request.workspaceId !== "remote").every((request) => request.engine === "v2")).toBe(true);
+});
+
+test("returning from remote B to remote A waits for fresh routing while retaining local readiness", async () => {
+  const statusA = deferred<{ enabled: boolean; chatRouting: boolean }>();
+  const statusB = deferred<{ enabled: boolean; chatRouting: boolean }>();
+  statusA.resolve({ enabled: false, chatRouting: false });
+  statusB.resolve({ enabled: false, chatRouting: false });
+  remoteStatuses.set("http://remote.invalid", statusA);
+  remoteStatuses.set("http://remote-b.invalid", statusB);
+  await mount("rem_remote");
+  await publishRouting(true);
+  expect(route().opencodeClient).not.toBeNull();
+  expect(route().opencodeBaseUrl).toBe("http://remote.invalid/workspace/remote/opencode");
+  await act(async () => {
+    route().setWorkspaces((current) => [...current, {
+      id: "rem_b", name: "B", displayNameResolved: "B", workspaceType: "remote",
+      remoteType: "openwork", path: "/tmp/b", baseUrl: "http://remote-b.invalid", openworkToken: "remote-b-token",
+    }]);
+  });
+
+  // Keep local revalidation pending: its continuously polled routing must survive navigation.
+  localStatus = deferred();
+  await act(async () => { route().navigateToWorkspaceSession("rem_b"); });
+  expect(route().selectedWorkspaceId).toBe("rem_b");
+  expect(route().opencodeClient).not.toBeNull();
+
+  const freshStatusA = deferred<{ enabled: boolean; chatRouting: boolean }>();
+  remoteStatuses.set("http://remote.invalid", freshStatusA);
+  await act(async () => { route().navigateToWorkspaceSession("rem_remote"); });
+  expect(route().selectedWorkspaceId).toBe("rem_remote");
+  expect(route().opencodeClient).toBeNull();
+  await act(async () => { freshStatusA.resolve({ enabled: true, chatRouting: true }); });
+  expect(route().opencodeClient).not.toBeNull();
+  expect(route().opencodeBaseUrl).toBe("http://remote.invalid/workspace/remote/opencode2");
+
+  await act(async () => { route().navigateToWorkspaceSession("ws_1"); });
+  expect(route().opencodeClient).not.toBeNull();
+  expect(route().opencodeBaseUrl.endsWith("/opencode2")).toBe(true);
+});
+
+test("editing an unselected remote endpoint refreshes it without accepting the old response", async () => {
+  await mount();
+  const stale = requests.find((request) => request.workspaceId === "remote");
+  if (!stale) throw new Error("Expected remote inventory load");
+  await act(async () => {
+    route().setWorkspaces((current) => current.map((workspace) => workspace.id === "rem_remote"
+      ? { ...workspace, baseUrl: "http://remote-new.invalid", openworkToken: "remote-token-2" }
+      : workspace));
+  });
+  const fresh = requests.find((request) => request.endpoint.baseUrl === "http://remote-new.invalid");
+  if (!fresh) throw new Error("Expected fresh remote inventory load");
+  await act(async () => { stale.response.resolve([session("remote", "obsolete")]); });
+  expect(route().sessionsByWorkspaceId.rem_remote).toEqual([]);
+  expect(route().retryingWorkspaceIds).toContain("rem_remote");
+  await act(async () => { fresh.response.resolve([session("remote", "fresh")]); });
+  expect(route().sessionsByWorkspaceId.rem_remote.map((item) => item.id)).toEqual(["fresh"]);
+  expect(route().workspaceConnectionOverrides.rem_remote.status).toBe("connected");
+});

--- a/apps/app/tests/workbench-store.test.ts
+++ b/apps/app/tests/workbench-store.test.ts
@@ -164,6 +164,65 @@ describe("workbench store", () => {
     expect(closeWorkbenchTab(state, otherSide, false).secondary).toEqual(side);
   });
 
+  for (const archivedId of ["owner", "side"]) {
+    test(`explicit archive metadata removes a retained ${archivedId} and its pair without pruning unknown history`, () => {
+      const primary = { workspaceId: "workspace-a", sessionId: "primary" };
+      const owner = { workspaceId: "workspace-a", sessionId: "owner" };
+      const side = { workspaceId: "workspace-a", sessionId: "side" };
+      const unknown = { workspaceId: "workspace-a", sessionId: "other-engine" };
+      const otherWorkspace = { workspaceId: "workspace-b", sessionId: archivedId };
+      let state = syncWorkbenchSnapshot(emptyWorkbench, {
+        workspaceId: primary.workspaceId, primarySessionId: primary.sessionId,
+        sessionsKnown: true, sessions: [primary],
+      });
+      for (const tab of [owner, side, unknown, otherWorkspace]) state = openWorkbenchTab(state, tab);
+      state = setWorkbenchSideChat(state, owner, side);
+      state = setWorkbenchSideChat(state, primary, otherWorkspace);
+      state = syncWorkbenchSnapshot(state, {
+        workspaceId: primary.workspaceId, primarySessionId: primary.sessionId,
+        sessionsKnown: true, sessions: [primary], archivedSessionIds: [archivedId],
+      });
+
+      expect(state.tabs.some((tab) => tab.workspaceId === "workspace-a" && tab.sessionId === archivedId)).toBe(false);
+      expect(state.tabs).toContainEqual(unknown);
+      expect(state.tabs).toContainEqual(otherWorkspace);
+      expect(Object.values(state.sideChats)).toEqual([otherWorkspace]);
+      expect(state.secondary).toEqual(otherWorkspace);
+    });
+  }
+
+  test("explicitly archiving the visible side chat clears the split and restores primary focus", () => {
+    const primary = { workspaceId: "workspace-a", sessionId: "primary" };
+    const side = { workspaceId: "workspace-a", sessionId: "side" };
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: primary.workspaceId, primarySessionId: primary.sessionId,
+      sessionsKnown: true, sessions: [primary, side],
+    });
+    state = setWorkbenchSplit(openWorkbenchTab(state, side), side);
+    state = syncWorkbenchSnapshot(state, {
+      workspaceId: primary.workspaceId, primarySessionId: primary.sessionId,
+      sessionsKnown: true, sessions: [primary, side], archivedSessionIds: [side.sessionId],
+    });
+    expect(state.tabs.map((tab) => tab.sessionId)).toEqual([primary.sessionId]);
+    expect(state.sideChats).toEqual({});
+    expect(state.secondary).toBeNull();
+    expect(state.focusedPane).toBe("primary");
+  });
+
+  test("keeps an explicitly archived primary viewable until navigating away", () => {
+    const primary = { workspaceId: "workspace-a", sessionId: "primary" };
+    const input = {
+      workspaceId: primary.workspaceId, primarySessionId: primary.sessionId,
+      sessionsKnown: true, sessions: [primary], archivedSessionIds: [primary.sessionId],
+    };
+    const state = syncWorkbenchSnapshot(emptyWorkbench, input);
+    expect(state.primary).toMatchObject(primary);
+    expect(state.tabs).toHaveLength(1);
+    const navigated = syncWorkbenchSnapshot(state, { ...input, primarySessionId: null });
+    expect(navigated.primary).toBeNull();
+    expect(navigated.tabs).toEqual([]);
+  });
+
   test("does not prune retained same-workspace tabs while the session index reloads", () => {
     let state = syncWorkbenchSnapshot(emptyWorkbench, {
       workspaceId: "workspace-a",
@@ -186,6 +245,36 @@ describe("workbench store", () => {
 
     expect(loading.tabs.map((tab) => tab.sessionId)).toEqual(["session-a", "session-b"]);
     expect(loading.secondary?.sessionId).toBe("session-b");
+  });
+
+  test("retains unpaired history across engine switches, workspace navigation, and reload", () => {
+    const first = { workspaceId: "workspace-a", sessionId: "v1-first", title: "First" };
+    const second = { workspaceId: "workspace-a", sessionId: "v1-second", title: "Second" };
+    const upgraded = { workspaceId: "workspace-a", sessionId: "v2-chat", title: "Upgraded" };
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: first.workspaceId, primarySessionId: first.sessionId,
+      sessionsKnown: true, sessions: [first, second],
+    });
+    state = openWorkbenchTab(state, second);
+    state = syncWorkbenchSnapshot(state, {
+      workspaceId: upgraded.workspaceId, primarySessionId: upgraded.sessionId,
+      sessionsKnown: true, sessions: [upgraded],
+    });
+    state = syncWorkbenchSnapshot(state, {
+      workspaceId: "workspace-b", primarySessionId: null, sessionsKnown: true, sessions: [],
+    });
+    const restored = { ...emptyWorkbench, tabs: state.tabs, sideChats: state.sideChats };
+    state = syncWorkbenchSnapshot(restored, {
+      workspaceId: first.workspaceId, primarySessionId: first.sessionId,
+      sessionsKnown: true, sessions: [first, second],
+    });
+    expect(state.tabs.map(tab => tab.sessionId)).toEqual([first.sessionId, second.sessionId, upgraded.sessionId]);
+    expect(state.primary).toMatchObject(first);
+    expect(state.secondary).toBeNull();
+    const closed = closeWorkbenchTab(state, second);
+    expect(closed.tabs.map(tab => tab.sessionId)).toEqual([first.sessionId, upgraded.sessionId]);
+    const archived = closeWorkbenchTab(state, upgraded, false);
+    expect(archived.tabs.map(tab => tab.sessionId)).toEqual([first.sessionId, second.sessionId]);
   });
 
   test("restores saved pairs when an initial session index omits their sessions", () => {

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -265,16 +265,16 @@ describe("workspace route session load budget", () => {
     const starts: string[] = [];
     let releaseWorkspaceA: (() => void) | undefined;
 
-    const firstWorkspaceA = coalescer.run("workspace-a", async () => {
+    const firstWorkspaceA = coalescer.run("workspace-a", "v1", async () => {
       starts.push("workspace-a");
       await new Promise<void>((resolve) => {
         releaseWorkspaceA = resolve;
       });
     });
-    const duplicateWorkspaceA = coalescer.run("workspace-a", async () => {
+    const duplicateWorkspaceA = coalescer.run("workspace-a", "v1", async () => {
       starts.push("workspace-a-duplicate");
     });
-    const workspaceB = coalescer.run("workspace-b", async () => {
+    const workspaceB = coalescer.run("workspace-b", "v1", async () => {
       starts.push("workspace-b");
     });
 
@@ -287,7 +287,7 @@ describe("workspace route session load budget", () => {
     await Promise.all([firstWorkspaceA, duplicateWorkspaceA, workspaceB]);
     expect(coalescer.isInFlight("workspace-a")).toBe(false);
 
-    await coalescer.run("workspace-a", async () => {
+    await coalescer.run("workspace-a", "v1", async () => {
       starts.push("workspace-a-after-settle");
     });
     expect(starts).toEqual(["workspace-a", "workspace-b", "workspace-a-after-settle"]);

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -1,118 +1,331 @@
 import { expect } from "vitest";
-import { go } from "@openwork/behaviors";
-import { observeTranscript, spec, type Probe, type User } from "@openwork/testkit";
+import { assertNoLiveSecret, go, liveOpenAiEnabled } from "@openwork/behaviors";
+import { observeTranscript, readTranscriptMessages, spec } from "@openwork/testkit";
 import { workspaceEngineUpgrade } from "../worlds/chat.ts";
 
-// Fresh-engine chat journeys cannot witness ownership after an upgrade.
-const test = spec.world(workspaceEngineUpgrade, { timeout: 600_000 });
-const reply = "Hello. Your upgrade conversation is working.";
+const live = liveOpenAiEnabled();
+const test = spec.world(workspaceEngineUpgrade, {
+  timeout: 900_000,
+  resources: {
+    surfaces: ["desktop"], services: ["den", "mock"],
+    nativeReason: "Engine ownership and sidecar persistence must survive Settings switches in one running Electron profile.",
+  },
+  needs: live ? { env: ["OPENAI_API_KEY"] } : {},
+});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-async function greet(user: User, probe: Probe) {
-  await using transcript = await observeTranscript(probe, [
-    { role: "user", text: "hi" }, { role: "assistant", text: reply },
-  ]);
-  await user.type("composer", "hi");
-  await user.click("Run task");
-  // Observe the user row itself: text left in the composer cannot satisfy this.
-  await probe.eventually(() => transcript.read(), {
-    within: 2_000, label: "sent hi visible in the user transcript",
-    until: (state) => isRecord(state) && Array.isArray(state.seen) && state.seen[0] === true,
-  });
-  await user.screenshot();
-  await user.see({ text: reply }, { timeoutMs: 90_000 });
-  await user.see("Run task", { timeoutMs: 30_000 });
-  expect(await transcript.finish()).toMatchObject({ seen: [true, true], violations: [], stopped: false });
-  await user.reload();
-  await user.see({ text: /^hi$/ }, { timeoutMs: 30_000 });
-  await user.see({ text: reply });
+function nativeItems(body: unknown): Record<string, unknown>[] {
+  assertNoLiveSecret(body);
+  const items = isRecord(body) ? body.data : body;
+  if (!Array.isArray(items) || !items.every(isRecord)) throw new Error("Unexpected native list response");
+  return items;
 }
 
-test("existing workspaces create usable sessions after changing chat engines", async ({ world, user, probe, step }) => {
-  const macPlatform = await probe.eval(() => (/Mac|iPhone|iPad|iPod/.test(navigator.platform)));
-  const paletteShortcut = macPlatform ? "Meta+K" : "Control+K";
-  const createPaletteChat = async () => {
-    const previousRoute = await probe.hash();
-    const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
-    await user.press(paletteShortcut);
-    await user.see(paletteInput);
-    await user.type(paletteInput, "New session", { replace: true });
-    await user.click({ role: "option", label: /^New session\b/ });
-    await probe.eventually(() => probe.hash(), {
-      within: 30_000, label: "palette opens a new chat in the selected workspace",
-      until: (hash) => hash !== previousRoute && hash.includes(`/workspace/${world.primary.workspaceId}/session/ses_`),
+function messageInfo(message: Record<string, unknown>) {
+  return isRecord(message.info) ? message.info : message;
+}
+
+function role(message: Record<string, unknown>) {
+  const info = messageInfo(message);
+  return info.role ?? info.type;
+}
+
+function messageText(message: Record<string, unknown>) {
+  const parts = Array.isArray(message.parts) ? message.parts : Array.isArray(message.content) ? message.content : [message];
+  return parts.filter(isRecord).filter(part => part.type === "text" && !part.synthetic)
+    .map(part => typeof part.text === "string" ? part.text : "").join("\n");
+}
+
+type Engine = "v1" | "v2";
+interface Conversation {
+  workspaceId: string;
+  sessionId: string;
+  engine: Engine;
+  prompt: string;
+  native: Record<string, unknown>[];
+  finalAnswers: { id: string; text: string }[];
+}
+
+test(`${live ? "real LLM" : "deterministic"}: completed workspace history survives v1/v2 switches and sidecar restart`, async ({ world, user, agent, probe, step, evidence }) => {
+  const primaryId = world.primary.workspaceId;
+  const conversations: Conversation[] = [];
+  const readRoute = async () => (await probe.hash()).replace(/^#/, "");
+  const sessionsPath = (workspaceId: string, engine: Engine) => `/workspace/${workspaceId}/${engine === "v2" ? "opencode2/api" : "opencode"}/session`;
+  const readSessions = async (workspaceId: string, engine: Engine) => {
+    const result = await probe.desktopApi(sessionsPath(workspaceId, engine));
+    expect(result.status).toBe(200);
+    return nativeItems(result.body).map(session => {
+      if (typeof session.id !== "string") throw new Error("Native session omitted its ID");
+      return session.id;
+    }).sort();
+  };
+  const readNative = async (conversation: { workspaceId: string; engine: Engine; sessionId: string }) => {
+    const result = await probe.desktopApi(`${sessionsPath(conversation.workspaceId, conversation.engine)}/${conversation.sessionId}/message`);
+    expect(result.status).toBe(200);
+    return nativeItems(result.body);
+  };
+  const visible = async () => ({
+    user: await readTranscriptMessages(probe, "user"),
+    assistant: await world.readFinalAnswerRows(),
+  });
+  const workspaceName = async (workspaceId: string) => {
+    const response = await probe.desktopApi("/workspaces");
+    expect(response.status).toBe(200);
+    const workspace = isRecord(response.body) && Array.isArray(response.body.items)
+      ? response.body.items.filter(isRecord).find(item => item.id === workspaceId) : null;
+    if (!workspace || typeof workspace.name !== "string") throw new Error("Workspace name missing");
+    return workspace.name;
+  };
+  const runtime = async () => {
+    const response = await probe.desktopApi("/experimental/engine-v2-preview/status");
+    expect(response.status).toBe(200);
+    if (!isRecord(response.body)) throw new Error("Engine status missing");
+    return response.body;
+  };
+  const switchEngine = async (engine: Engine) => {
+    await go(world.app, `/workspace/${primaryId}/settings/advanced`);
+    await user.click({ text: engine === "v2" ? "OpenCode v2 (preview)" : "OpenCode v1 (default)" });
+    const status = await probe.eventually(runtime, {
+      within: 120_000, label: `${engine} Settings selection settled`,
+      until: status => engine === "v2"
+        ? status.enabled === true && status.chatRouting === true && status.running === true && typeof status.pid === "number"
+        : status.enabled === false && status.chatRouting === false && status.running === false,
     });
-    await user.notSee(paletteInput);
-    await user.see("Run task", { timeoutMs: 30_000 });
+    expect(await probe.storage("openwork.preferences")).toMatchObject({
+      defaultModel: { providerID: world.providerId, modelID: world.modelId },
+    });
+    return status;
+  };
+  const verify = async (conversation: Conversation) => {
+    const route = `/workspace/${conversation.workspaceId}/session/${conversation.sessionId}`;
+    await probe.eventually(readRoute, { within: 30_000, label: `same session route ${conversation.sessionId}`, until: hash => hash === route });
+    await probe.eventually(visible, {
+      within: 60_000, label: `same prompt and native-ID final answers ${conversation.sessionId}`,
+      until: value => value.user.length === 1 && value.user[0]?.includes(conversation.prompt) === true
+        && JSON.stringify(value.assistant) === JSON.stringify(conversation.finalAnswers),
+    });
+    expect(await readNative(conversation)).toEqual(conversation.native);
+    const result = await probe.desktopApi(`${sessionsPath(conversation.workspaceId, conversation.engine)}/${conversation.sessionId}`);
+    expect(result.status).toBe(200);
+    const session = isRecord(result.body) && isRecord(result.body.data) ? result.body.data : result.body;
+    expect(session).toMatchObject({ id: conversation.sessionId });
+    expect(await readSessions(conversation.workspaceId, conversation.engine)).toContain(conversation.sessionId);
+    expect(await probe.storage("openwork.react.activeWorkspace")).toBe(conversation.workspaceId);
+    const surface = await probe.dom(`[data-session-surface-id="${conversation.sessionId}"]`);
+    expect(surface.elements.some(node => node.rect.width > 0 && node.rect.height > 0)).toBe(true);
+    const otherSurfaces = await probe.dom(`[data-session-surface-id]:not([data-session-surface-id="${conversation.sessionId}"])`);
+    expect(otherSurfaces.elements.filter(node => node.rect.width > 0 && node.rect.height > 0)).toEqual([]);
+    for (const other of conversations.filter(other => other.sessionId !== conversation.sessionId)) {
+      expect((await visible()).user.join("\n")).not.toContain(other.prompt);
+    }
     await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
-    await greet(user, probe);
+    await user.see("Run task");
+    expect(await readRoute()).toBe(route);
+  };
+  const reopen = async (conversation: Conversation) => {
+    if ((await readRoute()).includes("/settings/")) {
+      await user.click({ role: "button", label: "Back to app" });
+      await probe.eventually(readRoute, {
+        within: 30_000, label: "Back to app restores the workspace sidebar",
+        until: route => !route.includes("/settings/"),
+      });
+    }
+    // Select the workspace and its actual persisted row; never repair a missing row with go().
+    await user.click({ role: "button", label: await workspaceName(conversation.workspaceId) });
+    await user.click({ testId: `sidebar-session-${conversation.sessionId}` });
+    await verify(conversation);
+  };
+  const createChat = async (workspaceId: string, engine: Engine, entry: "button" | "palette" | "sidebar", marker: string) => {
+    const before = await readSessions(workspaceId, engine);
+    if (entry === "palette") {
+      const input = { placeholder: "Search actions, settings, and sessions…" };
+      await user.press(world.paletteShortcut);
+      await user.type(input, "New session", { replace: true });
+      await user.click({ role: "option", label: /^New session\b/ });
+      await user.notSee(input);
+    } else if (entry === "sidebar") {
+      const name = await workspaceName(workspaceId);
+      await user.hover({ role: "button", label: name });
+      await user.click({ role: "button", label: `New session · ${name}` });
+    } else {
+      await user.click({ role: "button", label: "New session" });
+    }
+    const sessionlessRoute = `/workspace/${workspaceId}/session`;
+    const empty = await probe.eventually(() => probe.composer(), {
+      within: 60_000, label: entry === "palette" ? "palette opens one allocated empty session" : "New session opens the sessionless composer",
+      until: state => (entry === "palette"
+        ? state.route.replace(/^#/, "").startsWith(`${sessionlessRoute}/ses_`)
+        : state.route.replace(/^#/, "") === sessionlessRoute) && state.composerEditable && !state.modelUnavailable
+        && state.draftText.trim() === "" && state.userMessageCount === 0,
+    });
+    const allocatedId = entry === "palette" ? empty.route.replace(/^#/, "").slice(sessionlessRoute.length + 1) : null;
+    if (allocatedId !== null) {
+      expect(allocatedId).toMatch(/^ses_[^/?#]+$/);
+      expect(before).not.toContain(allocatedId);
+      expect(await readSessions(workspaceId, engine)).toEqual([...before, allocatedId].sort());
+    } else {
+      expect(await readSessions(workspaceId, engine)).toEqual(before);
+    }
+    const prompt = `For upgrade conversation ${marker}, explain in one short plain-text sentence why keeping notes is useful. Do not use tools or markdown.`;
+    await using transcript = await observeTranscript(probe, [{ role: "user", text: prompt }]);
+    await user.type("composer", prompt);
+    await probe.eventually(() => probe.composer(), {
+      within: 30_000, label: "the selected model can submit the first prompt",
+      until: state => state.runTaskEnabled && state.draftText.trim() === prompt,
+    });
+    await user.click("Run task");
+    const route = await probe.eventually(readRoute, {
+      within: 30_000, label: "first send uses a session in the selected workspace",
+      until: hash => hash.startsWith(`${sessionlessRoute}/ses_`),
+    });
+    const sessionId = route.slice(sessionlessRoute.length + 1);
+    expect(sessionId).toMatch(/^ses_[^/?#]+$/);
+    if (allocatedId !== null) expect(sessionId).toBe(allocatedId);
+    const identity = { workspaceId, engine, sessionId };
+    const native = await probe.eventually(() => readNative(identity), {
+      within: 150_000, intervalMs: 500, label: `${engine} completed native assistant response`,
+      until: messages => messages.some(message => {
+        const info = messageInfo(message);
+        if (info.error || info.finish === "error") throw new Error("Native model request failed");
+        return role(message) === "assistant" && info.finish === "stop" && isRecord(info.time)
+          && typeof info.time.completed === "number" && messageText(message).trim().length > 0;
+      }),
+    });
+    expect(native.filter(message => role(message) === "user").map(messageText)).toEqual([prompt]);
+    const assistants = native.filter(message => role(message) === "assistant");
+    expect(assistants.length).toBeGreaterThan(0);
+    for (const message of native) {
+      const info = messageInfo(message);
+      expect(typeof info.id).toBe("string");
+      expect(info.error).toBeUndefined();
+      if (role(message) !== "assistant") continue;
+      expect(info.finish).toBe("stop");
+      if (engine === "v1") expect(info).toMatchObject({ providerID: world.providerId, modelID: world.modelId });
+      else expect(info.model).toMatchObject({ providerID: world.providerId, id: world.modelId });
+      if (world.live) {
+        if (!isRecord(info.tokens)) throw new Error("Real model response omitted token usage");
+        expect(info.tokens.output).toBeGreaterThan(0);
+      }
+    }
+    const finalAnswers = assistants.filter(message => messageText(message).trim()).map(message => {
+      const id = messageInfo(message).id;
+      if (typeof id !== "string") throw new Error("Native assistant omitted its ID");
+      return { id, text: messageText(message).replace(/\s+/g, " ").trim() };
+    });
+    expect(finalAnswers.length).toBeGreaterThan(0);
+    await probe.eventually(visible, {
+      within: 30_000, label: "native-ID final answer text rendered separately from reasoning steps",
+      until: value => value.user.length === 1 && value.user[0]?.includes(prompt) === true
+        && JSON.stringify(value.assistant) === JSON.stringify(finalAnswers),
+    });
+    await user.see("Run task", { timeoutMs: 30_000 });
+    expect(await transcript.finish()).toMatchObject({ seen: [true], violations: [], stopped: false });
+    const conversation = { ...identity, prompt, native, finalAnswers };
+    conversations.push(conversation);
+    expect(await readSessions(workspaceId, engine)).toEqual([...before, sessionId].sort());
+    // A disabled v2 sidecar is unavailable, not an ownership witness. Check old
+    // v1 IDs against it only after Settings has actually started it below.
+    if (engine === "v2") expect((await probe.desktopApi(`${sessionsPath(workspaceId, "v1")}/${sessionId}`)).status).toBe(404);
+    await verify(conversation);
+    evidence.recordAssertionEvidence(`${engine} completed composer-created conversation ${marker}`,
+      JSON.stringify({ ...conversation, providerId: world.providerId, modelId: world.modelId, live: world.live }), true);
+    return conversation;
   };
 
-  expect((await probe.desktopApi("/experimental/engine-v2-preview/status")).body).toMatchObject({ chatRouting: false });
-  await go(world.app, `/workspace/${world.primary.workspaceId}/settings/advanced`);
-  await user.see({ text: "OpenCode v2 (preview)" }, { timeoutMs: 30_000 });
-  await user.click({ text: "OpenCode v2 (preview)" });
-  await probe.eventually(() => probe.desktopApi("/experimental/engine-v2-preview/status"), {
-    within: 120_000, label: "v2 configured and running",
-    until: (response) => isRecord(response.body) && response.body.running === true && response.body.chatRouting === true,
+  const rendererOrigin = (await world.readRendererLifetime()).timeOrigin;
+  expect(await runtime()).toMatchObject({ chatRouting: false });
+  await go(world.app, `/workspace/${primaryId}/session`);
+  const first = await step("workspace A completes its first v1 conversation through New session", () => createChat(primaryId, "v1", "button", "amber"));
+  const second = await step("workspace A completes another v1 conversation through the chat palette", () => createChat(primaryId, "v1", "palette", "birch"));
+  const v1Inventory = await readSessions(primaryId, "v1");
+  const firstV2Runtime = await switchEngine("v2");
+  for (const conversation of [first, second]) {
+    expect((await probe.desktopApi(`${sessionsPath(primaryId, "v2")}/${conversation.sessionId}`)).status).toBe(404);
+  }
+  const saved = await step("Settings New session completes a v2 conversation in the existing workspace A", async () => {
+    expect(await readRoute()).toBe(`/workspace/${primaryId}/settings/advanced`);
+    await user.see({ role: "button", label: "Back to app" });
+    return createChat(primaryId, "v2", "palette", "cedar");
   });
-  await step("the Settings command palette creates a usable chat after enabling v2", createPaletteChat);
-  await go(world.app, `/workspace/${world.primary.workspaceId}/session`);
-  await user.reload();
-  await user.see("composer", { timeoutMs: 60_000 });
-
-  await step("a new chat in the selected existing workspace keeps the first message visible", async () => {
-    const previousRoute = await probe.hash();
-    await user.click({ role: "button", label: "New session" });
-    await probe.eventually(() => probe.hash(), { within: 30_000,
-      label: "new session route", until: (hash) => hash !== previousRoute && hash.includes("/session/ses_") });
-    await user.see("composer", { timeoutMs: 30_000 });
-    await greet(user, probe);
+  const pendingRowDeadline = (await world.readRendererLifetime()).now + 31_000;
+  const other = await step("create workspace B only after the v2 switch, then chat through its sidebar", async () => {
+    const workspace = await world.createOtherWorkspace();
+    expect(workspace.workspaceId).not.toBe(primaryId);
+    return createChat(workspace.workspaceId, "v2", "sidebar", "dune");
   });
+  const primaryV2Inventory = await readSessions(primaryId, "v2");
+  const otherV2Inventory = await readSessions(other.workspaceId, "v2");
 
-  await step("the chat command palette creates another usable v2 chat", createPaletteChat);
-
-  await step("a sidebar new session opens and runs in the configured engine", async () => {
-    if (!world.otherName) throw new Error("Existing workspace name missing");
-    await user.hover({ role: "button", label: world.otherName });
-    await user.click({ role: "button", label: `New session · ${world.otherName}` });
-    const route = await probe.eventually(() => probe.hash(), { within: 30_000,
-      label: "other workspace new session route",
-      until: (hash) => hash.includes(`/workspace/${world.other.workspaceId}/session/ses_`),
+  await step("after pending-row grace, the sidebar reopens A's same v2 ID and full transcript without reloading", async () => {
+    await probe.eventually(() => world.readRendererLifetime(), {
+      within: 35_000, intervalMs: 500, label: "outlive the 30-second optimistic session-row grace",
+      until: lifetime => lifetime.now >= pendingRowDeadline,
     });
-    const sessionId = route.split("/session/")[1]?.split(/[?#/]/)[0];
-    if (!sessionId) throw new Error("Created session route omitted its ID");
-    const prefix = `/workspace/${world.other.workspaceId}`;
-    expect((await probe.desktopApi(`${prefix}/opencode2/api/session/${sessionId}`)).status).toBe(200);
-    expect((await probe.desktopApi(`${prefix}/opencode/session/${sessionId}`)).status).toBe(404);
-    await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
-    await greet(user, probe);
+    const otherRoute = `/workspace/${other.workspaceId}/session/${other.sessionId}`;
+    expect(await readRoute()).toBe(otherRoute);
+    const refreshStartedAt = (await world.readRendererLifetime()).now;
+    // Visibility refresh skips loaded inventories. Use the existing targeted
+    // refresh action without selecting A, and do not issue probe GETs to A here.
+    await agent.run("workspace.reload_sessions", { workspaceId: primaryId });
+    const refresh = await probe.eventually(() => world.readWorkspaceInventoryRefresh(primaryId, "v2", refreshStartedAt), {
+      within: 30_000, intervalMs: 250, label: "renderer completes A's post-grace v2 list while B remains selected",
+      until: value => value.requests.length > 0 && value.loading === false && !value.error,
+    });
+    expect(refresh.route).toBe(otherRoute);
+    expect(refresh.selectedWorkspaceId).toBe(other.workspaceId);
+    expect(refresh.sessionIds).toEqual(primaryV2Inventory);
+    expect(refresh.sessionIds).toContain(saved.sessionId);
+    expect(refresh.sessionIds).not.toContain(other.sessionId);
+    for (const sessionId of v1Inventory) expect(refresh.sessionIds).not.toContain(sessionId);
+    evidence.recordAssertionEvidence("A's persisted v2 sidebar inventory survives an authoritative post-grace refresh before selecting A",
+      JSON.stringify({ refreshStartedAt, ...refresh, sessionId: saved.sessionId }), true);
+    await reopen(saved);
+    expect((await world.readRendererLifetime()).timeOrigin).toBe(rendererOrigin);
+    expect((await runtime()).pid).toBe(firstV2Runtime.pid);
+    expect(await readSessions(primaryId, "v1")).toEqual(v1Inventory);
+    for (const conversation of conversations) {
+      const wrongWorkspace = conversation.workspaceId === primaryId ? other.workspaceId : primaryId;
+      expect((await probe.desktopApi(`${sessionsPath(wrongWorkspace, conversation.engine)}/${conversation.sessionId}`)).status).toBe(404);
+    }
+    await user.screenshot();
   });
 
-  await step("switching back preserves v1 history and v1 can still create and run a chat", async () => {
-    await go(world.app, `/workspace/${world.primary.workspaceId}/settings/advanced`);
-    await user.click({ text: "OpenCode v1 (default)" });
-    await probe.eventually(() => probe.desktopApi("/experimental/engine-v2-preview/status"), {
-      within: 60_000, label: "v1 routing restored",
-      until: (response) => isRecord(response.body) && response.body.enabled === false && response.body.chatRouting === false,
-    });
-    await go(world.app, `/workspace/${world.primary.workspaceId}/session/${world.original.sessionId}`);
-    await user.see({ text: world.original.title }, { timeoutMs: 30_000 });
-    expect((await probe.desktopApi(`/workspace/${world.other.workspaceId}/opencode/session/${world.otherOriginal.sessionId}`)).status).toBe(200);
-    await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
-    await user.click({ role: "button", label: "New session" });
-    await probe.eventually(() => probe.hash(), { within: 30_000,
-      label: "new v1 session route",
-      until: (hash) => hash.includes("/session/ses_") && !hash.includes(world.original.sessionId),
-    });
-    await greet(user, probe);
+  await step("returning to v1 restores both original IDs and their complete native and visible histories", async () => {
+    await switchEngine("v1");
+    await reopen(first);
+    await reopen(second);
+    expect(await readSessions(primaryId, "v1")).toEqual(v1Inventory);
   });
 
-  await step("the chat command palette still creates a usable chat after returning to v1", createPaletteChat);
-  await go(world.app, `/workspace/${world.primary.workspaceId}/settings/advanced`);
-  await user.see({ text: "OpenCode v1 (default)" }, { timeoutMs: 30_000 });
-  await step("the Settings command palette still creates a usable v1 chat", createPaletteChat);
+  await step("enabling v2 again starts a new sidecar and restores its saved histories", async () => {
+    const restarted = await switchEngine("v2");
+    expect(restarted.pid).not.toBe(firstV2Runtime.pid);
+    await reopen(other);
+    await reopen(saved);
+    expect((await world.readRendererLifetime()).timeOrigin).toBe(rendererOrigin);
+    evidence.recordAssertionEvidence("Settings stopped and restarted the v2 sidecar without replacing the renderer",
+      JSON.stringify({ beforePid: firstV2Runtime.pid, afterPid: restarted.pid, sessionIds: [saved.sessionId, other.sessionId] }), true);
+  });
+
+  await step("renderer reload retains the saved v2 transcript and both workspaces' native histories", async () => {
+    const beforeReload = await runtime();
+    await user.reload();
+    await verify(saved);
+    expect((await world.readRendererLifetime()).timeOrigin).not.toBe(rendererOrigin);
+    expect((await runtime()).pid).toBe(beforeReload.pid);
+    await reopen(other);
+    await reopen(saved);
+    for (const conversation of conversations) expect(await readNative(conversation)).toEqual(conversation.native);
+    expect(new Set(conversations.map(conversation => conversation.sessionId)).size).toBe(4);
+    expect(await readSessions(primaryId, "v1")).toEqual(v1Inventory);
+    expect(await readSessions(primaryId, "v2")).toEqual(primaryV2Inventory);
+    expect(await readSessions(other.workspaceId, "v2")).toEqual(otherV2Inventory);
+    evidence.recordAssertionEvidence("Completed histories retain their native messages and IDs through engine switches and renderer reload",
+      JSON.stringify({ v1: [first.sessionId, second.sessionId], v2: [saved.sessionId, other.sessionId],
+        primaryId, otherWorkspaceId: other.workspaceId, unchangedSidecarPidAfterReload: beforeReload.pid }), true);
+    await user.screenshot();
+  });
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -2181,35 +2181,113 @@ export async function visualization(seed: Seed) {
 }
 
 
-/** A persisted workspace and conversation created before opting into the other engine. */
+/** One profile across engine switches; the journey, not the seed, creates its history. */
 export async function workspaceEngineUpgrade(seed: Seed) {
-  const providerId = "workspace-upgrade-mock";
-  const modelId = "workspace-upgrade-model";
-  const mock = seed.mock({ agentWorkloads: [{
-    promptMarker: "hi",
+  if (resolveEvalEngine() !== "v1") throw new SkipError("upgrade baseline requires OPENWORK_EVAL_ENGINE=v1");
+  const live = liveOpenAiEnabled();
+  const orgName = "Workspace engine upgrade";
+  const mocks: Record<string, ReturnType<Seed["mock"]>> = live ? {} : { agent: seed.mock({ agentWorkloads: [{
+    promptMarker: "upgrade conversation",
     finalReply: "Hello. Your upgrade conversation is working.",
     finalReplyChunkSize: 3,
     finalReplyDelayMs: 750,
     steps: [],
-  }] });
-  const den = await seed.den({ mocks: { agent: mock } });
-  const primaryPath = seed.tmpPath("upgrade-primary");
-  const otherPath = seed.tmpPath("upgrade-existing");
-  const app = await seed.desktop({ den, as: "admin", workspacePath: primaryPath, model: `${providerId}/${modelId}` });
-  const primary = await seed.workspace(app, primaryPath);
-  const provider = { provider: { [providerId]: {
-    npm: "@ai-sdk/openai-compatible", name: "Upgrade mock",
-    options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-upgrade-fixture" },
-    models: { [modelId]: { name: "Upgrade model" } },
-  } } };
-  await configureProvider(seed, app, primary.workspaceId, providerId, modelId, provider);
-  const original = await seedSessionRetry(seed, app, { title: "Before engine upgrade" });
-  const other = await seed.workspace(app, otherPath, { create: true });
-  await configureProvider(seed, app, other.workspaceId, providerId, modelId, provider);
-  const otherOriginal = await seedSessionRetry(seed, app, { title: "Existing workspace history" });
-  return { app, den, primary, other, original, otherOriginal, providerId, modelId,
-    otherName: otherPath.split("/").at(-1),
-  };
+  }] }) };
+  const den = await seed.den({ org: { name: orgName }, mocks });
+  const managed = await provisionLiveOpenAi(den.admin, orgName);
+  try {
+    const primaryPath = seed.tmpPath("upgrade-primary");
+    const otherPath = seed.tmpPath("upgrade-after-switch");
+    const app = await seed.desktop({ den, as: "admin", workspacePath: primaryPath });
+    const request = async (path: string, method = "GET", body?: unknown) => {
+      const result = await seed.evalIn(app, browserScript(async (path, method, body) => {
+        const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port") + path, {
+          method, headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token"), "Content-Type": "application/json" },
+          body, signal: AbortSignal.timeout(30_000),
+        });
+        const json: unknown = await response.json();
+        return { status: response.status, json };
+      }, [path, method, body === undefined ? null : JSON.stringify(body)]), { awaitPromise: true, timeoutMs: 35_000 });
+      assertNoLiveSecret(result);
+      return result;
+    };
+    const providerId = live ? await liveProviderId(request, managed.id) : "workspace-upgrade-mock";
+    const modelId = live ? liveOpenAiModel() : "workspace-upgrade-model";
+    const primary = await seed.workspace(app, primaryPath);
+    const provider = !live ? { provider: { [providerId]: {
+      npm: "@ai-sdk/openai-compatible", name: "Upgrade mock",
+      options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-upgrade-fixture" },
+      models: { [modelId]: { name: "Upgrade model" } },
+    } } } : {};
+    await configureProvider(seed, app, primary.workspaceId, providerId, modelId, provider, "v1");
+    const paletteShortcut = await seed.evalIn(app, browserScript(() =>
+      /Mac|iPhone|iPad|iPod/.test(navigator.platform) ? "Meta+K" : "Control+K", []));
+    return {
+      app, den, primary, providerId, modelId, live, paletteShortcut,
+      async readFinalAnswerRows(): Promise<{ id: string; text: string }[]> {
+        // This journey requests plain-text answers. Reasoning folds into :steps;
+        // the answer keeps its native ID and has no timestamp/action children.
+        return seed.evalIn(app, browserScript(() => [...document.querySelectorAll<HTMLElement>(
+          '[data-message-role="assistant"][data-message-id]:not([data-message-id$=":steps"])',
+        )].filter(node => node.getClientRects().length && getComputedStyle(node).visibility !== "hidden")
+          .map(node => ({ id: node.getAttribute("data-message-id") ?? "", text: node.innerText.replace(/\s+/g, " ").trim() })), []));
+      },
+      async readRendererLifetime(): Promise<{ timeOrigin: number; now: number }> {
+        return seed.evalIn(app, browserScript(() => ({ timeOrigin: performance.timeOrigin, now: Date.now() }), []));
+      },
+      async readWorkspaceInventoryRefresh(workspaceId: string, engine: "v1" | "v2", since: number): Promise<{
+        route: string;
+        selectedWorkspaceId: string | null;
+        loading: boolean | null;
+        error: string | null;
+        sessionIds: string[];
+        requests: { path: string; status: number; startedAt: number; completedAt: number }[];
+      }> {
+        // Observe only renderer-owned inventory reads and sidebar state, never
+        // issue an API request that could satisfy the refresh witness itself.
+        return seed.evalIn(app, browserScript((workspaceId, engine, since) => {
+          const sessionPath = `/workspace/${workspaceId}/${engine === "v2" ? "opencode2/api" : "opencode"}/session`;
+          const route = window.__openwork?.slice("route");
+          const workspace = route?.workspaces.find(workspace => workspace.id === workspaceId);
+          const requests = (window.__openwork?.events(200) ?? []).flatMap(event => {
+            const data = event.data;
+            if (event.name !== "log.fetch" || typeof data !== "object" || data === null
+              || !("url" in data) || typeof data.url !== "string"
+              || !("method" in data) || data.method !== "GET"
+              || !("status" in data) || data.status !== 200
+              || !("durationMs" in data) || typeof data.durationMs !== "number"
+              || event.at - data.durationMs < since) return [];
+            const path = new URL(data.url, location.href).pathname;
+            return path === sessionPath ? [{ path, status: data.status, startedAt: event.at - data.durationMs, completedAt: event.at }] : [];
+          });
+          return {
+            route: location.hash.replace(/^#/, ""), selectedWorkspaceId: route?.selectedWorkspaceId ?? null,
+            loading: workspace?.loading ?? null,
+            error: workspace?.error ?? null,
+            sessionIds: (route?.sessionsByWorkspaceId[workspaceId] ?? []).map(session => session.id).sort(),
+            requests,
+          };
+        }, [workspaceId, engine, since]));
+      },
+      async createOtherWorkspace() {
+        const status = await request("/experimental/engine-v2-preview/status");
+        if (!isRecord(status.json) || status.json.chatRouting !== true || status.json.running !== true) {
+          throw new Error("Workspace B must be created only after the Settings switch to v2");
+        }
+        const other = await seed.workspace(app, otherPath, { create: true });
+        // Hot-mirror the mock without reloading the renderer or clearing pending rows.
+        // Live mode inherits its managed provider through normal organization sync.
+        if (!live && (await request(`/workspace/${other.workspaceId}/config`, "PATCH", { opencode: provider })).status !== 200) {
+          throw new Error("Could not configure workspace B's model");
+        }
+        return other;
+      },
+      async [Symbol.asyncDispose]() { await managed[Symbol.asyncDispose](); },
+    };
+  } catch (error) {
+    await managed[Symbol.asyncDispose]();
+    throw error;
+  }
 }
 
 /** A running conversation whose workspace skills can change through OpenWork. */


### PR DESCRIPTION
## Summary
- Scope workspace session-list requests to their owning endpoint and engine; reject obsolete results and prioritize the selected workspace after routing discovery.
- Retain conversation tabs across engine-specific inventories, while respecting explicit archive metadata and workspace identity.
- Extend the upgrade journey with completed v1/v2 chats, a workspace created after the switch, authoritative post-grace sidebar refresh, sidecar restart, and transcript readback after reload. Supports deterministic and opt-in live OpenAI execution.

## Verification
- Source and merge commits: GitHub-verified signatures.
- Focused app regression tests: 70 passed, 0 failed.
- App typecheck, CI core/build, and Warden: passed.
- Additional real-LLM continuity run: **failed on the first v1 send**, before engine switching. Native message list stayed empty for 150 seconds; root cause unresolved. [Failure details and reproduction](https://github.com/different-ai/openwork/pull/4869#issuecomment-5626676695).
- The earlier local attempt failed before app startup due to Docker filesystem I/O errors; it is not passing evidence.
- Full local eval typecheck remains unresolved outside the edited sections; no clean-control equivalence claimed.

## Scope
This preserves engine-owned navigation state; it does not migrate conversations or automatically open v1 history through v2. End-to-end live continuity remains unverified despite the completed merge.