### PR TITLE
fix(den): revoke direct member access on removal

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -12,7 +12,7 @@
     "openapi:snapshot": "tsx scripts/generate-openapi-snapshot.ts",
     "smoke:config-object-payload-boundary": "tsx scripts/smoke-config-object-payload-boundary.ts",
     "test": "bun test --conditions development test/api-keys.test.ts test/bearer-session.test.ts test/cloud-provider-materialization-read-retry.test.ts test/remote-session-capability-wire.test.ts",
-    "test:db": "bun test --conditions development test/scim-provider-rotation.test.ts test/sso-provider-rotation.test.ts",
+    "test:db": "bun test --conditions development test/member-removal-rejoin.test.ts test/scim-provider-rotation.test.ts test/sso-provider-rotation.test.ts",
     "backfill:desktop-policies": "pnpm run build:den-db && tsx scripts/backfill-desktop-policies.ts",
     "migrate:skills-to-plugins": "pnpm run build:den-db && tsx scripts/migrate-skills-to-plugins.ts",
     "test:admin-scale": "bun test test/admin-scale-performance.test.ts",

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -2,13 +2,20 @@ import { and, asc, count, eq, gt, inArray, isNotNull, isNull, sql } from "@openw
 import {
   AuthSessionTable,
   AuthUserTable,
+  ConfigObjectAccessGrantTable,
   ConnectedAccountTable,
+  ConnectorInstanceAccessGrantTable,
+  DashboardAccessGrantTable,
+  DesktopPolicyMemberTable,
+  ExternalMcpConnectionAccessGrantTable,
   InvitationTable,
   LlmProviderAccessTable,
   LlmProviderMemberCredentialTable,
+  MarketplaceAccessGrantTable,
   MemberTable,
   OrganizationRoleTable,
   OrganizationTable,
+  PluginAccessGrantTable,
   ScimGroupMemberTable,
   ScimProviderTable,
   ScimUserTombstoneTable,
@@ -2039,6 +2046,7 @@ export async function removeOrganizationMember(input: {
     }
 
     const member = memberRow.member
+    const removedAt = new Date()
 
     if (input.removedByOrgMemberId) {
       const adminTeams = await tx.select({ id: TeamTable.id }).from(TeamTable)
@@ -2078,8 +2086,67 @@ export async function removeOrganizationMember(input: {
       .where(eq(LlmProviderAccessTable.orgMembershipId, member.id))
 
     await tx
+      .delete(DesktopPolicyMemberTable)
+      .where(and(
+        eq(DesktopPolicyMemberTable.organizationId, input.organizationId),
+        eq(DesktopPolicyMemberTable.orgMemberId, member.id),
+      ))
+
+    await tx
+      .delete(ExternalMcpConnectionAccessGrantTable)
+      .where(and(
+        eq(ExternalMcpConnectionAccessGrantTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionAccessGrantTable.orgMembershipId, member.id),
+      ))
+
+    await tx
+      .update(MarketplaceAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(MarketplaceAccessGrantTable.organizationId, input.organizationId),
+        eq(MarketplaceAccessGrantTable.orgMembershipId, member.id),
+        isNull(MarketplaceAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(ConfigObjectAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(ConfigObjectAccessGrantTable.organizationId, input.organizationId),
+        eq(ConfigObjectAccessGrantTable.orgMembershipId, member.id),
+        isNull(ConfigObjectAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(PluginAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(PluginAccessGrantTable.organizationId, input.organizationId),
+        eq(PluginAccessGrantTable.orgMembershipId, member.id),
+        isNull(PluginAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(ConnectorInstanceAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(ConnectorInstanceAccessGrantTable.organizationId, input.organizationId),
+        eq(ConnectorInstanceAccessGrantTable.orgMembershipId, member.id),
+        isNull(ConnectorInstanceAccessGrantTable.removedAt),
+      ))
+
+    await tx
+      .update(DashboardAccessGrantTable)
+      .set({ removedAt })
+      .where(and(
+        eq(DashboardAccessGrantTable.organizationId, input.organizationId),
+        eq(DashboardAccessGrantTable.orgMembershipId, member.id),
+        isNull(DashboardAccessGrantTable.removedAt),
+      ))
+
+    await tx
       .update(MemberTable)
-      .set({ removedAt: new Date(), removedByOrgMember: input.removedByOrgMemberId ?? null })
+      .set({ removedAt, removedByOrgMember: input.removedByOrgMemberId ?? null })
       .where(and(eq(MemberTable.id, member.id), eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
 
     return { ok: true, member }

--- a/ee/apps/den-api/test/member-removal-rejoin.test.ts
+++ b/ee/apps/den-api/test/member-removal-rejoin.test.ts
@@ -9,6 +9,7 @@ const organizationId = createDenTypeId("organization")
 const ownerUserId = createDenTypeId("user")
 const ownerMemberId = createDenTypeId("member")
 const removedUserId = createDenTypeId("user")
+const accessUserId = createDenTypeId("user")
 const bootstrapUserId = createDenTypeId("user")
 const reviveUserId = createDenTypeId("user")
 const legacyReviveUserId = createDenTypeId("user")
@@ -17,13 +18,23 @@ const scimUserId = createDenTypeId("user")
 
 const ownerEmail = `owner+${ownerUserId}@member-removal.test`
 const removedEmail = `removed+${removedUserId}@member-removal.test`
+const accessEmail = `access+${accessUserId}@member-removal.test`
 const bootstrapEmail = `bootstrap+${bootstrapUserId}@member-removal.test`
 const reviveEmail = `revive+${reviveUserId}@member-removal.test`
 const legacyReviveEmail = `legacy-revive+${legacyReviveUserId}@member-removal.test`
 const oldInviteEmail = `old-invite+${oldInviteUserId}@member-removal.test`
 const scimEmail = `scim+${scimUserId}@member-removal.test`
 
-const userIds = [ownerUserId, removedUserId, bootstrapUserId, reviveUserId, legacyReviveUserId, oldInviteUserId, scimUserId]
+const userIds = [
+  ownerUserId,
+  removedUserId,
+  accessUserId,
+  bootstrapUserId,
+  reviveUserId,
+  legacyReviveUserId,
+  oldInviteUserId,
+  scimUserId,
+]
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -53,6 +64,13 @@ async function cleanup() {
   const organizationIds = [...staleOrgs.map((row) => row.id), organizationId]
 
   await db.delete(schema.DesktopPolicyMemberTable).where(drizzle.inArray(schema.DesktopPolicyMemberTable.organizationId, organizationIds))
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.inArray(schema.ExternalMcpConnectionAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.DashboardAccessGrantTable).where(drizzle.inArray(schema.DashboardAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.MarketplaceAccessGrantTable).where(drizzle.inArray(schema.MarketplaceAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.ConfigObjectAccessGrantTable).where(drizzle.inArray(schema.ConfigObjectAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.PluginAccessGrantTable).where(drizzle.inArray(schema.PluginAccessGrantTable.organizationId, organizationIds))
+  await db.delete(schema.PluginTable).where(drizzle.inArray(schema.PluginTable.organizationId, organizationIds))
+  await db.delete(schema.ConnectorInstanceAccessGrantTable).where(drizzle.inArray(schema.ConnectorInstanceAccessGrantTable.organizationId, organizationIds))
   await db.delete(schema.DesktopPolicyTable).where(drizzle.inArray(schema.DesktopPolicyTable.organizationId, organizationIds))
   await db.delete(schema.ScimUserTombstoneTable).where(drizzle.inArray(schema.ScimUserTombstoneTable.organizationId, organizationIds))
   await db.delete(schema.ExternalIdentityTable).where(drizzle.inArray(schema.ExternalIdentityTable.organizationId, organizationIds))
@@ -145,6 +163,7 @@ beforeAll(async () => {
   await db.insert(schema.AuthUserTable).values([
     { id: ownerUserId, name: "Removal Owner", email: ownerEmail, emailVerified: true },
     { id: removedUserId, name: "Removed User", email: removedEmail, emailVerified: true },
+    { id: accessUserId, name: "Access User", email: accessEmail, emailVerified: true },
     { id: bootstrapUserId, name: "Bootstrap Removed", email: bootstrapEmail, emailVerified: true },
     { id: reviveUserId, name: "Revive Removed", email: reviveEmail, emailVerified: true },
     { id: legacyReviveUserId, name: "Legacy Revive Removed", email: legacyReviveEmail, emailVerified: true },
@@ -152,6 +171,9 @@ beforeAll(async () => {
     { id: scimUserId, name: "SCIM Removed", email: scimEmail, emailVerified: true },
   ])
   await db.insert(schema.OrganizationTable).values({ id: organizationId, name: "Member Removal Rejoin Test", slug: singleOrgSlug })
+  // Invitation roles are validated against the organization's role table, so a
+  // directly inserted org must carry the default roles a real org is born with.
+  await orgs.seedDefaultOrganizationRoles(organizationId)
   await db.insert(schema.MemberTable).values({ id: ownerMemberId, organizationId, userId: ownerUserId, role: "owner" })
 })
 
@@ -180,6 +202,220 @@ test("removeOrganizationMember keeps userId while setting removedAt", async () =
   expect(row?.userId).toBe(removedUserId)
   expect(row?.removedAt).toBeInstanceOf(Date)
   expect(row?.removedByOrgMember).toBe(ownerMemberId)
+})
+
+test("member removal revokes direct access and rejoining preserves only newly assigned grants", async () => {
+  if (!db || !schema || !orgs || !drizzle) {
+    throw new Error("test modules not initialized")
+  }
+
+  const memberId = createDenTypeId("member")
+  const oldPluginId = createDenTypeId("plugin")
+  const newPluginId = createDenTypeId("plugin")
+  const previouslyRevokedGrantId = createDenTypeId("pluginAccessGrant")
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId: accessUserId,
+    role: "member",
+  })
+  await db.insert(schema.PluginTable).values([
+    { id: oldPluginId, name: "Old member access" },
+    { id: newPluginId, name: "New invitation access" },
+  ].map((plugin) => ({ ...plugin, organizationId, createdByOrgMembershipId: ownerMemberId })))
+  for (const assignmentMemberId of [memberId, ownerMemberId]) {
+    await db.insert(schema.DashboardAccessGrantTable).values({
+      id: createDenTypeId("dashboardAccessGrant"),
+      organizationId,
+      dashboardId: createDenTypeId("dashboard"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.DesktopPolicyMemberTable).values({
+      id: createDenTypeId("desktopPolicyMember"),
+      organizationId,
+      desktopPolicyId: createDenTypeId("desktopPolicy"),
+      orgMemberId: assignmentMemberId,
+    })
+    await db.insert(schema.ExternalMcpConnectionAccessGrantTable).values({
+      id: createDenTypeId("externalMcpConnectionAccessGrant"),
+      organizationId,
+      externalMcpConnectionId: createDenTypeId("externalMcpConnection"),
+      orgMembershipId: assignmentMemberId,
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.MarketplaceAccessGrantTable).values({
+      id: createDenTypeId("marketplaceAccessGrant"),
+      organizationId,
+      marketplaceId: createDenTypeId("marketplace"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.ConfigObjectAccessGrantTable).values({
+      id: createDenTypeId("configObjectAccessGrant"),
+      organizationId,
+      configObjectId: createDenTypeId("configObject"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.PluginAccessGrantTable).values({
+      id: createDenTypeId("pluginAccessGrant"),
+      organizationId,
+      pluginId: oldPluginId,
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+    await db.insert(schema.ConnectorInstanceAccessGrantTable).values({
+      id: createDenTypeId("connectorInstanceAccessGrant"),
+      organizationId,
+      connectorInstanceId: createDenTypeId("connectorInstance"),
+      orgMembershipId: assignmentMemberId,
+      role: "viewer",
+      createdByOrgMembershipId: memberId,
+    })
+  }
+
+  const sharedPluginId = createDenTypeId("plugin")
+  await db.insert(schema.PluginAccessGrantTable).values([
+    { teamId: createDenTypeId("team") },
+    { orgWide: true },
+  ].map((target) => ({
+    id: createDenTypeId("pluginAccessGrant"),
+    organizationId,
+    pluginId: sharedPluginId,
+    role: "viewer",
+    createdByOrgMembershipId: memberId,
+    ...target,
+  })))
+
+  await db.insert(schema.PluginAccessGrantTable).values({
+    id: previouslyRevokedGrantId,
+    organizationId,
+    pluginId: newPluginId,
+    orgMembershipId: memberId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+    removedAt: past,
+  })
+  const { resolvePluginArchResourceRole } = await import("../src/routes/org/plugin-system/access.js")
+  const originalContext = await orgs.getOrganizationContextForUser({ organizationId, userId: accessUserId })
+  if (!originalContext) throw new Error("original member context missing")
+  const originalAccess = { organizationContext: originalContext, memberTeams: [], session: null }
+  expect(await resolvePluginArchResourceRole({ context: originalAccess, resourceKind: "plugin", resourceId: oldPluginId })).toBe("viewer")
+  expect(await resolvePluginArchResourceRole({ context: originalAccess, resourceKind: "plugin", resourceId: newPluginId })).toBeNull()
+
+  const removed = await orgs.removeOrganizationMember({
+    organizationId,
+    memberId,
+    removedByOrgMemberId: ownerMemberId,
+  })
+  if (!removed.ok) {
+    throw new Error(removed.message)
+  }
+
+  const [desktopAssignments, externalMcpAssignments] = await Promise.all([
+    db
+      .select()
+      .from(schema.DesktopPolicyMemberTable)
+      .where(drizzle.eq(schema.DesktopPolicyMemberTable.orgMemberId, memberId)),
+    db
+      .select()
+      .from(schema.ExternalMcpConnectionAccessGrantTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.orgMembershipId, memberId)),
+  ])
+  expect(desktopAssignments).toHaveLength(0)
+  expect(externalMcpAssignments).toHaveLength(0)
+
+  const [marketplaceGrants, configObjectGrants, pluginGrants, connectorGrants, dashboardGrants] = await Promise.all([
+    db
+      .select()
+      .from(schema.MarketplaceAccessGrantTable)
+      .where(drizzle.eq(schema.MarketplaceAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.ConfigObjectAccessGrantTable)
+      .where(drizzle.eq(schema.ConfigObjectAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.PluginAccessGrantTable)
+      .where(drizzle.eq(schema.PluginAccessGrantTable.orgMembershipId, memberId)),
+    db
+      .select()
+      .from(schema.ConnectorInstanceAccessGrantTable)
+      .where(drizzle.eq(schema.ConnectorInstanceAccessGrantTable.orgMembershipId, memberId)),
+    db.select().from(schema.DashboardAccessGrantTable).where(drizzle.eq(schema.DashboardAccessGrantTable.orgMembershipId, memberId)),
+  ])
+  const revokedGrants = [
+    ...marketplaceGrants,
+    ...configObjectGrants,
+    ...pluginGrants.filter((grant) => grant.id !== previouslyRevokedGrantId),
+    ...connectorGrants,
+    ...dashboardGrants,
+  ]
+  expect(revokedGrants).toHaveLength(5)
+  expect(revokedGrants.every((grant) => grant.removedAt instanceof Date)).toBe(true)
+
+  const member = await memberById(memberId)
+  expect(member?.removedAt).toBeInstanceOf(Date)
+  expect(revokedGrants.every((grant) => grant.removedAt?.getTime() === member?.removedAt?.getTime())).toBe(true)
+  expect(pluginGrants.find((grant) => grant.id === previouslyRevokedGrantId)?.removedAt?.getTime()).toBe(past.getTime())
+  expect(await orgs.getOrganizationContextForUser({ organizationId, userId: accessUserId })).toBeNull()
+  expect(await resolvePluginArchResourceRole({ context: originalAccess, resourceKind: "plugin", resourceId: oldPluginId })).toBeNull()
+
+  const [otherDesktop, otherMcp, otherMarketplace, otherConfig, otherPlugin, otherConnector, sharedPlugin, otherDashboard] = await Promise.all([
+    db.select().from(schema.DesktopPolicyMemberTable).where(drizzle.eq(schema.DesktopPolicyMemberTable.orgMemberId, ownerMemberId)),
+    db.select().from(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.eq(schema.ExternalMcpConnectionAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.MarketplaceAccessGrantTable).where(drizzle.eq(schema.MarketplaceAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.ConfigObjectAccessGrantTable).where(drizzle.eq(schema.ConfigObjectAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.PluginAccessGrantTable).where(drizzle.eq(schema.PluginAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.ConnectorInstanceAccessGrantTable).where(drizzle.eq(schema.ConnectorInstanceAccessGrantTable.orgMembershipId, ownerMemberId)),
+    db.select().from(schema.PluginAccessGrantTable).where(drizzle.eq(schema.PluginAccessGrantTable.pluginId, sharedPluginId)),
+    db.select().from(schema.DashboardAccessGrantTable).where(drizzle.eq(schema.DashboardAccessGrantTable.orgMembershipId, ownerMemberId)),
+  ])
+  for (const grants of [otherDesktop, otherMcp, otherMarketplace, otherConfig, otherPlugin, otherConnector, otherDashboard]) {
+    expect(grants).toHaveLength(1)
+  }
+  expect(sharedPlugin).toHaveLength(2)
+  expect([...otherMarketplace, ...otherConfig, ...otherPlugin, ...otherConnector, ...sharedPlugin, ...otherDashboard].every((grant) => grant.removedAt === null)).toBe(true)
+
+  const invitationId = createDenTypeId("invitation")
+  const placeholderId = createDenTypeId("member")
+  const newGrantId = createDenTypeId("pluginAccessGrant")
+  await createInvitation({ invitationId, memberId: placeholderId, email: accessEmail, role: "member" })
+  await db.insert(schema.PluginAccessGrantTable).values({
+    id: newGrantId,
+    organizationId,
+    pluginId: newPluginId,
+    orgMembershipId: placeholderId,
+    role: "viewer",
+    createdByOrgMembershipId: ownerMemberId,
+  })
+  const accepted = await orgs.acceptInvitationForUser({ userId: accessUserId, email: accessEmail, invitationId })
+  if (!accepted || accepted.status !== "accepted") throw new Error("rejoin invitation was not accepted")
+  expect(accepted.member.id).toBe(placeholderId)
+  expect(accepted.member.id).not.toBe(memberId)
+  expect((await memberById(memberId))?.userId).toBeNull()
+  expect((await memberById(memberId))?.removedAt?.getTime()).toBe(member?.removedAt?.getTime())
+
+  const rejoinedContext = await orgs.getOrganizationContextForUser({ organizationId, userId: accessUserId })
+  if (!rejoinedContext) throw new Error("rejoined member context missing")
+  expect(rejoinedContext.currentMember.id).toBe(placeholderId)
+  expect(rejoinedContext.currentMember.role).toBe("member")
+  const rejoinedAccess = { organizationContext: rejoinedContext, memberTeams: [], session: null }
+  expect(await resolvePluginArchResourceRole({ context: rejoinedAccess, resourceKind: "plugin", resourceId: oldPluginId })).toBeNull()
+  expect(await resolvePluginArchResourceRole({ context: rejoinedAccess, resourceKind: "plugin", resourceId: newPluginId })).toBe("viewer")
+  const grantsAfterRejoin = await db.select().from(schema.PluginAccessGrantTable)
+    .where(drizzle.eq(schema.PluginAccessGrantTable.orgMembershipId, memberId))
+  expect(grantsAfterRejoin).toHaveLength(pluginGrants.length)
+  expect(grantsAfterRejoin).toEqual(expect.arrayContaining(pluginGrants))
+  const newGrants = await db.select().from(schema.PluginAccessGrantTable)
+    .where(drizzle.eq(schema.PluginAccessGrantTable.orgMembershipId, placeholderId))
+  expect(newGrants).toHaveLength(1)
+  expect(newGrants[0]).toMatchObject({ id: newGrantId, pluginId: newPluginId, role: "viewer", removedAt: null })
 })
 
 test("bootstrap returns null for a user with a removed member row", async () => {

--- a/evals/specs/helpers/member-grant-fixture.ts
+++ b/evals/specs/helpers/member-grant-fixture.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from "node:crypto";
+import { queryDenDatabase } from "@openwork/testkit";
+
+// Arrange assignments only; removal and reprovisioning must cross Den's SCIM API.
+export async function seedMemberGrantFixture(databaseUrl: string, organizationId: string, managedMemberId: string, controlMemberId: string) {
+  const id = (prefix: string) => `${prefix}_${randomBytes(12).toString("hex").padStart(26, "0")}`;
+  const teamId = id("tem");
+  const connectorAccountId = id("cac");
+  await queryDenDatabase(databaseUrl,
+    "INSERT INTO team (id, organization_id, name) VALUES (?, ?, 'SCIM grant control team')",
+    [teamId, organizationId],
+  );
+  await queryDenDatabase(databaseUrl,
+    "INSERT INTO connector_account (id, organization_id, connector_type, remote_id, display_name, created_by_org_membership_id) VALUES (?, ?, 'github', ?, 'SCIM grant fixture', ?)",
+    [connectorAccountId, organizationId, connectorAccountId, controlMemberId],
+  );
+
+  const definitions = [
+    { table: "desktop_policy_member", resource: "desktop_policy", prefix: "dpo", grantPrefix: "dpm", memberColumn: "org_member_id", softDelete: false,
+      resourceColumns: "policy_name", resourceValues: "'SCIM grant fixture'" },
+    { table: "external_mcp_connection_access_grant", resource: "external_mcp_connection", prefix: "emc", grantPrefix: "emg", memberColumn: "org_membership_id", softDelete: false,
+      resourceColumns: "name, url, auth_type", resourceValues: "'SCIM grant fixture', 'https://unused.example.test/mcp', 'none'" },
+    { table: "marketplace_access_grant", resource: "marketplace", prefix: "mkt", grantPrefix: "mag", memberColumn: "org_membership_id", softDelete: true,
+      resourceColumns: "name", resourceValues: "'SCIM grant fixture'" },
+    { table: "config_object_access_grant", resource: "config_object", prefix: "cob", grantPrefix: "coa", memberColumn: "org_membership_id", softDelete: true,
+      resourceColumns: "title, object_type, source_mode", resourceValues: "'SCIM grant fixture', 'skill', 'cloud'" },
+    { table: "plugin_access_grant", resource: "plugin", prefix: "plg", grantPrefix: "pag", memberColumn: "org_membership_id", softDelete: true,
+      resourceColumns: "name", resourceValues: "'SCIM grant fixture'" },
+    { table: "connector_instance_access_grant", resource: "connector_instance", prefix: "cin", grantPrefix: "cia", memberColumn: "org_membership_id", softDelete: true,
+      resourceColumns: "name, connector_type, connector_account_id", resourceValues: "'SCIM grant fixture', 'github', ?" },
+    { table: "dashboard_access_grant", resource: "dashboard", prefix: "dsb", grantPrefix: "dsg", memberColumn: "org_membership_id", softDelete: true,
+      resourceColumns: "name, elements_json", resourceValues: "'SCIM grant fixture', JSON_ARRAY()" },
+  ];
+  const grants = [];
+  for (const definition of definitions) {
+    const { table, resource, memberColumn, softDelete } = definition;
+    const resourceId = id(definition.prefix);
+    const desktop = table === "desktop_policy_member";
+    const creatorColumn = desktop ? "created_by_org_member_id" : "created_by_org_membership_id";
+    await queryDenDatabase(databaseUrl,
+      `INSERT INTO ${resource} (id, organization_id, ${creatorColumn}, ${definition.resourceColumns}) VALUES (?, ?, ?, ${definition.resourceValues})`,
+      [resourceId, organizationId, controlMemberId, ...(resource === "connector_instance" ? [connectorAccountId] : [])],
+    );
+    const managedGrantId = id(definition.grantPrefix);
+    const expectedRows = [
+      { id: managedGrantId, memberId: managedMemberId, teamId: null, shared: false },
+      { id: id(definition.grantPrefix), memberId: controlMemberId, teamId: null, shared: false },
+      { id: id(definition.grantPrefix), memberId: null, teamId, shared: false },
+      { id: id(definition.grantPrefix), memberId: null, teamId: null, shared: true },
+    ];
+    for (const grant of expectedRows) {
+      // Desktop uses a role target instead of org_wide. Other grants deliberately
+      // name the managed member as creator, not just as the revocation target.
+      const columns = desktop ? "role" : "org_wide, created_by_org_membership_id";
+      const values = desktop ? "?" : `?, ?${softDelete ? ", 'viewer'" : ""}`;
+      await queryDenDatabase(databaseUrl,
+        `INSERT INTO ${table} (id, organization_id, ${resource}_id, ${memberColumn}, team_id, ${columns}${softDelete ? ", role" : ""}) VALUES (?, ?, ?, ?, ?, ${values})`,
+        [grant.id, organizationId, resourceId, grant.memberId, grant.teamId,
+          ...(desktop ? [grant.shared ? "member" : null] : [grant.shared, managedMemberId])],
+      );
+    }
+    grants.push({ table, resource, resourceId, memberColumn, softDelete, managedGrantId, expectedRows });
+  }
+
+  return async () => Promise.all(grants.map(async (grant) => ({
+    table: grant.table,
+    softDelete: grant.softDelete,
+    managedGrantId: grant.managedGrantId,
+    expectedRows: grant.expectedRows.map(({ id, memberId, teamId }) => ({ id, memberId, teamId, removedAt: null })),
+    // Read all assignments on the fixture resource, not just original IDs, so
+    // copying an old grant to a fresh membership cannot evade the final check.
+    rows: await queryDenDatabase(databaseUrl,
+      `SELECT *, ${grant.memberColumn} AS memberId, team_id AS teamId, ${grant.softDelete ? "removed_at" : "NULL"} AS removedAt FROM ${grant.table} WHERE organization_id = ? AND ${grant.resource}_id = ? ORDER BY id`,
+      [organizationId, grant.resourceId],
+    ),
+  })));
+}

--- a/evals/specs/scim-deprovisioned-sso-reprovision.test.ts
+++ b/evals/specs/scim-deprovisioned-sso-reprovision.test.ts
@@ -5,6 +5,7 @@ import { startMockIdpLab } from "@openwork/labs";
 import type { StartedMockIdpLab } from "@openwork/labs";
 import { createAdmin, eventually, inviteMember, queryDenDatabase, server, test } from "@openwork/testkit";
 import type { Den } from "@openwork/testkit";
+import { seedMemberGrantFixture } from "./helpers/member-grant-fixture.ts";
 import { enableScimFixtureSso } from "./helpers/scim-fixture.ts";
 
 // One IdP-shaped lifecycle that Okta's Provision Users + SSO combination
@@ -170,6 +171,7 @@ async function registerEnabledOidcSso(den: Den, idp: StartedMockIdpLab): Promise
 interface JourneyFacts {
   refusal: { claim: string; detail: string; passed: boolean };
   reprovision: { claim: string; detail: string; passed: boolean };
+  cleanup: { claim: string; detail: string; passed: boolean };
 }
 
 async function runDeprovisionedSsoJourney(org: JourneyOrg): Promise<JourneyFacts> {
@@ -198,10 +200,21 @@ async function runDeprovisionedSsoJourney(org: JourneyOrg): Promise<JourneyFacts
   if (created.response.status !== 201 || !scimUserId) {
     throw new Error(`SCIM user creation failed: HTTP ${created.response.status} ${created.text.slice(0, 500)}`);
   }
-  await eventually(
+  const orgBeforeDeprovision = await eventually(
     () => denFetch(den.ref, "/v1/org", { headers: orgHeaders }),
     { within: 90_000, label: "SCIM-created member to appear in organization context", until: ({ response, body }) => response.ok && orgHasJoinedMember(body, managedEmail) },
   );
+  const members = recordsField(orgBeforeDeprovision.body, "members");
+  const managedMemberId = stringField(members.find((member) => isRecord(member.user) && member.user.email === managedEmail), "id");
+  const controlMemberId = stringField(members.find((member) => isRecord(member.user) && member.user.email === controlEmail), "id");
+  if (!managedMemberId || !controlMemberId || managedMemberId === controlMemberId) throw new Error("Grant fixture requires distinct joined managed and control members");
+  const readGrants = await seedMemberGrantFixture(databaseUrl, organizationId, managedMemberId, controlMemberId);
+  const grantsBeforeDeprovision = await readGrants();
+  expect(grantsBeforeDeprovision).toHaveLength(7);
+  for (const grant of grantsBeforeDeprovision) {
+    expect(grant.rows, `${grant.table}: managed, control, team and shared grants before deactivation`).toHaveLength(4);
+    expect(grant.rows).toEqual(expect.arrayContaining(grant.expectedRows.map((row) => expect.objectContaining(row))));
+  }
 
   // The IdP deactivates the assignment. Den removes the member and tombstones
   // the identity; the global user goes with its last active membership.
@@ -216,6 +229,19 @@ async function runDeprovisionedSsoJourney(org: JourneyOrg): Promise<JourneyFacts
   );
   const userRowsAfterDeprovision = await queryDenDatabase(databaseUrl, "SELECT id FROM `user` WHERE email = ?", [managedEmail]);
   expect(userRowsAfterDeprovision, "deprovisioned user row").toHaveLength(0);
+  const grantsAfterDeprovision = await readGrants();
+  for (const grant of grantsAfterDeprovision) {
+    const managed = grant.rows.filter((row) => stringField(row, "id") === grant.managedGrantId);
+    if (grant.softDelete) {
+      expect(managed, `${grant.table}: retain the revoked direct grant`).toHaveLength(1);
+      expect(managed[0]).toMatchObject({ memberId: managedMemberId, removedAt: expect.any(Date) });
+    } else {
+      expect(managed, `${grant.table}: hard-delete the direct assignment`).toHaveLength(0);
+    }
+    const before = grantsBeforeDeprovision.find((entry) => entry.table === grant.table);
+    expect(grant.rows.filter((row) => stringField(row, "id") !== grant.managedGrantId), `${grant.table}: other member and shared grants remain unchanged`)
+      .toEqual(before?.rows.filter((row) => stringField(row, "id") !== grant.managedGrantId));
+  }
 
   // ── The deactivated person still tries the SSO link ──────────────────────
   const ssoAttempt = await attemptSsoSignIn(den, managedEmail);
@@ -272,6 +298,13 @@ async function runDeprovisionedSsoJourney(org: JourneyOrg): Promise<JourneyFacts
   expect(userRowsAfterReprovision, "exactly one user row after re-provision").toHaveLength(1);
   expect(passwordAfterReprovision.response.ok).toBe(false);
   expect(orgMemberRole(orgAfterReprovision.body, controlEmail)).toBe(controlRole);
+  const grantsAfterReprovision = await readGrants();
+  expect(grantsAfterReprovision, "reprovision must not revive, copy or retarget old grants, or alter control/shared grants").toEqual(grantsAfterDeprovision);
+  const cleanup = {
+    claim: `SCIM deactivation removes direct access without disturbing other members or shared grants, and reprovision does not restore old grants (${mode})`,
+    detail: "Before PATCH /Users active=false, all seven assignment types had a managed-member grant, a control-member grant, a team grant and a shared grant (role-scoped for desktop, org-wide otherwise). After HTTP 204, desktop/MCP direct rows were absent and marketplace/config/plugin/connector/dashboard direct rows remained with revocation timestamps. All 21 control/shared rows were unchanged, including grants created by the removed member. After POST /Users returned 201, every fixture resource's assignments exactly matched the post-deactivation snapshot, with no revived or copied grants.",
+    passed: true,
+  };
   const reprovision = {
     claim: `The IdP's re-provision restores access after the refused SSO attempt (${mode})`,
     detail: `POST /Users for ${managedEmail} returned ${reprovisioned.response.status} with id ${reprovisionedId}; GET reports active=${isRecord(reprovisionedGet.body) ? String(reprovisionedGet.body.active) : "?"}, /v1/org lists the member as ${orgMemberRole(orgAfterReprovision.body, managedEmail)}, exactly ${userRowsAfterReprovision.length} user row exists, password sign-in returned ${passwordAfterReprovision.response.status}, and ${controlEmail} is still ${orgMemberRole(orgAfterReprovision.body, controlEmail)}.`,
@@ -285,7 +318,7 @@ async function runDeprovisionedSsoJourney(org: JourneyOrg): Promise<JourneyFacts
       && !passwordAfterReprovision.response.ok
       && orgMemberRole(orgAfterReprovision.body, controlEmail) === controlRole,
   };
-  return { refusal, reprovision };
+  return { refusal, reprovision, cleanup };
 }
 
 test("a SCIM-deactivated member who tries SSO is refused without a ghost identity, so the IdP can re-provision them (multi-org Den)", { timeout: 600_000 }, async ({ evidence, place }) => {
@@ -312,6 +345,7 @@ test("a SCIM-deactivated member who tries SSO is refused without a ghost identit
   });
   evidence.recordAssertionEvidence(facts.refusal.claim, facts.refusal.detail, facts.refusal.passed);
   evidence.recordAssertionEvidence(facts.reprovision.claim, facts.reprovision.detail, facts.reprovision.passed);
+  evidence.recordAssertionEvidence(facts.cleanup.claim, facts.cleanup.detail, facts.cleanup.passed);
 });
 
 test("a SCIM-deactivated member who tries SSO is refused without a ghost identity, so the IdP can re-provision them (single-org Den)", { timeout: 600_000 }, async ({ evidence, place }) => {
@@ -347,4 +381,5 @@ test("a SCIM-deactivated member who tries SSO is refused without a ghost identit
   });
   evidence.recordAssertionEvidence(facts.refusal.claim, facts.refusal.detail, facts.refusal.passed);
   evidence.recordAssertionEvidence(facts.reprovision.claim, facts.reprovision.detail, facts.reprovision.passed);
+  evidence.recordAssertionEvidence(facts.cleanup.claim, facts.cleanup.detail, facts.cleanup.passed);
 });


### PR DESCRIPTION
## Summary

Canonical replacement for #3274, reconstructed on current `dev` at `c23085ad2`.

Removing an organization member should revoke their direct assignments, not leave stale grants behind. This keeps the existing removal transaction, organization lock, admin-team guard, credential revocation, and fresh-membership rejoin behavior unchanged.

- Hard-delete direct desktop-policy and external-MCP assignments; soft-revoke marketplace, config-object, plugin, connector-instance, and dashboard grants with the membership-removal timestamp.
- Preserve other recipients, shared team/org/role assignments, resource ownership, and prior revocation history. No migration.
- Extend the existing removal/rejoin regression to verify effective plugin access before removal and after explicit re-invitation. Old access stays denied; a grant assigned to the new invitation remains usable.
- Extend the existing SCIM deactivation/reprovision journey with all seven grant types, plus unchanged control/shared assignments. No new journey or provider integration.

## Verification

Head: `51b1ee83927bf21b863b8aecadbdef3c781fe217` (verified signature).

| Check | Result |
| --- | --- |
| `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/member-removal-rejoin.test.ts` | **8 passed, 0 failed, 0 skipped; 65 assertions; exit 0** |
| `pnpm evals:pr specs/scim-deprovisioned-sso-reprovision.test.ts` | **2 passed, 0 failed, 0 skipped; 6 recorded claims; exit 0** |
| Den DB, types, and email prerequisite builds | Passed |
| `git diff --check` | Passed |

The runtime journey cold-boots Den through `server()` for both single-org and multi-org cases on the exact head. Placement: local, using dedicated disposable MySQL 8.4 and Redis containers, isolated test databases, and a deterministic mock IdP. No shared database, real provider, or cloud sandbox was used. Both cases assert that the seven direct assignment types are revoked, all 21 control/shared rows remain unchanged, and reprovision does not revive, copy, or retarget old grants.

## Verdict: Passed

The selected removal/rejoin and SCIM cleanup claims pass. Current-head assertion evidence is published separately on this PR. This does not claim a full test-suite pass or approval; required CI and independent review remain merge gates.

Deferred: SAML-specific callback coverage, desktop UI, and unrelated SCIM identity/session lifecycle changes. #4803 owns the SAML follow-up. Its default-role fixture repair and `test:db` registration are reused identically here; the existing OIDC/protocol setup is otherwise untouched.
