### PR TITLE
fix(den-db): make pending Gateway preflight compatible with Vitess

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 packages/sdk/src/gen/** linguist-generated=true
+# 0097 has a reviewed byte-level compatibility pin in the local migration runner.
+/ee/packages/den-db/drizzle/0097_gateway_access_matrix.sql text eol=lf

--- a/ee/packages/den-db/drizzle/0097_gateway_access_matrix.md
+++ b/ee/packages/den-db/drizzle/0097_gateway_access_matrix.md
@@ -1,11 +1,172 @@
 # Gateway Matrix Migration 0097
 
-Status: complete registered SQL migration and source-serialized snapshot.
+Original authoring status: complete registered SQL migration and source-serialized snapshot.
 Offline generation and schema-delta inspection only; no database execution,
 runtime tests, service changes, commits, pushes, or deployment performed.
 The authoritative batch contract is `model-access-matrix.md` from the supplied
 external inference-gateway documentation; its key/matrix decisions supersede
 the historical plan.
+
+## Pending-Migration Vitess Recovery
+
+This is an explicitly authorized correction of the already-landed 0097 SQL for
+a deployment where 0097 is still pending, not a new migration or permission to
+replay an applied migration. Recovery base: `667b450fd` on `origin/dev`.
+
+| 0097 SQL bytes | SHA-256 |
+| --- | --- |
+| Before correction | `dec021c8b3bb9fb139b3e0737ac5618ab1ed74d64d82fe36e1fcfe71306f378d` |
+| After correction | `2882d271052bd27a6281e5a1b161056546c817d27e218ba69fecd5f00cb4db9a` |
+
+The three metadata `INSERT ... SELECT` guards become five flat SELECTs, without
+metadata joins, subqueries or DML. The complete-0096 check is split into eight
+required BASE TABLEs, eleven rollup observation columns, and one encrypted-key
+column. The twelve destination names must be absent regardless of table type,
+including views. Index presence counts twenty distinct `(TABLE_NAME, INDEX_NAME)`
+pairs, not statistics rows for individual indexed columns. The database scope
+stays outside the parenthesized OR of those exact twenty pairs.
+
+Every metadata SELECT evaluates `JSON_EXTRACT(IF(condition, '{}', '0097_reason'), '$')`.
+Success returns one row containing `{}`. Failure supplies a static non-JSON
+reason string, causing `ER_INVALID_JSON_TEXT_IN_PARAM` (3141), an SQL error rather
+than a warning or a result the migrator could ignore. A stop-on-error Drizzle
+execution therefore aborts before persistent DDL. The reason identifies the
+guard in the SQL; drivers need not include that string in their error message.
+The seven version, SQL-mode and data INSERT guards, all ten temporary sentinel
+values, and temporary-table lifecycle are unchanged. Every persistent DDL,
+backfill, constraint and index change is unchanged.
+
+The final two comments now precede the last ALTER rather than following its
+semicolon. Each breakpoint packet ends in actual SQL. No SQL in 0095, 0096,
+0098, 0099, older migrations, journal timestamps, snapshots or schema sources
+is changed, and no history is regenerated.
+
+The migration owner supplied prior read-only Vitess 8.4.11 observations: flat
+TABLES/COLUMNS/STATISTICS probes succeeded with expected counts and failed with
+3141 for deliberately wrong counts, including distinct table/index pairs.
+They also supplied the 1105 `Expected a single Statement` reproduction for
+`SELECT 1; -- comment`, and successful final-ALTER/0098/0099 execution after
+removing trailing comments in the diagnostic branch. These are supplied
+diagnostic findings, not tests executed or fresh deployment certification by
+this correction. The diagnostic branch is now empty at schema 0099; do not
+replay there or reuse another worktree's `.env`.
+
+Supplied deployment receipts cover 1 through 96, with exact matches reported
+for 0095/0096. Older 0003/0010/0015 hashes differ. That is NOT a clean-history
+claim. Those SQL files and receipts must remain untouched; investigate their
+provenance separately with the migration owner rather than accepting all old
+hashes, rewriting receipts, or replaying history.
+
+### Local Runner And Receipt Compatibility
+
+- Before any later authorized apply, the owner must establish from read-only
+  receipts and schema inspection that 0097 is pending and no persistent 0097
+  DDL has run. A missing receipt alone does not prove this: DDL auto-commits.
+  Mixed/partial Gateway state needs its own recovery plan, not a retry.
+- Deployments already recording the original 0097 hash must NOT replay 0097,
+  delete/restamp its receipt, change its timestamp, or baseline Gateway tables.
+  Timestamp-based pending selection and exact checksum validation are different
+  contracts; a migration being skipped does not certify its recorded bytes.
+- `scripts/migration-baseline.ts:historyPrefix` still checks every ordered hash
+  and timestamp, with one explicitly authorized known-equivalent hash alias.
+  The before-correction hash in the table above is accepted ONLY for tag
+  `0097_gateway_access_matrix`, journal time `1788895934602`, and current SQL
+  hash `2882d271052bd27a6281e5a1b161056546c817d27e218ba69fecd5f00cb4db9a`.
+  The receipt timestamp must also match. The current hash remains accepted by
+  the ordinary exact-match rule. An accepted original receipt remains unchanged
+  and counts as applied: 0097 is neither replayed nor restamped. Different tags,
+  times, unknown hashes or another replacement SQL hash do not qualify.
+- No other historical hash mismatch is permitted. The pending deployment with
+  receipts 1 through 96 does not use this alias at all. Its supplied 0095/0096
+  matches and 0003/0010/0015 discrepancies remain as reported; the older
+  discrepancies still fail local exact-prefix validation. No receipts, earlier
+  migrations or timestamps are rewritten, and no broader history is certified.
+- `scripts/dev-migrate.ts:matrixPreflightQueries` now recognizes the five JSON
+  assertions plus seven INSERT-derived guards. It reconstructs and pins the
+  reviewed 0097 source hash, checks all ten unique seed names, requires twelve
+  queries with five JSON assertions, and requires three complete-0096 queries
+  plus exactly one query for every other seed. Changed source bytes or unknown
+  layouts still raise `0097 preflight layout changed; review local startup integration before execution.`
+  Future 0097 edits require explicit review rather than silently weakening a
+  predicate or dropping an unrecognized statement.
+- `preflightMatrix` accepts JSON success only as one row whose `preflight` is an
+  empty object, either driver-decoded or parsed from a valid JSON string. Missing,
+  multiple, malformed, scalar, array or nonempty-object results fail closed.
+  Ordinary INSERT-derived SELECTs still pass only with zero rows. Query errors
+  propagate and abort before later guards. `completeSchema=false` skips all
+  three complete-0096 assertions, and only those; destination/index and all
+  version/mode/data checks still run. The embedded SQL checks still execute at
+  migration time, after 0096.
+- Loopback restrictions, active-session checks, interruption markers and exact
+  schema verification after receipt validation are unchanged. An accepted old
+  0097 hash cannot hide partial schema or unrelated drift. The prior layout and
+  old-0097-receipt integration blockers are covered by the focused checks below.
+  The SQL file has a narrowly scoped `text eol=lf` Git attribute so the reviewed
+  byte-level pin is stable across fresh platform checkouts.
+
+### Recovery Verification
+
+The orchestrator ran the following checks on the recovery working tree:
+
+- Offline preflight and migration-readiness tests: **36 passed, 0 failed, 0 skipped**.
+- `db:migrate:local --check-artifacts`: **99 ordered migrations and 41 foundation
+  statements validated**, without database access.
+- The targeted MySQL 8.4.10 schema-parity file: **11 passed, 0 failed, 0 skipped**,
+  including full migration replay, exported-schema parity, five successful JSON
+  guards and 25 invalid-metadata scenarios that raised error 3141.
+- Read-only probes on the user-supplied Vitess 8.4.11 branch: valid flat table,
+  column, index and distinct-table/index-count queries returned `{}`; deliberately
+  invalid counts raised error 3141. These establish the query shapes, not a full
+  corrected-file replay against populated Vitess data.
+- A separate read-only Vitess parser probe confirmed that a trailing comment
+  after a semicolon raises `Expected a single statement`, while the same SELECT
+  without the comment succeeds.
+
+The MySQL fixture was an owned disposable container, removed after verification.
+Initial fixture mount-inspection and child-process condition mistakes were
+corrected without changing migration assertions; the first schema-parity attempt
+had 10 passes and one environment failure before the final 11-pass run.
+No production database or migration receipts were modified.
+
+The focused offline `test/gateway-preflight.test.ts` checks exact metadata predicates/counts,
+the unchanged 35 non-metadata packets against a fingerprint from the original
+SQL, and actual SQL packet endings for 0097-0099. The added opt-in test in
+`test/migration-schema-parity.test.ts` uses the existing `DEN_DB_MYSQL_TEST_URL`
+scratch-database fixture, seeds only the 0095/0096 prerequisites, and exercises
+all five actual JSON guards. Negative cases remove a required table/column,
+occupy a destination with a table or view, and rename each of the twenty required
+indexes without reducing the total index count. It does not apply 0097 DDL or
+record migration receipts. MySQL coverage is not Vitess protocol certification.
+
+The existing local migration tests in `test/migration-readiness.test.ts` now
+cover the mixed result contract, malformed JSON results, every guard's stop-on-
+error behavior, three-assertion skipping, unknown layouts, the exact old/current
+0097 receipt pair, rejected alias variants and older drift, receipt preservation,
+and schema verification after accepting an original receipt. Their fake executor
+returns the JSON success row rather than treating all SELECTs as zero-row guards.
+
+Reproduction commands, from the repository root after dependency installation:
+
+```sh
+pnpm --dir ee/packages/den-db exec node --conditions=development --import tsx --test test/gateway-preflight.test.ts test/migration-readiness.test.ts
+pnpm --dir ee/packages/den-db db:migrate:local --check-artifacts
+NODE_OPTIONS=--conditions=development DEN_DB_MYSQL_TEST_URL="${ISOLATED_MYSQL_ADMIN_URL:?Set a dedicated disposable MySQL URL}" pnpm --dir ee/packages/den-db exec node --conditions=development --import tsx --test --test-concurrency=1 test/migration-schema-parity.test.ts
+```
+
+The last command needs a deliberately provisioned disposable MySQL fixture with
+CREATE/DROP DATABASE permission. It skips its database checks without a URL;
+never point it at production. `NODE_OPTIONS` is needed for the spawned Drizzle
+export process as well as its parent. The first two commands are offline.
+
+The diagnostic PlanetScale branch is already at schema 0099 with **zero journal
+receipts**; it is not an empty schema and must not undergo full migration replay.
+Its zero-row backfills do not validate populated production data. Fresh populated
+Vitess rehearsal and production-state/cutover review remain separate gates.
+
+The existing `Den DB Migrate` workflow can apply on migration changes landing on
+`dev` and on its configured schedule. Merging this patch therefore requires the
+owner's explicit deployment/cutover decision, including coordination of automatic
+retries and application writers. This document does not disable that workflow.
 
 ## Registration
 
@@ -27,7 +188,8 @@ pnpm exec node --conditions=development --import tsx scripts/generate-gateway-ma
 
 These historical generator commands intentionally reject a newer schema or
 journal tip. After later migrations, use `db:migrate:local --check-artifacts`
-to inspect the registered chain; do not regenerate 0097 against current source.
+to inspect the registered chain and reviewed preflight layout offline.
+Do not regenerate 0097 against current source.
 
 The generator rejects unrelated table/view drift. The schema-delta mode uses
 Drizzle's `generateMySQLMigration` on an in-memory copy of 0096 with the eight
@@ -50,12 +212,13 @@ their table-derived Drizzle snapshot labels change without rebuilding them.
   Split on the standard `--> statement-breakpoint` markers. Stop on first error;
   no force/ignore mode and no separate pooled connection per statement.
 - The embedded preflight is automatic: no exported helper or extra runner hook
-  is required. It uses a connection-local TEMPORARY table with primary-key
-  sentinels. Invalid source data attempts a duplicate sentinel INSERT, which
-  raises MySQL error 1062 naming the failed check BEFORE the first persistent DDL.
-  There are ten `INSERT ... SELECT '0097_...'` checks. A launcher may extract
-  their SELECT portions for an earlier read-only preflight before creating its
-  own durable interruption marker; the embedded checks must still execute.
+  is required for direct sequential SQL execution. Seven version/mode/data
+  checks use a connection-local TEMPORARY table with primary-key sentinels;
+  a duplicate INSERT raises MySQL error 1062 naming the failed check. Five flat
+  metadata SELECTs raise JSON error 3141 on failure. All run BEFORE persistent
+  DDL. The local read-only adapter handles both shapes and their different
+  success-result conventions as documented above. The embedded checks must
+  still execute, even after an earlier preflight.
 - Require CREATE TEMPORARY TABLES permission, ordinary migration DDL/DML rights,
   MySQL 8.0.16+ (including 8.4), and STRICT_TRANS_TABLES or STRICT_ALL_TABLES.
   MariaDB/TiDB are explicitly refused; other drivers or serverless sessions that
@@ -72,7 +235,7 @@ their table-derived Drizzle snapshot labels change without rebuilding them.
 
 ## Preflight Failures
 
-| Duplicate-entry marker | Required action before retry |
+| Failure marker (1062 duplicate or 3141 JSON guard) | Required action before retry |
 | --- | --- |
 | 0097_requires_mysql_8_0_16_or_later | Use a supported MySQL server, not MariaDB/TiDB |
 | 0097_requires_strict_sql_mode | Enable strict SQL mode on the migration connection |
@@ -94,8 +257,9 @@ validated, and historical attribution is preserved rather than linked to default
 - Coordinate a writer cutover. MySQL DDL auto-commits; this is not an online,
   transactional or blindly rerunnable migration. Old readers/writers use names
   that will no longer exist. Drain OAuth callbacks/refreshes as part of cutover.
-- No database execution or real-data preflight has happened during this batch.
-  Replay/rollback-failure journeys remain deferred to the verification phase.
+- No database execution or real-data preflight was performed by this correction.
+  Supplied earlier diagnostic findings are scoped above; replay/rollback-failure
+  journeys remain deferred to an authorized verification phase.
 - Confirm MySQL with enforced CHECK support (8.0.16+), strict SQL mode, and
   support for RENAME INDEX/CHANGE COLUMN.
   Do not disable checks or silently ignore invalid source data.

--- a/ee/packages/den-db/drizzle/0097_gateway_access_matrix.sql
+++ b/ee/packages/den-db/drizzle/0097_gateway_access_matrix.sql
@@ -2,10 +2,10 @@
 -- Execute every statement on ONE connection, stop on the first error, and
 -- quiesce writers/callbacks/refreshes before starting. Requires schema through 0096.
 -- No legacy inference key, OpenRouter, limit, bucket or ledger table is changed.
--- A temporary primary-key guard fails actionably BEFORE persistent DDL, without
--- relying on CHECK enforcement, stored routines, SIGNAL or client delimiters.
--- On failure, the duplicate key names the failed preflight. Close the connection
--- and fix the source deliberately; never IGNORE errors or silently delete rows.
+-- Guards fail BEFORE persistent DDL without CHECK, routines, SIGNAL or delimiters.
+-- Metadata guards raise JSON error 3141; temporary primary-key guards retain
+-- duplicate-key failures for version, SQL mode and data. Close the connection
+-- on failure; fix the source deliberately, never IGNORE errors or delete rows.
 CREATE TEMPORARY TABLE `__gateway_0097_preflight` (
   `failure` varchar(80) NOT NULL PRIMARY KEY
 );
@@ -37,66 +37,60 @@ SELECT '0097_requires_strict_sql_mode'
 WHERE FIND_IN_SET('STRICT_ALL_TABLES', @@SESSION.sql_mode) = 0
   AND FIND_IN_SET('STRICT_TRANS_TABLES', @@SESSION.sql_mode) = 0;
 --> statement-breakpoint
-INSERT INTO `__gateway_0097_preflight` (`failure`)
-SELECT '0097_requires_complete_0096_schema'
-WHERE (
-  SELECT COUNT(*) FROM information_schema.tables
-  WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE' AND table_name IN (
-    'inference_providers', 'inference_provider_models', 'inference_provider_credentials',
-    'inference_provider_access', 'inference_provider_oauth_states',
-    'inference_request_logs', 'inference_usage_rollups', 'inference_rollup_lock'
-  )
-) <> 8 OR (
-  SELECT COUNT(*) FROM information_schema.columns
-  WHERE table_schema = DATABASE() AND table_name = 'inference_usage_rollups'
-    AND column_name IN ('input_tokens_count', 'output_tokens_count', 'total_tokens_count',
-      'cache_read_tokens_count', 'cache_write_tokens_count', 'reasoning_tokens_count',
-      'cost_count', 'latency_count', 'ttfb_count', 'request_bytes_count', 'response_bytes_count')
-) <> 11 OR NOT EXISTS (
-  SELECT 1 FROM information_schema.columns WHERE table_schema = DATABASE()
-    AND table_name = 'inference_keys' AND column_name = 'encrypted_key'
+-- Vitess metadata queries must stay flat SELECTs: no joins, subqueries or DML.
+-- Invalid JSON raises ER_INVALID_JSON_TEXT_IN_PARAM (3141), not a warning, so
+-- Drizzle stops before persistent DDL. Success returns {} rather than no rows.
+SELECT JSON_EXTRACT(IF(COUNT(*) = 8, '{}', '0097_requires_complete_0096_schema'), '$') AS preflight
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME IN (
+  'inference_providers', 'inference_provider_models', 'inference_provider_credentials',
+  'inference_provider_access', 'inference_provider_oauth_states',
+  'inference_request_logs', 'inference_usage_rollups', 'inference_rollup_lock'
 );
 --> statement-breakpoint
-INSERT INTO `__gateway_0097_preflight` (`failure`)
-SELECT '0097_gateway_tables_already_exist'
-WHERE EXISTS (
-  SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN (
-    'gateway_providers', 'gateway_provider_models', 'gateway_provider_credentials',
-    'gateway_provider_access', 'gateway_provider_oauth_states', 'gateway_request_logs',
-    'gateway_usage_rollups', 'gateway_rollup_lock', 'gateway_keys', 'gateway_model_groups',
-    'gateway_model_group_models', 'gateway_credential_sets'
-  )
+SELECT JSON_EXTRACT(IF(COUNT(*) = 11, '{}', '0097_requires_complete_0096_schema'), '$') AS preflight
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'inference_usage_rollups'
+  AND COLUMN_NAME IN ('input_tokens_count', 'output_tokens_count', 'total_tokens_count',
+    'cache_read_tokens_count', 'cache_write_tokens_count', 'reasoning_tokens_count',
+    'cost_count', 'latency_count', 'ttfb_count', 'request_bytes_count', 'response_bytes_count');
+--> statement-breakpoint
+SELECT JSON_EXTRACT(IF(COUNT(*) = 1, '{}', '0097_requires_complete_0096_schema'), '$') AS preflight
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'inference_keys' AND COLUMN_NAME = 'encrypted_key';
+--> statement-breakpoint
+SELECT JSON_EXTRACT(IF(COUNT(*) = 0, '{}', '0097_gateway_tables_already_exist'), '$') AS preflight
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (
+  'gateway_providers', 'gateway_provider_models', 'gateway_provider_credentials',
+  'gateway_provider_access', 'gateway_provider_oauth_states', 'gateway_request_logs',
+  'gateway_usage_rollups', 'gateway_rollup_lock', 'gateway_keys', 'gateway_model_groups',
+  'gateway_model_group_models', 'gateway_credential_sets'
 );
 --> statement-breakpoint
-INSERT INTO `__gateway_0097_preflight` (`failure`)
-SELECT '0097_missing_legacy_indexes'
-WHERE EXISTS (
-  SELECT 1 FROM (
-    SELECT 'inference_providers' AS table_name, 'inference_providers_organization_id' AS index_name
-    UNION ALL SELECT 'inference_providers', 'inference_providers_org_provider_id'
-    UNION ALL SELECT 'inference_provider_models', 'inference_provider_models_model_id'
-    UNION ALL SELECT 'inference_provider_models', 'inference_provider_models_provider_model'
-    UNION ALL SELECT 'inference_provider_credentials', 'inference_provider_credentials_org_membership_id'
-    UNION ALL SELECT 'inference_provider_credentials', 'inference_provider_credentials_organization_id'
-    UNION ALL SELECT 'inference_provider_credentials', 'inference_provider_credentials_provider_subject'
-    UNION ALL SELECT 'inference_provider_access', 'inference_provider_access_org_membership_id'
-    UNION ALL SELECT 'inference_provider_access', 'inference_provider_access_team_id'
-    UNION ALL SELECT 'inference_provider_access', 'inference_provider_access_provider_org_membership'
-    UNION ALL SELECT 'inference_provider_access', 'inference_provider_access_provider_team'
-    UNION ALL SELECT 'inference_provider_oauth_states', 'inference_provider_oauth_states_state'
-    UNION ALL SELECT 'inference_provider_oauth_states', 'inference_provider_oauth_states_expires_at'
-    UNION ALL SELECT 'inference_request_logs', 'inference_request_logs_openwork_request_id'
-    UNION ALL SELECT 'inference_request_logs', 'inference_request_logs_org_started'
-    UNION ALL SELECT 'inference_request_logs', 'inference_request_logs_member_started'
-    UNION ALL SELECT 'inference_request_logs', 'inference_request_logs_provider_started'
-    UNION ALL SELECT 'inference_request_logs', 'inference_request_logs_started_at'
-    UNION ALL SELECT 'inference_usage_rollups', 'inference_usage_rollups_bucket_dimension'
-    UNION ALL SELECT 'inference_usage_rollups', 'inference_usage_rollups_org_granularity_bucket'
-  ) required_indexes
-  LEFT JOIN information_schema.statistics actual
-    ON actual.table_schema = DATABASE() AND actual.table_name = required_indexes.table_name
-    AND actual.index_name = required_indexes.index_name
-  WHERE actual.index_name IS NULL
+SELECT JSON_EXTRACT(IF(COUNT(DISTINCT TABLE_NAME, INDEX_NAME) = 20, '{}', '0097_missing_legacy_indexes'), '$') AS preflight
+FROM information_schema.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE() AND (
+  (TABLE_NAME = 'inference_providers' AND INDEX_NAME = 'inference_providers_organization_id')
+  OR (TABLE_NAME = 'inference_providers' AND INDEX_NAME = 'inference_providers_org_provider_id')
+  OR (TABLE_NAME = 'inference_provider_models' AND INDEX_NAME = 'inference_provider_models_model_id')
+  OR (TABLE_NAME = 'inference_provider_models' AND INDEX_NAME = 'inference_provider_models_provider_model')
+  OR (TABLE_NAME = 'inference_provider_credentials' AND INDEX_NAME = 'inference_provider_credentials_org_membership_id')
+  OR (TABLE_NAME = 'inference_provider_credentials' AND INDEX_NAME = 'inference_provider_credentials_organization_id')
+  OR (TABLE_NAME = 'inference_provider_credentials' AND INDEX_NAME = 'inference_provider_credentials_provider_subject')
+  OR (TABLE_NAME = 'inference_provider_access' AND INDEX_NAME = 'inference_provider_access_org_membership_id')
+  OR (TABLE_NAME = 'inference_provider_access' AND INDEX_NAME = 'inference_provider_access_team_id')
+  OR (TABLE_NAME = 'inference_provider_access' AND INDEX_NAME = 'inference_provider_access_provider_org_membership')
+  OR (TABLE_NAME = 'inference_provider_access' AND INDEX_NAME = 'inference_provider_access_provider_team')
+  OR (TABLE_NAME = 'inference_provider_oauth_states' AND INDEX_NAME = 'inference_provider_oauth_states_state')
+  OR (TABLE_NAME = 'inference_provider_oauth_states' AND INDEX_NAME = 'inference_provider_oauth_states_expires_at')
+  OR (TABLE_NAME = 'inference_request_logs' AND INDEX_NAME = 'inference_request_logs_openwork_request_id')
+  OR (TABLE_NAME = 'inference_request_logs' AND INDEX_NAME = 'inference_request_logs_org_started')
+  OR (TABLE_NAME = 'inference_request_logs' AND INDEX_NAME = 'inference_request_logs_member_started')
+  OR (TABLE_NAME = 'inference_request_logs' AND INDEX_NAME = 'inference_request_logs_provider_started')
+  OR (TABLE_NAME = 'inference_request_logs' AND INDEX_NAME = 'inference_request_logs_started_at')
+  OR (TABLE_NAME = 'inference_usage_rollups' AND INDEX_NAME = 'inference_usage_rollups_bucket_dimension')
+  OR (TABLE_NAME = 'inference_usage_rollups' AND INDEX_NAME = 'inference_usage_rollups_org_granularity_bucket')
 );
 --> statement-breakpoint
 INSERT INTO `__gateway_0097_preflight` (`failure`)
@@ -373,8 +367,8 @@ ALTER TABLE `gateway_provider_access`
   DROP INDEX `inference_provider_access_provider_org_membership`,
   DROP INDEX `inference_provider_access_provider_team`;
 --> statement-breakpoint
+-- gateway_keys intentionally stays empty. Mint ow_gw_ keys on the next
+-- authorized runtime connect, rotating the stable organization/member row.
 ALTER TABLE `gateway_provider_oauth_states`
   MODIFY COLUMN `credential_set_id` varchar(64) NOT NULL,
   ADD INDEX `gateway_provider_oauth_states_set_member` (`credential_set_id`,`org_membership_id`);
--- gateway_keys intentionally stays empty. Mint ow_gw_ keys on the next
--- authorized runtime connect, rotating the stable organization/member row.

--- a/ee/packages/den-db/scripts/dev-migrate.ts
+++ b/ee/packages/den-db/scripts/dev-migrate.ts
@@ -34,13 +34,22 @@ export function matrixPreflightQueries(plan: MigrationPlan) {
   const rename = statements.findIndex((sql) => /^RENAME TABLE\b/i.test(sql))
   const queries = statements.slice(0, rename).flatMap((sql) => {
     const match = /^INSERT INTO `__gateway_0097_preflight` \(`failure`\)\s+(SELECT '(0097_[a-z0-9_]+)'[\s\S]*)$/.exec(sql)
-    return match ? [{ name: match[2], sql: match[1] }] : []
+    if (match) return [{ name: match[2], sql: match[1], json: false }]
+    const json = /^SELECT JSON_EXTRACT\(IF\(COUNT\((?:\*|DISTINCT TABLE_NAME, INDEX_NAME)\) = \d+, '\{\}', '(0097_[a-z0-9_]+)'\), '\$'\) AS preflight\s+FROM information_schema\.(?:TABLES|COLUMNS|STATISTICS)\s+WHERE TABLE_SCHEMA = DATABASE\(\) AND [\s\S]+;$/.exec(sql)
+    return json ? [{ name: json[1], sql, json: true }] : []
   })
   const seed = statements.find((sql) => /^INSERT INTO `__gateway_0097_preflight` \(`failure`\) VALUES/.test(sql))
   const names = seed ? [...seed.matchAll(/'(0097_[a-z0-9_]+)'/g)].map((match) => match[1]) : []
-  if (rename < 0 || names.length < 10 || queries.length !== names.length
+  // Only the reviewed recovery SQL has this mixed result contract. Reconstruct
+  // the original bytes, rather than trusting a caller-supplied plan hash, so
+  // unknown predicates, packets or layouts cannot silently lose a guard.
+  const sourceHash = createHash("sha256").update(migration.sql.join("--> statement-breakpoint")).digest("hex")
+  if (sourceHash !== "2882d271052bd27a6281e5a1b161056546c817d27e218ba69fecd5f00cb4db9a"
+    || rename < 0 || names.length !== 10 || new Set(names).size !== 10 || queries.length !== 12
+    || queries.filter((query) => query.json).length !== 5
     || new Set(queries.map((query) => query.name)).size !== names.length
-    || names.some((name) => !queries.some((query) => query.name === name))) {
+    || names.some((name) => queries.filter((query) => query.name === name).length
+      !== (name === "0097_requires_complete_0096_schema" ? 3 : 1))) {
     throw new MigrationSafetyError("0097 preflight layout changed; review local startup integration before execution.")
   }
   return queries
@@ -49,7 +58,17 @@ export function matrixPreflightQueries(plan: MigrationPlan) {
 export async function preflightMatrix(executor: Executor, plan: MigrationPlan, completeSchema = true) {
   for (const query of matrixPreflightQueries(plan)) {
     if (!completeSchema && query.name === "0097_requires_complete_0096_schema") continue
-    if ((await executor.query(query.sql)).length) throw new MigrationSafetyError(`Preflight rejected ${query.name}; no rows were changed. ${recovery}`)
+    const rows = await executor.query(query.sql)
+    let passed = rows.length === 0
+    if (query.json) {
+      let value: unknown = rows[0]?.preflight
+      if (typeof value === "string") {
+        try { value = JSON.parse(value) } catch { value = undefined }
+      }
+      passed = rows.length === 1 && record(value) && Object.keys(value).length === 0
+        && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
+    }
+    if (!passed) throw new MigrationSafetyError(`Preflight rejected ${query.name}; no rows were changed. ${recovery}`)
   }
 }
 

--- a/ee/packages/den-db/scripts/migration-baseline.ts
+++ b/ee/packages/den-db/scripts/migration-baseline.ts
@@ -66,7 +66,14 @@ export type MigrationPlan = ReturnType<typeof loadMigrationPlan>
 export function historyPrefix(plan: MigrationPlan, rows: Record<string, unknown>[]) {
   for (const [index, row] of rows.entries()) {
     const entry = plan[index]
-    if (!entry || row.hash !== entry.hash || Number(row.created_at) !== entry.folderMillis) {
+    // 0097 changed only metadata preflights and comment placement. Recognize
+    // its original receipt only against this exact reviewed replacement;
+    // retain the receipt and applied prefix, never replay or restamp it.
+    const originalGatewayReceipt = entry?.tag === "0097_gateway_access_matrix"
+      && entry.folderMillis === 1788895934602
+      && entry.hash === "2882d271052bd27a6281e5a1b161056546c817d27e218ba69fecd5f00cb4db9a"
+      && row.hash === "dec021c8b3bb9fb139b3e0737ac5618ab1ed74d64d82fe36e1fcfe71306f378d"
+    if (!entry || (row.hash !== entry.hash && !originalGatewayReceipt) || Number(row.created_at) !== entry.folderMillis) {
       throw new MigrationSafetyError(`Migration history is not an exact hash/timestamp prefix at receipt ${index + 1}. ${recovery}`)
     }
   }

--- a/ee/packages/den-db/test/gateway-preflight.test.ts
+++ b/ee/packages/den-db/test/gateway-preflight.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const migration = readFileSync(new URL("../drizzle/0097_gateway_access_matrix.sql", import.meta.url), "utf8")
+const packets = migration.split("--> statement-breakpoint")
+const statements = packets.map((packet) => packet.replace(/^\s*--[^\n]*$/gm, "").trim()).filter(Boolean)
+const metadata = statements.filter((sql) => /information_schema\./i.test(sql))
+
+test("0097 keeps canonical LF bytes for its reviewed migration hash", () => {
+  const attributes = readFileSync(new URL("../../../../.gitattributes", import.meta.url), "utf8")
+  assert.match(attributes, /^\/ee\/packages\/den-db\/drizzle\/0097_gateway_access_matrix\.sql text eol=lf$/m)
+  assert.equal(migration.includes("\r"), false)
+})
+const sourceTables = [
+  "inference_providers", "inference_provider_models", "inference_provider_credentials",
+  "inference_provider_access", "inference_provider_oauth_states",
+  "inference_request_logs", "inference_usage_rollups", "inference_rollup_lock",
+]
+const observationColumns = [
+  "input_tokens_count", "output_tokens_count", "total_tokens_count", "cache_read_tokens_count",
+  "cache_write_tokens_count", "reasoning_tokens_count", "cost_count", "latency_count",
+  "ttfb_count", "request_bytes_count", "response_bytes_count",
+]
+const destinationTables = [
+  "gateway_providers", "gateway_provider_models", "gateway_provider_credentials",
+  "gateway_provider_access", "gateway_provider_oauth_states", "gateway_request_logs",
+  "gateway_usage_rollups", "gateway_rollup_lock", "gateway_keys", "gateway_model_groups",
+  "gateway_model_group_models", "gateway_credential_sets",
+]
+const requiredIndexes = [
+  ["inference_providers", "inference_providers_organization_id"],
+  ["inference_providers", "inference_providers_org_provider_id"],
+  ["inference_provider_models", "inference_provider_models_model_id"],
+  ["inference_provider_models", "inference_provider_models_provider_model"],
+  ["inference_provider_credentials", "inference_provider_credentials_org_membership_id"],
+  ["inference_provider_credentials", "inference_provider_credentials_organization_id"],
+  ["inference_provider_credentials", "inference_provider_credentials_provider_subject"],
+  ["inference_provider_access", "inference_provider_access_org_membership_id"],
+  ["inference_provider_access", "inference_provider_access_team_id"],
+  ["inference_provider_access", "inference_provider_access_provider_org_membership"],
+  ["inference_provider_access", "inference_provider_access_provider_team"],
+  ["inference_provider_oauth_states", "inference_provider_oauth_states_state"],
+  ["inference_provider_oauth_states", "inference_provider_oauth_states_expires_at"],
+  ["inference_request_logs", "inference_request_logs_openwork_request_id"],
+  ["inference_request_logs", "inference_request_logs_org_started"],
+  ["inference_request_logs", "inference_request_logs_member_started"],
+  ["inference_request_logs", "inference_request_logs_provider_started"],
+  ["inference_request_logs", "inference_request_logs_started_at"],
+  ["inference_usage_rollups", "inference_usage_rollups_bucket_dimension"],
+  ["inference_usage_rollups", "inference_usage_rollups_org_granularity_bucket"],
+]
+
+test("0097 metadata guards preserve the exact source predicates and fail-closed counts", () => {
+  const quoted = (names: string[]) => names.map((name) => `'${name}'`).join(", ")
+  const expected = [
+    { count: "COUNT(*) = 8", reason: "0097_requires_complete_0096_schema", table: "TABLES",
+      predicate: `TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME IN (${quoted(sourceTables)})` },
+    { count: "COUNT(*) = 11", reason: "0097_requires_complete_0096_schema", table: "COLUMNS",
+      predicate: `TABLE_NAME = 'inference_usage_rollups' AND COLUMN_NAME IN (${quoted(observationColumns)})` },
+    { count: "COUNT(*) = 1", reason: "0097_requires_complete_0096_schema", table: "COLUMNS",
+      predicate: "TABLE_NAME = 'inference_keys' AND COLUMN_NAME = 'encrypted_key'" },
+    { count: "COUNT(*) = 0", reason: "0097_gateway_tables_already_exist", table: "TABLES",
+      predicate: `TABLE_NAME IN (${quoted(destinationTables)})` },
+    { count: "COUNT(DISTINCT TABLE_NAME, INDEX_NAME) = 20", reason: "0097_missing_legacy_indexes", table: "STATISTICS",
+      predicate: `(${requiredIndexes.map(([table, index]) => `(TABLE_NAME = '${table}' AND INDEX_NAME = '${index}')`).join(" OR ")})` },
+  ]
+  const normalize = (sql: string) => sql.replace(/\s+/g, " ").replace(/\( /g, "(").replace(/ \)/g, ")").trim()
+  assert.equal(metadata.length, 5)
+  assert.deepEqual(metadata.map(normalize), expected.map(({ count, reason, table, predicate }) => normalize(
+    `SELECT JSON_EXTRACT(IF(${count}, '{}', '${reason}'), '$') AS preflight
+     FROM information_schema.${table} WHERE TABLE_SCHEMA = DATABASE() AND ${predicate};`,
+  )))
+  for (const sql of metadata) {
+    assert.equal(sql.match(/\bSELECT\b/gi)?.length, 1)
+    assert.doesNotMatch(sql, /\b(?:INSERT|UPDATE|DELETE|JOIN|UNION|EXISTS|HAVING)\b/i)
+  }
+  const rename = statements.findIndex((sql) => sql.startsWith("RENAME TABLE"))
+  assert.ok(rename > 0)
+  assert.ok(metadata.every((sql) => statements.indexOf(sql) < rename))
+})
+
+test("0097 keeps every non-metadata SQL packet unchanged from the recovery base", () => {
+  // Fingerprint of comment-stripped non-metadata packets at 667b450fd; original
+  // full SQL SHA-256: dec021c8b3bb9fb139b3e0737ac5618ab1ed74d64d82fe36e1fcfe71306f378d.
+  // Includes temporary guard creation/seeds/drop, version/mode/data guards,
+  // and every persistent DDL, backfill and index change, in their original order.
+  const unchanged = statements.filter((sql) => !/information_schema\./i.test(sql))
+  assert.equal(statements.length, 40)
+  assert.equal(unchanged.length, 35)
+  assert.equal(createHash("sha256").update(unchanged.join("\n--> statement-breakpoint\n")).digest("hex"),
+    "6dd874e369061b0b85623ecbec6073c52cb61bdabc718efbfd7373694e9300dd")
+})
+
+test("0097-0099 breakpoint packets end in SQL, not trailing comments", () => {
+  for (const file of ["0097_gateway_access_matrix.sql", "0098_gateway_provider_model_universe.sql", "0099_gateway_credential_set_creator.sql"]) {
+    const sql = readFileSync(new URL(`../drizzle/${file}`, import.meta.url), "utf8")
+    for (const [index, packet] of sql.split("--> statement-breakpoint").entries()) {
+      assert.ok(packet.trim().endsWith(";"), `${file} packet ${index + 1} must end with its SQL semicolon`)
+      const executable = packet.replace(/^\s*--[^\n]*$/gm, "").trim()
+      assert.equal(executable.match(/;/g)?.length, 1, `${file} packet ${index + 1} must contain one statement`)
+    }
+  }
+})

--- a/ee/packages/den-db/test/migration-readiness.test.ts
+++ b/ee/packages/den-db/test/migration-readiness.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict"
 import { spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
 import { readdirSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { describe, test } from "node:test"
 import { fileURLToPath } from "node:url"
 import { generateMySQLDrizzleJson } from "drizzle-kit/api"
 import * as schema from "../src/schema.ts"
-import { localConnectionConfig, matrixPreflightQueries, migrateLocalDatabase } from "../scripts/dev-migrate.ts"
+import { localConnectionConfig, matrixPreflightQueries, migrateLocalDatabase, preflightMatrix } from "../scripts/dev-migrate.ts"
 import { foundationSql, historyPrefix, journalTable, loadMigrationPlan, planAuthLookupIndexRepairs, recognizeBaseline, schemaDifferences, snapshotShape, stateTable } from "../scripts/migration-baseline.ts"
 
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
@@ -80,6 +81,9 @@ describe("local startup migration safety (offline)", () => {
       if (sql.startsWith(`SELECT hash, created_at FROM \`${journalTable}\``)) return options.receipts ?? []
       if (sql.startsWith(`SELECT 1 FROM \`${stateTable}\``)) return options.dirty ? [{ present: 1 }] : []
       if (options.invalid && sql.startsWith(`SELECT '${options.invalid}'`)) return [{ invalid: 1 }]
+      if (sql.startsWith("SELECT JSON_EXTRACT")) {
+        return [{ preflight: options.invalid && sql.includes(`'${options.invalid}'`) ? { invalid: true } : {} }]
+      }
       return []
     } }
     return { executor, queries }
@@ -103,6 +107,164 @@ describe("local startup migration safety (offline)", () => {
     assert.throws(() => historyPrefix(plan, receipts.slice(1)), /exact hash\/timestamp prefix/)
     assert.throws(() => historyPrefix(plan, [{ ...receipts[0], hash: "dirty" }]), /exact hash\/timestamp prefix/)
     assert.throws(() => historyPrefix(plan, [...receipts, receipts[95]]), /exact hash\/timestamp prefix/)
+  })
+
+  test("0097 current and known original receipts retain the same applied prefix without restamping", () => {
+    const current = plan[96]
+    assert.equal(current.tag, "0097_gateway_access_matrix")
+    assert.equal(current.folderMillis, 1788895934602)
+    assert.equal(current.hash, "2882d271052bd27a6281e5a1b161056546c817d27e218ba69fecd5f00cb4db9a")
+    for (const hash of [current.hash, "dec021c8b3bb9fb139b3e0737ac5618ab1ed74d64d82fe36e1fcfe71306f378d"]) {
+      for (const created_at of [1788895934602, "1788895934602"]) {
+        const receipts = plan.slice(0, 97).map((entry) => ({ hash: entry.hash, created_at: entry.folderMillis }))
+        const recorded = [...receipts.slice(0, 96), { hash, created_at }]
+        const before = structuredClone(recorded)
+        assert.equal(historyPrefix(plan, recorded), 97)
+        assert.deepEqual(recorded, before)
+        assert.deepEqual(plan.slice(historyPrefix(plan, recorded)).map((entry) => entry.tag), [
+          "0098_gateway_provider_model_universe", "0099_gateway_credential_set_creator",
+        ])
+      }
+    }
+  })
+
+  test("0097 receipt alias rejects unknown hashes, tags, timestamps, source changes and older drift", () => {
+    const receipts = plan.slice(0, 97).map((entry) => ({ hash: entry.hash, created_at: entry.folderMillis }))
+    receipts[96].hash = "dec021c8b3bb9fb139b3e0737ac5618ab1ed74d64d82fe36e1fcfe71306f378d"
+    const changedSql = [...plan[96].sql, "SELECT 1;"]
+    for (const replacement of [
+      { ...plan[96], tag: "0097_unreviewed_migration" },
+      { ...plan[96], folderMillis: 1788895934603 },
+      { ...plan[96], sql: changedSql, hash: createHash("sha256").update(changedSql.join("--> statement-breakpoint")).digest("hex") },
+    ]) {
+      const alteredPlan = plan.map((entry, index) => index === 96 ? replacement : entry)
+      const matchingTime = receipts.map((row, index) => index === 96 ? { ...row, created_at: replacement.folderMillis } : row)
+      assert.throws(() => historyPrefix(alteredPlan, matchingTime), /exact hash\/timestamp prefix at receipt 97/)
+    }
+    for (const row of [
+      { ...receipts[96], hash: "unknown" },
+      { ...receipts[96], created_at: 1788895934603 },
+      { hash: plan[96].hash, created_at: 1788895934603 },
+    ]) {
+      assert.throws(() => historyPrefix(plan, [...receipts.slice(0, 96), row]), /exact hash\/timestamp prefix at receipt 97/)
+    }
+    for (const index of [2, 9, 14, 94, 95, 97, 98]) {
+      const olderDrift = plan.map((entry) => ({ hash: entry.hash, created_at: entry.folderMillis }))
+      olderDrift[96] = { ...receipts[96] }
+      olderDrift[index].hash = receipts[96].hash
+      assert.throws(() => historyPrefix(plan, olderDrift), new RegExp(`exact hash/timestamp prefix at receipt ${index + 1}\\.`))
+    }
+  })
+
+  test("original 0097 receipts still require schema parity and do not rerun matrix guards", async () => {
+    for (const applied of [97, 99]) {
+      const receipts = plan.slice(0, applied).map((entry) => ({ hash: entry.hash, created_at: entry.folderMillis }))
+      receipts[96].hash = "dec021c8b3bb9fb139b3e0737ac5618ab1ed74d64d82fe36e1fcfe71306f378d"
+      const before = structuredClone(receipts)
+      const shape = shapeAt(`00${applied}_`)
+      const healthy = fixture(shape, { receipts })
+      await migrateLocalDatabase(healthy.executor, plan, true)
+      assert.ok(healthy.queries.every((sql) => sql.startsWith("SELECT")))
+      assert.ok(matrixPreflightQueries(plan).every((guard) => !healthy.queries.includes(guard.sql)))
+      const drifted = new Map(shape)
+      drifted.delete("column:gateway_provider_access.model_group_id")
+      const invalid = fixture(drifted, { receipts })
+      await assert.rejects(migrateLocalDatabase(invalid.executor, plan, true), /Schema differs from its recorded migration/)
+      assert.ok(invalid.queries.every((sql) => sql.startsWith("SELECT")))
+      assert.deepEqual(receipts, before)
+    }
+  })
+
+  test("matrix extraction preserves exactly five JSON assertions and seven INSERT-derived guards", () => {
+    const queries = matrixPreflightQueries(plan)
+    assert.deepEqual(queries.map(({ name, json }) => [name, json]), [
+      ["0097_requires_mysql_8_0_16_or_later", false],
+      ["0097_requires_strict_sql_mode", false],
+      ["0097_requires_complete_0096_schema", true],
+      ["0097_requires_complete_0096_schema", true],
+      ["0097_requires_complete_0096_schema", true],
+      ["0097_gateway_tables_already_exist", true],
+      ["0097_missing_legacy_indexes", true],
+      ["0097_invalid_typeid", false],
+      ["0097_orphan_or_cross_org_resource", false],
+      ["0097_invalid_credential_subject", false],
+      ["0097_invalid_audience", false],
+      ["0097_duplicate_audience_grants", false],
+    ])
+    assert.ok(queries.every((query) => query.sql.startsWith("SELECT")))
+  })
+
+  test("matrix extraction rejects missing, duplicate, unknown or altered guard layouts", () => {
+    const mutations: ((sql: string[]) => string[])[] = [
+      (sql) => sql.filter((packet) => !packet.includes("COUNT(*) = 11")),
+      (sql) => [...sql.slice(0, 4), sql[4], ...sql.slice(4)],
+      (sql) => [...sql.slice(0, 4), "SELECT 1;", ...sql.slice(4)],
+      (sql) => sql.map((packet) => packet.replace("COUNT(*) = 8", "COUNT(*) = 7")),
+      (sql) => sql.map((packet) => packet.replace("AND TABLE_TYPE = 'BASE TABLE'", "")),
+      (sql) => sql.map((packet) => packet.replace("AS preflight", "AS ignored")),
+      (sql) => sql.map((packet) => packet.replace("'0097_invalid_typeid'", "'0097_unknown_guard'")),
+      (sql) => sql.map((packet) => packet.replace("  ('0097_invalid_audience'),", "")),
+      (sql) => sql.filter((packet) => !packet.includes("DROP TEMPORARY TABLE")),
+      (sql) => sql.map((packet) => packet.replace("RENAME TABLE", "SELECT")),
+    ]
+    for (const mutate of mutations) {
+      const altered = plan.map((entry) => entry.tag === "0097_gateway_access_matrix" ? { ...entry, sql: mutate([...entry.sql]) } : entry)
+      // The original plan hash is deliberately retained: layout checks must
+      // inspect SQL bytes, not trust a stale hash alongside changed packets.
+      assert.throws(() => matrixPreflightQueries(altered), /0097 preflight layout changed/)
+    }
+  })
+
+  test("matrix JSON guards accept only one empty-object row while INSERT guards require no rows", async () => {
+    const queries = matrixPreflightQueries(plan)
+    for (const value of [{}, "{}", " \n{ }\t"]) {
+      const called: string[] = []
+      await preflightMatrix({ query: async (sql) => {
+        called.push(sql)
+        return sql.startsWith("SELECT JSON_EXTRACT") ? [{ preflight: value }] : []
+      } }, plan)
+      assert.deepEqual(called, queries.map((query) => query.sql))
+    }
+    const invalidRows: Record<string, unknown>[][] = [
+      [], [{}], [{ preflight: {} }, { preflight: {} }], [{ preflight: undefined }],
+      ...[null, false, 0, [], { unexpected: true }, new Date(0), "", "invalid", "null", "[]", "false", "0", '"{}"', '{"unexpected":true}', "{} trailing"]
+        .map((preflight) => [{ preflight }]),
+    ]
+    for (const target of queries) {
+      for (const rows of target.json ? invalidRows : [[{ failure: target.name }]]) {
+        const called: string[] = []
+        await assert.rejects(preflightMatrix({ query: async (sql) => {
+          called.push(sql)
+          return sql === target.sql ? rows : sql.startsWith("SELECT JSON_EXTRACT") ? [{ preflight: {} }] : []
+        } }, plan), /Preflight rejected/)
+        assert.deepEqual(called, queries.slice(0, queries.indexOf(target) + 1).map((query) => query.sql))
+      }
+    }
+  })
+
+  test("pre-0096 inspection skips all three schema assertions only and query errors abort", async () => {
+    const all = matrixPreflightQueries(plan)
+    const required = all.filter((query) => query.name !== "0097_requires_complete_0096_schema")
+    assert.equal(all.length - required.length, 3)
+    const called: string[] = []
+    await preflightMatrix({ query: async (sql) => {
+      called.push(sql)
+      return sql.startsWith("SELECT JSON_EXTRACT") ? [{ preflight: {} }] : []
+    } }, plan, false)
+    assert.deepEqual(called, required.map((query) => query.sql))
+    for (const completeSchema of [false, true]) {
+      const expected = completeSchema ? all : required
+      for (const target of expected) {
+        const failure = new Error("synthetic query failure")
+        const attempted: string[] = []
+        await assert.rejects(preflightMatrix({ query: async (sql) => {
+          attempted.push(sql)
+          if (sql === target.sql) throw failure
+          return sql.startsWith("SELECT JSON_EXTRACT") ? [{ preflight: {} }] : []
+        } }, plan, completeSchema), (error: unknown) => error === failure)
+        assert.deepEqual(attempted, expected.slice(0, expected.indexOf(target) + 1).map((query) => query.sql))
+      }
+    }
   })
 
   const lookupKeys = [

--- a/ee/packages/den-db/test/migration-schema-parity.test.ts
+++ b/ee/packages/den-db/test/migration-schema-parity.test.ts
@@ -575,6 +575,69 @@ test("migrations replay to exported schema and config object version inserts", {
   }
 })
 
+test("0097 metadata JSON guards accept 0096 and reject missing or conflicting metadata", { skip: !mysqlUrl, timeout: 120_000 }, async () => {
+  if (!mysqlUrl) return
+
+  const root = await mysql.createConnection(mysqlUrl)
+  const database = scratchDatabaseName()
+  let connection: mysql.Connection | undefined
+
+  try {
+    await root.query(`CREATE DATABASE ${quoteIdentifier(database)}`)
+    connection = await mysql.createConnection(databaseUrlFor(mysqlUrl, database))
+    await connection.query("CREATE TABLE `inference_keys` (`id` varchar(64) PRIMARY KEY)")
+    for (const file of ["0095_inference_gateway_providers.sql", "0096_inference_accounting_observations.sql"]) {
+      const sql = await readFile(join(migrationsFolder, file), "utf8")
+      await applyStatements(connection, sql.split("--> statement-breakpoint").map((packet) => packet.trim()).filter(Boolean))
+    }
+    const sql = await readFile(join(migrationsFolder, "0097_gateway_access_matrix.sql"), "utf8")
+    const guards = sql.split("--> statement-breakpoint")
+      .map((packet) => packet.replace(/^\s*--[^\n]*$/gm, "").trim())
+      .filter((packet) => /information_schema\./i.test(packet))
+    assert.equal(guards.length, 5)
+    for (const guard of guards) {
+      const rows = await queryRecords(connection, guard)
+      assert.equal(rows.length, 1)
+      const value = rows[0].preflight
+      assert.deepEqual(typeof value === "string" ? JSON.parse(value) : value, {})
+    }
+
+    const scenarios = [
+      { guard: 0, change: "RENAME TABLE `inference_rollup_lock` TO `preflight_decoy`",
+        restore: "RENAME TABLE `preflight_decoy` TO `inference_rollup_lock`" },
+      { guard: 1, change: "ALTER TABLE `inference_usage_rollups` DROP COLUMN `response_bytes_count`",
+        restore: "ALTER TABLE `inference_usage_rollups` ADD `response_bytes_count` bigint" },
+      { guard: 2, change: "ALTER TABLE `inference_keys` DROP COLUMN `encrypted_key`",
+        restore: "ALTER TABLE `inference_keys` ADD `encrypted_key` text" },
+      { guard: 3, change: "CREATE TABLE `gateway_providers` (`id` int)", restore: "DROP TABLE `gateway_providers`" },
+      { guard: 3, change: "CREATE VIEW `gateway_credential_sets` AS SELECT 1 AS id", restore: "DROP VIEW `gateway_credential_sets`" },
+      ...[...guards[4].matchAll(/TABLE_NAME = '([^']+)' AND INDEX_NAME = '([^']+)'/g)].map((match) => ({
+        guard: 4,
+        change: `ALTER TABLE ${quoteIdentifier(match[1])} RENAME INDEX ${quoteIdentifier(match[2])} TO \`preflight_decoy\``,
+        restore: `ALTER TABLE ${quoteIdentifier(match[1])} RENAME INDEX \`preflight_decoy\` TO ${quoteIdentifier(match[2])}`,
+      })),
+    ]
+    for (const scenario of scenarios) {
+      await connection.query(scenario.change)
+      try {
+        await assert.rejects(connection.query(guards[scenario.guard]), (error: unknown) => {
+          assert.ok(isRecord(error))
+          assert.equal(error.code, "ER_INVALID_JSON_TEXT_IN_PARAM")
+          assert.equal(error.errno, 3141)
+          return true
+        })
+      } finally {
+        await connection.query(scenario.restore)
+      }
+      await connection.query(guards[scenario.guard])
+    }
+  } finally {
+    await connection?.end().catch(() => {})
+    await root.query(`DROP DATABASE IF EXISTS ${quoteIdentifier(database)}`).catch(() => {})
+    await root.end()
+  }
+})
+
 test("0076 migrates workflow table, enums, and legacy data without changing IDs", { skip: !mysqlUrl, timeout: 120_000 }, async () => {
   if (!mysqlUrl) return
 


### PR DESCRIPTION
## Summary

Repair the pending `0097_gateway_access_matrix` migration after the production job failed on Vitess metadata query planning: [failed run](https://github.com/different-ai/openwork/actions/runs/34612414683/job/103305926859).

- Replace three metadata-in-DML/compound guards with five flat, fail-closed metadata SELECTs. Valid prerequisites return `{}`; invalid ones raise SQL error 3141, rather than a warning. Preserve the original table, column, destination, and index predicates.
- Move the final explanatory comments before their ALTER. Vitess rejects a trailing comment after the semicolon with `Expected a single statement`; the statement itself succeeds without that framing.
- Preserve every version/mode/data guard and persistent DDL/backfill packet. Do not change migrations 1–96, 0098, 0099, journal timestamps, or schema snapshots.
- Adapt the local startup guard/result contract. Retain already-applied original-0097 receipts only for the exact known old hash, tag, timestamp, and reviewed replacement hash; do not replay or restamp them. All other history and schema checks remain enforced.
- Pin this migration to LF checkout bytes so its explicit safety hash works across platforms.

## Recovery boundary — read before merging

The operator-supplied journal export contains receipts 1–96, with matching 0095/0096 hashes and no 0097 receipt. This is not evidence that only migration 96 ran. Older 0003/0010/0015 hash discrepancies remain flagged and untouched; this PR does not certify or rewrite the whole historical journal.

**Merging can trigger the existing production migration workflow.** Coordinate its scheduled retries, confirm the current production schema/receipt state and absence of partial 0097 effects, and establish the required maintenance/cutover conditions before merging. No production migration, deploy request, journal write, or deployment was executed for this PR.

The disposable PlanetScale diagnostic branch is already at schema 0099 with zero journal rows. Do not run the full migrator against it or treat a schema-only branch merge as proof that production data backfills have run.

## Verification

- Offline preflight and local-readiness checks: **36 passed, 0 failed, 0 skipped**.
- `db:migrate:local --check-artifacts`: 99 ordered migrations and 41 foundation statements validated offline.
- Targeted MySQL 8.4.10 fixture: **11 passed, 0 failed, 0 skipped**, including full migration replay/schema parity, five positive guards and 25 negative metadata scenarios. Owned fixture containers were removed.
- Read-only Vitess 8.4.11 probes: flat table/column/index and distinct-table/index-count predicates returned success for valid counts and error 3141 for invalid counts.
- Read-only parser probe: a SELECT followed by a trailing comment failed with error 1105; the identical SELECT without that comment succeeded.
- `git diff --check` and LF attribute inspection passed.

Earlier diagnostic execution completed the remaining SQL through 0099 on an empty Vitess branch using equivalent client metadata checks and corrected final-statement framing. That is not a populated-data rehearsal of this complete corrected SQL file. Populated Vitess backfill and production-state verification remain rollout prerequisites.

Initial local fixture setup attempts encountered a Docker inspection-shape error and an uninherited Node development condition. Both were corrected without weakening assertions; the final targeted run passed. No full application suite was run.
