### PR TITLE
fix(models): expose catalog reasoning variants for managed providers on OpenCode v2

### DIFF
--- a/apps/server/src/engine-v2-preview.test.ts
+++ b/apps/server/src/engine-v2-preview.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { CATALOG_FAST_VARIANT, FAST_DEFAULT_VARIANT, fastVariantId } from "@openwork/types/cloud-model-fast";
+import { renderOpencodeV2Config } from "./managed-opencode-v2.js";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -259,6 +261,36 @@ test("explicit Den variants on any model turn off catalog enrichment for that pr
     expect(spec).not.toHaveProperty("canonical");
   }
   expect(explicit.specs[1]?.models.find((model) => model.id === "gpt-5.4")?.config).toMatchObject({ variants: {} });
+});
+
+test("managed Fast metadata retains native effort and priority variants without catalog enrichment", () => {
+  const variants = {
+    [CATALOG_FAST_VARIANT]: { disabled: true, openworkNativeFast: 1, reasoningEfforts: ["low", "high"] },
+    low: { reasoningEffort: "medium" },
+    high: { disabled: true, reasoningEffort: "high" },
+  };
+  const result = mapRuntimeProvidersToV2Specs({
+    lpr_fast: {
+      id: "openai", npm: "@ai-sdk/openai", options: { apiKey: "fast-fixture-key" },
+      models: { "gpt-5.4": { id: "gpt-5.4", name: "Fast model", reasoning: true, variants } },
+    },
+  });
+  expect(result.skippedProviderIds).toEqual([]);
+  expect(result.specs[0]?.package).toBe("@opencode-ai/ai/providers/openai");
+  expect(result.specs[0]).not.toHaveProperty("canonical");
+  expect(renderOpencodeV2Config({ providers: result.specs, skills: [] })).toMatchObject({ providers: {
+    lpr_fast: {
+      package: "@opencode-ai/ai/providers/openai",
+      settings: { apiKey: "fast-fixture-key" },
+      models: { "gpt-5.4": { variants: [
+        { id: "low", settings: { providerOptions: { reasoningEffort: "medium" } } },
+        { id: FAST_DEFAULT_VARIANT, settings: { providerOptions: { serviceTier: "priority" } } },
+        { id: fastVariantId("low"), settings: { providerOptions: { reasoningEffort: "medium", serviceTier: "priority" } } },
+      ] } },
+    },
+  } });
+  expect(variants.high.disabled).toBe(true);
+  expect(Object.keys(variants)).toEqual([CATALOG_FAST_VARIANT, "low", "high"]);
 });
 
 test("providers without a catalog identity keep the native package path", () => {

--- a/apps/server/src/engine-v2-preview.test.ts
+++ b/apps/server/src/engine-v2-preview.test.ts
@@ -201,6 +201,77 @@ test("native organization providers retain their transport without an endpoint o
   expect(result.specs[1]?.models[0]?.config).toMatchObject({ id: "wire-model", tool_call: false, limit: { context: 1000000, output: 64000 } });
 });
 
+test("managed providers with a catalog identity defer reasoning variants to the engine catalog", () => {
+  const result = mapRuntimeProvidersToV2Specs({
+    lpr_openai: {
+      id: "openai", name: "Org OpenAI", npm: "@ai-sdk/openai", api: "https://api.openai.com/v1", options: { apiKey: "fixture-key" },
+      models: {
+        "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4", reasoning: true, release_date: "2026-03-05" },
+        "gpt-4.1": { id: "gpt-4.1", name: "GPT-4.1", reasoning: false },
+      },
+    },
+    lpr_anthropic: { id: "anthropic", npm: "@ai-sdk/anthropic", options: { apiKey: "fixture-key" }, models: { "claude-opus-4-6": { id: "claude-opus-4-6", name: "Opus", reasoning: true } } },
+    lpr_proxy: { id: "my-proxy", npm: "@ai-sdk/openai-compatible", options: { baseURL: "https://proxy.example/v1", apiKey: "fixture-key" }, models: { "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4" } } },
+  });
+  expect(result.skippedProviderIds).toEqual([]);
+  expect(result.specs.map((spec) => [spec.id, spec.package, spec.canonical])).toEqual([
+    ["lpr_anthropic", "aisdk:@ai-sdk/anthropic", "anthropic"],
+    ["lpr_openai", "aisdk:@ai-sdk/openai", "openai"],
+    ["lpr_proxy", "aisdk:@ai-sdk/openai-compatible", "my-proxy"],
+  ]);
+  // Model records stay untouched: no effort list is invented on this side.
+  expect(result.specs[1]?.models.map((model) => model.id)).toEqual(["gpt-4.1", "gpt-5.4"]);
+  expect(JSON.stringify(result)).not.toContain("variants");
+  expect(result.specs[1]?.baseUrl).toBe("https://api.openai.com/v1");
+  expect(result.specs[1]?.apiKey).toBe("fixture-key");
+});
+
+test("the model-less openwork provider keeps its own catalog identity without a canonical alias", () => {
+  const result = mapRuntimeProvidersToV2Specs({
+    openwork: {
+      id: "openwork", name: "OpenWork Models", npm: "@openrouter/ai-sdk-provider", env: ["OPENWORK_API_KEY"],
+      api: "https://inference.example/api/v1", options: { baseURL: "https://inference.example/api/v1" },
+    },
+  }, new Map([["OPENWORK_API_KEY", "fixture-openwork-key"]]));
+  expect(result.specs).toEqual([{
+    id: "openwork", name: "OpenWork Models", baseUrl: "https://inference.example/api/v1",
+    package: "aisdk:@openrouter/ai-sdk-provider", apiKey: "fixture-openwork-key", models: [],
+  }]);
+  expect(result.specs[0]).not.toHaveProperty("canonical");
+});
+
+test("explicit Den variants on any model turn off catalog enrichment for that provider", () => {
+  const explicit = mapRuntimeProvidersToV2Specs({
+    lpr_openai: {
+      id: "openai", npm: "@ai-sdk/openai", options: { apiKey: "fixture-key" },
+      models: {
+        "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4", reasoning: true, variants: {} },
+        "gpt-5.1": { id: "gpt-5.1", name: "GPT-5.1", reasoning: true },
+      },
+    },
+    lpr_disabled: {
+      id: "openai", npm: "@ai-sdk/openai", options: { apiKey: "fixture-key" },
+      models: { "gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4", reasoning: true, variants: { high: { disabled: true, reasoningEffort: "high" } } } },
+    },
+  });
+  for (const spec of explicit.specs) {
+    expect(spec.package).toBe("@opencode-ai/ai/providers/openai");
+    expect(spec).not.toHaveProperty("canonical");
+  }
+  expect(explicit.specs[1]?.models.find((model) => model.id === "gpt-5.4")?.config).toMatchObject({ variants: {} });
+});
+
+test("providers without a catalog identity keep the native package path", () => {
+  const result = mapRuntimeProvidersToV2Specs({
+    "user-proxy": { npm: "@ai-sdk/openai", options: { baseURL: "https://proxy.example/v1", apiKey: "fixture-key" }, models: { "gpt-5.4": { name: "GPT-5.4", reasoning: true } } },
+    "blank-id": { id: "  ", npm: "@ai-sdk/openai", options: { apiKey: "fixture-key" } },
+  });
+  expect(result.specs.map((spec) => [spec.id, spec.package, spec.canonical])).toEqual([
+    ["blank-id", "@opencode-ai/ai/providers/openai", undefined],
+    ["user-proxy", "@opencode-ai/ai/providers/openai", undefined],
+  ]);
+});
+
 test("native provider api endpoint and headers survive conversion", () => {
   expect(mapRuntimeProvidersToV2Specs({ native: {
     npm: "@ai-sdk/openai", api: "https://api.openai.com/v1", options: { apiKey: "fixture", headers: { "x-tenant": "fixture" } },

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -166,6 +166,50 @@ async function resolveBinary(config: ServerConfig): Promise<ResolvedBinary> {
   }
 }
 
+/**
+ * Reasoning effort choices ("variants") for managed models.
+ *
+ * Fix layer: the desktop v2 mirror, not Den. Den's catalog carries no
+ * `variants` (ee/apps/inference/src/models/base.json, openwork-models.json),
+ * and the rules that turn a model into effort choices live only inside the
+ * engines: v1 computes them from npm package + model id + release date
+ * (upstream packages/opencode/src/provider/transform.ts `variants()`), while the
+ * pinned v2 sidecar computes them from its own models.dev catalog
+ * (`reasoning_options` + npm package). Reproducing either table in Den or here
+ * would fork engine behavior, so instead the mirror describes each managed
+ * provider in catalog terms and lets the engine enrich it:
+ *
+ * - `canonical`: the catalog provider (Den's `id`, e.g. `openai`) behind a Den
+ *   `lpr_*` key. The sidecar copies that provider's catalog models, variants
+ *   included, onto our models with the same wire `modelID`.
+ * - an `aisdk:<npm>` package identity instead of the native
+ *   `@opencode-ai/ai/providers/*` package. The sidecar resolves both to the same
+ *   native adapter without installing anything, but only the AI SDK identity
+ *   routes catalog variant settings (`reasoningEffort`, `thinking`, ...)
+ *   through its settings translation. Under the native package the picker
+ *   would list the variants while requests ignored them.
+ *
+ * Catalog enrichment is additive in the engine: config variants merge into the
+ * copied ones and cannot remove them. So when Den supplies an explicit
+ * `variants` record for any model of a provider (including an empty or fully
+ * disabled one), Den owns variants for that provider: no catalog identity is
+ * declared and writeProviders emits exactly the enabled entries on the native
+ * package path. Providers without a catalog `id` keep that native path too.
+ */
+function catalogIdentity(
+  runtimeId: string,
+  value: Record<string, unknown>,
+  models: OpencodeV2ProviderSpec["models"],
+): { package: string; canonical?: string } | undefined {
+  const identity = typeof value.id === "string" && value.id.trim() ? value.id.trim() : undefined;
+  if (identity === undefined || typeof value.npm !== "string") return undefined;
+  if (models.some((model) => isRecord(model.config?.variants))) return undefined;
+  return {
+    package: `aisdk:${value.npm}`,
+    ...(identity === runtimeId ? {} : { canonical: identity }),
+  };
+}
+
 export function mapRuntimeProvidersToV2Specs(
   providerMap: Record<string, unknown>,
   storedCredentials: ReadonlyMap<string, string> = new Map(),
@@ -235,11 +279,16 @@ export function mapRuntimeProvidersToV2Specs(
         }))
         .sort((left, right) => left.id.localeCompare(right.id))
       : [];
+    // Only allowlisted AI SDK packages reach here, so the `aisdk:` identity
+    // never asks the sidecar to install a package.
+    const catalog = packageName ? catalogIdentity(id, value, models) : undefined;
     specs.push({
       id,
       name: typeof value.name === "string" ? value.name : id,
       ...(baseUrl ? { baseUrl } : {}),
-      ...(packageName ? { package: packageName } : {}),
+      ...(catalog
+        ? { package: catalog.package, ...(catalog.canonical ? { canonical: catalog.canonical } : {}) }
+        : packageName ? { package: packageName } : {}),
       ...(Object.keys(settings).length ? { settings } : {}),
       ...(isRecord(headers) ? { headers } : {}),
       apiKey: resolvedKey ?? UNSET_API_KEY,

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -166,36 +166,6 @@ async function resolveBinary(config: ServerConfig): Promise<ResolvedBinary> {
   }
 }
 
-/**
- * Reasoning effort choices ("variants") for managed models.
- *
- * Fix layer: the desktop v2 mirror, not Den. Den's catalog carries no
- * `variants` (ee/apps/inference/src/models/base.json, openwork-models.json),
- * and the rules that turn a model into effort choices live only inside the
- * engines: v1 computes them from npm package + model id + release date
- * (upstream packages/opencode/src/provider/transform.ts `variants()`), while the
- * pinned v2 sidecar computes them from its own models.dev catalog
- * (`reasoning_options` + npm package). Reproducing either table in Den or here
- * would fork engine behavior, so instead the mirror describes each managed
- * provider in catalog terms and lets the engine enrich it:
- *
- * - `canonical`: the catalog provider (Den's `id`, e.g. `openai`) behind a Den
- *   `lpr_*` key. The sidecar copies that provider's catalog models, variants
- *   included, onto our models with the same wire `modelID`.
- * - an `aisdk:<npm>` package identity instead of the native
- *   `@opencode-ai/ai/providers/*` package. The sidecar resolves both to the same
- *   native adapter without installing anything, but only the AI SDK identity
- *   routes catalog variant settings (`reasoningEffort`, `thinking`, ...)
- *   through its settings translation. Under the native package the picker
- *   would list the variants while requests ignored them.
- *
- * Catalog enrichment is additive in the engine: config variants merge into the
- * copied ones and cannot remove them. So when Den supplies an explicit
- * `variants` record for any model of a provider (including an empty or fully
- * disabled one), Den owns variants for that provider: no catalog identity is
- * declared and writeProviders emits exactly the enabled entries on the native
- * package path. Providers without a catalog `id` keep that native path too.
- */
 function catalogIdentity(
   runtimeId: string,
   value: Record<string, unknown>,

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -23,6 +23,13 @@ export interface OpencodeV2ProviderSpec {
   name: string;
   baseUrl?: string;
   package?: string;
+  /**
+   * Catalog provider this entry stands in for (for example `openai` behind a
+   * Den `lpr_*` id). The engine copies that catalog provider's model records,
+   * including the reasoning variants it derives itself, onto models that share
+   * a wire `modelID`. Only set together with an AI SDK `package` identity.
+   */
+  canonical?: string;
   settings?: Record<string, unknown>;
   headers?: Record<string, unknown>;
   apiKey: string;
@@ -112,6 +119,7 @@ export function renderOpencodeV2Config(input: {
     providerConfig[provider.id] = {
       name: provider.name,
       package: provider.package ?? "@opencode-ai/ai/providers/openai-compatible",
+      ...(provider.canonical ? { canonical: provider.canonical } : {}),
       settings: {
         ...provider.settings,
         ...(provider.baseUrl ? { baseURL: provider.baseUrl } : {}),

--- a/apps/server/src/managed-opencode.test.ts
+++ b/apps/server/src/managed-opencode.test.ts
@@ -10,6 +10,10 @@ import { loopbackFetch } from "./server-fetch.js";
 
 const roots: string[] = [];
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 afterEach(async () => {
   while (roots.length > 0) await rm(roots.pop()!, { recursive: true, force: true });
 });
@@ -188,6 +192,57 @@ describe("managed OpenCode startup", () => {
       } } } });
       expect(JSON.stringify(config)).not.toContain('"hidden"');
       expect(JSON.stringify(config)).not.toContain('"disabled"');
+    } finally { await managed.close(); }
+  });
+
+  test("writes catalog identity so the engine derives variants, and keeps explicit variants authoritative", async () => {
+    const root = await createRoot();
+    const bin = await writeExecutable(root, "provider-config.mjs", [
+      "const server = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => Response.json({ healthy: true, version: 'test', pid: process.pid }) });",
+      "console.log(`opencode server listening on http://127.0.0.1:${server.port}`);",
+      "process.on('SIGTERM', () => { server.stop(true); process.exit(0); });",
+    ]);
+    const managed = await createManagedOpencodeV2Server({ bin, rootDir: root });
+    try {
+      await managed.setProviders([
+        {
+          id: "lpr_catalog", name: "Catalog backed", apiKey: "catalog-key",
+          package: "aisdk:@ai-sdk/openai", canonical: "openai",
+          models: [{ id: "gpt-5.4", name: "GPT-5.4", config: { id: "gpt-5.4", reasoning: true, release_date: "2026-03-05" } }],
+        },
+        {
+          id: "openwork", name: "OpenWork Models", apiKey: "openwork-key", baseUrl: "https://inference.example/api/v1",
+          package: "aisdk:@openrouter/ai-sdk-provider", models: [],
+        },
+        {
+          id: "lpr_explicit", name: "Explicit", apiKey: "explicit-key", package: "@opencode-ai/ai/providers/openai",
+          models: [
+            { id: "silenced", name: "Silenced", config: { reasoning: true, variants: {} } },
+            { id: "all-disabled", name: "All disabled", config: { reasoning: true, variants: { high: { disabled: true, reasoningEffort: "high" } } } },
+          ],
+        },
+      ]);
+      const config: unknown = JSON.parse(await readFile(join(root, "config", "opencode.json"), "utf8"));
+      expect(config).toMatchObject({ providers: {
+        lpr_catalog: {
+          package: "aisdk:@ai-sdk/openai", canonical: "openai",
+          settings: { apiKey: "catalog-key", name: "lpr_catalog" },
+          models: { "gpt-5.4": { modelID: "gpt-5.4", capabilities: { output: ["text", "reasoning"] } } },
+        },
+        openwork: { package: "aisdk:@openrouter/ai-sdk-provider", settings: { baseURL: "https://inference.example/api/v1", apiKey: "openwork-key" }, models: {} },
+        lpr_explicit: {
+          package: "@opencode-ai/ai/providers/openai",
+          models: { silenced: { variants: [] }, "all-disabled": { variants: [] } },
+        },
+      } });
+      const providers = isRecord(config) && isRecord(config.providers) ? config.providers : {};
+      // The engine only invents variants for catalog-backed models; this side never does.
+      expect(isRecord(providers.lpr_catalog) && isRecord(providers.lpr_catalog.models) && isRecord(providers.lpr_catalog.models["gpt-5.4"])
+        ? providers.lpr_catalog.models["gpt-5.4"] : {}).not.toHaveProperty("variants");
+      expect(providers.openwork).not.toHaveProperty("canonical");
+      expect(providers.lpr_explicit).not.toHaveProperty("canonical");
+      // Catalog identity never carries credentials: the only key material is ours.
+      expect(JSON.stringify(config)).not.toContain('"env"');
     } finally { await managed.close(); }
   });
 

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -482,6 +482,45 @@ describe("Cloud provider materialization", () => {
     expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
   })
 
+  test("forwards the catalog identity and explicit variants verbatim without synthesizing effort choices", async () => {
+    // Den has no variant rules of its own: the catalog identity (`id`) lets the
+    // desktop engines derive reasoning variants, while an explicit `variants`
+    // record, even an empty one, reaches the runtime untouched so it can win.
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    provider.models = [
+      {
+        modelId: "claude-fable-5",
+        name: "Reasoner",
+        modelConfig: { id: "claude-fable-5", name: "Reasoner", reasoning: true, release_date: "2026-02-05", tool_call: true, apiKey: "leaked-into-model" },
+      },
+      {
+        modelId: "claude-quiet-5",
+        name: "Silenced",
+        modelConfig: { id: "claude-quiet-5", name: "Silenced", reasoning: true, variants: {} },
+      },
+      {
+        modelId: "claude-tuned-5",
+        name: "Tuned",
+        modelConfig: { id: "claude-tuned-5", name: "Tuned", reasoning: true, variants: { high: { reasoningEffort: "high" }, off: { disabled: true } } },
+      },
+    ]
+    const instance = makeInstance()
+
+    const result = await materialize({ providers: () => [provider], fetchImpl: instance.fetchImpl, force: true })
+
+    expect(result.ok).toBe(true)
+    const patch = providerPatchFromBody(instance.calls.find((call) => call.method === "PATCH")?.body)
+    const block = patch[provider.id]
+    expect(isRecord(block) && isRecord(block.models) ? block.models : null).toEqual({
+      "claude-fable-5": { id: "claude-fable-5", name: "Reasoner", reasoning: true, release_date: "2026-02-05", tool_call: true },
+      "claude-quiet-5": { id: "claude-quiet-5", name: "Silenced", reasoning: true, variants: {} },
+      "claude-tuned-5": { id: "claude-tuned-5", name: "Tuned", reasoning: true, variants: { high: { reasoningEffort: "high" }, off: { disabled: true } } },
+    })
+    expect(isRecord(block) ? block.id : null).toBe("anthropic")
+    expect(JSON.stringify(patch)).not.toContain("leaked-into-model")
+    expect(JSON.stringify(patch)).not.toContain("sk-anthropic")
+  })
+
   test("writes Azure resource name and API key env while preserving the provider env config", async () => {
     const provider = makeAzureProvider({
       AZURE_RESOURCE_NAME: "resource-name",

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -65,8 +65,8 @@ export interface MockAgentWorkload {
 export interface MockAgentRequest {
   model: string;
   reasoningEffort?: string | null;
-  /** Provider credential header as received (for example `Bearer <key>`); null when absent. */
-  authorization: string | null;
+  /** Non-identifying credential witness: a configured agentCredentials label, "unknown", or "missing". */
+  credential: string;
   promptMarker: string | null;
   matchedMarkers: string[];
   completedTools: number;
@@ -167,6 +167,8 @@ export interface StartMockMcpOptions {
   agentWorkloads?: MockAgentWorkload[];
   /** Verify native provider requests retain this private model header. */
   agentRequiredHeader?: { name: string; value: string };
+  /** Labelled bearer keys; the witness logs only the matching label, never a credential value. */
+  agentCredentials?: Record<string, string>;
   /** Spawn the mock with executable-discovery variables only, excluding inherited credentials. */
   isolatedProcessEnv?: boolean;
 }
@@ -475,7 +477,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     const response = await fetch(`${url}/admin/agent-workloads`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ workloads: options.agentWorkloads, requiredHeader: options.agentRequiredHeader }),
+      body: JSON.stringify({ workloads: options.agentWorkloads, requiredHeader: options.agentRequiredHeader, credentials: options.agentCredentials }),
       signal: AbortSignal.timeout(15_000),
     });
     if (!response.ok) {
@@ -539,7 +541,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
       completions.push({
         model: completion.model,
         reasoningEffort: typeof completion.reasoningEffort === "string" ? completion.reasoningEffort : null,
-        authorization: typeof completion.authorization === "string" ? completion.authorization : null,
+        credential: typeof completion.credential === "string" ? completion.credential : "missing",
         promptMarker: marker,
         matchedMarkers: completion.matchedMarkers.filter((value): value is string => typeof value === "string"),
         completedTools: completion.completedTools,

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -65,6 +65,8 @@ export interface MockAgentWorkload {
 export interface MockAgentRequest {
   model: string;
   reasoningEffort?: string | null;
+  /** Provider credential header as received (for example `Bearer <key>`); null when absent. */
+  authorization: string | null;
   promptMarker: string | null;
   matchedMarkers: string[];
   completedTools: number;
@@ -537,6 +539,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
       completions.push({
         model: completion.model,
         reasoningEffort: typeof completion.reasoningEffort === "string" ? completion.reasoningEffort : null,
+        authorization: typeof completion.authorization === "string" ? completion.authorization : null,
         promptMarker: marker,
         matchedMarkers: completion.matchedMarkers.filter((value): value is string => typeof value === "string"),
         completedTools: completion.completedTools,

--- a/evals/packages/labs/src/skill-jit-model.ts
+++ b/evals/packages/labs/src/skill-jit-model.ts
@@ -50,7 +50,7 @@ function matchesPrompt(description: string, prompt: string): boolean {
   return terms.some((_, index) => index + 3 <= terms.length && request.includes(` ${terms.slice(index, index + 3).join(" ")} `));
 }
 
-function decide(body: Record<string, unknown>, turn: { prompt: string; forcedSkillId?: string } | null) {
+function decide(body: Record<string, unknown>, turn: { prompt: string; forcedSkillId?: string } | null, credential: "unknown" | "missing") {
   const messages = Array.isArray(body.messages) ? body.messages.filter(record) : [];
   const latestUserIndex = messages.findLastIndex((message) => message.role === "user" && systemUpdate(message) === null);
   const prompt = text(messages[latestUserIndex]?.content);
@@ -58,6 +58,7 @@ function decide(body: Record<string, unknown>, turn: { prompt: string; forcedSki
   const results = messages.slice(latestUserIndex + 1).filter((message) => message.role === "tool");
   const request: MockAgentRequest = {
     model: typeof body.model === "string" ? body.model : "skill-jit-model",
+    credential,
     promptMarker: matched ? turn.prompt : null,
     matchedMarkers: matched ? [turn.prompt] : [],
     completedTools: results.length,
@@ -123,7 +124,7 @@ if (import.meta.main) {
         res.writeHead(200, { "content-type": "application/json" }).end("{}");
         return;
       }
-      const { request, reply } = decide(body, turn);
+      const { request, reply } = decide(body, turn, req.headers.authorization?.trim() ? "unknown" : "missing");
       requests.push(request);
       const call = request.kind === "tool";
       const delta = call ? { tool_calls: [{ index: 0, id: `call_skill_${requests.length}`, type: "function",

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -13,7 +13,10 @@ import { readdir, readFile } from 'node:fs/promises';
 const PACKAGED_BINARY = { env: ['OPENWORK_EVAL_ELECTRON_BINARY'] };
 const definitions = {
   'composer-model-picker-no-subscribe-promo.e2e.test.ts': {
-    cases: [{ id: 'MODEL-01', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } }],
+    cases: [
+      { id: 'MODEL-01', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+      { id: 'MODEL-02', engines: ['v2'], optIns: ['OPENWORK_EVAL_E2E_TESTS'], example: { placement: '--local', engine: 'v2' } },
+    ],
   },
   // Its registered OAuth callback and synthetic client exchange run on owned loopback services.
   'mcp-connection-consent.e2e.test.ts': { name: 'Authorize a connected client once', placement: 'local' },

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -146,6 +146,11 @@ test('registered case metadata names exact files, supported execution axes, and 
       engines: ['v2'],
     },
     {
+      spec: 'composer-model-picker-no-subscribe-promo.e2e.test.ts',
+      id: 'MODEL-02',
+      engines: ['v2'],
+    },
+    {
       spec: 'task-activity-shimmer.e2e.test.ts',
       id: 'ACT-01',
       engines: ['v1', 'v2'],

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -208,7 +208,9 @@ managedTest("MODEL-02 managed catalog providers derive reasoning effort from the
     expect(pinned.variants).toEqual(["low", "CustomExact"]);
     expect(pinned.record).not.toHaveProperty("canonical");
     // The public catalog exposes opaque IDs only; keys and settings stay inside the engine.
-    expect(JSON.stringify(catalog.body)).not.toMatch(/managed-den-resolved-key|managed-den-pinned-key|"settings":|"providerOptions":|"headers":|reasoningEffort|reasoningSummary/);
+    expect(JSON.stringify(catalog.body)).not.toContain(world.apiKey);
+    expect(JSON.stringify(catalog.body)).not.toContain(world.pinnedApiKey);
+    expect(JSON.stringify(catalog.body)).not.toMatch(/"settings":|"providerOptions":|"headers":|reasoningEffort|reasoningSummary/);
     evidence.recordJsonArtifact("MODEL-02 native catalog", { reasoning, standard, pinned, status: status.body });
   });
   await user.click({ role: "button", label: "Change model" });
@@ -229,7 +231,7 @@ managedTest("MODEL-02 managed catalog providers derive reasoning effort from the
   await step("High reaches the managed provider with the Den-resolved key and survives reload", async () => {
     const requests = await world.requests();
     expect(requests).toHaveLength(1);
-    expect(requests[0]).toMatchObject({ model: world.modelId, reasoningEffort: "high", authorization: `Bearer ${world.apiKey}` });
+    expect(requests[0]).toMatchObject({ model: world.modelId, reasoningEffort: "high", credential: "managed" });
     expect(await world.modelRequests()).toEqual([{ model: { providerID: world.providerId, id: world.modelId, variant: "high" } }]);
     const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
     expect(native.body).toMatchObject({ data: { model: { id: world.modelId, providerID: world.providerId, variant: "high" } } });
@@ -281,7 +283,7 @@ managedTest("MODEL-02 managed catalog providers derive reasoning effort from the
     await user.click("Run task");
     await probe.eventually(() => world.requests(), { within: 90_000, label: "standard managed model omits effort", until: (requests) => requests.length === 4 });
     const requests = await world.requests();
-    expect(requests[3]).toMatchObject({ model: world.standardModelId, reasoningEffort: null, authorization: `Bearer ${world.apiKey}` });
+    expect(requests[3]).toMatchObject({ model: world.standardModelId, reasoningEffort: null, credential: "managed" });
     const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
     const modelRequests = await world.modelRequests();
     expect(modelRequests).toEqual([
@@ -294,7 +296,7 @@ managedTest("MODEL-02 managed catalog providers derive reasoning effort from the
     evidence.recordJsonArtifact("MODEL-02 standard model request and native session", { requests, modelRequests, native });
     await user.see("Run task", { timeoutMs: 30_000 });
   });
-  await step("a Den-pinned model offers exactly its own efforts in the composer", async () => {
+  await step("a Den-pinned model offers exactly its own efforts and sends its explicit setting", async () => {
     await user.click({ role: "button", label: "Change model" });
     await user.click({ role: "button", label: /^Model\s+GPT-4\.1 witness/ });
     await user.type({ placeholder: "Search models..." }, "GPT-5.1 pinned");
@@ -309,12 +311,26 @@ managedTest("MODEL-02 managed catalog providers derive reasoning effort from the
     await user.see({ role: "button", label: "Change model" }, { text: /GPT-5\.1 pinned/ });
     await user.see({ role: "button", label: "Change model" }, { text: /CustomExact/ });
     await user.notSee({ placeholder: "Search models..." });
-  });
-  await step("every managed provider request carried only its own Den-resolved credential", async () => {
+    await user.type("composer", world.prompt);
+    await user.click("Run task");
+    await probe.eventually(() => world.requests(), { within: 90_000, label: "pinned custom effort reaches its provider", until: (requests) => requests.length === 5 });
     const requests = await world.requests();
-    expect(requests).toHaveLength(4);
-    expect(requests.map((request) => request.authorization)).toEqual(Array(4).fill(`Bearer ${world.apiKey}`));
-    expect(requests.some((request) => request.authorization?.includes(world.pinnedApiKey))).toBe(false);
-    evidence.recordJsonArtifact("MODEL-02 provider credential witness", requests.map((request) => ({ model: request.model, reasoningEffort: request.reasoningEffort, authorization: request.authorization })));
+    // The explicit Den variant carries its own setting (medium), not a catalog effort named CustomExact.
+    expect(requests[4]).toMatchObject({ model: world.pinnedModelId, reasoningEffort: "medium", credential: "pinned" });
+    const modelRequests = await world.modelRequests();
+    expect(modelRequests[3]).toEqual({ model: { providerID: world.pinnedProviderId, id: world.pinnedModelId, variant: "CustomExact" } });
+    expect(modelRequests).toHaveLength(4);
+    const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
+    expect(native.body).toMatchObject({ data: { model: { id: world.pinnedModelId, providerID: world.pinnedProviderId, variant: "CustomExact" } } });
+    evidence.recordJsonArtifact("MODEL-02 pinned model request and native session", { requests, modelRequests, native });
+    await user.see("Run task", { timeoutMs: 30_000 });
+  });
+  await step("each provider request carried only its own Den-resolved credential", async () => {
+    const requests = await world.requests();
+    expect(requests).toHaveLength(5);
+    expect(requests.map((request) => request.credential)).toEqual(["managed", "managed", "managed", "managed", "pinned"]);
+    expect(requests.filter((request) => request.model !== world.pinnedModelId).every((request) => request.credential === "managed")).toBe(true);
+    expect(requests.some((request) => request.credential === "unknown" || request.credential === "missing")).toBe(false);
+    evidence.recordJsonArtifact("MODEL-02 provider credential witness", requests.map((request) => ({ model: request.model, reasoningEffort: request.reasoningEffort, credential: request.credential })));
   });
 });

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -1,8 +1,26 @@
 import { spec } from "@openwork/testkit";
 import { expect } from "vitest";
 import { modelPicker, modelPickerEffortWeb } from "../worlds/chat.ts";
+import { managedVariantsWeb } from "../worlds/model-managed-variants.ts";
 
 const test = spec.world(modelPicker);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** One public model record from the native v2 catalog, with its opaque variant IDs. */
+function catalogModel(body: unknown, providerID: string, id: string) {
+  const data = isRecord(body) ? body.data : undefined;
+  const record = Array.isArray(data)
+    ? data.find((entry) => isRecord(entry) && entry.providerID === providerID && entry.id === id)
+    : undefined;
+  if (!isRecord(record)) throw new Error(`Native catalog is missing ${providerID}/${id}`);
+  const variants = Array.isArray(record.variants)
+    ? record.variants.flatMap((variant) => isRecord(variant) && typeof variant.id === "string" ? [variant.id] : [])
+    : [];
+  return { record, variants };
+}
 
 test("the composer model pickers keep their controls without the OpenWork Models subscribe promo", async ({ user, probe, step }) => {
   const draft = "Keep this draft while editing model settings.";
@@ -150,5 +168,153 @@ effortTest("MODEL-01 selected reasoning effort survives reload and reaches the n
     expect(native.body).toMatchObject({ data: { model: { id: "standard", providerID: world.providerId, variant: "default" } } });
     evidence.recordJsonArtifact("MODEL-01 unsupported model request and native session", { requests, modelRequests, native });
     await user.see("Run task", { timeoutMs: 30_000 });
+  });
+});
+
+const managedTest = spec.world(managedVariantsWeb, {
+  timeout: 420_000, resources: { surfaces: ["appWeb"], services: ["mock"] },
+});
+
+managedTest("MODEL-02 managed catalog providers derive reasoning effort from the native engine catalog", async ({ world, user, probe, step, evidence }) => {
+  expect(world.engine).toBe("v2");
+  const runtime = await world.runtimeFacts();
+  expect(runtime.browser).toContain("HeadlessChrome");
+  expect(runtime.electronBridge).toBe(false);
+  evidence.recordJsonArtifact("MODEL-02 headless runtime", runtime);
+  const prefix = `/workspace/${world.workspace.workspaceId}/opencode2/api`;
+  const status = await world.readNative("/experimental/engine-v2-preview/status");
+  expect(status.status).toBe(200);
+  expect(status.body).toMatchObject({ running: true, chatRouting: true, mirroredProviderIds: expect.arrayContaining([world.providerId, world.pinnedProviderId]) });
+  const catalog = await world.readNative(`${prefix}/model`);
+  expect(catalog.status).toBe(200);
+  await step("the engine catalog supplies effort choices only where Den left them to the catalog", async () => {
+    const reasoning = catalogModel(catalog.body, world.providerId, world.modelId);
+    const standard = catalogModel(catalog.body, world.providerId, world.standardModelId);
+    const pinned = catalogModel(catalog.body, world.pinnedProviderId, world.pinnedModelId);
+    // Den sent no variants: the engine copied its catalog list (models.dev
+    // reasoning_options) onto the wire model. Exact membership belongs to the
+    // live catalog; the contract is a non-empty, duplicate-free list that
+    // carries the standard efforts and none of the Den-pinned custom IDs.
+    expect(reasoning.variants.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(reasoning.variants).size).toBe(reasoning.variants.length);
+    expect(reasoning.variants).toEqual(expect.arrayContaining(["low", "high"]));
+    expect(reasoning.variants).not.toEqual(expect.arrayContaining(["CustomExact"]));
+    expect(reasoning.variants).not.toEqual(expect.arrayContaining(["hidden"]));
+    expect(reasoning.record).toMatchObject({ canonical: "openai", providerID: world.providerId });
+    // Same provider, no catalog reasoning options: nothing is invented.
+    expect(standard.variants).toEqual([]);
+    expect(standard.record).toMatchObject({ canonical: "openai" });
+    // Explicit Den variants win: exactly the enabled entries, no catalog set.
+    expect(pinned.variants).toEqual(["low", "CustomExact"]);
+    expect(pinned.record).not.toHaveProperty("canonical");
+    // The public catalog exposes opaque IDs only; keys and settings stay inside the engine.
+    expect(JSON.stringify(catalog.body)).not.toMatch(/managed-den-resolved-key|managed-den-pinned-key|"settings":|"providerOptions":|"headers":|reasoningEffort|reasoningSummary/);
+    evidence.recordJsonArtifact("MODEL-02 native catalog", { reasoning, standard, pinned, status: status.body });
+  });
+  await user.click({ role: "button", label: "Change model" });
+  await step("the composer offers the catalog efforts and none of another provider's pinned IDs", async () => {
+    await user.click({ role: "button", label: /^Effort/ });
+    await user.see({ role: "button", label: "Low" });
+    await user.see({ role: "button", label: "High" });
+    await user.notSee({ role: "button", label: "CustomExact" });
+    await user.notSee({ role: "button", label: /^Hidden/ });
+    await user.click({ role: "button", label: "High" });
+    await user.see({ role: "button", label: "Change model" }, { text: /High/ });
+  });
+  await user.press("Escape");
+  await user.type("composer", world.prompt);
+  await user.click("Run task");
+  await user.see({ text: "Air scatters blue light more strongly." }, { timeoutMs: 90_000 });
+  await user.see("Run task", { timeoutMs: 30_000 });
+  await step("High reaches the managed provider with the Den-resolved key and survives reload", async () => {
+    const requests = await world.requests();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ model: world.modelId, reasoningEffort: "high", authorization: `Bearer ${world.apiKey}` });
+    expect(await world.modelRequests()).toEqual([{ model: { providerID: world.providerId, id: world.modelId, variant: "high" } }]);
+    const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
+    expect(native.body).toMatchObject({ data: { model: { id: world.modelId, providerID: world.providerId, variant: "high" } } });
+    evidence.recordJsonArtifact("MODEL-02 first request and native session", { requests, native });
+    await user.reload();
+    await user.see("Run task", { timeoutMs: 60_000 });
+    await user.click({ role: "button", label: "Change model" });
+    await user.see({ role: "button", label: /^Effort\s+High/ });
+    await user.press("Escape");
+    await user.type("composer", world.prompt);
+    await user.click("Run task");
+    await probe.eventually(() => world.requests(), { within: 90_000, label: "reloaded effort reaches managed provider", until: (requests) => requests.length === 2 });
+    expect((await world.requests()).map((request) => request.reasoningEffort)).toEqual(["high", "high"]);
+    evidence.recordJsonArtifact("MODEL-02 reloaded provider requests", await world.requests());
+  });
+  await user.see("Run task", { timeoutMs: 30_000 });
+  await step("Low reaches the managed provider as low", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ role: "button", label: /^Effort/ });
+    await user.click({ role: "button", label: "Low" });
+    await user.see({ role: "button", label: "Change model" }, { text: /Low/ });
+    await user.press("Escape");
+    await user.type("composer", world.prompt);
+    await user.click("Run task");
+    await probe.eventually(() => world.requests(), { within: 90_000, label: "low effort reaches managed provider", until: (requests) => requests.length === 3 });
+    expect((await world.requests()).map((request) => request.reasoningEffort)).toEqual(["high", "high", "low"]);
+    const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
+    expect(native.body).toMatchObject({ data: { model: { id: world.modelId, providerID: world.providerId, variant: "low" } } });
+    evidence.recordJsonArtifact("MODEL-02 low effort request and native session", { requests: await world.requests(), native });
+  });
+  await user.see("Run task", { timeoutMs: 30_000 });
+  await step("a managed model without catalog reasoning options keeps effort unavailable", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ role: "button", label: /^Model\s+GPT-5\.4 witness/ });
+    await user.type({ placeholder: "Search models..." }, "GPT-4.1 witness");
+    await user.click({ role: "option", label: /^GPT-4\.1 witness/ });
+    await user.see({ role: "button", label: "Change model" }, { text: /GPT-4\.1 witness/ });
+    await user.notSee({ placeholder: "Search models..." });
+    await user.click({ role: "button", label: "Change model" });
+    await user.see({ role: "button", label: /^Effort\s+Unavailable/ });
+    const disabled = await probe.dom('[data-slot="model-select-root"] button:disabled');
+    expect(disabled.elements.some((button) => button.text.includes("Effort") && button.text.includes("Unavailable"))).toBe(true);
+    await user.press("Escape");
+    await probe.eventually(() => probe.dom('[data-slot="model-select-root"]'), {
+      within: 5_000, label: "effort picker finishes closing", until: (snapshot) => snapshot.elements.length === 0,
+    });
+    await user.notSee({ role: "button", label: /^Effort\s+Unavailable/ });
+    await user.type("composer", world.prompt);
+    await user.click("Run task");
+    await probe.eventually(() => world.requests(), { within: 90_000, label: "standard managed model omits effort", until: (requests) => requests.length === 4 });
+    const requests = await world.requests();
+    expect(requests[3]).toMatchObject({ model: world.standardModelId, reasoningEffort: null, authorization: `Bearer ${world.apiKey}` });
+    const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
+    const modelRequests = await world.modelRequests();
+    expect(modelRequests).toEqual([
+      { model: { providerID: world.providerId, id: world.modelId, variant: "high" } },
+      { model: { providerID: world.providerId, id: world.modelId, variant: "low" } },
+      { model: { providerID: world.providerId, id: world.standardModelId } },
+    ]);
+    // Native v2 canonicalizes an omitted variant to its internal default ID.
+    expect(native.body).toMatchObject({ data: { model: { id: world.standardModelId, providerID: world.providerId, variant: "default" } } });
+    evidence.recordJsonArtifact("MODEL-02 standard model request and native session", { requests, modelRequests, native });
+    await user.see("Run task", { timeoutMs: 30_000 });
+  });
+  await step("a Den-pinned model offers exactly its own efforts in the composer", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ role: "button", label: /^Model\s+GPT-4\.1 witness/ });
+    await user.type({ placeholder: "Search models..." }, "GPT-5.1 pinned");
+    await user.click({ role: "option", label: /^GPT-5\.1 pinned/ });
+    // Choosing a model that has effort choices continues into its effort pane.
+    await user.see({ role: "button", label: "Low" });
+    await user.see({ role: "button", label: "CustomExact" });
+    await user.notSee({ role: "button", label: "Medium" });
+    await user.notSee({ role: "button", label: "High" });
+    await user.notSee({ role: "button", label: /^Hidden/ });
+    await user.click({ role: "button", label: "CustomExact" });
+    await user.see({ role: "button", label: "Change model" }, { text: /GPT-5\.1 pinned/ });
+    await user.see({ role: "button", label: "Change model" }, { text: /CustomExact/ });
+    await user.notSee({ placeholder: "Search models..." });
+  });
+  await step("every managed provider request carried only its own Den-resolved credential", async () => {
+    const requests = await world.requests();
+    expect(requests).toHaveLength(4);
+    expect(requests.map((request) => request.authorization)).toEqual(Array(4).fill(`Bearer ${world.apiKey}`));
+    expect(requests.some((request) => request.authorization?.includes(world.pinnedApiKey))).toBe(false);
+    evidence.recordJsonArtifact("MODEL-02 provider credential witness", requests.map((request) => ({ model: request.model, reasoningEffort: request.reasoningEffort, authorization: request.authorization })));
   });
 });

--- a/evals/worlds/model-managed-variants.ts
+++ b/evals/worlds/model-managed-variants.ts
@@ -1,0 +1,106 @@
+import { addInitScript, browserScript, type Surface } from "@openwork/cdp";
+import { resolveEvalEngine, type Seed } from "@openwork/env";
+import { configureProvider } from "./chat.ts";
+
+/**
+ * Cloud-managed (Den) provider definitions on the native v2 engine.
+ *
+ * Den materializes an organization provider into the engine-global runtime
+ * config as a catalog-shaped record: catalog identity `id` (for example
+ * `openai`), the catalog `npm` package, `api`, `options`, and its model
+ * records. This world writes the same shape through the workspace config
+ * route, which lands in the same engine-global row the Den sync uses.
+ *
+ * Runtime provider keys deliberately avoid the `lpr_` prefix: the signed-out
+ * app sweeps `lpr_*` keys as orphans, and the mirror keys its behavior on the
+ * catalog identity, not the key. Credentials use the explicit `options.apiKey`
+ * resolution path because the host-token env store is not reachable from the
+ * headless web lane.
+ */
+async function seedSessionRetry(seed: Seed, app: Surface, title: string): Promise<{ sessionId: string; title: string }> {
+  const deadline = Date.now() + 60_000;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      return await seed.session(app, { title });
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 500));
+    }
+  }
+  throw new Error(`Session creation did not settle: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}
+
+export async function managedVariantsWeb(seed: Seed) {
+  const engine = resolveEvalEngine();
+  // Catalog-backed: no Den `variants`, so the engine derives effort choices.
+  const providerId = "managed-openai-witness";
+  const modelId = "gpt-5.4";
+  const standardModelId = "gpt-4.1";
+  const apiKey = "managed-den-resolved-key";
+  // Den-pinned: explicit `variants` win over the catalog for this provider.
+  const pinnedProviderId = "managed-openai-pinned";
+  const pinnedModelId = "gpt-5.1";
+  const pinnedApiKey = "managed-den-pinned-key";
+  const prompt = "Explain why the sky looks blue.";
+  const mock = seed.mock({ isolatedProcessEnv: true, agentWorkloads: [{
+    promptMarker: prompt, latestUserTurn: true, finalReply: "Air scatters blue light more strongly.", steps: [],
+  }] });
+  const workspacePath = seed.tmpPath("model-managed-variants");
+  const app = await seed.appWeb({ name: "model-managed-variants", workspacePath, mocks: { agent: mock } });
+  // Observe model references without consuming or changing the app's requests.
+  await addInitScript(app.client, () => {
+    window.__modelEffortRequests = [];
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+      if (method === "POST" && /\/opencode2\/api\/session\/[^/]+\/model$/.test(new URL(url, location.href).pathname)) {
+        const body: unknown = await new Request(input instanceof Request ? input.clone() : input, init).json();
+        window.__modelEffortRequests?.push(body);
+      }
+      return originalFetch(input, init);
+    };
+  });
+  const witness = app.mocks.agent;
+  if (!witness) throw new Error("Missing managed provider witness");
+  const workspace = await seed.workspace(app, workspacePath);
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, { provider: {
+    [providerId]: {
+      id: "openai", npm: "@ai-sdk/openai", name: "Managed OpenAI witness", api: "https://api.openai.com/v1",
+      options: { baseURL: `${witness.url}/v1`, apiKey },
+      models: {
+        [modelId]: { id: modelId, name: "GPT-5.4 witness", reasoning: true, release_date: "2026-03-05" },
+        [standardModelId]: { id: standardModelId, name: "GPT-4.1 witness", reasoning: false, release_date: "2025-04-14" },
+      },
+    },
+    [pinnedProviderId]: {
+      id: "openai", npm: "@ai-sdk/openai", name: "Managed OpenAI pinned", api: "https://api.openai.com/v1",
+      options: { baseURL: `${witness.url}/v1`, apiKey: pinnedApiKey },
+      models: {
+        [pinnedModelId]: { id: pinnedModelId, name: "GPT-5.1 pinned", reasoning: true, release_date: "2025-11-13", variants: {
+          low: { reasoningEffort: "low" }, CustomExact: { reasoningEffort: "high" },
+          hidden: { disabled: true, reasoningEffort: "high" },
+        } },
+      },
+    },
+  } }, engine);
+  const session = await seedSessionRetry(seed, app, "Managed effort contract");
+  return { app, engine, workspace, session, prompt, providerId, modelId, standardModelId, apiKey, pinnedProviderId, pinnedModelId, pinnedApiKey,
+    modelRequests: () => seed.evalIn(app, () => window.__modelEffortRequests ?? []),
+    runtimeFacts: async () => ({
+      ...await seed.evalIn(app, () => ({ browser: navigator.userAgent, electronBridge: Boolean(window.__OPENWORK_ELECTRON__) })),
+      sourceSha: app.actualSourceSha,
+    }),
+    readNative: (path: string) => seed.evalIn(app, browserScript(async (path) => {
+      const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
+      const response = await fetch(base + path, {
+        headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") },
+        signal: AbortSignal.timeout(15_000),
+      });
+      const body: unknown = await response.json();
+      return { status: response.status, body };
+    }, [path]), { awaitPromise: true, timeoutMs: 20_000 }),
+    requests: async () => (await witness.agentRequests({ promptMarker: prompt })).filter((request) => request.kind === "final"),
+  };
+}

--- a/evals/worlds/model-managed-variants.ts
+++ b/evals/worlds/model-managed-variants.ts
@@ -15,7 +15,8 @@ import { configureProvider } from "./chat.ts";
  * app sweeps `lpr_*` keys as orphans, and the mirror keys its behavior on the
  * catalog identity, not the key. Credentials use the explicit `options.apiKey`
  * resolution path because the host-token env store is not reachable from the
- * headless web lane.
+ * headless web lane; the returned key strings exist only to configure the
+ * provider and the witness labels, never for assertions on raw values.
  */
 async function seedSessionRetry(seed: Seed, app: Surface, title: string): Promise<{ sessionId: string; title: string }> {
   const deadline = Date.now() + 60_000;
@@ -43,7 +44,8 @@ export async function managedVariantsWeb(seed: Seed) {
   const pinnedModelId = "gpt-5.1";
   const pinnedApiKey = "managed-den-pinned-key";
   const prompt = "Explain why the sky looks blue.";
-  const mock = seed.mock({ isolatedProcessEnv: true, agentWorkloads: [{
+  // The witness logs credential labels only; key values never reach its public request log.
+  const mock = seed.mock({ isolatedProcessEnv: true, agentCredentials: { managed: apiKey, pinned: pinnedApiKey }, agentWorkloads: [{
     promptMarker: prompt, latestUserTurn: true, finalReply: "Air scatters blue light more strongly.", steps: [],
   }] });
   const workspacePath = seed.tmpPath("model-managed-variants");
@@ -79,7 +81,8 @@ export async function managedVariantsWeb(seed: Seed) {
       options: { baseURL: `${witness.url}/v1`, apiKey: pinnedApiKey },
       models: {
         [pinnedModelId]: { id: pinnedModelId, name: "GPT-5.1 pinned", reasoning: true, release_date: "2025-11-13", variants: {
-          low: { reasoningEffort: "low" }, CustomExact: { reasoningEffort: "high" },
+          // CustomExact maps to an effort no catalog-derived choice in this spec selects.
+          low: { reasoningEffort: "low" }, CustomExact: { reasoningEffort: "medium" },
           hidden: { disabled: true, reasoningEffort: "high" },
         } },
       },

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -503,7 +503,8 @@ function capabilitySearchArguments(messages) {
 function classifyAgentCredential(req) {
   const header = req.headers.authorization;
   if (typeof header !== "string" || !header.trim()) return "missing";
-  const bearer = header.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+  if (header.slice(0, 6).toLowerCase() !== "bearer" || ![" ", "\t"].includes(header[6])) return "unknown";
+  const bearer = header.slice(7).trim();
   const label = Object.entries(agentCredentials).find(([, value]) => value === bearer)?.[0];
   return label ?? "unknown";
 }

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -78,6 +78,9 @@ const requests = [];
 const drafts = [];
 let agentWorkloads = [];
 let agentRequiredHeader = null;
+// Labelled bearer keys the fixture expects. Requests are logged by label only;
+// the public /requests log never persists a credential value.
+let agentCredentials = {};
 const agentReplyGates = new Map();
 const AGENT_REPLY_GATE_TIMEOUT_MS = 60_000;
 let agentRepliesHeld = false;
@@ -495,6 +498,16 @@ function capabilitySearchArguments(messages) {
   return { name: matches[0].name };
 }
 
+// Non-identifying credential witness: the configured label, "unknown" for any
+// other bearer value, or "missing" when no Authorization header arrived.
+function classifyAgentCredential(req) {
+  const header = req.headers.authorization;
+  if (typeof header !== "string" || !header.trim()) return "missing";
+  const bearer = header.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+  const label = Object.entries(agentCredentials).find(([, value]) => value === bearer)?.[0];
+  return label ?? "unknown";
+}
+
 // Native OpenAI Responses witness for plain-text workloads. Unsupported tool
 // scripts fail explicitly instead of pretending they executed.
 async function handleAgentResponse(req, res, entry) {
@@ -503,7 +516,7 @@ async function handleAgentResponse(req, res, entry) {
   const matched = agentWorkloads.filter((workload) => text.includes(workload.promptMarker));
   const model = body.model;
   const workload = matched[0];
-  const base = { model, reasoningEffort: body.reasoning?.effort ?? null, authorization: req.headers.authorization ?? null, matchedMarkers: matched.map((item) => item.promptMarker), completedTools: 0, promptMarker: workload?.promptMarker ?? null, toolName: null, arguments: {} };
+  const base = { model, reasoningEffort: body.reasoning?.effort ?? null, credential: classifyAgentCredential(req), matchedMarkers: matched.map((item) => item.promptMarker), completedTools: 0, promptMarker: workload?.promptMarker ?? null, toolName: null, arguments: {} };
   if (agentRequiredHeader && req.headers[agentRequiredHeader.name.toLowerCase()] !== agentRequiredHeader.value) {
     entry.agentCompletion = { ...base, kind: "error" };
     json(res, 401, { error: { message: "provider authentication handler was bypassed" } });
@@ -557,7 +570,7 @@ async function handleAgentCompletion(req, res, entry) {
   const workload = matched[0];
   const scopedMessages = workload?.latestUserTurn ? messages.slice(latestUserIndex + 1) : messages;
   const completedTools = scopedMessages.filter((message) => message && typeof message === "object" && message.role === "tool").length;
-  const baseRequest = { model, reasoningEffort: body.reasoning_effort ?? null, authorization: req.headers.authorization ?? null, matchedMarkers, completedTools };
+  const baseRequest = { model, reasoningEffort: body.reasoning_effort ?? null, credential: classifyAgentCredential(req), matchedMarkers, completedTools };
 
   if (!Array.isArray(body.tools) || body.tools.length === 0) {
     entry.agentCompletion = { ...baseRequest, kind: "utility", promptMarker: matchedMarkers[0] ?? null, toolName: null, arguments: {} };
@@ -1326,7 +1339,15 @@ const server = http.createServer(async (req, res) => {
         releaseAgentReplyWaiters(state, false);
       }
       agentReplyGates.clear();
+      const credentials = body?.credentials;
+      if (credentials !== undefined && (!credentials || typeof credentials !== "object" || Array.isArray(credentials)
+        || Object.entries(credentials).some(([label, value]) => !label.trim() || ["unknown", "missing"].includes(label)
+          || typeof value !== "string" || !value))) {
+        json(res, 400, { error: "credentials must map non-reserved labels to non-empty bearer keys" });
+        return;
+      }
       agentRequiredHeader = requiredHeader ?? null;
+      agentCredentials = credentials ?? {};
       json(res, 200, { configured: agentWorkloads.length });
       return;
     }

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -503,7 +503,7 @@ async function handleAgentResponse(req, res, entry) {
   const matched = agentWorkloads.filter((workload) => text.includes(workload.promptMarker));
   const model = body.model;
   const workload = matched[0];
-  const base = { model, reasoningEffort: body.reasoning?.effort ?? null, matchedMarkers: matched.map((item) => item.promptMarker), completedTools: 0, promptMarker: workload?.promptMarker ?? null, toolName: null, arguments: {} };
+  const base = { model, reasoningEffort: body.reasoning?.effort ?? null, authorization: req.headers.authorization ?? null, matchedMarkers: matched.map((item) => item.promptMarker), completedTools: 0, promptMarker: workload?.promptMarker ?? null, toolName: null, arguments: {} };
   if (agentRequiredHeader && req.headers[agentRequiredHeader.name.toLowerCase()] !== agentRequiredHeader.value) {
     entry.agentCompletion = { ...base, kind: "error" };
     json(res, 401, { error: { message: "provider authentication handler was bypassed" } });
@@ -514,7 +514,10 @@ async function handleAgentResponse(req, res, entry) {
     json(res, 400, { error: { message: "Responses witness requires one plain-text workload" } });
     return;
   }
-  entry.agentCompletion = { ...base, kind: workload ? "final" : "utility" };
+  // Like Chat Completions, a tool-less request (title generation, summaries)
+  // is a utility turn even when its input quotes the workload prompt.
+  const offersTools = Array.isArray(body.tools) && body.tools.length > 0;
+  entry.agentCompletion = { ...base, kind: workload && offersTools ? "final" : "utility" };
   const reply = workload?.finalReply ?? "Active session workload";
   const item = { id: `msg_${randomUUID()}`, type: "message", role: "assistant", status: "completed", content: [{ type: "output_text", text: reply, annotations: [] }] };
   const response = { id: `resp_${randomUUID()}`, object: "response", created_at: Math.floor(Date.now() / 1000), model, status: "completed", output: [item], usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2, input_tokens_details: { cached_tokens: 0 }, output_tokens_details: { reasoning_tokens: 0 } } };
@@ -554,7 +557,7 @@ async function handleAgentCompletion(req, res, entry) {
   const workload = matched[0];
   const scopedMessages = workload?.latestUserTurn ? messages.slice(latestUserIndex + 1) : messages;
   const completedTools = scopedMessages.filter((message) => message && typeof message === "object" && message.role === "tool").length;
-  const baseRequest = { model, reasoningEffort: body.reasoning_effort ?? null, matchedMarkers, completedTools };
+  const baseRequest = { model, reasoningEffort: body.reasoning_effort ?? null, authorization: req.headers.authorization ?? null, matchedMarkers, completedTools };
 
   if (!Array.isArray(body.tools) || body.tools.length === 0) {
     entry.agentCompletion = { ...baseRequest, kind: "utility", promptMarker: matchedMarkers[0] ?? null, toolName: null, arguments: {} };

--- a/scripts/mock-oauth-mcp-server.test.mjs
+++ b/scripts/mock-oauth-mcp-server.test.mjs
@@ -34,7 +34,7 @@ async function stop(child) {
   await exited;
 }
 
-test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeout: 10_000 }, async (context) => {
+async function startMock(context) {
   const port = await reservePort();
   const origin = `http://127.0.0.1:${port}`;
   const child = spawn(process.execPath, [serverPath], {
@@ -65,6 +65,11 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     }
   });
 
+  return { origin, stderr: () => stderr };
+}
+
+test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeout: 10_000 }, async (context) => {
+  const { origin, stderr } = await startMock(context);
   const authorizeUrl = new URL(`${origin}/authorize`);
   authorizeUrl.searchParams.set("client_id", "test-client");
   authorizeUrl.searchParams.set("redirect_uri", `${origin}/callback`);
@@ -311,5 +316,61 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
   });
   assert.equal(failedResponse.status, 500);
   assert.deepEqual(await failedResponse.json(), { error: "internal_server_error" });
-  await waitFor(() => stderr.includes("[mock-oauth-mcp] request failed"));
+  await waitFor(() => stderr().includes("[mock-oauth-mcp] request failed"));
+});
+
+test("provider witnesses classify bearer credentials without exposing keys or miscounting utility turns", { timeout: 10_000 }, async (context) => {
+  const { origin } = await startMock(context);
+  const credentialKeys = { managed: "managed-fixture-key", pinned: "pinned-fixture-key" };
+  const credentialWorkload = await fetch(`${origin}/admin/agent-workloads`, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ credentials: credentialKeys, workloads: [{
+      promptMarker: "Credential witness", finalReply: "Credential checked", steps: [],
+    }] }),
+  });
+  assert.equal(credentialWorkload.status, 200);
+  const credentialCases = [
+    [`Bearer ${credentialKeys.managed}`, "managed"],
+    [`bEaReR\t${" ".repeat(4_096)}${credentialKeys.pinned}`, "pinned"],
+    ["Bearer unrelated-fixture-key", "unknown"],
+    [`Basic ${credentialKeys.managed}`, "unknown"],
+    [`Bearer${credentialKeys.managed}`, "unknown"],
+    [`Bearer ${" ".repeat(4_096)}`, "unknown"],
+    ["", "missing"],
+    [undefined, "missing"],
+  ];
+  for (const path of ["/v1/responses", "/v1/chat/completions"]) {
+    for (const [authorization] of credentialCases) {
+      const completion = await fetch(`${origin}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...(authorization === undefined ? {} : { authorization }) },
+        body: JSON.stringify({ model: "credential-model", input: "Credential witness",
+          messages: [{ role: "user", content: "Credential witness" }],
+          tools: [{ type: "function", name: "question", function: { name: "question" } }],
+        }),
+        signal: AbortSignal.timeout(2_000),
+      });
+      assert.equal(completion.status, 200);
+      await completion.body.cancel();
+    }
+    const utility = await fetch(`${origin}${path}`, {
+      method: "POST", headers: { "content-type": "application/json", authorization: `Bearer ${credentialKeys.managed}` },
+      body: JSON.stringify({ model: "credential-model", input: "Credential witness",
+        messages: [{ role: "user", content: "Credential witness" }], tools: [],
+      }),
+    });
+    assert.equal(utility.status, 200);
+    await utility.body.cancel();
+  }
+  const credentialLog = await (await fetch(`${origin}/requests`)).json();
+  const completions = credentialLog.requests.flatMap((entry) => entry.agentCompletion ?? [])
+    .filter((entry) => entry.model === "credential-model");
+  const expectedCredentials = [...credentialCases.map(([, label]) => label), "managed"];
+  assert.deepEqual(completions.map((entry) => entry.credential), [...expectedCredentials, ...expectedCredentials]);
+  const expectedKinds = [...credentialCases.map(() => "final"), "utility"];
+  assert.deepEqual(completions.map((entry) => entry.kind), [...expectedKinds, ...expectedKinds]);
+  for (const key of [...Object.values(credentialKeys), "unrelated-fixture-key"]) {
+    assert.equal(JSON.stringify(credentialLog).includes(key), false);
+  }
+
 });


### PR DESCRIPTION
## Summary

On the OpenCode v2 engine, Cloud-managed (Den) provider models showed no thinking/effort choices even though v1 exposed them for the same model. This PR makes the v2 mirror describe managed providers in catalog terms so the engine derives and applies the same reasoning variants it derives for its own catalog, and adds a MODEL-02 journey case for managed providers.

Final SHA: `bf553dd0de700e78cc73c65e63ed71617bb7d81b` (branch `fix/models-managed-v2-variants`, based on dev `3d414a50c`).

## Root cause

- v1 enriches models from its own models.dev database and computes variants internally (upstream `packages/opencode/src/provider/transform.ts` `variants()`: npm package + model id + release date rules).
- Den's catalog has no `variants` at all (`ee/apps/inference/src/models/base.json`, `openwork-models.json`: zero `variants` keys), so Den materialization (`ee/apps/den-api/src/llm/cloud-provider-materialization.ts`) and desktop sync (`apps/server/src/cloud-provider-sync.ts`) have nothing to pass through, and #4853's explicit-variants path in `managed-opencode-v2.ts` has nothing to carry.
- The pinned v2 sidecar (`0.0.0-beta-19086`) derives variants from its own catalog (`reasoning_options` + npm package) but only for catalog-matched providers. A provider written via the providers API with capability metadata alone (`reasoning`, `release_date`, `capabilities.output: [text, reasoning]`) gets `variants: []`. Verified against the real binary.

## Chosen fix layer (and why not Den)

Desktop v2 mirror (`apps/server/src/engine-v2-preview.ts`, `apps/server/src/managed-opencode-v2.ts`). Den emitting variants would require copying an engine-specific rule table (v1's `transform.ts` or v2's `reasoning_options` mapper) into Den and keeping it in lockstep with the sidecar pin; the catalog Den serves does not contain variants (refs above). Instead the mirror declares, for a managed provider that carries Den's catalog `id` (e.g. `openai`) plus an allowlisted npm and no explicit `variants`:

- `package: "aisdk:<npm>"` — resolved by the sidecar to the same native adapter without installing anything, and the only identity under which catalog variant settings are translated into the outgoing request (under the native `@opencode-ai/ai/providers/*` package the picker listed variants but requests ignored them).
- `canonical: "<id>"` when the runtime key differs from the catalog id (`lpr_*`), so the engine copies the catalog provider's model records (variants included) onto our models by wire model id. The `openwork` provider (`id === key`) gets the aisdk package only.

Explicit Den variants win: if any model of a provider carries a `variants` record (including empty / all-disabled), the provider stays on the existing #4853 native path with exactly the enabled entries and no catalog identity (catalog enrichment is additive in the engine and cannot be removed by config). Providers without a catalog `id` are unchanged. No hardcoded model lists; only the Den-resolved credential is written; the public catalog sanitizer (`server.ts`) still emits `{ id }` only.

## Changes

- `apps/server/src/engine-v2-preview.ts` — `catalogIdentity()` + rationale comment; `mapRuntimeProvidersToV2Specs` emits `package`/`canonical`.
- `apps/server/src/managed-opencode-v2.ts` — `OpencodeV2ProviderSpec.canonical`, written into `providers.<id>`.
- Tests: `engine-v2-preview.test.ts` (+4), `managed-opencode.test.ts` (+1), `ee/apps/den-api/test/cloud-provider-materialization.test.ts` (+1: identity and explicit variants pass through verbatim, no synthesized efforts, no key leak).
- Journey: `evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts` MODEL-02, new world `evals/worlds/model-managed-variants.ts` (`appWeb` + `mock`), registered in `evals/scripts/journey-catalog.mjs` and `journey-ci.test.mjs`.
- Witness: `scripts/mock-oauth-mcp-server.mjs` / `evals/packages/labs/src/mock-mcp.ts` record a configured credential *label* (`managed` / `pinned` / `unknown` / `missing`, never the value) and classify tool-less Responses calls as `utility` like the Chat Completions path.

## Verification (headless web lane, mock Den/Cloud fixture, real pinned v2 engine, one case at a time)

| Command | Exit | Result |
|---|---|---|
| `env -i … OPENWORK_EVAL_CHROME_HEADLESS=1 pnpm evals:e2e composer-model-picker-no-subscribe-promo --local --engine v2 --case MODEL-02` | 0 | placement: local (--local); passed 1 / failed 0 / skipped 0; verdict `passed` |
| same, `--case MODEL-01` (regression) | 0 | passed 1 / failed 0 / skipped 0; verdict `passed` |
| `pnpm --filter openwork-server test src/engine-v2-preview.test.ts src/managed-opencode.test.ts` | 0 | 33 pass / 0 fail |
| `pnpm --filter openwork-server typecheck` | 0 | |
| `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/cloud-provider-materialization.test.ts` | 0 | 28 pass / 0 fail |
| `node --test evals/scripts/journey-ci.test.mjs` | 0 | 13 pass |
| `node --test scripts/mock-oauth-mcp-server.test.mjs` | 0 | 1 pass |
| `pnpm warden:check` on `bf553dd0d` | 0 | No findings (4 skills: diff-security, confidentiality, spec-provenance, desktop-den-sync; run log `.warden/logs/05de4715-2026-09-11T01-11-15-871Z.jsonl`) |

Receipts (bound to `bf553dd0d`):
- `evals/results/test-runs/2026-09-11T01-14-31-055Z-model-02-managed-catalog-providers-derive-reasoning-effort-from-the-native-engin` (8 JSON artifacts)
- `evals/results/test-runs/2026-09-11T01-15-16-326Z-model-01-selected-reasoning-effort-survives-reload-and-reaches-the-native-provid`

`pnpm --dir evals typecheck` is red repo-wide (410 errors, 0 in files touched here; clean dev control shows 409 — the delta is `bun:sqlite` install-state types in `apps/server/src/workspace-kv-store.ts`, unrelated). Pre-existing.

## Claim → assertion (MODEL-02)

1. Catalog-derived variants for a managed reasoning model with no Den `variants`: native `/opencode2/api/model` shows `gpt-5.4` under the managed provider with `canonical: "openai"`, `package: "aisdk:@ai-sdk/openai"`, variants `[none, low, medium, high, xhigh]` (asserted non-empty, unique, ⊇ {low, high}, ∌ CustomExact/hidden). Negative: `gpt-4.1` has `variants: []`; the public payload contains no key value, `settings`, `providerOptions`, `headers`, `reasoningEffort`, `reasoningSummary`.
2. Effort picker + wire: trusted UI shows Low/High for the reasoning model; High → outgoing `/model` `variant: "high"`, provider Responses body `reasoning.effort: "high"`, native session `variant: "high"`; survives reload (2nd request `high`); Low → 3rd request `low`.
3. Non-reasoning managed model: `Effort Unavailable` (disabled), `/model` body without `variant`, provider request `reasoningEffort: null`.
4. Explicit Den variants win: pinned provider `gpt-5.1` native variants exactly `[low, CustomExact]`, no `canonical`; selecting CustomExact and submitting → 5th request `{ model: gpt-5.1, reasoningEffort: "medium" (the explicit variant's own setting), credential: "pinned" }`, `/model` `variant: "CustomExact"`.
5. Credentials: witness labels exactly `[managed, managed, managed, managed, pinned]`; none `unknown`/`missing`.
6. v1 unchanged: no v1 code path touched (`cloud-provider-sync.ts` metadata and Den materialization unchanged); MODEL-01 passes.

## Limits

- `aisdk:<npm>` and `canonical` are contracts of the pinned v2 beta (`constants.json` / `opencode-v2-artifacts.json`); re-verify on a sidecar bump.
- Effort sets on v2 are the engine's (models.dev `reasoning_options`), not literally v1's rule table; they match for OpenAI-style models but can differ where v1 has bespoke rules (e.g. GLM-5.2) — engine/catalog side, not fixable here without hardcoding.
- Fixture keys avoid the `lpr_` prefix (the signed-out headless app sweeps `lpr_*` as orphans); the mirror keys on the catalog `id`, not the runtime key, so the `lpr_*` path is the one exercised. The model-less `openwork` provider path is covered by unit tests, not by the journey. Exact catalog membership is not pinned (live models.dev feed).
- A provider mixing one model with explicit Den variants and others without loses enrichment for the others by design; Den emits no `variants` today so there is no production effect.
- `OPENWORK_REVIEW_URL` is unset; no hosted report was published. Evidence is inline below.

<!-- test-evidence -->
### MODEL-02 (verdict: passed, sha bf553dd0d, engine v2, surface appWeb, services mock)

Native catalog (redacted extract, `02-model-02-native-catalog.json`):
```json
{"reasoning":{"record":{"id":"gpt-5.4","providerID":"managed-openai-witness","canonical":"openai","package":"aisdk:@ai-sdk/openai","capabilities":{"output":["text","reasoning"]},"variants":[{"id":"none"},{"id":"low"},{"id":"medium"},{"id":"high"},{"id":"xhigh"}]}},"standard":{"record":{"id":"gpt-4.1","providerID":"managed-openai-witness","variants":[]}}}
```
Provider credential witness (`08-model-02-provider-credential-witness.json`):
```json
[{"model":"gpt-5.4","reasoningEffort":"high","credential":"managed"},{"model":"gpt-5.4","reasoningEffort":"high","credential":"managed"},{"model":"gpt-5.4","reasoningEffort":"low","credential":"managed"},{"model":"gpt-4.1","reasoningEffort":null,"credential":"managed"},{"model":"gpt-5.1","reasoningEffort":"medium","credential":"pinned"}]
```
First request + native session (`03-…json`, extract):
```json
{"requests":[{"model":"gpt-5.4","reasoningEffort":"high","credential":"managed","kind":"final"}],"native":{"status":200,"body":{"data":{"model":{"id":"gpt-5.4","providerID":"managed-openai-witness","variant":"high"}}}}}
```

### MODEL-01 (verdict: passed, sha bf553dd0d) — regression of the explicit-variants path; 6 artifacts in the receipt directory above.
