### PR TITLE
fix(models): widen the picker and truncate long labels

### DIFF
--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -316,7 +316,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         if (!open) props.onClose();
       }}
     >
-      <DialogContent className="flex max-h-[calc(100vh-2rem)] min-h-0 w-full max-w-lg flex-col overflow-hidden sm:max-w-lg">
+      <DialogContent className="flex max-h-[calc(100dvh-2rem)] min-h-0 flex-col overflow-hidden lg:max-w-3xl">
         <DialogHeader>
           <DialogTitle>{t("models.title")}</DialogTitle>
           <DialogDescription>
@@ -354,7 +354,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             </div>
           ) : null}
 
-          <div className="max-h-40 shrink-0 overflow-y-auto">
+          <div className="max-h-40 shrink-0 overflow-x-hidden overflow-y-auto">
           {props.gatewayConnectProviders?.map((provider) => (
             <div
               key={gatewayConnectProviderKey(provider)}
@@ -362,13 +362,13 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             >
               <ProviderIcon providerId={provider.providerId} providerName={provider.name} size={18} className="shrink-0 text-dls-secondary" />
               <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5 text-[13px] font-medium text-dls-text">
-                  <span className="truncate">{provider.name}</span>
-                  <Badge variant="outline" className="h-auto rounded-md px-1.5 py-0.5 text-[10px] text-dls-secondary">
-                    {OPENWORK_GATEWAY_BADGE_LABEL}
+                <div className="flex min-w-0 flex-col items-start gap-1 text-[13px] font-medium text-dls-text">
+                  <span className="max-w-full truncate" title={provider.name}>{provider.name}</span>
+                  <Badge variant="outline" title={OPENWORK_GATEWAY_BADGE_LABEL} className="h-auto min-w-0 max-w-full rounded-md px-1.5 py-0.5 text-[10px] text-dls-secondary">
+                    <span className="truncate">{OPENWORK_GATEWAY_BADGE_LABEL}</span>
                   </Badge>
                 </div>
-                <div className="truncate text-[11px] text-dls-secondary">{gatewayConnectCopy(provider.name)}</div>
+                <div className="truncate text-[11px] text-dls-secondary" title={gatewayConnectCopy(provider.name)}>{gatewayConnectCopy(provider.name)}</div>
               </div>
               <Button
                 size="sm"
@@ -384,10 +384,10 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
           </div>
 
           {/* Content */}
-          <div className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1 -mr-1">
+          <div className="min-h-0 flex-1 space-y-1 overflow-x-hidden overflow-y-auto pr-1 -mr-1">
             {currentOption && !disabledSet.has(currentOption.providerID) ? (
               <section aria-label={`Settings for ${currentOption.title}`} className="mb-3 rounded-xl border border-dls-border p-3" data-testid="current-model-settings">
-                <div className="text-xs font-medium">{currentOption.title} · {currentBehavior.label}</div>
+                <div className="truncate text-xs font-medium" title={`${currentOption.title} · ${currentBehavior.label}`}>{currentOption.title} · {currentBehavior.label}</div>
                 <p role="status" className="mt-1 text-xs text-muted-foreground">{currentBehavior.description}</p>
                 {behaviorControls.hasFast ? (
                   <div className="mt-2 space-y-1">
@@ -500,24 +500,27 @@ function ProviderAccordion({
           <Chevron size={14} className="shrink-0 text-dls-secondary" />
           <ProviderIcon providerId={group.id} size={18} className="shrink-0 text-dls-text" />
           <div className="min-w-0 flex-1">
-            <span className="text-[13px] font-medium text-dls-text">{group.name}</span>
+            <div className="flex min-w-0 items-baseline gap-2">
+              <span className="truncate text-[13px] font-medium text-dls-text" title={group.name}>{group.name}</span>
+              {" "}
+              <span className="shrink-0 whitespace-nowrap text-[11px] text-dls-secondary">
+                {totalModels} model{totalModels === 1 ? "" : "s"}
+              </span>
+            </div>
             {" "}
-            <span className="ml-2 text-[11px] text-dls-secondary">
-              {totalModels} model{totalModels === 1 ? "" : "s"}
-            </span>
+            <div className="flex flex-wrap items-center gap-1.5 empty:hidden">
+              {resolveProviderGroupBadges(group, organizationProviderLabel).map((badge) => (
+                <Badge
+                  key={badge.label}
+                  variant="outline"
+                  title={badge.label}
+                  className={`h-auto min-w-0 max-w-full rounded-md border-transparent px-1.5 py-0.5 text-[10px] ${badge.className}`}
+                >
+                  <span className="truncate">{badge.label}</span>
+                </Badge>
+              ))}
+            </div>
           </div>
-          {" "}
-          <span className="flex shrink-0 items-center gap-1.5">
-            {resolveProviderGroupBadges(group, organizationProviderLabel).map((badge) => (
-              <Badge
-                key={badge.label}
-                variant="outline"
-                className={`h-auto rounded-md border-transparent px-1.5 py-0.5 text-[10px] ${badge.className}`}
-              >
-                {badge.label}
-              </Badge>
-            ))}
-          </span>
         </button>
         {canToggleProvider ? (
           <button
@@ -589,8 +592,8 @@ function DefaultModelRow({
     >
       {recommended ? <Star size={12} className="shrink-0 text-amber-9" /> : <div className="w-3 shrink-0" />}
       <div className="min-w-0 flex-1">
-        <span className={["text-[12px]", active ? "font-medium text-dls-text" : "text-dls-text"].join(" ")}>{opt.title}</span>
-        <span className="ml-2 font-mono text-[10px] text-dls-secondary/60">{opt.modelID}</span>
+        <span className={["block truncate text-[12px]", active ? "font-medium text-dls-text" : "text-dls-text"].join(" ")} title={opt.title}>{opt.title}</span>
+        <span className="block truncate font-mono text-[10px] text-dls-secondary/60" title={opt.modelID}>{opt.modelID}</span>
       </div>
       {active ? <Check size={14} className="shrink-0 text-green-11" /> : null}
     </button>

--- a/apps/app/tests/model-picker-modal.test.ts
+++ b/apps/app/tests/model-picker-modal.test.ts
@@ -300,6 +300,62 @@ test("Automation preserves same-model settings, recovers Default and saves only 
   }
 });
 
+test("long picker labels retain full hover text and select the complete model ID", async () => {
+  const authSpy = spyOn(auth, "useDenAuth").mockReturnValue({ status: "signed_out", user: null, verifiedIdentity: null, isSignedIn: false, error: null, refresh: async () => undefined });
+  const den = await import("../src/app/lib/den");
+  const organization = "Synthetic organization with a very long display name";
+  const settingsSpy = spyOn(den, "readDenSettings").mockReturnValue({ ...den.readDenSettings(), activeOrgName: organization });
+  const providerID = "ipr_synthetic";
+  const modelID = `gwm_${"synthetic_gateway_model_revision_".repeat(4)}`;
+  const title = "Synthetic model with a long human-readable display name";
+  const providerName = "Synthetic gateway provider with a long display name";
+  const current = { providerID, modelID };
+  const options: ModelOption[] = [{ ...current, title, description: providerName, source: "cloud", isRecommended: true, isFree: false }];
+  const selected: unknown[] = [];
+  const toggled: unknown[] = [];
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  function Picker() {
+    const [disabledProviders, setDisabledProviders] = useState<string[]>([]);
+    return createElement(ModelPickerModal, { open: true, options, current, disabledProviders,
+      target: "session", query: "", setQuery: () => undefined, gatewayProviderIds: new Set([providerID]),
+      onSelect: (model) => selected.push(model), onBehaviorChange: () => undefined,
+      onToggleProvider: (id, enabled) => { toggled.push({ id, enabled }); setDisabledProviders(enabled ? [] : [id]); },
+      onOpenSettings: () => undefined, onClose: () => undefined });
+  }
+  const label = (text: string) => Array.from(document.querySelectorAll<HTMLElement>("[title]"))
+    .find((element) => element.title === text);
+  const toggle = async (text: string) => {
+    const button = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((element) => element.textContent === text);
+    if (!button) throw new Error(`Missing provider toggle: ${text}`);
+    await act(async () => button.click());
+  };
+  try {
+    await act(async () => root.render(createElement(PlatformProvider, { value: createDefaultPlatform(), children: createElement(Picker) })));
+    for (const text of [providerName, organization, "via OpenWork Gateway", title, modelID]) {
+      expect(label(text)?.textContent).toBe(text);
+    }
+    const header = label(providerName)?.closest("button");
+    expect(header?.textContent).toMatch(/1 model\b/);
+    expect(header?.querySelectorAll('[data-slot="badge"]')).toHaveLength(4);
+    await toggle("Enabled");
+    expect(label(modelID)).toBeUndefined();
+    expect(selected).toEqual([]);
+    await toggle("Enable");
+    const modelButton = label(modelID)?.closest("button");
+    if (!modelButton) throw new Error("The gateway model did not return after enabling its provider");
+    await act(async () => modelButton.click());
+    expect(selected).toEqual([current]);
+    expect(toggled).toEqual([{ id: providerID, enabled: false }, { id: providerID, enabled: true }]);
+  } finally {
+    await act(async () => root.unmount());
+    host.remove();
+    settingsSpy.mockRestore();
+    authSpy.mockRestore();
+  }
+});
+
 describe("model picker provider badges", () => {
   const importedCloudProviders = {
     ipr_gateway: { providerId: "ipr_gateway", source: "openwork_gateway" },

--- a/evals/specs/inference-gateway-desktop-sync.e2e.test.ts
+++ b/evals/specs/inference-gateway-desktop-sync.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, onTestFinished } from "vitest";
 import { screenshot, validate } from "@openwork/test-evidence";
+import { setViewport } from "@openwork/cdp";
 import { denFetch, evalIn, go, readAvailableModels } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
 import { app, browserScript, eventually, needs, server, SkipError, test } from "@openwork/testkit";
@@ -290,9 +291,27 @@ test("a gateway provider materializes on the desktop as its own ipr_ provider wi
   expect(gatewayModel?.selectable).toBe(true);
   expect(gatewayModel?.providerName).toBe(PROVIDER_NAME);
 
-  const badgeState = await evalIn(desktopApp, browserScript((providerName: string, badgeLabel: string) => {
-    const dialog = document.querySelector('[data-slot="dialog-content"]');
-    if (!dialog) return { error: "dialog missing" };
+  const readBadgeState = () => evalIn(desktopApp, browserScript((providerName: string, badgeLabel: string, modelID: string) => {
+    const dialog = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
+    if (!dialog) throw new Error("dialog missing");
+    const rect = dialog.getBoundingClientRect();
+    const overflow = [dialog, ...dialog.querySelectorAll<HTMLElement>("div, button, span")].filter((node) => {
+      if (!node.clientWidth) return false;
+      const box = node.getBoundingClientRect();
+      return box.left < rect.left - 1 || box.right > rect.right + 1
+        || (node.scrollWidth > node.clientWidth + 1 && getComputedStyle(node).textOverflow !== "ellipsis");
+    }).map((node) => `${node.tagName}.${node.className}`);
+    const labels = [["span.font-mono", modelID], ["button span.text-dls-text", providerName]].map(([selector, text]) => {
+      const node = [...dialog.querySelectorAll<HTMLElement>(selector)].find((span) => span.textContent === text);
+      if (!node) return null;
+      const style = getComputedStyle(node);
+      const height = node.getBoundingClientRect().height;
+      return {
+        text: node.textContent, title: node.title,
+        singleLineEllipsis: node.clientWidth > 0 && height > 0 && height <= parseFloat(style.lineHeight) + 1
+          && style.whiteSpace === "nowrap" && style.textOverflow === "ellipsis" && style.overflowX === "hidden",
+      };
+    });
     // Group headers read "<provider> <n> model(s) <badges…>"; badges follow the count.
     const headers = [...dialog.querySelectorAll("button")].filter((button) => /\b\d+ models?\b/.test((button.textContent ?? "").replace(/\s+/g, " ").trim()));
     const describe = (header: HTMLButtonElement) => ({
@@ -305,8 +324,14 @@ test("a gateway provider materializes on the desktop as its own ipr_ provider wi
       otherBadgedGroups: groups.filter((group) => !group.text.includes(providerName) && group.badged),
       unbadgedGroups: groups.filter((group) => !group.text.includes(providerName) && !group.badged),
       groupCount: groups.length,
+      viewport: { width: window.innerWidth, height: window.innerHeight, deviceScaleFactor: window.devicePixelRatio },
+      dialogWidth: rect.width,
+      dialogFits: rect.width > 0 && rect.height > 0 && rect.left >= -1 && rect.top >= -1
+        && rect.right <= window.innerWidth + 1 && rect.bottom <= window.innerHeight + 1,
+      overflow, labels,
     };
-  }, [PROVIDER_NAME, GATEWAY_BADGE_LABEL]));
+  }, [PROVIDER_NAME, GATEWAY_BADGE_LABEL, wireModelId]));
+  const badgeState = await readBadgeState();
   const gatewayGroup = isRecord(badgeState) && isRecord(badgeState.gatewayGroup) ? badgeState.gatewayGroup : null;
   const otherBadged = isRecord(badgeState) && Array.isArray(badgeState.otherBadgedGroups) ? badgeState.otherBadgedGroups : [];
   const unbadged = isRecord(badgeState) && Array.isArray(badgeState.unbadgedGroups) ? badgeState.unbadgedGroups : [];
@@ -319,6 +344,25 @@ test("a gateway provider materializes on the desktop as its own ipr_ provider wi
     `Model ${wireModelId} is selectable under ${String(gatewayModel?.providerName)}; group header ${JSON.stringify(gatewayGroup?.text)} carries the badge, ${otherBadged.length} other group(s) do, and ${unbadged.length} non-gateway group(s) do not.`,
     gatewayModel?.selectable === true && gatewayGroup?.badged === true && otherBadged.length === 0 && unbadged.length > 0,
   );
+  try {
+    for (const width of [320, 390, 1024, 1440]) {
+      await setViewport(desktopApp, { ...badgeState.viewport, width });
+      await eventually(async () => {
+        const layout = await readBadgeState();
+        const detail = `Models picker at ${width}px: ${JSON.stringify(layout)}`;
+        expect(layout.viewport.width, detail).toBe(width);
+        expect(layout.dialogFits, detail).toBe(true);
+        if (width >= 1024) expect(layout.dialogWidth, detail).toBeGreaterThan(512);
+        expect(layout.overflow, detail).toEqual([]);
+        expect(layout.labels, detail).toEqual([wireModelId, PROVIDER_NAME].map((text) => ({
+          text, title: text, singleLineEllipsis: true,
+        })));
+        return true;
+      }, { within: 5_000, intervalMs: 100, label: `Models picker containment at ${width}px` });
+    }
+  } finally {
+    await setViewport(desktopApp, badgeState.viewport);
+  }
   {
     const shot = await screenshot(desktopApp);
     const seen = await validate(shot, [


### PR DESCRIPTION
## Summary

The full Models dialog can squeeze provider names into narrow columns and scroll horizontally when gateway badges and long model IDs compete for space. Its inherited desktop width cap also overrides the intended wider layout.

Keep this fix scoped to the full picker: increase available desktop width, let provider metadata reflow, and truncate display text without changing the model references passed to selection.

## UI/UX impact

- Increase the desktop maximum width from the inherited 28rem cap to 48rem (768px at the default font size); retain the existing small-screen bottom sheet and use dynamic viewport height for the height bound.
- Place provider badges below the name/count, wrap the badge row, and prevent the model count from breaking across lines.
- Give model names and IDs separate, single-line rows with ellipses. Truncate long provider names, organization badges, and current-model headings while preserving their full text on hover.
- Bound gateway sign-in labels/badges similarly and suppress horizontal list scrolling.
- Preserve existing icons, colors, labels, search, model selection, provider toggles, and effort controls. No shared Dialog or Badge primitive changes.

## Verification

**Verdict: Incomplete — exact-head runtime layout evidence has not been produced.**

Passed:
- `pnpm --filter @openwork/app exec bun test --isolate ./tests/model-picker-modal.test.ts` — 17 passed, 0 failed, 0 skipped; exit 0. Includes full hover-text and complete-ID selection regression coverage with provider toggling.
- `pnpm evals:typecheck` — 414 eval source files, no errors; exit 0. The initial attempt reported six errors because the linked review package dependencies were not installed; installing those declared dependencies resolved the check without source or lockfile changes.
- `git diff --check origin/dev...HEAD` — exit 0.

Deferred / not run:
- `pnpm evals:e2e inference-gateway-desktop-sync` — the existing gateway picker journey now checks containment, desktop width, and single-line ellipses at 320, 390, 1024, and 1440px. These browser assertions have not been executed; component tests and typechecking are not substitutes for that proof.
- No runtime screenshots or end-to-end evidence are claimed.

## Integration note

This is independent of #4629, which replaces the model rows and already includes ID truncation. Reconcile the layout-only row styling when combining; this PR does not import its catalog, favorites, or access-policy changes.