### PR TITLE
Revert "fix(server): make workspace permission changes reach the engine's effective permissions (composer-run-mode)" (#4747)

### DIFF
--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -118,21 +118,6 @@ export function useDesktopRuntimeBoot() {
         };
 
         const startServerWithoutDesktopWorkspace = async () => {
-          // A renderer reload lands here whenever the selected workspace only
-          // exists in the server registry (workspaces created from the app are
-          // server-owned). The server is already serving it: restarting would
-          // kill the engine and every in-flight run for nothing.
-          const running = await openworkServerInfo().catch(() => null);
-          if (
-            isOpenworkServerInfoLike(running)
-            && isOpenworkServerReady(running)
-            && (running.remoteAccessEnabled === true) === preferredRemoteAccess
-          ) {
-            publishOpenworkServerInfo(running);
-            await window.__OPENWORK_ELECTRON__?.recovery?.recordHealthy?.().catch(() => undefined);
-            markReady();
-            return;
-          }
           setPhase("starting-engine", "Starting OpenWork server");
           const serverInfo = await openworkServerRestart({ remoteAccessEnabled: preferredRemoteAccess }).catch((error) => {
             console.warn("[desktop-boot] openworkServerRestart failed:", error);

--- a/evals/specs/composer-run-mode.e2e.test.ts
+++ b/evals/specs/composer-run-mode.e2e.test.ts
@@ -17,7 +17,7 @@ test("workspace run mode is opt-in, confirms Keep going, and preserves policy wh
 
   const read = async (path: string) => {
     const response = await probe.desktopApi(`${mount}/${path}`);
-    expect(response.status, `${path} ${JSON.stringify(response.body)}`).toBe(200);
+    expect(response.status, path).toBe(200);
     if (!isRecord(response.body)) throw new Error(`Expected an object from ${path}.`);
     return response.body;
   };

--- a/evals/worlds/desktop.ts
+++ b/evals/worlds/desktop.ts
@@ -3,12 +3,7 @@ import type { Seed } from "@openwork/env";
 export async function emptySession(seed: Seed) {
   const workspacePath = seed.tmpPath("empty-session");
   const app = await seed.desktop({ name: "empty-session" });
-  // Create the workspace at the declared tmp path. Without `create`, the seed
-  // adopts the first-launch default workspace, which the dev profile places
-  // inside the repo checkout on Daytona; the engine then merges the repo's
-  // `.opencode/opencode.json` (`"permission": "allow"`) over the workspace's
-  // own permission block, so workspace-level permission claims never hold.
-  const workspace = await seed.workspace(app, workspacePath, { create: true });
+  const workspace = await seed.workspace(app, workspacePath);
   const session = await seed.session(app);
   return { app, workspace, session, workspacePath };
 }


### PR DESCRIPTION
Reverts #4747 (`9a60a4b59`).

**Why:** the E2E risk gate found `active-session-workspace-storm` newly red on `dev` after Phase 1 (green in the 4 prior scheduled runs). Bisect with single-spec `daytona-e2e.yml` dispatches on throwaway branches (`bisect/storm-*`):

| ref | result |
|---|---|
| `bf722d514` (#4777) | green 2/2 |
| `a7cf63527` (#4847, landing-only) | green 2/3 (one flake) |
| `9a60a4b59` (#4747) | **red 4/4** (gate runs 34529322422 + 34531506976, bisect runs 34536909839 + 34536919184) |

Signature: on the sessionless New task route of the **second** workspace, `Timed out … waiting for selectable model mock-agent-workload-model`; the picker shows the mock model as current with "Model no longer available / Retry" and only "OpenCode Zen · 7 models" as providers — workspace 2's per-workspace provider config is not applied after switching workspaces (workspace 1 right after reload works).

This PR is the fast option to restore `dev`; a root-cause fix that keeps #4747's `composer-run-mode` intent is being prepared separately. Do not merge both.