### PR TITLE
fix(gateway): adapt legacy thinking for aliased Claude models

### DIFF
--- a/ee/apps/gateway/src/gateway.ts
+++ b/ee/apps/gateway/src/gateway.ts
@@ -357,6 +357,21 @@ function rewriteSelectedModel(prepared: PreparedRequest, upstream: ResolvedUpstr
     json.model = model
     modified = true
   }
+  // Wire aliases hide Claude's identity from clients' model-specific options.
+  // Apply the same legacy-thinking compatibility as the desktop plugin, but
+  // only after the model grant has resolved the authorized upstream model.
+  const claudeVersion = model?.match(/claude-[a-z]+-(\d+)(?:[.@-]|$)/i)
+  if (upstream.protocol === "anthropic_messages" && claudeVersion && Number(claudeVersion[1]) >= 5
+    && isJsonObject(json.thinking) && json.thinking.type === "enabled") {
+    const { budget_tokens, ...thinking } = json.thinking
+    json.thinking = { ...thinking, type: "adaptive" }
+    const outputConfig = isJsonObject(json.output_config) ? json.output_config : {}
+    json.output_config = {
+      ...outputConfig,
+      effort: outputConfig.effort ?? (typeof budget_tokens === "number" && budget_tokens > 16000 ? "max" : "high"),
+    }
+    modified = true
+  }
   if (upstream.protocol === "openai_chat" && json.stream === true) {
     json.stream_options = { ...(isJsonObject(json.stream_options) ? json.stream_options : {}), include_usage: true }
     modified = true

--- a/ee/apps/gateway/test/gateway.test.ts
+++ b/ee/apps/gateway/test/gateway.test.ts
@@ -398,6 +398,64 @@ test("anthropic: x-api-key auth, anthropic headers preserved, stream usage from 
   assert.equal(row.upstream_request_id, "req_anthropic")
 })
 
+test("adaptive thinking compatibility uses the granted model behind opaque aliases only for Anthropic messages", async (t) => {
+  const enabled = { type: "enabled", budget_tokens: 16000, display: "summarized" }
+  const adaptive = { type: "adaptive", display: "summarized" }
+  const format = { type: "json_schema", schema: { type: "object", properties: {} } }
+  const cases: Array<{ name: string; model?: string; input: Record<string, unknown>; expected?: Record<string, unknown> }> = [
+    { name: "16000 defaults to high", input: { thinking: enabled },
+      expected: { thinking: adaptive, output_config: { effort: "high" } } },
+    { name: "16001 defaults to max", model: "claude-opus-5@20260901", input: { thinking: { ...enabled, budget_tokens: 16001 } },
+      expected: { thinking: adaptive, output_config: { effort: "max" } } },
+    { name: "missing budget defaults to high", input: { thinking: { type: "enabled" } },
+      expected: { thinking: { type: "adaptive" }, output_config: { effort: "high" } } },
+    { name: "explicit effort and format survive", model: "claude-opus-5", input: { thinking: enabled, output_config: { effort: "low", format } },
+      expected: { thinking: adaptive, output_config: { effort: "low", format } } },
+    { name: "minor version preserves output fields", model: "claude-opus-5.1", input: { thinking: enabled, output_config: { format } },
+      expected: { thinking: adaptive, output_config: { format, effort: "high" } } },
+    { name: "future major and case-insensitive dated ID", model: "Claude-Opus-6-20260901", input: { thinking: enabled },
+      expected: { thinking: adaptive, output_config: { effort: "high" } } },
+    { name: "legacy 4-5", model: "claude-sonnet-4-5", input: { thinking: enabled, output_config: { format } } },
+    { name: "legacy 4.x", model: "claude-opus-4.6", input: { thinking: enabled } },
+    { name: "nonmatching version suffix", model: "claude-opus-5preview", input: { thinking: enabled } },
+    { name: "absent thinking", input: { output_config: { format } } },
+    { name: "disabled thinking", input: { thinking: { type: "disabled" } } },
+    { name: "already adaptive", input: { thinking: adaptive, output_config: { effort: "medium", format } } },
+  ]
+  for (const providerName of ["anthropic", "google-vertex-anthropic", "openai"]) {
+    for (const entry of cases) {
+      await t.test(`${providerName}: ${entry.name}`, async () => {
+        const vertex = providerName === "google-vertex-anthropic"
+        const fixture = createTestServer({
+          provider: { provider_id: providerName, settings: vertex ? { project: "test-project", location: "global" } : {} },
+          credential: vertex ? { kind: "oauth_google", secret: JSON.stringify({ accessToken: "ya29.token" }) } : undefined,
+        })
+        const selected = fixture.accessRows[0]
+        assert.ok(selected?.model)
+        selected.model.model_id = entry.model ?? "claude-fable-5"
+        const alias = createGatewayModelAlias({ modelGroupId: selected.group.id, credentialSetId: selected.credentialSet.id, gatewayProviderModelId: selected.model.id })
+        assert.match(alias, /^gwm_/)
+        const common = { messages: [{ role: "user", content: "hi" }], max_tokens: 32000 }
+        const response = await fixture.app.fetch(gatewayRequest({
+          path: providerName === "openai" ? "/chat/completions" : "/messages",
+          body: { model: alias, ...common, ...entry.input },
+        }))
+        assert.equal(response.status, 200)
+        await response.text()
+        assert.equal(fixture.upstreamRequests.length, 1)
+        const upstream = fixture.upstreamRequests[0]
+        assert.ok(upstream)
+        const expected = providerName === "openai" ? entry.input : entry.expected ?? entry.input
+        assert.deepEqual(parseJsonObject(upstream.body), {
+          ...common, ...expected,
+          ...(vertex ? { anthropic_version: "vertex-2023-10-16" } : { model: selected.model.model_id }),
+        })
+        if (vertex) assert.ok(upstream.url.endsWith(`/publishers/anthropic/models/${encodeURIComponent(selected.model.model_id)}:rawPredict`))
+      })
+    }
+  }
+})
+
 test("azure: api-key auth, api-version query preserved, resource base from settings, api_key_map picks the key env", async () => {
   const { app, upstreamRequests, logRows } = createTestServer({
     provider: { provider_id: "azure", provider_config: { npm: "@ai-sdk/azure" }, settings: { resourceName: "acme-openai" } },


### PR DESCRIPTION
## Problem
Gateway model aliases introduced in #4358 hide the upstream Claude identity from client-side thinking compatibility. The authorized upstream model is restored, but legacy `thinking.type: enabled` can still reach adaptive-only Claude models and be rejected.

## Change
- Normalize legacy thinking after resolving the authorized upstream model for Anthropic messages (including Vertex Anthropic).
- Match the existing desktop compatibility policy for Claude major versions 5 and later: use adaptive thinking, remove the legacy token budget, and translate the budget to high/max effort unless effort is explicitly set.
- Preserve output-format fields, disabled/absent/already-adaptive thinking, older Claude behavior, other protocols, and grant/credential selection.

## Verification
**Proof verdict: Incomplete** — focused Gateway route tests pass; cold-boot testkit journey evidence and end-to-end desktop chat reproduction are deferred for this quick fix. No deployment performed.

Passed:
- `NODE_OPTIONS=--conditions=development pnpm --filter @openwork-ee/gateway exec tsx --test test/gateway.test.ts` — 84 passed, 0 failed, 0 skipped; includes 36 new compatibility cases.
- `pnpm --dir evals typecheck` — 414 evals source files, no errors.
- `git diff --check`.

The new conversion cases failed against the unmodified implementation. An initial Vertex test expectation omitted URL encoding for dated model IDs; that assertion was corrected and the full Gateway test file then passed. Checks ran on the committed tree contents; rebase against refreshed dev was a no-op.

Deferred: extend and run `evals/specs/inference-gateway-org-provider.test.ts` with the alias plus legacy-thinking upstream witness assertion, and publish exact-head evidence. Required CI remains unchanged.

## UI/UX impact
None — existing UI/UX preserved. No model-picker layout, labels, controls, or interaction changes.