### PR TITLE
fix(server): make provider-sync reloads truthful about applied engine state

### DIFF
--- a/apps/server/src/cloud-provider-sync-drain-defer.test.ts
+++ b/apps/server/src/cloud-provider-sync-drain-defer.test.ts
@@ -28,10 +28,15 @@ type FakeEngine = {
 type Fixture = {
   engineA: FakeEngine;
   pool: EnginePool;
+  workspace: WorkspaceInfo;
   serverBaseUrl: string;
   spawnCount: () => number;
+  lastSpawnedUrl: () => string | null;
   releaseDrain: () => void;
   releaseProviderList: () => void;
+  /** Hold the next standby spawn until the returned release runs. */
+  holdNextSpawn: () => () => void;
+  setProviderApiKey: (value: string) => void;
 };
 
 const savedEnv = new Map<string, string | undefined>();
@@ -218,6 +223,7 @@ beforeEach(async () => {
   } as ServerConfig;
 
   let spawnCount = 0;
+  let spawnGate: Promise<void> | null = null;
   const pool = new EnginePool({
     config,
     template: {
@@ -234,6 +240,9 @@ beforeEach(async () => {
       registerTrusted: () => undefined,
       clearTrusted: () => undefined,
       spawn: async () => {
+        const gate = spawnGate;
+        spawnGate = null;
+        if (gate) await gate;
         const engine = await startFakeEngine();
         engines.push(engine);
         spawnCount += 1;
@@ -289,6 +298,7 @@ beforeEach(async () => {
     port: 0,
     async fetch(request) {
       const url = new URL(request.url);
+      // PUT /den-session verifies the organization's desktop policy first.
       if (url.pathname === "/v1/me/desktop-config") return Response.json({});
       if (url.pathname === "/v1/llm-providers") {
         markProviderListReached();
@@ -317,14 +327,26 @@ beforeEach(async () => {
       orgId: "org_a",
     }),
   });
-  if (sessionResponse.status !== 204) throw new Error(`failed to set Den session: ${sessionResponse.status}`);
+  if (sessionResponse.status !== 204) throw new Error(`failed to set Den session: ${sessionResponse.status} ${await sessionResponse.text()}`);
   await providerListReached;
 
   fixture = {
     engineA,
     pool,
+    workspace,
     serverBaseUrl,
     spawnCount: () => spawnCount,
+    lastSpawnedUrl: () => engines[engines.length - 1]?.handle.url ?? null,
+    holdNextSpawn: () => {
+      let release: () => void = () => undefined;
+      spawnGate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return () => release();
+    },
+    setProviderApiKey: (value) => {
+      provider.apiKey = value;
+    },
     releaseDrain: () => {
       if (heartbeat) clearInterval(heartbeat);
       heartbeat = null;
@@ -405,4 +427,63 @@ describe("cloud provider sync drain defer", () => {
     expect(settledStatus.reloadPending).toBe(false);
     expect(settledSpawnCount).toBe(2);
   }, 10_000);
+
+  test("credentialRotation: a key-only rotation rolls over although the config fingerprint is unchanged", async () => {
+    const { pool, releaseDrain, releaseProviderList, serverBaseUrl, setProviderApiKey, spawnCount } = currentFixture();
+    releaseDrain();
+    expect(await waitUntil(() => !pool.hasDrainingGeneration(), 5_000)).toBe(true);
+    releaseProviderList();
+    const materialized = await Promise.race([runSync(serverBaseUrl), timeout(5_000)]);
+    expect(materialized.status).toBe("applied");
+    expect(await waitUntil(async () => (await syncStatus(serverBaseUrl)).reloadPending === false, 5_000)).toBe(true);
+    expect(await waitUntil(() => !pool.hasDrainingGeneration(), 5_000)).toBe(true);
+    const spawnsBeforeRotation: number = spawnCount();
+    const primaryBeforeRotation = pool.primaryUrl();
+
+    // Den rotates only the key. The engine-visible config bytes are identical,
+    // so the pool's fingerprint cannot see the change; the forced rollover
+    // must still replace the generation holding the cached SDK client.
+    setProviderApiKey("sk-test-provider-rotated");
+    const rotated = await Promise.race([runSync(serverBaseUrl), timeout(5_000)]);
+    const status = await syncStatus(serverBaseUrl);
+
+    expect(rotated.status).toBe("applied");
+    expect(status.reloadPending).toBe(false);
+    expect(spawnCount()).toBe(spawnsBeforeRotation + 1);
+    expect(pool.primaryUrl()).not.toBe(primaryBeforeRotation);
+  }, 15_000);
+
+  test("inFlightCoalesce: a sync that coalesces into an in-flight rollover stays pending until its own rollover lands", async () => {
+    const { holdNextSpawn, lastSpawnedUrl, pool, releaseDrain, releaseProviderList, serverBaseUrl, spawnCount, workspace } = currentFixture();
+    releaseDrain();
+    expect(await waitUntil(() => !pool.hasDrainingGeneration(), 5_000)).toBe(true);
+
+    // Another caller's rollover is mid-spawn when the sync pass arrives.
+    const releaseSpawn = holdNextSpawn();
+    const inFlight = pool.requestRollover({ reason: "operation_route", workspace, manual: true });
+    const run = runSync(serverBaseUrl);
+    await sleep(25);
+    releaseProviderList();
+    await sleep(500);
+
+    // The coalesced acknowledgement is not a landed reload: the owed reload
+    // must stay visible while the queued rollover has not run yet.
+    const spawnsWhileHeld: number = spawnCount();
+    const heldStatus = await syncStatus(serverBaseUrl);
+    releaseSpawn();
+    expect(spawnsWhileHeld).toBe(1);
+    expect(heldStatus.reloadPending).toBe(true);
+
+    expect((await inFlight).action).toBe("rolled_over");
+    const result = await Promise.race([run, timeout(10_000)]);
+    expect(result.status).toBe("applied");
+    expect(await waitUntil(async () => (await syncStatus(serverBaseUrl)).reloadPending === false, 5_000)).toBe(true);
+    const settled = await syncStatus(serverBaseUrl);
+    const lastRun = isRecord(settled.lastRun) ? settled.lastRun : {};
+    expect(lastRun.status).toBe("applied");
+    // Initial standby, the in-flight rollover, then the sync's own queued
+    // rollover: the final primary is the last generation spawned.
+    expect(spawnCount()).toBe(3);
+    expect(pool.primaryUrl()).toBe(lastSpawnedUrl());
+  }, 20_000);
 });

--- a/apps/server/src/cloud-provider-sync-reload-guard.test.ts
+++ b/apps/server/src/cloud-provider-sync-reload-guard.test.ts
@@ -269,6 +269,75 @@ describe("engine reload guard", () => {
     expect(await waitUntil(() => rollovers === 1, 3_000)).toBe(true);
   });
 
+  test("a forced rollover the pool did not apply keeps the reload pending and the status loud until it lands", async () => {
+    previousReloadRetry = process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS;
+    process.env.OPENWORK_ENGINE_RELOAD_RETRY_MS = "50";
+    const root = await createTempRoot();
+    const engine = startFakeEngine();
+    const baseUrl = `http://127.0.0.1:${engine.port}`;
+    const config = serverConfig(root, baseUrl);
+    const rollovers: Array<{ forceStandby: boolean | undefined; reason: string }> = [];
+    let outcome: Awaited<ReturnType<EnginePool["requestRollover"]>> = { action: "skipped", reason: "unchanged" };
+    const fakePool = {
+      hasDrainingGeneration: () => false,
+      requestRollover: async (input: Parameters<EnginePool["requestRollover"]>[0]) => {
+        rollovers.push({ forceStandby: input.forceStandby, reason: input.reason });
+        return outcome;
+      },
+      connections: () => [{ generationId: "gen_fake", role: "primary", baseUrl, username: "", password: "" }],
+      primaryUrl: () => baseUrl,
+      routeRequest: () => null,
+      reportRequestSuccess: () => undefined,
+      reportRequestFailure: () => undefined,
+      snapshot: () => ({ generations: [] }),
+    } as unknown as EnginePool;
+    setEnginePoolForConfig(config, fakePool);
+    stops.push(() => clearEnginePoolForConfig(config));
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+    const den = startFakeDen({ providers: [guardProvider()] });
+    const put = await fetch(`${base}/den-session`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ baseUrl: den.url, token: "den_token", orgId: "org_test" }),
+    });
+    expect(put.status).toBe(204);
+
+    // The pool answered "skipped" to a forced request: nothing was applied, so
+    // the sync must neither clear the owed reload nor report the pass as applied.
+    const run = await readJsonObject(await fetch(`${base}/cloud-provider-sync/run`, {
+      method: "POST",
+      headers: hostHeaders(),
+      body: JSON.stringify({ reason: "skipped_by_pool" }),
+    }));
+    expect(rollovers.length).toBeGreaterThanOrEqual(1);
+    expect(rollovers.every((entry) => entry.forceStandby === true)).toBe(true);
+    expect(run.status).toBe("failed");
+    const stuck = await readJsonObject(await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() }));
+    expect(stuck.reloadPending).toBe(true);
+    const stuckLastRun = isRecord(stuck.lastRun) ? stuck.lastRun : {};
+    expect(stuckLastRun.status).toBe("failed");
+    expect(String(stuckLastRun.message ?? "")).toContain("skipped");
+
+    // The retry poll keeps asking; once a generation actually lands the owed
+    // reload clears and the status settles to a truthful applied.
+    outcome = { action: "rolled_over", generationId: "gen_next", drainingSessions: 0 };
+    const rolloversBefore = rollovers.length;
+    const settled = await (async () => {
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const status = await readJsonObject(await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() }));
+        const lastRun = isRecord(status.lastRun) ? status.lastRun : {};
+        if (lastRun.status === "applied" && status.reloadPending === false) return status;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      return null;
+    })();
+    expect(settled).not.toBeNull();
+    expect(rollovers.length).toBeGreaterThan(rolloversBefore);
+  });
+
   test("global provider patch defers the reload while sessions are busy and applies it once idle", async () => {
     const root = await createTempRoot();
     const engine = startFakeEngine();

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -227,7 +227,7 @@ describe("cloud provider sync gateway", () => {
         if (init?.method === "PUT") engineAuth.set(id, "synced-fixture-auth");
         return Response.json(true);
       }, { preconnect: globalThis.fetch.preconnect });
-      const sync = new CloudProviderSync({ config, env, fetchImpl, reloadEngine: async () => {} });
+      const sync = new CloudProviderSync({ config, env, fetchImpl, reloadEngine: reloadedInPlace });
       stops.push(() => sync.stop());
       if (mode !== "cold cleanup") {
         await sync.setSession({ baseUrl: "https://den.example.test", token: "fixture-session", orgId: "org_fixture" });
@@ -284,7 +284,7 @@ describe("cloud provider sync gateway", () => {
         return Response.json(true);
       }, { preconnect: globalThis.fetch.preconnect });
       if (ownership === "persisted sync") {
-        const sync = new CloudProviderSync({ config, env, fetchImpl, reloadEngine: async () => {} });
+        const sync = new CloudProviderSync({ config, env, fetchImpl, reloadEngine: reloadedInPlace });
         stops.push(() => sync.stop());
         await sync.setSession({ baseUrl: "https://den.example.test", token: "fixture-session", orgId: "org_fixture" });
         expect((await sync.run("genuine-ownership")).status).toBe("applied");
@@ -307,7 +307,7 @@ describe("cloud provider sync gateway", () => {
       engineRequests.length = 0;
       // New config and sync objects discard both in-memory ownership caches.
       const cold = new CloudProviderSync({ config: serverConfig(root, "https://engine.example.test"), env,
-        fetchImpl, reloadEngine: async () => {} });
+        fetchImpl, reloadEngine: reloadedInPlace });
       stops.push(() => cold.stop());
       await cold.clearSession();
       expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))[id]).toBeUndefined();
@@ -892,7 +892,7 @@ describe("cloud provider sync gateway", () => {
       models: { model: { id: "model", name: "Model" } },
     } } }));
     const sync = new CloudProviderSync({
-      config, env: new EnvService({ path: process.env.OPENWORK_ENV_STORE }), reloadEngine: async () => {},
+      config, env: new EnvService({ path: process.env.OPENWORK_ENV_STORE }), reloadEngine: reloadedInPlace,
       fetchImpl: Object.assign(async (input: URL | RequestInfo) => {
         const { pathname } = new URL(String(input));
         if (pathname === "/v1/inference-providers") return Response.json({ inferenceProviders: [] });
@@ -1044,7 +1044,7 @@ describe("cloud provider sync gateway", () => {
       config,
       env,
       fetchImpl,
-      reloadEngine: async () => undefined,
+      reloadEngine: reloadedInPlace,
       intervalMs: 3_600_000,
     });
     stops.push(() => sync.stop());

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { EnvService } from "./env-file.js";
 import { CloudProviderSync } from "./cloud-provider-sync.js";
 import { openworkRuntimeConfigFilePath } from "./openwork-runtime-config.js";
-import { clearEnginePoolForConfig, setEnginePoolForConfig, type EnginePool } from "./engine-pool.js";
+import { clearEnginePoolForConfig, setEnginePoolForConfig, type EnginePool, type RolloverOutcome } from "./engine-pool.js";
 import { readOpenworkWorkspaceConfig, writeOpenworkWorkspaceConfig } from "./openwork-workspace-config-store.js";
 import {
   readGlobalRuntimeOpencodeConfig,
@@ -19,6 +19,8 @@ import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
 
 const clientToken = "owt_cloud_provider_client";
+/** Stub reload that reports the engine applied the change in place. */
+const reloadedInPlace = async (): Promise<RolloverOutcome> => ({ action: "reloaded_in_place" });
 const hostToken = "owt_cloud_provider_host";
 const roots: string[] = [];
 const stops: Array<() => void | Promise<void>> = [];
@@ -411,7 +413,7 @@ describe("cloud provider sync gateway", () => {
       }, { preconnect: globalThis.fetch.preconnect });
       const env = new EnvService({ path: process.env.OPENWORK_ENV_STORE });
       const sync = new CloudProviderSync({ config, env, fetchImpl, engineBusy: async () => true,
-        reloadEngine: async () => { reloads += 1; }, intervalMs: 3_600_000 });
+        reloadEngine: async () => { reloads += 1; return reloadedInPlace(); }, intervalMs: 3_600_000 });
       stops.push(() => sync.stop());
       const session = { baseUrl: "https://den.example.test", token: "token-a", orgId: "org_a" };
       try {
@@ -643,6 +645,7 @@ describe("cloud provider sync gateway", () => {
       engineBusy: async () => engineBusy,
       reloadEngine: async () => {
         reloads += 1;
+        return reloadedInPlace();
       },
       intervalMs: 3_600_000,
     });
@@ -720,6 +723,7 @@ describe("cloud provider sync gateway", () => {
         reloads += 1;
         // A reload flips the pool onto a fresh generation.
         generationId = `generation-${reloads + 1}`;
+        return { action: "rolled_over", generationId, drainingSessions: 0 };
       },
       intervalMs: 3_600_000,
     });
@@ -768,7 +772,7 @@ describe("cloud provider sync gateway", () => {
       env: new EnvService({ path: process.env.OPENWORK_ENV_STORE }),
       fetchImpl,
       engineBusy: async () => draining,
-      reloadEngine: async () => { reloads += 1; },
+      reloadEngine: async () => { reloads += 1; return reloadedInPlace(); },
       intervalMs: 3_600_000,
     });
     stops.push(() => sync.stop());
@@ -845,6 +849,7 @@ describe("cloud provider sync gateway", () => {
       env: new EnvService({ path: process.env.OPENWORK_ENV_STORE }),
       reloadEngine: async () => {
         reloads += 1;
+        return reloadedInPlace();
       },
       intervalMs: 3_600_000,
     });
@@ -935,7 +940,7 @@ describe("cloud provider sync gateway", () => {
     const sync = new CloudProviderSync({
       config,
       env: new EnvService({ path: process.env.OPENWORK_ENV_STORE }),
-      reloadEngine: async () => undefined,
+      reloadEngine: reloadedInPlace,
       intervalMs: 3_600_000,
     });
     stops.push(() => sync.stop());
@@ -1202,7 +1207,7 @@ describe("cloud provider sync gateway", () => {
       config,
       env,
       fetchImpl,
-      reloadEngine: async () => undefined,
+      reloadEngine: reloadedInPlace,
       intervalMs: 3_600_000,
     });
     stops.push(() => sync.stop());
@@ -1299,7 +1304,7 @@ describe("cloud provider sync gateway", () => {
     const envValues = async () => new Map((await env.list()).map((entry) => [entry.key, entry.value]));
     const session = { baseUrl: "https://den.example.test", token: "den-token", orgId: "org-env-upgrade" };
     const newSync = () => {
-      const sync = new CloudProviderSync({ config, env, fetchImpl, reloadEngine: async () => undefined, intervalMs: 3_600_000 });
+      const sync = new CloudProviderSync({ config, env, fetchImpl, reloadEngine: reloadedInPlace, intervalMs: 3_600_000 });
       stops.push(() => sync.stop());
       return sync;
     };

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import type { GatewayAuthorizationRequest, GatewayDesktopOauthStartResponse, GatewayUsableModel } from "@openwork/types/den/gateway";
 import { catalogFastVariants, CLOUD_MODEL_CONFIG_VERSION } from "@openwork/types/cloud-model-fast";
 
+import { rolloverOutcomeApplied, type RolloverOutcome } from "./engine-pool.js";
 import type { EnvService } from "./env-file.js";
 import { ApiError } from "./errors.js";
 import { selectPrimaryCredentialEnvName, syncManagedProviderAuth } from "./managed-provider-auth.js";
@@ -198,7 +199,13 @@ type CloudProviderSyncPendingSession = {
 export type CloudProviderSyncOptions = {
   config: ServerConfig;
   env: EnvService;
-  reloadEngine: () => Promise<void>;
+  /**
+   * Bring the engine onto the materialized config and credentials. The
+   * outcome decides whether the owed reload clears: only an applied action
+   * (`rolled_over`, `reloaded_in_place`) proves the engine read them. A
+   * `skipped` or `coalesced` answer leaves the reload pending and retried.
+   */
+  reloadEngine: () => Promise<RolloverOutcome>;
   /**
    * Reports whether the managed engine currently has non-idle sessions.
    * When it returns true a pending engine reload is deferred to a later
@@ -801,7 +808,7 @@ function configuredReloadRetryMs(): number {
 export class CloudProviderSync {
   private readonly config: ServerConfig;
   private readonly env: EnvService;
-  private readonly reloadEngine: () => Promise<void>;
+  private readonly reloadEngine: () => Promise<RolloverOutcome>;
   private readonly engineBusy?: () => Promise<boolean>;
   private readonly fetchImpl: typeof globalThis.fetch;
   private readonly logger?: CloudProviderSyncLogger;
@@ -1111,7 +1118,12 @@ export class CloudProviderSync {
           return;
         }
         try {
-          await this.reloadEngine();
+          const outcome = await this.reloadEngine();
+          if (!rolloverOutcomeApplied(outcome)) {
+            // Still owed: the engine did not read the materialized config.
+            this.scheduleReloadRetry();
+            return;
+          }
           this.reloadPending = false;
           // A landed retry settles a previously failed run: without this the
           // status would stay "failed" forever even though the engine now
@@ -1300,8 +1312,22 @@ export class CloudProviderSync {
         this.scheduleReloadRetry();
       } else {
         try {
-          await this.reloadEngine();
-          this.reloadPending = false;
+          const outcome = await this.reloadEngine();
+          if (rolloverOutcomeApplied(outcome)) {
+            this.reloadPending = false;
+          } else if (outcome.action === "coalesced") {
+            // Parked behind a drain or throttle inside the pool: it lands
+            // later, so keep it owed and visible rather than calling it done.
+            reloadDeferred = true;
+            this.scheduleReloadRetry();
+          } else {
+            // The engine answered "skipped" to a change it must apply (a
+            // rotated key never shows in its config fingerprint). Clearing
+            // reloadPending here is what reported "applied" while the engine
+            // still served the previous credential.
+            reloadError = new Error(`cloud_provider_engine_reload_skipped: ${outcome.reason}`);
+            this.scheduleReloadRetry();
+          }
         } catch (error) {
           reloadError = error;
           // Self-heal like the busy-deferral path: without this, a failed
@@ -1429,8 +1455,9 @@ export class CloudProviderSync {
       this.scheduleReloadRetry();
     } else if (this.reloadPending) {
       try {
-        await this.reloadEngine();
-        this.reloadPending = false;
+        const outcome = await this.reloadEngine();
+        if (rolloverOutcomeApplied(outcome)) this.reloadPending = false;
+        else this.scheduleReloadRetry();
       } catch (error) {
         reloadError = error;
         // Sign-out cleanup must still reach the engine once it recovers.

--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -24,6 +24,7 @@ const ENV_NAMES = [
   "OPENWORK_ENGINE_DRAIN_TIMEOUT_MS",
   "OPENWORK_ENGINE_ABORT_SETTLE_MS",
   "OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS",
+  "OPENWORK_ENGINE_STANDBY_PREPARE_TIMEOUT_MS",
   "OPENWORK_POOL_LOG",
   "OPENWORK_POOL_STATE",
 ];
@@ -505,13 +506,24 @@ describe("engine pool", () => {
     const replacementUrl = pool.primaryUrl();
     expect(replacementUrl).not.toBe(primary.url);
     expect(standbyHealthChecks).toBe(1);
+    expect(await waitUntil(() => pool.snapshot().generations.length === 1, 5_000)).toBe(true);
 
-    expect(await pool.requestRollover({
-      reason: "cloud_provider_sync_unchanged",
+    // Provider sync only asks for a standby when it knows something changed,
+    // and a rotated credential never shows up in the config fingerprint. A
+    // forced request must therefore apply even when the bytes are unchanged;
+    // reporting "skipped" here is what left the engine on the old key.
+    delete fixture.hooks.waitForHealthy;
+    const forcedUnchanged = await pool.requestRollover({
+      reason: "cloud_provider_sync_credential_rotated",
       workspace: fixture.workspace,
       forceStandby: true,
-    })).toEqual({ action: "skipped", reason: "unchanged" });
-    expect(standbyHealthChecks).toBe(1);
+    });
+    expect(forcedUnchanged.action).toBe("rolled_over");
+    const rotatedUrl = pool.primaryUrl();
+    expect(rotatedUrl).not.toBe(replacementUrl);
+    // The plain (unforced) path still skips a byte-identical config.
+    expect(await pool.requestRollover({ reason: "unchanged", workspace: fixture.workspace }))
+      .toEqual({ action: "skipped", reason: "unchanged" });
 
     expect(await waitUntil(() => pool.snapshot().generations.length === 1, 5_000)).toBe(true);
     await fixture.setRuntimeConfig(JSON.stringify({ generation: 3 }));
@@ -524,7 +536,7 @@ describe("engine pool", () => {
       forceStandby: true,
     })).rejects.toThrow("standby spawn failed");
 
-    expect(pool.primaryUrl()).toBe(replacementUrl);
+    expect(pool.primaryUrl()).toBe(rotatedUrl);
     expect(pool.snapshot().generations).toEqual([expect.objectContaining({ role: "primary" })]);
     expect((await fixture.logLines()).some((line) => line.endsWith("POST /instance/dispose"))).toBe(false);
   });
@@ -617,7 +629,7 @@ describe("engine pool", () => {
     expect(await waitUntil(() => !primary.isAlive(), 5_000)).toBe(true);
   });
 
-  test("seeds the healthy standby before flipping and flips anyway when seeding fails", async () => {
+  test("seeds the healthy standby before flipping and keeps the live engine when seeding fails", async () => {
     const fixture = await createFixture();
     const seeded: Array<{ generationId: string; baseUrl: string; primaryAtSeed: string | null; hasAuth: boolean }> = [];
     let failSeed = false;
@@ -650,17 +662,99 @@ describe("engine pool", () => {
     expect(seeded[0]?.primaryAtSeed).toBe(primary.url);
     expect(seeded[0]?.hasAuth).toBe(true);
 
-    // A failed seed must not strand the pool on the old engine.
+    // A standby whose credential seed failed would serve every request with
+    // "API key is missing". It must never become primary: the live engine
+    // keeps serving, the standby is closed, and the caller learns the reload
+    // did not land so it can retry instead of reporting success.
     await fixture.setBusy(portOf(primary.url), []);
     expect(await waitUntil(async () => pool.snapshot().generations.length === 1, 5_000)).toBe(true);
     const secondPrimaryUrl = pool.primaryUrl();
     await fixture.setBusy(portOf(secondPrimaryUrl ?? "http://127.0.0.1:0"), ["ses_live_2"]);
     await fixture.setRuntimeConfig(JSON.stringify({ generation: 3 }));
     failSeed = true;
-    const second = await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace, manual: true });
-    expect(second.action).toBe("rolled_over");
+    await expect(pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace, manual: true }))
+      .rejects.toThrow("engine auth API rejected the seed");
     expect(seeded).toHaveLength(2);
+    expect(pool.primaryUrl()).toBe(secondPrimaryUrl);
+    expect(pool.snapshot().generations).toEqual([expect.objectContaining({ role: "primary" })]);
+    expect(await waitUntil(async () => (await fixture.logLines()).includes(`${portOf(seeded[1]?.baseUrl ?? "http://127.0.0.1:0")} SIGTERM`), 5_000)).toBe(true);
+
+    // Once seeding works again the same change lands on a fresh standby.
+    failSeed = false;
+    const third = await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace, manual: true });
+    expect(third.action).toBe("rolled_over");
+    expect(seeded).toHaveLength(3);
     expect(pool.primaryUrl()).not.toBe(secondPrimaryUrl);
+  });
+
+  test("a hung standby seed is bounded and leaves the live engine serving", async () => {
+    setEnv("OPENWORK_ENGINE_STANDBY_PREPARE_TIMEOUT_MS", "300");
+    const fixture = await createFixture();
+    let seeds = 0;
+    fixture.hooks.prepareStandby = () => {
+      seeds += 1;
+      return new Promise<void>(() => undefined);
+    };
+    const { pool, primary } = await createPool(fixture);
+    await fixture.setBusy(portOf(primary.url), ["ses_live"]);
+    await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
+
+    const startedAt = Date.now();
+    await expect(pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace }))
+      .rejects.toThrow(/standby preparation/i);
+    expect(Date.now() - startedAt).toBeLessThan(4_000);
+    expect(seeds).toBe(1);
+    expect(pool.primaryUrl()).toBe(primary.url);
+    expect(fixture.config.opencodeBaseUrl).toBe(primary.url);
+    expect(pool.snapshot().generations).toEqual([expect.objectContaining({ role: "primary" })]);
+  });
+
+  test("a request coalesced into an in-flight rollover settles only once its own rollover lands", async () => {
+    const fixture = await createFixture();
+    let releaseSpawn: () => void = () => undefined;
+    const spawnReleased = new Promise<void>((resolve) => {
+      releaseSpawn = resolve;
+    });
+    let spawns = 0;
+    const realSpawn = createManagedOpencodeServer;
+    fixture.hooks.spawn = async (template) => {
+      spawns += 1;
+      if (spawns === 1) await spawnReleased;
+      const handle = await realSpawn({ bin: template.bin, cwd: template.cwd, env: template.env });
+      cleanups.push(() => handle.close().catch(() => undefined));
+      return handle;
+    };
+    const { pool, primary } = await createPool(fixture);
+    await fixture.setBusy(portOf(primary.url), ["ses_live"]);
+    await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
+
+    const first = pool.requestRollover({ reason: "first", workspace: fixture.workspace });
+    expect(await waitUntil(() => spawns === 1, 2_000)).toBe(true);
+
+    // The second request carries a change the in-flight spawn may not have
+    // read (a rotated credential). Its promise must not resolve with a bare
+    // "coalesced" ack: that let the caller record the reload as landed while
+    // the engine was still being replaced with stale inputs.
+    const second = pool.requestRollover({ reason: "credential_rotated", workspace: fixture.workspace, forceStandby: true });
+    let secondSettled = false;
+    void second.then(() => { secondSettled = true; }, () => { secondSettled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    try {
+      expect(secondSettled).toBe(false);
+    } finally {
+      releaseSpawn();
+    }
+    expect((await first).action).toBe("rolled_over");
+    const afterFirst = pool.primaryUrl();
+    // Let the first drain finish so the forced follow-up can take its turn.
+    await fixture.setBusy(portOf(primary.url), []);
+    const outcome = await second;
+    expect(outcome.action).toBe("rolled_over");
+    expect(spawns).toBe(2);
+    // The last spawned generation is the one serving: the coalesced request
+    // landed after the in-flight one, with the final desired inputs.
+    expect(pool.primaryUrl()).not.toBe(afterFirst);
+    expect(pool.primaryUrl()).not.toBe(primary.url);
   });
 
   test("keeps a live session from another workspace on the draining generation", async () => {

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -88,11 +88,36 @@ export type EnginePoolHooks = {
 
 export type RolloverReason = string;
 
+/**
+ * What a rollover request did. Only `reloaded_in_place` and `rolled_over`
+ * mean the engine now serves the requested config; `skipped` and `coalesced`
+ * leave the caller's change owed, so a caller tracking a pending reload must
+ * keep it pending until one of the applied outcomes arrives.
+ */
 export type RolloverOutcome =
-  | { action: "skipped"; reason: "unchanged" }
+  | { action: "skipped"; reason: "unchanged" | "disposed" }
   | { action: "reloaded_in_place" }
   | { action: "coalesced" }
   | { action: "rolled_over"; generationId: string; drainingSessions: number };
+
+export type AppliedRolloverOutcome = Extract<RolloverOutcome, { action: "reloaded_in_place" | "rolled_over" }>;
+
+export function rolloverOutcomeApplied(outcome: RolloverOutcome): outcome is AppliedRolloverOutcome {
+  return outcome.action === "reloaded_in_place" || outcome.action === "rolled_over";
+}
+
+type RolloverRequest = {
+  reason: RolloverReason;
+  workspace: WorkspaceInfo;
+  manual: boolean;
+  awaitPostRefreshSync: boolean;
+  forceStandby: boolean;
+};
+
+type RolloverWaiter = {
+  resolve: (outcome: RolloverOutcome) => void;
+  reject: (error: unknown) => void;
+};
 
 type GenerationStatus = "starting" | "primary" | "draining" | "dead";
 
@@ -188,6 +213,15 @@ function drainPollIntervalMs(): number {
 /** Grace given to aborted sessions to unwind before the engine is closed. */
 function abortSettleMs(): number {
   return nonNegativeIntFromEnv("OPENWORK_ENGINE_ABORT_SETTLE_MS", 5_000);
+}
+
+/**
+ * Budget for seeding a healthy standby (managed provider credentials) before
+ * it may become primary. A seed that hangs past this is a failed rollover,
+ * never a silent flip onto an engine without keys.
+ */
+function standbyPrepareTimeoutMs(): number {
+  return positiveIntFromEnv("OPENWORK_ENGINE_STANDBY_PREPARE_TIMEOUT_MS", 30_000);
 }
 
 function portOf(url: string): number {
@@ -388,13 +422,9 @@ export class EnginePool {
   private readonly hooks: EnginePoolHooks;
   private generations: Generation[] = [];
   private inFlight: Promise<RolloverOutcome> | null = null;
-  private pendingRollover: {
-    reason: RolloverReason;
-    workspace: WorkspaceInfo;
-    manual: boolean;
-    awaitPostRefreshSync: boolean;
-    forceStandby: boolean;
-  } | null = null;
+  private pendingRollover: RolloverRequest | null = null;
+  /** Callers coalesced into `pendingRollover`; settled when that rollover runs. */
+  private pendingWaiters: RolloverWaiter[] = [];
   private lastSpawnAt = 0;
   private consecutiveConnectionFailures = 0;
   private lastRecoveryAt = Number.NEGATIVE_INFINITY;
@@ -600,8 +630,8 @@ export class EnginePool {
     /** Apply a config change through a healthy standby even when the primary is idle. */
     forceStandby?: boolean;
   }): Promise<RolloverOutcome> {
-    if (this.disposed) return { action: "skipped", reason: "unchanged" };
-    const request = {
+    if (this.disposed) return { action: "skipped", reason: "disposed" };
+    const request: RolloverRequest = {
       reason: input.reason,
       workspace: input.workspace,
       manual: input.manual === true,
@@ -620,29 +650,43 @@ export class EnginePool {
       this.hooks.logger?.log("info", "Engine rollover coalesced into the in-flight request.", {
         "engine.rollover.reason": request.reason,
       });
-      return { action: "coalesced" };
+      // The in-flight spawn may have read config and credentials from before
+      // this request. Settle only when the queued rollover itself lands, so a
+      // caller never records a change as applied that the engine has not read.
+      return new Promise<RolloverOutcome>((resolve, reject) => {
+        this.pendingWaiters.push({ resolve, reject });
+      });
     }
+    const waiters = this.pendingWaiters;
+    this.pendingWaiters = [];
     const run = this.runRollover(request);
     this.inFlight = run;
     try {
-      return await run;
+      const outcome = await run;
+      for (const waiter of waiters) waiter.resolve(outcome);
+      return outcome;
+    } catch (error) {
+      for (const waiter of waiters) waiter.reject(error);
+      throw error;
     } finally {
       this.inFlight = null;
       const next = this.pendingRollover;
       this.pendingRollover = null;
       if (next && !this.disposed) {
         void this.requestRollover(next).catch(() => undefined);
+      } else if (this.disposed) {
+        this.settleWaitersOnDispose();
       }
     }
   }
 
-  private async runRollover(request: {
-    reason: RolloverReason;
-    workspace: WorkspaceInfo;
-    manual: boolean;
-    awaitPostRefreshSync: boolean;
-    forceStandby: boolean;
-  }): Promise<RolloverOutcome> {
+  private settleWaitersOnDispose(): void {
+    const waiters = this.pendingWaiters;
+    this.pendingWaiters = [];
+    for (const waiter of waiters) waiter.resolve({ action: "skipped", reason: "disposed" });
+  }
+
+  private async runRollover(request: RolloverRequest): Promise<RolloverOutcome> {
     const { workspace, reason, manual, awaitPostRefreshSync, forceStandby } = request;
     // The standby reads config from disk at spawn, so make sure the file is
     // current before deciding anything.
@@ -655,9 +699,13 @@ export class EnginePool {
     // reloaded onto it. Skipping here is what keeps a repeating no-op sync
     // from spawning an engine every pass. Other directories reloaded in place
     // do not count: their dispose left this one serving the previous config.
+    // A forced request is exempt: its caller knows an input the fingerprint
+    // cannot see changed (a rotated credential, a persisted policy), and
+    // skipping it left the engine serving with the old key.
     const directory = directoryKey(workspace);
     if (
       !manual
+      && !forceStandby
       && primary
       && (primary.fingerprint === fingerprint || primary.reloadedDirectories.get(directory) === fingerprint)
     ) {
@@ -683,7 +731,7 @@ export class EnginePool {
           "engine.rollover.reason": reason,
         });
         await this.waitForDrain();
-        if (this.disposed) return { action: "skipped", reason: "unchanged" };
+        if (this.disposed) return { action: "skipped", reason: "disposed" };
         return this.runRollover(request);
       }
       // Cap: one primary plus one draining. Park this change; it lands when
@@ -760,20 +808,19 @@ export class EnginePool {
 
     if (this.hooks.prepareStandby) {
       try {
-        await this.hooks.prepareStandby(this.config, {
-          workspace,
-          generationId: generation.id,
-          baseUrl: handle.url,
-          username: handle.username,
-          password: handle.password,
-        });
+        await this.prepareStandbyBounded(generation, workspace);
       } catch (error) {
-        // The standby is healthy and the primary is still serving; a failed
-        // seed only means the next sync pass delivers credentials instead.
-        this.hooks.logger?.log("warn", "Engine standby preparation failed; flipping anyway.", {
+        // A standby without its credentials would answer every run with
+        // "API key is missing" while status called the reload landed. Keep
+        // the primary serving, close the standby, and let the caller's retry
+        // path bring the change back once seeding works.
+        this.generations = this.generations.filter((entry) => entry.id !== generation.id);
+        await handle.close().catch(() => undefined);
+        this.hooks.logger?.log("error", "Engine standby preparation failed; the live engine is untouched.", {
           "engine.rollover.reason": reason,
           "engine.rollover.failure": error instanceof Error ? error.message : String(error),
         });
+        throw error;
       }
     }
 
@@ -810,6 +857,34 @@ export class EnginePool {
     if (primary) this.startDrainMonitor(primary, workspace);
 
     return { action: "rolled_over", generationId: generation.id, drainingSessions: drainingSessions.length };
+  }
+
+  /** Seed the standby within a bounded budget; a hung seed is a failed rollover. */
+  private async prepareStandbyBounded(generation: Generation, workspace: WorkspaceInfo): Promise<void> {
+    const prepare = this.hooks.prepareStandby;
+    if (!prepare) return;
+    const standby: EnginePoolStandby = {
+      workspace,
+      generationId: generation.id,
+      baseUrl: generation.handle.url,
+      username: generation.handle.username,
+      password: generation.handle.password,
+    };
+    const budgetMs = standbyPrepareTimeoutMs();
+    let expire: (error: Error) => void = () => undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      expire = reject;
+    });
+    const timer = setTimeout(
+      () => expire(new Error(`Engine standby preparation did not complete within ${budgetMs}ms`)),
+      budgetMs,
+    );
+    timer.unref?.();
+    try {
+      await Promise.race([prepare(this.config, standby), timeout]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /**
@@ -1042,6 +1117,7 @@ export class EnginePool {
     this.disposed = true;
     this.hooks.onDisposed?.();
     this.pendingRollover = null;
+    this.settleWaitersOnDispose();
     if (this.recoveryTimer) clearTimeout(this.recoveryTimer);
     this.recoveryTimer = null;
     this.abortEventProxies();

--- a/apps/server/src/managed-provider-auth.test.ts
+++ b/apps/server/src/managed-provider-auth.test.ts
@@ -291,6 +291,59 @@ describe("managed provider auth delivery", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  test("bounds a hung engine auth PUT and DELETE instead of waiting forever", async () => {
+    const previousTimeout = process.env.OPENWORK_PROVIDER_AUTH_TIMEOUT_MS;
+    process.env.OPENWORK_PROVIDER_AUTH_TIMEOUT_MS = "150";
+    try {
+      const config = await makeConfig(dir);
+      await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });
+      const env = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-secret" }] };
+      const errors: Array<Record<string, unknown> | undefined> = [];
+      let hang = false;
+      const methods: string[] = [];
+      // Mirrors an engine whose auth API accepted the socket but never
+      // answers: the response arrives only when the request is aborted.
+      const fetchImpl: typeof globalThis.fetch = Object.assign(
+        (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+          methods.push(init?.method ?? "GET");
+          if (!hang) return Promise.resolve(new Response("{}", { status: 200 }));
+          return new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) return;
+            signal.addEventListener("abort", () => reject(signal.reason instanceof Error ? signal.reason : new Error("aborted")));
+          });
+        },
+        { preconnect: globalThis.fetch.preconnect },
+      );
+      const logger = { warn: () => {}, error: (_m: string, meta?: Record<string, unknown>) => errors.push(meta) };
+
+      // Deliver once so the provider is owned, then rotate against a hung PUT.
+      await syncManagedProviderAuth({ config, env, fetchImpl, logger });
+      hang = true;
+      const rotatedEnv = { list: async () => [{ key: "ANTHROPIC_API_KEY", value: "sk-ant-rotated" }] };
+      const startedAt = Date.now();
+      const rotated = await syncManagedProviderAuth({ config, env: rotatedEnv, fetchImpl, logger });
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(rotated.failed).toEqual([{ providerId: PROVIDER, status: null }]);
+      expect(rotated.delivered).toEqual([]);
+      expect(rotated.rotated).toEqual([]);
+
+      // A hung DELETE for a no-longer-managed provider is bounded the same way
+      // and keeps the removal owed for the next pass.
+      await writeRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, (current) => ({ ...current, provider: {} }));
+      const removalStartedAt = Date.now();
+      const removal = await syncManagedProviderAuth({ config, env: rotatedEnv, fetchImpl, logger });
+      expect(Date.now() - removalStartedAt).toBeLessThan(2_000);
+      expect(removal.removed).toEqual([]);
+      expect(methods).toEqual(["PUT", "PUT", "DELETE"]);
+      expect(JSON.stringify(errors)).not.toContain("sk-ant-rotated");
+      await rm(dir, { recursive: true, force: true });
+    } finally {
+      if (previousTimeout === undefined) delete process.env.OPENWORK_PROVIDER_AUTH_TIMEOUT_MS;
+      else process.env.OPENWORK_PROVIDER_AUTH_TIMEOUT_MS = previousTimeout;
+    }
+  });
+
   test("re-delivers after the engine is replaced", async () => {
     const config = await makeConfig(dir);
     await seedProvider(config, { id: "anthropic", env: ["ANTHROPIC_API_KEY"] });

--- a/apps/server/src/managed-provider-auth.ts
+++ b/apps/server/src/managed-provider-auth.ts
@@ -98,6 +98,18 @@ let cacheEpoch = 0;
 
 const fingerprint = (value: string) => createHash("sha256").update(value).digest("hex");
 
+/**
+ * Budget for one engine auth PUT/DELETE. The engine answers these on the
+ * loopback in milliseconds; a request that hangs (instance rebuild wedged,
+ * half-open socket) must surface as a failed delivery so the caller can keep
+ * the reload owed and retry, instead of stalling the sync queue or a standby
+ * flip forever.
+ */
+function authRequestTimeoutMs(): number {
+  const raw = Number(process.env.OPENWORK_PROVIDER_AUTH_TIMEOUT_MS ?? "");
+  return Number.isFinite(raw) && raw > 0 ? raw : 10_000;
+}
+
 function stateForConfig(config: ServerConfig): ManagedProviderAuthState {
   const current = stateByConfig.get(config);
   if (current) {
@@ -315,6 +327,7 @@ async function reconcileManagedProviderAuth(input: ManagedProviderAuthInput): Pr
         method: "PUT",
         headers,
         body: JSON.stringify({ type: "api", key: credential }),
+        signal: AbortSignal.timeout(authRequestTimeoutMs()),
       });
       if (!isCurrent()) return result;
       if (!response.ok) {
@@ -349,6 +362,7 @@ async function reconcileManagedProviderAuth(input: ManagedProviderAuthInput): Pr
       const response = await fetchImpl(`${target.baseUrl}/auth/${encodeURIComponent(providerId)}`, {
         method: "DELETE",
         headers,
+        signal: AbortSignal.timeout(authRequestTimeoutMs()),
       });
       if (!isCurrent()) return result;
       if (!response.ok) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -18,6 +18,7 @@ import {
   type EnginePoolConnection,
   type EngineEventProxyLease,
   type EngineSpawnTemplate,
+  type RolloverOutcome,
   type RolloverReason,
 } from "./engine-pool.js";
 import { withEngineDirectoryFence } from "./engine-directory-fence.js";
@@ -3248,8 +3249,9 @@ function createRoutes(
     readJsonBody,
     requireClientScope,
     resolveWorkspace,
-    reloadOpencodeEngine: (routeConfig, workspace) =>
-      reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState, { reason: "operation_route" }),
+    reloadOpencodeEngine: async (routeConfig, workspace) => {
+      await reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState, { reason: "operation_route" });
+    },
   });
 
   registerUiControlRoutes({ routes, jsonResponse, readJsonBody, requireClientScope });
@@ -4580,18 +4582,20 @@ async function reloadOpencodeEngine(
   workspace: WorkspaceInfo,
   serverState?: EngineMcpServerState,
   options?: { awaitPostRefreshSync?: boolean; forceStandby?: boolean; reason?: RolloverReason },
-): Promise<void> {
+): Promise<RolloverOutcome> {
   const pool = enginePoolForConfig(config);
   if (pool) {
-    await pool.requestRollover({
+    // The outcome is the caller's proof: only an applied action means the
+    // engine now reads the requested config and credentials.
+    return pool.requestRollover({
       reason: options?.reason ?? "engine_reload",
       workspace,
       awaitPostRefreshSync: options?.awaitPostRefreshSync,
       forceStandby: options?.forceStandby,
     });
-    return;
   }
   await reloadOpencodeEngineInPlace(config, workspace, serverState, options);
+  return { action: "reloaded_in_place" };
 }
 
 async function reloadOpencodeEngineInPlace(
@@ -5381,6 +5385,13 @@ export function createEnginePoolForConfig(input: {
           "provider.auth.skipped": result.skipped.length,
           "provider.auth.failed": result.failed.length,
         });
+        // A generation missing even one managed credential must not be
+        // promoted: the pool keeps the live engine and the caller retries.
+        if (result.failed.length > 0) {
+          throw new Error(
+            `Managed provider credential seed failed for ${result.failed.map((entry) => entry.providerId).join(", ")}`,
+          );
+        }
       },
       writeRuntimeConfigFile: (poolConfig) => writeOpenworkRuntimeConfigFile(poolConfig),
       registerTrusted: (poolConfig, generation) => registerTrustedOpencodeProcess(poolConfig, generation),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -18,6 +18,7 @@ import {
   type EnginePoolConnection,
   type EngineEventProxyLease,
   type EngineSpawnTemplate,
+  rolloverOutcomeApplied,
   type RolloverOutcome,
   type RolloverReason,
 } from "./engine-pool.js";
@@ -2280,9 +2281,24 @@ function createRoutes(
   // the established busy deferral.
   const applyManagedProviderReload = async (workspace: WorkspaceInfo): Promise<"reloaded" | "deferred"> => {
     const reloadDeferred = await shouldDeferInPlaceEngineReload(config, workspace, engineHasActiveSessions);
-    if (!reloadDeferred) await reloadOpencodeEngine(config, workspace, engineMcpServerState, { reason: "managed_provider_reload" });
-    if (reloadDeferred) cloudProviderSync.markReloadPending();
-    return reloadDeferred ? "deferred" : "reloaded";
+    if (reloadDeferred) {
+      cloudProviderSync.markReloadPending();
+      return "deferred";
+    }
+    // A key-only rotation through this route never shows in the pool's
+    // config fingerprint, so an unforced request would be skipped and the
+    // engine would keep serving the previous credential while the route
+    // answered "reloaded". Force the standby path, mirroring cloud sync, and
+    // only report "reloaded" once the engine actually read the change.
+    const outcome = await reloadOpencodeEngine(config, workspace, engineMcpServerState, {
+      reason: "managed_provider_reload",
+      forceStandby: true,
+    });
+    if (rolloverOutcomeApplied(outcome)) return "reloaded";
+    // Parked or skipped inside the pool: keep it owed so the sync retry
+    // path lands it instead of the caller believing it is done.
+    cloudProviderSync.markReloadPending();
+    return "deferred";
   };
   registerCoreRoutes({
     routes,

--- a/evals/specs/cloud-provider-sync-contract.e2e.test.ts
+++ b/evals/specs/cloud-provider-sync-contract.e2e.test.ts
@@ -92,6 +92,7 @@ interface SyncStatusFacts {
   lastRunAt: string;
   lastRunMessage: string;
   reloadDeferred: boolean;
+  reloadPending: boolean;
   providers: ProviderStatusEntry[];
   raw: Record<string, unknown>;
 }
@@ -175,6 +176,7 @@ function parseSyncStatus(payload: Record<string, unknown>): SyncStatusFacts {
     lastRunAt: typeof lastRun.at === "string" ? lastRun.at : "",
     lastRunMessage: typeof lastRun.message === "string" ? lastRun.message : "",
     reloadDeferred: detail.reloadDeferred === true,
+    reloadPending: payload.reloadPending === true,
     providers: providers.map((entry) => ({
       cloudProviderId: typeof entry.cloudProviderId === "string" ? entry.cloudProviderId : "",
       providerId: typeof entry.providerId === "string" ? entry.providerId : "",
@@ -351,9 +353,16 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   await using desktopApp = await app({ den, as: "member", place });
 
   // ── Claim 1: terminal status ────────────────────────────────────────────
-  const isTerminal = (status: SyncStatusFacts): boolean =>
-    published.every((provider) => status.providers.some((entry) => entry.cloudProviderId === provider.cloudId))
-    && (status.lastRunStatus === "applied" || status.lastRunStatus === "noop");
+  // A terminal status reflects the providers assigned *right now*: every
+  // expected id present, every id deleted since publication absent, and the
+  // last run settled with nothing still pending against the engine.
+  const terminalFor = (expectedIds: readonly string[], absentIds: readonly string[]) =>
+    (status: SyncStatusFacts): boolean =>
+      expectedIds.every((id) => status.providers.some((entry) => entry.cloudProviderId === id))
+      && absentIds.every((id) => status.providers.every((entry) => entry.cloudProviderId !== id))
+      && (status.lastRunStatus === "applied" || status.lastRunStatus === "noop")
+      && !status.reloadPending;
+  const isTerminal = terminalFor(published.map((provider) => provider.cloudId), []);
   const terminalDeadline = Date.now() + TERMINAL_BUDGET_MS;
   let latestStatus: SyncStatusFacts | null = null;
   let terminalReached = false;
@@ -727,6 +736,10 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   // identity even when the server reuses the same loopback address. Do not
   // navigate, focus, manually sync, or reload the renderer to repair it.
   const beforeRestart = parseSyncStatus(await readSyncStatusPayload(desktopApp));
+  // The catalog provider was deleted earlier in this journey; a correct
+  // replacement server must restore exactly the surviving assignments and
+  // never resurrect the deleted one.
+  const isTerminalAfterRestart = terminalFor([customProviderId, thirdProviderId], [catalogProviderId]);
   const restart = await evalIn(desktopApp, async () => {
     const invoke = window.__OPENWORK_ELECTRON__?.invokeDesktop;
     if (!invoke) throw new Error("Desktop runtime bridge unavailable");
@@ -750,13 +763,15 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
     within: 30_000,
     intervalMs: 500,
     label: "automatic session redelivery after same-address runtime replacement",
-    until: (status) => status.hasSession && isTerminal(status) && status.lastRunAt !== beforeRestart.lastRunAt,
+    until: (status) => status.hasSession && isTerminalAfterRestart(status) && status.lastRunAt !== beforeRestart.lastRunAt,
   });
+  expect(redelivered.providers.some((entry) => entry.cloudProviderId === catalogProviderId)).toBe(false);
+  expect([customProviderId, thirdProviderId].every((id) => redelivered.providers.some((entry) => entry.cloudProviderId === id))).toBe(true);
   expect(await evalIn(desktopApp, () => ({ timeOrigin: performance.timeOrigin, route: location.hash })))
     .toMatchObject({ timeOrigin: restart.timeOrigin, route: restart.route });
   evidence.recordAssertionEvidence(
     "same-address runtime replacement automatically restores the signed-in session",
-    `Runtime generation changed without renderer reload, navigation or account change; the replacement server reached ${redelivered.lastRunStatus} within 30 seconds with both assigned providers restored.`,
+    `Runtime generation changed without renderer reload, navigation or account change; the replacement server reached ${redelivered.lastRunStatus} within 30 seconds with the two surviving assignments restored and the deleted catalog provider still absent.`,
     true,
   );
 });

--- a/evals/specs/managed-provider-env-delivery-reload.test.ts
+++ b/evals/specs/managed-provider-env-delivery-reload.test.ts
@@ -1,14 +1,15 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { eventually, test } from "@openwork/testkit";
+import { eventually, mcpMock, needs, test } from "@openwork/testkit";
 import { expect } from "vitest";
 
 import { resetManagedProviderAuthCache } from "../../apps/server/src/managed-provider-auth.js";
 import { openworkRuntimeConfigFilePath } from "../../apps/server/src/openwork-runtime-config.js";
 import { startServer } from "../../apps/server/src/server.js";
 import type { ServerConfig } from "../../apps/server/src/types.js";
+import { bootManagedOpenworkServer, close, isRecord, listen } from "../worlds/openwork-server-cli.ts";
 
 const CLIENT_TOKEN = "owt_managed_provider_env_client";
 const HOST_TOKEN = "owt_managed_provider_env_host";
@@ -284,5 +285,144 @@ test("stored managed provider credentials reload only after full session or auth
     if (previousEnvStore === undefined) delete process.env.OPENWORK_ENV_STORE;
     else process.env.OPENWORK_ENV_STORE = previousEnvStore;
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+function replyTexts(result: unknown): string[] {
+  if (!isRecord(result) || !Array.isArray(result.parts)) return [];
+  return result.parts.filter(isRecord).map((part) => (typeof part.text === "string" ? part.text : "")).filter(Boolean);
+}
+
+function sessionId(value: unknown): string {
+  if (!isRecord(value) || typeof value.id !== "string") throw new Error("Session creation returned no id");
+  return value.id;
+}
+
+/**
+ * Boundary proof for a key-only rotation against the real managed v1 engine.
+ *
+ * The provider's config bytes never change: Den rotates only the credential.
+ * The engine caches an SDK client with the key it was built with, so the
+ * rotation must land through a fresh engine generation; a reload the pool
+ * "skipped" because the config fingerprint matched left every later run on
+ * the revoked key while sync status still said "applied".
+ */
+test("a Den key-only rotation reaches the real managed engine through an applied rollover", { timeout: 420_000 }, async ({ place }) => {
+  needs({ commands: ["bun"] });
+  const keyA = "sk-rotation-eval-key-a";
+  const keyB = "sk-rotation-eval-key-b";
+  const markerA = `ROTATION-BEFORE-${Date.now()}`;
+  const markerB = `ROTATION-AFTER-${Date.now()}`;
+  const replyA = `REPLY-BEFORE-${Date.now()}`;
+  const replyB = `REPLY-AFTER-${Date.now()}`;
+  const workloads = [{ promptMarker: markerA, finalReply: replyA, steps: [] }, { promptMarker: markerB, finalReply: replyB, steps: [] }];
+  const scratch = await realpath(await mkdtemp(join(tmpdir(), "openwork-key-rotation-")));
+  const workspace = join(scratch, "workspace");
+  await mkdir(workspace);
+  const token = "owt_key_rotation_client";
+  const hostToken = `${token}-host`;
+  let output = "";
+  const flipCount = () => output.split("Engine rollover flipped to the new generation.").length - 1;
+
+  // The provider witness accepts exactly one key at a time on its native
+  // Responses endpoint, so a request carrying the previous key is a 401.
+  const { handle: witness } = await mcpMock({
+    agentWorkloads: workloads,
+    agentRequiredHeader: { name: "authorization", value: `Bearer ${keyA}` },
+  }).boot(place);
+  const provider = {
+    id: "lpr_rotation",
+    providerId: "openai",
+    name: "Rotation provider",
+    source: "custom",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    providerConfig: { env: ["ROTATION_PROVIDER_API_KEY"], npm: "@ai-sdk/openai", options: { baseURL: `${witness.url}/v1` } },
+    apiKey: keyA,
+    apiKeys: null,
+    models: [{ id: "mock-agent-workload-model", name: "Rotation model", config: {
+      tool_call: true, limit: { context: 128_000, output: 4_096 }, modalities: { input: ["text"], output: ["text"] },
+    } }],
+  };
+  const den = createServer((request, response) => {
+    const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+    if (path === "/v1/me/desktop-config") sendJson(response, 200, {});
+    else if (path === "/v1/llm-providers") sendJson(response, 200, { llmProviders: [provider] });
+    else if (path === `/v1/llm-providers/${provider.id}/connect`) sendJson(response, 200, { llmProvider: provider });
+    else sendJson(response, 404, { error: "not_found" });
+  });
+  const denUrl = await listen(den);
+  let managed: Awaited<ReturnType<typeof bootManagedOpenworkServer>> | undefined;
+  try {
+    managed = await bootManagedOpenworkServer({
+      scratch, workspace, token, sink: (chunk) => { output += chunk; },
+      env: { OPENWORK_ENGINE_RELOAD_RETRY_MS: "1000" },
+    });
+    const base = managed.base;
+    const host = { "x-openwork-host-token": hostToken, "content-type": "application/json" };
+    const syncStatus = async () => {
+      const response = await fetch(`${base}/cloud-provider-sync/status`, { headers: { authorization: `Bearer ${token}` } });
+      const payload: unknown = await response.json();
+      if (!isRecord(payload)) throw new Error("sync status is not an object");
+      return payload;
+    };
+    const settledSync = (label: string) => eventually(syncStatus, {
+      within: 120_000, intervalMs: 250, label,
+      until: (status) => isRecord(status.lastRun) && status.lastRun.status === "applied" && status.reloadPending === false,
+    });
+
+    const session = await fetch(`${base}/den-session`, {
+      method: "PUT", headers: host, body: JSON.stringify({ baseUrl: denUrl, token: "den-token", orgId: "org_rotation" }),
+    });
+    expect(session.status).toBe(204);
+    await settledSync("first materialization applied through a rollover");
+    const flipsAfterMaterialization = flipCount();
+    expect(flipsAfterMaterialization).toBeGreaterThanOrEqual(1);
+
+    // Warm the SDK client with key A: a completed reply proves the engine
+    // built its provider from the synced config and credential.
+    const model = { providerID: provider.id, modelID: "mock-agent-workload-model" };
+    const first = await managed.engine("POST", `/session/${sessionId(await managed.engine("POST", "/session", {}))}/message`, {
+      model, parts: [{ type: "text", text: `Reply to the request marked ${markerA}.` }],
+    });
+    expect(replyTexts(first)).toContain(replyA);
+    const beforeRotation = await witness.agentRequests({ promptMarker: markerA, atLeast: 1, timeoutMs: 10_000 });
+    expect(beforeRotation.some((request) => request.kind === "final")).toBe(true);
+    expect(beforeRotation.some((request) => request.kind === "error")).toBe(false);
+
+    // Rotate the key only. Config bytes are identical; the witness now
+    // rejects A and accepts B.
+    const rotatedAt = new Date().toISOString();
+    provider.apiKey = keyB;
+    const flipped = await fetch(`${witness.url}/admin/agent-workloads`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ workloads, requiredHeader: { name: "authorization", value: `Bearer ${keyB}` } }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    expect(flipped.ok).toBe(true);
+    const runtimeBefore = await (await fetch(`${base}/runtime-config/providers`, { headers: host })).text();
+    const run = await fetch(`${base}/cloud-provider-sync/run`, { method: "POST", headers: host, body: JSON.stringify({ reason: "key_rotated" }) });
+    const runResult: unknown = await run.json();
+    expect(runResult).toMatchObject({ status: "applied" });
+    expect(await (await fetch(`${base}/runtime-config/providers`, { headers: host })).text()).toBe(runtimeBefore);
+    await settledSync("key rotation applied");
+
+    // The next run must authenticate with B. With the rollover skipped, the
+    // engine's cached client still sent A and the witness answered 401.
+    const second = await managed.engine("POST", `/session/${sessionId(await managed.engine("POST", "/session", {}))}/message`, {
+      model, parts: [{ type: "text", text: `Reply to the request marked ${markerB}.` }],
+    });
+    const afterRotation = await witness.agentRequests({ promptMarker: markerB, sinceIso: rotatedAt, atLeast: 1, timeoutMs: 10_000 });
+    // The negative half: no request for the new turn carried the revoked key.
+    expect(afterRotation.filter((request) => request.kind === "error")).toEqual([]);
+    expect(afterRotation.some((request) => request.kind === "final")).toBe(true);
+    expect(replyTexts(second)).toContain(replyB);
+    // "Applied" must mean a generation actually replaced the one holding the
+    // cached client, not a skipped rollover that only cleared the flag.
+    expect(flipCount()).toBeGreaterThan(flipsAfterMaterialization);
+  } finally {
+    await managed?.stop();
+    await close(den);
+    await witness.stop();
+    await rm(scratch, { recursive: true, force: true });
   }
 });

--- a/evals/specs/managed-provider-env-delivery-reload.test.ts
+++ b/evals/specs/managed-provider-env-delivery-reload.test.ts
@@ -418,7 +418,44 @@ test("a Den key-only rotation reaches the real managed engine through an applied
     expect(replyTexts(second)).toContain(replyB);
     // "Applied" must mean a generation actually replaced the one holding the
     // cached client, not a skipped rollover that only cleared the flag.
-    expect(flipCount()).toBeGreaterThan(flipsAfterMaterialization);
+    const flipsAfterDenRotation = flipCount();
+    expect(flipsAfterDenRotation).toBeGreaterThan(flipsAfterMaterialization);
+
+    // The same key-only rotation through the local `PUT /env` route. Config
+    // bytes are still identical, so an unforced rollover request was
+    // fingerprint-skipped here while the route answered ok: the engine kept
+    // sending the revoked key. Den mirrors the new key so a later sync pass
+    // cannot roll it back.
+    const keyC = "sk-rotation-eval-key-c";
+    const markerC = `ROTATION-LOCAL-${Date.now()}`;
+    const replyC = `REPLY-LOCAL-${Date.now()}`;
+    provider.apiKey = keyC;
+    const flippedLocal = await fetch(`${witness.url}/admin/agent-workloads`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        workloads: [...workloads, { promptMarker: markerC, finalReply: replyC, steps: [] }],
+        requiredHeader: { name: "authorization", value: `Bearer ${keyC}` },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    expect(flippedLocal.ok).toBe(true);
+    const localRotatedAt = new Date().toISOString();
+    const localPut = await fetch(`${base}/env`, {
+      method: "PUT", headers: host, body: JSON.stringify({ entries: [{ key: "ROTATION_PROVIDER_API_KEY", value: keyC }] }),
+    });
+    expect(localPut.status).toBe(200);
+    expect(await localPut.json()).toEqual({ ok: true, count: 1 });
+    expect(await (await fetch(`${base}/runtime-config/providers`, { headers: host })).text()).toBe(runtimeBefore);
+    await settledSync("local key rotation left nothing owed");
+
+    const third = await managed.engine("POST", `/session/${sessionId(await managed.engine("POST", "/session", {}))}/message`, {
+      model, parts: [{ type: "text", text: `Reply to the request marked ${markerC}.` }],
+    });
+    const afterLocalRotation = await witness.agentRequests({ promptMarker: markerC, sinceIso: localRotatedAt, atLeast: 1, timeoutMs: 10_000 });
+    expect(afterLocalRotation.filter((request) => request.kind === "error")).toEqual([]);
+    expect(afterLocalRotation.some((request) => request.kind === "final")).toBe(true);
+    expect(replyTexts(third)).toContain(replyC);
+    expect(flipCount()).toBeGreaterThan(flipsAfterDenRotation);
   } finally {
     await managed?.stop();
     await close(den);


### PR DESCRIPTION
## Problem

After a managed provider's API key was rotated, the server could report the reload as done while the engine kept serving with the previous key. Every following run failed with an auth error from the provider while the sync status said `applied` and `reloadPending: false`.

Root cause: the engine pool decides whether a reload is needed from a fingerprint of the config bytes, binary, and models URL. Credentials are not part of that fingerprint, so a key-only change looked like "nothing changed" and the rollover was skipped. Callers then cleared their pending state without checking what the pool actually did.

## Fix

One behaviour, applied consistently: **a reload is only reported as applied when the engine actually read the new config and credentials.**

- `EnginePool.requestRollover` honours `forceStandby` even when the fingerprint is unchanged, since the caller knows an input the fingerprint cannot see has changed.
- `reloadOpencodeEngine` returns the `RolloverOutcome` instead of `void`; cloud sync clears `reloadPending` only on `rolled_over` / `reloaded_in_place`, keeps it owed and retries on `coalesced`, and fails the run and retries on `skipped`.
- A request coalesced into an in-flight rollover now settles with the *queued* rollover's outcome instead of returning `coalesced` immediately.
- A standby that fails or hangs while receiving its credentials is closed and the rollover rejected; the live primary keeps serving. Auth PUT/DELETE get a 10 s budget (`OPENWORK_PROVIDER_AUTH_TIMEOUT_MS`), standby preparation a 30 s budget (`OPENWORK_ENGINE_STANDBY_PREPARE_TIMEOUT_MS`).
- The local `PUT /env` route (`applyManagedProviderReload`) had the same gap: it requested an unforced rollover and answered `reloaded`. It now forces the standby path and reports `deferred` (with the reload kept pending for the sync retry) when the pool did not apply the change.
- `cloud-provider-sync-contract.e2e` terminal predicate no longer requires a provider the journey deletes.

## Proof (head of this PR, rebased on `dev` `f128bff74`)

| Check | Result |
|---|---|
| `pnpm evals:pr specs/managed-provider-env-delivery-reload.test.ts` | 2 passed. Red first on unfixed `server.ts`: `:455 expected [ {…}, {…} ] to deeply equal []` (two `kind: "error"` witness requests after the `PUT /env` rotation, engine still sent the revoked key) |
| `pnpm evals:pr specs/opencode-v2-provider-hot-inject.test.ts` | 1 passed |
| `bun test src/engine-pool.test.ts` | 31 pass |
| `bun test src/managed-provider-auth.test.ts` | 18 pass |
| `bun test src/cloud-provider-sync-reload-guard.test.ts` | 9 pass |
| `bun test src/cloud-provider-sync-drain-defer.test.ts` | 5 pass |
| `bun test src/cloud-provider-sync.e2e.test.ts` | 20 pass |
| `pnpm --filter openwork-server typecheck` | 0 errors |

The key-rotation journey runs a real managed v1 engine against an `mcpMock` provider witness that accepts exactly one bearer key at a time. It rotates the key twice with identical provider config bytes: once through Den sync, once through the local `PUT /env` route. Each rotation must produce a new engine generation, a completed reply with the new key, and zero requests carrying the revoked key.

**Verdict: Incomplete.** `cloud-provider-sync-contract.e2e` (the predicate fix) needs a Den + Electron lane run (`pnpm evals:e2e cloud-provider-sync-contract`) that has not been executed. Everything else above is passing at this head.

## Rebase notes

Rebased onto current `dev` after #4358 (Gateway providers), #4876 and #4888 touched the same files. The fingerprint-skip exemption was re-applied by hand to the new per-directory `reloadedDirectories` check. The Gateway sync test fixtures were aligned with the `Promise<RolloverOutcome>` contract.

## Deferred

- v2 readiness matching unqualified model ids, empty desired providers passing vacuously, catalog fetch without per-request timeout: documented in the audit, owned by v2 files, not touched here.

**UI/UX impact:** None — server-only change, existing UI/UX preserved.
