### PR TITLE
fix(den-api): restore codemode-native-binding and microsoft-365-routes tests after the native-action policy change (#4830)

### DIFF
--- a/ee/apps/den-api/test/codemode-native-binding.test.ts
+++ b/ee/apps/den-api/test/codemode-native-binding.test.ts
@@ -46,6 +46,7 @@ beforeAll(async () => {
   seedRequiredEnv()
   mock.module("../src/capability-sources/native-provider-connections.js", () => ({
     listNativeProviderUsableEntries: () => Promise.resolve([entry]),
+    nativeProviderConnectionPolicyError: () => Promise.resolve(null),
   }))
   mock.module("../src/mcp/invoke.js", () => ({
     invokeMcpOperation: (input: unknown) => {

--- a/ee/apps/den-api/test/microsoft-365-routes.test.ts
+++ b/ee/apps/den-api/test/microsoft-365-routes.test.ts
@@ -1,3 +1,5 @@
+import { eq } from "@openwork-ee/den-db/drizzle"
+import { OrganizationTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, describe, expect, spyOn, test } from "bun:test"
 import { Hono, type MiddlewareHandler } from "hono"
@@ -152,7 +154,17 @@ describe("Microsoft 365 bounded management routes", () => {
     const registry = await import("../src/capability-sources/provider-registry.js")
     const orgs = await import("../src/orgs.js")
     const session = await import("../src/session.js")
+    const { db } = await import("../src/db.js")
     const context = organizationContext()
+    // The default resolver reads the organization's Connect policy from the
+    // database when no credential resolves (#4830); a missing organization row
+    // reads as policy_blocked, so persist the fixture organization.
+    await db.insert(OrganizationTable).values({
+      id: context.organization.id,
+      name: context.organization.name,
+      slug: context.organization.slug,
+      metadata: null,
+    })
     const otherContext = { ...context, currentMember: organizationContext().currentMember }
     const teamId = createDenTypeId("team")
     const writerId = createDenTypeId("externalMcpConnection")
@@ -269,6 +281,7 @@ describe("Microsoft 365 bounded management routes", () => {
       defaults.mockRestore()
       clients.mockRestore()
       accounts.mockRestore()
+      await db.delete(OrganizationTable).where(eq(OrganizationTable.id, context.organization.id))
     }
   })
 


### PR DESCRIPTION
## Root cause

A den-api full-suite regression check (local report `reports/denapi-regression-2026-09-10.md`, git-excluded; junit + per-file logs alongside) compared `dev` `2fcbae60e` → `9a60a4b59` per file on fresh MySQL databases and found exactly 2 deterministic regressions (0/2 red before, 2/2 red after). Both are caused by #4830 `fix(connect): honor organization policy for native actions` (98f7a687b), which added `nativeProviderConnectionPolicyError` to `native-provider-connections.ts` and consulted it from the native token resolvers. #4830 touched neither test file, and its CI ran den-api's 4-file `test` script, which does not include them.

## What changed (test-only, 2 files, +14 lines)

**(a) `test/codemode-native-binding.test.ts` — file failed to load.**
Its `mock.module("../src/capability-sources/native-provider-connections.js")` only exported `listNativeProviderUsableEntries`; `src/mcp/native-capabilities.ts` (reached via `codemode-tools.js`) now also imports `nativeProviderConnectionPolicyError`, so bun raised `SyntaxError: Export named 'nativeProviderConnectionPolicyError' not found`. Added `nativeProviderConnectionPolicyError: () => Promise.resolve(null)` to the mock (matches the real `Promise<NativeProviderPolicyError | null>` signature; `null` = policy allows).

**(b) `test/microsoft-365-routes.test.ts` › "default resolver binds named connector configuration and token reads without a legacy fallback" — got 403, expected 409.**
Decision: **fix the test, not the product.** Evidence from `gh pr diff 4830` and `nativeProviderConnectionPolicyError`:

```ts
return {
  kind: "policy_blocked",
  message: organization
    ? "Connect is disabled for this organization. Ask your administrator to have it re-enabled."
    : "This organization is unavailable. Ask your administrator to check your organization access.",
}
```

The missing-organization branch has its own deliberately authored, administrator-directed message. Failing closed on an organization that does not exist is an explicit #4830 product choice (consistent with the PR's "client version does not bypass a disabled organization's authorization policy" framing), not an accident. The test's `organizationContext()` builds a synthetic organization that is never inserted, so once the resolver falls through to the policy lookup (no credential for `unavailableId` / wrong provider / corrupt header / other member / `defaultCredentialId = null`) the lookup misses and returns 403.

Fix: insert the fixture organization row into `OrganizationTable` before the assertions and delete it in `finally`, the same way neighbouring DB-backed route tests (e.g. `grant-native-capabilities.test.ts`) do. No mocking of the policy helper, so the test keeps exercising the real #4830 code path: with a persisted org and default (enabled) policy, a genuinely unresolved credential still yields `needs_connection` / 409.

## Proof

Lane: **local macOS**, no Daytona needed (pure den-api unit/route tests). Reproduced the report's setup: bun 1.3.9, node 24.20.0, pnpm 11.4.0, MySQL 8.4 in `docker run --name denapi-4830-mysql -p 3307:3306 mysql:8.4`, one fresh database per worktree, schema via `pnpm --filter @openwork-ee/den-db exec drizzle-kit push --force`, env `DATABASE_URL`, `DEN_DB_ENCRYPTION_KEY`, `BETTER_AUTH_SECRET=y*32`, `BETTER_AUTH_URL=http://127.0.0.1:8790`. Each file run in its own `bun test --conditions development --timeout 60000 <file>` process from `ee/apps/den-api`.

**Red on unmodified `origin/dev`** (clean detached control worktree at `cac8ac7c1`, `git status` clean):

```
== codemode-native-binding
SyntaxError: Export named 'nativeProviderConnectionPolicyError' not found in module '.../src/capability-sources/native-provider-connections.ts'.
 0 pass / 1 fail   EXIT=1
== microsoft-365-routes
245 |       expect((await request(unavailableId)).status).toBe(409)
Expected: 409  Received: 403
 42 pass / 1 fail   EXIT=1
```

**Green on this branch** (`ee81913ad`), 2 isolated runs each:

```
codemode-native-binding run1:  1 pass  0 fail
microsoft-365-routes    run1: 43 pass  0 fail
codemode-native-binding run2:  1 pass  0 fail
microsoft-365-routes    run2: 43 pass  0 fail
leftover 'Microsoft Routes Test' organization rows after run: 0
```

**Other checks in `ee/apps/den-api` on this branch:**

```
pnpm test  → bun test … api-keys bearer-session cloud-provider-materialization-read-retry remote-session-capability-wire
             24 pass / 0 fail, 4 files, exit 0
npx tsc -p tsconfig.json --noEmit → exit 0
```

`packages/docs/openapi.json` and the Spectral baseline are untouched (`git diff --name-only origin/dev..HEAD | grep -E 'openapi|spectral'` → none); `pnpm api:lint` input is unchanged.

## Noticed but not touched

- Running the two files in **one** bun process (`bun test a.test.ts b.test.ts`) still fails `microsoft-365-routes` with `Export named 'resolveDefaultNativeProviderCredentialId' not found` — that is the pre-existing process-wide `mock.module` leak from `codemode-native-binding` (present in the report's BEFORE whole-suite run, 32×). Per-file isolation is the authoritative method; no change here.
- The 84 pre-existing failing tests in 36 files listed in the regression report are unchanged.
- Neither of these two files is in den-api's CI `test` script; a MySQL-backed CI job would have caught both regressions (the report has the input list for that).
