### PR TITLE
feat(skills): materialize authorized Cloud skills as native v2 skills just in time

### DIFF
--- a/apps/server/src/cloud-native-skills.test.ts
+++ b/apps/server/src/cloud-native-skills.test.ts
@@ -1,0 +1,250 @@
+import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CloudNativeSkillSyncError,
+  cloudNativeSkillId,
+  cloudNativeSkillScopeKey,
+  createCloudNativeSkillSync,
+} from "./cloud-native-skills.js";
+import type { McpFetch } from "./connect-mcp-transport.js";
+import { renderOpencodeV2Config } from "./managed-opencode-v2.js";
+
+const INDEX_URI = "skill://index.json";
+const BRIEFING_URI = "skill://customer-briefing/SKILL.md";
+const TRIAGE_URI = "skill://support-triage/SKILL.md";
+const BRIEFING_BODY = "---\nname: customer-briefing\ndescription: Prepare a briefing\n---\n\n# Briefing\n\nDo the briefing.\n";
+const TRIAGE_BODY = "---\nname: support-triage\ndescription: Triage support\n---\n\nTriage steps.\n";
+
+function indexFor(uris: string[]): unknown {
+  return {
+    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    skills: uris.map((url) => ({ name: url.split("/")[2], type: "skill-md", description: "d", url, capability: "skill:x" })),
+  };
+}
+
+function cloudConfig(token: string): Record<string, unknown> {
+  return { type: "remote", url: "https://api.example.test/mcp/agent", headers: { Authorization: `Bearer ${token}` } };
+}
+
+function fakeCloud(options: {
+  index: unknown;
+  bodies: Record<string, string | undefined>;
+  gate?: () => Promise<void>;
+}): { fetcher: McpFetch; reads: string[] } {
+  const reads: string[] = [];
+  const json = (payload: unknown) => new Response(JSON.stringify(payload), {
+    status: 200, headers: { "content-type": "application/json", "mcp-session-id": "session-1" },
+  });
+  const fetcher: McpFetch = async (_url, init) => {
+    const body: unknown = JSON.parse(String(init?.body));
+    if (typeof body !== "object" || body === null) throw new Error("bad request");
+    const request = body as { id?: number; method: string; params?: { uri?: string } };
+    if (request.method === "initialize") {
+      return json({ jsonrpc: "2.0", id: request.id, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "fake", version: "1" } } });
+    }
+    if (request.method === "notifications/initialized") return new Response(null, { status: 202 });
+    if (request.method === "resources/read") {
+      const uri = request.params?.uri ?? "";
+      reads.push(uri);
+      await options.gate?.();
+      const text = uri === INDEX_URI
+        ? (typeof options.index === "string" ? options.index : JSON.stringify(options.index))
+        : options.bodies[uri];
+      if (text === undefined) return json({ jsonrpc: "2.0", id: request.id, error: { code: -32602, message: "Skill is no longer available" } });
+      return json({ jsonrpc: "2.0", id: request.id, result: { contents: [{ uri, mimeType: "text/markdown", text }] } });
+    }
+    throw new Error(`unexpected method ${request.method}`);
+  };
+  return { fetcher, reads };
+}
+
+async function withRoot(run: (root: string) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), "openwork-cloud-skills-"));
+  try { await run(join(base, "cloud-skills")); } finally { await rm(base, { recursive: true, force: true }); }
+}
+
+test("skill ids and scope keys are stable, opaque hashes", () => {
+  expect(cloudNativeSkillId(BRIEFING_URI)).toBe(`openwork-cloud-${createHash("sha256").update(BRIEFING_URI).digest("hex").slice(0, 16)}`);
+  expect(cloudNativeSkillId(BRIEFING_URI)).toMatch(/^openwork-cloud-[0-9a-f]{16}$/);
+  const scope = cloudNativeSkillScopeKey(cloudConfig("secret-token"));
+  expect(scope).toMatch(/^[0-9a-f]{16}$/);
+  expect(scope).not.toContain("secret");
+  expect(cloudNativeSkillScopeKey(cloudConfig("other-token"))).not.toBe(scope);
+  expect(cloudNativeSkillScopeKey(null)).toBeNull();
+  expect(cloudNativeSkillScopeKey({ url: "https://api.example.test/mcp" })).toBeNull();
+  expect(cloudNativeSkillScopeKey({ ...cloudConfig("t"), enabled: false })).toBeNull();
+});
+
+test("fresh fetch materializes every body verbatim under the scope root and registers only that root", async () => {
+  await withRoot(async (root) => {
+    const cloud = fakeCloud({ index: indexFor([BRIEFING_URI, TRIAGE_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY, [TRIAGE_URI]: TRIAGE_BODY } });
+    const registered: Array<string | null> = [];
+    const sync = createCloudNativeSkillSync({
+      root, fetcher: cloud.fetcher,
+      readCloudConfig: async () => cloudConfig("token-a"),
+      register: async (directory) => { registered.push(directory); },
+    });
+    const state = await sync.sync();
+    const scope = cloudNativeSkillScopeKey(cloudConfig("token-a"));
+    expect(state.root).toBe(join(root, String(scope)));
+    expect(state.skills.map((skill) => skill.id)).toEqual([cloudNativeSkillId(BRIEFING_URI), cloudNativeSkillId(TRIAGE_URI)].sort());
+    for (const skill of state.skills) {
+      expect(skill.location).toBe(join(root, String(scope), skill.id, "SKILL.md"));
+      expect(await readFile(skill.location, "utf8")).toBe(skill.uri === BRIEFING_URI ? BRIEFING_BODY : TRIAGE_BODY);
+      expect((await stat(skill.location)).mode & 0o777).toBe(0o600);
+      expect((await stat(join(root, String(scope), skill.id))).mode & 0o777).toBe(0o700);
+    }
+    expect((await stat(root)).mode & 0o777).toBe(0o700);
+    expect(registered).toEqual([join(root, String(scope))]);
+    expect(cloud.reads.filter((uri) => uri === INDEX_URI)).toHaveLength(1);
+
+    // No cache: the next admission reads the index and every body again, and
+    // an unchanged set does not rewrite the native registration.
+    await sync.sync();
+    expect(cloud.reads.filter((uri) => uri === INDEX_URI)).toHaveLength(2);
+    expect(cloud.reads.filter((uri) => uri === BRIEFING_URI)).toHaveLength(2);
+    expect(registered).toHaveLength(1);
+    expect((await readdir(root)).sort()).toEqual([String(scope)]);
+  });
+});
+
+test("body updates and removals keep ids stable and drop obsolete directories", async () => {
+  await withRoot(async (root) => {
+    const bodies: Record<string, string | undefined> = { [BRIEFING_URI]: BRIEFING_BODY, [TRIAGE_URI]: TRIAGE_BODY };
+    const catalog = { index: indexFor([BRIEFING_URI, TRIAGE_URI]), bodies };
+    const cloud = fakeCloud(catalog);
+    const sync = createCloudNativeSkillSync({ root, fetcher: cloud.fetcher, readCloudConfig: async () => cloudConfig("t"), register: async () => {} });
+    const first = await sync.sync();
+    bodies[BRIEFING_URI] = `${BRIEFING_BODY}\nUpdated.\n`;
+    catalog.index = indexFor([BRIEFING_URI]);
+    const second = await sync.sync();
+    expect(second.skills.map((skill) => skill.id)).toEqual([cloudNativeSkillId(BRIEFING_URI)]);
+    const firstBriefingId = first.skills.find((skill) => skill.uri === BRIEFING_URI)?.id ?? "";
+    expect(second.skills[0]?.id).toBe(firstBriefingId);
+    expect(await readFile(second.skills[0]?.location ?? "", "utf8")).toBe(`${BRIEFING_BODY}\nUpdated.\n`);
+    expect(await readdir(String(second.root))).toEqual([cloudNativeSkillId(BRIEFING_URI)]);
+  });
+});
+
+test("fails closed without Cloud auth: empty desired set, root cleared, no fetch", async () => {
+  await withRoot(async (root) => {
+    const cloud = fakeCloud({ index: indexFor([BRIEFING_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY } });
+    let config: Record<string, unknown> | null = cloudConfig("t");
+    const registered: Array<string | null> = [];
+    const sync = createCloudNativeSkillSync({ root, fetcher: cloud.fetcher, readCloudConfig: async () => config, register: async (directory) => { registered.push(directory); } });
+    await sync.sync();
+    expect(await stat(root).then(() => true)).toBe(true);
+    config = null;
+    const state = await sync.sync();
+    expect(state).toEqual({ root: null, skills: [] });
+    expect(registered.at(-1)).toBeNull();
+    expect(await stat(root).then(() => true, () => false)).toBe(false);
+    expect(cloud.reads.filter((uri) => uri === INDEX_URI)).toHaveLength(1);
+  });
+});
+
+test("fails closed on malformed index, rejected session, and partial body reads", async () => {
+  await withRoot(async (root) => {
+    const registered: Array<string | null> = [];
+    let fetcher: McpFetch = fakeCloud({ index: indexFor([BRIEFING_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY } }).fetcher;
+    const sync = createCloudNativeSkillSync({
+      root, fetcher: (url, init) => fetcher(url, init), readCloudConfig: async () => cloudConfig("t"),
+      register: async (directory) => { registered.push(directory); },
+    });
+    const code = async () => {
+      const error: unknown = await sync.sync().catch((caught: unknown) => caught);
+      return error instanceof CloudNativeSkillSyncError ? error.code : error;
+    };
+    await sync.sync();
+    expect(registered.at(-1)).not.toBeNull();
+
+    fetcher = fakeCloud({ index: "{not json", bodies: {} }).fetcher;
+    expect(await code()).toBe("cloud_skill_index_malformed");
+    expect(await stat(root).then(() => true, () => false)).toBe(false);
+    expect(registered.at(-1)).toBeNull();
+    expect(sync.current()).toEqual({ root: null, skills: [] });
+
+    fetcher = fakeCloud({ index: { skills: [{ name: "x", type: "skill-md", url: "https://not-a-skill" }] }, bodies: {} }).fetcher;
+    expect(await code()).toBe("cloud_skill_index_malformed");
+
+    fetcher = fakeCloud({ index: indexFor([BRIEFING_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY } }).fetcher;
+    await sync.sync();
+    expect(registered.at(-1)).not.toBeNull();
+    fetcher = fakeCloud({ index: indexFor([BRIEFING_URI, TRIAGE_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY } }).fetcher;
+    expect(await code()).toBe("cloud_skill_body_unavailable");
+    expect(registered.at(-1)).toBeNull();
+    expect(await stat(root).then(() => true, () => false)).toBe(false);
+
+    fetcher = async () => new Response("unauthorized", { status: 401 });
+    expect(await code()).toBe("cloud_skill_session_failed");
+  });
+});
+
+test("switching scope removes the previous root and registers the new one", async () => {
+  await withRoot(async (root) => {
+    const cloud = fakeCloud({ index: indexFor([BRIEFING_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY } });
+    let config = cloudConfig("token-a");
+    const registered: Array<string | null> = [];
+    const sync = createCloudNativeSkillSync({ root, fetcher: cloud.fetcher, readCloudConfig: async () => config, register: async (directory) => { registered.push(directory); } });
+    const first = await sync.sync();
+    config = cloudConfig("token-b");
+    // The global config write path notices the scope change before the next prompt.
+    await sync.reconcileScope();
+    expect(registered.at(-1)).toBeNull();
+    expect(await stat(root).then(() => true, () => false)).toBe(false);
+    const second = await sync.sync();
+    expect(second.root).not.toBe(first.root);
+    expect((await readdir(root)).sort()).toEqual([String(cloudNativeSkillScopeKey(config))]);
+    expect(registered.at(-1)).toBe(second.root);
+    // Unchanged scope is not an invalidation.
+    await sync.reconcileScope();
+    expect(registered.at(-1)).toBe(second.root);
+    expect(await stat(String(second.root)).then(() => true, () => false)).toBe(true);
+  });
+});
+
+test("a config change during an in-flight sync discards that generation", async () => {
+  await withRoot(async (root) => {
+    let release: (() => void) | undefined;
+    let gateArmed = true;
+    const cloud = fakeCloud({
+      index: indexFor([BRIEFING_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY },
+      gate: () => gateArmed ? new Promise<void>((resolve) => { release = resolve; }) : Promise.resolve(),
+    });
+    let config: Record<string, unknown> | null = cloudConfig("token-a");
+    const registered: Array<string | null> = [];
+    const sync = createCloudNativeSkillSync({ root, fetcher: cloud.fetcher, readCloudConfig: async () => config, register: async (directory) => { registered.push(directory); } });
+    const pending = sync.sync();
+    while (!release) await new Promise((resolve) => setTimeout(resolve, 5));
+    // Sign-out lands while the index read is in flight.
+    config = null;
+    const generation = sync.generation();
+    const reconcile = sync.reconcileScope();
+    while (sync.generation() === generation) await new Promise((resolve) => setTimeout(resolve, 5));
+    gateArmed = false;
+    release();
+    const state = await pending;
+    await reconcile;
+    expect(state).toEqual({ root: null, skills: [] });
+    expect(registered.every((directory) => directory === null)).toBe(true);
+    expect(await stat(root).then(() => true, () => false)).toBe(false);
+  });
+});
+
+test("the generated engine config keeps skill directories across provider rewrites", () => {
+  const skills = ["/state/cloud-skills/abcd"];
+  const first = renderOpencodeV2Config({ providers: [], skills });
+  expect(first.skills).toEqual(skills);
+  const second = renderOpencodeV2Config({
+    providers: [{ id: "p", name: "P", baseUrl: "https://p.test/v1", apiKey: "k", models: [{ id: "m", name: "M" }] }],
+    permissions: [],
+    skills,
+  });
+  expect(second.skills).toEqual(skills);
+  expect(Object.keys(second.providers ?? {})).toEqual(["p"]);
+  expect(renderOpencodeV2Config({ providers: [], skills: [] })).not.toHaveProperty("skills");
+});

--- a/apps/server/src/cloud-native-skills.test.ts
+++ b/apps/server/src/cloud-native-skills.test.ts
@@ -181,6 +181,30 @@ test("fails closed on malformed index, rejected session, and partial body reads"
 
     fetcher = async () => new Response("unauthorized", { status: 401 });
     expect(await code()).toBe("cloud_skill_session_failed");
+    for (const transportError of [new TypeError("fetch failed"), new DOMException("Timed out", "TimeoutError")]) {
+      fetcher = fakeCloud({ index: indexFor([BRIEFING_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY } }).fetcher;
+      await sync.sync();
+      fetcher = async () => { throw transportError; };
+      expect(await code()).toBe("cloud_skill_session_failed");
+      expect(sync.current()).toEqual({ root: null, skills: [] });
+      expect(registered.at(-1)).toBeNull();
+      expect(await stat(root).then(() => true, () => false)).toBe(false);
+    }
+  });
+});
+
+test("transport recovery does not hide a failed native unregistration", async () => {
+  await withRoot(async (root) => {
+    const cleanupError = new Error("Native unregistration failed");
+    let fetcher: McpFetch = fakeCloud({ index: indexFor([BRIEFING_URI]), bodies: { [BRIEFING_URI]: BRIEFING_BODY } }).fetcher;
+    const sync = createCloudNativeSkillSync({
+      root, fetcher: (url, init) => fetcher(url, init), readCloudConfig: async () => cloudConfig("t"),
+      register: async (directory) => { if (directory === null) throw cleanupError; },
+    });
+    await sync.sync();
+    fetcher = async () => { throw new TypeError("fetch failed"); };
+    await expect(sync.sync()).rejects.toBe(cleanupError);
+    expect(await stat(root).then(() => true, () => false)).toBe(false);
   });
 });
 

--- a/apps/server/src/cloud-native-skills.ts
+++ b/apps/server/src/cloud-native-skills.ts
@@ -1,0 +1,320 @@
+// OpenWork Cloud skills as native OpenCode v2 skills. The host reads the
+// authorized skill index and every SKILL.md body fresh from the openwork-cloud
+// MCP connection, materializes them into an engine-private directory, and
+// registers only that directory through the generated config `skills` list.
+// The agent never sees a Connect hop for skills: the native skill tool loads
+// them like workspace skills.
+import { createHash, randomBytes } from "node:crypto";
+import { chmod, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+
+import { openMcpResourceReader, type McpFetch } from "./connect-mcp-transport.js";
+import { externalFetch } from "./server-fetch.js";
+
+export const CLOUD_NATIVE_SKILL_ID_PREFIX = "openwork-cloud-";
+const SKILL_INDEX_URI = "skill://index.json";
+const MAX_INDEX_BYTES = 1024 * 1024;
+const MAX_SKILLS = 200;
+const MAX_BODY_BYTES = 256 * 1024;
+const BODY_CONCURRENCY = 4;
+const MAX_STALE_RETRIES = 3;
+
+export type CloudNativeSkillSyncCode =
+  | "cloud_skill_session_failed"
+  | "cloud_skill_index_unavailable"
+  | "cloud_skill_index_malformed"
+  | "cloud_skill_index_too_large"
+  | "cloud_skill_body_unavailable"
+  | "cloud_skill_body_too_large"
+  | "cloud_skill_sync_stale"
+  | "cloud_skill_engine_unavailable";
+
+export class CloudNativeSkillSyncError extends Error {
+  readonly code: CloudNativeSkillSyncCode;
+  constructor(code: CloudNativeSkillSyncCode, message: string) {
+    super(message);
+    this.name = "CloudNativeSkillSyncError";
+    this.code = code;
+  }
+}
+
+export type CloudNativeSkillBody = { uri: string; content: string };
+
+/** One materialized skill: native id, directory-based location, verbatim body. */
+export type CloudNativeSkill = { id: string; uri: string; location: string; content: string };
+
+/** `root` is the active scope directory registered in native config, or null when cleared. */
+export type CloudNativeSkillState = { root: string | null; skills: CloudNativeSkill[] };
+
+export const EMPTY_CLOUD_NATIVE_SKILL_STATE: CloudNativeSkillState = { root: null, skills: [] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function authorizationHeader(config: Record<string, unknown>): string | null {
+  if (!isRecord(config.headers)) return null;
+  for (const [key, value] of Object.entries(config.headers)) {
+    if (key.toLowerCase() === "authorization" && typeof value === "string" && value.trim()) return value;
+  }
+  return null;
+}
+
+/**
+ * Opaque scope for one endpoint + credential pair. Null means no Cloud auth is
+ * configured, so the desired native set is empty. Never derived into logs or
+ * paths as raw credential material.
+ */
+export function cloudNativeSkillScopeKey(config: Record<string, unknown> | null): string | null {
+  if (!config || config.enabled === false) return null;
+  const url = typeof config.url === "string" ? config.url : "";
+  const authorization = authorizationHeader(config);
+  if (!/^https?:\/\//.test(url) || !authorization) return null;
+  return createHash("sha256").update(`${url}\n${authorization}`).digest("hex").slice(0, 16);
+}
+
+/** Stable native id for one skill URI; body updates never change it. */
+export function cloudNativeSkillId(uri: string): string {
+  return `${CLOUD_NATIVE_SKILL_ID_PREFIX}${createHash("sha256").update(uri).digest("hex").slice(0, 16)}`;
+}
+
+const skillIndexSchema = z.object({
+  skills: z.array(z.object({
+    name: z.string().min(1).max(64),
+    type: z.string().max(64),
+    url: z.string().startsWith("skill://").max(1024),
+  }).passthrough()),
+}).passthrough();
+
+/**
+ * Fresh read of the skill index and every listed SKILL.md body through one
+ * initialized MCP session. No cache: any transport, auth, size, or shape
+ * problem throws so the caller can fail closed.
+ */
+export async function fetchCloudNativeSkills(
+  config: Record<string, unknown>,
+  fetcher: McpFetch = externalFetch,
+): Promise<CloudNativeSkillBody[]> {
+  const reader = await openMcpResourceReader({ config, fetcher, clientName: "openwork-server-cloud-skills" });
+  if (!reader) {
+    throw new CloudNativeSkillSyncError("cloud_skill_session_failed", "OpenWork Cloud skill session could not be initialized");
+  }
+  const indexText = await reader.read(SKILL_INDEX_URI);
+  if (indexText === null) {
+    throw new CloudNativeSkillSyncError("cloud_skill_index_unavailable", "OpenWork Cloud skill index could not be read");
+  }
+  if (Buffer.byteLength(indexText, "utf8") > MAX_INDEX_BYTES) {
+    throw new CloudNativeSkillSyncError("cloud_skill_index_too_large", "OpenWork Cloud skill index exceeds the size limit");
+  }
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(indexText);
+  } catch {
+    throw new CloudNativeSkillSyncError("cloud_skill_index_malformed", "OpenWork Cloud skill index is not valid JSON");
+  }
+  const parsed = skillIndexSchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    throw new CloudNativeSkillSyncError("cloud_skill_index_malformed", "OpenWork Cloud skill index has an unexpected shape");
+  }
+  const uris: string[] = [];
+  for (const skill of parsed.data.skills) {
+    if (skill.type !== "skill-md" || uris.includes(skill.url)) continue;
+    uris.push(skill.url);
+  }
+  if (uris.length > MAX_SKILLS) {
+    throw new CloudNativeSkillSyncError("cloud_skill_index_too_large", `OpenWork Cloud skill index lists more than ${MAX_SKILLS} skills`);
+  }
+  const bodies: CloudNativeSkillBody[] = [];
+  let next = 0;
+  const worker = async () => {
+    while (next < uris.length) {
+      const uri = uris[next++];
+      if (uri === undefined) return;
+      const content = await reader.read(uri);
+      if (content === null) {
+        throw new CloudNativeSkillSyncError("cloud_skill_body_unavailable", `OpenWork Cloud skill body could not be read: ${uri}`);
+      }
+      if (Buffer.byteLength(content, "utf8") > MAX_BODY_BYTES) {
+        throw new CloudNativeSkillSyncError("cloud_skill_body_too_large", `OpenWork Cloud skill body exceeds the size limit: ${uri}`);
+      }
+      bodies.push({ uri, content });
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(BODY_CONCURRENCY, uris.length) }, worker));
+  return bodies.sort((left, right) => left.uri.localeCompare(right.uri));
+}
+
+async function writePrivateFile(path: string, content: string): Promise<void> {
+  const temporary = `${path}.tmp-${randomBytes(6).toString("hex")}`;
+  await writeFile(temporary, content, { mode: 0o600 });
+  await chmod(temporary, 0o600);
+  await rename(temporary, path);
+}
+
+async function privateDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: 0o700 });
+  await chmod(path, 0o700);
+}
+
+async function listDirectories(path: string): Promise<string[]> {
+  try {
+    return (await readdir(path, { withFileTypes: true })).filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Publish `<root>/<scopeKey>/<skillId>/SKILL.md` for every skill. Bodies are
+ * staged first, then moved into place with atomic per-file renames so the
+ * native watcher never observes a partially written SKILL.md. Obsolete skill
+ * directories and every other scope directory are removed.
+ */
+export async function materializeCloudNativeSkills(
+  root: string,
+  scopeKey: string,
+  bodies: CloudNativeSkillBody[],
+): Promise<CloudNativeSkillState> {
+  const scopeDir = join(root, scopeKey);
+  await privateDir(root);
+  const stage = join(root, `.stage-${randomBytes(6).toString("hex")}`);
+  const skills: CloudNativeSkill[] = [];
+  try {
+    await privateDir(stage);
+    for (const body of bodies) {
+      const id = cloudNativeSkillId(body.uri);
+      await privateDir(join(stage, id));
+      await writePrivateFile(join(stage, id, "SKILL.md"), body.content);
+      skills.push({ id, uri: body.uri, location: join(scopeDir, id, "SKILL.md"), content: body.content });
+    }
+    skills.sort((left, right) => left.id.localeCompare(right.id));
+    await privateDir(scopeDir);
+    const keep = new Set(skills.map((skill) => skill.id));
+    for (const existing of await listDirectories(scopeDir)) {
+      if (!keep.has(existing)) await rm(join(scopeDir, existing), { recursive: true, force: true });
+    }
+    for (const skill of skills) {
+      const target = join(scopeDir, skill.id);
+      const current = await readFile(join(target, "SKILL.md"), "utf8").catch(() => null);
+      if (current === skill.content) continue;
+      if (current === null) {
+        await rm(target, { recursive: true, force: true });
+        await rename(join(stage, skill.id), target);
+      } else {
+        await rename(join(stage, skill.id, "SKILL.md"), join(target, "SKILL.md"));
+      }
+    }
+    for (const other of await listDirectories(root)) {
+      if (other !== scopeKey && !other.startsWith(".stage-")) await rm(join(root, other), { recursive: true, force: true });
+    }
+  } finally {
+    await rm(stage, { recursive: true, force: true });
+  }
+  return { root: scopeDir, skills };
+}
+
+export interface CloudNativeSkillSync {
+  /** Fresh fetch + materialize + native registration. Throws (after clearing) on failure. */
+  sync(): Promise<CloudNativeSkillState>;
+  /** Bump the generation, unregister the root, and delete every materialized file. */
+  invalidate(): Promise<void>;
+  /** Invalidate only when the configured scope no longer matches the registered one. */
+  reconcileScope(): Promise<void>;
+  /** Forget registration state and delete files; used when the engine (re)starts with an empty config. */
+  reset(): Promise<void>;
+  current(): CloudNativeSkillState;
+  generation(): number;
+}
+
+export function createCloudNativeSkillSync(options: {
+  root: string;
+  readCloudConfig: () => Promise<Record<string, unknown> | null>;
+  register: (directory: string | null) => Promise<void>;
+  fetcher?: McpFetch;
+}): CloudNativeSkillSync {
+  let generation = 0;
+  let registered: string | null = null;
+  let activeScope: string | null = null;
+  let current: CloudNativeSkillState = EMPTY_CLOUD_NATIVE_SKILL_STATE;
+  let queue: Promise<unknown> = Promise.resolve();
+
+  function enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const next = queue.catch(() => undefined).then(task);
+    queue = next;
+    return next;
+  }
+
+  async function setRegistered(directory: string | null): Promise<void> {
+    if (registered === directory) return;
+    await options.register(directory);
+    registered = directory;
+  }
+
+  async function clearAll(): Promise<void> {
+    current = EMPTY_CLOUD_NATIVE_SKILL_STATE;
+    activeScope = null;
+    try {
+      await setRegistered(null);
+    } finally {
+      await rm(options.root, { recursive: true, force: true });
+    }
+  }
+
+  async function attempt(): Promise<CloudNativeSkillState | "stale"> {
+    const started = generation;
+    const cloud = await options.readCloudConfig();
+    const scope = cloudNativeSkillScopeKey(cloud);
+    if (generation !== started) return "stale";
+    activeScope = scope;
+    if (!cloud || !scope) {
+      await clearAll();
+      return current;
+    }
+    let bodies: CloudNativeSkillBody[];
+    try {
+      bodies = await fetchCloudNativeSkills(cloud, options.fetcher);
+    } catch (error) {
+      if (generation !== started) return "stale";
+      await clearAll();
+      throw error;
+    }
+    if (generation !== started) return "stale";
+    const state = await materializeCloudNativeSkills(options.root, scope, bodies);
+    if (generation !== started) return "stale";
+    await setRegistered(state.root);
+    current = state;
+    return state;
+  }
+
+  return {
+    async sync() {
+      for (let retry = 0; retry < MAX_STALE_RETRIES; retry++) {
+        const result = await enqueue(attempt);
+        if (result !== "stale") return result;
+      }
+      throw new CloudNativeSkillSyncError("cloud_skill_sync_stale", "OpenWork Cloud configuration kept changing during skill synchronization");
+    },
+    invalidate() {
+      generation++;
+      return enqueue(clearAll);
+    },
+    async reconcileScope() {
+      const scope = cloudNativeSkillScopeKey(await options.readCloudConfig());
+      if (scope === activeScope) return;
+      generation++;
+      await enqueue(clearAll);
+    },
+    reset() {
+      generation++;
+      return enqueue(async () => {
+        current = EMPTY_CLOUD_NATIVE_SKILL_STATE;
+        activeScope = null;
+        registered = null;
+        await rm(options.root, { recursive: true, force: true });
+      });
+    },
+    current: () => current,
+    generation: () => generation,
+  };
+}

--- a/apps/server/src/cloud-native-skills.ts
+++ b/apps/server/src/cloud-native-skills.ts
@@ -276,8 +276,11 @@ export function createCloudNativeSkillSync(options: {
       bodies = await fetchCloudNativeSkills(cloud, options.fetcher);
     } catch (error) {
       if (generation !== started) return "stale";
+      // Only a successfully cleared registry may admit a turn without Cloud
+      // skills. Cleanup failures still propagate and block admission.
       await clearAll();
-      throw error;
+      if (error instanceof CloudNativeSkillSyncError) throw error;
+      throw new CloudNativeSkillSyncError("cloud_skill_session_failed", "OpenWork Cloud skill transport is unavailable");
     }
     if (generation !== started) return "stale";
     const state = await materializeCloudNativeSkills(options.root, scope, bodies);

--- a/apps/server/src/connect-mcp-transport.ts
+++ b/apps/server/src/connect-mcp-transport.ts
@@ -85,17 +85,22 @@ export async function mcpPost(fetcher: McpFetch, url: string, headers: Record<st
   return { response, payload: await readMcpPayload(response, requestId) };
 }
 
+export type McpResourceReader = {
+  /** Resource text, or null when the read failed or returned no matching text. */
+  read(uri: string): Promise<string | null>;
+};
+
 /**
- * Reads one JSON resource from an openwork-cloud config. Returns the resource
- * text, or null when the config is unusable (invalid URL, disabled, auth
- * rejected, transport or protocol error) so callers can try another candidate.
+ * Opens one initialized Streamable HTTP session against an openwork-cloud
+ * config. Returns null when the config is unusable (invalid URL, disabled, auth
+ * rejected, transport or protocol error). The reader issues sequential
+ * `resources/read` requests on that session.
  */
-export async function readMcpResourceText(input: {
+export async function openMcpResourceReader(input: {
   config: Record<string, unknown>;
-  uri: string;
   fetcher: McpFetch;
   clientName: string;
-}): Promise<string | null> {
+}): Promise<McpResourceReader | null> {
   const url = typeof input.config.url === "string" ? input.config.url : "";
   if (!/^https?:\/\//.test(url) || input.config.enabled === false) return null;
   const baseHeaders = stringHeaders(input.config.headers);
@@ -122,17 +127,37 @@ export async function readMcpResourceText(input: {
   };
   const notification = await mcpPost(input.fetcher, url, sessionHeaders, { jsonrpc: "2.0", method: "notifications/initialized", params: {} });
   if (notification.response.status !== 202 || notification.payload !== null) return null;
-  const resource = await mcpPost(input.fetcher, url, sessionHeaders, {
-    id: 2,
-    jsonrpc: "2.0",
-    method: "resources/read",
-    params: { uri: input.uri },
-  });
-  if (!resource.response.ok) return null;
-  const contents = jsonRpcResult(resource.payload)?.contents;
-  if (!Array.isArray(contents)) return null;
-  const text = contents.find((item) => isRecord(item) && item.uri === input.uri && typeof item.text === "string")?.text;
-  return typeof text === "string" ? text : null;
+  let nextId = 2;
+  return {
+    async read(uri) {
+      const resource = await mcpPost(input.fetcher, url, sessionHeaders, {
+        id: nextId++,
+        jsonrpc: "2.0",
+        method: "resources/read",
+        params: { uri },
+      });
+      if (!resource.response.ok) return null;
+      const contents = jsonRpcResult(resource.payload)?.contents;
+      if (!Array.isArray(contents)) return null;
+      const text = contents.find((item) => isRecord(item) && item.uri === uri && typeof item.text === "string")?.text;
+      return typeof text === "string" ? text : null;
+    },
+  };
+}
+
+/**
+ * Reads one JSON resource from an openwork-cloud config. Returns the resource
+ * text, or null when the config is unusable (invalid URL, disabled, auth
+ * rejected, transport or protocol error) so callers can try another candidate.
+ */
+export async function readMcpResourceText(input: {
+  config: Record<string, unknown>;
+  uri: string;
+  fetcher: McpFetch;
+  clientName: string;
+}): Promise<string | null> {
+  const reader = await openMcpResourceReader(input);
+  return reader ? reader.read(input.uri) : null;
 }
 
 export function escapeXml(value: string): string {

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -7,6 +7,13 @@ import { join } from "node:path";
 
 import constants from "../../../constants.json" with { type: "json" };
 import {
+  CloudNativeSkillSyncError,
+  createCloudNativeSkillSync,
+  EMPTY_CLOUD_NATIVE_SKILL_STATE,
+  type CloudNativeSkillState,
+  type CloudNativeSkillSyncCode,
+} from "./cloud-native-skills.js";
+import {
   createManagedOpencodeV2Server,
   installOpencodeV2Binary,
   type ManagedOpencodeV2Server,
@@ -17,6 +24,7 @@ import { runtimeStorageDir } from "./runtime-db.js";
 import {
   isEngineGlobalRuntimeConfigId,
   onRuntimeOpencodeConfigWrite,
+  readGlobalRuntimeMcpConfig,
   readGlobalRuntimeOpencodeConfig,
   readEffectiveRuntimeOpencodeConfig,
   runtimeMcpMap,
@@ -29,6 +37,8 @@ import type { ServerConfig } from "./types.js";
 const OPENCODE_V2_VERSION = constants.opencodeV2Version;
 const PREVIEW_STATE_FILE = "engine-v2-preview.json";
 const UNSET_API_KEY = "openwork-engine-v2-preview-unset";
+/** Reserved Connect MCP name; kept in sync with OPENWORK_CLOUD_MCP_NAME in cloud-mcp-health.ts. */
+const OPENWORK_CLOUD_MCP_NAME = "openwork-cloud";
 // A cold sidecar can return HTTP 503 while its model catalog initializes for 17–20 seconds.
 const CATALOG_MIRROR_TIMEOUT_MS = 60_000;
 
@@ -64,6 +74,8 @@ export interface EngineV2Preview {
   connection(): { url: string; username: string; password: string } | undefined;
   ensureWorkspaceReady(directory: string): Promise<void>;
   syncWorkspaceMcp(workspaceId: string, directory: string): Promise<void>;
+  /** Fresh materialization of authorized Cloud skills as native skills. `failure` is set when they failed closed (cleared) for this admission. */
+  syncCloudSkills(): Promise<{ root: string; state: CloudNativeSkillState; failure?: CloudNativeSkillSyncCode }>;
   stop(): Promise<void>;
 }
 
@@ -323,6 +335,28 @@ export function createEngineV2Preview(options: { config: ServerConfig; env?: Pic
   const workspaceMcp = new Map<string, Map<string, string>>();
   const mcpInFlight = new Map<string, Promise<void>>();
   const mcpWorkspaces = new Map<string, string>();
+  const cloudSkillsRoot = join(rootDir, "cloud-skills");
+  const cloudSkills = createCloudNativeSkillSync({
+    root: cloudSkillsRoot,
+    readCloudConfig: () => readGlobalRuntimeMcpConfig(config, OPENWORK_CLOUD_MCP_NAME),
+    register: async (directory) => {
+      const active = sidecar;
+      if (!active) throw new CloudNativeSkillSyncError("cloud_skill_engine_unavailable", "OpenCode v2 is not running");
+      await active.setSkills(directory ? [directory] : []);
+    },
+  });
+
+  async function syncCloudSkills(): Promise<{ root: string; state: CloudNativeSkillState; failure?: CloudNativeSkillSyncCode }> {
+    if (!sidecar) throw new CloudNativeSkillSyncError("cloud_skill_engine_unavailable", "OpenCode v2 is not running");
+    try {
+      return { root: cloudSkillsRoot, state: await cloudSkills.sync() };
+    } catch (error) {
+      if (!(error instanceof CloudNativeSkillSyncError)) throw error;
+      // Skills fail closed, the conversation does not: sync() already cleared
+      // and unregistered the root, so the caller admits without Cloud skills.
+      return { root: cloudSkillsRoot, state: EMPTY_CLOUD_NATIVE_SKILL_STATE, failure: error.code };
+    }
+  }
 
   async function syncWorkspaceMcp(workspaceId: string, directory: string): Promise<void> {
     mcpWorkspaces.set(directory, workspaceId);
@@ -489,6 +523,9 @@ export function createEngineV2Preview(options: { config: ServerConfig; env?: Pic
     binSource = resolved.source;
     if (!enabled || !allowRunning) return;
     await mkdir(workspaceDir, { recursive: true });
+    // A previous process may have left materialized cloud skills behind. The
+    // fresh engine config registers none until the first sync succeeds.
+    await cloudSkills.reset();
     const opencodeModelsUrl = await resolveOpencodeModelsUrl();
     const managed = await createManagedOpencodeV2Server({
       bin: resolved.bin,
@@ -509,6 +546,11 @@ export function createEngineV2Preview(options: { config: ServerConfig; env?: Pic
       const unsubscribeConfig = onRuntimeOpencodeConfigWrite((_writeConfig, workspaceId) => {
         const global = isEngineGlobalRuntimeConfigId(workspaceId);
         if (global) scheduleMirror();
+        // A replaced or removed openwork-cloud config invalidates the
+        // materialized skills before the next prompt can register a new scope.
+        if (global) void cloudSkills.reconcileScope().catch((error) => {
+          if (sidecar) lastError = `Cloud skills: ${errorMessage(error)}`;
+        });
         // Connections installed through OpenWork also update already-open
         // locations while a conversation is active. Request admission joins
         // the same serialized reconciliation rather than racing it.
@@ -626,5 +668,5 @@ export function createEngineV2Preview(options: { config: ServerConfig; env?: Pic
     if (enabled) void start().catch(recordStartError);
   }
   if (!options.deferStart) startWhenReady();
-  return { start: startWhenReady, status, setEnabled, setChatRouting, connection, ensureWorkspaceReady, syncWorkspaceMcp, stop };
+  return { start: startWhenReady, status, setEnabled, setChatRouting, connection, ensureWorkspaceReady, syncWorkspaceMcp, syncCloudSkills, stop };
 }

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -57,6 +57,8 @@ export interface ManagedOpencodeV2Server {
   fetchJson(path: string, init?: { method?: string; body?: unknown; directory?: string; timeoutMs?: number }): Promise<{ status: number; json: unknown }>;
   injectProvider(spec: OpencodeV2ProviderSpec): Promise<void>;
   setProviders(specs: OpencodeV2ProviderSpec[]): Promise<void>;
+  /** Extra absolute skill directories registered through native config `skills`. */
+  setSkills(directories: string[]): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -75,6 +77,59 @@ function diagnostics(exitCode: number | null, stdout: string, stderr: string): E
   );
 }
 
+/** The whole generated engine config: every writer emits all current keys. */
+export function renderOpencodeV2Config(input: {
+  providers: OpencodeV2ProviderSpec[];
+  permissions?: EnginePermissionRule[];
+  skills: string[];
+}): Record<string, unknown> {
+  const providerConfig: Record<string, unknown> = {};
+  for (const provider of input.providers) {
+    const models: Record<string, unknown> = {};
+    for (const model of provider.models) {
+      const config = model.config ?? {};
+      const modalities = isRecord(config.modalities) ? config.modalities : {};
+      models[model.id] = {
+        name: model.name,
+        ...(typeof config.id === "string" ? { modelID: config.id } : {}),
+        capabilities: {
+          tools: typeof config.tool_call === "boolean" ? config.tool_call : true,
+          input: modalities.input ?? ["text"],
+          output: config.reasoning === true
+            ? [...new Set([...(Array.isArray(modalities.output) ? modalities.output : ["text"]), "reasoning"])]
+            : modalities.output ?? ["text"],
+        },
+        limit: config.limit ?? { context: 128_000, output: 8_192 },
+        ...(typeof config.family === "string" ? { family: config.family } : {}),
+        ...(isRecord(config.options) ? { settings: config.options } : {}),
+        ...(isRecord(config.variants) ? {
+          variants: nativeModelVariants(config.variants, provider.package),
+        } : {}),
+        ...(isRecord(config.headers) ? { headers: config.headers } : {}),
+        ...(config.status === "deprecated" ? { disabled: true } : {}),
+      };
+    }
+    providerConfig[provider.id] = {
+      name: provider.name,
+      package: provider.package ?? "@opencode-ai/ai/providers/openai-compatible",
+      settings: {
+        ...provider.settings,
+        ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),
+        apiKey: provider.apiKey,
+        name: provider.id,
+      },
+      ...(provider.headers ? { headers: provider.headers } : {}),
+      models,
+    };
+  }
+  return {
+    $schema: "https://opencode.ai/config.json",
+    providers: providerConfig,
+    ...(input.permissions ? { permissions: input.permissions } : {}),
+    ...(input.skills.length ? { skills: [...input.skills] } : {}),
+  };
+}
+
 export async function createManagedOpencodeV2Server(
   options: ManagedOpencodeV2ServerOptions,
 ): Promise<ManagedOpencodeV2Server> {
@@ -86,6 +141,8 @@ export async function createManagedOpencodeV2Server(
   const username = "opencode";
   let url = "";
   const providers = new Map<string, OpencodeV2ProviderSpec>();
+  let skills: string[] = [];
+  let writes: Promise<void> = Promise.resolve();
   const opencodeModelsUrl = (options.env?.OPENCODE_MODELS_URL ?? process.env.OPENCODE_MODELS_URL)?.replace(/\/+$/, "");
   // The engine needs OS paths and locale settings, not the server's provider,
   // cloud, database, or control-plane credentials. Unknown keys stay private.
@@ -111,7 +168,9 @@ export async function createManagedOpencodeV2Server(
   // Replace the generated config before boot, removing stale managed-policy
   // registrations while retaining independent engine permissions. Leave the
   // old entrypoint on disk: another configuration may still reference it.
-  await writeProviders();
+  // Boot registers no skill directories: a stale materialized root is never
+  // visible until a fresh cloud skill sync succeeds.
+  await writeConfig();
   const child = spawn(options.bin, ["serve", "--hostname", hostname, "--port", String(port)], {
     env: {
       ...inherited,
@@ -192,53 +251,22 @@ export async function createManagedOpencodeV2Server(
     return { healthy, version, pid };
   }
 
-  async function writeProviders(): Promise<void> {
-    const providerConfig: Record<string, unknown> = {};
-    for (const provider of providers.values()) {
-      const models: Record<string, unknown> = {};
-      for (const model of provider.models) {
-        const config = model.config ?? {};
-        const modalities = isRecord(config.modalities) ? config.modalities : {};
-        models[model.id] = {
-          name: model.name,
-          ...(typeof config.id === "string" ? { modelID: config.id } : {}),
-          capabilities: {
-            tools: typeof config.tool_call === "boolean" ? config.tool_call : true,
-            input: modalities.input ?? ["text"],
-            output: config.reasoning === true
-              ? [...new Set([...(Array.isArray(modalities.output) ? modalities.output : ["text"]), "reasoning"])]
-              : modalities.output ?? ["text"],
-          },
-          limit: config.limit ?? { context: 128_000, output: 8_192 },
-          ...(typeof config.family === "string" ? { family: config.family } : {}),
-          ...(isRecord(config.options) ? { settings: config.options } : {}),
-          ...(isRecord(config.variants) ? {
-            variants: nativeModelVariants(config.variants, provider.package),
-          } : {}),
-          ...(isRecord(config.headers) ? { headers: config.headers } : {}),
-          ...(config.status === "deprecated" ? { disabled: true } : {}),
-        };
-      }
-      providerConfig[provider.id] = {
-        name: provider.name,
-        package: provider.package ?? "@opencode-ai/ai/providers/openai-compatible",
-        settings: {
-          ...provider.settings,
-          ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),
-          apiKey: provider.apiKey,
-          name: provider.id,
-        },
-        ...(provider.headers ? { headers: provider.headers } : {}),
-        models,
-      };
-    }
+  // Every rewrite (providers, permissions, skills) serializes through one
+  // queue and emits the whole current state, so no writer drops another's keys.
+  function writeConfig(): Promise<void> {
+    const next = writes.catch(() => undefined).then(writeConfigNow);
+    writes = next;
+    return next;
+  }
+
+  async function writeConfigNow(): Promise<void> {
     const target = join(configDir, "opencode.json");
     const temporary = `${target}.tmp-${randomBytes(8).toString("hex")}`;
-    await writeFile(temporary, `${JSON.stringify({
-      $schema: "https://opencode.ai/config.json",
-      providers: providerConfig,
+    await writeFile(temporary, `${JSON.stringify(renderOpencodeV2Config({
+      providers: [...providers.values()],
       ...(options.permissions ? { permissions: await options.permissions() } : {}),
-    }, null, 2)}\n`, { mode: 0o600 });
+      skills,
+    }), null, 2)}\n`, { mode: 0o600 });
     await rename(temporary, target);
   }
 
@@ -276,14 +304,18 @@ export async function createManagedOpencodeV2Server(
     fetchJson,
     async injectProvider(spec) {
       providers.set(spec.id, spec);
-      await writeProviders();
+      await writeConfig();
     },
     async setProviders(specs) {
       providers.clear();
       for (const spec of specs) {
         providers.set(spec.id, spec);
       }
-      await writeProviders();
+      await writeConfig();
+    },
+    async setSkills(directories) {
+      skills = [...directories];
+      await writeConfig();
     },
     close,
   };

--- a/apps/server/src/opencode-proxy-gate.test.ts
+++ b/apps/server/src/opencode-proxy-gate.test.ts
@@ -4,6 +4,7 @@ import {
   assertOpencodeProxyAllowed,
   normalizeOpencodeDirectory,
   proxyOpencodeRequest,
+  proxyOpencodeV2Request,
   scopeWorkspaceOpencodeRequest,
 } from "./server.js";
 import { ApiError } from "./errors.js";
@@ -139,6 +140,49 @@ describe("proxyOpencodeRequest read-only guard", () => {
       request: new Request(url, { method }),
     });
   };
+
+  test("native Cloud catalog reads expose metadata, not private bodies or paths, to shared clients", async () => {
+    const cloud = {
+      id: "openwork-cloud-0123456789abcdef", name: "briefing", description: "Prepare a briefing", slash: true,
+      content: "OWNER_PRIVATE_INSTRUCTIONS", location: "/private/cloud-skills/scope/SKILL.md",
+      futurePrivateField: "OWNER_PRIVATE_INSTRUCTIONS",
+    };
+    const local = { id: "local-briefing", name: "local", content: "Workspace instructions", location: "/workspace/.opencode/skills/local/SKILL.md" };
+    const engine = Bun.serve({
+      hostname: "127.0.0.1", port: 0,
+      fetch(request) {
+        const path = decodeURIComponent(new URL(request.url).pathname);
+        return Response.json({ data: path.includes(cloud.id) ? cloud : [local, cloud] });
+      },
+    });
+    try {
+      for (const scope of ["viewer", "collaborator", undefined, "owner"] as const) {
+        for (const suffix of ["/api/skill", "/api/skill/", "/api/%73kill", `/api/skill/${cloud.id}`]) {
+          const proxyPath = `/opencode2${suffix}`;
+          const url = new URL(`http://openwork.invalid/workspace/ws_ro${proxyPath}`);
+          const response = await proxyOpencodeV2Request({
+            actor: actor(scope), config: readOnlyConfig, workspace, proxyPath, url,
+            request: new Request(url),
+            connection: { url: `http://127.0.0.1:${engine.port}`, username: "opencode", password: "fixture-only" },
+            syncCloudSkills: async () => { throw new Error("Catalog reads must not sync or alter Cloud skills"); },
+          });
+          expect(response.status).toBe(200);
+          const payload = await response.json();
+          const entry = Array.isArray(payload.data) ? payload.data[1] : payload.data;
+          expect(entry).toEqual(scope === "owner" ? cloud : {
+            id: cloud.id, name: cloud.name, description: cloud.description, slash: true,
+          });
+          if (Array.isArray(payload.data)) expect(payload.data[0]).toEqual(local);
+          if (scope !== "owner") {
+            expect(JSON.stringify(payload)).not.toContain("OWNER_PRIVATE_INSTRUCTIONS");
+            expect(JSON.stringify(payload)).not.toContain("/private/cloud-skills");
+          }
+        }
+      }
+    } finally {
+      await engine.stop(true);
+    }
+  });
 
   test("rejects native proxy writes on a read-only server (parity with the removed ensureWritable wrapper routes)", async () => {
     for (const method of ["POST", "DELETE", "PATCH", "PUT"]) {

--- a/apps/server/src/opencode-v2-instructions.test.ts
+++ b/apps/server/src/opencode-v2-instructions.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildOpenWorkV2Instructions, nativeSkillBody, waitForOpenWorkV2Skills } from "./opencode-v2-instructions.js";
+
+async function withWorkspace(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-v2-skills-"));
+  try { await run(root); } finally { await rm(root, { recursive: true, force: true }); }
+}
+
+test("native-valid skills with a directory/name mismatch or no description do not block admission", async () => {
+  await withWorkspace(async (root) => {
+    const mismatch = join(root, ".opencode", "skills", "release-notes", "SKILL.md");
+    const bare = join(root, ".claude", "skills", "nested", "Bare_Skill", "SKILL.md");
+    const flat = join(root, ".opencode", "skills", "quick.md");
+    await mkdir(join(mismatch, ".."), { recursive: true });
+    await mkdir(join(bare, ".."), { recursive: true });
+    await writeFile(mismatch, "---\nname: Release Notes Writer\n---\n\nWrite release notes.\n");
+    await writeFile(bare, "No frontmatter at all.\n");
+    await writeFile(flat, "---\ndescription: quick\n---\nQuick body\n");
+    let reads = 0;
+    await waitForOpenWorkV2Skills(root, async () => {
+      reads++;
+      return { data: [
+        { id: "release-notes", name: "Release Notes Writer", location: mismatch, content: "\nWrite release notes.\n" },
+        { id: "Bare_Skill", name: "Bare_Skill", location: bare, content: "No frontmatter at all.\n" },
+        { id: "quick", name: "quick", description: "quick", location: flat, content: "Quick body\n" },
+        { id: "plugin-skill", name: "plugin-skill", location: join(root, ".opencode", "plugins", "x", "SKILL.md"), content: "unrelated" },
+      ] };
+    });
+    expect(reads).toBe(1);
+  });
+});
+
+test("content edits and removals under managed roots are awaited by body, not by OpenWork validation", async () => {
+  await withWorkspace(async (root) => {
+    const skill = join(root, ".opencode", "skills", "notes", "SKILL.md");
+    await mkdir(join(skill, ".."), { recursive: true });
+    await writeFile(skill, "---\nname: notes\n---\nCurrent body\n");
+    const deleted = join(root, ".opencode", "skills", "gone", "SKILL.md");
+    let reads = 0;
+    await waitForOpenWorkV2Skills(root, async () => {
+      reads++;
+      return reads === 1
+        ? { data: [{ id: "notes", name: "notes", location: skill, content: "Old body" }, { id: "gone", name: "gone", location: deleted, content: "x" }] }
+        : { data: [{ id: "notes", name: "notes", location: skill, content: "Current body\n" }] };
+    });
+    expect(reads).toBe(2);
+  });
+});
+
+test("skipped native files (malformed frontmatter) are neither expected nor treated as removed", async () => {
+  await withWorkspace(async (root) => {
+    const broken = join(root, ".opencode", "skills", "broken", "SKILL.md");
+    await mkdir(join(broken, ".."), { recursive: true });
+    await writeFile(broken, "---\nname: [unclosed\n---\nBody\n");
+    expect(nativeSkillBody("---\nname: 3\n---\nx")).toBeNull();
+    expect(nativeSkillBody("---\nslash: yes\n---\nx")).toBeNull();
+    expect(nativeSkillBody("plain")).toBe("plain");
+    let reads = 0;
+    await waitForOpenWorkV2Skills(root, async () => { reads++; return { data: [] }; });
+    expect(reads).toBe(1);
+  });
+});
+
+test("materialized cloud skills must be present with their bodies and stale cloud entries gone", async () => {
+  await withWorkspace(async (root) => {
+    const cloudRoot = join(root, "state", "cloud-skills");
+    const scope = join(cloudRoot, "0123456789abcdef");
+    const location = join(scope, "openwork-cloud-aaaaaaaaaaaaaaaa", "SKILL.md");
+    const content = "---\nname: customer-briefing\ndescription: Brief\n---\n\nDo the briefing.\n";
+    const stale = join(cloudRoot, "fedcba9876543210", "openwork-cloud-bbbbbbbbbbbbbbbb", "SKILL.md");
+    let reads = 0;
+    await waitForOpenWorkV2Skills(root, async () => {
+      reads++;
+      if (reads === 1) return { data: [{ id: "openwork-cloud-bbbbbbbbbbbbbbbb", name: "old", location: stale, content: "old" }] };
+      if (reads === 2) return { data: [{ id: "openwork-cloud-aaaaaaaaaaaaaaaa", name: "customer-briefing", location, content: "Previous body" }] };
+      return { data: [{ id: "openwork-cloud-aaaaaaaaaaaaaaaa", name: "customer-briefing", location, content: "\nDo the briefing.\n" }] };
+    }, { root: cloudRoot, state: { root: scope, skills: [{ id: "openwork-cloud-aaaaaaaaaaaaaaaa", uri: "skill://customer-briefing/SKILL.md", location, content }] } });
+    expect(reads).toBe(3);
+  });
+});
+
+test("v2 guidance routes organization skills through the native catalog, not Connect", () => {
+  for (const connected of [true, false]) {
+    const value = buildOpenWorkV2Instructions(connected);
+    expect(value.operatingInstructions).not.toContain("remote skills");
+    expect(value.operatingInstructions).not.toContain("remote skill catalog");
+    expect(value.operatingInstructions).toContain("Authorized organization skills are in the native skill catalog");
+    expect(value.skillInstructions).not.toContain("provided by OpenWork Connect");
+    expect(value.skillInstructions).toContain("openwork-cloud-");
+    expect(Buffer.byteLength(JSON.stringify(value), "utf8")).toBeLessThanOrEqual(7 * 1024);
+  }
+});

--- a/apps/server/src/opencode-v2-instructions.ts
+++ b/apps/server/src/opencode-v2-instructions.ts
@@ -1,8 +1,8 @@
-import { listSkills } from "./skills.js";
-import { readFile, realpath } from "node:fs/promises";
+import { readdir, readFile, realpath } from "node:fs/promises";
 import { join, sep } from "node:path";
 import { parseFrontmatter } from "./frontmatter.js";
 import { OPENWORK_AGENT_PROMPT } from "./openwork-agent-prompt.js";
+import type { CloudNativeSkillState } from "./cloud-native-skills.js";
 
 export const OPENWORK_V2_INSTRUCTION_KEY = "openwork.context";
 
@@ -10,30 +10,100 @@ function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** Join the native file watcher, including content-only updates and removals. */
-export async function waitForOpenWorkV2Skills(directory: string, readNative: () => Promise<unknown>): Promise<void> {
-  const root = await realpath(directory);
-  const expected = await Promise.all((await listSkills(directory, false)).filter((skill) => !skill.error).map(async (skill) => ({
-    name: skill.name, description: skill.description ?? "", path: await realpath(skill.path), content: parseFrontmatter(await readFile(skill.path, "utf8")).body.trim(),
-  })));
+/** Skill roots the pinned engine derives from a workspace `.opencode` / `.claude` directory. */
+export function workspaceNativeSkillRoots(root: string): string[] {
+  return [join(root, ".opencode", "skills"), join(root, ".opencode", "skill"), join(root, ".claude", "skills")];
+}
+
+async function scanSkillFiles(directory: string): Promise<string[]> {
+  const files: string[] = [];
+  const visit = async (current: string, top: boolean): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(current, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path, false);
+      } else if (entry.name === "SKILL.md" || (top && entry.name.endsWith(".md"))) {
+        // Native scan pattern: {*.md,**/SKILL.md} relative to the skill root.
+        files.push(path);
+      }
+    }
+  };
+  await visit(directory, true);
+  return files;
+}
+
+/** Body the engine publishes for a markdown file, or null when it would skip the file. */
+export function nativeSkillBody(content: string): string | null {
+  let parsed: { data: Record<string, unknown>; body: string };
+  try {
+    parsed = parseFrontmatter(content);
+  } catch {
+    return null;
+  }
+  const { name, description, slash } = parsed.data;
+  if (name !== undefined && typeof name !== "string") return null;
+  if (description !== undefined && typeof description !== "string") return null;
+  if (slash !== undefined && typeof slash !== "boolean") return null;
+  return parsed.body.trim();
+}
+
+type Expected = { path: string; content: string };
+
+/**
+ * Join the native file watcher, including content-only updates and removals.
+ * Reconciliation uses the engine's own contract (location + body) rather than
+ * OpenWork's stricter create/delete validation, so a native-valid workspace
+ * skill with a directory/name mismatch or no description never blocks admission.
+ * When `cloud` is supplied, the materialized organization skills must be
+ * present with their exact bodies and no stale entry may remain under the root.
+ */
+export async function waitForOpenWorkV2Skills(
+  directory: string,
+  readNative: () => Promise<unknown>,
+  cloud?: { root: string; state: CloudNativeSkillState },
+): Promise<void> {
+  const canonicalPath = (path: string) => realpath(path).catch(() => path);
+  const root = await canonicalPath(directory);
+  const managedRoots = workspaceNativeSkillRoots(root);
+  const scanned = new Set<string>();
+  const expected: Expected[] = [];
+  for (const skillRoot of managedRoots) {
+    for (const file of await scanSkillFiles(skillRoot)) {
+      const path = await canonicalPath(file);
+      scanned.add(path);
+      const content = await readFile(file, "utf8").catch(() => null);
+      const body = content === null ? null : nativeSkillBody(content);
+      if (body !== null) expected.push({ path, content: body });
+    }
+  }
+  const cloudRoot = cloud ? `${await canonicalPath(cloud.root)}${sep}` : null;
+  const expectedCloud: Expected[] = [];
+  for (const skill of cloud?.state.skills ?? []) {
+    expectedCloud.push({ path: await canonicalPath(skill.location), content: nativeSkillBody(skill.content) ?? skill.content.trim() });
+  }
   const deadline = Date.now() + 5_000;
   do {
     const payload = await readNative();
     if (!record(payload) || !Array.isArray(payload.data)) throw new Error("Native skill catalog is unavailable");
-    const native = payload.data.filter(record).filter((skill) => typeof skill.name === "string"
-      && typeof skill.location === "string" && typeof skill.content === "string");
+    const native = payload.data.filter(record).filter((skill) => typeof skill.location === "string" && typeof skill.content === "string");
     const canonical = await Promise.all(native.map(async (skill) => ({
-      skill, path: await realpath(String(skill.location)).catch(() => String(skill.location)),
+      path: await canonicalPath(String(skill.location)), content: String(skill.content).trim(),
     })));
-    const matches = expected.every((skill) => canonical.some((entry) => entry.path === skill.path
-      && entry.skill.name === skill.name && entry.skill.description === skill.description
-      && String(entry.skill.content).trim() === skill.content));
+    const present = (skill: Expected) => canonical.some((entry) => entry.path === skill.path && entry.content === skill.content);
+    const matches = expected.every(present) && expectedCloud.every(present);
     // Only reconcile directories OpenWork manages. Native plugin-provided
     // skills elsewhere under .opencode are not deleted workspace skills.
-    const managedRoots = [join(root, ".opencode", "skills") + sep, join(root, ".claude", "skills") + sep];
-    const removed = canonical.some((entry) => managedRoots.some((directory) => entry.path.startsWith(directory))
-      && !expected.some((skill) => skill.path === entry.path));
-    if (matches && !removed) return;
+    const removed = canonical.some((entry) => managedRoots.some((skillRoot) => entry.path.startsWith(skillRoot + sep))
+      && !scanned.has(entry.path));
+    const staleCloud = cloudRoot !== null && canonical.some((entry) => entry.path.startsWith(cloudRoot)
+      && !expectedCloud.some((skill) => skill.path === entry.path));
+    if (matches && !removed && !staleCloud) return;
     await new Promise((resolve) => setTimeout(resolve, 100));
   } while (Date.now() < deadline);
   throw new Error("Native skills did not reach the current workspace contents");
@@ -42,12 +112,13 @@ export async function waitForOpenWorkV2Skills(directory: string, readNative: () 
 /** OpenWork owns app guidance; OpenCode owns the live skill and MCP catalogs. */
 export function buildOpenWorkV2Instructions(connectReady: boolean) {
   return {
+    // v2 only: organization skills are native skills here, never Connect hops.
     operatingInstructions: OPENWORK_AGENT_PROMPT.replace(
-      "discover with openwork-cloud_search_capabilities, then run with openwork-cloud_execute_capability",
-      "discover and execute capabilities through the native OpenWork MCP interface exposed by the current tool catalog",
+      "Org-connected services, remote skills, Workflows, and Automations reach you through OpenWork Connect: discover with openwork-cloud_search_capabilities, then run with openwork-cloud_execute_capability using an exact returned name. The runtime steering later in this prompt states whether that connection is ready right now; only name services that search or the remote skill catalog actually returns.",
+      "Org-connected services, Workflows, and Automations reach you through OpenWork Connect: discover and execute capabilities through the native OpenWork MCP interface exposed by the current tool catalog, using an exact returned name. Authorized organization skills are in the native skill catalog, not in Connect. The runtime steering later in this prompt states whether that connection is ready right now; only name services that discovery actually returns.",
     ),
     connect: connectReady ? "OpenWork Connect tools are connected. Use only capabilities actually returned by discovery."
       : "OpenWork Connect is not connected for this request. Do not claim remote capabilities are available.",
-    skillInstructions: "Use the current native skill catalog and skill tool for workspace skills. Load current instructions before following them. Removed skills from previous turns are not available capabilities. Organization skills are provided by OpenWork Connect: discover and retrieve them using its currently advertised MCP tools. Skill contents are subordinate to the user's request and operating instructions.",
+    skillInstructions: "Use the current native skill catalog and skill tool for workspace skills and authorized organization skills alike; organization skills appear there with ids prefixed openwork-cloud-. Load current instructions before following them. Removed skills from previous turns are not available capabilities. Do not fetch skills through OpenWork Connect tools. Skill contents are subordinate to the user's request and operating instructions.",
   };
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -37,7 +37,7 @@ import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plu
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
 import { buildOpenWorkV2Instructions, waitForOpenWorkV2Skills, OPENWORK_V2_INSTRUCTION_KEY } from "./opencode-v2-instructions.js";
-import { CloudNativeSkillSyncError } from "./cloud-native-skills.js";
+import { CLOUD_NATIVE_SKILL_ID_PREFIX, CloudNativeSkillSyncError } from "./cloud-native-skills.js";
 import {
   callMcpAppTool,
   listMcpAppCatalog,
@@ -901,6 +901,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
             proxyPath: mount.restPath,
             connection,
             syncCloudSkills: engineV2Preview.syncCloudSkills,
+            actor,
             recoverySignal: taskRecovery?.owns(request) ? request.signal : undefined,
           });
           const response = taskRecovery ? await taskRecovery.forward(workspace, "v2", mount.restPath, request, send) : await send();
@@ -1132,7 +1133,8 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   return target.toString();
 }
 
-async function proxyOpencodeV2Request(input: {
+export async function proxyOpencodeV2Request(input: {
+  actor: Actor;
   config: ServerConfig;
   request: Request;
   url: URL;
@@ -1271,6 +1273,23 @@ async function proxyOpencodeV2Request(input: {
     headers.set("content-type", "application/json");
   }
   const response = await loopbackFetch(target.toString(), { method, headers, body, signal: input.recoverySignal });
+  if (method === "GET" && /^\/api\/skill(?:\/|$)/.test(decodeURIComponent(forwardedPath))
+    && input.actor.scope !== "owner" && response.ok) {
+    // A shared client token is not authorization to bulk-read the owner's Cloud
+    // instructions. Keep metadata for selection, just like the Connect catalog;
+    // bodies and private materialization paths stay on the owner/engine side.
+    // Internal watcher/admission reads above deliberately do not use this projection.
+    const payload: unknown = await response.json();
+    const raw = isRecord(payload) && "data" in payload ? payload.data : payload;
+    const publicSkill = (value: unknown) => {
+      if (!isRecord(value) || typeof value.id !== "string") {
+        throw new ApiError(502, "invalid_engine_response", "Invalid skill metadata");
+      }
+      if (!value.id.startsWith(CLOUD_NATIVE_SKILL_ID_PREFIX)) return value;
+      return Object.fromEntries(Object.entries(value).filter(([key]) => ["id", "name", "description", "slash"].includes(key)));
+    };
+    return jsonResponse({ data: Array.isArray(raw) ? raw.map(publicSkill) : publicSkill(raw) });
+  }
   if (method === "GET" && /^\/api\/provider(?:\/|$)/.test(decodeURIComponent(forwardedPath)) && response.ok) {
     // Provider.Info includes request settings/headers, which may contain the
     // mirrored server-owned key. Clients only need public catalog metadata.

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -37,6 +37,7 @@ import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plu
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
 import { buildOpenWorkV2Instructions, waitForOpenWorkV2Skills, OPENWORK_V2_INSTRUCTION_KEY } from "./opencode-v2-instructions.js";
+import { CloudNativeSkillSyncError } from "./cloud-native-skills.js";
 import {
   callMcpAppTool,
   listMcpAppCatalog,
@@ -899,6 +900,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
             workspace,
             proxyPath: mount.restPath,
             connection,
+            syncCloudSkills: engineV2Preview.syncCloudSkills,
             recoverySignal: taskRecovery?.owns(request) ? request.signal : undefined,
           });
           const response = taskRecovery ? await taskRecovery.forward(workspace, "v2", mount.restPath, request, send) : await send();
@@ -1137,6 +1139,7 @@ async function proxyOpencodeV2Request(input: {
   workspace: WorkspaceInfo;
   proxyPath: string;
   connection: { url: string; username: string; password: string };
+  syncCloudSkills: EngineV2Preview["syncCloudSkills"];
   recoverySignal?: AbortSignal;
 }): Promise<Response> {
   const method = input.request.method.toUpperCase();
@@ -1217,13 +1220,28 @@ async function proxyOpencodeV2Request(input: {
     const mcpPayload: unknown = mcpResponse.ok ? await mcpResponse.json() : null;
     const connectReady = isRecord(mcpPayload) && Array.isArray(mcpPayload.data) && mcpPayload.data.some((entry) =>
       isRecord(entry) && entry.name === "openwork-cloud" && isRecord(entry.status) && entry.status.status === "connected");
+    // Authorized organization skills are materialized fresh as native skills
+    // on every admission. Skills fail closed, the conversation does not: any
+    // Cloud auth/transport failure has already cleared and unregistered the
+    // materialized root, so the prompt is admitted without Cloud skills and the
+    // waiter below confirms none remain in the native registry.
+    let cloudSkills: Awaited<ReturnType<EngineV2Preview["syncCloudSkills"]>>;
+    try {
+      cloudSkills = await input.syncCloudSkills();
+    } catch (error) {
+      if (error instanceof CloudNativeSkillSyncError) throw new ApiError(502, error.code, error.message);
+      throw new ApiError(502, "cloud_skill_sync_failed", "OpenWork Cloud skills could not be synchronized");
+    }
+    if (cloudSkills.failure) {
+      console.warn(`[openwork-server] Cloud skills unavailable for this turn (${cloudSkills.failure}); admitting without Cloud skills`);
+    }
     const skillUrl = new URL(target);
     skillUrl.pathname = "/api/skill";
     await waitForOpenWorkV2Skills(input.workspace.path, async () => {
       const response = await loopbackFetch(skillUrl.toString(), { headers: internalHeaders, signal: AbortSignal.timeout(5_000) });
       if (!response.ok) throw new ApiError(502, "engine_skill_sync_failed", "Native skills are unavailable");
       return response.json();
-    });
+    }, cloudSkills);
     const value = buildOpenWorkV2Instructions(connectReady);
     const instructionUrl = new URL(target);
     instructionUrl.pathname = `/api/session/${encodeURIComponent(sessionId)}/instructions/entries/${OPENWORK_V2_INSTRUCTION_KEY}`;

--- a/evals/packages/labs/src/index.ts
+++ b/evals/packages/labs/src/index.ts
@@ -10,3 +10,4 @@ export * from "./release-feed.ts";
 export * from "./mock-planetscale.ts";
 export * from "./mock-atlassian.ts";
 export * from "./mock-inference.ts";
+export * from "./mock-cloud-skills.ts";

--- a/evals/packages/labs/src/mock-cloud-skills.ts
+++ b/evals/packages/labs/src/mock-cloud-skills.ts
@@ -117,8 +117,12 @@ function readBody(request: IncomingMessage): Promise<string> {
 function bearerToken(request: IncomingMessage): string | null {
   const header = request.headers.authorization;
   if (typeof header !== "string") return null;
-  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
-  return match?.[1]?.trim() || null;
+  // Linear scan, no backtracking: "Bearer" + at least one space, then the token.
+  const trimmed = header.trim();
+  const scheme = trimmed.slice(0, 6);
+  const rest = trimmed.slice(6);
+  if (scheme.toLowerCase() !== "bearer" || rest === rest.trimStart()) return null;
+  return rest.trim() || null;
 }
 
 export function mockCloudSkillUri(name: string): string {
@@ -332,7 +336,10 @@ export async function startMockCloudSkills(options: StartMockCloudSkillsOptions 
       response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-store", ...headers });
       response.end(`event: message\ndata: ${JSON.stringify(payload)}\n\n`);
     } catch (error) {
-      writeJson(response, 500, { error: error instanceof Error ? error.message : String(error) });
+      // Keep the exception detail on the fixture's own stderr; the wire only
+      // carries a stable code so no stack or internal path is disclosed.
+      console.error(`[mock-cloud-skills] request handler failed: ${error instanceof Error ? error.message : String(error)}`);
+      writeJson(response, 500, { error: "mock_cloud_skills_error" });
     }
   });
 

--- a/evals/packages/labs/src/mock-cloud-skills.ts
+++ b/evals/packages/labs/src/mock-cloud-skills.ts
@@ -1,0 +1,445 @@
+// In-process stand-in for the OpenWork Cloud `/mcp/agent` endpoint, scoped to
+// what the desktop host needs for just-in-time Cloud skills: a Streamable HTTP
+// MCP server that serves `skill://index.json` and each `skill://<name>/SKILL.md`
+// per bearer identity, advertises the two Connect routing tools, and records
+// every request with a SAFE identity label. Credentials never enter the log.
+//
+// It mirrors ee/apps/den-api/src/mcp/agent.ts (index shape, standard SKILL.md
+// framing, SSE-by-default transport) without importing product source.
+import { randomBytes } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+import type { MockAgentRequest, MockAuthorizeRequest, MockMcpHandle, MockToolCall } from "./mock-mcp.ts";
+
+export const MOCK_CLOUD_SKILL_INDEX_URI = "skill://index.json";
+export const MOCK_CLOUD_SKILL_INDEX_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26"];
+const DEFAULT_PROTOCOL_VERSION = "2025-06-18";
+
+/** Identity label for a request that presented no bearer token. */
+export const MOCK_CLOUD_ANONYMOUS = "anonymous";
+/** Identity label for a bearer token this fixture never minted. */
+export const MOCK_CLOUD_UNKNOWN = "unknown";
+
+export interface MockCloudSkill {
+  /** Kebab-case machine identifier; also the `skill://<name>/SKILL.md` path segment. */
+  name: string;
+  description: string;
+  title?: string;
+  /** Instructions below the frontmatter, served verbatim. */
+  body: string;
+  /** Defaults to a synthetic `plugin:<...>:<...>` capability. */
+  capability?: string;
+}
+
+export interface MockCloudSkillsRequest {
+  at: string;
+  /** HTTP method. */
+  method: string;
+  path: string;
+  /** JSON-RPC method, or null for non-RPC traffic (health, GET stream probes). */
+  rpcMethod: string | null;
+  /** `resources/read` target, when any. */
+  uri: string | null;
+  /** `tools/call` name, when any. */
+  toolName: string | null;
+  /** Safe identity label (the label passed to the fixture), anonymous, or unknown. Never the credential. */
+  identity: string;
+  authorized: boolean;
+  status: number;
+}
+
+export interface MockCloudSkillsLogQuery {
+  sinceIso?: string;
+  identity?: string;
+  rpcMethod?: string;
+  uri?: string;
+}
+
+export interface StartMockCloudSkillsOptions {
+  /** Identity labels to mint credentials for. More can be added with `addIdentity`. */
+  identities?: readonly string[];
+  /** Wire framing for JSON-RPC results. The real endpoint streams SSE. */
+  transport?: "sse" | "json";
+  port?: number;
+}
+
+export interface MockCloudSkillsHandle extends MockMcpHandle {
+  /** The `/mcp/agent` URL the host must be pointed at (loopback, trusted for global persist). */
+  agentUrl: string;
+  /** Mint or return the bearer credential for a label. Keep it out of evidence. */
+  credential(identity: string): string;
+  addIdentity(identity: string): string;
+  identities(): string[];
+  publishSkill(identity: string, skill: MockCloudSkill): void;
+  /** Replace only the instructions body; name, title and description are unchanged. */
+  updateSkillBody(identity: string, name: string, body: string): void;
+  revokeSkill(identity: string, name: string): boolean;
+  skills(identity: string): MockCloudSkill[];
+  /** An unauthorized identity keeps its credential but every MCP request answers 401. */
+  setAuthorization(identity: string, authorized: boolean): void;
+  isAuthorized(identity: string): boolean;
+  skillUri(name: string): string;
+  /** Exactly what `resources/read` returns for this identity's skill right now. */
+  skillMarkdown(identity: string, name: string): string | null;
+  log(query?: MockCloudSkillsLogQuery): MockCloudSkillsRequest[];
+  /** Names of every `tools/call` served, in order. Empty proves the host never routed skills through Connect tools. */
+  toolCallNames(query?: MockCloudSkillsLogQuery): string[];
+  resourceReads(query?: MockCloudSkillsLogQuery): MockCloudSkillsRequest[];
+  clearLog(): void;
+}
+
+interface JsonRpcMessage {
+  jsonrpc?: unknown;
+  id?: unknown;
+  method?: unknown;
+  params?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function rpcId(message: JsonRpcMessage): string | number | null {
+  return typeof message.id === "string" || typeof message.id === "number" ? message.id : null;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => { body += chunk; });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+function bearerToken(request: IncomingMessage): string | null {
+  const header = request.headers.authorization;
+  if (typeof header !== "string") return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match?.[1]?.trim() || null;
+}
+
+export function mockCloudSkillUri(name: string): string {
+  return `skill://${name}/SKILL.md`;
+}
+
+/** Same framing as the real endpoint: normalized frontmatter, then the body verbatim. */
+export function mockCloudSkillMarkdown(skill: MockCloudSkill): string {
+  return `---\nname: ${skill.name}\ndescription: ${JSON.stringify(skill.description)}\n---\n\n${skill.body}`;
+}
+
+export function mockCloudSkillIndex(skills: readonly MockCloudSkill[]) {
+  return {
+    $schema: MOCK_CLOUD_SKILL_INDEX_SCHEMA,
+    skills: skills.map((skill) => ({
+      name: skill.name,
+      type: "skill-md" as const,
+      title: skill.title ?? skill.name,
+      description: skill.description,
+      url: mockCloudSkillUri(skill.name),
+      capability: skill.capability ?? `plugin:plg_mock_cloud_skills:cob_${skill.name.replaceAll("-", "_")}`,
+    })),
+  };
+}
+
+const CONNECT_TOOLS = [
+  {
+    name: "search_capabilities",
+    description: "Search connection actions, saved Workflows, and skills by keyword.",
+    inputSchema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+  },
+  {
+    name: "execute_capability",
+    description: "Call a capability found via search_capabilities, by its exact name.",
+    inputSchema: { type: "object", properties: { name: { type: "string" }, body: {} }, required: ["name"] },
+  },
+];
+
+function assertSkillName(name: string): void {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name) || name.length > 64) {
+    throw new Error(`Mock Cloud skill names must be kebab-case (received ${JSON.stringify(name)}).`);
+  }
+}
+
+export async function startMockCloudSkills(options: StartMockCloudSkillsOptions = {}): Promise<MockCloudSkillsHandle> {
+  const transport = options.transport ?? "sse";
+  const credentials = new Map<string, string>();
+  const identityByToken = new Map<string, string>();
+  const authorized = new Map<string, boolean>();
+  const skillsByIdentity = new Map<string, Map<string, MockCloudSkill>>();
+  const log: MockCloudSkillsRequest[] = [];
+  let sessionCounter = 0;
+
+  const addIdentity = (identity: string): string => {
+    const existing = credentials.get(identity);
+    if (existing) return existing;
+    if (!identity.trim() || identity === MOCK_CLOUD_ANONYMOUS || identity === MOCK_CLOUD_UNKNOWN) {
+      throw new Error(`Invalid mock Cloud identity label ${JSON.stringify(identity)}.`);
+    }
+    const token = `mock-cloud-${randomBytes(24).toString("hex")}`;
+    credentials.set(identity, token);
+    identityByToken.set(token, identity);
+    authorized.set(identity, true);
+    skillsByIdentity.set(identity, new Map());
+    return token;
+  };
+  for (const identity of options.identities ?? []) addIdentity(identity);
+
+  const requireIdentity = (identity: string): Map<string, MockCloudSkill> => {
+    const skills = skillsByIdentity.get(identity);
+    if (!skills) throw new Error(`Unknown mock Cloud identity ${JSON.stringify(identity)}; add it first.`);
+    return skills;
+  };
+
+  const resolveIdentity = (request: IncomingMessage): { identity: string; authorized: boolean } => {
+    const token = bearerToken(request);
+    if (!token) return { identity: MOCK_CLOUD_ANONYMOUS, authorized: false };
+    const identity = identityByToken.get(token);
+    if (!identity) return { identity: MOCK_CLOUD_UNKNOWN, authorized: false };
+    return { identity, authorized: authorized.get(identity) === true };
+  };
+
+  const rpcResult = (identity: string, message: JsonRpcMessage): { result?: unknown; error?: { code: number; message: string } } => {
+    const params = isRecord(message.params) ? message.params : {};
+    switch (message.method) {
+      case "initialize": {
+        const requested = typeof params.protocolVersion === "string" ? params.protocolVersion : "";
+        return { result: {
+          protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.includes(requested) ? requested : DEFAULT_PROTOCOL_VERSION,
+          capabilities: { tools: { listChanged: true }, resources: { listChanged: true } },
+          serverInfo: { name: "mock-openwork-cloud-skills", version: "1.0.0" },
+        } };
+      }
+      case "ping":
+        return { result: {} };
+      case "tools/list":
+        return { result: { tools: CONNECT_TOOLS } };
+      case "tools/call": {
+        const name = typeof params.name === "string" ? params.name : "";
+        if (!CONNECT_TOOLS.some((tool) => tool.name === name)) {
+          return { error: { code: -32602, message: `Unknown tool ${name}` } };
+        }
+        // Served, not rejected: a spec proves the zero-call contract from the log,
+        // never from a tool failure the host could have swallowed.
+        return { result: { content: [{ type: "text", text: JSON.stringify({ matches: [], mock: "cloud-skills" }) }] } };
+      }
+      case "resources/list": {
+        const skills = [...requireIdentity(identity).values()];
+        return { result: { resources: [
+          { uri: MOCK_CLOUD_SKILL_INDEX_URI, name: "agent-skills-index", title: "Available Agent Skills", mimeType: "application/json" },
+          ...skills.map((skill) => ({ uri: mockCloudSkillUri(skill.name), name: skill.name, title: skill.title ?? skill.name, description: skill.description, mimeType: "text/markdown" })),
+        ] } };
+      }
+      case "resources/templates/list":
+        return { result: { resourceTemplates: [] } };
+      case "prompts/list":
+        return { result: { prompts: [] } };
+      case "resources/read": {
+        const uri = typeof params.uri === "string" ? params.uri : "";
+        const skills = requireIdentity(identity);
+        if (uri === MOCK_CLOUD_SKILL_INDEX_URI) {
+          return { result: { contents: [{ uri, mimeType: "application/json", text: JSON.stringify(mockCloudSkillIndex([...skills.values()])) }] } };
+        }
+        const skill = [...skills.values()].find((candidate) => mockCloudSkillUri(candidate.name) === uri);
+        if (!skill) return { error: { code: -32002, message: "Resource not found" } };
+        return { result: { contents: [{ uri, mimeType: "text/markdown", text: mockCloudSkillMarkdown(skill) }] } };
+      }
+      default:
+        return { error: { code: -32601, message: "Method not found" } };
+    }
+  };
+
+  const writeJson = (response: ServerResponse, status: number, payload: unknown, headers: Record<string, string> = {}): void => {
+    response.writeHead(status, { "content-type": "application/json", "cache-control": "no-store", ...headers });
+    response.end(JSON.stringify(payload));
+  };
+
+  const server: Server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    const who = resolveIdentity(request);
+    const entry: MockCloudSkillsRequest = {
+      at: new Date().toISOString(), method: request.method ?? "GET", path: url.pathname,
+      rpcMethod: null, uri: null, toolName: null, identity: who.identity, authorized: who.authorized, status: 0,
+    };
+    log.push(entry);
+    response.once("finish", () => { entry.status = response.statusCode; });
+    try {
+      if (url.pathname === "/health") {
+        writeJson(response, 200, { ok: true, identities: [...credentials.keys()], transport });
+        return;
+      }
+      if (url.pathname !== "/mcp/agent") {
+        writeJson(response, 404, { error: "not_found" });
+        return;
+      }
+      if (!who.authorized) {
+        // Read the body so the connection stays reusable, then refuse. No OAuth
+        // metadata is advertised: the host must not be lured into a sign-in flow.
+        if (request.method === "POST") await readBody(request);
+        writeJson(response, 401, { error: who.identity === MOCK_CLOUD_ANONYMOUS ? "missing_token" : "invalid_token" }, { "www-authenticate": "Bearer" });
+        return;
+      }
+      if (request.method === "GET") {
+        // No server-initiated stream in this fixture.
+        writeJson(response, 405, { error: "method_not_allowed" });
+        return;
+      }
+      if (request.method === "DELETE") {
+        response.writeHead(200).end();
+        return;
+      }
+      if (request.method !== "POST") {
+        writeJson(response, 405, { error: "method_not_allowed" });
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(await readBody(request));
+      } catch {
+        writeJson(response, 400, { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+        return;
+      }
+      const messages: JsonRpcMessage[] = (Array.isArray(parsed) ? parsed : [parsed]).filter(isRecord);
+      const first = messages[0];
+      entry.rpcMethod = first && typeof first.method === "string" ? first.method : null;
+      for (const message of messages) {
+        const params = isRecord(message.params) ? message.params : {};
+        if (message.method === "resources/read" && typeof params.uri === "string") entry.uri = params.uri;
+        if (message.method === "tools/call" && typeof params.name === "string") entry.toolName = params.name;
+      }
+      const responses = messages.flatMap((message) => {
+        const id = rpcId(message);
+        if (id === null) return [];
+        const outcome = rpcResult(who.identity, message);
+        return [outcome.error ? { jsonrpc: "2.0", id, error: outcome.error } : { jsonrpc: "2.0", id, result: outcome.result }];
+      });
+      if (responses.length === 0) {
+        response.writeHead(202).end();
+        return;
+      }
+      const headers: Record<string, string> = {};
+      if (messages.some((message) => message.method === "initialize")) {
+        sessionCounter += 1;
+        headers["mcp-session-id"] = `mock-cloud-session-${sessionCounter}`;
+      }
+      const payload = Array.isArray(parsed) ? responses : responses[0];
+      if (transport === "json") {
+        writeJson(response, 200, payload, headers);
+        return;
+      }
+      response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-store", ...headers });
+      response.end(`event: message\ndata: ${JSON.stringify(payload)}\n\n`);
+    } catch (error) {
+      writeJson(response, 500, { error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port ?? 0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Mock Cloud skills server did not bind a TCP port.");
+  const url = `http://127.0.0.1:${address.port}`;
+  const agentUrl = `${url}/mcp/agent`;
+
+  const filterLog = (query: MockCloudSkillsLogQuery = {}): MockCloudSkillsRequest[] => log.filter((entry) =>
+    (query.sinceIso === undefined || entry.at >= query.sinceIso)
+    && (query.identity === undefined || entry.identity === query.identity)
+    && (query.rpcMethod === undefined || entry.rpcMethod === query.rpcMethod)
+    && (query.uri === undefined || entry.uri === query.uri));
+
+  let stopped = false;
+  const stop = async (): Promise<void> => {
+    if (stopped) return;
+    stopped = true;
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  };
+  const unsupported = (feature: string) => async (): Promise<never> => {
+    throw new Error(`The mock Cloud skills fixture does not ${feature}.`);
+  };
+  const authorizeRequests = (entries: MockCloudSkillsRequest[]): MockAuthorizeRequest[] => entries.map((entry) => ({
+    method: entry.method, path: entry.path, url: entry.path, at: entry.at, status: entry.status, tokenId: entry.identity,
+  }));
+
+  return {
+    url,
+    mcpUrl: agentUrl,
+    agentUrl,
+    credential: addIdentity,
+    addIdentity,
+    identities: () => [...credentials.keys()],
+    publishSkill(identity, skill) {
+      assertSkillName(skill.name);
+      requireIdentity(identity).set(skill.name, { ...skill });
+    },
+    updateSkillBody(identity, name, body) {
+      const skills = requireIdentity(identity);
+      const existing = skills.get(name);
+      if (!existing) throw new Error(`Identity ${identity} has no skill ${name} to update.`);
+      skills.set(name, { ...existing, body });
+    },
+    revokeSkill(identity, name) {
+      return requireIdentity(identity).delete(name);
+    },
+    skills: (identity) => [...requireIdentity(identity).values()].map((skill) => ({ ...skill })),
+    setAuthorization(identity, value) {
+      requireIdentity(identity);
+      authorized.set(identity, value);
+    },
+    isAuthorized: (identity) => authorized.get(identity) === true,
+    skillUri: mockCloudSkillUri,
+    skillMarkdown(identity, name) {
+      const skill = requireIdentity(identity).get(name);
+      return skill ? mockCloudSkillMarkdown(skill) : null;
+    },
+    log: (query) => filterLog(query).map((entry) => ({ ...entry })),
+    toolCallNames: (query) => filterLog(query).flatMap((entry) => entry.toolName ? [entry.toolName] : []),
+    resourceReads: (query) => filterLog({ ...query, rpcMethod: "resources/read" }).map((entry) => ({ ...entry })),
+    clearLog() { log.length = 0; },
+    // MockMcpHandle compatibility so the fixture can ride seed.appWeb({ mocks }).
+    async requests() {
+      return authorizeRequests(filterLog());
+    },
+    async toolCalls(opts = {}): Promise<MockToolCall[]> {
+      const read = () => filterLog({ sinceIso: opts.sinceIso }).flatMap((entry) => entry.toolName && (!opts.name || entry.toolName === opts.name)
+        ? [{ name: entry.toolName, args: {}, tokenId: entry.identity, at: entry.at }] : []);
+      const wanted = opts.atLeast ?? 0;
+      const deadline = Date.now() + (opts.timeoutMs ?? 120_000);
+      let calls = read();
+      while (calls.length < wanted && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        calls = read();
+      }
+      return calls;
+    },
+    async agentRequests(): Promise<MockAgentRequest[]> {
+      return [];
+    },
+    agentReplyState: unsupported("serve agent reply gates"),
+    releaseAgentReply: unsupported("serve agent reply gates"),
+    async handshakes(opts = {}) {
+      const read = () => authorizeRequests(filterLog({ sinceIso: opts.sinceIso, rpcMethod: "initialize" }));
+      const wanted = opts.atLeast ?? 0;
+      const deadline = Date.now() + (opts.timeoutMs ?? 120_000);
+      let handshakes = read();
+      while (handshakes.length < wanted && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        handshakes = read();
+      }
+      return handshakes;
+    },
+    authorizeRequestSince: unsupported("serve OAuth authorization"),
+    configureOAuthRedirectUris: unsupported("serve OAuth authorization"),
+    configureOAuthCallback: unsupported("serve OAuth authorization"),
+    resetOAuth: unsupported("serve OAuth authorization"),
+    holdRefreshResponses: unsupported("serve OAuth refresh"),
+    pendingRefreshResponses: unsupported("serve OAuth refresh"),
+    releaseRefreshResponse: unsupported("serve OAuth refresh"),
+    stop,
+    [Symbol.asyncDispose]: stop,
+  };
+}

--- a/evals/packages/labs/src/skill-jit-model.ts
+++ b/evals/packages/labs/src/skill-jit-model.ts
@@ -1,0 +1,143 @@
+import { createServer } from "node:http";
+import { fileURLToPath } from "node:url";
+import type { MockAgentRequest } from "./mock-mcp.ts";
+
+export const skillJitModelScript = fileURLToPath(import.meta.url);
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function text(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(text).join("\n");
+  if (!record(value)) return "";
+  return text(value.content ?? value.text);
+}
+
+function systemUpdate(message: Record<string, unknown>): string | null {
+  const update = message.role === "user" ? text(message.content).match(/^<system-update>\n([\s\S]*)\n<\/system-update>$/) : null;
+  return update ? update[1].replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&") : null;
+}
+
+function catalog(messages: Record<string, unknown>[]) {
+  const system = messages.flatMap((message) => {
+    if (message.role === "system" || message.role === "developer") return [text(message.content)];
+    const update = systemUpdate(message);
+    return update === null ? [] : [update];
+  }).join("\n");
+  if (!system.includes("You are OpenWork.")) throw new Error("The model did not receive OpenWork operating instructions");
+  const skills = new Map<string, { id: string; name: string; description: string }>();
+  for (const update of system.split(/(?=<available_skills>|The available skills have changed|New skills are available|The following skill IDs|Skill guidance is no longer available|No skills are currently available)/)) {
+    if (update.startsWith("<available_skills>") || update.startsWith("The available skills have changed")
+      || update.startsWith("Skill guidance is no longer available") || update.startsWith("No skills are currently available")) skills.clear();
+    for (const [, entry] of update.matchAll(/<skill>([\s\S]*?)<\/skill>/g)) {
+      const id = entry.match(/<id>([^<]+)<\/id>/)?.[1];
+      const name = entry.match(/<name>([^<]+)<\/name>/)?.[1];
+      const description = entry.match(/<description>([^<]+)<\/description>/)?.[1];
+      if (id && name && description) skills.set(id, { id, name, description });
+    }
+    const removed = update.match(/The following skill IDs are no longer available and must not be used: ([^\n]+)\./)?.[1];
+    for (const id of removed?.split(", ") ?? []) skills.delete(id);
+  }
+  return [...skills.values()];
+}
+
+function matchesPrompt(description: string, prompt: string): boolean {
+  const words = (value: string) => value.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+  const request = ` ${words(prompt).join(" ")} `;
+  const terms = words(description);
+  return terms.some((_, index) => index + 3 <= terms.length && request.includes(` ${terms.slice(index, index + 3).join(" ")} `));
+}
+
+function decide(body: Record<string, unknown>, turn: { prompt: string; forcedSkillId?: string } | null) {
+  const messages = Array.isArray(body.messages) ? body.messages.filter(record) : [];
+  const latestUserIndex = messages.findLastIndex((message) => message.role === "user" && systemUpdate(message) === null);
+  const prompt = text(messages[latestUserIndex]?.content);
+  const matched = turn !== null && prompt.includes(turn.prompt);
+  const results = messages.slice(latestUserIndex + 1).filter((message) => message.role === "tool");
+  const request: MockAgentRequest = {
+    model: typeof body.model === "string" ? body.model : "skill-jit-model",
+    promptMarker: matched ? turn.prompt : null,
+    matchedMarkers: matched ? [turn.prompt] : [],
+    completedTools: results.length,
+    kind: matched ? "final" : "utility",
+    toolName: null,
+    arguments: {},
+    at: new Date().toISOString(),
+  };
+  if (!matched) return { request, reply: "Active session workload" };
+  if (results.length) {
+    const reply = text(results.at(-1)?.content);
+    if (!reply) throw new Error("The model received no tool result text");
+    return { request, reply };
+  }
+  const skills = catalog(messages);
+  const tools = Array.isArray(body.tools) ? body.tools.filter(record) : [];
+  const tool = tools.find((item) => item.type === "function" && record(item.function) && item.function.name === "skill");
+  const parameters = tool && record(tool.function) && record(tool.function.parameters) ? tool.function.parameters : null;
+  const idSchema = parameters && record(parameters.properties) && record(parameters.properties.id) ? parameters.properties.id : null;
+  if (parameters?.type === "object" && idSchema?.type === "string"
+    && (!Array.isArray(parameters.required) || parameters.required.every((key) => key === "id"))) {
+    const matches = skills.filter((skill) => matchesPrompt(skill.description, prompt)
+      && (!Array.isArray(idSchema.enum) || idSchema.enum.includes(skill.id)));
+    const id = turn.forcedSkillId ?? (matches.length === 1 ? matches[0].id : null);
+    if (id) {
+      request.kind = "tool";
+      request.toolName = "skill";
+      request.arguments = { id };
+    }
+  }
+  return { request, reply: "OpenWork: UNAVAILABLE" };
+}
+
+if (import.meta.main) {
+  let turn: { prompt: string; forcedSkillId?: string } | null = null;
+  const requests: MockAgentRequest[] = [];
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.method === "GET" && req.url === "/health") {
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({ ok: true, host: "127.0.0.1" }));
+        return;
+      }
+      if (req.method === "GET" && req.url === "/requests") {
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({
+          requests: requests.map((request) => ({ method: "POST", path: "/v1/chat/completions", url: "/v1/chat/completions", at: request.at, agentCompletion: request })),
+        }));
+        return;
+      }
+      if (req.method !== "POST" || !["/admin/skill-turn", "/v1/chat/completions"].includes(req.url ?? "")) {
+        res.writeHead(404).end();
+        return;
+      }
+      let raw = "";
+      for await (const chunk of req) raw += String(chunk);
+      const body: unknown = JSON.parse(raw);
+      if (!record(body)) throw new Error("Model input must be an object");
+      if (req.url === "/admin/skill-turn") {
+        if (typeof body.prompt !== "string" || !body.prompt.trim()
+          || (body.forcedSkillId !== undefined && (typeof body.forcedSkillId !== "string" || !body.forcedSkillId))) {
+          throw new Error("Invalid skill turn");
+        }
+        turn = { prompt: body.prompt, ...(typeof body.forcedSkillId === "string" ? { forcedSkillId: body.forcedSkillId } : {}) };
+        res.writeHead(200, { "content-type": "application/json" }).end("{}");
+        return;
+      }
+      const { request, reply } = decide(body, turn);
+      requests.push(request);
+      const call = request.kind === "tool";
+      const delta = call ? { tool_calls: [{ index: 0, id: `call_skill_${requests.length}`, type: "function",
+        function: { name: request.toolName, arguments: JSON.stringify(request.arguments) } }] } : { content: reply };
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      for (const [content, finish] of [[{ role: "assistant" }, null], [delta, null], [{}, call ? "tool_calls" : "stop"]]) {
+        res.write(`data: ${JSON.stringify({ id: "chatcmpl-skill-jit", object: "chat.completion.chunk", model: request.model,
+          choices: [{ index: 0, delta: content, finish_reason: finish }] })}\n\n`);
+      }
+      res.end("data: [DONE]\n\n");
+    } catch (error) {
+      console.error("[skill-jit-model] request failed", error);
+      res.writeHead(500, { "content-type": "application/json" }).end(JSON.stringify({ error: "Skill witness failed" }));
+    }
+  });
+  server.listen(Number(process.env.PORT ?? 3979), "127.0.0.1");
+}

--- a/evals/packages/labs/test/mock-cloud-skills.test.ts
+++ b/evals/packages/labs/test/mock-cloud-skills.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MOCK_CLOUD_SKILL_INDEX_SCHEMA,
+  MOCK_CLOUD_SKILL_INDEX_URI,
+  mockCloudSkillMarkdown,
+  startMockCloudSkills,
+  type MockCloudSkillsHandle,
+} from "../src/mock-cloud-skills.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The same minimal Streamable HTTP client the desktop host uses for discovery reads. */
+async function readPayload(response: Response): Promise<unknown> {
+  const raw = await response.text();
+  if (!response.headers.get("content-type")?.includes("text/event-stream")) return raw.trim() ? JSON.parse(raw) : null;
+  const data = raw.split(/\r?\n/).filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trim());
+  return data.length ? JSON.parse(data.join("\n")) : null;
+}
+
+async function rpc(url: string, token: string | null, body: unknown, extraHeaders: Record<string, string> = {}) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      ...extraHeaders,
+    },
+    body: JSON.stringify(body),
+  });
+  return { response, payload: await readPayload(response) };
+}
+
+async function readResource(mock: MockCloudSkillsHandle, token: string | null, uri: string): Promise<{ status: number; text: string | null; error: unknown }> {
+  const initialized = await rpc(mock.agentUrl, token, {
+    id: 1, jsonrpc: "2.0", method: "initialize",
+    params: { capabilities: {}, clientInfo: { name: "labs-test", version: "1.0.0" }, protocolVersion: "2025-06-18" },
+  });
+  if (!initialized.response.ok) return { status: initialized.response.status, text: null, error: null };
+  const result = isRecord(initialized.payload) && isRecord(initialized.payload.result) ? initialized.payload.result : null;
+  assert.equal(result?.protocolVersion, "2025-06-18");
+  const sessionId = initialized.response.headers.get("mcp-session-id");
+  assert.ok(sessionId, "initialize returns a session id");
+  const session = { "mcp-session-id": sessionId, "mcp-protocol-version": "2025-06-18" };
+  const notified = await rpc(mock.agentUrl, token, { jsonrpc: "2.0", method: "notifications/initialized", params: {} }, session);
+  assert.equal(notified.response.status, 202);
+  assert.equal(notified.payload, null);
+  const read = await rpc(mock.agentUrl, token, { id: 2, jsonrpc: "2.0", method: "resources/read", params: { uri } }, session);
+  const payload = isRecord(read.payload) ? read.payload : {};
+  const contents = isRecord(payload.result) && Array.isArray(payload.result.contents) ? payload.result.contents : [];
+  const match = contents.find((item) => isRecord(item) && item.uri === uri && typeof item.text === "string");
+  return { status: read.response.status, text: isRecord(match) && typeof match.text === "string" ? match.text : null, error: payload.error ?? null };
+}
+
+for (const transport of ["sse", "json"] as const) {
+  test(`${transport}: identities read only their own index and bodies; the log names identities, never credentials`, async () => {
+    await using mock = await startMockCloudSkills({ identities: ["account-a", "account-b"], transport });
+    const tokenA = mock.credential("account-a");
+    const tokenB = mock.credential("account-b");
+    assert.notEqual(tokenA, tokenB);
+    mock.publishSkill("account-a", { name: "amber-report", description: "Amber report for A", body: "Reply with CODE-A." });
+    mock.publishSkill("account-b", { name: "amber-report", description: "Amber report for B", body: "Reply with CODE-B." });
+    mock.publishSkill("account-a", { name: "only-a", description: "Only A has this.", body: "A only." });
+
+    const indexA = await readResource(mock, tokenA, MOCK_CLOUD_SKILL_INDEX_URI);
+    assert.equal(indexA.status, 200);
+    const parsedA: unknown = JSON.parse(indexA.text ?? "null");
+    assert.ok(isRecord(parsedA) && Array.isArray(parsedA.skills));
+    assert.equal(parsedA.$schema, MOCK_CLOUD_SKILL_INDEX_SCHEMA);
+    assert.deepEqual(parsedA.skills.map((skill) => isRecord(skill) ? skill.name : null).sort(), ["amber-report", "only-a"]);
+    for (const skill of parsedA.skills) {
+      assert.ok(isRecord(skill));
+      assert.equal(skill.type, "skill-md");
+      assert.match(String(skill.url), /^skill:\/\/[a-z0-9-]+\/SKILL\.md$/);
+      assert.match(String(skill.capability), /^(?:skill:[^:]+|plugin:[^:]+:[^:]+)$/);
+    }
+
+    const indexB = await readResource(mock, tokenB, MOCK_CLOUD_SKILL_INDEX_URI);
+    const parsedB: unknown = JSON.parse(indexB.text ?? "null");
+    assert.ok(isRecord(parsedB) && Array.isArray(parsedB.skills));
+    assert.deepEqual(parsedB.skills.map((skill) => isRecord(skill) ? skill.name : null), ["amber-report"]);
+
+    const bodyA = await readResource(mock, tokenA, mock.skillUri("amber-report"));
+    const bodyB = await readResource(mock, tokenB, mock.skillUri("amber-report"));
+    assert.equal(bodyA.text, mockCloudSkillMarkdown({ name: "amber-report", description: "Amber report for A", body: "Reply with CODE-A." }));
+    assert.ok(bodyA.text?.includes("CODE-A") && !bodyA.text.includes("CODE-B"));
+    assert.ok(bodyB.text?.includes("CODE-B") && !bodyB.text.includes("CODE-A"));
+    assert.match(bodyA.text ?? "", /^---\nname: amber-report\ndescription: "Amber report for A"\n---\n\n/);
+    const missing = await readResource(mock, tokenB, mock.skillUri("only-a"));
+    assert.equal(missing.text, null);
+    assert.ok(isRecord(missing.error) && missing.error.code === -32002);
+
+    const reads = mock.resourceReads();
+    assert.deepEqual(reads.map((entry) => [entry.identity, entry.uri]), [
+      ["account-a", MOCK_CLOUD_SKILL_INDEX_URI],
+      ["account-b", MOCK_CLOUD_SKILL_INDEX_URI],
+      ["account-a", "skill://amber-report/SKILL.md"],
+      ["account-b", "skill://amber-report/SKILL.md"],
+      ["account-b", "skill://only-a/SKILL.md"],
+    ]);
+    const serialized = JSON.stringify(mock.log());
+    assert.ok(!serialized.includes(tokenA) && !serialized.includes(tokenB), "credentials never enter the request log");
+    assert.ok(mock.log().every((entry) => entry.authorized && entry.status === 200 || entry.status === 202));
+    assert.deepEqual(mock.toolCallNames(), []);
+  });
+}
+
+test("body-only updates, revocation and de-authorization change what the next read returns", async () => {
+  await using mock = await startMockCloudSkills({ identities: ["account-a"] });
+  const token = mock.credential("account-a");
+  mock.publishSkill("account-a", { name: "amber-report", description: "Amber", body: "first" });
+  assert.equal((await readResource(mock, token, mock.skillUri("amber-report"))).text?.endsWith("\n\nfirst"), true);
+  mock.updateSkillBody("account-a", "amber-report", "second");
+  const updated = await readResource(mock, token, mock.skillUri("amber-report"));
+  assert.equal(updated.text?.endsWith("\n\nsecond"), true);
+  assert.ok(!updated.text?.includes("first"));
+  assert.match(updated.text ?? "", /^---\nname: amber-report\ndescription: "Amber"\n---/);
+
+  assert.equal(mock.revokeSkill("account-a", "amber-report"), true);
+  assert.equal(mock.revokeSkill("account-a", "amber-report"), false);
+  const index: unknown = JSON.parse((await readResource(mock, token, MOCK_CLOUD_SKILL_INDEX_URI)).text ?? "null");
+  assert.ok(isRecord(index) && Array.isArray(index.skills) && index.skills.length === 0);
+  assert.ok(isRecord((await readResource(mock, token, mock.skillUri("amber-report"))).error));
+
+  mock.setAuthorization("account-a", false);
+  const denied = await readResource(mock, token, MOCK_CLOUD_SKILL_INDEX_URI);
+  assert.equal(denied.status, 401);
+  const anonymous = await readResource(mock, null, MOCK_CLOUD_SKILL_INDEX_URI);
+  assert.equal(anonymous.status, 401);
+  const stranger = await readResource(mock, "mock-cloud-not-minted", MOCK_CLOUD_SKILL_INDEX_URI);
+  assert.equal(stranger.status, 401);
+  const refused = mock.log().filter((entry) => entry.status === 401);
+  assert.deepEqual(refused.map((entry) => [entry.identity, entry.authorized]), [["account-a", false], ["anonymous", false], ["unknown", false]]);
+  mock.setAuthorization("account-a", true);
+  assert.equal((await readResource(mock, token, MOCK_CLOUD_SKILL_INDEX_URI)).status, 200);
+});
+
+test("advertises the Connect routing tools and records every tools/call by name", async () => {
+  await using mock = await startMockCloudSkills({ identities: ["account-a"], transport: "json" });
+  const token = mock.credential("account-a");
+  const listed = await rpc(mock.agentUrl, token, { id: 1, jsonrpc: "2.0", method: "tools/list", params: {} });
+  const tools = isRecord(listed.payload) && isRecord(listed.payload.result) && Array.isArray(listed.payload.result.tools) ? listed.payload.result.tools : [];
+  assert.deepEqual(tools.map((tool) => isRecord(tool) ? tool.name : null), ["search_capabilities", "execute_capability"]);
+  const called = await rpc(mock.agentUrl, token, { id: 2, jsonrpc: "2.0", method: "tools/call", params: { name: "search_capabilities", arguments: { query: "amber" } } });
+  assert.equal(called.response.status, 200);
+  assert.ok(isRecord(called.payload) && isRecord(called.payload.result));
+  const unknown = await rpc(mock.agentUrl, token, { id: 3, jsonrpc: "2.0", method: "tools/call", params: { name: "not_a_tool" } });
+  assert.ok(isRecord(unknown.payload) && isRecord(unknown.payload.error));
+  assert.deepEqual(mock.toolCallNames(), ["search_capabilities", "not_a_tool"]);
+  assert.deepEqual((await mock.toolCalls({ name: "search_capabilities" })).map((call) => [call.name, call.tokenId]), [["search_capabilities", "account-a"]]);
+  const since = new Date(Date.now() + 60_000).toISOString();
+  assert.deepEqual(mock.toolCallNames({ sinceIso: since }), []);
+  assert.equal((await mock.handshakes()).length, 0);
+  const batch = await rpc(mock.agentUrl, token, [
+    { id: 4, jsonrpc: "2.0", method: "initialize", params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "t", version: "1" } } },
+    { id: 5, jsonrpc: "2.0", method: "ping" },
+  ]);
+  assert.ok(Array.isArray(batch.payload) && batch.payload.length === 2);
+  assert.equal(isRecord(batch.payload[0]) && isRecord(batch.payload[0].result) ? batch.payload[0].result.protocolVersion : null, "2025-03-26");
+  assert.equal((await mock.handshakes()).length, 1);
+  const stream = await fetch(mock.agentUrl, { headers: { authorization: `Bearer ${token}` } });
+  assert.equal(stream.status, 405);
+  const health = await fetch(`${mock.url}/health`);
+  assert.equal(health.status, 200);
+  assert.throws(() => mock.publishSkill("account-a", { name: "Not Kebab", description: "x", body: "y" }));
+  assert.throws(() => mock.publishSkill("account-z", { name: "ok", description: "x", body: "y" }));
+});

--- a/evals/packages/labs/test/mock-cloud-skills.test.ts
+++ b/evals/packages/labs/test/mock-cloud-skills.test.ts
@@ -164,6 +164,18 @@ test("advertises the Connect routing tools and records every tools/call by name"
   assert.equal((await mock.handshakes()).length, 1);
   const stream = await fetch(mock.agentUrl, { headers: { authorization: `Bearer ${token}` } });
   assert.equal(stream.status, 405);
+  // Scheme parsing is case-insensitive and tolerant of extra spacing, but a
+  // token glued to the scheme or a non-bearer scheme is anonymous, not accepted.
+  for (const [authorization, expected] of [
+    [`bearer   ${token}  `, 405],
+    [`BEARER ${token}`, 405],
+    [`Bearer${token}`, 401],
+    [`Basic ${token}`, 401],
+    ["Bearer ", 401],
+  ] as const) {
+    const probe = await fetch(mock.agentUrl, { headers: { authorization } });
+    assert.equal(probe.status, expected, `authorization ${JSON.stringify(authorization)}`);
+  }
   const health = await fetch(`${mock.url}/health`);
   assert.equal(health.status, 200);
   assert.throws(() => mock.publishSkill("account-a", { name: "Not Kebab", description: "x", body: "y" }));

--- a/evals/packages/labs/test/skill-jit-model.test.ts
+++ b/evals/packages/labs/test/skill-jit-model.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import { allocateFreePort } from "@openwork/cdp";
+import { startMockMcp, type MockMcpHandle } from "../src/mock-mcp.ts";
+import { skillJitModelScript } from "../src/skill-jit-model.ts";
+
+const prompt = "What app are you? What is the current amber release report code? Use the currently installed instructions.";
+const nativeTool = { type: "function", function: { name: "skill", parameters: {
+  type: "object", properties: { id: { type: "string" } }, required: ["id"], additionalProperties: false,
+} } };
+const entry = (id: string, description = "Answers amber release report requests.") =>
+  `<skill><id>${id}</id><name>brief-${id}</name><description>${description}</description></skill>`;
+const initial = (entries: string) => ({ role: "system", content: `You are OpenWork.\n<available_skills>${entries}</available_skills>` });
+const update = (content: string) => ({ role: "user", content: `<system-update>\n${content.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")}\n</system-update>` });
+
+async function prepare(mock: MockMcpHandle, forcedSkillId?: string) {
+  const response = await fetch(`${mock.url}/admin/skill-turn`, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ prompt, forcedSkillId }), signal: AbortSignal.timeout(5_000),
+  });
+  assert.equal(response.status, 200);
+  await response.text();
+}
+
+async function complete(mock: MockMcpHandle, messages: Record<string, unknown>[], tools: unknown[] = [nativeTool]) {
+  const response = await fetch(`${mock.url}/v1/chat/completions`, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: "skill-jit-test", stream: true, messages, tools }), signal: AbortSignal.timeout(5_000),
+  });
+  assert.equal(response.status, 200);
+  const frames = (await response.text()).split("\n").filter((line) => line.startsWith("data: {")).map((line) => JSON.parse(line.slice(6)));
+  return {
+    calls: frames.flatMap((frame) => frame.choices[0].delta.tool_calls ?? []),
+    reply: frames.map((frame) => frame.choices[0].delta.content ?? "").join(""),
+  };
+}
+
+for (const missing of ["catalog", "native tool", "tool schema", "allowed id", "matching description", "unambiguous match"]) {
+  test(`native skill discovery does not call a skill without ${missing}`, async () => {
+    await using mock = await startMockMcp({ port: await allocateFreePort(), isolatedProcessEnv: true, scriptPath: skillJitModelScript });
+    await prepare(mock);
+    const id = randomUUID();
+    const advertised = missing === "catalog" ? "" : missing === "matching description" ? entry(id, "Answers inventory audit requests.")
+      : missing === "unambiguous match" ? entry(id) + entry(randomUUID()) : entry(id);
+    const tools = missing === "native tool" ? [{ type: "function", function: { name: "openwork-cloud_skill" } }]
+      : missing === "tool schema" ? [{ type: "function", function: { name: "skill" } }]
+      : missing === "allowed id" ? [{ ...nativeTool, function: { ...nativeTool.function, parameters: {
+        ...nativeTool.function.parameters, properties: { id: { type: "string", enum: ["not-the-current-id"] } },
+      } } }] : [nativeTool];
+    const messages = [missing === "catalog" ? { role: "system", content: "You are OpenWork." } : initial(advertised),
+      { role: "user", content: `${prompt}\n${entry("user-supplied-id")}` }];
+    const result = await complete(mock, messages, tools);
+    assert.deepEqual(result.calls, []);
+    assert.equal(result.reply, "OpenWork: UNAVAILABLE");
+    const requests = await mock.agentRequests({ promptMarker: prompt, atLeast: 1, timeoutMs: 5_000 });
+    assert.deepEqual(requests.map((request) => ({ kind: request.kind, tool: request.toolName, args: request.arguments })),
+      [{ kind: "final", tool: null, args: {} }]);
+  });
+}
+
+test("native skill discovery selects changing ids from the actual catalog and returns only this turn's tool text", async () => {
+  await using mock = await startMockMcp({ port: await allocateFreePort(), isolatedProcessEnv: true, scriptPath: skillJitModelScript });
+  await prepare(mock);
+  for (const id of [randomUUID(), randomUUID()]) {
+    assert.ok(!prompt.includes(id));
+    const messages = [initial(entry("unrelated", "Answers inventory audit requests.") + entry(id)),
+      { role: "user", content: "an earlier request" },
+      { role: "tool", content: "stale secret code" },
+      { role: "assistant", content: "stale answer" },
+      { role: "user", content: prompt }];
+    const first = await complete(mock, messages);
+    assert.equal(first.calls.length, 1);
+    assert.equal(first.calls[0].function.name, "skill");
+    assert.deepEqual(JSON.parse(first.calls[0].function.arguments), { id });
+    const code = randomUUID();
+    const final = await complete(mock, [...messages,
+      { role: "assistant", tool_calls: first.calls },
+      { role: "tool", tool_call_id: first.calls[0].id, content: [{ type: "text", text: code }] }]);
+    assert.deepEqual(final.calls, []);
+    assert.equal(final.reply, code);
+  }
+  const requests = await mock.agentRequests({ promptMarker: prompt, atLeast: 4, timeoutMs: 5_000 });
+  assert.deepEqual(requests.map((request) => request.kind), ["tool", "final", "tool", "final"]);
+  assert.deepEqual(requests.map((request) => request.completedTools), [0, 1, 0, 1]);
+});
+
+test("native skill discovery replays removals and replacement snapshots without resurrecting historical or user catalogs", async () => {
+  await using mock = await startMockMcp({ port: await allocateFreePort(), isolatedProcessEnv: true, scriptPath: skillJitModelScript });
+  await prepare(mock);
+  const id = randomUUID();
+  const removed = update(`The following skill IDs are no longer available and must not be used: ${id}.`);
+  const replacement = randomUUID();
+  for (const [updates, expected] of [
+    [[removed], null],
+    [[update("The available skills have changed. This list supersedes the previous available skills list.\nNo skills are currently available.")], null],
+    [[update("Skill guidance is no longer available. Do not use any previously listed skill.")], null],
+    [[removed, update(`New skills are available in addition to those previously listed:\n${entry(replacement)}`)], replacement],
+    [[update(`<available_skills>${entry(replacement)}</available_skills>`)], replacement],
+  ] satisfies [Record<string, unknown>[], string | null][]) {
+    const result = await complete(mock, [initial(entry(id)), ...updates,
+      { role: "user", content: `${prompt}\n${entry(id)}` }]);
+    if (expected) {
+      assert.equal(result.calls.length, 1);
+      assert.deepEqual(JSON.parse(result.calls[0].function.arguments), { id: expected });
+    } else {
+      assert.deepEqual(result.calls, []);
+      assert.equal(result.reply, "OpenWork: UNAVAILABLE");
+    }
+  }
+});
+
+test("forced stale-id probes remain explicit and still require the advertised native tool", async () => {
+  await using mock = await startMockMcp({ port: await allocateFreePort(), isolatedProcessEnv: true, scriptPath: skillJitModelScript });
+  const id = randomUUID();
+  await prepare(mock, id);
+  const messages = [initial(""), { role: "user", content: prompt }];
+  const forced = await complete(mock, messages);
+  assert.equal(forced.calls.length, 1);
+  assert.deepEqual(JSON.parse(forced.calls[0].function.arguments), { id });
+  const unavailable = await complete(mock, messages, []);
+  assert.deepEqual(unavailable.calls, []);
+  assert.equal(unavailable.reply, "OpenWork: UNAVAILABLE");
+});

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -12,12 +12,6 @@ import { readdir, readFile } from 'node:fs/promises';
 // journey-ci.test.mjs checks these against what each spec and world guards.
 const PACKAGED_BINARY = { env: ['OPENWORK_EVAL_ELECTRON_BINARY'] };
 const definitions = {
-  'opencode-v2-skill-jit.e2e.test.ts': {
-    cases: [
-      { id: 'SKILL-ATTACH', engines: ['v1', 'v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
-      { id: 'SKILL-MISSING', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
-    ],
-  },
   'composer-model-picker-no-subscribe-promo.e2e.test.ts': {
     cases: [{ id: 'MODEL-01', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } }],
   },
@@ -69,6 +63,17 @@ const definitions = {
   },
   'saved-app-creation.e2e.test.ts': {
     cases: [{ id: 'APP-ISOLATION', engines: ['v1', 'v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v1' } }],
+  },
+  // Its Cloud endpoint is an in-process loopback MCP fixture reachable only from the spec process.
+  'opencode-v2-skill-jit.e2e.test.ts': {
+    name: 'Use Cloud and workspace skills just in time', placement: 'local',
+    cases: [
+      { id: 'SKILL-ATTACH', engines: ['v1', 'v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+      { id: 'SKILL-MISSING', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+      { id: 'SKILL-CLOUD-01', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+      { id: 'SKILL-CLOUD-02', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+      { id: 'SKILL-NATIVE-01', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+    ],
   },
 };
 

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -177,6 +177,21 @@ test('registered case metadata names exact files, supported execution axes, and 
       id: 'APP-ISOLATION',
       engines: ['v1', 'v2'],
     },
+    {
+      spec: 'opencode-v2-skill-jit.e2e.test.ts',
+      id: 'SKILL-CLOUD-01',
+      engines: ['v2'],
+    },
+    {
+      spec: 'opencode-v2-skill-jit.e2e.test.ts',
+      id: 'SKILL-CLOUD-02',
+      engines: ['v2'],
+    },
+    {
+      spec: 'opencode-v2-skill-jit.e2e.test.ts',
+      id: 'SKILL-NATIVE-01',
+      engines: ['v2'],
+    },
   ]);
   for (const registered of registeredCases) {
     assert(entries.some(entry => entry.spec === registered.spec));

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -140,8 +140,6 @@ test('mixed-world specs: a prerequisite one case declares is never promoted to t
 test('registered case metadata names exact files, supported execution axes, and defaults', async () => {
   const entries = await catalog();
   assert.deepEqual(registeredCases.map(({ spec, id, engines }) => ({ spec, id, engines })), [
-    { spec: 'opencode-v2-skill-jit.e2e.test.ts', id: 'SKILL-ATTACH', engines: ['v1', 'v2'] },
-    { spec: 'opencode-v2-skill-jit.e2e.test.ts', id: 'SKILL-MISSING', engines: ['v2'] },
     {
       spec: 'composer-model-picker-no-subscribe-promo.e2e.test.ts',
       id: 'MODEL-01',
@@ -177,6 +175,8 @@ test('registered case metadata names exact files, supported execution axes, and 
       id: 'APP-ISOLATION',
       engines: ['v1', 'v2'],
     },
+    { spec: 'opencode-v2-skill-jit.e2e.test.ts', id: 'SKILL-ATTACH', engines: ['v1', 'v2'] },
+    { spec: 'opencode-v2-skill-jit.e2e.test.ts', id: 'SKILL-MISSING', engines: ['v2'] },
     {
       spec: 'opencode-v2-skill-jit.e2e.test.ts',
       id: 'SKILL-CLOUD-01',

--- a/evals/specs/opencode-v2-skill-jit.e2e.test.ts
+++ b/evals/specs/opencode-v2-skill-jit.e2e.test.ts
@@ -453,18 +453,12 @@ jitTest("SKILL-CLOUD-02 two accounts on one endpoint never see each other's skil
     );
   });
 
-  await step("de-authorizing account B makes the skill disappear before the next prompt", async () => {
-    world.cloud.setAuthorization(skillJitAccounts.b, false);
-    const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
-    talk.expectNoCodes(turn.fresh);
-    expect(await world.cloudNativeSkills()).toEqual([]);
-    expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
-    const refused = world.cloud.log({ sinceIso: turn.startedAt, identity: skillJitAccounts.b }).filter((entry) => entry.status === 401);
-    expect(refused.length).toBeGreaterThan(0);
-    expect(world.cloud.resourceReads({ sinceIso: turn.startedAt }).filter((read) => read.status === 200)).toEqual([]);
-  });
-
-  await step("removing the Cloud config empties the registry, stops all endpoint contact, and leaves no private files in the workspace or home", async () => {
+  await step("removing the Cloud config while B's skill is materialized deletes the private files, empties the registry, stops all endpoint contact, and leaves nothing in the workspace or home", async () => {
+    // Switching to B already deleted A's private file; B's is live until the config goes away.
+    const [locationA, locationB] = locations;
+    if (!locationA || !locationB) throw new Error("Both account materializations must have been recorded");
+    expect(await world.materializedFileExists(locationA)).toBe(false);
+    expect(await world.materializedFileExists(locationB)).toBe(true);
     const removal = await world.removeCloud();
     expect(removal.status).toBe(200);
     expect(removal.remaining).not.toContain("openwork-cloud");
@@ -474,13 +468,38 @@ jitTest("SKILL-CLOUD-02 two accounts on one endpoint never see each other's skil
     expect(await world.cloudNativeSkills()).toEqual([]);
     expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
     expect(world.cloud.log().length).toBe(contactsBefore);
+    // The engine-private bodies are gone from disk, not merely unregistered.
+    for (const location of locations) expect(await world.materializedFileExists(location)).toBe(false);
     expect(await world.workspaceFilesContaining([codeA, codeB, cloudNativeSkillIdPrefix])).toEqual([]);
     for (const location of locations) expect(world.locationLeaks(location)).toEqual({ workspace: false, home: false });
     expect(world.cloud.toolCallNames()).toEqual([]);
     evidence.recordAssertionEvidence(
-      "Without a Cloud config the host never contacts the endpoint, the registry has no Cloud entries, and no skill body reached the workspace or home",
-      `fixtureRequestsBefore=${contactsBefore}; after=${world.cloud.log().length}; workspaceMatches=0; privateLocations=${locations.length}`,
+      "Removing the Cloud config with an active materialization deletes the private SKILL.md files, empties the registry, and stops endpoint contact; no body reached the workspace or home",
+      `fixtureRequestsBefore=${contactsBefore}; after=${world.cloud.log().length}; privateLocations=${locations.length}; filesRemaining=0; workspaceMatches=0`,
       true,
+    );
+  });
+
+  await step("re-authorizing B then losing authorization (401) fails closed: the skill and its file disappear before the next prompt", async () => {
+    expect((await world.authorizeCloud(skillJitAccounts.b)).status).toBe(200);
+    const restored = await talk.ask(catalogTurn, codeB);
+    expect(restored.text).not.toContain(codeA);
+    const entry = expectCloudNativeEntry((await world.cloudNativeSkills())[0], world, codeB);
+    expect(await world.materializedFileExists(entry.location)).toBe(true);
+    world.cloud.setAuthorization(skillJitAccounts.b, false);
+    const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
+    talk.expectNoCodes(turn.fresh);
+    expect(await world.cloudNativeSkills()).toEqual([]);
+    expect(await world.materializedFileExists(entry.location)).toBe(false);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
+    const refused = world.cloud.log({ sinceIso: turn.startedAt, identity: skillJitAccounts.b }).filter((log) => log.status === 401);
+    expect(refused.length).toBeGreaterThan(0);
+    expect(world.cloud.resourceReads({ sinceIso: turn.startedAt }).filter((read) => read.status === 200)).toEqual([]);
+    expect(world.cloud.toolCallNames()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "A 401 from the Cloud endpoint clears the materialized skill and its file before the prompt is admitted; the conversation still answers",
+      `refused401=${refused.length}; registryAfter=0; fileRemaining=false; answeredUnavailable=${turn.text.includes("UNAVAILABLE")}`,
+      turn.text.includes("UNAVAILABLE"),
     );
   });
 });

--- a/evals/specs/opencode-v2-skill-jit.e2e.test.ts
+++ b/evals/specs/opencode-v2-skill-jit.e2e.test.ts
@@ -462,6 +462,12 @@ jitTest("SKILL-CLOUD-02 two accounts on one endpoint never see each other's skil
     const removal = await world.removeCloud();
     expect(removal.status).toBe(200);
     expect(removal.remaining).not.toContain("openwork-cloud");
+    // The DELETE itself must clear the private file and the registry, before
+    // any later prompt admission gets a chance to reconcile them away.
+    await probe.eventually(() => world.materializedFileExists(locationB), {
+      within: 5_000, label: "the removed account's private SKILL.md is deleted by the Cloud removal", until: (exists) => exists === false,
+    });
+    expect(await world.cloudNativeSkills()).toEqual([]);
     const contactsBefore = world.cloud.log().length;
     const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
     talk.expectNoCodes(turn.fresh);

--- a/evals/specs/opencode-v2-skill-jit.e2e.test.ts
+++ b/evals/specs/opencode-v2-skill-jit.e2e.test.ts
@@ -343,6 +343,29 @@ jitTest("SKILL-CLOUD-01 a Cloud skill is native before the first prompt, updates
     expect(registry).toHaveLength(1);
     const entry = expectCloudNativeEntry(registry[0], world, code);
     skillId = entry.id;
+    await step("shared clients can select Cloud skills but cannot bulk-read their bodies or private locations", async () => {
+      const cloudReads = world.cloud.resourceReads().length;
+      for (const scope of ["viewer", "collaborator"] as const) {
+        for (const encoded of [false, true]) {
+          const shared = await world.sharedNativeSkills(scope, encoded);
+          expect(shared.status).toBe(200);
+          const data = record(shared.json) && Array.isArray(shared.json.data) ? shared.json.data : [];
+          const skill = data.find((value) => record(value) && value.id === skillId);
+          expect(skill).toMatchObject({ id: skillId, name: world.cloudSkillName, description: cloudSkillDescription });
+          expect(skill).not.toHaveProperty("content");
+          expect(skill).not.toHaveProperty("location");
+          expect(shared.text).not.toContain(code);
+          expect(shared.text).not.toContain(entry.location);
+        }
+      }
+      expect(world.cloud.resourceReads()).toHaveLength(cloudReads);
+      expectCloudNativeEntry((await world.cloudNativeSkills())[0], world, code);
+      evidence.recordAssertionEvidence(
+        "Viewer and collaborator catalog reads expose metadata only while owner and internal native loading retain the complete skill",
+        "normal and encoded catalog routes: 200; Cloud body/path absent for both shared scopes; no extra Cloud fetch; owner body preserved",
+        true,
+      );
+    });
     expect(await talk.skillToolIds(turn.prompt)).toEqual([skillId]);
     const reads = world.cloud.resourceReads({ sinceIso: turn.startedAt });
     expect(reads.every((read) => read.identity === account && read.authorized)).toBe(true);

--- a/evals/specs/opencode-v2-skill-jit.e2e.test.ts
+++ b/evals/specs/opencode-v2-skill-jit.e2e.test.ts
@@ -1,9 +1,16 @@
 import { randomUUID } from "node:crypto";
 import { expect } from "vitest";
 import { liveOpenAiEnabled } from "@openwork/behaviors";
-import { observeTranscript, readTranscriptMessages, spec, type User } from "@openwork/testkit";
+import { observeTranscript, readTranscriptMessages, spec, type Probe, type User } from "@openwork/testkit";
 import { skillLifecycle } from "../worlds/chat.ts";
 import { selectedSkillsWeb } from "../worlds/selected-skills.ts";
+import {
+  cloudNativeSkillIdPrefix,
+  skillJitAccounts,
+  skillJitWeb,
+  type NativeSkillEntry,
+  type SkillJitTurnTarget,
+} from "../worlds/skill-jit.ts";
 
 const test = spec.world(skillLifecycle, {
   timeout: 900_000,
@@ -195,5 +202,320 @@ selectedTest("SKILL-MISSING a selected skill removed from the native registry fa
   evidence.recordJsonArtifact("SKILL-MISSING no false submission", {
     nativeRequests: await world.nativeRequests(), providerRequests: world.providerRequests(),
     assistantMessages: await readTranscriptMessages(probe, "assistant"),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Headless app-web world: Cloud skills materialized natively, just in time.
+// The Cloud endpoint is an identity-scoped fixture; codes are random, unseen,
+// and never appear in prompts or skill metadata. Every claim carries its
+// negative half (other account, other code, no Connect tool call, no leak).
+// ---------------------------------------------------------------------------
+
+const jitTest = spec.world(skillJitWeb, {
+  timeout: 900_000,
+  resources: { surfaces: ["appWeb"], services: ["mock"] },
+});
+
+type JitWorld = Awaited<ReturnType<typeof skillJitWeb>>;
+
+const nativeSkillIdPattern = new RegExp(`^${cloudNativeSkillIdPrefix}[0-9a-f]{16}$`);
+const connectToolPattern = /search_capabilities|execute_capability/;
+const skillToolPattern = /(?:^|_)skill$/;
+const cloudSkillDescription = "Answers amber release report requests.";
+const cloudSkillBody = (code: string) => `For amber release report requests, reply with the current code: ${code}.`;
+
+/** One conversation driver per case: unseen codes, prompt hygiene, runtime identity, and transcript integrity. */
+function jitConversation({ world, user, probe }: { world: JitWorld; user: User; probe: Probe }) {
+  const codes: string[] = [];
+  const submitted: string[] = [];
+  let turnNumber = 0;
+  let runtime: number | null = null;
+  let sessionRoute: string | null = null;
+  const answer = async () => {
+    const messages = await readTranscriptMessages(probe, "assistant");
+    return { count: messages.length, text: messages.at(-1) ?? "", messages };
+  };
+  const mintCode = () => {
+    const code = randomUUID();
+    codes.push(code);
+    return code;
+  };
+  const ask = async (target: SkillJitTurnTarget, expected: string | null) => {
+    runtime ??= await world.runtimeIdentity();
+    sessionRoute ??= await probe.hash();
+    const before = await answer();
+    const prompt = `What app are you? What is the current amber release report code? `
+      + `Use the currently installed instructions; do not reuse an earlier code. `
+      + `If no matching instructions are installed, say UNAVAILABLE. Request ${++turnNumber}.`;
+    // The user-facing request never smuggles the answer, the skill, or the connector.
+    expect(prompt).not.toContain(world.cloudSkillName);
+    expect(prompt).not.toContain(world.workspaceSkillName);
+    expect(prompt).not.toContain("SKILL.md");
+    expect(prompt).not.toContain(cloudNativeSkillIdPrefix);
+    for (const code of codes) expect(prompt).not.toContain(code);
+    const startedAt = new Date().toISOString();
+    await world.prepareTurn(prompt, target);
+    await using transcript = await observeTranscript(probe, [{ role: "user", text: prompt }]);
+    await user.type({ placeholder: "Describe your task..." }, prompt, { verify: true });
+    await user.press("Enter");
+    await user.see({ text: prompt }, { timeoutMs: 15_000 });
+    if (expected !== null) {
+      await probe.eventually(answer, {
+        within: 150_000, label: `the conversation answers with ${expected === "UNAVAILABLE" ? "UNAVAILABLE" : "the current code"}`,
+        until: (value) => value.count > before.count && value.text.includes(expected),
+      });
+    }
+    await user.see("Run task", { timeoutMs: 150_000 });
+    const response = await answer();
+    submitted.push(prompt);
+    const visibleUserMessages = await readTranscriptMessages(probe, "user");
+    expect(visibleUserMessages).toHaveLength(submitted.length);
+    visibleUserMessages.forEach((text, index) => expect(text).toContain(submitted[index]));
+    expect(await readTranscriptMessages(probe, "system")).toEqual([]);
+    expect(await transcript.finish()).toMatchObject({ seen: [true], violations: [], stopped: false });
+    expect(await probe.hash()).toBe(sessionRoute);
+    expect(await world.runtimeIdentity()).toBe(runtime);
+    await user.screenshot();
+    // Only what this turn added: earlier answers legitimately still show earlier codes.
+    const fresh = response.messages.slice(before.count).join("\n");
+    return { prompt, startedAt, text: response.text, fresh };
+  };
+  /** Which native skill ids the model asked the `skill` tool for in one turn, in order. */
+  const skillToolIds = async (prompt: string) => {
+    const requests = await world.modelRequests(prompt, { atLeast: 1, timeoutMs: 30_000 });
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests.filter((request) => request.kind === "error")).toEqual([]);
+    // The model never routed skills through Connect tools.
+    expect(requests.filter((request) => typeof request.toolName === "string" && connectToolPattern.test(request.toolName))).toEqual([]);
+    return requests
+      .filter((request) => request.kind === "tool" && typeof request.toolName === "string" && skillToolPattern.test(request.toolName))
+      .map((request) => String(request.arguments.id ?? ""));
+  };
+  const firstModelRequestAt = async (prompt: string) => (await world.modelRequests(prompt, { atLeast: 1, timeoutMs: 30_000 }))
+    .map((request) => request.at).sort()[0] ?? "";
+  const expectNoCodes = (text: string, except: string | null = null) => {
+    for (const code of codes) if (code !== except) expect(text).not.toContain(code);
+  };
+  return { ask, mintCode, skillToolIds, firstModelRequestAt, expectNoCodes, codes, runtime: () => runtime };
+}
+
+function expectCloudNativeEntry(entry: NativeSkillEntry | undefined, world: JitWorld, code: string): NativeSkillEntry {
+  if (!entry) throw new Error("The native registry has no Cloud skill entry");
+  expect(entry.id).toMatch(nativeSkillIdPattern);
+  expect(entry.name).toBe(world.cloudSkillName);
+  expect(entry.content.trim()).toContain(cloudSkillBody(code));
+  expect(entry.location).not.toBe("");
+  expect(world.locationLeaks(entry.location)).toEqual({ workspace: false, home: false });
+  return entry;
+}
+
+jitTest("SKILL-CLOUD-01 a Cloud skill is native before the first prompt, updates by body, and disappears on revoke", async ({ world, user, probe, step, evidence }) => {
+  const talk = jitConversation({ world, user, probe });
+  const account = skillJitAccounts.a;
+  const catalogTurn: SkillJitTurnTarget = { kind: "catalog", skill: world.cloudSkillName };
+  const indexUri = "skill://index.json";
+  const skillUri = world.cloud.skillUri(world.cloudSkillName);
+  let skillId = "";
+
+  await step("without a Cloud connection the conversation knows OpenWork and no Cloud skill exists", async () => {
+    expect(await world.cloudNativeSkills()).toEqual([]);
+    const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
+    expect(turn.text).toMatch(/OpenWork/i);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
+    expect(world.cloud.log()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "No Cloud config means no Cloud skill and no contact with the Cloud endpoint",
+      `registry cloud entries=0; fixture requests=${world.cloud.log().length}; answer=${JSON.stringify(turn.text.slice(0, 80))}`,
+      true,
+    );
+  });
+
+  await step("authorizing account A makes the unseen skill body answer the very first prompt through the native skill tool", async () => {
+    const code = talk.mintCode();
+    world.cloud.publishSkill(account, { name: world.cloudSkillName, description: cloudSkillDescription, body: cloudSkillBody(code) });
+    const receipt = await world.authorizeCloud(account);
+    expect(receipt.status).toBe(200);
+    expect(receipt.desiredPresent).toBe(true);
+    const turn = await talk.ask(catalogTurn, code);
+    talk.expectNoCodes(turn.text, code);
+    const registry = await world.cloudNativeSkills();
+    expect(registry).toHaveLength(1);
+    const entry = expectCloudNativeEntry(registry[0], world, code);
+    skillId = entry.id;
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([skillId]);
+    const reads = world.cloud.resourceReads({ sinceIso: turn.startedAt });
+    expect(reads.every((read) => read.identity === account && read.authorized)).toBe(true);
+    const indexRead = reads.find((read) => read.uri === indexUri);
+    const bodyRead = reads.find((read) => read.uri === skillUri);
+    if (!indexRead || !bodyRead) throw new Error(`Expected index and body reads, saw ${JSON.stringify(reads.map((read) => read.uri))}`);
+    const modelAt = await talk.firstModelRequestAt(turn.prompt);
+    expect(indexRead.at <= modelAt).toBe(true);
+    expect(bodyRead.at <= modelAt).toBe(true);
+    expect(world.cloud.toolCallNames()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "The host read skill://index.json and the SKILL.md body before the first model request, registered the skill natively, and made zero Connect tool calls",
+      `id=${skillId}; indexRead=${indexRead.at}; bodyRead=${bodyRead.at}; firstModelRequest=${modelAt}; toolsCall=${world.cloud.toolCallNames().length}; location outside workspace/home=${JSON.stringify(world.locationLeaks(entry.location))}`,
+      true,
+    );
+  });
+
+  await step("a body-only update returns the new code on the next turn with the same skill id and runtime", async () => {
+    const previous = talk.codes[0] ?? "";
+    const code = talk.mintCode();
+    const runtimeBefore = await world.runtimeIdentity();
+    world.cloud.updateSkillBody(account, world.cloudSkillName, cloudSkillBody(code));
+    const turn = await talk.ask(catalogTurn, code);
+    expect(turn.text).not.toContain(previous);
+    const registry = await world.cloudNativeSkills();
+    expect(registry).toHaveLength(1);
+    const entry = expectCloudNativeEntry(registry[0], world, code);
+    expect(entry.id).toBe(skillId);
+    expect(entry.content).not.toContain(previous);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([skillId]);
+    expect(await world.runtimeIdentity()).toBe(runtimeBefore);
+    expect(world.cloud.toolCallNames()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "A body-only update keeps the native id stable and replaces the served instructions without restarting the engine",
+      `id=${entry.id}; pid=${runtimeBefore}; newCodeVisible=${turn.text.includes(code)}; oldCodeVisible=${turn.text.includes(previous)}`,
+      entry.id === skillId && turn.text.includes(code) && !turn.text.includes(previous),
+    );
+  });
+
+  await step("revoking the skill removes it before the next prompt, and a forced load of the stale id fails honestly", async () => {
+    expect(world.cloud.revokeSkill(account, world.cloudSkillName)).toBe(true);
+    const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
+    talk.expectNoCodes(turn.fresh);
+    expect(await world.cloudNativeSkills()).toEqual([]);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
+    const reads = world.cloud.resourceReads({ sinceIso: turn.startedAt });
+    expect(reads.some((read) => read.uri === indexUri && read.identity === account)).toBe(true);
+    expect(reads.filter((read) => read.uri === skillUri)).toEqual([]);
+    const firstRead = reads.map((read) => read.at).sort()[0] ?? "";
+    expect(firstRead <= await talk.firstModelRequestAt(turn.prompt)).toBe(true);
+
+    const forced = await talk.ask({ kind: "forced", skillId }, null);
+    talk.expectNoCodes(forced.fresh);
+    expect(forced.fresh).not.toContain(cloudSkillBody("").slice(0, 40));
+    expect(await world.cloudNativeSkills()).toEqual([]);
+    const forcedIds = await talk.skillToolIds(forced.prompt);
+    expect(forcedIds).toEqual([skillId]);
+    expect(world.cloud.toolCallNames()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "After revocation the registry is empty before the next prompt and forcing the stale native id yields no instructions",
+      `staleId=${skillId}; forcedToolRounds=${forcedIds.length}; codesVisible=false; cloudToolCalls=${world.cloud.toolCallNames().length}`,
+      true,
+    );
+  });
+});
+
+jitTest("SKILL-CLOUD-02 two accounts on one endpoint never see each other's skill body, and removing Cloud leaves nothing behind", async ({ world, user, probe, step, evidence }) => {
+  const talk = jitConversation({ world, user, probe });
+  const catalogTurn: SkillJitTurnTarget = { kind: "catalog", skill: world.cloudSkillName };
+  const codeA = talk.mintCode();
+  const codeB = talk.mintCode();
+  const locations: string[] = [];
+  world.cloud.publishSkill(skillJitAccounts.a, { name: world.cloudSkillName, description: cloudSkillDescription, body: cloudSkillBody(codeA) });
+  world.cloud.publishSkill(skillJitAccounts.b, { name: world.cloudSkillName, description: cloudSkillDescription, body: cloudSkillBody(codeB) });
+
+  await step("account A receives only A's body", async () => {
+    expect((await world.authorizeCloud(skillJitAccounts.a)).status).toBe(200);
+    const turn = await talk.ask(catalogTurn, codeA);
+    expect(turn.text).not.toContain(codeB);
+    const entry = expectCloudNativeEntry((await world.cloudNativeSkills())[0], world, codeA);
+    expect(entry.content).not.toContain(codeB);
+    locations.push(entry.location);
+    const reads = world.cloud.resourceReads({ sinceIso: turn.startedAt });
+    expect(reads.length).toBeGreaterThan(0);
+    expect(reads.filter((read) => read.identity !== skillJitAccounts.a)).toEqual([]);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([entry.id]);
+  });
+
+  await step("switching the connection to account B replaces the body; B never sees A's code", async () => {
+    expect((await world.authorizeCloud(skillJitAccounts.b)).status).toBe(200);
+    const turn = await talk.ask(catalogTurn, codeB);
+    expect(turn.text).not.toContain(codeA);
+    const registry = await world.cloudNativeSkills();
+    expect(registry).toHaveLength(1);
+    const entry = expectCloudNativeEntry(registry[0], world, codeB);
+    expect(entry.content).not.toContain(codeA);
+    locations.push(entry.location);
+    const reads = world.cloud.resourceReads({ sinceIso: turn.startedAt });
+    expect(reads.length).toBeGreaterThan(0);
+    expect(reads.filter((read) => read.identity === skillJitAccounts.a)).toEqual([]);
+    expect(reads.every((read) => read.identity === skillJitAccounts.b && read.authorized)).toBe(true);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([entry.id]);
+    expect(world.cloud.toolCallNames()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "Account B's turn read only B's resources and answered only B's code",
+      `reads=${reads.length}; identities=${JSON.stringify([...new Set(reads.map((read) => read.identity))])}; aCodeVisible=${turn.text.includes(codeA)}; bCodeVisible=${turn.text.includes(codeB)}`,
+      !turn.text.includes(codeA) && turn.text.includes(codeB),
+    );
+  });
+
+  await step("de-authorizing account B makes the skill disappear before the next prompt", async () => {
+    world.cloud.setAuthorization(skillJitAccounts.b, false);
+    const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
+    talk.expectNoCodes(turn.fresh);
+    expect(await world.cloudNativeSkills()).toEqual([]);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
+    const refused = world.cloud.log({ sinceIso: turn.startedAt, identity: skillJitAccounts.b }).filter((entry) => entry.status === 401);
+    expect(refused.length).toBeGreaterThan(0);
+    expect(world.cloud.resourceReads({ sinceIso: turn.startedAt }).filter((read) => read.status === 200)).toEqual([]);
+  });
+
+  await step("removing the Cloud config empties the registry, stops all endpoint contact, and leaves no private files in the workspace or home", async () => {
+    const removal = await world.removeCloud();
+    expect(removal.status).toBe(200);
+    expect(removal.remaining).not.toContain("openwork-cloud");
+    const contactsBefore = world.cloud.log().length;
+    const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
+    talk.expectNoCodes(turn.fresh);
+    expect(await world.cloudNativeSkills()).toEqual([]);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
+    expect(world.cloud.log().length).toBe(contactsBefore);
+    expect(await world.workspaceFilesContaining([codeA, codeB, cloudNativeSkillIdPrefix])).toEqual([]);
+    for (const location of locations) expect(world.locationLeaks(location)).toEqual({ workspace: false, home: false });
+    expect(world.cloud.toolCallNames()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "Without a Cloud config the host never contacts the endpoint, the registry has no Cloud entries, and no skill body reached the workspace or home",
+      `fixtureRequestsBefore=${contactsBefore}; after=${world.cloud.log().length}; workspaceMatches=0; privateLocations=${locations.length}`,
+      true,
+    );
+  });
+});
+
+jitTest("SKILL-NATIVE-01 a malformed workspace skill never blocks prompt admission while the workspace skill lifecycle still converges", async ({ world, user, probe, step }) => {
+  const talk = jitConversation({ world, user, probe });
+  const catalogTurn: SkillJitTurnTarget = { kind: "catalog", skill: world.workspaceSkillName };
+  const install = async (code: string, description: string) => {
+    const result = await world.installWorkspaceSkill({ description, content: cloudSkillBody(code) });
+    expect(result.status).toBe(200);
+  };
+
+  await step("a directory/name mismatch without a description is admitted and answered", async () => {
+    await world.writeWorkspaceSkillFile("mismatched-directory", "---\nname: some-other-name\n---\n\nThis skill has no description and lives in a directory that does not match its name.\n");
+    const turn = await talk.ask(catalogTurn, "UNAVAILABLE");
+    expect(turn.text).toMatch(/OpenWork/i);
+    expect(await talk.skillToolIds(turn.prompt)).toEqual([]);
+    expect(await world.cloudNativeSkills()).toEqual([]);
+  });
+
+  await step("installing, editing and removing the workspace skill still changes the next answer", async () => {
+    const first = talk.mintCode();
+    await install(first, "Answers amber release report requests.");
+    const installed = await talk.ask(catalogTurn, first);
+    const ids = await talk.skillToolIds(installed.prompt);
+    expect(ids).toHaveLength(1);
+    expect(ids[0]).not.toMatch(nativeSkillIdPattern);
+    const second = talk.mintCode();
+    await install(second, "Answers amber release report requests.");
+    const updated = await talk.ask(catalogTurn, second);
+    expect(updated.text).not.toContain(first);
+    expect((await world.removeWorkspaceSkill()).status).toBe(200);
+    const removed = await talk.ask(catalogTurn, "UNAVAILABLE");
+    talk.expectNoCodes(removed.fresh);
+    expect(await talk.skillToolIds(removed.prompt)).toEqual([]);
+    expect(world.cloud.log()).toEqual([]);
   });
 });

--- a/evals/worlds/skill-jit.ts
+++ b/evals/worlds/skill-jit.ts
@@ -1,7 +1,7 @@
 import { browserScript } from "@openwork/cdp";
 import { deriveMockEnv, type MockBoot, type Place, type Seed } from "@openwork/env";
 import { startMockCloudSkills, type MockAgentRequest, type MockCloudSkillsHandle } from "@openwork/labs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, relative, resolve, sep } from "node:path";
 import { configureProvider } from "./chat.ts";
@@ -259,6 +259,10 @@ export async function skillJitWeb(seed: Seed, context: { place: Place }) {
         if (needles.some((needle) => text.includes(needle))) matches.push(relative(workspacePath, path));
       }
       return matches.sort();
+    },
+    /** Whether a previously reported engine-private SKILL.md still exists on disk (the engine runs on this host). */
+    async materializedFileExists(location: string): Promise<boolean> {
+      return access(location).then(() => true, () => false);
     },
     /** Whether a registry location sits inside the workspace or the real home directory. */
     locationLeaks(location: string): { workspace: boolean; home: boolean } {

--- a/evals/worlds/skill-jit.ts
+++ b/evals/worlds/skill-jit.ts
@@ -1,0 +1,285 @@
+import { browserScript } from "@openwork/cdp";
+import { deriveMockEnv, type MockBoot, type Place, type Seed } from "@openwork/env";
+import { startMockCloudSkills, type MockAgentRequest, type MockCloudSkillsHandle } from "@openwork/labs";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, relative, resolve, sep } from "node:path";
+import { configureProvider } from "./chat.ts";
+
+/** Account labels the fixture mints credentials for. Labels are safe to log; credentials are not. */
+export const skillJitAccounts = Object.freeze({ a: "account-a", b: "account-b" });
+/** Both Cloud accounts publish a skill under this name; only the body differs per account. */
+export const skillJitCloudSkillName = "amber-release-report";
+/** The workspace-scoped skill installed through the OpenWork skills route in the native lifecycle case. */
+export const skillJitWorkspaceSkillName = "release-briefing";
+/** Every native skill materialized from OpenWork Cloud is registered under this id prefix. */
+export const cloudNativeSkillIdPrefix = "openwork-cloud-";
+
+export interface NativeSkillEntry {
+  id: string;
+  name: string;
+  description: string;
+  location: string;
+  content: string;
+}
+
+export type SkillJitTurnTarget =
+  | { kind: "catalog"; skill: string }
+  | { kind: "forced"; skillId: string };
+
+export interface CloudReconcileReceipt {
+  status: number;
+  desiredPresent: boolean | null;
+  deliveryState: string | null;
+  engineStatus: string | null;
+  failureCodes: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function parseNativeSkills(payload: unknown): NativeSkillEntry[] {
+  const data = isRecord(payload) && Array.isArray(payload.data) ? payload.data : Array.isArray(payload) ? payload : null;
+  if (!data) throw new Error("The native skill registry response was not a list.");
+  return data.filter(isRecord).map((entry) => {
+    const name = readString(entry.name) ?? "";
+    return {
+      id: readString(entry.id) ?? name,
+      name,
+      description: readString(entry.description) ?? "",
+      location: readString(entry.location) ?? "",
+      content: readString(entry.content) ?? "",
+    };
+  });
+}
+
+async function listFilesRecursively(root: string): Promise<string[]> {
+  const output: string[] = [];
+  const walk = async (directory: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) await walk(path);
+      else if (entry.isFile()) output.push(path);
+    }
+  };
+  await walk(root);
+  return output;
+}
+
+function isInside(path: string, root: string): boolean {
+  const relativePath = relative(resolve(root), resolve(path));
+  return relativePath === "" || (!relativePath.startsWith("..") && !relativePath.startsWith(sep) && !/^[A-Za-z]:/.test(relativePath));
+}
+
+/**
+ * Headless app-web fixture for just-in-time skills on the native v2 engine.
+ *
+ * The world owns: a deterministic model witness (seed.mock) whose only tool
+ * step is the native `skill` tool, an identity-scoped mock of the OpenWork
+ * Cloud `/mcp/agent` endpoint serving `skill://` resources, and typed seed-side
+ * steps that persist that endpoint as the account-global Cloud MCP config for
+ * one account at a time. Nothing here injects renderer prompts or evaluates
+ * browser code on behalf of a spec body.
+ */
+export async function skillJitWeb(seed: Seed, context: { place: Place }) {
+  if (context.place.kind !== "local") {
+    throw new Error("skillJitWeb runs on local placement only: its Cloud skill fixture is an in-process loopback MCP server.");
+  }
+  const providerId = "skill-jit-mock";
+  const modelId = "skill-jit-model";
+  const workspacePath = seed.tmpPath("skill-jit");
+  const booted: { cloud: MockCloudSkillsHandle | null } = { cloud: null };
+  const cloudBoot: MockBoot = {
+    async boot() {
+      const handle = await startMockCloudSkills({ identities: [skillJitAccounts.a, skillJitAccounts.b] });
+      booted.cloud = handle;
+      return { handle, env: ({ name, url, mcpUrl }) => deriveMockEnv(name, url, mcpUrl) };
+    },
+  };
+  const app = await seed.appWeb({
+    name: "skill-jit",
+    workspacePath,
+    mocks: { agent: seed.mock({ isolatedProcessEnv: true }), cloud: cloudBoot },
+  });
+  const agentMock = app.mocks.agent;
+  const cloud = booted.cloud;
+  if (!agentMock || !cloud) throw new Error("The app-web fixture did not boot both the model witness and the Cloud skill fixture.");
+
+  const workspace = await seed.workspace(app, workspacePath);
+  const credentials = await seed.evalIn(app, browserScript(() => ({
+    port: localStorage.getItem("openwork.server.port"),
+    token: localStorage.getItem("openwork.server.token"),
+  }), []));
+  if (!credentials.port || !credentials.token) throw new Error("The app-web renderer has no local server credentials.");
+  const serverUrl = `http://127.0.0.1:${credentials.port}`;
+  const serverToken = credentials.token;
+  const request = async (path: string, init: { method?: string; body?: unknown; timeoutMs?: number } = {}) => {
+    const response = await fetch(serverUrl + path, {
+      method: init.method ?? "GET",
+      headers: { Authorization: `Bearer ${serverToken}`, ...(init.body === undefined ? {} : { "Content-Type": "application/json" }) },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      signal: AbortSignal.timeout(init.timeoutMs ?? 30_000),
+    });
+    const text = await response.text();
+    let json: unknown = null;
+    try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+    return { status: response.status, json, text };
+  };
+
+  // Native v2 conversation regardless of the inherited engine selector.
+  const preview = await request("/experimental/engine-v2-preview", { method: "PUT", body: { enabled: true, chatRouting: true }, timeoutMs: 180_000 });
+  if (preview.status !== 200) throw new Error(`Could not enable the native engine: ${preview.status} ${preview.text.slice(0, 300)}`);
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    permission: { skill: "allow" },
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Skill JIT model",
+        options: { baseURL: `${agentMock.url}/v1`, apiKey: "sk-skill-jit-fixture" },
+        models: { [modelId]: { name: "Skill JIT model", tool_call: true } },
+      },
+    },
+  }, "v2");
+  const session = await createSession(seed, app, "Amber release report");
+  const nativeSkillPath = `/workspace/${encodeURIComponent(workspace.workspaceId)}/opencode2/api/skill`;
+  const cloudMcpPath = `/workspace/${encodeURIComponent(workspace.workspaceId)}/mcp/openwork-cloud`;
+  const cloudReceipt = (status: number, json: unknown): CloudReconcileReceipt => {
+    const health = isRecord(json) ? json : {};
+    const failures = Array.isArray(health.failures) ? health.failures : [];
+    return {
+      status,
+      desiredPresent: isRecord(health.desired) && typeof health.desired.present === "boolean" ? health.desired.present : null,
+      deliveryState: isRecord(health.delivery) ? readString(health.delivery.state) : null,
+      engineStatus: isRecord(health.engine) ? readString(health.engine.status) : null,
+      failureCodes: failures.flatMap((failure) => isRecord(failure) && typeof failure.code === "string" ? [failure.code] : []),
+    };
+  };
+
+  return {
+    app,
+    workspace,
+    session,
+    workspaceRoot: workspacePath,
+    /** The signed-in eval user's real home; nothing engine-private may land there. */
+    realHome: homedir(),
+    engine: "v2" as const,
+    providerId,
+    modelId,
+    cloud,
+    cloudSkillName: skillJitCloudSkillName,
+    workspaceSkillName: skillJitWorkspaceSkillName,
+    /** Arrange the deterministic model turn: one native `skill` call, then the tool text as the visible answer. */
+    async prepareTurn(prompt: string, target: SkillJitTurnTarget): Promise<void> {
+      const step = target.kind === "catalog"
+        ? { tool: "skill", argumentsFrom: "skill-catalog", arguments: { skill: target.skill } }
+        : { tool: "skill", arguments: { id: target.skillId } };
+      const result = await fetch(`${agentMock.url}/admin/agent-workloads`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ workloads: [{
+          latestUserTurn: true, promptMarker: prompt, finalReply: "OpenWork: UNAVAILABLE", finalReplyFrom: "last-tool-text", steps: [step],
+        }] }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!result.ok) throw new Error(`Could not arrange the model turn: HTTP ${result.status}`);
+    },
+    /** Persist the fixture endpoint as the global Cloud MCP config using one account's minted bearer token. */
+    async authorizeCloud(identity: string): Promise<CloudReconcileReceipt> {
+      const result = await request(`${cloudMcpPath}/reconcile`, { method: "POST", timeoutMs: 120_000, body: {
+        config: {
+          type: "remote", url: cloud.agentUrl, enabled: true, oauth: false,
+          headers: { Authorization: `Bearer ${cloud.credential(identity)}` },
+        },
+        trigger: `skill-jit:${identity}`,
+      } });
+      return cloudReceipt(result.status, result.json);
+    },
+    /** Remove the global Cloud MCP config; the host must stop contacting the endpoint. */
+    async removeCloud(): Promise<{ status: number; remaining: string[] }> {
+      const result = await request(cloudMcpPath, { method: "DELETE", timeoutMs: 60_000 });
+      const items = isRecord(result.json) && Array.isArray(result.json.items) ? result.json.items : [];
+      return { status: result.status, remaining: items.flatMap((item) => isRecord(item) && typeof item.name === "string" ? [item.name] : []) };
+    },
+    /** Install or overwrite the workspace skill through the authoring API (validated shape; the app uses this route). */
+    async installWorkspaceSkill(input: { description: string; content: string }): Promise<{ status: number }> {
+      const result = await request(`/workspace/${encodeURIComponent(workspace.workspaceId)}/skills`, { method: "POST", body: {
+        name: skillJitWorkspaceSkillName, description: input.description, content: input.content,
+      } });
+      return { status: result.status };
+    },
+    async removeWorkspaceSkill(): Promise<{ status: number }> {
+      const result = await request(`/workspace/${encodeURIComponent(workspace.workspaceId)}/skills/${encodeURIComponent(skillJitWorkspaceSkillName)}`, { method: "DELETE" });
+      return { status: result.status };
+    },
+    async cloudHealth(): Promise<CloudReconcileReceipt> {
+      const result = await request(`${cloudMcpPath}/health`);
+      return cloudReceipt(result.status, result.json);
+    },
+    /** The engine's live native skill registry, as the proxied v2 route exposes it. */
+    async nativeSkills(): Promise<NativeSkillEntry[]> {
+      const result = await request(nativeSkillPath);
+      if (result.status !== 200) throw new Error(`Native skill registry unavailable: HTTP ${result.status}`);
+      return parseNativeSkills(result.json);
+    },
+    async cloudNativeSkills(): Promise<NativeSkillEntry[]> {
+      const result = await request(nativeSkillPath);
+      if (result.status !== 200) throw new Error(`Native skill registry unavailable: HTTP ${result.status}`);
+      return parseNativeSkills(result.json).filter((skill) => skill.id.startsWith(cloudNativeSkillIdPrefix));
+    },
+    /** PID of the running v2 conversation runtime. */
+    async runtimeIdentity(): Promise<number> {
+      const result = await request("/experimental/engine-v2-preview/status");
+      if (!isRecord(result.json) || result.json.running !== true || result.json.chatRouting !== true || typeof result.json.pid !== "number") {
+        throw new Error("The v2 conversation runtime is not running");
+      }
+      return result.json.pid;
+    },
+    /** What the model witness saw for one prompt: tool rounds with their arguments, then the final round. */
+    modelRequests(prompt: string, opts: { atLeast?: number; timeoutMs?: number } = {}): Promise<MockAgentRequest[]> {
+      return agentMock.agentRequests({ promptMarker: prompt, ...opts });
+    },
+    /** Write a raw workspace SKILL.md at a directory the skills route would never choose. */
+    async writeWorkspaceSkillFile(directoryName: string, markdown: string): Promise<string> {
+      const directory = join(workspacePath, ".opencode", "skills", directoryName);
+      await mkdir(directory, { recursive: true });
+      const path = join(directory, "SKILL.md");
+      await writeFile(path, markdown, "utf8");
+      return path;
+    },
+    /** Workspace-relative paths of files whose contents include any needle. */
+    async workspaceFilesContaining(needles: readonly string[]): Promise<string[]> {
+      const matches: string[] = [];
+      for (const path of await listFilesRecursively(workspacePath)) {
+        const text = await readFile(path, "utf8").catch(() => "");
+        if (needles.some((needle) => text.includes(needle))) matches.push(relative(workspacePath, path));
+      }
+      return matches.sort();
+    },
+    /** Whether a registry location sits inside the workspace or the real home directory. */
+    locationLeaks(location: string): { workspace: boolean; home: boolean } {
+      return {
+        workspace: location.length > 0 && isInside(location, workspacePath),
+        home: location.length > 0 && isInside(location, homedir()),
+      };
+    },
+  };
+}
+
+async function createSession(seed: Seed, app: Awaited<ReturnType<Seed["appWeb"]>>, title: string) {
+  const deadline = Date.now() + 60_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await seed.session(app, { title });
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  throw new Error(`Session creation did not settle: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}

--- a/evals/worlds/skill-jit.ts
+++ b/evals/worlds/skill-jit.ts
@@ -1,9 +1,11 @@
-import { browserScript } from "@openwork/cdp";
 import { deriveMockEnv, type MockBoot, type Place, type Seed } from "@openwork/env";
+import { readHeadlessRuntimeManifest, resolveHeadlessWorldRuntimePaths } from "@openwork/world";
+import { fileURLToPath } from "node:url";
 import { startMockCloudSkills, type MockAgentRequest, type MockCloudSkillsHandle } from "@openwork/labs";
 import { access, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, relative, resolve, sep } from "node:path";
+import { skillJitModelScript } from "../packages/labs/src/skill-jit-model.ts";
 import { configureProvider } from "./chat.ts";
 
 /** Account labels the fixture mints credentials for. Labels are safe to log; credentials are not. */
@@ -105,24 +107,34 @@ export async function skillJitWeb(seed: Seed, context: { place: Place }) {
   const app = await seed.appWeb({
     name: "skill-jit",
     workspacePath,
-    mocks: { agent: seed.mock({ isolatedProcessEnv: true }), cloud: cloudBoot },
+    mocks: { agent: seed.mock({ isolatedProcessEnv: true, scriptPath: skillJitModelScript }), cloud: cloudBoot },
   });
   const agentMock = app.mocks.agent;
   const cloud = booted.cloud;
   if (!agentMock || !cloud) throw new Error("The app-web fixture did not boot both the model witness and the Cloud skill fixture.");
 
   const workspace = await seed.workspace(app, workspacePath);
-  const credentials = await seed.evalIn(app, browserScript(() => ({
-    port: localStorage.getItem("openwork.server.port"),
-    token: localStorage.getItem("openwork.server.token"),
-  }), []));
-  if (!credentials.port || !credentials.token) throw new Error("The app-web renderer has no local server credentials.");
-  const serverUrl = `http://127.0.0.1:${credentials.port}`;
-  const serverToken = credentials.token;
-  const request = async (path: string, init: { method?: string; body?: unknown; timeoutMs?: number } = {}) => {
+  // The renderer intentionally keeps its collaborator token. Fixture-only
+  // owner reads use an owner bearer minted through this owned runtime's host API.
+  const paths = resolveHeadlessWorldRuntimePaths(fileURLToPath(new URL("../../", import.meta.url)), app.handle.name);
+  const runtime = await readHeadlessRuntimeManifest(paths.runtimeManifestPath);
+  if (!runtime || runtime.openworkUrl !== app.openworkUrl || runtime.workspace !== app.workspaceRoot) {
+    throw new Error("The skill fixture could not identify its owned headless runtime");
+  }
+  const ownerResponse = await fetch(`${runtime.openworkUrl}/tokens`, {
+    method: "POST", headers: { "X-OpenWork-Host-Token": runtime.hostToken, "Content-Type": "application/json" },
+    body: JSON.stringify({ scope: "owner", label: "skill-jit-owner" }), signal: AbortSignal.timeout(15_000),
+  });
+  const owner: unknown = await ownerResponse.json();
+  if (ownerResponse.status !== 201 || !isRecord(owner) || typeof owner.token !== "string") {
+    throw new Error(`Could not arrange owner catalog probe: HTTP ${ownerResponse.status}`);
+  }
+  const serverUrl = runtime.openworkUrl;
+  const serverToken = owner.token;
+  const request = async (path: string, init: { method?: string; body?: unknown; timeoutMs?: number; token?: string } = {}) => {
     const response = await fetch(serverUrl + path, {
       method: init.method ?? "GET",
-      headers: { Authorization: `Bearer ${serverToken}`, ...(init.body === undefined ? {} : { "Content-Type": "application/json" }) },
+      headers: { Authorization: `Bearer ${init.token ?? serverToken}`, ...(init.body === undefined ? {} : { "Content-Type": "application/json" }) },
       body: init.body === undefined ? undefined : JSON.stringify(init.body),
       signal: AbortSignal.timeout(init.timeoutMs ?? 30_000),
     });
@@ -131,6 +143,15 @@ export async function skillJitWeb(seed: Seed, context: { place: Place }) {
     try { json = text ? JSON.parse(text) : null; } catch { json = null; }
     return { status: response.status, json, text };
   };
+
+  const sharedTokens = new Map<"viewer" | "collaborator", string>();
+  for (const scope of ["viewer", "collaborator"] as const) {
+    const issued = await request("/tokens", { method: "POST", body: { scope, label: `skill-jit-${scope}` } });
+    if (issued.status !== 201 || !isRecord(issued.json) || typeof issued.json.token !== "string") {
+      throw new Error(`Could not arrange ${scope} catalog probe: HTTP ${issued.status}`);
+    }
+    sharedTokens.set(scope, issued.json.token);
+  }
 
   // Native v2 conversation regardless of the inherited engine selector.
   const preview = await request("/experimental/engine-v2-preview", { method: "PUT", body: { enabled: true, chatRouting: true }, timeoutMs: 180_000 });
@@ -174,16 +195,10 @@ export async function skillJitWeb(seed: Seed, context: { place: Place }) {
     cloud,
     cloudSkillName: skillJitCloudSkillName,
     workspaceSkillName: skillJitWorkspaceSkillName,
-    /** Arrange the deterministic model turn: one native `skill` call, then the tool text as the visible answer. */
     async prepareTurn(prompt: string, target: SkillJitTurnTarget): Promise<void> {
-      const step = target.kind === "catalog"
-        ? { tool: "skill", argumentsFrom: "skill-catalog", arguments: { skill: target.skill } }
-        : { tool: "skill", arguments: { id: target.skillId } };
-      const result = await fetch(`${agentMock.url}/admin/agent-workloads`, {
+      const result = await fetch(`${agentMock.url}/admin/skill-turn`, {
         method: "POST", headers: { "content-type": "application/json" },
-        body: JSON.stringify({ workloads: [{
-          latestUserTurn: true, promptMarker: prompt, finalReply: "OpenWork: UNAVAILABLE", finalReplyFrom: "last-tool-text", steps: [step],
-        }] }),
+        body: JSON.stringify({ prompt, ...(target.kind === "forced" ? { forcedSkillId: target.skillId } : {}) }),
         signal: AbortSignal.timeout(15_000),
       });
       if (!result.ok) throw new Error(`Could not arrange the model turn: HTTP ${result.status}`);
@@ -225,6 +240,12 @@ export async function skillJitWeb(seed: Seed, context: { place: Place }) {
       const result = await request(nativeSkillPath);
       if (result.status !== 200) throw new Error(`Native skill registry unavailable: HTTP ${result.status}`);
       return parseNativeSkills(result.json);
+    },
+    /** Read the same native catalog with a fixture-owned shared-client token. */
+    async sharedNativeSkills(scope: "viewer" | "collaborator", encoded = false) {
+      const token = sharedTokens.get(scope);
+      if (!token) throw new Error(`Missing ${scope} probe credential`);
+      return request(encoded ? nativeSkillPath.replace("/skill", "/%73kill/") : nativeSkillPath, { token });
     },
     async cloudNativeSkills(): Promise<NativeSkillEntry[]> {
       const result = await request(nativeSkillPath);


### PR DESCRIPTION
## Conflict repair after #4878 landed

Head: `d66c065131e7fcc6356acc6a0cb1fdef629605be`; base: `dev` at `3b6db1dca072ec1d38131ac608e5be2b0c9a8a62`. Rebased after #4878 merged, preserved both selected-skill and Cloud-skill suites, and combined the duplicate journey-catalog entries so no registered case is lost. Production behavior is unchanged by this conflict repair.

**Disappearing text is handled separately in #4918.** That PR preserves mounted user messages across pending-to-native ID replacement, with deterministic component regressions and a final-head CONT-01 runtime check. It targets dev independently and is not included here. The historical transient below is not declared fixed by this rebase.

**Verification: Incomplete for full evidence publication; conflict-focused checks passed.**
- `node --test evals/scripts/journey-ci.test.mjs`: 17 passed, 0 failed after reconciling case ordering.
- Evals typecheck passed.
- On this exact head, `pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case SKILL-ATTACH` and `--case SKILL-CLOUD-01`: each exit 0; 1 passed, 0 failed, 0 selected skips. Other cases were filtered out, not passed.
- Full Cloud02/Native01/Electron/Daytona reruns were not part of this conflict repair; earlier same-feature runs remain historical. Hosted evidence upload still awaits terminal credential setup.

**UI/UX impact of this repair:** None — existing UI/UX preserved. The text-continuity behavior change is isolated in #4918.

---

## Earlier-head readiness — September 11

Head: `ec6611f7444245340e2efafe21003bd36a525677`; rebased onto `dev` at `679784ef62488df107dd3559cdba9582de061f63`. Conflict-free, with CodeQL and security clearance passing. Required CI passed on its single retry after a provider-sync timeout. GitHub now reports CLEAN / MERGEABLE / APPROVED. Not merged.

### Repairs
- Kept current native model variants while resolving the config-writer conflict.
- Replaced the mock bearer regex with linear parsing and removed exception details from HTTP error responses; both CodeQL alerts now report fixed.
- Viewer and collaborator native Cloud catalog reads now expose only selection metadata, not skill bodies, private file locations, or future private fields. Owner reads and internal engine loading retain complete bodies; workspace-local reads and shared-client prompt execution are preserved.
- The model witness now chooses from the actual native catalog and advertised tool schema. Missing/ambiguous catalog or missing tool does not produce a skill call.
- Network/timeout failures continue without Cloud skills only after successful unregistration and cleanup; cleanup failure still blocks admission.

**Verification: Failed — a transcript-continuity assertion failed once on this head; the identical diagnostic rerun passed.** The failed record is retained and its cause is not established. Hosted evidence publication is also incomplete.

At 14:30 PDT, SKILL-CLOUD-01 observed one zero-count frame after the user message had appeared during revocation. The final transcript and earlier skill/privacy/update assertions passed, but that run did not reach its remaining revocation checks. At 14:34 PDT the unchanged case passed, followed by CLOUD-02 and NATIVE-01. No assertion was relaxed and no unrelated transcript UI change was bundled. A green rerun does not prove the transient is fixed.

CI attempt 1 also timed out waiting for provider-sync status in `early identity cancels a previous provider fetch and stays dormant across timer ticks`; its exact focused local test passed. This is not classified as pre-existing. Only the failed CI jobs were retried; attempt 2 passed on the same head. The first failure remains recorded and no test was weakened.

Latest focused attempts on this exact head, each exit 0 with 1 passed / 0 failed / 0 selected skips (the earlier CLOUD-01 failure above remains part of the verdict):
```sh
pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case SKILL-CLOUD-01
pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case SKILL-CLOUD-02
pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case SKILL-NATIVE-01
```
Fresh isolated app-web profiles, real v2 engine, mock providers. Covers first-turn discovery, body updates, revocation, shared-client metadata-only reads (ordinary/encoded routes), account switching, removal/401 cleanup, and workspace-skill lifecycle. Other cases were filtered out, not passed.

Focused diagnostics passed: 27 server tests (proxy gate, Cloud materialization, native instructions), 13 labs tests (Cloud endpoint and discovery witness), server typecheck, evals typecheck. The optional layers audit reported violations outside changed files; no clean control was run, so it is not classified as pre-existing.

Deferred: legacy Electron journey, Daytona, and hosted report publication. `pnpm evals:e2e --publish --pr 4881 --all` could not publish the saved records because review credentials were unavailable and the terminal requires secret-store sign-in. Historical evidence below does not certify this head. No runtime rerun is needed solely to publish.

**UI/UX impact:** No screen, label, color, icon or layout changes. Cloud skills load through the native engine. Non-owner catalog reads retain selection metadata but no longer reveal private bodies/paths; normal skill selection and collaborator execution remain intact. Offline Cloud failures no longer unnecessarily block conversation submission.

---

## Original implementation and historical proof

## Summary

On the v2 engine, authorized OpenWork Cloud skills become **native OpenCode skills**, materialized by the host just in time. Before every proxied `prompt|command|generate`, the server reads `skill://index.json` and every `skill://…/SKILL.md` body fresh through the `openwork-cloud` MCP connection (one initialized session, no cache), writes them into an engine-private auth-scoped root, and registers only that directory via the generated config `skills` list. The model discovers and loads organization skills with the native `skill` tool. No `search_capabilities` / `execute_capability` hop is needed or advertised for skills; the v1 path (`connect-skill-catalog.ts`, `<available_remote_skills>`) is unchanged.

Base: `origin/dev` `c23085ad2`. Final SHA: **`8bef57b846ad47f03980fb25b372535931f94bba`** (3 SSH-signed commits, `%G?` = `G`).

### Native id / location contract (for the composer attachment work)

| | |
|---|---|
| Native skill `id` | `openwork-cloud-<first 16 hex of sha256(uri)>` — stable across body updates, e.g. `openwork-cloud-b25c1058ca9c17bc` |
| `uri` | the index entry's `url`, e.g. `skill://amber-release-report/SKILL.md` |
| `location` | `<runtimeStorageDir>/opencode-v2/state/cloud-skills/<scopeKey>/<id>/SKILL.md` |
| `scopeKey` | `sha256(url + "\n" + Authorization)[0:16]` — opaque, never raw credential |
| `name` | the Cloud skill's frontmatter `name`, body verbatim (`content` in `GET /workspace/:id/opencode2/api/skill`) |
| Exported helpers | `cloudNativeSkillId(uri)`, `CLOUD_NATIVE_SKILL_ID_PREFIX` in `apps/server/src/cloud-native-skills.ts` |

### Behaviour

- **Skills fail closed, the conversation does not.** Auth/transport/malformed/partial failure clears and unregisters the root and the prompt is admitted without Cloud skills (`failure` code logged). No Cloud config → empty set. Bounds: index ≤1 MiB, ≤200 skills, body ≤256 KiB, 4 concurrent reads.
- **Invalidation.** Global Cloud config replacement/removal (reconcile/DELETE routes, `cloud-mcp-health`) goes through the runtime-config write listener → generation bump, unregister, delete files; native watcher removes entries before the next prompt. In-flight syncs whose generation changed are discarded (≤3 retries). Boot deletes any leftover root before the engine config is written with no `skills`.
- **Single serialized config writer** (`renderOpencodeV2Config`) so provider/permission rewrites preserve `skills`.
- **Over-strict reconciliation fixed (#7).** The admission waiter now reconciles by native location + body using the engine's own discovery rules (`{*.md,**/SKILL.md}`, id = dir basename, optional description) instead of `listSkills()`; native-valid workspace skills with dir/name mismatch or no description no longer time out with "Native skills did not reach the current workspace contents". Create/delete API validation is untouched.
- **v2 prompt text**: the "remote skills … through OpenWork Connect" paragraph is replaced for v2 only; v1 `openwork-agent-prompt.ts` unchanged.

### Files

`apps/server/src/`: `cloud-native-skills.ts` (+test, new), `opencode-v2-instructions.ts` (+test, new), `connect-mcp-transport.ts` (`openMcpResourceReader`), `managed-opencode-v2.ts`, `engine-v2-preview.ts`, `server.ts` (admission block).
`evals/`: `worlds/skill-jit.ts` (new headless app-web world), `packages/labs/src/mock-cloud-skills.ts` (+test, new identity-scoped Cloud fixture), `specs/opencode-v2-skill-jit.e2e.test.ts` (3 new cases; legacy case untouched), `scripts/journey-catalog.mjs`, `scripts/journey-ci.test.mjs`.

No `apps/app/**`, `ee/**`, or `evals/worlds/chat.ts` changes.

## Verification (all on `8bef57b84`, isolated headless web lane, real pinned v2 engine 0.0.0-beta-19086, synthetic Cloud fixture, no live org data)

```
env -i HOME=… TMPDIR=… PATH=<sidecars>:<node24>:<bun>:/usr/bin:/bin:/usr/sbin OPENWORK_EVAL_CHROME_HEADLESS=1 \
  pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case <ID>
```

| Case | Exit | Result | Receipt |
|---|---|---|---|
| `SKILL-CLOUD-01` | 0 | passed (18.8 s) | `evals/results/test-runs/2026-09-11T01-02-20-490Z-skill-cloud-01-…/test-run.json` |
| `SKILL-CLOUD-02` | 0 | passed (20.2 s) | `evals/results/test-runs/2026-09-11T01-02-41-329Z-skill-cloud-02-…/test-run.json` |
| `SKILL-NATIVE-01` | 0 | passed (17.3 s) | `evals/results/test-runs/2026-09-11T01-03-03-820Z-skill-native-01-…/test-run.json` |

Diagnostics (not proof): `bun test src/opencode-v2-instructions.test.ts src/cloud-native-skills.test.ts src/engine-v2-preview.test.ts` → 31 pass / 0 fail, exit 0. `tsc --noEmit` (apps/server) → exit 0. `node scripts/journey-ci.test.mjs` → exit 0. `node --test packages/labs/test/mock-cloud-skills.test.ts` → exit 0. Full `bun test` in apps/server: 5 failures, all reproduced on a clean `origin/dev` control worktree with equivalent sidecar setup (`mcp.oauth-flow.e2e`, `mcp.authorization-link.e2e`, `opencode-models-url`, `types-package-exports`, `openwork-capabilities-knowledge`) → pre-existing/environmental, untouched here.

### Claim → assertion mapping

| Acceptance | Case / assertion |
|---|---|
| 1. Cloud-only skill in `/api/skill` with stable namespaced id before first prompt admitted; in first model request catalog | CLOUD-01 step 2: fixture `resources/read` of index + body timestamps ≤ first model request; registry id matches `^openwork-cloud-[0-9a-f]{16}$`; model `skill` tool call argument `id` equals registry id |
| 2. Full body via native skill tool, zero skill-related Connect calls | CLOUD-01 step 2: registry `content` contains the verbatim unseen body; answer contains the random code; `toolCallNames()` on the mock Den = `[]`; no model tool call matching `search_capabilities|execute_capability` |
| 3. Update reflected next turn, same PID, no reload | CLOUD-01 step 3: new code answered, old code absent, same id, `runtimeIdentity()` (engine PID) unchanged |
| 4. Revoke → gone before next prompt; forced load fails honestly | CLOUD-01 step 4: registry `[]`, index read precedes first model request, forced `skill` call with stale id yields no body/code |
| 5. Isolation / account scoping / sign-out | CLOUD-02: B never sees A's code; A's file deleted on switch; DELETE config deletes B's file and empties registry *before* any prompt (bounded 5 s); zero endpoint contact afterwards; no body/id in workspace; locations outside workspace and home; 401 clears file+registry and the conversation still answers |
| 6. Existing workspace JIT still passes; v1 unchanged | NATIVE-01 step 2 (install → edit → remove converge on the real engine, web surface); v1 files untouched; `connect-skill-catalog.test.ts` still green |
| 7. Over-strict reconciliation | NATIVE-01 step 1 (dir/name mismatch, no description, prompt admitted) + `opencode-v2-instructions.test.ts` regression |

### Limits

- The legacy case `workspace skills change during an ongoing conversation` boots Electron via `seed.desktop` and was **not run** in this session (Electron/Daytona out of scope); `SKILL-NATIVE-01` covers the same lifecycle on the real engine through the web surface. Verdict for that specific case: Incomplete.
- Registering the spec file in the catalog sets its CI placement to `local` (the fixture is an in-process loopback server); previously the file was unlisted and defaulted to Daytona.
- Screenshots in the receipts are unvalidated context (`vision: defer`), not claims; `pendingJudgments = 0`.
- `OPENWORK_REVIEW_URL` is not configured; no hosted report. Evidence is inline below.
- Scope key is endpoint+credential; token rotation re-scopes (old files deleted, fresh fetch). No durable member/org identity is persisted host-side today.

### Warden

`pnpm warden:check` on clean committed `8bef57b84`: exit 0, **No findings** across diff-security-review, confidentiality-review, spec-provenance-review. 2 files skipped (`apps/server/src/server.ts`, `limit:file_lines`). Run id `e7c5ef90-2026-09-11T01-03-34-410Z`. Two earlier runs on `ca16bfaa8` / `4f79c676b` each surfaced one medium spec-provenance finding (removal cleanup not verified on disk / not verified before the next prompt); both fixed by the two follow-up commits and re-run.

<!-- test-evidence -->
## Test evidence (inline; hosted publisher not configured)

Verdict: **Passed** for `SKILL-CLOUD-01`, `SKILL-CLOUD-02`, `SKILL-NATIVE-01` on `8bef57b846ad47f03980fb25b372535931f94bba`. Reproduce: `pnpm evals:e2e opencode-v2-skill-jit --local --engine v2 --case <ID>`.

<details><summary><b>SKILL-CLOUD-01 a Cloud skill is native before the first prompt, updates by body, and disappears on revoke</b> — outcome <code>passed</code>, gitSha <code>8bef57b846ad</code>, engine v2</summary>

Receipt: `evals/results/test-runs/2026-09-11T01-02-20-490Z-skill-cloud-01-a-cloud-skill-is-native-before-the-first-prompt-updates-by-body-a/test-run.json`

Steps:

- ok (1000 ms): without a Cloud connection the conversation knows OpenWork and no Cloud skill exists
- ok (1941 ms): authorizing account A makes the unseen skill body answer the very first prompt through the native skill tool
- ok (1768 ms): a body-only update returns the new code on the next turn with the same skill id and runtime
- ok (2879 ms): revoking the skill removes it before the next prompt, and a forced load of the stale id fails honestly

Assertion evidence (4 witness records; screenshots are unvalidated context, not claims):

- **No Cloud config means no Cloud skill and no contact with the Cloud endpoint** — passed=True
  `registry cloud entries=0; fixture requests=0; answer="OpenWork: UNAVAILABLE"`
- **The host read skill://index.json and the SKILL.md body before the first model request, registered the skill natively, and made zero Connect tool calls** — passed=True
  `id=openwork-cloud-b25c1058ca9c17bc; indexRead=2026-09-11T01:02:32.212Z; bodyRead=2026-09-11T01:02:32.213Z; firstModelRequest=2026-09-11T01:02:32.530Z; toolsCall=0; location outside workspace/home={"workspace":false,"home":false}`
- **A body-only update keeps the native id stable and replaces the served instructions without restarting the engine** — passed=True
  `id=openwork-cloud-b25c1058ca9c17bc; pid=49362; newCodeVisible=true; oldCodeVisible=false`
- **After revocation the registry is empty before the next prompt and forcing the stale native id yields no instructions** — passed=True
  `staleId=openwork-cloud-b25c1058ca9c17bc; forcedToolRounds=1; codesVisible=false; cloudToolCalls=0`

</details>

<details><summary><b>SKILL-CLOUD-02 two accounts on one endpoint never see each other's skill body, and removing Cloud leaves nothing behind</b> — outcome <code>passed</code>, gitSha <code>8bef57b846ad</code>, engine v2</summary>

Receipt: `evals/results/test-runs/2026-09-11T01-02-41-329Z-skill-cloud-02-two-accounts-on-one-endpoint-never-see-each-other-s-skill-body-an/test-run.json`

Steps:

- ok (2020 ms): account A receives only A's body
- ok (1948 ms): switching the connection to account B replaces the body; B never sees A's code
- ok (1230 ms): removing the Cloud config while B's skill is materialized deletes the private files, empties the registry, stops all endpoint contact, and leaves nothing in the workspace or home
- ok (3270 ms): re-authorizing B then losing authorization (401) fails closed: the skill and its file disappear before the next prompt

Assertion evidence (3 witness records; screenshots are unvalidated context, not claims):

- **Account B's turn read only B's resources and answered only B's code** — passed=True
  `reads=2; identities=["account-b"]; aCodeVisible=false; bCodeVisible=true`
- **Removing the Cloud config with an active materialization deletes the private SKILL.md files, empties the registry, and stops endpoint contact; no body reached the workspace or home** — passed=True
  `fixtureRequestsBefore=34; after=34; privateLocations=2; filesRemaining=0; workspaceMatches=0`
- **A 401 from the Cloud endpoint clears the materialized skill and its file before the prompt is admitted; the conversation still answers** — passed=True
  `refused401=7; registryAfter=0; fileRemaining=false; answeredUnavailable=true`

</details>

<details><summary><b>SKILL-NATIVE-01 a malformed workspace skill never blocks prompt admission while the workspace skill lifecycle still converges</b> — outcome <code>passed</code>, gitSha <code>8bef57b846ad</code>, engine v2</summary>

Receipt: `evals/results/test-runs/2026-09-11T01-03-03-820Z-skill-native-01-a-malformed-workspace-skill-never-blocks-prompt-admission-while-/test-run.json`

Steps:

- ok (1245 ms): a directory/name mismatch without a description is admitted and answered
- ok (4464 ms): installing, editing and removing the workspace skill still changes the next answer

Assertion evidence (0 witness records; screenshots are unvalidated context, not claims):


</details>


