### PR TITLE
fix(chat): attach explicitly selected skills natively on OpenCode v2

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -43,12 +43,18 @@ type ModelBinding = {
 type PromptPart = {
   type?: unknown;
   text?: unknown;
+  synthetic?: unknown;
+  metadata?: unknown;
 };
+
+function selectedSkill(part: PromptPart): Record<string, unknown> | null {
+  return part.type === "text" && part.synthetic === true ? readRecord(part.metadata, "openworkSelectedSkill") : null;
+}
 
 /** The exact native prompt body, also used to correlate text-only user acknowledgements. */
 export function v2PromptText(parts: readonly PromptPart[]): string {
   return parts
-    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .filter((part) => part.type === "text" && typeof part.text === "string" && !selectedSkill(part))
     .map((part) => typeof part.text === "string" ? part.text : "")
     .join("");
 }
@@ -1883,6 +1889,43 @@ export function createClientV2(
           response: new Response(null, { status: 400 }),
         };
       }
+      const selections = (parameters.parts ?? []).flatMap((part) => {
+        const selection = selectedSkill(part);
+        return selection ? [selection] : [];
+      });
+      const skills: { id: string }[] = [];
+      if (selections.length) {
+        // Resolve against the same workspace's live registry, never guess an ID
+        // from prose or silently fall back to asking the model to load a skill.
+        const catalog = await request("GET", "/api/skill", undefined, options?.signal);
+        if (!catalog.response.ok) return failedResult(catalog);
+        for (const selection of selections) {
+          const id = readString(selection, "id");
+          const name = readString(selection, "name");
+          const matches = responseItems(catalog.payload).filter((skill) => id
+            ? readString(skill, "id") === id : Boolean(name) && readString(skill, "name") === name);
+          const resolvedID = matches.length === 1 ? readString(matches[0], "id") : undefined;
+          if (!resolvedID) {
+            return unsupportedResult(baseUrl, "skill.attachment", `Selected skill ${name ?? id ?? "(unknown)"} is unavailable or ambiguous in OpenCode v2. Nothing was sent.`);
+          }
+          if (!skills.some((skill) => skill.id === resolvedID)) skills.push({ id: resolvedID });
+        }
+        // The pinned native prompt materializes attachments without running the
+        // skill tool's permission check. Ask the engine (including its policy
+        // hooks) rather than treating catalog membership as authorization.
+        const permission = await request("POST",
+          `/api/session/${encodeURIComponent(parameters.sessionID)}/permission`,
+          { action: "skill", resources: skills.map((skill) => skill.id), save: skills.map((skill) => skill.id) },
+          options?.signal);
+        if (!permission.response.ok) return failedResult(permission);
+        const effect = readString(responseData(permission.payload), "effect");
+        if (effect !== "allow") {
+          const message = effect === "ask"
+            ? "Selected skills require permission. Nothing was sent. Choose Always allow for these skills in the permission request, then send again."
+            : "Selected skills are not permitted in OpenCode v2. Nothing was sent.";
+          return unsupportedResult(baseUrl, "skill.attachment", message);
+        }
+      }
       const modelResult = await request(
         "POST",
         `/api/session/${encodeURIComponent(parameters.sessionID)}/model`,
@@ -1904,7 +1947,7 @@ export function createClientV2(
       const promptResult = await request(
         "POST",
         `/api/session/${encodeURIComponent(parameters.sessionID)}/prompt`,
-        { text },
+        { text, ...(skills.length ? { skills } : {}) },
         options?.signal,
       );
       return promptResult.response.ok ? successfulResult(promptResult, {}) : failedResult(promptResult);

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1457,6 +1457,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                     aria-expanded={toolMenuOpen}
                     aria-haspopup="dialog"
                     title={t("composer.tools_label")}
+                    aria-label={t("composer.tools_label")}
                   >
                     <Plus size={16} />
                   </button>

--- a/apps/app/src/react-app/domains/session/sync/mention-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/mention-parts.ts
@@ -13,7 +13,13 @@ export function mentionPromptParts(part: InstructionMention): [TextPartInput, Te
     type: "text",
     text: label,
     ...(part.type === "connect-skill" ? { metadata: { openworkComposerToken: encodeConnectSkillToken(part) } } : {}),
-  }, { type: "text", text: instruction, synthetic: true }];
+  }, {
+    type: "text", text: instruction, synthetic: true,
+    // Preserve selection identity through every send path. v1 still receives
+    // the instruction; the v2 adapter replaces it with a native attachment.
+    ...(part.type === "skill" ? { metadata: { openworkSelectedSkill: { name: part.name } } } : {}),
+    ...(part.type === "connect-skill" ? { metadata: { openworkSelectedSkill: { id: part.capability } } } : {}),
+  }];
 }
 
 function mentionContent(part: InstructionMention): { label: string; instruction: string } {

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -5,12 +5,78 @@ import {
   createClientV2,
   createV2EventTranslationState,
   translateV2Event,
+  v2PromptText,
   type V2MappedMessage,
 } from "../src/app/lib/opencode-v2-adapter";
 import { parseDynamicToolUIPart } from "../src/react-app/domains/session/sync/parse-tool-parts";
 import { codeModeToolCalls } from "../src/lib/code-mode-tools";
 import { getModelBehaviorControls, getModelBehaviorOptions } from "../src/app/lib/model-behavior";
 import { catalogFastVariants, fastVariantId, nativeModelVariants } from "@openwork/types/cloud-model-fast";
+import { mentionPromptParts } from "../src/react-app/domains/session/sync/mention-parts";
+
+describe("explicit native skill attachments", () => {
+  test("preserves v1 instructions but attaches live native IDs on v2, deduplicated", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: { path: string; body: unknown }[] = [];
+    globalThis.fetch = async (input, init) => {
+      const request = new Request(input, init);
+      requests.push({ path: new URL(request.url).pathname, body: request.method === "POST" ? await request.json() : null });
+      return jsonResponse({ data: request.url.endsWith("/skill") ? [{ id: "native-release", name: "release" }] : { effect: "allow" } });
+    };
+    try {
+      const selected = mentionPromptParts({ type: "skill", name: "release" });
+      expect(selected[1]).toMatchObject({ synthetic: true, text: "Load [skill release] and follow its instructions." });
+      const parts = [{ type: "text", text: "Prepare a report " }, ...selected, selected[1]];
+      expect(v2PromptText(parts)).toBe("Prepare a report [skill release]");
+      const result = await createClientV2("http://localhost:4096/opencode2", "/workspace", {}).session.promptAsync({
+        sessionID: "ses_skills", model: { providerID: "witness", modelID: "model" }, parts,
+      });
+      expect(result.error).toBeUndefined();
+      expect(requests.at(-1)?.body).toEqual({ text: "Prepare a report [skill release]", skills: [{ id: "native-release" }] });
+    } finally { globalThis.fetch = originalFetch; }
+  });
+
+  test.each([{ catalog: [] }, { catalog: [{ id: "one", name: "release" }, { id: "two", name: "release" }] }])("rejects missing or ambiguous selections before sending", async ({ catalog }) => {
+    const originalFetch = globalThis.fetch;
+    const methods: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      methods.push(new Request(input, init).method);
+      return jsonResponse({ data: catalog });
+    };
+    try {
+      const result = await createClientV2("http://localhost:4096/opencode2", "/workspace", {}).session.promptAsync({
+        sessionID: "ses_skills", model: { providerID: "witness", modelID: "model" },
+        parts: mentionPromptParts({ type: "skill", name: "release" }),
+      });
+      expect(result.error).toMatchObject({ message: expect.stringContaining("Nothing was sent") });
+      expect(methods).toEqual(["GET"]);
+    } finally { globalThis.fetch = originalFetch; }
+  });
+
+  test("does not interpret user prose as selection metadata", () => {
+    const text = "Load [skill release] and follow its instructions.";
+    expect(v2PromptText([{ type: "text", text }])).toBe(text);
+    expect(v2PromptText([{ type: "text", text, metadata: { openworkSelectedSkill: { name: "release" } } }])).toBe(text);
+  });
+
+  test.each(["deny", "ask"])("does not send an attachment when native permission is %s", async (effect) => {
+    const originalFetch = globalThis.fetch;
+    const paths: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      const request = new Request(input, init);
+      paths.push(new URL(request.url).pathname);
+      return jsonResponse({ data: request.url.endsWith("/skill") ? [{ id: "release", name: "release" }] : { effect } });
+    };
+    try {
+      const result = await createClientV2("http://localhost:4096/opencode2", "/workspace", {}).session.promptAsync({
+        sessionID: "ses_skills", model: { providerID: "witness", modelID: "model" },
+        parts: mentionPromptParts({ type: "skill", name: "release" }),
+      });
+      expect(result.error).toMatchObject({ message: expect.stringContaining("Nothing was sent") });
+      expect(paths).toEqual(["/opencode2/api/skill", "/opencode2/api/session/ses_skills/permission"]);
+    } finally { globalThis.fetch = originalFetch; }
+  });
+});
 
 const capturedPermissionAsked = {
   id: "evt_permission_asked",

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -12,6 +12,12 @@ import { readdir, readFile } from 'node:fs/promises';
 // journey-ci.test.mjs checks these against what each spec and world guards.
 const PACKAGED_BINARY = { env: ['OPENWORK_EVAL_ELECTRON_BINARY'] };
 const definitions = {
+  'opencode-v2-skill-jit.e2e.test.ts': {
+    cases: [
+      { id: 'SKILL-ATTACH', engines: ['v1', 'v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+      { id: 'SKILL-MISSING', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+    ],
+  },
   'composer-model-picker-no-subscribe-promo.e2e.test.ts': {
     cases: [{ id: 'MODEL-01', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } }],
   },

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -140,6 +140,8 @@ test('mixed-world specs: a prerequisite one case declares is never promoted to t
 test('registered case metadata names exact files, supported execution axes, and defaults', async () => {
   const entries = await catalog();
   assert.deepEqual(registeredCases.map(({ spec, id, engines }) => ({ spec, id, engines })), [
+    { spec: 'opencode-v2-skill-jit.e2e.test.ts', id: 'SKILL-ATTACH', engines: ['v1', 'v2'] },
+    { spec: 'opencode-v2-skill-jit.e2e.test.ts', id: 'SKILL-MISSING', engines: ['v2'] },
     {
       spec: 'composer-model-picker-no-subscribe-promo.e2e.test.ts',
       id: 'MODEL-01',

--- a/evals/specs/opencode-v2-skill-jit.e2e.test.ts
+++ b/evals/specs/opencode-v2-skill-jit.e2e.test.ts
@@ -134,7 +134,8 @@ selectedTest("SKILL-ATTACH explicitly selected skills reach the first native mod
     await user.see({ text: world.reply }, { timeoutMs: 90_000 });
     await user.see("Run task", { timeoutMs: 30_000 });
   });
-  const prompts = await world.promptRequests();
+  const nativeRequests = await world.nativeRequests();
+  const prompts = nativeRequests.filter((request) => request.kind === "prompt").map((request) => request.body);
   expect(prompts).toHaveLength(1);
   const requests = world.providerRequests().filter((request) => record(request)
     && JSON.stringify(request.messages).includes(world.prompt));
@@ -143,6 +144,9 @@ selectedTest("SKILL-ATTACH explicitly selected skills reach the first native mod
   const modelRequests = await world.modelRequests();
   if (world.engine === "v2") {
     expect(prompts[0]).toEqual({ text: expect.stringContaining(world.prompt), skills: [{ id: nativeID }] });
+    // The engine's own permission evaluation is consulted for the resolved id before anything is submitted.
+    expect(nativeRequests.map((request) => request.kind)).toEqual(["permission", "prompt"]);
+    expect(nativeRequests[0]?.body).toMatchObject({ action: "skill", resources: [nativeID] });
     expect(JSON.stringify(prompts[0])).not.toContain("Load ");
     expect(JSON.stringify(first)).toContain(world.skillBody);
     expect(requests).toHaveLength(1);
@@ -165,7 +169,7 @@ selectedTest("SKILL-ATTACH explicitly selected skills reach the first native mod
   expect(await readTranscriptMessages(probe, "user")).toEqual(visible);
   expect(await readTranscriptMessages(probe, "system")).toEqual([]);
   evidence.recordJsonArtifact("SKILL-ATTACH boundary and reload", {
-    engine: world.engine, runtime, nativeID, prompts, modelRequests,
+    engine: world.engine, runtime, nativeID, nativeRequests, modelRequests,
     firstRequestContainsFullBody: JSON.stringify(first).includes(world.skillBody),
     finalRequestContainsFullBody: JSON.stringify(requests.at(-1)).includes(world.skillBody),
     providerRequestCount: requests.length, visibleBeforeReload: visible,
@@ -185,11 +189,11 @@ selectedTest("SKILL-MISSING a selected skill removed from the native registry fa
   });
   await user.click("Run task");
   await user.see({ text: /Selected skill .* is unavailable or ambiguous in OpenCode v2\. Nothing was sent\./ }, { timeoutMs: 30_000 });
-  expect(await world.promptRequests()).toEqual([]);
+  expect(await world.nativeRequests()).toEqual([]);
   expect(world.providerRequests()).toEqual([]);
   expect(await readTranscriptMessages(probe, "assistant")).toEqual([]);
   evidence.recordJsonArtifact("SKILL-MISSING no false submission", {
-    promptRequests: await world.promptRequests(), providerRequests: world.providerRequests(),
+    nativeRequests: await world.nativeRequests(), providerRequests: world.providerRequests(),
     assistantMessages: await readTranscriptMessages(probe, "assistant"),
   });
 });

--- a/evals/specs/opencode-v2-skill-jit.e2e.test.ts
+++ b/evals/specs/opencode-v2-skill-jit.e2e.test.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { expect } from "vitest";
 import { liveOpenAiEnabled } from "@openwork/behaviors";
-import { observeTranscript, readTranscriptMessages, spec } from "@openwork/testkit";
+import { observeTranscript, readTranscriptMessages, spec, type User } from "@openwork/testkit";
 import { skillLifecycle } from "../worlds/chat.ts";
+import { selectedSkillsWeb } from "../worlds/selected-skills.ts";
 
 const test = spec.world(skillLifecycle, {
   timeout: 900_000,
@@ -99,3 +100,96 @@ test("workspace skills change during an ongoing conversation", async ({ world, u
 function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+const selectedTest = spec.world(selectedSkillsWeb, {
+  timeout: 420_000, resources: { surfaces: ["appWeb"], services: ["mock"] },
+});
+
+const openSkillMenu = async (user: User, name: string) => {
+  await user.click({ role: "button", label: "Agents, commands, skills, plugins, and connections" });
+  await user.click({ role: "button", label: "Skills" });
+  await user.click({ role: "button", label: new RegExp(name) });
+};
+
+selectedTest("SKILL-ATTACH explicitly selected skills reach the first native model request and survive reload", async ({ world, user, probe, evidence, step }) => {
+  const runtime = await world.runtimeFacts();
+  expect(runtime.browser).toContain("HeadlessChrome");
+  expect(runtime.electronBridge).toBe(false);
+  const prefix = `/workspace/${world.workspace.workspaceId}/opencode2/api`;
+  const before = world.engine === "v2" ? await world.readNative("/experimental/engine-v2-preview/status") : null;
+  let nativeID = "";
+  if (world.engine === "v2") {
+    expect(before?.body).toMatchObject({ running: true, chatRouting: true });
+    const catalog = await world.readNative(`${prefix}/skill`);
+    const skills = record(catalog.body) && Array.isArray(catalog.body.data) ? catalog.body.data.filter(record) : [];
+    const skill = skills.find((entry) => entry.name === world.skillName);
+    expect(skill?.content).toContain(world.skillBody);
+    if (typeof skill?.id !== "string") throw new Error("Selected skill is not natively registered");
+    nativeID = skill.id;
+  }
+  await step("choose a real skill pill and submit through the composer", async () => {
+    await openSkillMenu(user, world.skillName);
+    await user.type("composer", ` ${world.prompt}`);
+    await user.click("Run task");
+    await user.see({ text: world.reply }, { timeoutMs: 90_000 });
+    await user.see("Run task", { timeoutMs: 30_000 });
+  });
+  const prompts = await world.promptRequests();
+  expect(prompts).toHaveLength(1);
+  const requests = world.providerRequests().filter((request) => record(request)
+    && JSON.stringify(request.messages).includes(world.prompt));
+  expect(requests.length).toBeGreaterThan(0);
+  const first = requests[0];
+  const modelRequests = await world.modelRequests();
+  if (world.engine === "v2") {
+    expect(prompts[0]).toEqual({ text: expect.stringContaining(world.prompt), skills: [{ id: nativeID }] });
+    expect(JSON.stringify(prompts[0])).not.toContain("Load ");
+    expect(JSON.stringify(first)).toContain(world.skillBody);
+    expect(requests).toHaveLength(1);
+    expect(modelRequests).toEqual([expect.objectContaining({ kind: "final", completedTools: 0, toolName: null })]);
+    expect(await world.readNative("/experimental/engine-v2-preview/status")).toEqual(before);
+  } else {
+    expect(JSON.stringify(prompts[0])).toContain(`Load [skill ${world.skillName}] and follow its instructions.`);
+    expect(JSON.stringify(first)).not.toContain(world.skillBody);
+    expect(modelRequests.some((request) => request.toolName === "skill")).toBe(true);
+    expect(JSON.stringify(requests.at(-1))).toContain(world.skillBody);
+  }
+  const visible = await readTranscriptMessages(probe, "user");
+  expect(visible).toHaveLength(1);
+  expect(visible[0]).toContain(world.prompt);
+  expect(visible[0]).not.toContain("Load ");
+  expect(visible[0]).not.toContain(world.skillBody);
+  expect(await readTranscriptMessages(probe, "system")).toEqual([]);
+  await user.reload();
+  await user.see({ text: world.reply }, { timeoutMs: 60_000 });
+  expect(await readTranscriptMessages(probe, "user")).toEqual(visible);
+  expect(await readTranscriptMessages(probe, "system")).toEqual([]);
+  evidence.recordJsonArtifact("SKILL-ATTACH boundary and reload", {
+    engine: world.engine, runtime, nativeID, prompts, modelRequests,
+    firstRequestContainsFullBody: JSON.stringify(first).includes(world.skillBody),
+    finalRequestContainsFullBody: JSON.stringify(requests.at(-1)).includes(world.skillBody),
+    providerRequestCount: requests.length, visibleBeforeReload: visible,
+    visibleAfterReload: await readTranscriptMessages(probe, "user"),
+  });
+});
+
+selectedTest("SKILL-MISSING a selected skill removed from the native registry fails visibly without a model request", async ({ world, user, probe, evidence }) => {
+  expect(world.engine).toBe("v2");
+  await openSkillMenu(user, world.skillName);
+  await user.type("composer", ` ${world.prompt}`);
+  // External fixture change after selection: no user action is replaced by API writes.
+  await world.removeSkill();
+  await probe.eventually(() => world.readNative(`/workspace/${world.workspace.workspaceId}/opencode2/api/skill`), {
+    within: 30_000, label: "removed skill leaves the same engine's native registry",
+    until: (result) => !JSON.stringify(result.body).includes(world.skillName),
+  });
+  await user.click("Run task");
+  await user.see({ text: /Selected skill .* is unavailable or ambiguous in OpenCode v2\. Nothing was sent\./ }, { timeoutMs: 30_000 });
+  expect(await world.promptRequests()).toEqual([]);
+  expect(world.providerRequests()).toEqual([]);
+  expect(await readTranscriptMessages(probe, "assistant")).toEqual([]);
+  evidence.recordJsonArtifact("SKILL-MISSING no false submission", {
+    promptRequests: await world.promptRequests(), providerRequests: world.providerRequests(),
+    assistantMessages: await readTranscriptMessages(probe, "assistant"),
+  });
+});

--- a/evals/worlds/selected-skills.ts
+++ b/evals/worlds/selected-skills.ts
@@ -1,0 +1,116 @@
+import { addInitScript, browserScript } from "@openwork/cdp";
+import { resolveEvalEngine, type Seed } from "@openwork/env";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import { configureProvider } from "./chat.ts";
+
+declare global {
+  interface Window { __selectedSkillPrompts?: unknown[] }
+}
+
+/** Explicit selection, not model-initiated discovery. No Den or Electron. */
+export async function selectedSkillsWeb(seed: Seed) {
+  const engine = resolveEvalEngine();
+  const skillName = "selected-briefing";
+  const skillBody = "When preparing a briefing, include the exact phrase AMBER_BODY_ONLY_7391. Keep the briefing concise.";
+  const prompt = "Prepare a short briefing.";
+  const reply = "The briefing is ready.";
+  const workspacePath = seed.tmpPath("selected-skills");
+  const skillDirectory = join(workspacePath, ".opencode", "skills", skillName);
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(join(skillDirectory, "SKILL.md"), `---\nname: ${skillName}\ndescription: Prepare a concise briefing.\n---\n${skillBody}\n`);
+  const mock = seed.mock({ isolatedProcessEnv: true, agentWorkloads: [{
+    promptMarker: prompt, latestUserTurn: true, finalReply: reply,
+    steps: engine === "v1" ? [{ tool: "skill", arguments: { name: skillName } }] : [],
+  }] });
+  const app = await seed.appWeb({ name: "selected-skills", workspacePath, mocks: { agent: mock } });
+  const witness = app.mocks.agent;
+  if (!witness) throw new Error("Missing selected-skills provider witness");
+  // A transparent provider-boundary witness: records exactly what the native
+  // engine sends, then forwards it unchanged to the standard model mock.
+  const providerRequests: unknown[] = [];
+  const proxy = createServer(async (request, response) => {
+    try {
+      let body = "";
+      for await (const chunk of request) body += chunk;
+      if (body) providerRequests.push(JSON.parse(body));
+      const upstream = await fetch(`${witness.url}${request.url}`, {
+        method: request.method, headers: { "content-type": "application/json" },
+        ...(body ? { body } : {}),
+      });
+      response.writeHead(upstream.status, { "content-type": upstream.headers.get("content-type") ?? "application/json" });
+      const reader = upstream.body?.getReader();
+      if (reader) {
+        try {
+          for (;;) {
+            const chunk = await reader.read();
+            if (chunk.done) break;
+            response.write(chunk.value);
+          }
+        } finally { reader.releaseLock(); }
+      }
+      response.end();
+    } catch { response.writeHead(502); response.end("Provider witness failed"); }
+  });
+  await new Promise<void>((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+  const address = proxy.address();
+  if (!address || typeof address === "string") throw new Error("Missing provider witness port");
+  const dispose = async () => {
+    proxy.closeAllConnections();
+    await new Promise<void>((resolve, reject) => proxy.close((error) => error ? reject(error) : resolve()));
+  };
+  try {
+    await addInitScript(app.client, () => {
+      window.__selectedSkillPrompts = [];
+      const original = window.fetch.bind(window);
+      window.fetch = async (input, init) => {
+        const request = new Request(input instanceof Request ? input.clone() : input, init);
+        if (request.method === "POST" && /\/(?:prompt|prompt_async)$/.test(new URL(request.url).pathname)) {
+          window.__selectedSkillPrompts?.push(await request.clone().json());
+        }
+        return original(input, init);
+      };
+    });
+    const workspace = await seed.workspace(app, workspacePath);
+    const providerId = "selected-skill-witness";
+    const modelId = "briefing-model";
+    await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+      permission: { skill: "allow" },
+      provider: { [providerId]: {
+        npm: "@ai-sdk/openai-compatible", name: "Selected skill witness",
+        options: { baseURL: `http://127.0.0.1:${address.port}/v1`, apiKey: "synthetic-skill-key" },
+        models: { [modelId]: { name: "Briefing witness", tool_call: true } },
+      } },
+    }, engine);
+    // Native catalog readiness is not renderer hydration. Do not create the
+    // fixture session until the real composer has the arranged model.
+    const ready = await seed.evalIn(app, async () => {
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        if (document.querySelector('[aria-label="Change model"]')?.textContent?.includes("Briefing witness")) return true;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      return false;
+    }, { awaitPromise: true, timeoutMs: 35_000 });
+    if (!ready) throw new Error("Selected-skill composer did not hydrate the fixture model");
+    const session = await seed.session(app, { title: "Selected skill contract" });
+    return {
+      app, workspace, session, engine, skillName, skillBody, prompt, reply, modelId,
+      removeSkill: () => rm(skillDirectory, { recursive: true }),
+      promptRequests: () => seed.evalIn(app, () => window.__selectedSkillPrompts ?? []),
+      providerRequests: () => providerRequests,
+      modelRequests: () => witness.agentRequests({ promptMarker: prompt }),
+      runtimeFacts: () => seed.evalIn(app, () => ({ browser: navigator.userAgent, electronBridge: Boolean(window.__OPENWORK_ELECTRON__) })),
+      readNative: (path: string) => seed.evalIn(app, browserScript(async (path) => {
+        const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port") + path, {
+          headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") },
+          signal: AbortSignal.timeout(15_000),
+        });
+        const body: unknown = await response.json();
+        return { status: response.status, body };
+      }, [path]), { awaitPromise: true, timeoutMs: 20_000 }),
+      [Symbol.asyncDispose]: dispose,
+    };
+  } catch (error) { await dispose(); throw error; }
+}

--- a/evals/worlds/selected-skills.ts
+++ b/evals/worlds/selected-skills.ts
@@ -5,6 +5,10 @@ import { createServer } from "node:http";
 import { join } from "node:path";
 import { configureProvider } from "./chat.ts";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 declare global {
   interface Window { __selectedSkillPrompts?: unknown[] }
 }
@@ -66,8 +70,9 @@ export async function selectedSkillsWeb(seed: Seed) {
       const original = window.fetch.bind(window);
       window.fetch = async (input, init) => {
         const request = new Request(input instanceof Request ? input.clone() : input, init);
-        if (request.method === "POST" && /\/(?:prompt|prompt_async)$/.test(new URL(request.url).pathname)) {
-          window.__selectedSkillPrompts?.push(await request.clone().json());
+        const pathname = new URL(request.url).pathname;
+        if (request.method === "POST" && /\/(?:prompt|prompt_async|permission)$/.test(pathname)) {
+          window.__selectedSkillPrompts?.push({ kind: pathname.endsWith("/permission") ? "permission" : "prompt", body: await request.clone().json() });
         }
         return original(input, init);
       };
@@ -98,7 +103,12 @@ export async function selectedSkillsWeb(seed: Seed) {
     return {
       app, workspace, session, engine, skillName, skillBody, prompt, reply, modelId,
       removeSkill: () => rm(skillDirectory, { recursive: true }),
-      promptRequests: () => seed.evalIn(app, () => window.__selectedSkillPrompts ?? []),
+      /** Native-boundary requests the app made, in order: permission asks and prompt submissions. */
+      nativeRequests: async () => {
+        const entries = await seed.evalIn(app, () => window.__selectedSkillPrompts ?? []);
+        return entries.flatMap((entry) => isRecord(entry) && (entry.kind === "permission" || entry.kind === "prompt")
+          ? [{ kind: entry.kind, body: entry.body }] : []);
+      },
       providerRequests: () => providerRequests,
       modelRequests: () => witness.agentRequests({ promptMarker: prompt }),
       runtimeFacts: () => seed.evalIn(app, () => ({ browser: navigator.userAgent, electronBridge: Boolean(window.__OPENWORK_ELECTRON__) })),


### PR DESCRIPTION
## Current-head readiness — September 11

Head: `aadc82d0ce4f84ceaf8a1281539149cfe422f13b`; rebased onto `dev` at `679784ef62488df107dd3559cdba9582de061f63`. GitHub reports CLEAN / MERGEABLE with required checks and security clearance passing. Not merged.

**Verification: Incomplete for published evidence; the selected runtime tests passed.**

- Passed on this head: `pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case SKILL-ATTACH` and `--case SKILL-MISSING`. Each exited 0: 1 passed, 0 failed, 0 selected skips; other cases were filtered out, not passed. Fresh isolated app-web profiles, real v2 engine, mock provider.
- Attachment reaches the first model request; native permission evaluation precedes submission; reload preserves the transcript. Removed selection fails visibly without sending.
- Earlier rebase diagnostics: app typecheck passed; adapter tests 90 passed / 1 failed. The same model-behavior failure reproduced on clean dev (84 passed / 1 failed); it was not changed here.
- Deferred: v1 journey rerun, native deny/ask runtime proof and Electron/Daytona coverage. Historical evidence below does not certify this head.
- `pnpm evals:e2e --publish --pr 4878 --all` could not publish the saved records: review credentials were not available in the terminal and the secret-store login is required. No test rerun is needed solely to publish.

**UI/UX impact:** No additional UI/UX changes from the rebase. The original feature attaches selected skills natively, shows an error rather than sending when unavailable/ambiguous/denied, and adds the existing title as the tools button accessible label. Existing layout and v1 instruction behavior are preserved.

---

## Original implementation and historical proof

## Problem

Selecting a skill in the composer turned into prose ("Load [skill …] and follow its instructions"). On OpenCode v2 the adapter flattened parts into `{ text }` and never used the native prompt `skills` attachment, so the skill body was only in context if the model remembered to call the skill tool.

## What changed

- `apps/app/src/react-app/domains/session/sync/mention-parts.ts`: the generated skill/connect-skill instruction part carries `metadata.openworkSelectedSkill` (`{ name }` for workspace skills, `{ id }` for connect skills). v1 still receives the instruction text unchanged.
- `apps/app/src/app/lib/opencode-v2-adapter.ts` (`promptAsync`): for each selection, resolve the id against the same engine's live `GET /api/skill`; fail with a visible error when the selection is missing or ambiguous; `POST /api/session/:id/permission { action: "skill", resources, save }` and refuse to send unless the engine answers `allow`; then `POST …/prompt { text, skills: [{ id }] }` (pinned beta-19086 `PromptInput.SkillAttachment` shape). `v2PromptText` drops only selection-marked synthetic parts, so the visible text and the acknowledgement correlation stay the user's own text.
- `composer.tsx`: the icon-only tools button gains `aria-label` (same string as its title) so trusted UI input can open it.
- Journey `evals/specs/opencode-v2-skill-jit.e2e.test.ts` gains registered headless-web cases `SKILL-ATTACH` (v1+v2) and `SKILL-MISSING` (v2) on a new dedicated world `evals/worlds/selected-skills.ts` (transparent provider-boundary proxy in front of the standard model mock; no `evals/worlds/chat.ts` edits). Catalog: `journey-catalog.mjs` + `journey-ci.test.mjs`.

Final SHA: `9ca2b91841105d872ba6f07cc2ea4ef2a1ac65db` (base `origin/dev` `c23085ad2`). Both commits SSH-signed (`%G?` = `G`).

## Acceptance → assertion mapping

| # | Claim | Case | Assertion (spec) |
|---|---|---|---|
| 1 | v2 submits native `skills: [{ id }]`; full body in the FIRST model request, no skill tool call | SKILL-ATTACH v2 | `prompts[0]` equals `{ text: …, skills: [{ id: nativeID }] }` where `nativeID` was read from the same engine's `/api/skill`; provider-boundary proxy's first request contains the full skill body; exactly 1 provider request; model witness `completedTools: 0, toolName: null`; engine pid unchanged |
| 1b | Engine permission evaluation is consulted for the resolved id before sending | SKILL-ATTACH v2 | native request order is `["permission", "prompt"]`, permission body `{ action: "skill", resources: [nativeID] }` |
| 2 | Transcript shows user text, no "Load …", no leaked/duplicate internal message | SKILL-ATTACH v1+v2 | exactly 1 visible user message containing the prompt, not containing `Load ` or the skill body; `system` transcript empty |
| 3 | Unregistered selection fails visibly, nothing sent | SKILL-MISSING v2 | skill dir removed after the pill is chosen (fixture change, not a user-action substitute); registry polled until gone; visible error `Selected skill … is unavailable or ambiguous in OpenCode v2. Nothing was sent.`; zero native requests, zero provider requests, zero assistant messages |
| 4 | v1 unchanged | SKILL-ATTACH v1 | prompt contains the existing `Load [skill …]` instruction; first provider request does **not** contain the body; a `skill` tool call happens; final request contains the body; same transcript assertions |
| 5 | Reload shows the message exactly once | SKILL-ATTACH v1+v2 | after `user.reload()` the user transcript equals the pre-reload list (length 1) and `system` is empty |

Adapter unit diagnostics (`apps/app/tests/opencode-v2-adapter.test.ts`, 6 new): dedup + native shape; missing/ambiguous catalog → error before any POST; prose is never treated as selection metadata; `deny`/`ask` permission → error, prompt never posted.

## Commands and exit codes (on `9ca2b9184`, isolated worktree, headless web lane only)

```
env -i HOME=… TMPDIR=… PATH=… OPENWORK_EVAL_CHROME_HEADLESS=1 pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case SKILL-ATTACH   → exit 0, passed 1 / failed 0 / skipped 0
… --engine v2 --case SKILL-MISSING                                                                                                        → exit 0, passed 1 / failed 0 / skipped 0
… --engine v1 --case SKILL-ATTACH                                                                                                         → exit 0, passed 1 / failed 0 / skipped 0
pnpm --filter @openwork/app typecheck                                                                                                     → exit 0
bun test tests/opencode-v2-adapter.test.ts                                                                                                → 89 pass / 1 fail (see pre-existing)
node --test evals/scripts/journey-ci.test.mjs                                                                                             → 13 pass / 0 fail
pnpm warden:check (bare, clean committed head)                                                                                            → exit 0, No findings
```

Receipts (worktree `evals/results/test-runs/`): `2026-09-11T00-27-41-500Z-skill-attach-…` (v2), `2026-09-11T00-27-57-851Z-skill-missing-…` (v2), `2026-09-11T00-28-12-481Z-skill-attach-…` (v1); each `test-run.json` records `gitSha: 9ca2b918…`.

## Warden

Run 1 on `76817b148`: 3 skills clean, 1 medium spec-provenance advisory ("SKILL-ATTACH does not prove native permission evaluation is consulted"). Fixed by the second commit (permission-before-prompt witness). Run 2 on `9ca2b9184`: `2100a313-2026-09-11T00-28-52-677Z` — diff-security-review, confidentiality-review, spec-provenance-review, desktop-den-sync-review all **No findings**. Skipped files: none (8/8 changed files reviewed).

## Pre-existing (classified against a clean `origin/dev` `c23085ad2` control worktree)

- `bun test tests/opencode-v2-adapter.test.ts`: `v2 provider catalog retains display names…` fails identically on the control (83 pass / 1 fail there).
- `evals` `tsc --noEmit`: 410 errors on both branch and control, none in files touched here.

## Limits

- **Native deny is not observable in this lane.** A `SKILL-DENIED` case was attempted: the workspace `permission.skill` block never reaches the v2 engine here (live `/api/agent` showed every agent with a leading `{action:"*",resource:"*",effect:"allow"}` and no `skill` rules; no `openwork` agent), so the engine honestly answered `allow`. That is `apps/server` engine-config plumbing, outside this PR. The deny/ask branches of the adapter are covered by unit diagnostics only; the e2e proves the evaluation is requested and ordered before the prompt.
- The `ask` outcome refuses to send and leaves the engine's pending permission request visible for the user to resolve, then requires a resend.
- Hosted evidence publisher not configured (`OPENWORK_REVIEW_URL` unset); evidence is inline below. Electron/Daytona not exercised. The pre-existing `skillLifecycle` case in this spec was not run (it boots Den/desktop).

## For Task B (Cloud skills → native v2 registry)

Cloud-sourced skills flow through this path with no adapter change as long as: (1) they appear in the engine's `GET /api/skill` with a stable `id`, (2) the connect-skill pill's `capability` string equals that native `id` (the adapter matches connect skills by `id`, workspace skills by unique `name`), and (3) the engine's `skill` permission evaluation returns `allow` (or has rules) for those ids.

<!-- test-evidence -->
### Test evidence (inline, redacted JSON extracts, commit `9ca2b9184`)

**SKILL-ATTACH v2** — `passed`
```json
{"engine":"v2","runtime":{"browser":"…HeadlessChrome/153…","electronBridge":false},"nativeID":"selected-briefing",
 "nativeRequests":[{"kind":"permission","body":{"action":"skill","resources":["selected-briefing"],"save":["selected-briefing"]}},
                   {"kind":"prompt","body":{"text":"[skill selected-briefing]  Prepare a short briefing.","skills":[{"id":"selected-briefing"}]}}],
 "modelRequests":[{"kind":"final","completedTools":0,"toolName":null}],
 "firstRequestContainsFullBody":true,"providerRequestCount":1,
 "visibleBeforeReload":["selected-briefing  Prepare a short briefing.\n…"],"visibleAfterReload":["selected-briefing  Prepare a short briefing.\n…"]}
```

**SKILL-MISSING v2** — `passed`
```json
{"nativeRequests":[],"providerRequests":[],"assistantMessages":[]}
```
(visible error asserted: `Selected skill … is unavailable or ambiguous in OpenCode v2. Nothing was sent.`)

**SKILL-ATTACH v1** — `passed`
```json
{"engine":"v1","prompts":[{"parts":[{"type":"text","text":"[skill selected-briefing]"},{"type":"text","text":"Load [skill selected-briefing] and follow its instructions.","synthetic":true,"metadata":{"openworkSelectedSkill":{"name":"selected-briefing"}}},{"type":"text","text":"  Prepare a short briefing."}]}],
 "modelRequests toolName":["skill",null],"firstRequestContainsFullBody":false,"finalRequestContainsFullBody":true,"providerRequestCount":2,
 "visibleBeforeReload":["selected-briefing  Prepare a short briefing.\n…"],"visibleAfterReload":["selected-briefing  Prepare a short briefing.\n…"]}
```

Verdict: **Passed** for the three registered cases; native-deny e2e **Incomplete** (unarrangeable in this lane, see Limits).
