### PR TITLE
feat(chat): wider, interactive visualization mockups that repair model slips

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -555,8 +555,19 @@ const AssistantMessage = React.memo(
               )
             }
 
+            // Mockups break out of the reading column so designs get real width:
+            // centered on the message list, capped by its container width.
+            const wide =
+              group.part.type === "dynamic-tool" && group.part.toolName === "openwork_visualization"
             return (
-              <div key={`tool-${index}`} className="w-full">
+              <div
+                key={`tool-${index}`}
+                className={
+                  wide
+                    ? "relative left-1/2 w-[max(100%,min(72rem,calc(100cqw-1.5rem)))] max-w-none -translate-x-1/2"
+                    : "w-full"
+                }
+              >
                 <ToolMessage part={group.part} />
               </div>
             )

--- a/apps/app/src/components/tools/visualization-tool.tsx
+++ b/apps/app/src/components/tools/visualization-tool.tsx
@@ -1,61 +1,239 @@
 import { useState } from "react";
-import { ImageIcon, Monitor, Smartphone } from "lucide-react";
 import {
-  visualizationSchema,
+  ChevronDown,
+  ChevronDownIcon,
+  ImageIcon,
+  LayoutTemplate,
+  Maximize2,
+  Monitor,
+  Smartphone,
+} from "lucide-react";
+import {
+  parseVisualization,
   type Visualization,
+  type VisualizationBlock,
+  type VisualizationSection,
 } from "@openwork/types/visualization";
 import type { AnyToolPart } from "@/lib/tool-aggregate";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { useMessageList } from "@/components/chat/message-list-provider";
 
-function MockBlock({
-  block,
-}: {
-  block: Visualization["sections"][number]["blocks"][number];
-}) {
+const ON_VALUES = /^(on|true|yes|enabled|active|checked)$/i;
+
+function isOn(value: string | undefined) {
+  return value !== undefined && ON_VALUES.test(value.trim());
+}
+
+function splitCells(row: string) {
+  return row.split("|").map((cell) => cell.trim());
+}
+
+/** One mock control. Interactive state is local to the preview and never leaves it. */
+function MockBlock({ block, compact }: { block: VisualizationBlock; compact: boolean }) {
+  const [on, setOn] = useState(() => isOn(block.value));
+  const [selected, setSelected] = useState<string | undefined>(() => block.value ?? block.items?.[0]);
+  const hint = block.hint ? (
+    <p className="mt-1.5 text-xs text-muted-foreground">{block.hint}</p>
+  ) : null;
+
   switch (block.kind) {
     case "metric":
       return (
         <div className="rounded-xl border bg-background p-4">
-          <div className="text-xs text-muted-foreground">{block.label}</div>
-          <div className="mt-2 text-2xl font-semibold tracking-tight">
+          <div className="text-xs font-medium text-muted-foreground">{block.label}</div>
+          <div className="mt-1.5 text-3xl font-semibold tracking-tight tabular-nums">
             {block.value ?? "—"}
           </div>
+          {hint}
         </div>
       );
     case "field":
       return (
-        <div className="space-y-2">
-          <div className="text-xs font-medium">{block.label}</div>
-          <div className="min-h-9 rounded-lg border bg-background px-3 py-2 text-sm text-muted-foreground">
-            {block.value ?? "Enter a value…"}
-          </div>
-        </div>
+        <label className="block space-y-1.5">
+          <span className="text-xs font-medium">{block.label}</span>
+          <Input
+            defaultValue={block.value ?? ""}
+            placeholder="Enter a value…"
+            aria-label={block.label}
+          />
+          {hint}
+        </label>
       );
-    case "button":
+    case "button": {
+      const variant =
+        block.tone === "destructive"
+          ? "destructive"
+          : block.tone === "muted"
+            ? "secondary"
+            : block.tone === "primary"
+              ? "default"
+              : "outline";
       return (
         <div>
-          <span className="inline-flex min-h-9 items-center rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background">
+          <Button type="button" variant={variant} size={compact ? "sm" : "default"}>
             {block.label}
-          </span>
+          </Button>
+          {hint}
         </div>
       );
+    }
+    case "toggle":
+      return (
+        <div className="flex items-start justify-between gap-4 rounded-xl border bg-background px-4 py-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">{block.label}</div>
+            {hint}
+          </div>
+          <Switch
+            checked={on}
+            onCheckedChange={setOn}
+            aria-label={block.label}
+            className="mt-0.5"
+          />
+        </div>
+      );
+    case "select":
+      return (
+        <label className="block space-y-1.5">
+          <span className="text-xs font-medium">{block.label}</span>
+          <span className="relative block">
+            <select
+              aria-label={block.label}
+              value={selected ?? ""}
+              onChange={(event) => setSelected(event.target.value)}
+              className="h-9 w-full appearance-none rounded-lg border border-border bg-background px-3 pr-9 text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30"
+            >
+              {(block.items ?? [block.value ?? "Choose…"]).map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+            <ChevronDownIcon
+              aria-hidden="true"
+              className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+          </span>
+          {hint}
+        </label>
+      );
+    case "segmented":
+      return (
+        <div className="space-y-1.5">
+          <div className="text-xs font-medium">{block.label}</div>
+          <div
+            role="radiogroup"
+            aria-label={block.label}
+            className="inline-flex max-w-full flex-wrap gap-1 rounded-xl bg-muted p-1"
+          >
+            {(block.items ?? []).map((item) => {
+              const active = item === selected;
+              return (
+                <button
+                  key={item}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => setSelected(item)}
+                  className={cn(
+                    "rounded-lg px-3 py-1.5 text-sm transition-colors",
+                    active
+                      ? "bg-background font-medium text-foreground shadow-xs"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {item}
+                </button>
+              );
+            })}
+          </div>
+          {hint}
+        </div>
+      );
+    case "chips":
+      return (
+        <div className="space-y-1.5">
+          <div className="text-xs font-medium">{block.label}</div>
+          <div className="flex flex-wrap gap-1.5">
+            {(block.items ?? []).map((item) => (
+              <Badge
+                key={item}
+                variant={
+                  block.tone === "destructive"
+                    ? "destructive"
+                    : block.tone === "primary" || item === block.value
+                      ? "default"
+                      : block.tone === "muted"
+                        ? "secondary"
+                        : "outline"
+                }
+                className="h-6 px-2.5"
+              >
+                {item}
+              </Badge>
+            ))}
+          </div>
+          {hint}
+        </div>
+      );
+    case "table": {
+      const [header, ...rows] = (block.items ?? []).map(splitCells);
+      return (
+        <div className="min-w-0 space-y-1.5">
+          <div className="text-sm font-medium">{block.label}</div>
+          <div className="overflow-x-auto rounded-xl border bg-background">
+            <table className="w-full text-sm">
+              {header && (
+                <thead className="bg-muted/50 text-xs text-muted-foreground">
+                  <tr>
+                    {header.map((cell, index) => (
+                      <th key={index} scope="col" className="px-3 py-2 text-left font-medium">
+                        {cell}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+              )}
+              <tbody className="divide-y">
+                {rows.map((row, rowIndex) => (
+                  <tr key={rowIndex} className="hover:bg-muted/30">
+                    {row.map((cell, cellIndex) => (
+                      <td key={cellIndex} className="px-3 py-2 align-top">
+                        {cell}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {hint}
+        </div>
+      );
+    }
     case "list":
       return (
-        <div className="rounded-xl border bg-background p-4">
-          <div className="mb-2 text-sm font-medium">{block.label}</div>
+        <div className="rounded-xl border bg-background">
+          <div className="border-b px-4 py-2.5 text-sm font-medium">{block.label}</div>
           <ul className="divide-y">
             {block.items?.map((item, index) => (
-              <li key={index} className="py-2 text-sm text-muted-foreground">
-                {item}
+              <li key={index} className="flex items-start gap-2.5 px-4 py-2.5 text-sm hover:bg-muted/30">
+                <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
+                <span className="min-w-0">{item}</span>
               </li>
             ))}
           </ul>
+          {hint && <div className="px-4 pb-3">{hint}</div>}
         </div>
       );
     case "image":
       return (
-        <div className="flex min-h-32 flex-col items-center justify-center gap-2 rounded-xl border border-dashed bg-muted/40 p-4 text-xs text-muted-foreground">
+        <div className="flex aspect-video min-h-28 flex-col items-center justify-center gap-2 rounded-xl border border-dashed bg-muted/40 p-4 text-xs text-muted-foreground">
           <ImageIcon className="size-5" aria-hidden="true" />
           {block.label}
         </div>
@@ -65,24 +243,205 @@ function MockBlock({
         <div>
           <div className="text-sm font-medium">{block.label}</div>
           {block.value && (
-            <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
+            <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
               {block.value}
             </p>
           )}
+          {hint}
         </div>
       );
   }
 }
 
+function MockSection({ section, mobile }: { section: VisualizationSection; mobile: boolean }) {
+  const [open, setOpen] = useState(true);
+  const columns = mobile
+    ? "grid-cols-1"
+    : section.columns === "three"
+      ? "grid-cols-1 @min-[560px]:grid-cols-2 @min-[820px]:grid-cols-3"
+      : section.columns === "two"
+        ? "grid-cols-1 @min-[560px]:grid-cols-2"
+        : "grid-cols-1";
+  return (
+    <section className="rounded-xl border bg-card/60">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left"
+      >
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold tracking-tight">{section.title}</h3>
+          {section.description && (
+            <p className="mt-0.5 text-xs text-muted-foreground">{section.description}</p>
+          )}
+        </div>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform",
+            open ? "" : "-rotate-90",
+          )}
+        />
+      </button>
+      {open && (
+        <div className={cn("grid gap-4 border-t px-4 py-4 [&>*]:min-w-0", columns)}>
+          {section.blocks.map((block, index) => (
+            <MockBlock key={index} block={block} compact={mobile} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** The mock screen itself: navigation pages, description, and sections. */
+function MockScreen({
+  design,
+  mobile,
+  probe = true,
+}: {
+  design: Visualization;
+  mobile: boolean;
+  probe?: boolean;
+}) {
+  const navigation = design.navigation ?? [];
+  const hasPages = design.sections.some(
+    (section) => section.nav !== undefined && navigation.includes(section.nav),
+  );
+  const [active, setActive] = useState(() => navigation[0]);
+  const visible = hasPages
+    ? design.sections.filter(
+        (section) => !section.nav || !navigation.includes(section.nav) || section.nav === active,
+      )
+    : design.sections;
+
+  return (
+    <div
+      data-testid={probe ? "visualization-preview" : undefined}
+      data-viewport={mobile ? "mobile" : "desktop"}
+      className={cn(
+        "@container mx-auto overflow-hidden rounded-xl border bg-background shadow-sm",
+        mobile ? "max-w-[360px]" : "w-full",
+      )}
+    >
+      {navigation.length > 0 && (
+        <div
+          role={hasPages ? "tablist" : undefined}
+          aria-label={hasPages ? "Pages" : undefined}
+          className="flex gap-1 overflow-x-auto border-b px-3 pt-2 [scrollbar-width:none]"
+        >
+          {navigation.map((label) => {
+            const current = hasPages ? label === active : label === navigation[0];
+            return (
+              <button
+                key={label}
+                type="button"
+                role={hasPages ? "tab" : undefined}
+                aria-selected={hasPages ? current : undefined}
+                aria-current={!hasPages && current ? "page" : undefined}
+                onClick={hasPages ? () => setActive(label) : undefined}
+                className={cn(
+                  "-mb-px shrink-0 whitespace-nowrap rounded-t-md border-b-2 px-3 py-2 text-sm",
+                  current
+                    ? "border-foreground font-medium text-foreground"
+                    : "border-transparent text-muted-foreground",
+                  hasPages ? "hover:text-foreground" : "cursor-default",
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <div className="space-y-4 p-4 sm:p-5">
+        {design.description && (
+          <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">
+            {design.description}
+          </p>
+        )}
+        {visible.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            Nothing on this page yet.
+          </p>
+        ) : (
+          visible.map((section, index) => (
+            <MockSection key={`${active ?? ""}-${index}`} section={section} mobile={mobile} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ViewportToggle({
+  mobile,
+  onChange,
+}: {
+  mobile: boolean;
+  onChange: (mobile: boolean) => void;
+}) {
+  return (
+    <div className="flex rounded-lg bg-muted p-0.5" role="group" aria-label="Preview size">
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Desktop preview"
+        aria-pressed={!mobile}
+        onClick={() => onChange(false)}
+        className={mobile ? "" : "bg-background shadow-xs hover:bg-background"}
+      >
+        <Monitor className="size-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Mobile preview"
+        aria-pressed={mobile}
+        onClick={() => onChange(true)}
+        className={mobile ? "bg-background shadow-xs hover:bg-background" : ""}
+      >
+        <Smartphone className="size-4" />
+      </Button>
+    </div>
+  );
+}
+
 export function VisualizationTool({ part }: { part: AnyToolPart }) {
   const [mobile, setMobile] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const { setPrompt } = useMessageList();
-  if (part.state === "output-error")
+
+  if (part.state === "output-error") {
+    const detail = part.errorText?.split("\n").filter((line) => line.startsWith("- ")) ?? [];
     return (
-      <div role="alert" className="text-sm text-destructive">
-        Couldn’t create this visualization. Ask to try again.
+      <div
+        role="alert"
+        className="my-3 flex flex-wrap items-start justify-between gap-3 rounded-2xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm"
+      >
+        <div className="min-w-0 space-y-1">
+          <div className="font-medium text-destructive">Couldn’t create this visualization.</div>
+          {detail.length > 0 && (
+            <ul className="text-xs text-muted-foreground">
+              {detail.slice(0, 4).map((line, index) => (
+                <li key={index}>{line.replace(/^- /, "")}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            setPrompt("Try the visualization again, fixing the validation issues from the last attempt.")
+          }
+        >
+          Try again
+        </Button>
       </div>
     );
+  }
   if (part.state === "output-denied")
     return (
       <div role="status" className="text-sm text-muted-foreground">
@@ -95,6 +454,7 @@ export function VisualizationTool({ part }: { part: AnyToolPart }) {
         Creating visualization…
       </div>
     );
+
   let output: unknown = part.output;
   if (typeof output === "string") {
     try {
@@ -103,105 +463,74 @@ export function VisualizationTool({ part }: { part: AnyToolPart }) {
       output = null;
     }
   }
-  const parsed = visualizationSchema.safeParse(output);
-  if (!parsed.success)
+  const parsed = parseVisualization(output);
+  if (!parsed.ok)
     return (
       <div role="alert" className="text-sm text-muted-foreground">
         This visualization couldn’t be displayed. Ask for a new version.
       </div>
     );
   const design = parsed.data;
+  const requestChanges = () =>
+    setPrompt(
+      `Revise visualization "${design.title}" (id: ${design.id}, version ${design.revision}). Create version ${design.revision + 1} with these changes: `,
+    );
+
   return (
     <section
       aria-label={`Visualization: ${design.title}, revision ${design.revision}`}
-      className="my-3 min-w-0 break-words overflow-hidden rounded-2xl border bg-background text-foreground"
+      className="my-3 min-w-0 overflow-hidden rounded-2xl border bg-card text-foreground shadow-xs break-words"
       data-testid="visualization-card"
     >
       <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
-        <div>
-          <div className="text-sm font-medium">{design.title}</div>
-          <div className="text-xs text-muted-foreground">
-            Visualization · v{design.revision} · Mockup
+        <div className="flex min-w-0 items-center gap-2.5">
+          <LayoutTemplate className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium">{design.title}</div>
+            <div className="text-xs text-muted-foreground">
+              Visualization · v{design.revision} · Mockup
+            </div>
           </div>
         </div>
-        <div className="flex gap-1" role="group" aria-label="Preview size">
+        <div className="flex items-center gap-1">
+          <ViewportToggle mobile={mobile} onChange={setMobile} />
           <Button
-            variant={mobile ? "ghost" : "secondary"}
-            size="sm"
-            aria-label="Desktop preview"
-            aria-pressed={!mobile}
-            onClick={() => setMobile(false)}
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Open full size"
+            onClick={() => setExpanded(true)}
           >
-            <Monitor className="size-4" />
-          </Button>
-          <Button
-            variant={mobile ? "secondary" : "ghost"}
-            size="sm"
-            aria-label="Mobile preview"
-            aria-pressed={mobile}
-            onClick={() => setMobile(true)}
-          >
-            <Smartphone className="size-4" />
+            <Maximize2 className="size-4" />
           </Button>
         </div>
       </div>
       <div className="bg-muted/30 p-3 sm:p-5">
-        <div
-          data-testid="visualization-preview"
-          data-viewport={mobile ? "mobile" : "desktop"}
-          className={`mx-auto overflow-hidden rounded-xl border bg-background shadow-sm ${mobile ? "max-w-[360px]" : "w-full"}`}
-        >
-          {design.navigation && (
-            <div className="flex flex-wrap gap-x-4 gap-y-2 border-b px-5 py-3 text-xs text-muted-foreground">
-              {design.navigation.map((label, index) => (
-                <span
-                  key={index}
-                  className={index === 0 ? "font-medium text-foreground" : ""}
-                >
-                  {label}
-                </span>
-              ))}
-            </div>
-          )}
-          <div className="@container space-y-6 p-5">
-            {design.description && (
-              <p className="text-sm text-muted-foreground">
-                {design.description}
-              </p>
-            )}
-            {design.sections.map((section, index) => (
-              <section key={index} className="space-y-3">
-                <h3 className="text-base font-semibold tracking-tight">
-                  {section.title}
-                </h3>
-                <div
-                  className={`grid gap-3 [&>*]:min-w-0 ${mobile ? "grid-cols-1" : section.columns === "three" ? "grid-cols-1 @min-[480px]:grid-cols-3" : section.columns === "two" ? "grid-cols-1 @min-[480px]:grid-cols-2" : "grid-cols-1"}`}
-                >
-                  {section.blocks.map((block, blockIndex) => (
-                    <MockBlock key={blockIndex} block={block} />
-                  ))}
-                </div>
-              </section>
-            ))}
-          </div>
-        </div>
+        <MockScreen design={design} mobile={mobile} />
       </div>
       <div className="flex flex-wrap items-center justify-between gap-2 border-t px-4 py-3">
         <p className="text-xs text-muted-foreground">
           A design sketch. Controls are for illustration.
         </p>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() =>
-            setPrompt(
-              `Revise visualization "${design.title}" (id: ${design.id}, version ${design.revision}). Create version ${design.revision + 1} with these changes: `,
-            )
-          }
-        >
+        <Button variant="outline" size="sm" onClick={requestChanges}>
           Request changes
         </Button>
       </div>
+      <Dialog open={expanded} onOpenChange={setExpanded}>
+        <DialogContent className="max-h-[92dvh] gap-0 overflow-y-auto p-0 lg:w-[calc(100vw-3rem)] lg:max-w-[100rem]">
+          <div className="flex items-center justify-between gap-3 border-b px-5 py-3 pr-16">
+            <DialogTitle className="text-sm font-medium">
+              {design.title}
+              <span className="ml-2 font-normal text-muted-foreground">
+                v{design.revision} · Mockup
+              </span>
+            </DialogTitle>
+            <ViewportToggle mobile={mobile} onChange={setMobile} />
+          </div>
+          <div className="bg-muted/30 p-4 sm:p-6">
+            {expanded && <MockScreen design={design} mobile={mobile} probe={false} />}
+          </div>
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }

--- a/apps/app/tests/visualization-tool.test.tsx
+++ b/apps/app/tests/visualization-tool.test.tsx
@@ -1,0 +1,135 @@
+/** @jsxImportSource react */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createOpenworkServerClient } from "../src/app/lib/openwork-server";
+import { MessageListProvider } from "../src/components/chat/message-list-provider";
+import { VisualizationTool } from "../src/components/tools/visualization-tool";
+import type { AnyToolPart } from "../src/lib/tool-aggregate";
+
+const design = {
+  id: "admin-controls",
+  title: "Desktop controls",
+  revision: 1,
+  navigation: ["Overview", "Teams", "Activity"],
+  sections: [
+    { title: "Summary", blocks: [{ kind: "metric", label: "Controlled members", value: "14" }] },
+    { title: "Rules", nav: "Teams", columns: "two", blocks: [
+      { kind: "toggle", label: "Allow uploads", value: "Off" },
+      { kind: "segmented", label: "Management", items: ["Self-managed", "Controlled"], value: "Controlled" },
+      { kind: "table", label: "Devices", items: ["Device | State", "MBP-1 | Active", "WIN-2 | Applying"] },
+    ] },
+    { title: "Recent", nav: "Activity", blocks: [{ kind: "list", label: "Log", items: ["Enabled by Ada", "<script>window.mockupExecuted = true</script>"] }] },
+  ],
+};
+
+const base = { type: "dynamic-tool", toolName: "openwork_visualization", toolCallId: "call-1", input: design } as const;
+const available = (output: unknown = JSON.stringify(design)): AnyToolPart => ({ ...base, state: "output-available", output });
+const failed = (errorText: string): AnyToolPart => ({ ...base, state: "output-error", errorText });
+
+let container: HTMLDivElement;
+let root: Root;
+let prompts: string[];
+
+function mount(toolPart: AnyToolPart) {
+  prompts = [];
+  const client = createOpenworkServerClient({ baseUrl: "http://unused.invalid" });
+  return act(async () => {
+    root.render(
+      <MessageListProvider client={client} workspaceId="w" sessionId="s" readOnly={false}
+        showThinking={false} developerMode={false} displaySuggestions={false} providerConnectedCount={0}
+        dispatchAction={() => {}} setPrompt={(text) => { prompts.push(text); }} onRevertToUserMessage={() => {}}
+        onForkAtMessage={() => {}} onEditUserMessage={() => {}} onMcpReconnect={async () => { throw new Error("unused"); }}
+        onMcpReopenAuthorization={async () => {}} onMcpRetry={() => {}}>
+        <VisualizationTool part={toolPart} />
+      </MessageListProvider>,
+    );
+  });
+}
+
+const click = (element: Element | null) =>
+  act(async () => { element?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+const byText = (text: string) =>
+  Array.from(container.querySelectorAll<HTMLElement>("button, li, td, div, span")).find((node) => node.textContent?.trim() === text) ?? null;
+
+beforeAll(() => {
+  GlobalRegistrator.register({ url: "http://localhost/" });
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterAll(async () => {
+  await act(async () => { root.unmount(); });
+  await GlobalRegistrator.unregister();
+});
+
+describe("VisualizationTool", () => {
+  test("navigation items become pages when sections name them", async () => {
+    await mount(available());
+    expect(container.textContent).toContain("Visualization · v1 · Mockup");
+    expect(container.textContent).toContain("Controlled members");
+    expect(container.textContent).not.toContain("Allow uploads");
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    expect(tabs.map((tab) => tab.textContent)).toEqual(["Overview", "Teams", "Activity"]);
+
+    await click(tabs[1]);
+    expect(container.textContent).toContain("Controlled members");
+    expect(container.textContent).toContain("Allow uploads");
+    expect(container.textContent).not.toContain("Enabled by Ada");
+    expect(container.querySelectorAll("th").length).toBe(2);
+    expect(container.querySelectorAll("td").length).toBe(4);
+
+    await click(tabs[2]);
+    expect(container.textContent).toContain("Enabled by Ada");
+    expect(container.querySelectorAll("script").length).toBe(0);
+    expect(Reflect.get(globalThis, "mockupExecuted")).toBeUndefined();
+  });
+
+  test("mock controls respond locally without sending anything", async () => {
+    await mount(available());
+    await click(container.querySelectorAll<HTMLElement>('[role="tab"]')[1]);
+    const toggle = container.querySelector<HTMLElement>('[role="switch"]');
+    expect(toggle?.getAttribute("aria-checked")).toBe("false");
+    await click(toggle);
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+
+    const radios = Array.from(container.querySelectorAll<HTMLElement>('[role="radio"]'));
+    expect(radios.map((radio) => radio.getAttribute("aria-checked"))).toEqual(["false", "true"]);
+    await click(radios[0]);
+    expect(radios.map((radio) => radio.getAttribute("aria-checked"))).toEqual(["true", "false"]);
+
+    const collapse = byText("Rules")?.closest("button") ?? null;
+    await click(collapse);
+    expect(container.textContent).not.toContain("Allow uploads");
+    expect(prompts).toEqual([]);
+
+    await click(byText("Request changes"));
+    expect(prompts).toEqual([
+      'Revise visualization "Desktop controls" (id: admin-controls, version 1). Create version 2 with these changes: ',
+    ]);
+  });
+
+  test("a rejected design explains what to fix and offers a retry", async () => {
+    await mount(failed(
+      "Visualization rejected. Fix these and call openwork_visualization again with the complete design:\n- sections: Too big: expected array to have <=12 items\n- sections.0.blocks.3.kind: Invalid option\nLimits: …",
+    ));
+    expect(container.textContent).toContain("Couldn’t create this visualization.");
+    expect(container.textContent).toContain("sections: Too big");
+    expect(container.textContent).toContain("blocks.3.kind: Invalid option");
+    await click(byText("Try again"));
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]).toContain("Try the visualization again");
+  });
+
+  test("older stored output without navigation pages still renders every section", async () => {
+    const legacy = { ...design, navigation: ["Home"], sections: design.sections.map(({ nav: _nav, ...section }) => section) };
+    await mount(available(JSON.stringify(legacy)));
+    expect(container.querySelectorAll('[role="tab"]').length).toBe(0);
+    expect(container.textContent).toContain("Home");
+    expect(container.textContent).toContain("Allow uploads");
+    expect(container.textContent).toContain("Enabled by Ada");
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -844,9 +844,39 @@ describe("OpenWorkExtensionsPreview semantic tool surface", () => {
     expect(fake.requests).toHaveLength(0);
     await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: [] })).rejects.toThrow();
     await expect(plugin.tool.openwork_visualization.execute({ ...design, revision: 0 })).rejects.toThrow();
-    await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: Array(9).fill(design.sections[0]) })).rejects.toThrow();
-    await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: [{ title: "Unsafe", blocks: [{ kind: "html", label: "Code" }] }] })).rejects.toThrow();
+    await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: Array(13).fill(design.sections[0]) })).rejects.toThrow(/sections.*12|at most 12/i);
+    await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: [{ title: "Unsafe", blocks: [{ kind: "html", label: "Code" }] }] })).rejects.toThrow(/blocks\.0\.kind/);
     expect(fake.requests).toHaveLength(0);
+  });
+
+  test("repairs common model slips in a visualization instead of failing it", async () => {
+    const plugin = await OpenWorkExtensionsPreview();
+    const sloppy = {
+      id: " admin-controls ", title: "  Controls  ", revision: "2",
+      navigation: ["Overview", "Teams", ""],
+      sections: [
+        { title: "Rules", columns: 2, page: "Teams", blocks: [
+          { kind: "Toggle", label: "Allow uploads", value: true },
+          { kind: "metric", label: "Devices", value: 14 },
+          { kind: "select", label: "Grace", options: ["None", "1 h", " ", "24 h"], value: "1 h" },
+          { kind: "text", value: "Only a value, no label" },
+          { kind: "text", label: "   " },
+        ] },
+      ],
+    };
+    const rendered = JSON.parse(await plugin.tool.openwork_visualization.execute(sloppy));
+    expect(rendered).toMatchObject({
+      id: "admin-controls", title: "Controls", revision: 2, navigation: ["Overview", "Teams"],
+      sections: [{ title: "Rules", columns: "two", nav: "Teams", blocks: [
+        { kind: "toggle", label: "Allow uploads", value: "true" },
+        { kind: "metric", label: "Devices", value: "14" },
+        { kind: "select", label: "Grace", items: ["None", "1 h", "24 h"], value: "1 h" },
+        { kind: "text", label: "Only a value, no label" },
+      ] }],
+    });
+    expect(rendered.sections[0].blocks).toHaveLength(4);
+    await expect(plugin.tool.openwork_visualization.execute({ ...sloppy, sections: [{ title: "Empty", blocks: [{ kind: "text", label: " " }] }] }))
+      .rejects.toThrow(/Fix these and call openwork_visualization again/);
   });
 
   test("proposes an Automation without creating anything or calling a backend", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -3,7 +3,7 @@ import { ApiError } from "../errors.js";
 import { uiBridgeRequest } from "./openwork-ui-bridge.js";
 import { createGmailAttachmentFulfillment, type GmailAttachmentDependencies } from "./gmail-attachment-fulfillment.js";
 import { z } from "zod";
-import { visualizationSchema } from "@openwork/types/visualization";
+import { parseVisualization, visualizationSchema } from "@openwork/types/visualization";
 import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
 import { automationProposalSchema } from "@openwork/types/automations";
 import {
@@ -987,10 +987,12 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown, _options
   },
   tool: {
     openwork_visualization: {
-      description: "Show a lightweight UI mockup inline in OpenWork using native OpenWork styling. Use for wireframes, screen layouts, and design iteration instead of ASCII UI. Provide a title, optional navigation, and sections of text, metrics, fields, buttons, lists, or image placeholders. These are mock controls, not a working app. For revisions, keep the same id and send the complete updated mockup with an increased revision; earlier versions remain in the conversation. No HTML, scripts, servers, or files needed.",
+      description: "Show a lightweight, interactive UI mockup inline in OpenWork using native OpenWork styling. Use for wireframes, screen layouts, component inventories, and design iteration instead of ASCII UI. Provide a title, optional navigation, and sections of blocks: text, metric, field, button, list, image, toggle, select, segmented, chips, or table. Navigation items become clickable pages when sections set nav to one of them; sections without nav appear on every page. Toggles, segmented controls, selects, and fields are tappable in the preview but change nothing outside it. Keep each mockup focused (up to 12 sections of 16 blocks); split large inventories into several mockups. For revisions, keep the same id and send the complete updated mockup with an increased revision; earlier versions remain in the conversation. No HTML, scripts, servers, or files needed.",
       args: visualizationSchema.shape,
       async execute(rawArgs: unknown) {
-        return JSON.stringify(visualizationSchema.parse(rawArgs));
+        const result = parseVisualization(rawArgs);
+        if (!result.ok) throw new Error(result.message);
+        return JSON.stringify(result.data);
       },
     },
     openwork_context: {

--- a/packages/types/src/visualization.ts
+++ b/packages/types/src/visualization.ts
@@ -1,12 +1,64 @@
 import { z } from "zod";
 
 // A bounded, declarative mockup: all content renders as text, never HTML or code.
-const text = z.string().trim().min(1).max(500);
+export const VISUALIZATION_LIMITS = {
+  text: 500,
+  value: 2000,
+  description: 1000,
+  navigation: 10,
+  sections: 12,
+  blocks: 16,
+  items: 24,
+} as const;
+
+const text = z.string().trim().min(1).max(VISUALIZATION_LIMITS.text);
+
+export const visualizationBlockKinds = [
+  "text",
+  "metric",
+  "field",
+  "button",
+  "list",
+  "image",
+  "toggle",
+  "select",
+  "segmented",
+  "chips",
+  "table",
+] as const;
+
+export const visualizationTones = ["default", "primary", "destructive", "muted"] as const;
+
 const blockSchema = z.object({
-  kind: z.enum(["text", "metric", "field", "button", "list", "image"]),
+  kind: z
+    .enum(visualizationBlockKinds)
+    .describe(
+      "text: heading + paragraph. metric: big number. field: input with placeholder. button: action. list: rows. image: placeholder. toggle: on/off switch (value 'On' or 'Off'). select: dropdown (items = options, value = selected). segmented: tab-like control (items = options, value = selected). chips: tags or status badges (items). table: rows as items using ' | ' between cells; the first item is the header row.",
+    ),
   label: text,
-  value: z.string().max(2000).optional(),
-  items: z.array(text).max(12).optional(),
+  value: z.string().max(VISUALIZATION_LIMITS.value).optional(),
+  items: z.array(text).max(VISUALIZATION_LIMITS.items).optional(),
+  tone: z
+    .enum(visualizationTones)
+    .optional()
+    .describe("Visual emphasis for button and chips blocks."),
+  hint: z
+    .string()
+    .max(VISUALIZATION_LIMITS.text)
+    .optional()
+    .describe("Small helper text shown under the block."),
+});
+
+const sectionSchema = z.object({
+  title: text,
+  description: z.string().max(VISUALIZATION_LIMITS.description).optional(),
+  columns: z.enum(["one", "two", "three"]).default("one"),
+  nav: text
+    .optional()
+    .describe(
+      "Navigation item this section belongs to. Sections without nav show on every page; when at least one section names a nav item, the navigation becomes clickable pages.",
+    ),
+  blocks: z.array(blockSchema).min(1).max(VISUALIZATION_LIMITS.blocks),
 });
 
 export const visualizationSchema = z.object({
@@ -16,18 +68,122 @@ export const visualizationSchema = z.object({
     .describe("Stable design id; reuse for revisions."),
   title: text,
   revision: z.number().int().min(1).max(9999),
-  description: z.string().max(1000).optional(),
-  navigation: z.array(text).max(8).optional(),
-  sections: z
-    .array(
-      z.object({
-        title: text,
-        columns: z.enum(["one", "two", "three"]).default("one"),
-        blocks: z.array(blockSchema).min(1).max(12),
-      }),
-    )
-    .min(1)
-    .max(8),
+  description: z.string().max(VISUALIZATION_LIMITS.description).optional(),
+  navigation: z.array(text).max(VISUALIZATION_LIMITS.navigation).optional(),
+  sections: z.array(sectionSchema).min(1).max(VISUALIZATION_LIMITS.sections),
 });
 
 export type Visualization = z.infer<typeof visualizationSchema>;
+export type VisualizationSection = Visualization["sections"][number];
+export type VisualizationBlock = VisualizationSection["blocks"][number];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toText(value: unknown, max: number): string | undefined {
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+function toItems(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value
+    .map((item) => toText(item, VISUALIZATION_LIMITS.text))
+    .filter((item): item is string => item !== undefined);
+  return items.length ? items : undefined;
+}
+
+function normalizeBlock(input: unknown): unknown {
+  if (!isRecord(input)) return input;
+  const kind = typeof input.kind === "string" ? input.kind.trim().toLowerCase() : input.kind;
+  const label =
+    toText(input.label, VISUALIZATION_LIMITS.text) ??
+    toText(input.title, VISUALIZATION_LIMITS.text) ??
+    toText(input.name, VISUALIZATION_LIMITS.text);
+  const rawValue = toText(input.value, VISUALIZATION_LIMITS.value);
+  // A block with only a value still renders: promote the value to its label.
+  const value = label === undefined ? undefined : rawValue;
+  const items = toItems(input.items) ?? toItems(input.options) ?? toItems(input.rows);
+  const tone = typeof input.tone === "string" ? input.tone.trim().toLowerCase() : undefined;
+  const hint = toText(input.hint, VISUALIZATION_LIMITS.text);
+  return {
+    kind,
+    label: label ?? (rawValue ? toText(rawValue, 120) : undefined),
+    ...(value !== undefined ? { value } : {}),
+    ...(items ? { items } : {}),
+    ...(tone ? { tone } : {}),
+    ...(hint ? { hint } : {}),
+  };
+}
+
+function normalizeSection(input: unknown): unknown {
+  if (!isRecord(input)) return input;
+  const columns =
+    typeof input.columns === "string"
+      ? input.columns.trim().toLowerCase()
+      : input.columns === 2
+        ? "two"
+        : input.columns === 3
+          ? "three"
+          : input.columns === 1
+            ? "one"
+            : undefined;
+  const blocks = Array.isArray(input.blocks)
+    ? input.blocks.map(normalizeBlock).filter((block) => isRecord(block) && block.label !== undefined)
+    : input.blocks;
+  const description = toText(input.description, VISUALIZATION_LIMITS.description);
+  const nav = toText(input.nav ?? input.page ?? input.tab, VISUALIZATION_LIMITS.text);
+  return {
+    title: toText(input.title, VISUALIZATION_LIMITS.text) ?? toText(input.name, VISUALIZATION_LIMITS.text),
+    ...(description ? { description } : {}),
+    ...(columns ? { columns } : {}),
+    ...(nav ? { nav } : {}),
+    blocks,
+  };
+}
+
+/**
+ * Lenient pre-pass that repairs the mistakes models make most often (untrimmed
+ * strings, numbers instead of strings, empty items, synonyms like `options`)
+ * before strict validation. Structural problems still fail validation.
+ */
+export function normalizeVisualizationInput(input: unknown): unknown {
+  if (!isRecord(input)) return input;
+  const revision =
+    typeof input.revision === "string" && /^\d+$/.test(input.revision.trim())
+      ? Number(input.revision.trim())
+      : input.revision;
+  const description = toText(input.description, VISUALIZATION_LIMITS.description);
+  const navigation = toItems(input.navigation ?? input.nav ?? input.tabs);
+  return {
+    id: typeof input.id === "string" ? input.id.trim() : input.id,
+    title: toText(input.title, VISUALIZATION_LIMITS.text),
+    revision: revision ?? 1,
+    ...(description ? { description } : {}),
+    ...(navigation ? { navigation } : {}),
+    sections: Array.isArray(input.sections) ? input.sections.map(normalizeSection) : input.sections,
+  };
+}
+
+export type VisualizationParseResult =
+  | { ok: true; data: Visualization }
+  | { ok: false; message: string };
+
+/** Normalize then validate; on failure, return one readable message the model can act on. */
+export function parseVisualization(input: unknown): VisualizationParseResult {
+  const parsed = visualizationSchema.safeParse(normalizeVisualizationInput(input));
+  if (parsed.success) return { ok: true, data: parsed.data };
+  const lines = parsed.error.issues.slice(0, 8).map((issue) => {
+    const path = issue.path.length ? issue.path.map(String).join(".") : "design";
+    return `- ${path}: ${issue.message}`;
+  });
+  const limits = `Limits: up to ${VISUALIZATION_LIMITS.sections} sections, ${VISUALIZATION_LIMITS.blocks} blocks per section, ${VISUALIZATION_LIMITS.items} items per block, ${VISUALIZATION_LIMITS.navigation} navigation items; block kinds: ${visualizationBlockKinds.join(", ")}.`;
+  return {
+    ok: false,
+    message: `Visualization rejected. Fix these and call openwork_visualization again with the complete design:\n${lines.join("\n")}\n${limits} Split a large inventory into several mockups if needed.`,
+  };
+}


### PR DESCRIPTION
## Why

Model-authored mockups via `openwork_visualization` were cramped inside the 48rem reading column, every control was static, and a minor slip in the tool arguments (an untrimmed label, a number for `value`, one section too many) surfaced as a dead-end "Couldn't create this visualization. Ask to try again." with no way for the model or the person to know what to fix.

## What changed

**Layout**
- The mockup card breaks out of the reading column: `max(100%, min(72rem, 100cqw - 1.5rem))`, centered on the message list. Text stays in the column; only the design gets wide.
- Full-size dialog (expand icon) for reviewing large inventories.
- Sections render as collapsible cards with an optional description; block grids honor `columns` with container queries.

**Interactivity (local to the preview, never leaves it)**
- `navigation` items become clickable pages when a section sets `nav`. Sections without `nav` show on every page. Old designs (no `nav`) render exactly as before.
- New block kinds: `toggle`, `select`, `segmented`, `chips`, `table`; optional `tone` and `hint`. Toggles flip, segmented controls select, selects open, fields type.

**Fewer failures, better failures**
- `parseVisualization` in `@openwork/types/visualization` normalizes common slips before strict validation: trims strings, coerces numbers/booleans to text, drops empty items, accepts `options`/`rows`/`page`/`tab` synonyms, promotes a value-only block to a labeled one, coerces `"2"` → `2` for revision.
- Limits raised to 12 sections / 16 blocks / 24 items / 10 nav items.
- When validation still fails, the tool throws one readable message listing exact paths (`sections.2.blocks.4.kind: Invalid option…`) plus the limits, so the model can fix and re-call. The chat card shows those lines and a **Try again** button.

## Screenshots

![Editor page: segmented controls, toggles, chips, buttons](https://github.com/user-attachments/assets/f30f7360-a023-4d34-824c-9f2c86fbb5ae)

![Teams page with table](https://github.com/user-attachments/assets/90d59218-fd8c-48d8-a22f-1d4a0c17b49d)

![Mobile preview](https://github.com/user-attachments/assets/438c0ea1-f92f-46b0-8b6a-159930131760)

## Verification

- `apps/app`: `pnpm typecheck` clean; new `tests/visualization-tool.test.tsx` (pages, local toggle/segmented state, collapse, request-changes prompt, error card, legacy output) — 4 pass.
- `apps/server`: `pnpm typecheck` clean; `openwork-extensions-preview.test.ts` updated for the new limits plus a new "repairs common model slips" case — 29 pass.
- Screenshots above are from a throwaway Vite harness rendering the real component with the app CSS (harness not committed).
- `evals/specs/visualization.e2e.test.ts` assertions (labels, `visualization-preview` ≤ 360px on mobile, request-changes draft, two cards for two revisions) are preserved; not run locally (needs the Daytona/Electron world).
