### PR TITLE
fix(models): preserve cloud Fast mode across desktop engines

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -197,6 +197,8 @@ jobs:
         run: |
           rm -rf packages/types/dist
           pnpm --filter openwork-server build
+      - name: Check packaged Fast module consumption
+        run: node --test packages/types/tests/packaged-cloud-model-fast.test.mjs
       - name: Typecheck Electron main against the IPC contract
         run: pnpm --filter @openwork/desktop typecheck:electron
       - name: Check virtual display bootstrap contract

--- a/apps/app/src/app/cloud/import-state.ts
+++ b/apps/app/src/app/cloud/import-state.ts
@@ -7,6 +7,7 @@ export type CloudImportedProvider = {
   updatedAt: string | null;
   modelIds: string[];
   importedAt: number | null;
+  modelConfigVersion?: number;
 };
 
 export type CloudImportedMarketplace = {
@@ -83,6 +84,7 @@ export function readWorkspaceCloudImports(value: unknown): WorkspaceCloudImports
         source: typeof entry.source === "string" ? entry.source.trim() || null : null,
         updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt.trim() || null : null,
         modelIds: readStringArray(entry.modelIds),
+        modelConfigVersion: typeof entry.modelConfigVersion === "number" ? entry.modelConfigVersion : undefined,
         importedAt: typeof entry.importedAt === "number" && Number.isFinite(entry.importedAt)
           ? entry.importedAt
           : null,

--- a/apps/app/src/app/lib/model-behavior.ts
+++ b/apps/app/src/app/lib/model-behavior.ts
@@ -1,6 +1,7 @@
 import type { ProviderListItem } from "../types";
 import type { ModelBehaviorOption } from "../types";
 import { t } from "../../i18n";
+import { FAST_DEFAULT_VARIANT, FAST_VARIANT_PREFIX, fastVariantId } from "@openwork/types/cloud-model-fast";
 
 type ProviderModel = ProviderListItem["models"][string];
 
@@ -28,7 +29,29 @@ export const normalizeModelBehaviorValue = (value: string | null) => {
   return value?.trim() ? value : null;
 };
 
-const getVariantKeys = (model: ProviderModel | undefined) => Object.keys(model?.variants ?? {});
+const getVariantKeys = (model: ProviderModel | undefined) => Object.entries(model?.variants ?? {})
+  .filter(([, value]) => value.disabled !== true).map(([key]) => key);
+
+export const FAST_PRICING_WARNING = "Fast uses priority processing at higher pricing. Effort is unchanged.";
+
+/** Verified engine materializers advertise these combinations. No inference from
+ * model names or raw catalog modes, and no extra session/queue state. */
+export function getModelBehaviorControls<T extends Pick<ModelBehaviorOption, "value">>(options: readonly T[], value: string | null) {
+  const hasFast = options.some((option) => option.value === FAST_DEFAULT_VARIANT);
+  const standard = options.filter((option) => !hasFast || !option.value?.startsWith(FAST_VARIANT_PREFIX));
+  const fastBase = hasFast ? standard.find((option) => fastVariantId(option.value) === value) : undefined;
+  const base = fastBase ?? standard.find((option) => option.value === value);
+  const counterpart = base && options.find((option) => option.value === fastVariantId(base.value));
+  return {
+    hasFast,
+    fast: fastBase !== undefined,
+    toggleValue: counterpart ? (fastBase ? base?.value : counterpart.value) : undefined,
+    options: fastBase ? standard.flatMap((option) => {
+      const fastOption = options.find((entry) => entry.value === fastVariantId(option.value));
+      return fastOption ? [{ ...option, value: fastOption.value }] : [];
+    }) : standard,
+  };
+}
 
 const sortVariantKeys = (keys: string[]) =>
   keys.slice().sort((a, b) => {
@@ -92,7 +115,7 @@ export const nextModelBehaviorValue = (
   options: readonly Pick<ModelBehaviorOption, "value">[],
   current: string | null,
 ) => {
-  const values = options.map((option) => option.value);
+  const values = getModelBehaviorControls(options, current).options.map((option) => option.value);
   if (values.length < 2) return null;
   const currentIndex = values.indexOf(current);
   return values[(currentIndex + 1) % values.length] ?? null;
@@ -103,7 +126,7 @@ export const previousModelBehaviorValue = (
   options: readonly Pick<ModelBehaviorOption, "value">[],
   current: string | null,
 ) => {
-  const values = options.map((option) => option.value);
+  const values = getModelBehaviorControls(options, current).options.map((option) => option.value);
   if (values.length < 2) return null;
   const currentIndex = values.indexOf(current);
   if (currentIndex === -1) return values[values.length - 1] ?? null;
@@ -138,7 +161,14 @@ export const getModelBehaviorOptions = (
   providerName?: string | null,
 ): ModelBehaviorOption[] => {
   const variantKeys = sortVariantKeys(getVariantKeys(model));
+  const hasFast = variantKeys.includes(FAST_DEFAULT_VARIANT);
   return [defaultBehaviorOption(), ...variantKeys.map((key) => {
+    const baseKey = hasFast ? [null, ...variantKeys.filter((entry) => !entry.startsWith(FAST_VARIANT_PREFIX))]
+      .find((entry) => fastVariantId(entry) === key) : undefined;
+    if (baseKey !== undefined) {
+      const label = baseKey === null ? defaultBehaviorOption().label : getVariantLabel(baseKey);
+      return { value: key, label: `${label} + Fast`, description: FAST_PRICING_WARNING };
+    }
     const label = getVariantLabel(key);
     return {
       value: key,

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -138,6 +138,8 @@ function parseCloudImportedProvider(value: unknown): CloudImportedProvider | nul
     source: "source" in value && typeof value.source === "string" ? value.source : null,
     updatedAt: "updatedAt" in value && typeof value.updatedAt === "string" ? value.updatedAt : null,
     modelIds: value.modelIds,
+    ...("modelConfigVersion" in value && typeof value.modelConfigVersion === "number"
+      ? { modelConfigVersion: value.modelConfigVersion } : {}),
     importedAt: "importedAt" in value && typeof value.importedAt === "number" ? value.importedAt : null,
   };
 }

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Check, ChevronDown, ChevronLeft, ChevronRight, Settings2, Star } from "lucide-react";
 
 import type { ModelBehaviorOption, ModelOption, ModelRef } from "@/app/types";
-import { getModelBehaviorSelection, getModelBehaviorSummary } from "@/app/lib/model-behavior";
+import { FAST_PRICING_WARNING, getModelBehaviorControls, getModelBehaviorSelection, getModelBehaviorSummary } from "@/app/lib/model-behavior";
 import { ProviderIcon } from "@/react-app/design-system/provider-icon";
 import {
   Popover,
@@ -361,6 +361,7 @@ export function ModelSelect({
     thinkingFor && isSameModel(value, thinkingFor)
       ? behaviorValue
       : (thinkingFor?.behaviorValue ?? null);
+  const thinkingControls = getModelBehaviorControls(thinkingOptions, thinkingValue);
 
   const applyThinking = (option: ModelBehaviorOption) => {
     if (!thinkingFor) return;
@@ -453,7 +454,7 @@ export function ModelSelect({
                 setPane("effort");
               }}
             >
-              <span className="min-w-0 flex-1 font-medium text-foreground">Effort</span>
+              <span className="min-w-0 flex-1 font-medium text-foreground">{getModelBehaviorControls(selectedThinkingOptions, behaviorValue).hasFast ? "Effort and speed" : "Effort"}</span>
               <span className="max-w-24 truncate text-muted-foreground">
                 {selectedThinkingOptions.length > 0 ? effectiveBehaviorLabel : "Unavailable"}
               </span>
@@ -543,8 +544,21 @@ export function ModelSelect({
             <p role="status" className="px-3 py-2 text-xs text-muted-foreground">
               {getModelBehaviorSelection(thinkingOptions, thinkingValue).description}
             </p>
+            {thinkingControls.hasFast ? (
+              <div className="border-b border-border px-3 pb-2">
+                <button type="button" aria-pressed={thinkingControls.fast}
+                  disabled={thinkingControls.toggleValue === undefined}
+                  className="flex w-full items-center justify-between rounded-lg px-2 py-2 text-sm hover:bg-accent disabled:opacity-50"
+                  onClick={() => {
+                    if (thinkingControls.toggleValue !== undefined) applyThinking({ value: thinkingControls.toggleValue, label: "Fast", description: FAST_PRICING_WARNING });
+                  }}>
+                  <span>Fast</span><span>{thinkingControls.fast ? "On" : "Off"}</span>
+                </button>
+                <p className="text-xs text-muted-foreground">{FAST_PRICING_WARNING}</p>
+              </div>
+            ) : null}
             <div className="min-h-0 flex-1 overflow-y-auto p-1">
-              {thinkingOptions.map((option) => {
+              {thinkingControls.options.map((option) => {
                 const selected = option.value === thinkingValue;
                 return (
                   <button

--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
@@ -1,5 +1,6 @@
 import { applyEdits, modify } from "jsonc-parser";
 import type { ProviderConfig } from "@opencode-ai/sdk/v2/client";
+import { catalogFastVariants, CLOUD_MODEL_CONFIG_VERSION } from "@openwork/types/cloud-model-fast";
 
 import type {
   DenOrgLlmProvider,
@@ -242,6 +243,8 @@ export const isCloudProviderOutOfSync = (
   provider: DenOrgLlmProvider,
   importedProvider: CloudImportedProvider,
 ) =>
+  (importedProvider.modelConfigVersion !== CLOUD_MODEL_CONFIG_VERSION
+    && provider.models.some((model) => catalogFastVariants(model.config, provider.providerConfig.npm) !== undefined)) ||
   importedProvider.providerId !== getCloudManagedProviderId(provider) ||
   importedProvider.sourceProviderId !== provider.providerId ||
   (importedProvider.source ?? null) !== provider.source ||
@@ -285,6 +288,8 @@ export const buildCloudProviderConfig = (
           (next as Record<string, unknown>)[key] = value;
         }
       }
+      const variants = catalogFastVariants(raw, provider.providerConfig.npm);
+      if (variants) Object.assign(next, { variants });
       return [model.id, next];
     }),
   );

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from "react";
+import { CLOUD_MODEL_CONFIG_VERSION } from "@openwork/types/cloud-model-fast";
 
 import { applyEdits, modify, parse } from "jsonc-parser";
 import type {
@@ -1843,6 +1844,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           source: provider.source,
           updatedAt: provider.updatedAt ?? null,
           modelIds: getProviderModelIds(provider),
+          modelConfigVersion: CLOUD_MODEL_CONFIG_VERSION,
           importedAt: Date.now(),
         },
       };

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -21,7 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { t } from "@/i18n";
 import { readDenSettings } from "@/app/lib/den";
-import { getModelBehaviorSelection } from "@/app/lib/model-behavior";
+import { FAST_PRICING_WARNING, getModelBehaviorControls, getModelBehaviorSelection } from "@/app/lib/model-behavior";
 import {
   gatewayConnectCopy,
   gatewayConnectProviderKey,
@@ -163,6 +163,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   const currentOption = props.options.find((option) => modelEquals(option, props.current));
   const currentBehavior = getModelBehaviorSelection(currentOption?.behaviorOptions ?? [],
     props.currentBehaviorValue !== undefined ? props.currentBehaviorValue : currentOption?.behaviorValue ?? null);
+  const behaviorControls = getModelBehaviorControls(currentBehavior.options, currentBehavior.value);
 
   // Reset on open
   useEffect(() => {
@@ -388,8 +389,18 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               <section aria-label={`Settings for ${currentOption.title}`} className="mb-3 rounded-xl border border-dls-border p-3" data-testid="current-model-settings">
                 <div className="text-xs font-medium">{currentOption.title} · {currentBehavior.label}</div>
                 <p role="status" className="mt-1 text-xs text-muted-foreground">{currentBehavior.description}</p>
+                {behaviorControls.hasFast ? (
+                  <div className="mt-2 space-y-1">
+                    <Button type="button" size="sm" variant={behaviorControls.fast ? "secondary" : "outline"}
+                      aria-pressed={behaviorControls.fast} disabled={behaviorControls.toggleValue === undefined}
+                      onClick={() => {
+                        if (behaviorControls.toggleValue !== undefined) props.onBehaviorChange(props.current, behaviorControls.toggleValue);
+                      }}>Fast: {behaviorControls.fast ? "On" : "Off"}</Button>
+                    <p className="text-xs text-muted-foreground">{FAST_PRICING_WARNING}</p>
+                  </div>
+                ) : null}
                 <div role="group" aria-label="Thinking and effort" className="mt-2 flex flex-wrap gap-2">
-                  {currentBehavior.options.map((option) => (
+                  {behaviorControls.options.map((option) => (
                     <Button key={option.value === null ? "default" : `variant-${option.value}`} type="button" size="sm"
                       variant={option.value === currentBehavior.value ? "secondary" : "outline"}
                       aria-pressed={option.value === currentBehavior.value}

--- a/apps/app/tests/cloud-model-fast.test.ts
+++ b/apps/app/tests/cloud-model-fast.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { CATALOG_FAST_VARIANT, CLOUD_MODEL_CONFIG_VERSION, FAST_DEFAULT_VARIANT, catalogFastVariants, fastVariantId, nativeModelVariants, materializeLegacyFastProviders } from "@openwork/types/cloud-model-fast";
+import { buildCloudProviderConfig, isCloudProviderOutOfSync } from "../src/react-app/domains/connections/provider-auth/cloud-provider-config";
+import { readWorkspaceCloudImports } from "../src/app/cloud/import-state";
+import type { DenOrgLlmProviderConnection } from "../src/app/lib/den";
+import { createOpenworkServerClient } from "../src/app/lib/openwork-server";
+import { getModelBehaviorControls } from "../src/app/lib/model-behavior";
+
+const fast = { provider: { body: { service_tier: "priority" } }, cost: { input: 10, output: 60 } };
+const config = { experimental: { modes: { fast, pro: { provider: { body: { model: "unverified" } } } } },
+  variants: { high: { reasoningEffort: "high" }, CustomExact: { reasoningEffort: "low", textVerbosity: "high" },
+    default: { reasoningEffort: "medium" }, hidden: { disabled: true, reasoningEffort: "low" } } };
+const provider: DenOrgLlmProviderConnection = {
+  id: "lpr_synthetic", providerId: "openai", name: "Synthetic", source: "custom",
+  providerConfig: { npm: "@ai-sdk/openai" }, hasApiKey: true, apiKey: "synthetic", apiKeys: null,
+  createdAt: null, updatedAt: null, models: [{ id: "model", name: "Model", config, createdAt: null }],
+};
+
+describe("catalog Fast runtime gate", () => {
+  test("realistic Astra reasoning_options stays disabled until a verified engine materializes it", () => {
+    const efforts = ["low", "medium", "high", "xhigh", "max"];
+    const raw = { reasoning: true, reasoning_options: [{ type: "effort", values: efforts }],
+      cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+      experimental: { modes: { fast: { provider: { body: { service_tier: "priority" } },
+        cost: { input: 20, output: 100, cache_read: 2, cache_write: 25 } } } } };
+    const serialized = buildCloudProviderConfig({ ...provider, models: [{ id: "gpt-6-astra", name: "Synthetic Astra", config: raw, createdAt: null }] })
+      .models?.["gpt-6-astra"];
+    expect(serialized?.variants).toEqual({ [CATALOG_FAST_VARIANT]: { disabled: true, openworkNativeFast: 1, reasoningEfforts: efforts } });
+    expect(nativeModelVariants(serialized?.variants, "@opencode-ai/ai/providers/openai-compatible")).toEqual([]);
+    const native = nativeModelVariants(serialized?.variants, "@opencode-ai/ai/providers/openai");
+    expect(native.map((variant) => variant.id)).toEqual([...efforts, FAST_DEFAULT_VARIANT, ...efforts.map(fastVariantId)]);
+    for (const effort of efforts) {
+      expect(native.find((variant) => variant.id === effort)?.settings).toEqual({ providerOptions: { reasoningEffort: effort } });
+      expect(native.find((variant) => variant.id === fastVariantId(effort))?.settings)
+        .toEqual({ providerOptions: { reasoningEffort: effort, serviceTier: "priority" } });
+    }
+    const choices = [{ value: null }, ...native.map(({ id }) => ({ value: id }))];
+    expect(getModelBehaviorControls(choices, "high").toggleValue).toBe(fastVariantId("high"));
+    expect(getModelBehaviorControls(choices, fastVariantId("low")).toggleValue).toBe("low");
+    expect(native.find((variant) => variant.id === FAST_DEFAULT_VARIANT)?.settings).toEqual({ providerOptions: { serviceTier: "priority" } });
+    expect(raw).not.toHaveProperty("variants");
+  });
+
+  test("pinned v1 materialization preserves custom and disabled variants without mutating imports", () => {
+    const serialized = buildCloudProviderConfig(provider);
+    const providers = { lpr_synthetic: { ...serialized }, untouched: { npm: "@ai-sdk/openai-compatible", models: {} } };
+    const result = materializeLegacyFastProviders(providers);
+    expect(result).toMatchObject({ lpr_synthetic: { models: { model: { variants: {
+      ...config.variants,
+      [fastVariantId("CustomExact")]: { reasoningEffort: "low", textVerbosity: "high", serviceTier: "priority" },
+      [FAST_DEFAULT_VARIANT]: { serviceTier: "priority" },
+    } } } } });
+    expect(JSON.stringify(result)).not.toContain(CATALOG_FAST_VARIANT);
+    expect(JSON.stringify(result)).not.toContain(fastVariantId("hidden"));
+    expect(serialized.models?.model.variants?.[CATALOG_FAST_VARIANT]).toEqual({ disabled: true, openworkNativeFast: 1 });
+    expect(result.untouched).toBe(providers.untouched);
+    expect(materializeLegacyFastProviders(result)).toEqual(result);
+  });
+
+  test("advertised efforts fill gaps without overriding custom variants or resurrecting disabled ones", () => {
+    const serialized = catalogFastVariants({ ...config,
+      reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+      variants: { ...config.variants, high: { reasoningEffort: "low", textVerbosity: "high" }, low: { disabled: true } },
+    }, "@ai-sdk/openai");
+    const native = nativeModelVariants(serialized, "@opencode-ai/ai/providers/openai");
+    expect(native.filter((entry) => entry.id === "high")).toHaveLength(1);
+    expect(native.find((entry) => entry.id === fastVariantId("high"))?.settings)
+      .toEqual({ providerOptions: { reasoningEffort: "low", textVerbosity: "high", serviceTier: "priority" } });
+    expect(native.map((entry) => entry.id)).not.toContain("low");
+    expect(native.map((entry) => entry.id)).not.toContain(fastVariantId("low"));
+    expect(native.find((entry) => entry.id === "medium")?.settings).toEqual({ providerOptions: { reasoningEffort: "medium" } });
+    expect(native.find((entry) => entry.id === "default")?.settings).toEqual({ providerOptions: { reasoningEffort: "medium" } });
+    expect(native.find((entry) => entry.id === FAST_DEFAULT_VARIANT)?.settings).toEqual({ providerOptions: { serviceTier: "priority" } });
+  });
+
+  test("stores only disabled metadata; native combines it with exact custom variants and Default", () => {
+    const serialized = buildCloudProviderConfig(provider).models?.model;
+    expect(serialized?.experimental).toBeUndefined();
+    expect(serialized?.variants?.[CATALOG_FAST_VARIANT]).toEqual({ disabled: true, openworkNativeFast: 1 });
+    expect(config.variants).not.toHaveProperty(CATALOG_FAST_VARIANT);
+    const variants = nativeModelVariants(serialized?.variants, "@opencode-ai/ai/providers/openai");
+    expect(variants.map((entry) => entry.id)).toEqual([
+      "high", "CustomExact", "default", FAST_DEFAULT_VARIANT,
+      fastVariantId("high"), fastVariantId("CustomExact"), fastVariantId("default"),
+    ]);
+    expect(variants.find((entry) => entry.id === fastVariantId("CustomExact"))?.settings).toEqual({
+      providerOptions: { reasoningEffort: "low", textVerbosity: "high", serviceTier: "priority" },
+    });
+    expect(variants.find((entry) => entry.id === FAST_DEFAULT_VARIANT)?.settings).toEqual({ providerOptions: { serviceTier: "priority" } });
+    expect(JSON.stringify(variants)).not.toContain("openworkNativeFast");
+    expect(nativeModelVariants(serialized?.variants, "@opencode-ai/ai/providers/openai-compatible").map((entry) => entry.id))
+      .toEqual(["high", "CustomExact", "default"]);
+  });
+
+  test("does not synthesize unsupported adapters, modes, body overrides, or colliding IDs", () => {
+    for (const npm of [undefined, "@ai-sdk/openai-compatible", "@ai-sdk/anthropic", "@openrouter/ai-sdk-provider"]) {
+      expect(catalogFastVariants(config, npm)).toBeUndefined();
+    }
+    for (const mode of [true, {}, { provider: { body: { service_tier: "flex" } } },
+      { provider: { body: { service_tier: "priority", model: "other" } } },
+      { ...fast, provider: { ...fast.provider, headers: { test: "value" } } }]) {
+      expect(catalogFastVariants({ experimental: { modes: { fast: mode } } }, "@ai-sdk/openai")).toBeUndefined();
+    }
+    for (const id of [CATALOG_FAST_VARIANT, FAST_DEFAULT_VARIANT]) {
+      expect(catalogFastVariants({ ...config, variants: { [id]: { reasoningEffort: "high" } } }, "@ai-sdk/openai")).toBeUndefined();
+    }
+    expect(catalogFastVariants({ ...config, provider: { npm: "@ai-sdk/anthropic" } }, "@ai-sdk/openai")).toBeUndefined();
+    expect(catalogFastVariants({ experimental: { modes: { pro: fast } } }, "@ai-sdk/openai")).toBeUndefined();
+  });
+
+  test("reconciles a pre-serializer import once even when IDs and updatedAt have not changed", () => {
+    const imported = { cloudProviderId: provider.id, providerId: provider.id, sourceProviderId: provider.providerId,
+      name: provider.name, source: provider.source, updatedAt: provider.updatedAt, modelIds: ["model"], importedAt: 1 };
+    expect(isCloudProviderOutOfSync(provider, imported)).toBe(true);
+    expect(isCloudProviderOutOfSync(provider, { ...imported, modelConfigVersion: 1 })).toBe(true);
+    const restored = readWorkspaceCloudImports({ cloudImports: { providers: {
+      [provider.id]: { ...imported, modelConfigVersion: CLOUD_MODEL_CONFIG_VERSION },
+    } } }).providers[provider.id];
+    expect(isCloudProviderOutOfSync(provider, restored)).toBe(false);
+  });
+
+  test("server-authoritative sync status keeps the serializer version instead of reporting permanent drift", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ hasSession: true, lastRun: null, providers: [{
+      cloudProviderId: provider.id, providerId: provider.id, sourceProviderId: provider.providerId,
+      name: provider.name, source: provider.source, updatedAt: null, modelIds: ["model"], importedAt: 1,
+      modelConfigVersion: CLOUD_MODEL_CONFIG_VERSION,
+    }] }));
+    try {
+      const client = createOpenworkServerClient({ baseUrl: "http://synthetic.test", token: "synthetic" });
+      const status = await client.getCloudProviderSyncStatus();
+      expect(status.providers[0].modelConfigVersion).toBe(CLOUD_MODEL_CONFIG_VERSION);
+      expect(isCloudProviderOutOfSync(provider, status.providers[0])).toBe(false);
+    } finally { fetchSpy.mockRestore(); }
+  });
+});

--- a/apps/app/tests/model-behavior.test.ts
+++ b/apps/app/tests/model-behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { CATALOG_FAST_VARIANT, catalogFastVariants, fastVariantId, nativeModelVariants } from "@openwork/types/cloud-model-fast";
 
 import type { ProviderListItem } from "../src/app/types";
 import {
@@ -8,6 +9,7 @@ import {
   sanitizeModelBehaviorValue,
   nextModelBehaviorValue,
   previousModelBehaviorValue,
+  getModelBehaviorControls,
 } from "../src/app/lib/model-behavior";
 
 type ProviderModel = ProviderListItem["models"][string];
@@ -69,6 +71,32 @@ const model: ProviderModel = {
 };
 
 describe("model behavior options", () => {
+  test("Fast and effort stay independent, including custom IDs, Default, and keyboard cycling", () => {
+    const raw = catalogFastVariants({ variants: { high: { reasoningEffort: "high" }, low: { reasoningEffort: "low" },
+      CustomExact: { reasoningEffort: "medium" }, default: { reasoningEffort: "low" } },
+      experimental: { modes: { fast: { provider: { body: { service_tier: "priority" } } } } } }, "@ai-sdk/openai");
+    const native = { ...model, variants: Object.fromEntries(nativeModelVariants(raw, "@opencode-ai/ai/providers/openai")
+      .map((entry) => [entry.id, {}])) };
+    const options = getModelBehaviorOptions("lpr_synthetic", native);
+    for (const value of [null, "high", "low", "CustomExact", "default"]) {
+      const on = getModelBehaviorControls(options, value);
+      expect(on.toggleValue).toBe(fastVariantId(value));
+      const off = getModelBehaviorControls(options, on.toggleValue ?? null);
+      expect(off.fast).toBe(true);
+      expect(off.toggleValue).toBe(value);
+      expect(off.options.find((entry) => entry.label === "High")?.value).toBe(fastVariantId("high"));
+      expect(getModelBehaviorSummary("lpr_synthetic", native, on.toggleValue ?? null).description).toContain("higher pricing");
+    }
+    expect(nextModelBehaviorValue(options, fastVariantId("low"))).toBe(fastVariantId("high"));
+    expect(previousModelBehaviorValue(options, fastVariantId("high"))).toBe(fastVariantId("low"));
+    expect(nextModelBehaviorValue(options, "low")).toBe("high");
+    const stale = getModelBehaviorControls(options, "retired-custom");
+    expect(stale.toggleValue).toBeUndefined();
+    expect(getModelBehaviorSummary("lpr_synthetic", native, "retired-custom").value).toBe("retired-custom");
+    const legacy = getModelBehaviorOptions("lpr_synthetic", { ...model, variants: { high: {}, [CATALOG_FAST_VARIANT]: { disabled: true } } });
+    expect(legacy.map((entry) => entry.value)).toEqual([null, "high"]);
+    expect(getModelBehaviorControls(legacy, "high").hasFast).toBe(false);
+  });
   test("preserves opaque variant IDs through selection and saved-value normalization", () => {
     const custom = { ...model, variants: { CustomExact: {}, default: {}, high: {} } };
     expect(getModelBehaviorOptions("openai", custom).map((option) => option.value)).toEqual([null, "high", "CustomExact", "default"]);

--- a/apps/app/tests/model-picker-modal.test.ts
+++ b/apps/app/tests/model-picker-modal.test.ts
@@ -4,6 +4,7 @@ import { act, createElement, useState } from "react";
 import type { CreateAutomation } from "@openwork/types/automations";
 import type { AutomationProviderCatalog, AutomationModelOption } from "../src/react-app/domains/automations/automation-model-options";
 import type { ModelOption } from "../src/app/types";
+import { fastVariantId } from "@openwork/types/cloud-model-fast";
 
 // Base UI detects DOM support when its module loads.
 GlobalRegistrator.register({ url: "http://localhost" });
@@ -117,6 +118,102 @@ test("compact picker leaves unadvertised effort unavailable but can clear a stal
     queryClient.clear();
     policySpy.mockRestore();
     authSpy.mockRestore();
+  }
+});
+
+for (const surface of ["compact", "full"]) {
+  test(`${surface} picker toggles native Fast without resetting effort and hides it for legacy catalogs`, async () => {
+    const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
+    const { WorkspaceProvider } = await import("../src/react-app/shell/workspace-provider");
+    const { ModelSelect } = await import("../src/components/model-select");
+    const policy = await import("../src/react-app/domains/cloud/desktop-config-provider");
+    const policySpy = spyOn(policy, "useCheckDesktopRestriction").mockReturnValue(() => false);
+    const authSpy = spyOn(auth, "useDenAuth").mockReturnValue({ status: "signed_out", user: null, verifiedIdentity: null, isSignedIn: false, error: null, refresh: async () => undefined });
+    const current = { providerID: "fixture", modelID: "reasoner" };
+    const standard = [null, "low", "high", "CustomExact"].map((value) => ({ value,
+      label: value === null ? "Default" : value === "CustomExact" ? value : value.charAt(0).toUpperCase() + value.slice(1), description: "" }));
+    let behaviorOptions = [...standard, ...standard.map((option) => ({ ...option, value: fastVariantId(option.value), label: `${option.label} + Fast` }))];
+    let value: string | null = "high";
+    const changes: Array<string | null> = [];
+    const selected: unknown[] = [];
+    const queryClient = new QueryClient();
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    const change = (next: string | null) => { changes.push(next); value = next; render(); };
+    const render = () => {
+      const options: ModelOption[] = [{ ...current, title: "Synthetic model", description: "Fixture", isFree: false,
+        behaviorTitle: "Effort", behaviorLabel: "Default", behaviorDescription: "", behaviorValue: null, behaviorOptions }];
+      const picker = surface === "compact" ? createElement(ModelSelect, {
+        open: true, value: current, fallbackOptions: options, behaviorValue: value,
+        onOpenChange: () => undefined, onChange: (model) => selected.push(model), onBehaviorChange: change,
+      }) : createElement(ModelPickerModal, {
+        open: true, options, current, currentBehaviorValue: value, target: "session", query: "", setQuery: () => undefined,
+        onSelect: (model) => selected.push(model), onBehaviorChange: (_model, next) => change(next),
+        onOpenSettings: () => undefined, onClose: () => undefined,
+      });
+      root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children:
+        createElement(QueryClientProvider, { client: queryClient, children:
+          createElement(WorkspaceProvider, { client: null, selectedWorkspaceRoot: "/fixture", children: picker }) }) }));
+    };
+    const settings = () => document.querySelector(surface === "compact" ? '[data-slot="model-thinking-submenu"]' : '[data-testid="current-model-settings"]');
+    const openSettings = async () => {
+      if (surface !== "compact" || settings()) return;
+      const button = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-slot="model-select-root"] button')).find((entry) => entry.textContent?.includes("Effort"));
+      if (!button) throw new Error("Missing effort menu");
+      await act(async () => button.click());
+    };
+    try {
+      await act(async () => render());
+      for (const label of ["Fast", "Low", "Fast", "CustomExact", "Fast", "Default", "Fast"]) {
+        await openSettings();
+        expect(settings()?.textContent).toContain("higher pricing");
+        const button = Array.from(settings()?.querySelectorAll<HTMLButtonElement>("button") ?? [])
+          .find((entry) => label === "Fast" ? entry.textContent?.startsWith("Fast") : entry.textContent === label);
+        if (!button) throw new Error(`Missing ${surface} ${label} control`);
+        await act(async () => button.click());
+      }
+      expect(changes).toEqual([fastVariantId("high"), fastVariantId("low"), "low", "CustomExact",
+        fastVariantId("CustomExact"), fastVariantId(null), null]);
+      expect(selected).toEqual([]);
+      behaviorOptions = standard;
+      value = "high";
+      await act(async () => render());
+      await openSettings();
+      expect(settings()?.textContent).not.toContain("Fast");
+      expect(settings()?.textContent).not.toContain("higher pricing");
+    } finally {
+      await act(async () => root.unmount());
+      host.remove(); queryClient.clear(); policySpy.mockRestore(); authSpy.mockRestore();
+    }
+  });
+}
+
+test("Fast Default and custom effort persist in the same session variant read by queued sends", async () => {
+  const { getSessionModelSelection, useSessionModelStore } = await import("../src/react-app/domains/session/surface/session-model-store");
+  const { setQueuedSendContext, getQueuedSendContext, clearQueuedSendContext } = await import("../src/react-app/domains/session/sync/queued-send-context");
+  const { createOpenworkServerClient } = await import("../src/app/lib/openwork-server");
+  const sessionId = "synthetic-fast-session";
+  const model = { providerID: "fixture", modelID: "model" };
+  const before = useSessionModelStore.getState().bySessionId;
+  const stored = localStorage.getItem("openwork.sessionModels.v1");
+  setQueuedSendContext(sessionId, { workspaceId: "fixture", workspaceRoot: "/fixture", opencodeBaseUrl: "http://synthetic.test/opencode2",
+    openworkToken: "synthetic", client: createOpenworkServerClient({ baseUrl: "http://synthetic.test" }),
+    agent: null, variant: "high", model, environmentRuntimeKey: null });
+  try {
+    useSessionModelStore.getState().setModel(sessionId, model, "high");
+    for (const variant of [fastVariantId("CustomExact"), fastVariantId(null), null]) {
+      useSessionModelStore.getState().setVariant(sessionId, variant);
+      expect(getSessionModelSelection(sessionId)).toEqual({ model, variant });
+      expect(localStorage.getItem("openwork.sessionModels.v1")).toContain(JSON.stringify({ model, variant }));
+      // The drainer deliberately prefers session memory over its older context.
+      expect(getQueuedSendContext(sessionId)?.variant).toBe("high");
+    }
+  } finally {
+    clearQueuedSendContext(sessionId);
+    useSessionModelStore.setState({ bySessionId: before });
+    if (stored === null) localStorage.removeItem("openwork.sessionModels.v1");
+    else localStorage.setItem("openwork.sessionModels.v1", stored);
   }
 });
 

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -9,7 +9,8 @@ import {
 } from "../src/app/lib/opencode-v2-adapter";
 import { parseDynamicToolUIPart } from "../src/react-app/domains/session/sync/parse-tool-parts";
 import { codeModeToolCalls } from "../src/lib/code-mode-tools";
-import { getModelBehaviorOptions } from "../src/app/lib/model-behavior";
+import { getModelBehaviorControls, getModelBehaviorOptions } from "../src/app/lib/model-behavior";
+import { catalogFastVariants, fastVariantId, nativeModelVariants } from "@openwork/types/cloud-model-fast";
 
 const capturedPermissionAsked = {
   id: "evt_permission_asked",
@@ -2116,19 +2117,47 @@ test("v2 prompts set the exact selected variant on the native model ref and omit
   };
   try {
     const client = createClientV2("http://owner.test/opencode2", "/workspace", {});
-    for (const variant of ["high", "CustomExact", undefined]) {
+    for (const variant of ["high", "CustomExact", fastVariantId("CustomExact"), undefined]) {
       const result = await client.session.promptAsync({ sessionID: "ses_effort", model: { providerID: "witness", modelID: "model" }, variant, parts: [{ type: "text", text: "Hello" }] });
       expect(result.response.status).toBe(204);
     }
     expect(writes.filter((write) => write.path.endsWith("/model")).map((write) => write.body)).toEqual([
       { model: { providerID: "witness", id: "model", variant: "high" } },
       { model: { providerID: "witness", id: "model", variant: "CustomExact" } },
+      { model: { providerID: "witness", id: "model", variant: fastVariantId("CustomExact") } },
       { model: { providerID: "witness", id: "model" } },
     ]);
     expect(writes.filter((write) => write.path.endsWith("/prompt")).map((write) => write.body)).toEqual([
-      { text: "Hello" }, { text: "Hello" }, { text: "Hello" },
+      { text: "Hello" }, { text: "Hello" }, { text: "Hello" }, { text: "Hello" },
     ]);
   } finally { globalThis.fetch = originalFetch; }
+});
+
+test("v2 redacted catalog preserves Fast identities without requiring provider settings in the UI", async () => {
+  const variants = nativeModelVariants(catalogFastVariants({ variants: { high: { reasoningEffort: "high" } },
+    experimental: { modes: { fast: { provider: { body: { service_tier: "priority" } } } } } }, "@ai-sdk/openai"),
+  "@opencode-ai/ai/providers/openai");
+  const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    // The server's publicModel sanitizer intentionally exposes only variant IDs.
+    if (request.url.endsWith("/api/model")) return jsonResponse({ data: [{ id: "model", providerID: "witness", name: "Witness",
+      variants: variants.map(({ id }) => ({ id })) }] });
+    if (request.url.endsWith("/api/provider")) return jsonResponse({ data: [{ id: "witness", name: "Witness" }] });
+    if (request.url.endsWith("/api/model/default")) return jsonResponse({ data: {} });
+    throw new Error(`Unexpected request: ${request.url}`);
+  });
+  try {
+    const client = createClientV2("http://synthetic.test/opencode2", "/workspace", {});
+    const result = await client.provider.list();
+    const model = result.data?.all[0]?.models.model;
+    if (!model) throw new Error("Missing mapped model");
+    const options = getModelBehaviorOptions("witness", model);
+    expect(options.find((option) => option.value === fastVariantId("high"))?.label).toBe("High + Fast");
+    expect(getModelBehaviorControls(options, "high").toggleValue).toBe(fastVariantId("high"));
+    expect(getModelBehaviorControls(options, fastVariantId("high")).toggleValue).toBe("high");
+    expect(getModelBehaviorControls(options, fastVariantId(null)).toggleValue).toBeNull();
+    expect(JSON.stringify(model)).not.toContain("serviceTier");
+  } finally { fetchSpy.mockRestore(); }
 });
 
 describe("v2 question forms", () => {

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -82,13 +82,15 @@ describe("workspace root preparation", () => {
 });
 
 describe("bundled OpenCode runtime", () => {
-  it("pins the engine release containing the timestamp-based session loop repair", async () => {
+  it("pins the engine release preserving OpenAI priority for GPT-6 without losing the session loop repair", async () => {
     const constantsPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../constants.json");
     const constants = JSON.parse(await readFile(constantsPath, "utf8"));
 
     // OpenCode #40990 stops old assistant messages with lexicographically
     // later IDs from short-circuiting a newly appended user turn.
-    assert.equal(constants.opencodeVersion, "v1.18.18");
+    // 1.18.30 also includes #47659 / #47671: updated OpenAI capabilities and
+    // preservation of explicit service tiers, including GPT-6 Astra priority.
+    assert.equal(constants.opencodeVersion, "v1.18.30");
   });
 });
 

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -874,6 +874,40 @@ describe("cloud provider sync gateway", () => {
     expect(engineRequests).toContain("PUT /auth/lpr_test");
   });
 
+  test("preserves disabled Fast metadata and reconciles an unchanged catalog after serializer upgrade", async () => {
+    const root = await createRoot();
+    const config = serverConfig(root, "https://engine.example.test");
+    config.workspaces = [];
+    const provider = buildProvider([{ id: "model", name: "Model", config: {
+      reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+      experimental: { modes: { fast: { provider: { body: { service_tier: "priority" } } } } },
+    } }]);
+    provider.providerConfig.npm = "@ai-sdk/openai";
+    await writeGlobalRuntimeOpencodeConfig(config, () => ({ provider: { lpr_test: {
+      models: { model: { id: "model", name: "Model" } },
+    } } }));
+    const sync = new CloudProviderSync({
+      config, env: new EnvService({ path: process.env.OPENWORK_ENV_STORE }), reloadEngine: async () => {},
+      fetchImpl: Object.assign(async (input: URL | RequestInfo) => {
+        const { pathname } = new URL(String(input));
+        if (pathname === "/v1/inference-providers") return Response.json({ inferenceProviders: [] });
+        return Response.json(pathname.endsWith("/connect")
+          ? { llmProvider: provider } : { llmProviders: [provider] });
+      }, { preconnect: () => {} }),
+    });
+    stops.push(() => sync.stop());
+    await sync.setSession({ baseUrl: "https://den.example.test", token: "synthetic", orgId: "org_test" });
+    expect((await sync.run()).status).toBe("applied");
+    expect(sync.status().providers[0]?.modelConfigVersion).toBe(2);
+    const written = runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test;
+    const model = expectRecord(expectRecord(written.models, "serialized models").model, "serialized model");
+    expect(model.variants).toEqual({ __openwork_catalog_fast_v1: {
+      disabled: true, openworkNativeFast: 1, reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+    } });
+    expect(JSON.stringify(written)).not.toContain('"experimental"');
+    expect((await sync.run()).status).toBe("noop");
+  });
+
   test("skips a per-member provider that needs the member's key", async () => {
     const root = await createRoot();
     const config = serverConfig(root, "https://engine.example.test");

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import type { GatewayAuthorizationRequest, GatewayDesktopOauthStartResponse, GatewayUsableModel } from "@openwork/types/den/gateway";
+import { catalogFastVariants, CLOUD_MODEL_CONFIG_VERSION } from "@openwork/types/cloud-model-fast";
 
 import type { EnvService } from "./env-file.js";
 import { ApiError } from "./errors.js";
@@ -46,6 +47,7 @@ export type CloudProviderSyncStatusProvider = {
   updatedAt: string | null;
   modelIds: string[];
   importedAt: number;
+  modelConfigVersion: number;
 };
 
 /**
@@ -610,7 +612,7 @@ function providerEnvEntries(provider: DenProviderConnection): EnvEntry[] {
   return entries;
 }
 
-function buildModelConfig(model: DenProviderModel): JsonRecord {
+function buildModelConfig(model: DenProviderModel, providerNpm: unknown): JsonRecord {
   // Older Den responses included routing labels in the display name. Keep the
   // wire ID and selection metadata, but don't expose those labels in the picker.
   const selection = model.modelGroupName && model.credentialSetName ? ` (${model.modelGroupName} / ${model.credentialSetName})` : "";
@@ -622,13 +624,15 @@ function buildModelConfig(model: DenProviderModel): JsonRecord {
     const value = model.config[key];
     if (value !== undefined) next[key] = value;
   }
+  const variants = catalogFastVariants(model.config, providerNpm);
+  if (variants) next.variants = variants;
   return next;
 }
 
 function buildProviderConfig(provider: DenProviderConnection): JsonRecord {
   const models: JsonRecord = {};
   for (const model of [...provider.models].sort((left, right) => left.id.localeCompare(right.id))) {
-    models[model.id] = buildModelConfig(model);
+    models[model.id] = buildModelConfig(model, provider.providerConfig.npm);
   }
   const config: JsonRecord = {
     id: provider.providerId,
@@ -1378,6 +1382,7 @@ export class CloudProviderSync {
         source: entry.provider.source,
         updatedAt: entry.provider.updatedAt,
         modelIds: entry.provider.models.map((model) => model.id).sort(),
+        modelConfigVersion: CLOUD_MODEL_CONFIG_VERSION,
         importedAt,
       };
     });

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -1,4 +1,5 @@
 import type { EnginePermissionRule } from "./managed-policy-rules.js";
+import { nativeModelVariants } from "@openwork/types/cloud-model-fast";
 // Parallel v2 lane prototype: provider injection is a watched-config write. This module
 // deliberately has no reload/dispose call, unlike managed-opencode.ts and server.ts reloadOpencodeEngine.
 import { spawn } from "node:child_process";
@@ -212,13 +213,7 @@ export async function createManagedOpencodeV2Server(
           ...(typeof config.family === "string" ? { family: config.family } : {}),
           ...(isRecord(config.options) ? { settings: config.options } : {}),
           ...(isRecord(config.variants) ? {
-            variants: Object.entries(config.variants).flatMap(([id, value]) => {
-              if (!isRecord(value) || value.disabled === true) return [];
-              const { disabled, ...settings } = value;
-              // Mirrored adapters are native: unlike v1 AI SDK options, their
-              // model settings take generation options under providerOptions.
-              return [{ id, settings: { providerOptions: settings } }];
-            }),
+            variants: nativeModelVariants(config.variants, provider.package),
           } : {}),
           ...(isRecord(config.headers) ? { headers: config.headers } : {}),
           ...(config.status === "deprecated" ? { disabled: true } : {}),

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { managedPolicyPluginPath } from "./managed-policy-plugin.js";
+import { catalogFastVariants, fastVariantId } from "@openwork/types/cloud-model-fast";
 
 import {
   buildOpenworkRuntimeConfig,
@@ -68,6 +69,24 @@ describe("openwork runtime config file", () => {
       managedPolicy: { allowCustomProviders: false }, provider,
     }).enabled_providers).toEqual(["lpr_legacy", "ipr_gateway", "openwork", "opencode"]);
     expect(buildOpenworkRuntimeConfigObjectFromSnapshot({ provider }).enabled_providers).toBeUndefined();
+  });
+
+  test("expands Fast for the pinned v1 engine only in the emitted config", () => {
+    const variants = catalogFastVariants({
+      reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+      experimental: { modes: { fast: { provider: { body: { service_tier: "priority" } } } } },
+    }, "@ai-sdk/openai");
+    const snapshot = { provider: { lpr_synthetic: { npm: "@ai-sdk/openai", models: { "gpt-6-astra": { variants } } } } };
+    const before = JSON.stringify(snapshot);
+    const rendered = buildOpenworkRuntimeConfigObjectFromSnapshot(snapshot);
+    expect(rendered).toMatchObject({ provider: { lpr_synthetic: { models: { "gpt-6-astra": { variants: {
+      high: { reasoningEffort: "high" },
+      [fastVariantId("high")]: { reasoningEffort: "high", serviceTier: "priority" },
+      [fastVariantId("low")]: { reasoningEffort: "low", serviceTier: "priority" },
+      [fastVariantId(null)]: { serviceTier: "priority" },
+    } } } } } });
+    expect(JSON.stringify(snapshot)).toBe(before);
+    expect(JSON.stringify(rendered.provider)).not.toContain("openworkNativeFast");
   });
   test("managed browser restrictions use scalar actions in global and agent permissions", () => {
     const parsed = buildOpenworkRuntimeConfigObjectFromSnapshot({

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -1,4 +1,5 @@
 import { legacyExecutionPermissions } from "./managed-policy-rules.js";
+import { materializeLegacyFastProviders } from "@openwork/types/cloud-model-fast";
 import { isManagedPolicyPlugin } from "./managed-policy-plugin.js";
 /**
  * Runtime OpenCode configuration injected via a server-managed config file
@@ -61,7 +62,7 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
   const disabledProviders = runtimeDisabledProviderList(runtimeConfig);
   const permissions = legacyExecutionPermissions(runtimeConfig.managedPolicy?.execution);
   const { managedPolicy: _managedPolicy, ...engineConfig } = runtimeConfig;
-  const provider = runtimeProviderMap(runtimeConfig);
+  const provider = materializeLegacyFastProviders(runtimeProviderMap(runtimeConfig));
   return {
     ...engineConfig,
     ...(runtimeConfig.managedPolicy?.allowCustomProviders === false ? { enabled_providers: [

--- a/constants.json
+++ b/constants.json
@@ -1,4 +1,4 @@
 {
-  "opencodeVersion": "v1.18.18",
+  "opencodeVersion": "v1.18.30",
   "opencodeV2Version": "0.0.0-beta-19086"
 }

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto"
+import { catalogFastVariants, materializeLegacyFastProviders } from "@openwork/types/cloud-model-fast"
 import { and, asc, eq, inArray, isNull, sql } from "@openwork-ee/den-db/drizzle"
 import {
   LlmProviderModelTable,
@@ -330,7 +331,7 @@ function providerEnvEntries(provider: CloudProviderMaterializationProvider): Env
   return entries
 }
 
-function buildModelConfig(model: CloudProviderMaterializationProvider["models"][number]) {
+function buildModelConfig(model: CloudProviderMaterializationProvider["models"][number], providerNpm: unknown) {
   const next: JsonRecord = {
     id: model.modelId,
     name: model.name,
@@ -343,6 +344,8 @@ function buildModelConfig(model: CloudProviderMaterializationProvider["models"][
     }
   }
 
+  const variants = catalogFastVariants(model.modelConfig, providerNpm)
+  if (variants) next.variants = variants
   return next
 }
 
@@ -350,7 +353,7 @@ function buildProviderConfig(provider: CloudProviderMaterializationProvider) {
   const models: JsonRecord = {}
   const sortedModels = [...provider.models].sort((left, right) => left.modelId.localeCompare(right.modelId))
   for (const model of sortedModels) {
-    models[model.modelId] = buildModelConfig(model)
+    models[model.modelId] = buildModelConfig(model, provider.providerConfig.npm)
   }
 
   const config: JsonRecord = {
@@ -631,12 +634,16 @@ function buildRuntimeProviderPatch(prepared: PreparedMaterialization, currentMan
 }
 
 function materializedProviderStateMatches(prepared: PreparedMaterialization, currentManagedProviders: JsonRecord) {
-  const desiredManagedProviders: JsonRecord = {}
+  const desiredManagedProviders: Record<string, JsonRecord> = {}
   for (const provider of prepared.providers) {
     desiredManagedProviders[provider.runtimeProviderId] = provider.config
   }
 
-  return stableJson(currentManagedProviders) === stableJson(desiredManagedProviders)
+  const current = stableJson(currentManagedProviders)
+  // New v1 engines expose the expanded config; older servers still expose the
+  // disabled import metadata. Accept either to avoid reloads on every resolve.
+  return current === stableJson(desiredManagedProviders)
+    || current === stableJson(materializeLegacyFastProviders(desiredManagedProviders))
 }
 
 function materializedEnvStateMatches(entries: EnvEntry[], snapshot: EnvSnapshot) {

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -2,6 +2,7 @@ import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, describe, expect, test } from "bun:test"
 import type { CloudProviderMaterializationProvider } from "../src/llm/cloud-provider-materialization.js"
 import { runtimeProviderEnvTag } from "../src/llm/provider-credentials.js"
+import { materializeLegacyFastProviders } from "@openwork/types/cloud-model-fast"
 
 // Fixed row ids so the provider-scoped runtime env names are stable across
 // the suite: a models.dev provider's declared names leave Den as
@@ -351,6 +352,35 @@ async function materialize(input: {
 }
 
 describe("Cloud provider materialization", () => {
+  test("preserves catalog Fast metadata and accepts expanded v1 readback without repeated writes", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "synthetic" })
+    provider.providerConfig = { npm: "@ai-sdk/openai", env: ["SYNTHETIC_API_KEY"] }
+    provider.models = [{ modelId: "model", name: "Model", modelConfig: {
+      reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+    } }]
+    const before = computeCloudProviderMaterializationFingerprint([provider])
+    provider.models[0].modelConfig.experimental = { modes: { fast: { provider: { body: { service_tier: "priority" } } } } }
+    expect(computeCloudProviderMaterializationFingerprint([provider])).not.toBe(before)
+    const instance = makeInstance()
+    const result = await materialize({ providers: () => [provider], fetchImpl: instance.fetchImpl, force: true })
+    expect(result.status).toBe("applied")
+    const written = instance.calls.find((call) => call.path === "/runtime-config/providers")?.body
+    expect(written).toMatchObject({ provider: { [provider.id]: { models: { model: { variants: {
+      __openwork_catalog_fast_v1: { disabled: true, openworkNativeFast: 1, reasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    } } } } } })
+    expect(JSON.stringify(written)).not.toContain('"reasoningEffort"')
+    expect(JSON.stringify(written)).not.toContain('"experimental"')
+    const runtime = instance.runtimeProvider(provider.id)
+    if (!runtime) throw new Error("Missing materialized provider")
+    const compiled = materializeLegacyFastProviders({ [provider.id]: runtime })
+    const configuredEnv = Array.isArray(runtime.env) ? runtime.env : []
+    const envName = configuredEnv.find((value): value is string => typeof value === "string")
+    if (!envName) throw new Error("Missing synthetic credential name")
+    const restarted = makeInstance({ runtimeProviders: compiled, envValues: { [envName]: "synthetic" } })
+    const next = await materialize({ providers: () => [provider], fetchImpl: restarted.fetchImpl, force: true })
+    expect(next.status).toBe("noop")
+    expect(writeCalls(restarted.calls)).toEqual([])
+  })
   test("does not rewrite matching provider state after the den-api cache is lost", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const instance = makeInstance({

--- a/evals/specs/catalog-fast-mode-wire.test.ts
+++ b/evals/specs/catalog-fast-mode-wire.test.ts
@@ -1,0 +1,188 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { eventually, test } from "@openwork/testkit";
+import { expect } from "vitest";
+import { CATALOG_FAST_VARIANT, FAST_VARIANT_PREFIX, fastVariantId } from "@openwork/types/cloud-model-fast";
+import { buildCloudProviderConfig } from "../../apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config";
+import { buildOpenworkRuntimeConfigObjectFromSnapshot } from "../../apps/server/src/openwork-runtime-config";
+
+import versions from "../../constants.json";
+import { createManagedOpencodeServer } from "../../apps/server/src/managed-opencode";
+import { createManagedOpencodeV2Server, installOpencodeV2Binary } from "../../apps/server/src/managed-opencode-v2";
+
+const exec = promisify(execFile);
+const advertisedEfforts = ["low", "medium", "high", "xhigh", "max"];
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Both verified engine paths must preserve exact wire model IDs and effort.
+// Stored metadata stays disabled until rendered for the pinned engine.
+for (const engine of ["v1", "v2"]) {
+  test(`${engine} dispatches catalog Fast independently of effort`, { timeout: 180_000 }, async ({ evidence }) => {
+    const binary = engine === "v1"
+      ? process.env.OPENWORK_EVAL_OPENCODE_BIN_V1 ?? join(import.meta.dirname, "../../apps/desktop/resources/sidecars", process.platform === "win32" ? "opencode.exe" : "opencode")
+      : process.env.OPENWORK_EVAL_OPENCODE2_BIN ?? await installOpencodeV2Binary(
+        join(tmpdir(), "openwork-opencode-v2-verified"), versions.opencodeV2Version,
+      );
+    expect((await exec(binary, ["--version"])).stdout.trim()).toBe(
+      engine === "v1" ? versions.opencodeVersion.replace(/^v/, "") : `opencode2 v${versions.opencodeV2Version}`,
+    );
+
+    const requests: { model: unknown; effort: unknown; tier: unknown; verbosity: unknown; generation: boolean }[] = [];
+    const witness = createServer(async (request, response) => {
+      if (request.method === "GET") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const body: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      if (request.url === "/v1/responses" && isRecord(body)) {
+        requests.push({ model: body.model, effort: isRecord(body.reasoning) ? body.reasoning.effort ?? null : null,
+          tier: body.service_tier ?? null, verbosity: isRecord(body.text) ? body.text.verbosity ?? null : null,
+          generation: Array.isArray(body.tools) && body.tools.length > 0 });
+      }
+      // Capture dispatch only: never run a real model or execute a tool. A 400
+      // is intentional and non-retryable; successful completion is not claimed.
+      response.writeHead(400, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "Synthetic wire witness", type: "invalid_request_error" } }));
+    });
+    await new Promise<void>((resolve) => witness.listen(0, "127.0.0.1", resolve));
+    const address = witness.address();
+    if (!address || typeof address === "string") throw new Error("Witness did not bind");
+    const baseURL = `http://127.0.0.1:${address.port}`;
+    const root = await mkdtemp(join(tmpdir(), "catalog-fast-wire-"));
+    const directory = join(root, "workspace");
+    await mkdir(directory);
+    const configPath = join(root, "base.json");
+    const rawModelConfig = {
+      name: "Synthetic mode witness", reasoning: true, limit: { context: 128_000, output: 8_192 },
+      reasoning_options: [{ type: "effort", values: advertisedEfforts }],
+      // Exercise Default + Fast's merge with an existing model option without
+      // pinning a reasoning effort or changing the actual wire model ID.
+      options: engine === "v1" ? { textVerbosity: "high" } : { providerOptions: { textVerbosity: "high" } },
+      cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+      experimental: { modes: { fast: {
+        provider: { body: { service_tier: "priority" } }, cost: { input: 20, output: 100, cache_read: 2, cache_write: 25 },
+      } } },
+    };
+    const provider = buildCloudProviderConfig({
+      id: "lpr_witness", providerId: "openai", source: "custom", name: "Synthetic witness",
+      providerConfig: { npm: "@ai-sdk/openai", options: { apiKey: "synthetic-only", baseURL: `${baseURL}/v1` } },
+      hasApiKey: true, apiKey: "synthetic-only", apiKeys: null, createdAt: null, updatedAt: null,
+      models: [
+        { id: "gpt-6-astra", name: "Synthetic mode witness", config: rawModelConfig, createdAt: null },
+        { id: "gpt-5.4", name: "GPT-5.4 control", createdAt: null,
+          config: { ...rawModelConfig, reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh"] }] } },
+      ],
+    });
+    const models = provider.models ?? {};
+    const runtime = buildOpenworkRuntimeConfigObjectFromSnapshot({ provider: { witness: { ...provider } } });
+    // Isolate provider dispatch from unrelated OpenWork plugins in this test.
+    await writeFile(configPath, JSON.stringify(engine === "v1" ? { provider: runtime.provider } : {}));
+    const env = {
+      HOME: root, OPENCODE_CONFIG: configPath, OPENCODE_MODELS_URL: baseURL,
+      OPENCODE_DISABLE_MODELS_FETCH: "1", XDG_CONFIG_HOME: join(root, "xdg"),
+      XDG_DATA_HOME: join(root, "data"), XDG_STATE_HOME: join(root, "state"),
+      XDG_CACHE_HOME: join(root, "cache"),
+    };
+    const server = engine === "v1"
+      ? await createManagedOpencodeServer({ bin: binary, cwd: directory, env, timeoutMs: 60_000 })
+      : await createManagedOpencodeV2Server({ bin: binary, rootDir: root, env });
+    try {
+      if ("injectProvider" in server) {
+        await server.injectProvider({
+          id: "witness", name: "Synthetic witness", apiKey: "synthetic-only",
+          baseUrl: `${baseURL}/v1`, package: "@opencode-ai/ai/providers/openai",
+          models: Object.entries(models).map(([id, config]) => ({ id, name: config.name ?? id, config })),
+        });
+      }
+      const request = async (path: string, body?: unknown): Promise<unknown> => {
+        const url = new URL(path, server.url);
+        url.searchParams.set(engine === "v1" ? "directory" : "location[directory]", directory);
+        const response = await fetch(url, {
+          method: body === undefined ? "GET" : "POST",
+          headers: { "content-type": "application/json", authorization:
+            `Basic ${Buffer.from(`${server.username}:${server.password}`).toString("base64")}` },
+          body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(60_000),
+        });
+        if (engine === "v2" && body !== undefined && path.endsWith("/model")) {
+          expect(response.status).toBe(204);
+          return undefined;
+        }
+        expect(response.status).toBe(200);
+        return response.json();
+      };
+      const catalog = await eventually(
+        async () => JSON.stringify(await request(engine === "v1" ? "/provider" : "/api/model")),
+        { within: 15_000, intervalMs: 100, label: "watched provider config becomes visible", until: (value) => value.includes("gpt-6-astra") },
+      );
+      expect(catalog).not.toContain(CATALOG_FAST_VARIANT);
+      expect(catalog).toContain(fastVariantId("high"));
+      if (engine === "v2") {
+        const payload: unknown = JSON.parse(catalog);
+        const entries = isRecord(payload) && Array.isArray(payload.data) ? payload.data : [];
+        const model = entries.find((entry) => isRecord(entry) && entry.id === "gpt-6-astra");
+        const variants = isRecord(model) && Array.isArray(model.variants)
+          ? model.variants.flatMap((entry) => isRecord(entry) && typeof entry.id === "string" ? [entry.id] : []) : [];
+        evidence.recordAssertionEvidence("Realistic Astra native catalog variant IDs", JSON.stringify(variants), true);
+        expect(variants).toHaveLength(advertisedEfforts.length * 2 + 1);
+        expect(variants).toEqual(expect.arrayContaining([...advertisedEfforts, fastVariantId(null), ...advertisedEfforts.map(fastVariantId)]));
+      }
+      const dispatches: { model: string; variant: string | null; effort: unknown; tier: unknown; verbosity: unknown }[] = [];
+      for (const model of Object.keys(models)) {
+        const created = await request(engine === "v1" ? "/session" : "/api/session", engine === "v1"
+          ? { title: "Synthetic dispatch witness" }
+          : { model: { providerID: "witness", id: model } });
+        const data = engine === "v2" && isRecord(created) ? created.data : created;
+        if (!isRecord(data) || typeof data.id !== "string") throw new Error("Session ID missing");
+        const sessionID = data.id;
+        const selections: Array<string | null> = [
+          "high", fastVariantId("high"), fastVariantId("low"), "low",
+          ...(model === "gpt-6-astra" ? ["medium", "xhigh", "max"] : ["medium", "xhigh"]).flatMap((effort) => [effort, fastVariantId(effort)]),
+          null, fastVariantId(null), null,
+        ];
+        for (const variant of selections) {
+          if (engine === "v2") await request(`/api/session/${sessionID}/model`, { model: {
+            providerID: "witness", id: model, ...(variant === null ? {} : { variant }),
+          } });
+          const offset = requests.length;
+          await request(engine === "v1" ? `/session/${data.id}/message` : `/api/session/${data.id}/prompt`, engine === "v1"
+            ? { model: { providerID: "witness", modelID: model }, ...(variant === null ? {} : { variant }), parts: [{ type: "text", text: "Reply hello." }] }
+            : { text: "Reply hello." });
+          const dispatched = await eventually(
+            () => requests.slice(offset).find((entry) => entry.model === model && entry.generation),
+            { within: 30_000, intervalMs: 100, label: `${engine} ${model} ${variant} reaches the wire`, until: (value) => value !== undefined },
+          );
+          if (!dispatched) throw new Error("No generation request reached the witness");
+          dispatches.push({ model, variant, effort: dispatched.effort, tier: dispatched.tier, verbosity: dispatched.verbosity });
+          if (engine === "v2") await eventually(async () => {
+            const active = await request("/api/session/active");
+            if (!isRecord(active) || !isRecord(active.data)) return false;
+            const session = active.data[sessionID];
+            return !isRecord(session) || session.type !== "running";
+          }, { within: 30_000, intervalMs: 100, label: "synthetic request settles before the next selection", until: (value) => value });
+        }
+      }
+      evidence.recordAssertionEvidence("Synthetic provider wire dispatches", JSON.stringify({ engine, dispatches }), true);
+      for (const row of dispatches) {
+        const expectedEffort = advertisedEfforts.find((effort) => row.variant === effort || row.variant === fastVariantId(effort))
+          ?? (row.model === "gpt-5.4" ? "medium" : null);
+        expect(row.effort, `${engine} ${row.model} ${row.variant}: reasoning effort on the wire`).toBe(expectedEffort);
+        expect(row.verbosity).toBe("high");
+        expect(row.tier, `${engine} ${row.model} ${row.variant}: service_tier on the wire`)
+          .toBe(row.variant?.startsWith(FAST_VARIANT_PREFIX) ? "priority" : null);
+      }
+    } finally {
+      await server.close();
+      witness.closeAllConnections();
+      await new Promise<void>((resolve, reject) => witness.close((error) => error ? reject(error) : resolve()));
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/evals/specs/gmail-draft-attachments.test.ts
+++ b/evals/specs/gmail-draft-attachments.test.ts
@@ -7,7 +7,7 @@ import { gmailAttachmentFixtures, gmailDraftAttachments, gmailReplyFixtures } fr
 test("Gmail attachments cross the real MCP, engine hook, host and Den boundaries without sending or changing identity", { timeout: 600_000 }, async ({ place, evidence }) => {
   needs({ commands: ["bun", "pnpm"], placement: "local" });
   await using world = await gmailDraftAttachments(place);
-  console.log(`placement: ${place.kind} (real managed OpenCode 1.18.18, isolated Den, synthetic Google and model)`);
+  console.log(`placement: ${place.kind} (pinned managed OpenCode, isolated Den, synthetic Google and model)`);
   const uploads = () => world.requests().filter((entry) => entry.path === "/v1/direct-uploads/google-workspace/gmail-drafts");
   async function finish(id: string) {
     const messages = await eventually(async () => {

--- a/evals/worlds/gmail-draft-attachments.ts
+++ b/evals/worlds/gmail-draft-attachments.ts
@@ -9,6 +9,7 @@ import { localMysqlIsRunning, localRedisIsRunning, mcpMock, server, SkipError, t
 import { startMockGoogle } from "@openwork/labs";
 import { gmailDraftModel, gmailResultObjects } from "../packages/labs/src/gmail-draft-model.ts";
 import { bootManagedOpenworkServer, close, engineBinary, isRecord, listen } from "./openwork-server-cli.ts";
+import constants from "../../constants.json";
 
 export const gmailAttachmentFixtures = [
   { filename: "inventory.csv", mimeType: "text/csv", bytes: Buffer.from("sku,quantity\nfixture-widget,17\n") },
@@ -63,9 +64,9 @@ export async function gmailDraftAttachments(place: Place) {
   if (place.kind !== "local" || process.env.OPENWORK_EVAL_DEN_API_URL) throw new SkipError("isolated local Den for loopback Gmail witnesses");
   if (execFileSync("bun", ["--version"], { encoding: "utf8", timeout: 10_000 }).trim() !== "1.3.14") throw new SkipError("pinned Bun 1.3.14");
   const binary = engineBinary();
-  if (!binary) throw new SkipError("OpenCode v1.18.18 via OPENWORK_OPENCODE_BIN or prepared sidecar");
+  if (!binary) throw new SkipError(`OpenCode ${constants.opencodeVersion} via OPENWORK_OPENCODE_BIN or prepared sidecar`);
   const version = execFileSync(binary, ["--version"], { encoding: "utf8", timeout: 10_000 }).trim();
-  if (version.replace(/^v/, "") !== "1.18.18") throw new SkipError(`pinned OpenCode 1.18.18 (found ${version})`);
+  if (version.replace(/^v/, "") !== constants.opencodeVersion.replace(/^v/, "")) throw new SkipError(`pinned OpenCode ${constants.opencodeVersion} (found ${version})`);
   if (!await localMysqlIsRunning() || !await localRedisIsRunning()) throw new SkipError("local MySQL and Redis; run pnpm dev:den:mysql");
   const stack = new AsyncDisposableStack();
   try {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,13 @@
   "private": true,
   "type": "module",
   "exports": {
-    "./cloud-model-fast": "./src/cloud-model-fast.ts",
+    "./cloud-model-fast": {
+      "types": "./src/cloud-model-fast.ts",
+      "development": "./src/cloud-model-fast.ts",
+      "bun": "./src/cloud-model-fast.ts",
+      "browser": "./src/cloud-model-fast.ts",
+      "default": "./dist/cloud-model-fast.js"
+    },
     ".": {
       "types": "./src/index.ts",
       "development": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./cloud-model-fast": "./src/cloud-model-fast.ts",
     ".": {
       "types": "./src/index.ts",
       "development": "./src/index.ts",

--- a/packages/types/src/cloud-model-fast.ts
+++ b/packages/types/src/cloud-model-fast.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+export const CLOUD_MODEL_CONFIG_VERSION = 2;
+export const CATALOG_FAST_VARIANT = "__openwork_catalog_fast_v1";
+export const FAST_VARIANT_PREFIX = "__openwork_fast_v1/";
+export const FAST_DEFAULT_VARIANT = `${FAST_VARIANT_PREFIX}default`;
+
+const fastMode = z.object({
+  provider: z.object({ body: z.object({ service_tier: z.literal("priority") }).strict() }).strict(),
+  cost: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+const reasoningEffort = z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
+const effortOption = z.object({ type: z.literal("effort"), values: z.array(reasoningEffort) }).strict();
+const fastMetadata = z.object({
+  disabled: z.literal(true), openworkNativeFast: z.literal(1), reasoningEfforts: z.array(reasoningEffort).optional(),
+}).strict();
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export function fastVariantId(effort: string | null): string {
+  return effort === null ? FAST_DEFAULT_VARIANT : `${FAST_VARIANT_PREFIX}variant/${encodeURIComponent(effort)}`;
+}
+
+/** Keep stored/imported metadata disabled. Only verified engine materializers
+ * expand it; older servers cannot accidentally advertise a broken Fast option. */
+export function catalogFastVariants(config: Record<string, unknown>, providerNpm: unknown): Record<string, unknown> | undefined {
+  const variants = isRecord(config.variants) ? config.variants : {};
+  const experimental = isRecord(config.experimental) ? config.experimental : {};
+  const modes = isRecord(experimental.modes) ? experimental.modes : {};
+  const modelProvider = isRecord(config.provider) ? config.provider : {};
+  if (providerNpm !== "@ai-sdk/openai"
+    || (modelProvider.npm !== undefined && modelProvider.npm !== providerNpm)
+    || !fastMode.safeParse(modes.fast).success
+    || Object.keys(variants).some((id) => id === CATALOG_FAST_VARIANT || id.startsWith(FAST_VARIANT_PREFIX))) return undefined;
+  const reasoningEfforts = [...new Set((Array.isArray(config.reasoning_options) ? config.reasoning_options : []).flatMap((option) => {
+    const parsed = effortOption.safeParse(option);
+    return parsed.success ? parsed.data.values : [];
+  }))];
+  return { ...variants, [CATALOG_FAST_VARIANT]: {
+    disabled: true, openworkNativeFast: 1,
+    ...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+  } };
+}
+
+export function nativeModelVariants(raw: unknown, providerPackage: string | undefined) {
+  const variants = isRecord(raw) ? raw : {};
+  const enabled = Object.entries(variants).flatMap(([id, value]) => {
+    if (!isRecord(value) || value.disabled === true) return [];
+    const { disabled, ...options } = value;
+    return [{ id, settings: { providerOptions: options } }];
+  });
+  const metadata = fastMetadata.safeParse(variants[CATALOG_FAST_VARIANT]);
+  if (providerPackage !== "@opencode-ai/ai/providers/openai"
+    || !metadata.success
+    || Object.keys(variants).some((id) => id.startsWith(FAST_VARIANT_PREFIX))) return enabled;
+  // Catalog efforts are not OpenCode variants. Expand only here, and never
+  // resurrect an explicitly disabled variant or overwrite custom settings.
+  for (const effort of metadata.data.reasoningEfforts ?? []) {
+    if (!Object.hasOwn(variants, effort)) enabled.push({ id: effort, settings: { providerOptions: { reasoningEffort: effort } } });
+  }
+  return [
+    ...enabled,
+    { id: FAST_DEFAULT_VARIANT, settings: { providerOptions: { serviceTier: "priority" } } },
+    ...enabled.map((variant) => ({
+      id: fastVariantId(variant.id),
+      settings: { providerOptions: { ...variant.settings.providerOptions, serviceTier: "priority" } },
+    })),
+  ];
+}
+
+/** Emit v1 provider config for the pinned managed engine (1.18.30 or newer).
+ * Do not use this for arbitrary external engines or mutate the stored config. */
+export function materializeLegacyFastProviders(providers: Record<string, Record<string, unknown>>) {
+  const result = { ...providers };
+  for (const [id, provider] of Object.entries(providers)) {
+    if (provider.npm !== "@ai-sdk/openai" || !isRecord(provider.models)) continue;
+    const models = { ...provider.models };
+    for (const [modelId, model] of Object.entries(models)) {
+      if (!isRecord(model) || !isRecord(model.variants)
+        || !fastMetadata.safeParse(model.variants[CATALOG_FAST_VARIANT]).success
+        || (isRecord(model.provider) && model.provider.npm !== undefined && model.provider.npm !== provider.npm)
+        || Object.keys(model.variants).some((key) => key.startsWith(FAST_VARIANT_PREFIX))) continue;
+      const { [CATALOG_FAST_VARIANT]: _metadata, ...variants } = model.variants;
+      for (const variant of nativeModelVariants(model.variants, "@opencode-ai/ai/providers/openai")) {
+        if (!Object.hasOwn(variants, variant.id)) variants[variant.id] = variant.settings.providerOptions;
+      }
+      models[modelId] = { ...model, variants };
+    }
+    result[id] = { ...provider, models };
+  }
+  return result;
+}

--- a/packages/types/tests/packaged-cloud-model-fast.test.mjs
+++ b/packages/types/tests/packaged-cloud-model-fast.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Run after @openwork/types build. Workspace symlinks hide Node's prohibition
+// on loading TypeScript inside node_modules; copy the actual distributable files.
+test("packaged cloud-model-fast imports in plain Node without a TypeScript loader", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "openwork-types-packaged-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const source = fileURLToPath(new URL("../", import.meta.url));
+  const destination = join(root, "node_modules/@openwork/types");
+  mkdirSync(destination, { recursive: true });
+  const manifest = JSON.parse(readFileSync(join(source, "package.json"), "utf8"));
+  copyFileSync(join(source, "package.json"), join(destination, "package.json"));
+  for (const directory of manifest.files) {
+    cpSync(join(source, directory), join(destination, directory), { recursive: true });
+  }
+  cpSync(join(source, "node_modules/zod"), join(root, "node_modules/zod"), {
+    recursive: true, dereference: true,
+  });
+
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", `
+    import assert from "node:assert/strict";
+    import { CATALOG_FAST_VARIANT, FAST_DEFAULT_VARIANT, catalogFastVariants,
+      nativeModelVariants, materializeLegacyFastProviders } from "@openwork/types/cloud-model-fast";
+    assert.ok(import.meta.resolve("@openwork/types/cloud-model-fast").endsWith("/dist/cloud-model-fast.js"));
+    const variants = catalogFastVariants({ experimental: { modes: {
+      fast: { provider: { body: { service_tier: "priority" } } },
+    } } }, "@ai-sdk/openai");
+    assert.equal(variants[CATALOG_FAST_VARIANT].disabled, true);
+    assert.deepEqual(nativeModelVariants(variants, "@opencode-ai/ai/providers/openai"), [
+      { id: FAST_DEFAULT_VARIANT, settings: { providerOptions: { serviceTier: "priority" } } },
+    ]);
+    const legacy = materializeLegacyFastProviders({ synthetic: {
+      npm: "@ai-sdk/openai", models: { model: { variants } },
+    } });
+    assert.deepEqual(legacy.synthetic.models.model.variants, {
+      [FAST_DEFAULT_VARIANT]: { serviceTier: "priority" },
+    });
+  `], {
+    cwd: root, encoding: "utf8", timeout: 15_000,
+    env: { ...process.env, NODE_PATH: "", NODE_OPTIONS: "" },
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup"
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    "cloud-model-fast": "src/cloud-model-fast.ts",
     "agent-context-diagnostics": "src/agent-context-diagnostics.ts",
     "openwork-affordance": "src/openwork-affordance.ts",
     "openwork-context": "src/openwork-context.ts",


### PR DESCRIPTION
## Summary
- Preserve catalog-advertised OpenAI Fast metadata across all cloud provisioning paths and reconcile existing imports.
- Add independent Fast controls with a higher-pricing warning to both model pickers, preserving Default, reasoning effort, custom variants, and queued selections.
- Materialize verified priority variants for managed OpenCode v1 and native v2 without changing model identities.
- Upgrade bundled OpenCode v1 from 1.18.18 to 1.18.30: its updated OpenAI SDK preserves explicit priority for GPT-6 instead of dropping it through an older model capability gate.

## Verification
- 147 focused tests passed during implementation, covering picker behavior, serialization, reconciliation, desktop runtime, adapters, and real-engine request dispatch.
- App and server typechecks passed.
- Real-engine loopback tests cover GPT-6 Astra and GPT-5.4: priority only with Fast, all advertised efforts preserved, and Default/Fast/Default transitions within the same session.
- Final-head wire evidence will be attached separately.

## Scope and limitations
- No database migration is needed; the existing model-config JSON already preserves catalog modes.
- Supports the verified OpenAI priority body; does not claim Pro or other adapters are supported.
- Externally overridden older v1 binaries are not repaired by this change.
- Full Electron visual smoke testing, full release qualification, paid inference, and billing verification were not performed.
- Gmail journey changes only replace a hard-coded engine pin with constants; no Gmail behavior changed and that journey was not run.