### PR TITLE
fix(ci): let active alpha builds finish

### DIFF
--- a/.github/workflows/alpha-macos-aarch64.yml
+++ b/.github/workflows/alpha-macos-aarch64.yml
@@ -51,7 +51,7 @@ permissions:
 
 concurrency:
   group: alpha-macos-aarch64-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   publish-alpha-macos-aarch64:


### PR DESCRIPTION
## Summary
- Set alpha macOS concurrency cancellation to false while keeping the existing per-ref concurrency group.
- Let active signed/notarized builds finish publishing; newer pushes replace the pending run instead of cancelling active work.

## Verification
- git diff --check passed.
- Reviewed the complete base-branch diff: one workflow setting changed.
- No build or publish run triggered for this configuration-only change.