### PR TITLE
fix(composer): let Home/End move the caret instead of being swallowed by document scroll

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -25,6 +25,7 @@ import {
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_BACKSPACE_COMMAND,
+  KEY_DOWN_COMMAND,
   KEY_ENTER_COMMAND,
   PASTE_COMMAND,
   type SerializedTextNode,
@@ -39,6 +40,7 @@ import { parseConnectSkillToken } from "./connect-skill-token";
 import { encodeConnectorToken, parseConnectorToken } from "./connector-token";
 import { shouldCollapsePastedText, splitPastedText } from "./pasted-text";
 import { insertPastedText } from "./pasted-text-insertion";
+import { lineBoundaryMoveForKey } from "./line-boundary-keys";
 
 type PastedTextToken = { label: string; lines: number; text: string };
 
@@ -1259,6 +1261,30 @@ function MentionChipNavigationPlugin() {
   return null;
 }
 
+// Home / End move the caret to the line boundary (Shift extends). See
+// lineBoundaryMoveForKey for why Chromium on macOS does not do this itself.
+function LineBoundaryKeysPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_DOWN_COMMAND,
+      (event: KeyboardEvent) => {
+        const move = lineBoundaryMoveForKey(event);
+        if (!move) return false;
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return false;
+        event.preventDefault();
+        selection.modify(move.alter, move.backward, "lineboundary");
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor]);
+
+  return null;
+}
+
 function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEditorHandle> }) {
   const [editor] = useLexicalComposerContext();
 
@@ -1398,6 +1424,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         <PastedTextExpandPlugin pastedText={props.pastedText} onExpandPastedText={props.onExpandPastedText} />
         <AttachmentChipPlugin onRemoveAttachment={props.onRemoveAttachment} onExpandAttachment={props.onExpandAttachment} />
         <MentionChipNavigationPlugin />
+        <LineBoundaryKeysPlugin />
         <ImperativeHandlePlugin editorRef={ref} />
       </div>
     </LexicalComposer>

--- a/apps/app/src/react-app/domains/session/surface/composer/line-boundary-keys.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/line-boundary-keys.ts
@@ -1,0 +1,22 @@
+export type LineBoundaryMove = {
+  alter: "move" | "extend";
+  backward: boolean;
+};
+
+type LineBoundaryKeyEvent = Pick<KeyboardEvent, "key" | "shiftKey" | "metaKey" | "ctrlKey" | "altKey">;
+
+/**
+ * Home / End (optionally with Shift) move or extend the caret to the visual
+ * line boundary inside the composer.
+ *
+ * On macOS Chromium binds the bare keys to `scrollTo{Beginning,End}OfDocument`
+ * and only moves the caret when nothing in the scroll chain accepts that
+ * scroll; the shell's `body { overscroll-behavior: none }` ends the chain at
+ * `body`, so the caret never moved. Any other modifier (Cmd/Ctrl/Alt) keeps the
+ * platform's own binding, e.g. Ctrl+Home on Windows for document start.
+ */
+export function lineBoundaryMoveForKey(event: LineBoundaryKeyEvent): LineBoundaryMove | null {
+  if (event.metaKey || event.ctrlKey || event.altKey) return null;
+  if (event.key !== "Home" && event.key !== "End") return null;
+  return { alter: event.shiftKey ? "extend" : "move", backward: event.key === "Home" };
+}

--- a/apps/app/tests/composer-line-boundary-keys.test.ts
+++ b/apps/app/tests/composer-line-boundary-keys.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { lineBoundaryMoveForKey } from "../src/react-app/domains/session/surface/composer/line-boundary-keys";
+
+function key(key: string, modifiers: Partial<Record<"shiftKey" | "metaKey" | "ctrlKey" | "altKey", boolean>> = {}) {
+  return { key, shiftKey: false, metaKey: false, ctrlKey: false, altKey: false, ...modifiers };
+}
+
+test("bare Home and End move the caret to the line boundary", () => {
+  expect(lineBoundaryMoveForKey(key("Home"))).toEqual({ alter: "move", backward: true });
+  expect(lineBoundaryMoveForKey(key("End"))).toEqual({ alter: "move", backward: false });
+});
+
+test("Shift+Home and Shift+End extend the selection to the line boundary", () => {
+  expect(lineBoundaryMoveForKey(key("Home", { shiftKey: true }))).toEqual({ alter: "extend", backward: true });
+  expect(lineBoundaryMoveForKey(key("End", { shiftKey: true }))).toEqual({ alter: "extend", backward: false });
+});
+
+test("Cmd, Ctrl and Alt chords keep the platform binding", () => {
+  for (const modifier of ["metaKey", "ctrlKey", "altKey"] as const) {
+    expect(lineBoundaryMoveForKey(key("Home", { [modifier]: true }))).toBeNull();
+    expect(lineBoundaryMoveForKey(key("End", { [modifier]: true }))).toBeNull();
+    expect(lineBoundaryMoveForKey(key("Home", { [modifier]: true, shiftKey: true }))).toBeNull();
+  }
+});
+
+test("every other key is left to the editor and the transcript", () => {
+  for (const other of ["PageUp", "PageDown", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Enter", "Escape", "Tab", "a", "e", " "]) {
+    expect(lineBoundaryMoveForKey(key(other))).toBeNull();
+    expect(lineBoundaryMoveForKey(key(other, { shiftKey: true }))).toBeNull();
+  }
+});

--- a/evals/packages/cdp/src/input.ts
+++ b/evals/packages/cdp/src/input.ts
@@ -404,6 +404,13 @@ const EDITING_COMMANDS: Record<string, string[]> = {
   "Control+A": ["selectAll"],
   "Meta+ArrowDown": ["moveToEndOfDocument"],
   "Control+End": ["moveToEndOfDocument"],
+  // macOS standard key bindings: bare Home/End scroll the document and only
+  // move the caret when nothing in the scroll chain accepts the scroll. Named
+  // on every lane so specs see the same keys a Mac user presses.
+  Home: ["scrollToBeginningOfDocument"],
+  End: ["scrollToEndOfDocument"],
+  "Shift+Home": ["moveToBeginningOfDocumentAndModifySelection"],
+  "Shift+End": ["moveToEndOfDocumentAndModifySelection"],
 };
 
 export async function pressKey(surface: Surface, key: string): Promise<void> {

--- a/evals/specs/composer-home-end-caret.e2e.test.ts
+++ b/evals/specs/composer-home-end-caret.e2e.test.ts
@@ -49,10 +49,12 @@ test("Home and End move the caret inside a multi-line draft instead of being swa
   });
 
   await step("PageUp and PageDown are left to the browser and the transcript", async () => {
+    // Where the caret lands is the platform's call (macOS scrolls, Linux and
+    // Windows page the caret); the composer must not claim either key.
     for (const key of ["PageUp", "PageDown"]) {
       await user.press(key);
       expect(await lastKeydown()).toEqual({ key, prevented: false });
-      expect(await caret()).toEqual({ anchor: `${secondLine}@${secondLine.length}`, focus: `${secondLine}@${secondLine.length}` });
+      expect(await caret()).not.toBeNull();
     }
   });
 

--- a/evals/specs/composer-home-end-caret.e2e.test.ts
+++ b/evals/specs/composer-home-end-caret.e2e.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { emptySession } from "../worlds/desktop.ts";
+
+const test = spec.world(emptySession);
+
+const firstLine = "first line";
+const secondLine = "second line";
+
+test("Home and End move the caret inside a multi-line draft instead of being swallowed", async ({ user, probe, step, evidence }) => {
+  // The composer caret, read from the live DOM selection as "text@offset" for
+  // both ends so collapsed moves and Shift extensions are distinguishable.
+  const caret = () => probe.eval(() => {
+    const selection = window.getSelection();
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!selection || !editor || !selection.anchorNode || !selection.focusNode || !editor.contains(selection.anchorNode)) return null;
+    const point = (node: Node, offset: number) => `${node.textContent ?? ""}@${offset}`;
+    return { anchor: point(selection.anchorNode, selection.anchorOffset), focus: point(selection.focusNode, selection.focusOffset) };
+  });
+  // Window-level record of the last keydown so the spec can tell "the composer
+  // handled this key" from "the browser default ran".
+  await probe.eval(() => {
+    window.addEventListener("keydown", (event) => {
+      document.body.dataset.lastKeydown = JSON.stringify({ key: event.key, prevented: event.defaultPrevented });
+    });
+  });
+  const lastKeydown = () => probe.eval(() => JSON.parse(document.body.dataset.lastKeydown ?? "null"));
+
+  await user.type("composer", firstLine);
+  await user.press("Shift+Enter");
+  await user.type("composer", secondLine);
+  await user.see("composer", { text: `${firstLine}\n${secondLine}` });
+  expect(await caret()).toEqual({ anchor: `${secondLine}@${secondLine.length}`, focus: `${secondLine}@${secondLine.length}` });
+
+  await step("Home and End move to the start and end of the current line", async () => {
+    await user.press("Home");
+    expect(await caret()).toEqual({ anchor: `${secondLine}@0`, focus: `${secondLine}@0` });
+    expect(await lastKeydown()).toEqual({ key: "Home", prevented: true });
+    await user.press("End");
+    expect(await caret()).toEqual({ anchor: `${secondLine}@${secondLine.length}`, focus: `${secondLine}@${secondLine.length}` });
+    expect(await lastKeydown()).toEqual({ key: "End", prevented: true });
+  });
+
+  await step("Shift+Home extends the selection to the line start, not the document start", async () => {
+    await user.press("Shift+Home");
+    expect(await caret()).toEqual({ anchor: `${secondLine}@${secondLine.length}`, focus: `${secondLine}@0` });
+    await user.press("Shift+End");
+    expect(await caret()).toEqual({ anchor: `${secondLine}@${secondLine.length}`, focus: `${secondLine}@${secondLine.length}` });
+  });
+
+  await step("PageUp and PageDown are left to the browser and the transcript", async () => {
+    for (const key of ["PageUp", "PageDown"]) {
+      await user.press(key);
+      expect(await lastKeydown()).toEqual({ key, prevented: false });
+      expect(await caret()).toEqual({ anchor: `${secondLine}@${secondLine.length}`, focus: `${secondLine}@${secondLine.length}` });
+    }
+  });
+
+  const draft = (await probe.composer()).draftText;
+  evidence.recordAssertionEvidence(
+    "navigation keys never edit the draft",
+    JSON.stringify({ draft, caret: await caret() }),
+    draft === `${firstLine}\n${secondLine}`,
+  );
+  expect(draft).toBe(`${firstLine}\n${secondLine}`);
+});


### PR DESCRIPTION
## Bug

In the session composer on macOS, pressing Home / End (and Shift+Home / Shift+End) does nothing. Cmd+Left/Right, Ctrl+A/Ctrl+E and PageUp/PageDown behave normally; a plain `<textarea>` in the same Electron page moves the caret as expected.

## Root cause

Not a key handler — nothing in `apps/app/src` or `apps/desktop/electron` binds Home/End for the composer (the only matches are the narrow-pane tab switcher, the find bar and `scroll-controller.ts`, which explicitly ignores keys inside `[contenteditable=true]`). #4742's PageUp browsing is unrelated.

On macOS Chromium maps bare Home/End to the editing commands `scrollToBeginningOfDocument` / `scrollToEndOfDocument` and only moves the caret in a contenteditable when nothing in the scroll chain accepts the scroll. The shell sets `body { overscroll-behavior: none }` (`apps/app/src/app/index.css:816`, added in #3773 for the phone/tablet shell), which terminates the chain at `body`, so the scroll is "consumed" and the caret fallback never runs. Reproduced live via CDP (real System Events keystrokes into a dev desktop): with the composer focused mid second line, Home/End left the caret at `second line@6`; toggling `body.style.overscrollBehavior = "auto"` at runtime made Home move to `second line@0`; a plain `<div contenteditable>` in `<body>` showed the identical failure and worked as `position:fixed` / with `html,body{overflow:visible}`. Cmd+Left/Right and Ctrl+A/E use `moveTo…OfLine/Paragraph` commands, which is why they were unaffected. Bare Electron 43 + a page with `body{overflow:hidden}` but without `overscroll-behavior:none` moved the caret correctly.

## Fix (smallest)

- `composer/line-boundary-keys.ts`: `lineBoundaryMoveForKey` — bare Home/End → move to line boundary, Shift → extend; any Cmd/Ctrl/Alt chord returns `null` so platform bindings (Cmd+Home doc start, Ctrl+Home on Windows) are untouched.
- `composer/editor.tsx`: `LineBoundaryKeysPlugin` registers a Lexical `KEY_DOWN_COMMAND` listener that calls `selection.modify(alter, backward, "lineboundary")` and prevents the default only for those keys. Enter/Shift+Enter, ArrowUp history recall, PageUp/PageDown, Escape, Tab and mention-chip navigation are not touched.
- `evals/packages/cdp/src/input.ts`: `pressKey("Home"|"End"|"Shift+Home"|"Shift+End")` now sends the macOS editing commands so specs exercise the same path a Mac user does on every lane.

Removing `overscroll-behavior: none` was considered and rejected: it exists for the mobile shell's rubber-banding, and the composer should not depend on the scroll chain to get caret navigation.

## Tests

- `apps/app/tests/composer-line-boundary-keys.test.ts` — 4 tests, `bun test --isolate ./tests/composer-line-boundary-keys.test.ts`: 4 pass / 0 fail.
- `evals/specs/composer-home-end-caret.e2e.test.ts` — types two lines with Shift+Enter, presses Home/End/Shift+Home/Shift+End and asserts the DOM caret (`text@offset`) and that the composer prevented the default; asserts PageUp/PageDown are *not* prevented and leave the caret alone; asserts the draft is unchanged.
- `pnpm --filter @openwork/app typecheck` exit 0. `git diff --check` clean.

Live verification (dev desktop, real macOS keystrokes, caret read over CDP): Home → `second line@0`, End → `second line@11`, Shift+Home → anchor `@6` focus `@0`, Shift+End → focus `@11`, Cmd+Left/Right and Ctrl+A/E unchanged, PageUp not prevented.

## Proof

Lane: **Daytona** (`OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=cb5177afb74937007490841a194b39cdf0a02ac7 pnpm evals:e2e composer-home-end-caret --daytona`), sandbox built from the PR head (`sandboxSha == gitSha`, no ref mismatch): `passed 1 / failed 0 / skipped 0`, verdict **Passed**; all 3 steps green, sandbox deleted. Evidence is in the sticky test-evidence comment below.

A first Daytona run at `23976f051` failed only on an over-specified PageUp claim in the new spec (Linux pages the caret; macOS scrolls); the claim was narrowed to what the composer owns (it must not intercept PageUp/PageDown). No product change between the two runs.
