### PR TITLE
fix(app): announce earlier messages only while a read is in flight

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -179,10 +179,16 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput) {
       if (second !== undefined) window.cancelAnimationFrame(second);
     };
   }, [input.owner, query.isSuccess, hasFullSnapshot]);
+  const snapshot = hasFullSnapshot ? null : query.data?.snapshot ?? null;
+  const limit = openingHistoryWindow(saved).limit;
   return {
     saved,
     options,
-    snapshot: hasFullSnapshot ? null : query.data?.snapshot ?? null,
+    snapshot,
+    // A newest window that came back shorter than its limit already holds the
+    // whole conversation. Only a full window, a saved-position window, or an
+    // unavailable preview can still be missing earlier messages.
+    partial: snapshot === null || limit === undefined || snapshot.messages.length >= limit,
     backgroundReady: hasFullSnapshot || backgroundOwner === input.owner,
     ensureFullSnapshot,
     runWithFullSnapshot,
@@ -207,15 +213,22 @@ export function SessionHistoryLoading({ saved, failed = false }: { saved: Sessio
   </div>;
 }
 
-export function SessionHistoryStatus({ complete, pending, failed, onRetry }: {
+export function SessionHistoryStatus({ complete, pending, loading, failed, onRetry }: {
   complete: boolean;
   pending: boolean;
+  /** The uncapped read is in flight and may still add earlier messages. */
+  loading: boolean;
   failed: boolean;
   onRetry: () => Promise<unknown>;
 }) {
   const [retrying, setRetrying] = useState(false);
   const retryPending = useRef(false);
   if (complete || (pending && !failed && !retrying)) return null;
+  // Only a read that is actually in flight may announce loading. A read that
+  // is not enabled yet, paused, or reverted by a cancellation has nothing to
+  // report, and an announcement derived from missing history alone would sit
+  // over the first message with nothing left to clear it.
+  if (!loading && !failed && !retrying) return null;
   return <div data-thread-history-status className="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
     <div role={failed && !retrying ? "alert" : "status"} aria-live="polite" className="pointer-events-auto flex items-center gap-2 rounded-md bg-dls-surface/95 px-3 py-1 text-xs text-dls-secondary shadow-sm">
       <span>{retrying ? pending ? "Loading conversation…" : "Loading earlier messages…" : failed

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -3309,6 +3309,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
           </div>
         </div>
         <SessionHistoryStatus key={sessionOwner} complete={hasFullHistory} pending={pendingSessionLoad}
+          loading={snapshotQuery.isFetching && openingHistory.partial}
           failed={snapshotQuery.isError && !snapshotQuery.isFetching} onRetry={() => snapshotQuery.refetch()} />
         <SessionScrollOverlay
           sessionId={props.sessionId}

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -40,6 +40,9 @@ afterAll(async () => {
   if (ownedDom) await GlobalRegistrator.unregister();
 });
 
+// A newest window that fills its limit may still be missing earlier messages.
+const fullWindow = Array.from({ length: 24 }, (_, index) => `w${index}`);
+
 function snapshot(id: string, title: string, ids: string[] = [], revert?: string): OpenworkSessionSnapshot {
   return {
     session: { id, title, version: "1", time: { created: 1, updated: 1 }, revert: revert ? { messageID: revert } : undefined },
@@ -97,7 +100,7 @@ function fixture() {
     const failed = full.isError && !full.isFetching;
     return <><span>Composer {owner}</span><input aria-label="Draft" /><div className="relative"><div data-thread-scroll><SessionHistoryBoundary owner={cacheOwner} pending={pending} saved={opening.saved} failed={failed}>
       <div>{current?.session.title}</div>{messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.id}</div>)}
-    </SessionHistoryBoundary></div><SessionHistoryStatus key={cacheOwner} complete={Boolean(full.data)} pending={pending} failed={failed} onRetry={() => full.refetch()} /></div></>;
+    </SessionHistoryBoundary></div><SessionHistoryStatus key={cacheOwner} complete={Boolean(full.data)} pending={pending} loading={full.isFetching && opening.partial} failed={failed} onRetry={() => full.refetch()} /></div></>;
   }
   async function renderInput(options: ReturnType<typeof input>, mount: { strict?: boolean; onMount?: (ensure: () => Promise<OpenworkSessionSnapshot>) => void } = {}) {
     const tree = <QueryClientProvider client={client}><Harness options={options} onMount={mount.onMount} /></QueryClientProvider>;
@@ -339,27 +342,34 @@ describe("opening a thread", () => {
   test("partial, failed, retrying, and complete history status stays outside the reader's scroll geometry", async () => {
     const view = fixture();
     await view.render();
-    await view.resolve(0, snapshot("a", "Reading preview", ["anchor"]));
+    await view.resolve(0, snapshot("a", "Reading preview", [...fullWindow, "anchor"]));
     const scroller = view.host.querySelector<HTMLDivElement>("[data-thread-scroll]");
     if (!scroller) throw new Error("Missing scroll viewport");
     scroller.scrollTop = 800;
     const anchor = scroller.querySelector('[data-message-id="anchor"]');
-    const checkGeometry = () => {
+    const checkGeometry = (status: string | null) => {
       expect(view.host.querySelector("[data-thread-scroll]")).toBe(scroller);
       expect(scroller.scrollTop).toBe(800);
       expect(scroller.querySelector('[data-message-id="anchor"]')).toBe(anchor);
       expect(scroller.querySelector("[data-thread-history-status]")).toBeNull();
-      expect(view.host.querySelector("[data-thread-history-status]")?.className).toContain("absolute");
+      const element = view.host.querySelector("[data-thread-history-status]");
+      if (status === null) expect(element).toBeNull();
+      else {
+        expect(element?.className).toContain("absolute");
+        expect(element?.textContent).toContain(status);
+      }
     };
-    checkGeometry();
+    // Nothing is in flight until the uncapped read is staged.
+    checkGeometry(null);
     await paint();
     await paint();
+    checkGeometry("Loading earlier messages…");
     await act(async () => view.reads[1].reject(new Error("Full read unavailable")));
     await settle();
-    checkGeometry();
+    checkGeometry("could not be loaded");
     await act(async () => view.host.querySelector("button")?.click());
-    checkGeometry();
-    await view.resolve(2, snapshot("a", "Full history", ["before", "anchor", "after"]));
+    checkGeometry("Retrying…");
+    await view.resolve(2, snapshot("a", "Full history", ["before", ...fullWindow, "anchor", "after"]));
     expect(scroller.scrollTop).toBe(800);
     expect(scroller.querySelector('[data-message-id="anchor"]')).toBe(anchor);
     expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
@@ -565,10 +575,12 @@ describe("opening a thread", () => {
     expect(view.host.querySelector('[data-thread-loading-visual]')).toBeNull();
     expect(view.host.textContent).toContain("Composer a");
     expect(view.reads.map((read) => read.window)).toEqual([{ limit: 24 }]);
-    await view.resolve(0, "Latest messages");
+    await view.resolve(0, snapshot("a", "Latest messages", fullWindow));
     expect(view.host.querySelector('[data-thread-loading-visual]')).toBeNull();
     expect(view.host.textContent).toContain("Latest messages");
     expect(view.reads).toHaveLength(1);
+    // The window is full, yet nothing is loading until the read is staged.
+    expect(view.host.querySelector('[role="status"]')).toBeNull();
     await paint();
     expect(view.reads).toHaveLength(1);
     await paint();
@@ -582,6 +594,46 @@ describe("opening a thread", () => {
     expect(view.host.querySelector('[role="status"]')).toBeNull();
     await act(async () => { jest.advanceTimersByTime(150); });
     expect(view.host.querySelector('[data-thread-loading-visual]')).toBeNull();
+  });
+
+  test("a short preview never announces earlier messages, and a reverted read does not stay announced", async () => {
+    // A newest window shorter than its limit is the whole conversation: the
+    // uncapped read still runs, but there are no earlier messages to announce
+    // over the first one.
+    const short = fixture();
+    await short.render();
+    await short.resolve(0, snapshot("a", "Whole conversation", ["first", "second"]));
+    await paint();
+    await paint();
+    expect(short.reads.map((read) => read.window)).toEqual([{ limit: 24 }, undefined]);
+    expect(short.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(short.host.querySelectorAll("[data-message-id]")).toHaveLength(2);
+    await short.resolve(1, snapshot("a", "Whole conversation", ["first", "second"]));
+    expect(short.host.querySelector("[data-thread-history-status]")).toBeNull();
+    await cleanups.pop()?.();
+
+    // A cancelled read reverts to idle without history. The announcement must
+    // follow the read, not the missing history, or it never clears.
+    const view = fixture();
+    await view.render();
+    await view.resolve(0, snapshot("a", "Partial window", fullWindow));
+    await paint();
+    await paint();
+    expect(view.host.querySelector('[role="status"]')?.textContent).toBe("Loading earlier messages…");
+    await act(async () => { await view.client.cancelQueries({ queryKey: snapshotKey("workspace", "a"), exact: true }); });
+    await settle();
+    expect(view.reads[1].signal.aborted).toBe(true);
+    expect(view.client.getQueryState(snapshotKey("workspace", "a"))).toMatchObject({ status: "pending", fetchStatus: "idle" });
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.host.querySelector('[role="alert"]')).toBeNull();
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(24);
+    await act(async () => { void view.client.refetchQueries({ queryKey: snapshotKey("workspace", "a"), exact: true }); });
+    await settle();
+    expect(view.reads).toHaveLength(3);
+    expect(view.host.querySelector('[role="status"]')?.textContent).toBe("Loading earlier messages…");
+    await view.resolve(2, snapshot("a", "Complete history", ["earlier", ...fullWindow]));
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(25);
   });
 
   test("saved positions request their own region, while a late previous-thread preview cannot render in the destination", async () => {


### PR DESCRIPTION
## Problem

In the desktop app, a "Loading earlier messages…" status appears at the top of the transcript, overlays the first message, and stays there after history has loaded. (ENG-12)

The status was derived from *"complete history has not landed yet"* rather than *"a read is running"*. Whenever the uncapped snapshot read was not enabled yet, paused, or reverted by a cancellation, the indicator announced loading with nothing left to clear it. For a conversation shorter than the 24-message opening window it also flashed a claim that was never true: that window already held the whole conversation.

## Change

- `SessionHistoryStatus` takes a `loading` prop and only announces loading while the uncapped snapshot read is actually fetching.
- `useOpeningSessionHistory` exposes `partial`: a newest window that came back shorter than its limit is the whole conversation, so no earlier-messages announcement is made for it.
- The surface passes `loading={snapshotQuery.isFetching && openingHistory.partial}`.

Unchanged: the failure banner, Retry, the "Retrying…" feedback, the boundary's "Loading latest messages…" state, and the status staying outside the reader's scroll geometry (the existing geometry test still guards `scrollTop` and the reading anchor).

Deferred: the ticket asks whether the indicator should be inline in the scroll container instead of an overlay. Moving it into the scroller would shift the reader's position when it appears or disappears, which the geometry test deliberately prevents; any placement change is a separate product decision.

## UI/UX impact

1. The "Loading earlier messages…" status no longer appears when no read is in flight. Before: it stayed over the first message indefinitely. After: it appears only while the uncapped read runs and clears when it settles.
2. The status no longer appears for conversations shorter than the 24-message opening window. Before: a brief false flash over the first message. After: nothing.
3. Everything else preserved: same placement, styling, failure banner, Retry, and retrying feedback.

## Verification

Verdict: **Incomplete** — no exact-head E2E evidence.

- `pnpm --filter @openwork/app exec bun test --isolate ./tests/session-history.test.tsx` → 24 pass, 0 fail (on the pushed head). One new test covers both failure modes: a short preview announces nothing, and a cancelled read reverted to idle does not stay announced and re-announces only when a read actually restarts. Two existing tests were updated to use a preview that fills its window, which is the only case that can be missing earlier messages.
- The same tests against the unchanged source fail on exactly those three assertions, so they discriminate.
- `pnpm --filter @openwork/app typecheck` → clean.
- Not run: no journey in `evals/specs` asserts this indicator. The closest covering journey is `new-split-session.e2e.test.ts` (a reopened conversation renders its earlier messages); it was not executed on this head.
