### PR TITLE
feat(agent): session.send messages a session by id without moving the person's pane

### DIFF
--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -80,7 +80,8 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const createTaskControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.create_task",
     label: "Create a new task",
-    description: "Create a new session in the selected workspace.",
+    description: "Create a new session in the selected workspace and open it in the person's focused pane. Use session.create to start sessions without changing what is on screen.",
+    effects: { data: "write", ui: "navigate", external: false },
     sideEffect: "mutation",
     disabled: !canCreateTask || !selectedWorkspaceId,
     execute: async () => {
@@ -110,7 +111,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const openSessionControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.open",
     label: "Open a session by ID",
-    description: "Focus a visible session or reuse its existing tab. Use list_sessions first to get the session ID.",
+    description: "Show a session to the person: focus it if visible, else open it in the focused pane. Only for when they should see it; use session.read to inspect and session.send to message a session without opening it.",
     effects: { data: "none", ui: "navigate", external: false },
     sideEffect: "navigation",
     requiresArgs: true,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2631,7 +2631,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const composerSetTextControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "composer.set_text",
     label: "Type into the composer",
-    description: "Replace the current session draft and type the supplied text visibly.",
+    description: "Replace the draft of the composer the person currently has focused and type the supplied text visibly. Focus-bound: it targets whichever pane is focused when it runs, never a session by id. To message another session use session.send.",
     effects: { data: "none", ui: "focus", external: false },
     sideEffect: "none",
     disabled: archived || !archiveStateKnown || archiveHeld,
@@ -2652,7 +2652,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const composerSendControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "composer.send",
     label: "Send the composer prompt",
-    description: "Send the currently visible composer draft to the active session.",
+    description: "Send the draft of the composer the person currently has focused to that session. Focus-bound: if focus moved since composer.set_text, the draft goes to the newly focused session. Disabled while that session is mid-turn. To message another session use session.send.",
     sideEffect: "mutation",
     disabled: archived || !archiveStateKnown || archiveHeld || sessionModelUnavailable || (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle" || queuedDrainState.phase.kind === "admission_unknown",
     targetRef: composerShellRef,
@@ -2666,7 +2666,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const composerStopControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "composer.stop",
     label: "Stop the current run",
-    description: "Stop the current streaming session run.",
+    description: "Stop the run of the session the person currently has focused. Focus-bound: it never targets a session by id.",
     sideEffect: "mutation",
     disabled: stopping || (!chatStreaming && queuedDrainState.phase.kind !== "sending" && queuedDrainState.phase.kind !== "admission_unknown"),
     targetRef: composerShellRef,

--- a/apps/app/tests/control-focus-bound-composer.test.tsx
+++ b/apps/app/tests/control-focus-bound-composer.test.tsx
@@ -1,0 +1,143 @@
+/** @jsxImportSource react */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, useMemo } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+
+import {
+  OpenworkControlProvider,
+  useControlAction,
+  type OpenworkControlAPI,
+  type OpenworkControlAction,
+} from "../src/react-app/shell/control/control-provider";
+
+/**
+ * Why acting on another session used to move the person's pane.
+ *
+ * The composer registers `composer.set_text` / `composer.send` only from the
+ * surface that is the control target (session-surface.tsx:
+ * `useControlAction(props.isControlTarget ? … : null)`, with
+ * `isControlTarget={activeWorkbenchPane === "primary" | "secondary"}` in
+ * session-page.tsx). There is one registration slot per action id, so the
+ * actions are bound to whichever pane is focused at execution time, not to a
+ * session. An agent that wanted to message session B therefore had to make B
+ * the focused pane first (session.open), which is the navigation the person
+ * saw, and any focus change between set_text and send re-pointed both actions
+ * at the newly focused session. This test pins that mechanics down so the
+ * headless path (session.send by id, executed on the server) is the documented
+ * way to reach a session.
+ */
+
+type Surface = { sessionId: string; drafts: string[]; sent: string[] };
+
+function ComposerSurface({ surface, controlTarget }: { surface: Surface; controlTarget: boolean }) {
+  const setText = useMemo<OpenworkControlAction>(() => ({
+    id: "composer.set_text",
+    label: "Type into the composer",
+    effects: { data: "none", ui: "focus", external: false },
+    sideEffect: "none",
+    execute: (args) => {
+      const text = typeof args === "object" && args && "text" in args && typeof args.text === "string" ? args.text : "";
+      surface.drafts.push(text);
+      return { draftLength: text.length };
+    },
+  }), [surface]);
+  const send = useMemo<OpenworkControlAction>(() => ({
+    id: "composer.send",
+    label: "Send the composer prompt",
+    sideEffect: "mutation",
+    execute: () => {
+      surface.sent.push(surface.drafts.at(-1) ?? "");
+      return true;
+    },
+  }), [surface]);
+  useControlAction(controlTarget ? setText : null);
+  useControlAction(controlTarget ? send : null);
+  return null;
+}
+
+function Workbench({ a, b, focused }: { a: Surface; b: Surface; focused: "a" | "b" }) {
+  return (
+    <MemoryRouter>
+      <OpenworkControlProvider>
+        <ComposerSurface surface={a} controlTarget={focused === "a"} />
+        <ComposerSurface surface={b} controlTarget={focused === "b"} />
+      </OpenworkControlProvider>
+    </MemoryRouter>
+  );
+}
+
+const ownedDom = typeof window === "undefined";
+let previousActEnvironment: unknown;
+let container: HTMLDivElement;
+let root: Root;
+
+beforeAll(() => {
+  if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  previousActEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterAll(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousActEnvironment);
+  if (ownedDom) await GlobalRegistrator.unregister();
+});
+
+function api(): OpenworkControlAPI {
+  const current = window.__openworkControl;
+  if (!current) throw new Error("control API not mounted");
+  return current;
+}
+
+test("composer.* follow the focused pane: a focus change between set_text and send misroutes the draft", async () => {
+  const a: Surface = { sessionId: "ses_a", drafts: [], sent: [] };
+  const b: Surface = { sessionId: "ses_b", drafts: [], sent: [] };
+
+  await act(async () => { root.render(<Workbench a={a} b={b} focused="a" />); });
+
+  // Both composer actions are registered exactly once and carry no session id.
+  const descriptors = api().context().availableAffordances.filter((entry) => entry.id.startsWith("composer."));
+  expect(descriptors.map((entry) => entry.id).sort()).toEqual(["composer.send", "composer.set_text"]);
+  expect(descriptors.every((entry) => entry.arguments.every((argument) => argument.name !== "sessionId"))).toBe(true);
+
+  // The agent "types" for session A while A is focused …
+  let typed: unknown;
+  await act(async () => {
+    typed = await api().command({ id: "composer.set_text", args: { text: "Report for A" } });
+  });
+  expect(typed).toMatchObject({ ok: true, effects: { ui: "focus" } });
+  expect(a.drafts).toEqual(["Report for A"]);
+  expect(b.drafts).toEqual([]);
+
+  // … the person clicks pane B before the agent's next call lands …
+  await act(async () => { root.render(<Workbench a={a} b={b} focused="b" />); });
+
+  // … and composer.send now resolves to B's handler: the draft meant for A is
+  // sent from B. This is the misroute observed in the audit session.
+  let sent: unknown;
+  await act(async () => {
+    sent = await api().command({ id: "composer.send" });
+  });
+  expect(sent).toMatchObject({ ok: true });
+  expect(a.sent).toEqual([]);
+  expect(b.sent).toEqual([""]);
+});
+
+test("effects.ui is descriptive metadata: nothing in dispatch reads it, so only the action body decides what moves", async () => {
+  const a: Surface = { sessionId: "ses_a", drafts: [], sent: [] };
+  const b: Surface = { sessionId: "ses_b", drafts: [], sent: [] };
+  await act(async () => { root.render(<Workbench a={a} b={b} focused="a" />); });
+
+  // A command that claims ui:none and one that claims ui:navigate run through
+  // the same path and are reported back verbatim; there is no gate to honour.
+  const noneResult = await act(async () => api().command({ id: "composer.send" }));
+  expect(noneResult).toMatchObject({ ok: true, effects: { data: "write", ui: "none", external: false } });
+  const focusResult = await act(async () => api().command({ id: "composer.set_text", args: { text: "x" } }));
+  expect(focusResult).toMatchObject({ ok: true, effects: { data: "none", ui: "focus", external: false } });
+});

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -55,6 +55,17 @@ const createResultSchema = z.object({
   })),
 });
 
+const sendResultSchema = z.object({
+  ok: z.literal(true),
+  accepted: z.literal(true),
+  sessionId: z.string(),
+  workspaceId: z.string(),
+  workspace: z.string(),
+  title: z.string(),
+  messageId: z.string().regex(/^msg_[0-9a-f]{26}$/),
+  revealed: z.boolean().optional(),
+});
+
 const automationProposalResultSchema = z.object({
   ok: z.literal(true),
   kind: z.literal("automation-proposal"),
@@ -232,6 +243,16 @@ function startFakeOpenWorkServer(options: { failPromptText?: string; failSession
             parts: [{ type: "text", text: "We decided to ship the archive importer first." }],
           },
         ]);
+      }
+
+      // Existing sessions accept follow-up prompts the way the engine does:
+      // the message is persisted and 204 comes back at once, busy or not.
+      if (/^\/workspace\/ws_[12]\/opencode\/session\/ses_(alpha|beta|archive|foreign)\/prompt_async$/.test(url.pathname)) {
+        z.object({
+          messageID: z.string().regex(/^msg_[0-9a-f]{12}[0-9a-f]{14}$/),
+          parts: z.array(z.object({ type: z.literal("text"), text: z.string() }).strict()).length(1),
+        }).strict().parse(record.body);
+        return new Response(null, { status: 204 });
       }
 
       if (/^\/workspace\/ws_2\/opencode\/session\/ses_created_\d+\/prompt_async$/.test(url.pathname)) {
@@ -721,6 +742,97 @@ describe("OpenWorkExtensionsPreview session tools", () => {
         },
       },
     ]);
+  });
+
+  test("session.send appends a prompt to an existing session by id without touching the UI", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/main" });
+
+    // The target lives in a workspace other than the caller's: resolution is
+    // by id across workspaces, never by what the person has selected.
+    const output = await plugin.tool.openwork_execute.execute({
+      id: "session.send",
+      args: { sessionId: "ses_archive", text: "Status update: the importer shipped." },
+    }, { sessionID: "ses_origin", workspaceId: "ws_1" });
+    const parsed = affordanceResultSchema("session.send", sendResultSchema).parse(JSON.parse(output));
+
+    expect(parsed.effects).toEqual({ data: "write", ui: "none", external: false });
+    expect(parsed.result).toMatchObject({
+      ok: true,
+      accepted: true,
+      sessionId: "ses_archive",
+      workspaceId: "ws_2",
+      workspace: "Archive",
+      title: "Archive decisions",
+    });
+    expect(parsed.result.revealed).toBeUndefined();
+    const prompts = fake.requests.filter((request) => request.pathname.endsWith("/prompt_async") && request.method === "POST");
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]?.pathname).toBe("/workspace/ws_2/opencode/session/ses_archive/prompt_async");
+    expect(prompts[0]?.body).toEqual({
+      messageID: parsed.result.messageId,
+      parts: [{ type: "text", text: "Status update: the importer shipped." }],
+    });
+    // Headless by default: no session.open, no composer, no reload.
+    expect(fake.uiControlRequests).toEqual([]);
+    // No new session is created; the existing one receives the message.
+    expect(fake.requests.filter((request) => request.pathname === "/workspace/ws_2/opencode/session" && request.method === "POST")).toEqual([]);
+  });
+
+  test("session.send reveal=true sends first, then asks the desktop to open that session for the requester", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/main" });
+
+    const output = await plugin.tool.openwork_execute.execute({
+      id: "session.send",
+      args: { sessionId: "ses_alpha", text: "Please take a look.", reveal: true },
+    }, { sessionID: "ses_origin", workspaceId: "ws_1" });
+    const parsed = affordanceResultSchema("session.send", sendResultSchema).parse(JSON.parse(output));
+
+    expect(parsed.effects).toEqual({ data: "write", ui: "navigate", external: false });
+    expect(parsed.result.revealed).toBe(true);
+    const promptIndex = fake.requests.findIndex((request) => request.pathname === "/workspace/ws_1/opencode/session/ses_alpha/prompt_async");
+    const openIndex = fake.requests.findIndex((request) => request.pathname === "/experimental/ui-control/request");
+    expect(promptIndex).toBeGreaterThanOrEqual(0);
+    expect(openIndex).toBeGreaterThan(promptIndex);
+    expect(fake.uiControlRequests).toEqual([
+      {
+        authorization: "Bearer test-token",
+        body: {
+          kind: "command",
+          input: { id: "session.open", args: { sessionId: "ses_alpha" }, origin: { sessionId: "ses_origin", workspaceId: "ws_1" } },
+        },
+      },
+    ]);
+  });
+
+  test("session.send refuses unknown and foreign sessions before anything reaches the engine", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/main" });
+    const failure = z.object({ ok: z.literal(false), id: z.literal("session.send"), error: z.string(), code: z.literal("failed") });
+
+    const missing = failure.parse(JSON.parse(await plugin.tool.openwork_execute.execute({
+      id: "session.send",
+      args: { sessionId: "ses_missing", text: "hello" },
+    }, { sessionID: "ses_origin" })));
+    expect(missing.error).toBe("Session ses_missing was not found in matching OpenWork workspaces");
+
+    // The native engine route returns ses_foreign, but it lives outside every
+    // workspace root, so the ownership check refuses to message it.
+    const foreign = failure.parse(JSON.parse(await plugin.tool.openwork_execute.execute({
+      id: "session.send",
+      args: { sessionId: "ses_foreign", text: "hello" },
+    }, { sessionID: "ses_origin" })));
+    expect(foreign.error).toBe("Session ses_foreign was not found in matching OpenWork workspaces");
+
+    const scoped = failure.parse(JSON.parse(await plugin.tool.openwork_execute.execute({
+      id: "session.send",
+      args: { sessionId: "ses_alpha", text: "hello", workspaceId: "ws_2" },
+    }, { sessionID: "ses_origin" })));
+    expect(scoped.error).toBe("Session ses_alpha was not found in matching OpenWork workspaces");
+
+    expect(fake.requests.filter((request) => request.method === "POST")).toEqual([]);
+    expect(fake.uiControlRequests).toEqual([]);
   });
 
   test("reports a created session as failed when its native prompt does not start", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { realpath } from "node:fs/promises";
 import { ApiError } from "../errors.js";
 import { uiBridgeRequest } from "./openwork-ui-bridge.js";
@@ -93,6 +94,13 @@ const sessionCreateArgsSchema = z.object({
   workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Defaults to the workspace containing the current session."),
 });
 
+const sessionSendArgsSchema = z.object({
+  sessionId: z.string().trim().min(1).describe("Session ID of the existing session to message, from session.search, session.read, or session.list_sessions."),
+  text: z.string().trim().min(1).max(100_000).describe("Prompt text appended to that session as a new user message."),
+  workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Omit to resolve the session across all workspaces."),
+  reveal: z.boolean().optional().describe("true to also open that session in the person's focused pane after sending. Defaults to false: nothing on screen changes."),
+});
+
 const workspaceSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
@@ -138,6 +146,7 @@ For lightweight UI mockups, wireframes, and design iterations, use openwork_visu
 Use openwork_context when the request depends on the current OpenWork screen, open tabs, split view, focused pane, sidebar, side panel, settings panel, or available app actions.
 Each affordance declares its effects and executor. Use openwork_query only for side-effect-free affordances whose executor is OpenWork. Use openwork_execute for OpenWork commands without activating the desktop window. If executor names another tool, call that exact tool instead.
 Reading another session does not require opening it. Prefer session.search then session.read for transcript questions; use session.create for new chats and a UI command only when the user asks to navigate.
+Messaging another session does not require opening it either: use session.send { sessionId, text } to append a prompt to that session by id; nothing on screen changes unless you pass reveal: true. composer.set_text and composer.send type into whichever composer the person currently has focused, so never use them to reach a different session.
 To open settings or navigate the app, use openwork_execute with ids from openwork_context such as settings.panel.open — never browser_* tools for the OpenWork app itself.`;
 
 // External-web mechanics only: the app-surface section above owns the rule
@@ -220,6 +229,9 @@ function preserveMcpResult(output: unknown): void {
 const affordanceReadEffects: OpenworkAffordanceEffects = { data: "read", ui: "none", external: false };
 const affordanceWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: false };
 const affordanceExternalWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: true };
+// session.send with reveal=true: the message is written headlessly, then the
+// target session is opened in the person's pane on their behalf.
+const affordanceWriteNavigateEffects: OpenworkAffordanceEffects = { data: "write", ui: "navigate", external: false };
 // A proposal writes nothing anywhere: it is rendered for a person to act on.
 const affordanceProposalEffects: OpenworkAffordanceEffects = { data: "none", ui: "none", external: false };
 
@@ -436,6 +448,14 @@ async function executeOpenworkAffordance(
       request.id,
       await createOpenWorkSessions(request.args ?? {}, context),
       affordanceWriteEffects,
+    );
+  }
+  if (request.id === "session.send") {
+    const sent = await sendToOpenWorkSession(request.args ?? {}, context);
+    return affordanceResult(
+      request.id,
+      sent,
+      sent.ok && sent.revealed === true ? affordanceWriteNavigateEffects : affordanceWriteEffects,
     );
   }
   if (request.id === "automation.propose") {
@@ -739,6 +759,87 @@ async function readOpenWorkSession(rawArgs: unknown): Promise<object> {
   }
 
   return { ok: false, error: `Session ${args.sessionId} was not found in matching OpenWork workspaces` };
+}
+
+/**
+ * Resolve an existing session by id to the workspace that owns it. Same
+ * lookup as session.read: every matching workspace is probed and the
+ * ownership check in readWorkspaceSession refuses foreign sessions.
+ */
+async function locateOpenWorkSession(
+  sessionId: string,
+  workspaceId: string | undefined,
+): Promise<{ workspace: OpenWorkWorkspace; session: SessionInfo } | { error: string }> {
+  const workspaces = filterWorkspaces(await listOpenWorkWorkspaces(), workspaceId);
+  if (!workspaces.length) {
+    return { error: workspaceId ? `No workspace matched ${workspaceId}` : "No OpenWork workspaces are available" };
+  }
+  for (const workspace of workspaces) {
+    try {
+      return { workspace, session: await readWorkspaceSession(workspace, sessionId) };
+    } catch {
+      if (workspaceId) break;
+    }
+  }
+  return { error: `Session ${sessionId} was not found in matching OpenWork workspaces` };
+}
+
+let lastSendMessageStamp = 0;
+
+/** Same shape the desktop composer uses (see app/lib/opencode.ts createPromptMessageID). */
+function createSendMessageId(): string {
+  lastSendMessageStamp = Math.max(Date.now() * 0x1000, lastSendMessageStamp + 1);
+  return `msg_${lastSendMessageStamp.toString(16).padStart(12, "0").slice(-12)}${randomUUID().replaceAll("-", "").slice(0, 14)}`;
+}
+
+type SendToOpenWorkSessionResult =
+  | { ok: false; error: string }
+  | {
+    ok: true;
+    accepted: true;
+    sessionId: string;
+    workspaceId: string;
+    workspace: string;
+    title: string;
+    messageId: string;
+    revealed?: boolean;
+  };
+
+/**
+ * Append a prompt to an existing session by id through the engine's
+ * prompt_async, exactly as session.create starts a new one. The engine
+ * persists the user message immediately and returns 204; when that session
+ * is mid-turn its running loop picks the message up at the next step instead
+ * of rejecting it. Nothing on screen changes unless `reveal` is true, in
+ * which case the desktop is asked to open the session afterwards (best
+ * effort: the message is already sent if that fails).
+ */
+async function sendToOpenWorkSession(rawArgs: unknown, context: OpenCodeContext): Promise<SendToOpenWorkSessionResult> {
+  const args = sessionSendArgsSchema.parse(rawArgs);
+  const located = await locateOpenWorkSession(args.sessionId, args.workspaceId);
+  if ("error" in located) return { ok: false, error: located.error };
+  const { workspace, session } = located;
+  const messageId = createSendMessageId();
+  await postJson(
+    `/workspace/${encodeURIComponent(workspace.id)}/opencode/session/${encodeURIComponent(session.id)}/prompt_async`,
+    { messageID: messageId, parts: [{ type: "text", text: args.text }] },
+  );
+  const result: SendToOpenWorkSessionResult = {
+    ok: true,
+    accepted: true,
+    sessionId: session.id,
+    workspaceId: workspace.id,
+    workspace: workspaceLabel(workspace),
+    title: sessionTitle(session),
+    messageId,
+  };
+  if (args.reveal !== true) return result;
+  const opened = await uiControlRequest("command", {
+    id: "session.open",
+    args: { sessionId: session.id },
+    ...affordanceOrigin(context),
+  });
+  return { ...result, revealed: isRecord(opened) && opened.ok === true };
 }
 
 function serverUrl(): string {

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
@@ -20,6 +20,22 @@ describe("OpenWork provider adapters", () => {
       effects: { data: "read", ui: "none", external: false },
       executor: { kind: "openwork" },
     });
+    // Talking to a session is a server command addressed by id: it declares
+    // no UI effect, so agents never need session.open + composer.* for it.
+    const send = contributions.flatMap((contribution) => contribution.affordances)
+      .find((affordance) => affordance.id === "session.send");
+    expect(send).toMatchObject({
+      kind: "command",
+      provider: { id: "openwork-server", kind: "builtin" },
+      effects: { data: "write", ui: "none", external: false },
+      executor: { kind: "openwork" },
+    });
+    expect(send?.arguments.map((argument) => [argument.name, argument.required])).toEqual([
+      ["sessionId", true],
+      ["text", true],
+      ["workspaceId", false],
+      ["reveal", false],
+    ]);
     for (const contribution of contributions) {
       expect(openworkFeatureContributionSchema.safeParse(contribution).success).toBe(true);
     }

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
@@ -112,6 +112,20 @@ function sessionContribution(): OpenworkFeatureContribution {
         arguments: [argument("sessions", "array", true, "Session titles and self-contained prompts.")],
         effects: writeEffects,
       }),
+      affordance({
+        id: "session.send",
+        kind: "command",
+        title: "Send a prompt to a session",
+        description: "Append a prompt to an existing session by id without opening it. The message is written immediately; a session that is mid-turn handles it at its next step. Nothing on screen changes unless reveal is true. This is the way to talk to another session: composer.set_text and composer.send only reach the composer the person has focused.",
+        provider,
+        arguments: [
+          argument("sessionId", "string", true, "Session id from session.search, session.read, or session.list_sessions."),
+          argument("text", "string", true, "Prompt text appended as a new user message."),
+          argument("workspaceId", "string", false, "Optional workspace id or name."),
+          argument("reveal", "boolean", false, "true to also open that session in the person's focused pane after sending. Defaults to false."),
+        ],
+        effects: writeEffects,
+      }),
     ],
     guidance: [],
   };

--- a/docs/features/headless-session-control.md
+++ b/docs/features/headless-session-control.md
@@ -1,0 +1,100 @@
+# Headless session control: agents address sessions by id, the UI moves only on request
+
+Status: shipped with `session.send` (this note documents the decision and the remaining follow-ups).
+
+## Symptom
+
+A person orchestrating many sessions from one chat saw the app's active pane jump to
+whichever session the orchestrating agent was acting on. Relays were also misrouted:
+in one afternoon five messages landed in the wrong session (twice in the orchestrator
+itself, once in a session of another workspace, once in a finished session), and
+`composer.send` answered `Action is disabled` whenever the visible session was mid-turn.
+
+## Root cause
+
+The only way an agent could talk to an existing session was
+`session.open` → `composer.set_text` → `composer.send`, and the composer actions are
+focus-bound, not session-bound.
+
+- `apps/app/src/react-app/domains/session/surface/session-surface.tsx` registers
+  `composer.set_text`, `composer.send`, and `composer.stop` with
+  `useControlAction(props.isControlTarget ? action : null)`; `session-page.tsx` passes
+  `isControlTarget={activeWorkbenchPane === "primary" | "secondary"}`. There is one
+  registration slot per action id (`registerAction` in
+  `shell/control/control-provider.tsx`), so the id resolves to whichever pane is focused
+  at execution time. Neither action takes a `sessionId`.
+- Therefore the navigation was **incidental, not intrinsic**: the engine can accept a
+  prompt for any session (`POST /session/{id}/prompt_async`, already used by
+  `session.create` in `apps/server/src/opencode-plugins/openwork-extensions-preview.ts`),
+  but no affordance exposed it, so the agent navigated to make the target the focused
+  composer.
+- Any focus change between `set_text` and `send` re-pointed both actions at the newly
+  focused session (`apps/app/tests/control-focus-bound-composer.test.tsx` reproduces
+  this deterministically). `composer.send` is also disabled while the visible session's
+  `model.transitionState !== "idle"`, which is the `Action is disabled` error.
+- `effects.ui` in `packages/types/src/openwork-affordance.ts` is descriptive metadata for
+  the model: nothing in `executeAction`/`executeCommand` reads it. It was also untruthful
+  for `session.create_task` (declared `ui: none`, opens the new session in the focused
+  pane).
+
+## Principle
+
+Control-plane actions are addressed by id and headless by default. A UI change is either
+an explicit opt-in on the action (`reveal: true`) or a separate action whose only job is
+to show something (`session.open`, `workbench.session.focus`).
+
+The same split exists in comparable products:
+
+- VS Code: `workspace.openTextDocument` / edits work on documents headlessly;
+  `window.showTextDocument` is the separate "show it" call and takes `preserveFocus` so
+  even showing need not steal focus.
+- Cursor Cloud Agents: follow-ups are `POST /v0/agents/{id}/followup` (and
+  `POST /v1/agents/{id}/runs`) addressed by agent id; the editor is a view the person
+  moves. A busy agent gets a structured `409 agent_busy`, not a UI error.
+- Slack apps: `chat.postMessage` posts to a channel id without switching the user's view.
+- tmux: `send-keys -t <target>` types into a pane without selecting it.
+- OS accessibility APIs act on element references, not on "whatever has focus".
+
+## What changed
+
+- **A. `session.send { sessionId, text, workspaceId?, reveal? }`** — a server-executed
+  command (`provider: openwork-server`, same trust as `session.create`) in
+  `openwork-extensions-preview.ts`. It resolves the session across workspaces with the
+  same ownership check as `session.read`, posts `prompt_async` with a generated
+  `messageID`, and returns `{ accepted: true, sessionId, workspaceId, title, messageId }`.
+  With `reveal: true` it sends first, then issues one `session.open` through the UI
+  mailbox stamped with the requester's `origin`, and reports `revealed`. `effects.ui` is
+  `navigate` only when the reveal actually happened.
+- **Queue semantics (engine, opencode 1.18.18):** `prompt_async` persists the user message
+  and returns 204 immediately (`server/routes/instance/httpapi/handlers/session.ts`
+  `promptAsync`, forked). `SessionPrompt.prompt` → `loop` → `SessionRunState.ensureRunning`
+  (`effect/runner.ts`): if the session is already running, the call awaits the existing
+  run and the running loop picks the new user message up at its next step; nothing is
+  rejected or dropped. If no `model` is given, the session's stored model is used.
+  `evals/specs/session-send-headless-by-id.test.ts` witnesses this against the real
+  engine.
+- **B. by-id actions already headless:** `session.rename`, `session.pin`,
+  `session.archive` act by id and do not navigate (archive closes the tab only when the
+  target is the one on screen). No change needed beyond documentation.
+- **C. truthful effects:** `session.create_task` now declares `ui: navigate`;
+  `session.open`, `workbench.session.focus` keep `ui: navigate`; `composer.set_text`
+  keeps `ui: focus`.
+- **D. focus-bound actions say so:** `composer.set_text` / `composer.send` /
+  `composer.stop` descriptions state they target the focused composer and point to
+  `session.send`; the agent system instruction says the same.
+
+## Attribution
+
+`session.send` does not stamp the requester into the recipient's message: the sender's
+own transcript holds the tool call and its result (`messageId`), which is the trail.
+Stamping would alter the user-visible text the recipient answers to.
+
+## Follow-ups (not in this change)
+
+- A desktop e2e (`.e2e.test.ts`) that drives the real renderer with three open sessions;
+  the PR-lane spec proves the mailbox receives no command, which is the only path by
+  which the renderer navigates.
+- `session.stop` by id is tracked in #4904 (gated on a product decision about stopping
+  another session's work without confirmation).
+- `session.read` returning `status`/`working` (#4903) lets an agent decide whether to
+  send now or wait.

--- a/docs/mcp-ui-control-profile.md
+++ b/docs/mcp-ui-control-profile.md
@@ -51,6 +51,8 @@ This may navigate OpenWork away from the user's current session while the lookup
 
 Inside OpenWork, agents control the app through the semantic tools (`openwork_context`, `openwork_query`, `openwork_execute`) using affordance ids from context. External MCP clients can also use the hidden **OpenWork UI Control** MCP via **Settings -> Extensions -> Show hidden**.
 
+In-app agents do not need `session.open` to work with another session: `session.read` reads any session by id and `session.send { sessionId, text }` messages it, both without changing what the person sees (`docs/features/headless-session-control.md`). `composer.set_text` / `composer.send` type into the composer the person currently has focused.
+
 ## Install
 
 ```bash

--- a/evals/specs/session-send-headless-by-id.test.ts
+++ b/evals/specs/session-send-headless-by-id.test.ts
@@ -1,0 +1,230 @@
+import { spec } from "@openwork/testkit";
+import { expect } from "vitest";
+import {
+  agentSessionSend,
+  HOLD_MARKER,
+  MOCK_REPLY,
+  ORCHESTRATE_MARKER,
+  type HandledUiControlItem,
+} from "../worlds/agent-session-send.ts";
+
+const test = spec.world(agentSessionSend, { needs: { commands: ["bun"] }, timeout: 300_000 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sessionIdOf(value: unknown): string {
+  if (!isRecord(value) || typeof value.id !== "string") throw new Error(`Expected a created session: ${JSON.stringify(value)}`);
+  return value.id;
+}
+
+type Transcript = Array<{ id: string; role: string; text: string }>;
+
+function transcript(value: unknown): Transcript {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((message) => {
+    if (!isRecord(message) || !isRecord(message.info) || !Array.isArray(message.parts)) return [];
+    const text = message.parts
+      .filter(isRecord)
+      .filter((part) => part.type === "text" && part.synthetic !== true)
+      .map((part) => (typeof part.text === "string" ? part.text : ""))
+      .join("");
+    return [{
+      id: typeof message.info.id === "string" ? message.info.id : "",
+      role: typeof message.info.role === "string" ? message.info.role : "",
+      text,
+    }];
+  });
+}
+
+function completedExecuteOutputs(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  const outputs: Record<string, unknown>[] = [];
+  for (const message of value) {
+    if (!isRecord(message) || !Array.isArray(message.parts)) continue;
+    for (const part of message.parts) {
+      if (!isRecord(part) || part.type !== "tool" || part.tool !== "openwork_execute" || !isRecord(part.state)) continue;
+      if (part.state.status !== "completed" || typeof part.state.output !== "string") continue;
+      const parsed: unknown = JSON.parse(part.state.output);
+      if (isRecord(parsed)) outputs.push(parsed);
+    }
+  }
+  return outputs;
+}
+
+function commands(handled: HandledUiControlItem[]): HandledUiControlItem[] {
+  return handled.filter((item) => item.kind === "command");
+}
+
+function statusOf(value: unknown, sessionId: string): string {
+  if (!isRecord(value)) return "unknown";
+  const entry = value[sessionId];
+  return isRecord(entry) && typeof entry.type === "string" ? entry.type : "idle";
+}
+
+test("an agent messages another session by id while the person keeps looking at a third one, and nothing on screen changes", async ({ world, probe, step, evidence }) => {
+  const model = { providerID: "mock", modelID: "mock" };
+  const orchestrator = sessionIdOf(await world.engine("POST", "/session", { title: "Orchestrator (session 1)" }));
+  const target = sessionIdOf(await world.engine("POST", "/session", { title: "Importer work (session 2)" }));
+  const viewed = sessionIdOf(await world.engine("POST", "/session", { title: "What the person is reading (session 3)" }));
+  const messages = (sessionId: string) => world.engine("GET", `/session/${encodeURIComponent(sessionId)}/message`);
+  const read = async (sessionId: string) => transcript(await messages(sessionId));
+
+  // The person is looking at session 3. The fake window answers context reads
+  // and refuses every command, so any attempt to move the pane is recorded.
+  const window = await world.attachWindow({
+    screen: "session",
+    conversations: { layout: { kind: "single", focused: "primary", primarySessionId: viewed }, tabs: [{ sessionId: viewed }] },
+    availableAffordances: [],
+  });
+
+  try {
+    // Session 2 has one earlier turn, so it carries a stored model and a known transcript length.
+    await world.engine("POST", `/session/${encodeURIComponent(target)}/message`, { model, parts: [{ type: "text", text: "Start the importer." }] });
+    const targetBefore = await read(target);
+    expect(targetBefore.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(await read(viewed)).toEqual([]);
+
+    const relay = "Relay from session 1: the archive importer shipped this morning.";
+    const first = await step("session 1 sends to session 2 by id; session 2 receives and answers; the window receives no command", async () => {
+      world.script.toolCall = { name: "openwork_execute", arguments: { id: "session.send", args: { sessionId: target, text: relay } } };
+      const turn = await world.engine("POST", `/session/${encodeURIComponent(orchestrator)}/message`, {
+        model,
+        parts: [{ type: "text", text: `${ORCHESTRATE_MARKER} Let the importer session know it shipped.` }],
+      });
+      expect(transcript([turn]).at(-1)?.text).toBe(MOCK_REPLY);
+
+      const outputs = completedExecuteOutputs(await messages(orchestrator));
+      expect(outputs).toHaveLength(1);
+      const output = outputs[0];
+      expect(output).toMatchObject({ ok: true, id: "session.send", effects: { data: "write", ui: "none", external: false } });
+      const result = isRecord(output?.result) ? output.result : {};
+      expect(result).toMatchObject({ ok: true, accepted: true, sessionId: target, workspaceId: world.workspaceId, title: "Importer work (session 2)" });
+      expect(result.revealed).toBeUndefined();
+      const messageId = typeof result.messageId === "string" ? result.messageId : "";
+      expect(messageId).toMatch(/^msg_[0-9a-f]{26}$/);
+
+      const delivered = await probe.eventually(() => read(target), {
+        within: 60_000,
+        label: "session 2 holds the relayed user message and its assistant reply",
+        until: (value) => value.length === targetBefore.length + 2 && value.at(-1)?.role === "assistant",
+      });
+      expect(delivered.slice(0, targetBefore.length)).toEqual(targetBefore);
+      expect(delivered[targetBefore.length]).toEqual({ id: messageId, role: "user", text: relay });
+      expect(delivered.at(-1)?.text).toBe(MOCK_REPLY);
+      expect(world.requests.some((request) => request.userText === relay)).toBe(true);
+
+      // Negative half: session 3 stays untouched and the window was never asked to do anything.
+      expect(await read(viewed)).toEqual([]);
+      expect(commands(window.handled)).toEqual([]);
+      evidence.recordAssertionEvidence(
+        "session.send reaches a session by id without any UI command",
+        `Session 1's openwork_execute(session.send) returned accepted=true, messageId=${messageId}, effects.ui=none; session 2 gained exactly that user message plus a reply; session 3 has no messages; the window's mailbox saw ${commands(window.handled).length} commands.`,
+        commands(window.handled).length === 0,
+      );
+      return { messageId };
+    });
+
+    await step("a session that is mid-turn keeps the new message and handles it after its current step, without a rejection", async () => {
+      const before = await read(target);
+      await world.engine("POST", `/session/${encodeURIComponent(target)}/prompt_async`, {
+        model,
+        parts: [{ type: "text", text: `${HOLD_MARKER} keep working on the importer.` }],
+      });
+      await probe.eventually(() => world.engine("GET", "/session/status"), {
+        within: 30_000,
+        label: "session 2 is busy on a held provider stream",
+        until: (value) => statusOf(value, target) === "busy",
+      });
+
+      const second = "Second relay from session 1, sent while session 2 is busy.";
+      world.script.toolCall = { name: "openwork_execute", arguments: { id: "session.send", args: { sessionId: target, text: second } } };
+      const startedAt = Date.now();
+      await world.engine("POST", `/session/${encodeURIComponent(orchestrator)}/message`, {
+        model,
+        parts: [{ type: "text", text: `${ORCHESTRATE_MARKER} Send the second relay.` }],
+      });
+      const elapsedMs = Date.now() - startedAt;
+      const outputs = completedExecuteOutputs(await messages(orchestrator));
+      expect(outputs).toHaveLength(2);
+      expect(outputs[1]).toMatchObject({ ok: true, id: "session.send", result: { accepted: true, sessionId: target } });
+
+      // Accepted and persisted while session 2 is still busy; the model has not seen it yet.
+      const whileBusy = await read(target);
+      expect(statusOf(await world.engine("GET", "/session/status"), target)).toBe("busy");
+      expect(whileBusy.slice(0, before.length)).toEqual(before);
+      expect(whileBusy.filter((message) => message.role === "user").map((message) => message.text)).toEqual([
+        ...before.filter((message) => message.role === "user").map((message) => message.text),
+        `${HOLD_MARKER} keep working on the importer.`,
+        second,
+      ]);
+      expect(world.requests.some((request) => request.userText === second)).toBe(false);
+
+      world.release();
+      const settled = await probe.eventually(() => read(target), {
+        within: 60_000,
+        label: "session 2 answers the held prompt and then the relay sent while it was busy",
+        until: (value) => value.filter((message) => message.role === "assistant").length === before.filter((message) => message.role === "assistant").length + 2,
+      });
+      expect(settled.at(-1)?.role).toBe("assistant");
+      await probe.eventually(() => world.engine("GET", "/session/status"), {
+        within: 30_000,
+        label: "session 2 returns to idle",
+        until: (value) => statusOf(value, target) === "idle",
+      });
+      expect(world.requests.some((request) => request.userText === second)).toBe(true);
+      expect(commands(window.handled)).toEqual([]);
+      evidence.recordAssertionEvidence(
+        "Sending to a busy session queues into its running turn",
+        `The relay was accepted in ${elapsedMs} ms while session 2 was busy, was already in its transcript before its model saw it, and was answered after the held step completed; still no UI command.`,
+        elapsedMs < 30_000,
+      );
+    });
+
+    await step("reveal: true is the explicit opt-in: the message is sent first, then one session.open for session 2 reaches the window on behalf of session 1", async () => {
+      const before = await read(target);
+      const text = "Third relay: please take a look at this one.";
+      world.script.toolCall = { name: "openwork_execute", arguments: { id: "session.send", args: { sessionId: target, text, reveal: true } } };
+      await world.engine("POST", `/session/${encodeURIComponent(orchestrator)}/message`, {
+        model,
+        parts: [{ type: "text", text: `${ORCHESTRATE_MARKER} Send and show me.` }],
+      });
+      const output = completedExecuteOutputs(await messages(orchestrator))[2];
+      // The fake window refuses commands, so the message is delivered, the
+      // reveal is reported as not done, and effects.ui stays truthful: nothing moved.
+      expect(output).toMatchObject({ ok: true, id: "session.send", effects: { data: "write", ui: "none", external: false }, result: { accepted: true, revealed: false } });
+      await probe.eventually(() => read(target), {
+        within: 60_000,
+        label: "session 2 received the third relay",
+        until: (value) => value.some((message) => message.role === "user" && message.text === text),
+      });
+      expect(commands(window.handled).map((item) => item.input)).toEqual([
+        { id: "session.open", args: { sessionId: target }, origin: expect.objectContaining({ sessionId: orchestrator }) },
+      ]);
+      expect((await read(target)).slice(0, before.length)).toEqual(before);
+      evidence.recordAssertionEvidence(
+        "UI change is an explicit opt-in",
+        "Only with reveal: true did exactly one session.open for session 2 reach the window, stamped with session 1 as origin, after the message was already written.",
+        commands(window.handled).length === 1,
+      );
+    });
+
+    await step("an unknown session id is refused before anything reaches the engine or the window", async () => {
+      const targetBefore = await read(target);
+      world.script.toolCall = { name: "openwork_execute", arguments: { id: "session.send", args: { sessionId: "ses_does_not_exist", text: "lost" } } };
+      await world.engine("POST", `/session/${encodeURIComponent(orchestrator)}/message`, {
+        model,
+        parts: [{ type: "text", text: `${ORCHESTRATE_MARKER} Message a session that does not exist.` }],
+      });
+      const output = completedExecuteOutputs(await messages(orchestrator))[3];
+      expect(output).toMatchObject({ ok: false, id: "session.send", code: "failed" });
+      expect(String(output?.error)).toContain("ses_does_not_exist");
+      expect(await read(target)).toEqual(targetBefore);
+      expect(await read(viewed)).toEqual([]);
+      expect(commands(window.handled)).toHaveLength(1);
+    });
+  } finally {
+    await window.detach();
+  }
+});

--- a/evals/worlds/agent-session-send.ts
+++ b/evals/worlds/agent-session-send.ts
@@ -1,0 +1,289 @@
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
+import type { Seed } from "@openwork/env";
+import {
+  bootManagedOpenworkServer,
+  close,
+  isRecord,
+  listen,
+  readBody,
+  sendJson,
+  sendStream,
+  type ManagedOpenworkServer,
+} from "./openwork-server-cli.ts";
+
+export const MOCK_REPLY = "MOCK OK";
+/** A user message carrying this marker makes the mock model run the scripted tool call. */
+export const ORCHESTRATE_MARKER = "[orchestrate]";
+/** A user message carrying this marker keeps the mock model streaming nothing until `release()`. */
+export const HOLD_MARKER = "[hold]";
+
+export type ScriptedToolCall = { name: string; arguments: Record<string, unknown> };
+
+export type ProviderRequest = {
+  model: string;
+  userText: string;
+  toolResults: string[];
+};
+
+export type HandledUiControlItem = {
+  id: string;
+  kind: string;
+  input: unknown;
+  createdAt: number;
+};
+
+export interface FakeWindow {
+  /** Every mailbox item the window answered, in order. Commands are refused, so a UI change can only be observed here. */
+  handled: HandledUiControlItem[];
+  detach(): Promise<void>;
+}
+
+export interface AgentSessionSendWorld extends AsyncDisposable {
+  base: string;
+  token: string;
+  workspaceId: string;
+  requests: ProviderRequest[];
+  /** The tool call the mock model issues when its user message contains ORCHESTRATE_MARKER. */
+  script: { toolCall: ScriptedToolCall | null };
+  /** Let every held turn finish. */
+  release(): void;
+  engine(method: string, path: string, body?: unknown): Promise<unknown>;
+  output(): string;
+  attachWindow(context: Record<string, unknown>): Promise<FakeWindow>;
+}
+
+function toolResultContents(body: unknown): string[] {
+  if (!isRecord(body) || !Array.isArray(body.messages)) return [];
+  const results: string[] = [];
+  for (const message of body.messages) {
+    if (!isRecord(message) || message.role !== "tool") continue;
+    const serialized = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+    results.push(serialized ?? "");
+  }
+  return results;
+}
+
+function lastMessageIsToolResult(body: unknown): boolean {
+  if (!isRecord(body) || !Array.isArray(body.messages)) return false;
+  const last = body.messages.at(-1);
+  return isRecord(last) && last.role === "tool";
+}
+
+function latestUserText(body: unknown): string {
+  if (!isRecord(body) || !Array.isArray(body.messages)) return "";
+  for (let index = body.messages.length - 1; index >= 0; index -= 1) {
+    const message = body.messages[index];
+    if (!isRecord(message) || message.role !== "user") continue;
+    if (typeof message.content === "string") return message.content;
+    if (Array.isArray(message.content)) {
+      return message.content
+        .filter(isRecord)
+        .map((part) => (typeof part.text === "string" ? part.text : ""))
+        .join("");
+    }
+  }
+  return "";
+}
+
+function mockProvider(
+  requests: ProviderRequest[],
+  script: { toolCall: ScriptedToolCall | null },
+  holds: Set<() => void>,
+): Server {
+  return createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "POST" && url.pathname.endsWith("/chat/completions")) {
+        const body: unknown = JSON.parse(await readBody(request));
+        const toolResults = toolResultContents(body);
+        const userText = latestUserText(body);
+        // A turn that just received its tool result must finish with text;
+        // earlier tool results in the history do not make this a follow-up.
+        const answeringTool = lastMessageIsToolResult(body);
+        requests.push({
+          model: isRecord(body) && typeof body.model === "string" ? body.model : "?",
+          userText,
+          toolResults,
+        });
+        const id = `chatcmpl-agent-session-send-${requests.length}`;
+        if (userText.includes(HOLD_MARKER) && !answeringTool) {
+          // Stay mid-turn until the spec releases the hold: the engine sees a
+          // busy session with an open provider stream.
+          await new Promise<void>((resolve) => {
+            holds.add(resolve);
+          });
+        }
+        const toolCall = script.toolCall;
+        sendStream(response, !answeringTool && toolCall && userText.includes(ORCHESTRATE_MARKER)
+          ? [
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: `call_${requests.length}`, type: "function", function: { name: toolCall.name, arguments: JSON.stringify(toolCall.arguments) } }] }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+          ]
+          : [
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: MOCK_REPLY }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+          ]);
+        return;
+      }
+      sendJson(response, 200, { object: "list", data: [] });
+    })().catch((error: unknown) => {
+      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
+      else response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+}
+
+function uiControlItems(value: unknown): HandledUiControlItem[] {
+  if (!isRecord(value) || !Array.isArray(value.items)) {
+    throw new Error(`Invalid UI control pending response: ${JSON.stringify(value)}`);
+  }
+  return value.items.map((item) => {
+    if (!isRecord(item) || typeof item.id !== "string" || typeof item.kind !== "string" || typeof item.createdAt !== "number") {
+      throw new Error(`Invalid UI control item: ${JSON.stringify(item)}`);
+    }
+    return { id: item.id, kind: item.kind, input: item.input, createdAt: item.createdAt };
+  });
+}
+
+/**
+ * A managed openwork-server with a real engine, a scripted OpenAI-compatible
+ * mock model, and a fake OpenWork window that polls the UI-control mailbox
+ * and refuses every command. The window is the witness for "nothing on
+ * screen changed": the renderer only navigates when a command reaches it.
+ */
+export async function agentSessionSend(seed: Seed): Promise<AgentSessionSendWorld> {
+  const root = seed.tmpPath("agent-session-send");
+  await mkdir(root, { recursive: true });
+  const scratch = await realpath(root);
+  const workspace = join(scratch, "workspace");
+  await mkdir(workspace, { recursive: true });
+
+  const requests: ProviderRequest[] = [];
+  const script: { toolCall: ScriptedToolCall | null } = { toolCall: null };
+  const holds = new Set<() => void>();
+  const release = () => {
+    for (const resolve of holds) resolve();
+    holds.clear();
+  };
+  const provider = mockProvider(requests, script, holds);
+  const providerUrl = await listen(provider);
+  await writeFile(join(workspace, "opencode.json"), JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      mock: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Mock provider",
+        options: { baseURL: `${providerUrl}/v1`, apiKey: "test" },
+        models: {
+          mock: {
+            name: "mock",
+            tool_call: true,
+            reasoning: false,
+            temperature: true,
+            modalities: { input: ["text"], output: ["text"] },
+            limit: { context: 128_000, output: 4_096 },
+            cost: { input: 0, output: 0 },
+          },
+        },
+      },
+    },
+  }, null, 2));
+
+  const token = "agent-session-send-client-token";
+  let output = "";
+  const sink = (chunk: string) => { output += chunk; };
+  let managed: ManagedOpenworkServer | null = null;
+  const windows = new Set<FakeWindow>();
+
+  const dispose = async () => {
+    release();
+    const detachResults = await Promise.allSettled([...windows].map((window) => window.detach()));
+    if (managed) await managed.stop();
+    await close(provider);
+    await rm(scratch, { recursive: true, force: true });
+    const failed = detachResults.find((result) => result.status === "rejected");
+    if (failed?.status === "rejected") throw failed.reason;
+  };
+
+  try {
+    managed = await bootManagedOpenworkServer({ scratch, workspace, token, sink });
+    const server = managed;
+    const headers = { authorization: `Bearer ${token}`, "content-type": "application/json" };
+
+    const request = async (path: string, init: RequestInit, timeoutMs: number): Promise<unknown> => {
+      const response = await fetch(`${server.base}${path}`, {
+        ...init,
+        headers,
+        signal: init.signal ? AbortSignal.any([init.signal, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs),
+      });
+      const text = await response.text();
+      if (!response.ok) throw new Error(`${init.method ?? "GET"} ${path} → ${response.status}: ${text.slice(0, 400)}`);
+      return text ? JSON.parse(text) : null;
+    };
+
+    const attachWindow = async (context: Record<string, unknown>): Promise<FakeWindow> => {
+      const handled: HandledUiControlItem[] = [];
+      const controller = new AbortController();
+      let detached = false;
+      let loopError: unknown = null;
+
+      const handle = async (items: HandledUiControlItem[]) => {
+        for (const item of items) {
+          handled.push(item);
+          const result = item.kind === "context"
+            ? { ok: true, context }
+            : { ok: false, error: "unsupported in fake window" };
+          await request(`/experimental/ui-control/${encodeURIComponent(item.id)}/reply`, {
+            method: "POST",
+            body: JSON.stringify({ result }),
+            signal: controller.signal,
+          }, 5_000);
+        }
+      };
+
+      await handle(uiControlItems(await request("/experimental/ui-control/pending", { method: "GET", signal: controller.signal }, 5_000)));
+      const loop = (async () => {
+        while (!detached) {
+          const value = await request("/experimental/ui-control/pending?wait=1", { method: "GET", signal: controller.signal }, 15_000);
+          if (!detached) await handle(uiControlItems(value));
+        }
+      })().catch((error: unknown) => {
+        if (!detached) loopError = error;
+      });
+
+      const fakeWindow: FakeWindow = {
+        handled,
+        async detach() {
+          if (detached) return;
+          detached = true;
+          controller.abort();
+          await loop;
+          windows.delete(fakeWindow);
+          if (loopError) throw loopError;
+        },
+      };
+      windows.add(fakeWindow);
+      return fakeWindow;
+    };
+
+    return {
+      base: server.base,
+      token,
+      workspaceId: server.workspaceId,
+      requests,
+      script,
+      release,
+      engine: server.engine,
+      output: () => output,
+      attachWindow,
+      [Symbol.asyncDispose]: dispose,
+    };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+}

--- a/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
+++ b/packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
@@ -8,9 +8,9 @@ OpenWork's cross-chat memory currently comes from saved session history. It is n
 When an agent is running inside the OpenWork app, it can use OpenWork's semantic UI actions to look up past chats:
 
 - `session.list_sessions` lists every loaded session across the workspaces the app knows about (pinned first, then newest). Pass `limit` to cap the count or `workspaceId` to narrow to one workspace.
-- `session.open` opens a matching session by ID.
-- `session.read_transcript` reads recent messages from the currently open session.
-- `session.latest_message` reads the newest message in the currently open session.
+- `session.search` finds sessions by title or transcript text.
+- `session.read` reads recent messages from any session by ID, without opening it.
+- `session.open` shows a session to you, when you ask to see it.
 
 That means you can ask things like:
 
@@ -21,12 +21,23 @@ That means you can ask things like:
 
 ## What happens
 
-1. The agent lists sessions and matches by session ID, title, workspace, or topic words you provided.
-2. If there is one clear match, the agent opens that session.
-3. The agent reads the transcript and answers from the returned messages.
-4. If there are multiple likely matches, the agent asks which session you meant.
+1. The agent lists or searches sessions and matches by session ID, title, workspace, or topic words you provided.
+2. If there is one clear match, the agent reads that session's transcript by ID and answers from the returned messages.
+3. If there are multiple likely matches, the agent asks which session you meant.
+4. If you asked to open the chat, the agent opens it after reading.
 
-Because this uses the OpenWork UI, the agent may briefly navigate away from your current session to inspect another one. You can ask it to return to the current session afterward.
+Reading a session (`session.search`, `session.read`) never changes what is on your screen. An agent only opens another session (`session.open`) when you ask to see it.
+
+## How agents manage other sessions
+
+Agents address other sessions by id, and by default nothing on your screen changes. Showing you something is a separate, explicit step.
+
+- **Read**: `session.search` and `session.read` return transcripts without opening anything.
+- **Talk**: `session.send { sessionId, text }` appends a prompt to an existing session by id. The message is written immediately; if that session is in the middle of a turn, its run handles the new message at its next step (nothing is rejected or lost). `session.create` starts new sessions the same way.
+- **Show**: `session.open` and `workbench.session.focus` are the only actions that move your pane. `session.send { reveal: true }` sends first and then opens that session for you.
+- **File**: `session.rename`, `session.pin`, and `session.archive` act by id and do not open the session (archiving the session you are looking at closes its tab).
+
+`composer.set_text`, `composer.send`, and `composer.stop` are different: they type into, send from, or stop whichever composer *you* currently have focused. They are for "type this for me here", never for reaching another session — if you switch panes while the agent is typing, the text goes to the pane you switched to. Agents are told to use `session.send` instead.
 
 ## Current limits
 


### PR DESCRIPTION
## Problem

A person orchestrating many sessions from one chat saw the active pane jump to whichever session the orchestrating agent acted on, and relays were misrouted (five in one afternoon: twice into the orchestrator itself, once into a session of another workspace, once into a finished session). `composer.send` also answered `Action is disabled` whenever the visible session was mid-turn.

## RCA

The only way to talk to an existing session was `session.open` → `composer.set_text` → `composer.send`, and the composer actions are **focus-bound, not session-bound**:

- `apps/app/src/react-app/domains/session/surface/session-surface.tsx` registers `composer.set_text` / `composer.send` / `composer.stop` with `useControlAction(props.isControlTarget ? action : null)`; `session-page.tsx` passes `isControlTarget={activeWorkbenchPane === "primary" | "secondary"}`. One registration slot per id (`registerAction`, `shell/control/control-provider.tsx`) means the id resolves to whichever pane is focused when the call lands. Neither takes a `sessionId`.
- The navigation was therefore **incidental, not intrinsic**: the engine already accepts a prompt for any session (`POST /session/{id}/prompt_async`, used by `session.create`), but no affordance exposed it, so the agent navigated to make the target the focused composer. A focus change between `set_text` and `send` re-pointed both at the newly focused session; `composer.send` is disabled while the visible session's `transitionState !== "idle"`.
- `effects.ui` (`packages/types/src/openwork-affordance.ts`) is descriptive metadata for the model: nothing in `executeAction` / `executeCommand` reads it. It was also untruthful for `session.create_task` (`ui: none`, but it opens the new session in the focused pane).

`apps/app/tests/control-focus-bound-composer.test.tsx` reproduces the misroute deterministically (focus flips between `set_text` and `send`; B's handler receives the send meant for A).

## Principle

Control-plane actions are addressed by id and headless by default; a UI change is an explicit opt-in (`reveal: true`) or a separate "show me" action (`session.open`, `workbench.session.focus`). Same split as VS Code (`openTextDocument` vs `showTextDocument` + `preserveFocus`), Cursor Cloud Agents (`POST /v0/agents/{id}/followup`, `409 agent_busy`), Slack `chat.postMessage` to a channel id, tmux `send-keys -t`. Details: `docs/features/headless-session-control.md`.

## What changes

- **`session.send { sessionId, text, workspaceId?, reveal? }`** — server-executed command (`openwork-server` provider, same trust as `session.create`) in `apps/server/src/opencode-plugins/openwork-extensions-preview.ts`. Resolves the session across workspaces with the same ownership check as `session.read`, posts `prompt_async` with a generated `messageID`, returns `{ accepted: true, sessionId, workspaceId, title, messageId }`, and never touches the UI. `reveal: true` sends first, then issues one `session.open` through the UI mailbox stamped with the requester `origin`, reporting `revealed`; `effects.ui` is `navigate` only when the reveal actually happened.
- **Queue semantics** (opencode 1.18.18, verified in source and by the spec): `prompt_async` persists the user message and returns 204 at once; `SessionRunState.ensureRunning` makes a call against a running session await the existing run, whose loop picks the new user message up at its next step. Nothing is rejected or lost. Omitting `model` uses the session's stored model.
- **Truthful effects**: `session.create_task` now declares `ui: navigate`. `session.open` / `workbench.session.focus` remain the only navigate actions; `composer.set_text` keeps `ui: focus`.
- **Focus-bound actions say so**: `composer.set_text` / `composer.send` / `composer.stop` and `session.open` descriptions, plus the agent system instruction, point agents at `session.send` for another session.
- `session.rename` / `session.pin` / `session.archive` already act by id without navigating (archive closes the tab only when the target is on screen) — verified, no code change.
- Docs: `cross-chat-memory.mdx` gets "How agents manage other sessions"; `docs/mcp-ui-control-profile.md` no longer tells clients to open a session before reading it.

**Attribution:** `session.send` does not stamp the requester into the recipient's message; the sender's transcript holds the tool call and `messageId`, which is the trail (the recipient answers the user-visible text as written).

Related: #4903 (status/working in `session.read`), #4904 (`session.stop` by id, gated). Independent of both; expect a trivial both-added conflict in `cross-chat-memory.mdx` and `openwork-provider-adapters.ts` whichever lands second.

## Verification

Head: `ca629d183a1974e618aa3597ebc0296e255c0f74`. Lane: **local** for all checks. The PR-lane spec's world (`agentSessionSend`, like its sibling `agentUiContext`) boots a managed `openwork-server` + real engine in-process and does not take Daytona placement, so there is no Daytona variant of it; it runs in CI's `pnpm evals:pr`.

| Command | Result |
| --- | --- |
| `bun --conditions=development test src/opencode-plugins/openwork-extensions-preview.test.ts src/opencode-plugins/openwork-provider-adapters.test.ts` (apps/server) | Exit 0: 37 passed, 0 failed (3 new `session.send` cases + descriptor case) |
| `bun test --isolate tests/control-focus-bound-composer.test.tsx` (apps/app) | Exit 0: 2 passed, 0 failed |
| `pnpm evals:pr specs/session-send-headless-by-id.test.ts` | Exit 0: 1 passed, 0 failed, 0 skipped — evidence in the sticky comment |
| `tsc --noEmit` in apps/server, apps/app | Exit 0 |
| `git diff --check` | Exit 0 |

The spec drives the real engine with a scripted model and a fake window that polls the UI-control mailbox and refuses every command: session 1's `openwork_execute(session.send)` reaches session 2 by id (accepted, `messageId` matches the persisted user message, session 2 answers), session 3 has no messages, the mailbox saw **0 commands**; a second send while session 2 is busy on a held provider stream is accepted, already in the transcript before the model sees it, and answered after the held step; `reveal: true` yields exactly one `session.open` for session 2 with session 1 as origin, after the message was written; an unknown id is refused before anything reaches the engine or the window.

Verdict: **Passed** (local lane).
