### PR TITLE
feat(den): align My Library with Desktop

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/library-screen.tsx
@@ -1,16 +1,17 @@
 "use client";
 
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { ChevronRight, LayoutGrid, List, Plus, RefreshCw, Search } from "lucide-react";
+import { ChevronRight, LayoutGrid, List, Plus, RefreshCw, Search, TriangleAlert } from "lucide-react";
 
 import { DenBrandMark } from "../../_components/ui/brand-mark";
-import { buttonVariants, DenButton } from "../../_components/ui/button";
+import { DenButton } from "../../_components/ui/button";
 import { DenChip } from "../../_components/ui/chip";
 import { DenInput } from "../../_components/ui/input";
-import { DenList, DenListRow } from "../../_components/ui/list-row";
-import { DenNotice } from "../../_components/ui/notice";
+import { DenList } from "../../_components/ui/list-row";
 import { UnderlineTabs } from "../../_components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../_components/ui/tooltip";
 import { getLibraryPluginRoute, getOrgAccessFlags, getYourConnectionsRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { type LibraryItem, useLibrary } from "./library-data";
@@ -25,6 +26,8 @@ import {
   LIBRARY_DEFAULT_STATE,
   LIBRARY_KINDS,
   LIBRARY_LAYOUT_KEY,
+  LIBRARY_STATES,
+  type LibraryEmptyState,
   type LibraryKind,
   type LibraryLayout,
   type LibraryState,
@@ -75,14 +78,11 @@ export function LibraryRow({ item, isFocused, orgName, orgSlug, layout }: {
 }) {
   const state = getLibraryState(item);
   const source = getSource(item, orgName);
-  const connectionHref = item.type === "connection"
-    ? `${getYourConnectionsRoute(orgSlug)}?connectionId=${encodeURIComponent(item.id)}`
-    : undefined;
   const rowHref = item.type === "plugin"
     ? getLibraryPluginRoute(orgSlug, item.id)
     : item.type === "workflow"
       ? `/dashboard/library/workflows/${encodeURIComponent(item.id)}`
-      : connectionHref;
+      : `${getYourConnectionsRoute(orgSlug)}?connectionId=${encodeURIComponent(item.id)}`;
   const iconUrl = item.type === "connection" && item.provider === "google-workspace"
     ? "/integrations/google.svg"
     : item.type === "plugin"
@@ -90,64 +90,115 @@ export function LibraryRow({ item, isFocused, orgName, orgSlug, layout }: {
       : undefined;
   const simpleIconSlug = item.type === "connection" && item.provider === "microsoft-365" ? "microsoft" : undefined;
   const serviceUrl = item.type === "connection" && item.transport === "mcp" ? item.url : undefined;
-  const nonPersonSource = source && !source.isPerson ? source : null;
+  const ready = state === "ready";
+  const kindLabel = item.type === "connection" ? "MCP" : item.type === "workflow" ? "Workflow"
+    : hasLibraryComponent(item, "skill") && !hasLibraryComponent(item, "mcp") ? "Skill" : "Plugin";
+  const statusLabel = ready ? item.type === "connection" ? "Connected" : "Ready to use" : kindLabel;
+  const nextAction = state === "needs_signin" ? "Sign in"
+    : state === "needs_admin_setup" ? "Needs admin setup"
+      : state === "needs_setup" ? "Ready to set up" : "View details";
+  const meta = (
+    <span data-library-source>
+      {item.type === "connection" ? <span>{item.transport === "native" ? "Native" : "Cloud"} · </span> : null}
+      {source?.label ?? orgName}
+    </span>
+  );
+  const kindBadge = <DenChip data-library-chip="" className="!rounded-md !px-1.5 !text-[10px]">{kindLabel}</DenChip>;
 
+  // Keep web links and Den provenance while matching Desktop's neutral card
+  // anatomy. A plugin's availability must never claim its MCPs are connected.
   return (
-    <DenListRow
-      layout={layout}
-      leading={(
-        <DenBrandMark
-          name={item.name}
-          iconUrl={iconUrl}
-          simpleIconSlug={simpleIconSlug}
-          serviceUrl={serviceUrl}
-          className="h-10 w-10 shrink-0 rounded-[12px] border border-gray-100 bg-white"
-        />
-      )}
-      title={item.name}
-      chips={(
-        <>
-          <DenChip data-library-chip="" tone={item.type === "connection" ? "info" : "neutral"}>
-            {item.type === "connection" ? "MCP" : item.type === "workflow" ? "Workflow" : hasLibraryComponent(item, "skill") && !hasLibraryComponent(item, "mcp") ? "Skill" : "Plugin"}
-          </DenChip>
-          {item.type === "connection" ? (
-            <DenChip data-library-chip="" tone={item.transport === "mcp" ? "neutral" : "teal"}>
-              {item.transport === "mcp" ? "Cloud" : "Native"}
-            </DenChip>
-          ) : null}
-          {state !== "ready" ? (
-            <DenChip data-library-chip="" tone="warning">
-              {state === "needs_signin" ? "Connect your account" : state === "needs_admin_setup" ? "Waiting on your admin" : "Needs setup"}
-            </DenChip>
-          ) : null}
-          {source?.isPerson ? <DenChip data-library-chip="" data-library-source="" tone="info">{source.label}</DenChip> : null}
-        </>
-      )}
-      meta={item.description || nonPersonSource ? (
-        <>
-          {item.description}
-          {nonPersonSource ? (
-            <>
-              {item.description ? <span aria-hidden> · </span> : null}
-              <span data-library-source>{nonPersonSource.label}</span>
-            </>
-          ) : null}
-        </>
-      ) : undefined}
-      action={state !== "ready" && connectionHref ? (
-        <span className={buttonVariants({ size: "xs", variant: state === "needs_signin" ? "primary" : "ghost" })}>
-          {state === "needs_signin" ? "Sign in" : "Details"}
-        </span>
-      ) : <ChevronRight aria-hidden className="h-4 w-4 text-gray-400" />}
+    <Link
       href={rowHref}
-      focused={isFocused}
-      dataAttributes={{
-        "data-library-item-type": item.type,
-        "data-library-item-state": item.type === "connection" || item.type === "workflow" ? item.state : undefined,
-        "data-library-item-key": `${item.type}-${item.id}`,
-        "data-library-focused": isFocused ? "" : undefined,
-      }}
-    />
+      data-library-item-type={item.type}
+      data-library-item-state={item.type === "connection" || item.type === "workflow" ? item.state : undefined}
+      data-library-item-key={`${item.type}-${item.id}`}
+      data-library-focused={isFocused ? "" : undefined}
+      className={`group flex min-w-0 w-full gap-3 text-left transition-colors hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 ${layout === "grid" ? "h-full items-start rounded-xl border border-gray-200 bg-white p-4" : "items-center px-3.5 py-2"} ${isFocused ? "ring-2 ring-inset ring-blue-200" : ""}`}
+    >
+      <DenBrandMark
+        name={item.name}
+        iconUrl={iconUrl}
+        simpleIconSlug={simpleIconSlug}
+        serviceUrl={serviceUrl}
+        className={`${layout === "grid" ? "size-10" : "size-8"} rounded-lg`}
+        imageClassName={layout === "grid" ? "size-6" : "size-5"}
+      />
+      {layout === "grid" ? (
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <h3 className="min-w-0 break-words text-sm font-semibold text-gray-900">{item.name}</h3>
+            <DenChip data-library-chip="" data-library-ready={ready ? "" : undefined} tone={ready ? "success" : "neutral"} className="!rounded-md !px-1.5 !text-[10px]">
+              {statusLabel}
+            </DenChip>
+            {ready && item.type === "workflow" ? kindBadge : null}
+          </div>
+          {item.description ? <p className="mt-0.5 line-clamp-2 break-words text-xs text-gray-500">{item.description}</p> : null}
+          <div className="mt-1 text-[11px] text-gray-500">{meta}</div>
+          <div className="mt-2 text-[11px] font-medium text-gray-900 group-hover:opacity-80">{nextAction}</div>
+        </div>
+      ) : (
+        <>
+          <div className="flex min-w-0 flex-1 items-center gap-1.5 sm:w-44 sm:flex-none">
+            <span className="truncate text-[13px] font-medium text-gray-900">{item.name}</span>
+            {ready ? <span data-library-ready="" className="size-1.5 shrink-0 rounded-full bg-emerald-600"><span className="sr-only">{statusLabel}</span></span> : null}
+          </div>
+          <div className="flex w-20 shrink-0">{kindBadge}</div>
+          <p className="hidden min-w-0 flex-1 truncate text-xs text-gray-500 sm:block">{item.description}</p>
+          <div className="hidden max-w-40 shrink-0 truncate text-[11px] text-gray-500 lg:block">{meta}</div>
+          {ready ? <ChevronRight aria-hidden className="size-3.5 shrink-0 text-gray-400" /> : (
+            <span className="inline-flex h-7 shrink-0 items-center rounded-lg border border-gray-200 px-3 text-xs font-medium text-gray-900">{nextAction}</span>
+          )}
+        </>
+      )}
+    </Link>
+  );
+}
+
+export function LibraryAddControl({ action, label, disabledReason }: {
+  action: ReturnType<typeof getLibraryAddAction>;
+  label: string;
+  disabledReason: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={action ? <a href={action.href} /> : <button type="button" aria-disabled="true" />}
+        aria-label={action?.label ?? label}
+        title={action?.label ?? disabledReason}
+        className={`inline-flex size-8 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 ${action ? "" : "cursor-not-allowed opacity-70"}`}
+      >
+        <Plus aria-hidden className="size-5" />
+      </TooltipTrigger>
+      <TooltipContent>{action?.label ?? disabledReason}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function LibraryEmpty({ empty, addAction, disabledReason, error, onAction, onRefresh }: {
+  empty: LibraryEmptyState;
+  addAction: ReturnType<typeof getLibraryAddAction>;
+  disabledReason: string;
+  error?: string;
+  onAction: (action: LibraryEmptyState["action"]) => void;
+  onRefresh: () => void;
+}) {
+  const actionLabel = empty.action === "clear_filters" ? "Clear filters"
+    : LIBRARY_STATES.find((tab) => tab.value === empty.action)?.label;
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-[10px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center" data-library-empty={error ? "refresh" : empty.action}>
+      <h2 className="text-[15px] font-medium text-gray-900">{error ? "Your Library is unavailable" : empty.title}</h2>
+      <p className="max-w-md text-[13px] text-gray-500">{error ?? empty.description}</p>
+      {error ? (
+        <DenButton variant="secondary" onClick={onRefresh}>Refresh</DenButton>
+      ) : empty.action === "add" ? addAction ? (
+        <DenButton href={addAction.href} variant="secondary">{addAction.label}</DenButton>
+      ) : (
+        <p className="text-[13px] text-gray-500">{disabledReason}</p>
+      ) : (
+        <DenButton variant="secondary" onClick={() => onAction(empty.action)}>{actionLabel}</DenButton>
+      )}
+    </div>
   );
 }
 
@@ -165,6 +216,11 @@ export function LibraryScreen() {
   const requestedFocus = searchParams.get("focus");
   const access = getOrgAccessFlags(orgContext?.currentMember.role ?? "member", orgContext?.currentMember.isOwner ?? false, orgContext?.roles);
   const addAction = getLibraryAddAction({ kind: activeKind, isAdmin: access.isAdmin, mcpConnections: orgContext?.capabilities.mcpConnections === true, orgSlug });
+  const addLabel = activeKind === "mcps" ? "Add MCP" : activeKind === "skills" ? "Create skill" : "Add plugin";
+  const disabledReason = !orgContext ? "Loading your organization…"
+    : activeKind === "mcps" && !orgContext.capabilities.mcpConnections ? "Connections are not enabled for this organization."
+      : "An organization admin manages additions to this Library.";
+  const errorMessage = error ? error instanceof Error ? error.message : "Failed to load library." : undefined;
   const view = getLibraryView(items, activeKind, activeState, query);
 
   useEffect(() => {
@@ -210,35 +266,33 @@ export function LibraryScreen() {
   ));
 
   return (
+    <TooltipProvider>
     <div className="px-4 pb-7 pt-5 sm:px-8" data-testid="den-library" data-library-kind={activeKind} data-library-layout={layout}>
       <DashboardHeaderActions>
-      {addAction ? (
-        <DenButton href={addAction.href} variant="ghost" size="sm" className="!h-8 w-8 !p-0 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2" aria-label={addAction.label} title={addAction.label}>
-          <Plus aria-hidden className="h-5 w-5" />
-        </DenButton>
-      ) : (
-        <DenButton variant="ghost" size="sm" className="!h-8 w-8 !p-0" disabled aria-label="Add to My Library" title="A workspace admin manages additions to this Library.">
-          <Plus aria-hidden className="h-5 w-5" />
-        </DenButton>
-      )}
+        <LibraryAddControl action={addAction} label={addLabel} disabledReason={disabledReason} />
       </DashboardHeaderActions>
 
-      <div className="mb-5 flex min-w-0 flex-wrap items-center justify-between gap-x-7 gap-y-3 border-b border-gray-200">
-        <div className="min-w-0 flex-1 overflow-x-auto">
+      <div className="mb-4 flex h-12 min-w-0 items-end justify-between gap-x-7 border-b border-gray-200">
+        <div className="-mb-px min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <UnderlineTabs
-            className="!border-0 [&>nav]:!m-0 [&>nav]:!flex-nowrap [&>nav]:!gap-7 [&_[role=tab]]:h-12 [&_[role=tab]]:shrink-0 [&_[role=tab]]:!pb-0 [&_[role=tab]]:!text-[14px] [&_[role=tab]]:!font-normal [&_[role=tab]]:!leading-5 [&_[role=tab]]:!text-gray-500 [&_[role=tab][aria-selected=true]]:!border-gray-900 [&_[role=tab][aria-selected=true]]:!text-gray-900"
-            tabs={view.tabs.map((tab) => ({ ...tab, count: view.counts[tab.value], countClassName: "!h-[22px] min-w-6 justify-center !px-1.5 !py-0 !text-[12px]" }))}
+            className="!border-0 [&>nav]:!m-0 [&>nav]:!flex-nowrap [&>nav]:!gap-7 [&_[role=tab]]:h-12 [&_[role=tab]]:shrink-0 [&_[role=tab]]:!pb-0 [&_[role=tab]]:!text-sm [&_[role=tab]]:!leading-5 [&_[role=tab]]:focus-visible:outline-2 [&_[role=tab]]:focus-visible:outline-gray-900 [&_[role=tab][aria-selected=true]]:!border-gray-900 [&_[role=tab][aria-selected=true]]:!text-gray-900"
+            tabs={view.tabs.map((tab) => ({
+              ...tab,
+              count: view.counts[tab.value],
+              countTone: tab.value === "needs_signin" || tab.value === "needs_setup" ? "warning" : tab.value === "needs_admin_setup" ? "danger" : "neutral",
+              countClassName: `!h-[22px] min-w-6 justify-center !px-1.5 !py-0 !text-xs ${view.counts[tab.value] === 0 ? "!bg-gray-100 !text-gray-500" : ""}`,
+            }))}
             activeTab={view.activeState}
             onChange={setActiveState}
             showZeroCounts
           />
         </div>
-        <div className="w-full shrink-0 pb-3 lg:w-[280px] lg:pb-0">
+        <div className="w-[min(280px,40%)] shrink-0 self-center sm:ml-auto sm:w-[280px]">
           <DenInput type="search" icon={Search} value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search your library" aria-label="Search your library" className="!h-9 !rounded-[10px]" />
         </div>
       </div>
 
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-3" aria-label="Library filters">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-2" aria-label="Library filters">
         <div className="flex items-center gap-2">
           {LIBRARY_KINDS.map((filter) => (
             <button
@@ -246,7 +300,7 @@ export function LibraryScreen() {
               type="button"
               aria-pressed={activeKind === filter.value}
               onClick={() => { setActiveKind(filter.value); setActiveState(LIBRARY_DEFAULT_STATE); }}
-              className={`inline-flex h-[30px] items-center rounded-full border px-3 text-[13px] transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${activeKind === filter.value ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 bg-white text-gray-500 hover:border-gray-400 hover:text-gray-900"}`}
+              className={`inline-flex h-[30px] items-center rounded-full border px-3 text-[13px] font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${activeKind === filter.value ? "border-gray-900 bg-gray-900 text-white" : "border-gray-200 bg-white text-gray-500 hover:border-gray-400 hover:text-gray-900"}`}
             >
               {filter.label}
             </button>
@@ -254,45 +308,51 @@ export function LibraryScreen() {
         </div>
         <div className="ml-auto flex items-center gap-1" role="group" aria-label="Library view">
           {([{ value: "grid", label: "Card view", icon: LayoutGrid }, { value: "list", label: "List view", icon: List }] satisfies { value: LibraryLayout; label: string; icon: typeof List }[]).map(({ value, label, icon: Icon }) => (
-            <button key={value} type="button" aria-label={label} title={label} aria-pressed={layout === value} onClick={() => selectLayout(value)} className={`flex h-[30px] w-8 items-center justify-center rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 ${layout === value ? "bg-gray-100 text-gray-900" : "text-gray-500 hover:bg-gray-100"}`}>
-              <Icon aria-hidden className="h-4 w-4" />
-            </button>
+            <Tooltip key={value}>
+              <TooltipTrigger type="button" aria-label={label} title={label} aria-pressed={layout === value} onClick={() => selectLayout(value)} className={`flex h-[30px] w-8 items-center justify-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 ${layout === value ? "bg-gray-100 text-gray-900" : "text-gray-500 hover:bg-gray-100"}`}>
+                <Icon aria-hidden className="size-4" />
+              </TooltipTrigger>
+              <TooltipContent>{label}</TooltipContent>
+            </Tooltip>
           ))}
-          <button type="button" aria-label="Refresh" title="Refresh" disabled={isFetching} onClick={() => void refetch()} className="flex h-[30px] w-8 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50">
-            <RefreshCw aria-hidden className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+          <button type="button" aria-label="Refresh" title="Refresh" disabled={isFetching} onClick={() => void refetch()} className="flex h-[30px] w-8 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50">
+            <RefreshCw aria-hidden className={`size-4 ${isFetching ? "animate-spin" : ""}`} />
           </button>
+          {errorMessage && items.length > 0 ? (
+            <Tooltip>
+              <TooltipTrigger aria-label="Library refresh failed" className="flex h-[30px] w-8 items-center justify-center rounded-lg bg-amber-50 text-amber-700 hover:bg-amber-100">
+                <TriangleAlert aria-hidden className="size-4" />
+              </TooltipTrigger>
+              <TooltipContent>{errorMessage} Use Refresh to try again.</TooltipContent>
+            </Tooltip>
+          ) : null}
         </div>
       </div>
 
-      {error ? (
-        <DenNotice tone="error" message={error instanceof Error ? error.message : "Failed to load library."} />
-      ) : isLoading ? (
-        <div role="status" className="rounded-[10px] border border-gray-200 bg-white px-6 py-10 text-[14px] text-gray-500">Loading your library...</div>
-      ) : view.visibleItems.length === 0 ? (
-        <div className="rounded-[10px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center" data-library-empty={view.empty.action}>
-          <h2 className="text-[15px] font-medium text-gray-900">{view.empty.title}</h2>
-          <p className="mt-2 text-[13px] text-gray-500">{view.empty.description}</p>
-          <div className="mt-4 flex justify-center">
-            {view.empty.action === "add" ? addAction ? (
-              <DenButton href={addAction.href} size="sm">{addAction.label}</DenButton>
-            ) : (
-              <p className="text-[13px] text-gray-500">Ask a workspace admin to add {activeKind === "mcps" ? "MCPs" : activeKind}.</p>
-            ) : (
-              <DenButton size="sm" variant="secondary" onClick={() => {
-                if (view.empty.action === "clear_search") setQuery("");
-                else if (view.empty.action === "needs_signin" || view.empty.action === "needs_admin_setup" || view.empty.action === "needs_setup") setActiveState(view.empty.action);
-                else setActiveState("ready");
-              }}>
-                {view.empty.action === "clear_search" ? "Clear search" : view.empty.action === "needs_signin" ? "Needs your sign-in" : view.empty.action === "ready" ? "Ready to use" : "View setup needed"}
-              </DenButton>
-            )}
-          </div>
+      {isLoading ? (
+        <div role="status" aria-label="Loading your library" className={layout === "list" ? "flex flex-col gap-2" : "grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3"}>
+          {[0, 1, 2].map((index) => <div key={index} aria-hidden className={`bg-gray-100 motion-safe:animate-pulse ${layout === "list" ? "h-[42px] rounded-lg" : "h-[104px] rounded-xl"}`} />)}
         </div>
+      ) : view.visibleItems.length === 0 ? (
+        <LibraryEmpty
+          empty={view.empty}
+          addAction={addAction}
+          disabledReason={disabledReason}
+          error={items.length === 0 ? errorMessage : undefined}
+          onRefresh={() => void refetch()}
+          onAction={(action) => {
+            if (action === "clear_filters") {
+              setQuery("");
+              setActiveState(LIBRARY_DEFAULT_STATE);
+            } else if (action !== "add") setActiveState(action);
+          }}
+        />
       ) : (
         <section data-library-section={view.activeState} aria-label={view.tabs.find((tab) => tab.value === view.activeState)?.label}>
-          {layout === "grid" ? <div data-library-grid className="grid grid-cols-1 gap-4 xl:grid-cols-2 2xl:grid-cols-3">{rows}</div> : <div data-library-list><DenList>{rows}</DenList></div>}
+          {layout === "grid" ? <div data-library-grid className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">{rows}</div> : <div data-library-list className="overflow-x-auto"><DenList className="min-w-[560px] !rounded-xl">{rows}</DenList></div>}
         </section>
       )}
     </div>
+    </TooltipProvider>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/library-view.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/library-view.ts
@@ -13,12 +13,20 @@ export const LIBRARY_KINDS: readonly { value: LibraryKind; label: string }[] = [
   { value: "skills", label: "Skills" },
   { value: "plugins", label: "Plugins" },
 ];
+// Match Desktop's wording, but only show states supplied by Den's member
+// inventory. Local/hidden/disabled workspace items are not Den records.
 export const LIBRARY_STATES: readonly { value: LibraryState; label: string }[] = [
   { value: "ready", label: "Ready to use" },
   { value: "needs_signin", label: "Needs your sign-in" },
   { value: "needs_admin_setup", label: "Needs admin setup" },
-  { value: "needs_setup", label: "Needs setup" },
+  { value: "needs_setup", label: "Ready to set up" },
 ];
+
+export type LibraryEmptyState = {
+  title: string;
+  description: string;
+  action: "add" | "clear_filters" | LibraryState;
+};
 
 export function parseLibraryLayout(value: string | null): LibraryLayout {
   return value === "list" ? "list" : "grid";
@@ -83,8 +91,9 @@ export function getLibraryView(items: readonly LibraryItem[], kind: LibraryKind,
   const visibleItems = kindItems.filter((item) => getLibraryState(item) === activeState
     && (!normalizedQuery || item.name.toLowerCase().includes(normalizedQuery) || item.description?.toLowerCase().includes(normalizedQuery)));
   const label = kind === "mcps" ? "MCPs" : kind;
-  const empty = normalizedQuery
-    ? { title: `No ${label} match your search`, description: "Try a different search or clear it to see this tab.", action: "clear_search" }
+  const nextState = LIBRARY_STATES.find((tab) => counts[tab.value] > 0)?.value ?? "ready";
+  const empty: LibraryEmptyState = normalizedQuery
+    ? { title: "No library items match these filters.", description: "Try changing your search or filters.", action: "clear_filters" }
     : kindItems.length === 0
       ? {
           title: `No ${label} yet`,
@@ -98,15 +107,13 @@ export function getLibraryView(items: readonly LibraryItem[], kind: LibraryKind,
       : activeState === "ready"
         ? {
             title: `No ${label} ready to use`,
-            description: counts.needs_signin > 0
-              ? "Sign in to your account to start using them."
-              : "Setup needs to be completed before you can use them.",
-            action: counts.needs_signin > 0 ? "needs_signin" : counts.needs_admin_setup > 0 ? "needs_admin_setup" : "needs_setup",
+            description: "Your items need attention before they are ready. Choose a status to review the next step.",
+            action: nextState,
           }
         : {
-            title: `No ${label} need ${activeState === "needs_signin" ? "your sign-in" : activeState === "needs_admin_setup" ? "admin setup" : "setup"}`,
-            description: "Check another status tab for your items.",
-            action: "ready",
+            title: "No items in this state",
+            description: "Try changing your search or filters.",
+            action: nextState,
           };
   return { counts, tabs, activeState, visibleItems, empty };
 }

--- a/ee/apps/den-web/tests/library-view.test.ts
+++ b/ee/apps/den-web/tests/library-view.test.ts
@@ -4,7 +4,7 @@ import { act, createElement, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { LibraryConnectionItem, LibraryItem, LibraryPluginItem } from "../app/(den)/dashboard/_components/library-data";
-import { LibraryRow } from "../app/(den)/dashboard/_components/library-screen";
+import { LibraryAddControl, LibraryEmpty, LibraryRow } from "../app/(den)/dashboard/_components/library-screen";
 import { DashboardHeaderActions, DashboardHeaderActionsProvider, DashboardHeaderActionsSlot } from "../app/(den)/dashboard/_components/dashboard-header-actions";
 import {
   getLibraryAddAction,
@@ -15,6 +15,8 @@ import {
   LIBRARY_DEFAULT_KIND,
   LIBRARY_DEFAULT_STATE,
   LIBRARY_KINDS,
+  LIBRARY_STATES,
+  type LibraryLayout,
   parseLibraryLayout,
 } from "../app/(den)/dashboard/_components/library-view";
 
@@ -36,6 +38,8 @@ describe("My Library filters", () => {
     expect(LIBRARY_KINDS.map((kind) => kind.label)).toEqual(["MCPs", "Skills", "Plugins"]);
     expect(LIBRARY_DEFAULT_KIND).toBe("mcps");
     expect(LIBRARY_DEFAULT_STATE).toBe("ready");
+    // Den does not invent Desktop's local/hidden/disabled states.
+    expect(LIBRARY_STATES.map((state) => state.label)).toEqual(["Ready to use", "Needs your sign-in", "Needs admin setup", "Ready to set up"]);
     const view = getLibraryView(items, LIBRARY_DEFAULT_KIND, LIBRARY_DEFAULT_STATE, "");
     expect(view.tabs.map((tab) => tab.label)).toEqual(["Ready to use", "Needs your sign-in"]);
     expect(view.visibleItems).toEqual([mcp]);
@@ -74,8 +78,10 @@ describe("My Library filters", () => {
       expect(view.activeState).toBe(state);
       expect(view.visibleItems).toEqual([]);
     }
-    expect(getLibraryView([mcp], "mcps", "needs_admin_setup", "").empty.title).toBe("No MCPs need admin setup");
-    expect(getLibraryView([mcp], "mcps", "needs_setup", "").empty.title).toBe("No MCPs need setup");
+    expect(getLibraryView([mcp], "mcps", "needs_admin_setup", "").empty.title).toBe("No items in this state");
+    expect(getLibraryView([mcp], "mcps", "needs_setup", "").empty.title).toBe("No items in this state");
+    // Recovery goes to a populated state, not back to an equally empty Ready tab.
+    expect(getLibraryView([native], "mcps", "needs_setup", "").empty.action).toBe("needs_signin");
   });
 
   test("counts only the selected kind, independently of search, without a source filter", () => {
@@ -141,7 +147,7 @@ describe("My Library empty states and entry points", () => {
   });
 
   test("does not confuse search misses or unavailable records with an empty catalog", () => {
-    expect(getLibraryView([], "mcps", "ready", "missing").empty.action).toBe("clear_search");
+    expect(getLibraryView([], "mcps", "ready", "missing").empty).toEqual({ title: "No library items match these filters.", description: "Try changing your search or filters.", action: "clear_filters" });
     expect(getLibraryView([native], "mcps", "ready", "").empty).toMatchObject({ title: "No MCPs ready to use", action: "needs_signin" });
     expect(getLibraryView([{ ...mcp, state: "needs_admin_setup" }], "mcps", "ready", "").empty.action).toBe("needs_admin_setup");
     expect(getLibraryView([{ ...mcp, state: "available" }], "mcps", "ready", "").empty.action).toBe("needs_setup");
@@ -172,6 +178,80 @@ describe("My Library empty states and entry points", () => {
     }
   });
 
+  test("matches neutral connected cards without treating plugin bundles as connected MCPs", () => {
+    const connectedMarkup = renderToStaticMarkup(createElement(LibraryRow, { item: mcp, isFocused: false, orgName: "Workspace", orgSlug: null, layout: "grid" }));
+    const link = connectedMarkup.match(/<a\b[^>]*>/)?.[0];
+    expect(link).toContain("bg-white");
+    expect(link).toContain("border-gray-200");
+    expect(link).not.toMatch(/(?:bg|border|ring)-(?:green|emerald)-/);
+    expect(connectedMarkup).toContain('data-library-ready=""');
+    expect(connectedMarkup).toContain("Connected");
+    expect(connectedMarkup).toContain("View details");
+    expect(connectedMarkup).toContain("Cloud");
+    const bundleMarkup = renderToStaticMarkup(createElement(LibraryRow, { item: plugin, isFocused: false, orgName: "Workspace", orgSlug: null, layout: "grid" }));
+    expect(bundleMarkup).toContain("Ready to use");
+    expect(bundleMarkup).not.toContain("Connected");
+    const pendingMarkup = renderToStaticMarkup(createElement(LibraryRow, { item: { ...mcp, state: "available" }, isFocused: false, orgName: "Workspace", orgSlug: null, layout: "grid" }));
+    expect(pendingMarkup).toContain("Ready to set up");
+    expect(pendingMarkup).not.toContain("data-library-ready=");
+  });
+
+  test("keeps person, team, catalog, and organization provenance in cards and rows", () => {
+    for (const edges of [
+      [{ kind: "person", sharedBy: { orgMembershipId: "member-1", name: "Test Member" }, grantedAt: "2026-09-11T10:00:00Z" }],
+      plugin.edges,
+      [{ kind: "catalog", marketplace: { id: "catalog-1", name: "Tools" } }],
+      [{ kind: "org_wide" }],
+    ] satisfies LibraryPluginItem["edges"][]) {
+      for (const layout of ["grid", "list"] satisfies LibraryLayout[]) {
+        const markup = renderToStaticMarkup(createElement(LibraryRow, { item: { ...plugin, edges }, isFocused: false, orgName: "Workspace", orgSlug: null, layout }));
+        expect(markup).toContain("data-library-source");
+        expect(markup).toContain(edges[0].kind === "person" ? "Shared by Test" : edges[0].kind === "team" ? "Design" : edges[0].kind === "catalog" ? "Catalog" : "Workspace");
+        expect(markup.match(/<a\s/g)).toHaveLength(1);
+      }
+    }
+  });
+
+  test("header Add stays focusable but has no destination when Den permissions forbid authoring", () => {
+    const disabledReason = "An organization admin manages additions to this Library.";
+    const blocked = renderToStaticMarkup(createElement(LibraryAddControl, { action: null, label: "Create skill", disabledReason }));
+    expect(blocked).toContain('aria-label="Create skill"');
+    expect(blocked).toContain('aria-disabled="true"');
+    expect(blocked).toContain(disabledReason);
+    expect(blocked).not.toContain("href=");
+    expect(blocked).not.toContain('disabled=""');
+    const action = getLibraryAddAction({ kind: "mcps", isAdmin: false, mcpConnections: true, orgSlug: null });
+    const enabled = renderToStaticMarkup(createElement(LibraryAddControl, { action, label: "Add MCP", disabledReason }));
+    expect(enabled).toContain('aria-label="View available MCPs"');
+    expect(enabled).toContain('href="/dashboard/your-connections"');
+    expect(enabled).not.toContain("/dashboard/mcp-connections");
+    expect(enabled.match(/<a\s/g)).toHaveLength(1);
+  });
+
+  test("empty-state recovery distinguishes a failed load from an empty inventory", () => {
+    const props = {
+      empty: getLibraryView([], "mcps", "ready", "").empty,
+      addAction: { label: "Add MCP", href: "/dashboard/mcp-connections" },
+      disabledReason: "Connections are not enabled for this organization.",
+      onAction: () => {}, onRefresh: () => {},
+    };
+    const failed = renderToStaticMarkup(createElement(LibraryEmpty, { ...props, error: "Try again later." }));
+    expect(failed).toContain("Your Library is unavailable");
+    expect(failed).toContain("Refresh");
+    expect(failed).not.toContain("No MCPs yet");
+    expect(failed).not.toContain("Add MCP");
+    const normal = renderToStaticMarkup(createElement(LibraryEmpty, props));
+    expect(normal).toContain("No MCPs yet");
+    expect(normal).toContain('href="/dashboard/mcp-connections"');
+    expect(normal).not.toContain("Your Library is unavailable");
+    const blocked = renderToStaticMarkup(createElement(LibraryEmpty, { ...props, addAction: null }));
+    expect(blocked).toContain(props.disabledReason);
+    expect(blocked).not.toContain("href=");
+    const noMatches = renderToStaticMarkup(createElement(LibraryEmpty, { ...props, empty: getLibraryView(items, "mcps", "needs_signin", "missing").empty }));
+    expect(noMatches).toContain("Clear filters");
+    expect(noMatches).not.toContain("Add MCP");
+  });
+
   test("defaults to grid and respects a persisted explicit list selection", () => {
     expect(parseLibraryLayout(null)).toBe("grid");
     expect(parseLibraryLayout("invalid")).toBe("grid");
@@ -183,8 +263,10 @@ describe("My Library empty states and entry points", () => {
     for (const layout of ["grid", "list"] satisfies ("grid" | "list")[]) {
       const connectionMarkup = renderToStaticMarkup(createElement(LibraryRow, { item: native, isFocused: false, orgName: "Workspace", orgSlug: null, layout }));
       expect(connectionMarkup).toContain('href="/dashboard/your-connections?connectionId=native-1"');
-      expect(connectionMarkup).toContain("Connect your account");
+      expect(connectionMarkup).not.toContain("Connected");
       expect(connectionMarkup).toContain("Sign in");
+      expect(connectionMarkup).toContain("Native");
+      expect(connectionMarkup).not.toContain("Local ·");
       expect(connectionMarkup.match(/<a\s/g)).toHaveLength(1);
       const pluginMarkup = renderToStaticMarkup(createElement(LibraryRow, { item: plugin, isFocused: true, orgName: "Workspace", orgSlug: null, layout }));
       expect(pluginMarkup).toContain('href="/dashboard/library/plugins/plugin-1"');

--- a/evals/specs/plugin-from-connector.e2e.test.ts
+++ b/evals/specs/plugin-from-connector.e2e.test.ts
@@ -223,6 +223,7 @@ test("an admin creates a collection-ready plugin by picking an existing connecto
     // Follow the existing organization-scoped navigation rather than inventing a slug.
     await user.click({ role: "link", label: "My Library" });
     await user.see({ testId: "den-library" }, { timeoutMs: 90_000 });
+    await user.see({ role: "heading", label: "My Library" });
     expect((await probe.dom('[data-testid="den-library"][data-library-kind="mcps"][data-library-layout="grid"]')).elements).toHaveLength(1);
     const filters = await probe.dom('[aria-label="Library filters"] button[aria-pressed]:not([aria-label])');
     expect(filters.elements.map((element) => element.text)).toEqual(["MCPs", "Skills", "Plugins"]);
@@ -232,13 +233,48 @@ test("an admin creates a collection-ready plugin by picking an existing connecto
     await user.notSee({ role: "button", label: /^All$/ });
     await user.notSee({ role: "tab", label: /^All\b/ });
     await user.notSee({ role: "button", label: "Show hidden" });
+    await user.notSee({ role: "tab", label: /^Disabled\b/ });
+    await user.notSee({ role: "button", label: /^Advanced\b/ });
+    await user.notSee({ text: "Add workspace MCP" });
+    await user.notSee({ text: "Local · this workspace" });
     await user.see({ role: "link", label: "Add MCP" });
     expect((await probe.dom('a[aria-label="Add MCP"]')).elements).toMatchObject([{ text: "" }]);
     const pluginKey = `plugin-${resolved.plugin?.pluginId}`;
+    const connectionLink = `a[data-library-item-key="connection-${world.connection.id}"][data-library-item-type="connection"][data-library-item-state="connected"][href="/dashboard/your-connections?connectionId=${world.connection.id}"]`;
+    const pluginLink = `a[data-library-item-key="${pluginKey}"][data-library-item-type="plugin"][href="/dashboard/library/plugins/${resolved.plugin?.pluginId}"]`;
     await user.see({ text: world.connection.name });
     expect((await probe.dom(`[data-library-grid] [data-library-item-key="connection-${world.connection.id}"]`)).elements).toHaveLength(1);
     expect((await probe.dom(`[data-library-item-key="${pluginKey}"]`)).elements).toHaveLength(0);
     expect((await probe.dom('[data-library-list]')).elements).toHaveLength(0);
+    expect((await probe.dom(`${connectionLink}[class~="bg-white"][class~="border-gray-200"]`)).elements).toMatchObject([{ text: expect.stringContaining("View details") }]);
+    expect((await probe.dom(`${connectionLink}[class*="emerald"], ${connectionLink}[class*="green"]`)).elements).toHaveLength(0);
+    expect((await probe.dom(`${connectionLink} [data-library-ready][class~="bg-emerald-50"][class~="text-emerald-700"]`)).elements.map((element) => element.text)).toEqual(["Connected"]);
+
+    await step("list layout survives reload and can be switched back to cards", async () => {
+      await user.click({ role: "button", label: "List view" });
+      expect(await probe.storage("openwork:den:library:layout")).toBe("list");
+      expect((await probe.dom('[data-testid="den-library"][data-library-kind="mcps"][data-library-layout="list"]')).elements).toHaveLength(1);
+      expect((await probe.dom(`[data-library-list] ${connectionLink}`)).elements).toHaveLength(1);
+      expect((await probe.dom('[data-library-grid]')).elements).toHaveLength(0);
+      await user.reload();
+      await user.see({ text: world.connection.name }, { timeoutMs: 90_000 });
+      expect(await probe.storage("openwork:den:library:layout")).toBe("list");
+      expect((await probe.dom('button[aria-label="List view"][aria-pressed="true"]')).elements).toHaveLength(1);
+      expect((await probe.dom('[data-testid="den-library"][data-library-kind="mcps"][data-library-layout="list"]')).elements).toHaveLength(1);
+      expect((await probe.dom(`[data-library-list] ${connectionLink}`)).elements).toHaveLength(1);
+      expect((await probe.dom('[data-library-grid]')).elements).toHaveLength(0);
+      expect((await probe.dom(`[data-library-item-key="${pluginKey}"]`)).elements).toHaveLength(0);
+      await user.click({ role: "button", label: "Card view" });
+      expect(await probe.storage("openwork:den:library:layout")).toBe("grid");
+      expect((await probe.dom('button[aria-label="Card view"][aria-pressed="true"]')).elements).toHaveLength(1);
+      expect((await probe.dom(`[data-library-grid] ${connectionLink}`)).elements).toHaveLength(1);
+      expect((await probe.dom('[data-library-list]')).elements).toHaveLength(0);
+    });
+
+    await user.click({ role: "button", label: "Skills" });
+    await user.see({ text: "No skills yet" });
+    expect((await probe.dom('[data-testid="den-library"][data-library-kind="skills"] [data-library-item-key]')).elements).toHaveLength(0);
+    expect((await probe.dom('a[aria-label="Create skill"]')).elements).toMatchObject([{ text: "" }]);
 
     await user.click({ role: "button", label: "Plugins" });
     await user.see({ text: world.pluginName });
@@ -248,6 +284,40 @@ test("an admin creates a collection-ready plugin by picking an existing connecto
     expect((await probe.dom(`[data-library-grid] [data-library-item-key="${pluginKey}"]`)).elements).toHaveLength(1);
     expect((await probe.dom('[data-testid="den-library"] [data-library-item-type="connection"]')).elements).toHaveLength(0);
     expect((await probe.dom('a[aria-label="Add plugin"]')).elements).toMatchObject([{ text: "" }]);
+    expect((await probe.dom(pluginLink)).elements).toMatchObject([{ text: expect.stringContaining("View details") }]);
+    expect((await probe.dom(`${pluginLink} [data-library-ready]`)).elements.map((element) => element.text)).toEqual(["Ready to use"]);
+
+    await step("Clear filters restores Plugins without changing the selected kind", async () => {
+      await user.type({ placeholder: "Search your library" }, "no-such-library-item");
+      await user.see({ text: "No library items match these filters." });
+      expect((await probe.dom('[data-testid="den-library"] [data-library-item-key]')).elements).toHaveLength(0);
+      await user.click({ role: "button", label: "Clear filters" });
+      await user.see({ placeholder: "Search your library" }, { value: "" });
+      await user.see({ text: world.pluginName });
+      await user.notSee({ text: "No library items match these filters." });
+      await user.notSee({ role: "button", label: "Clear filters" });
+      expect((await probe.dom('[data-testid="den-library"][data-library-kind="plugins"][data-library-layout="grid"]')).elements).toHaveLength(1);
+      expect((await probe.dom('[data-testid="den-library"] [role="tab"][aria-selected="true"]')).elements).toMatchObject([{ text: expect.stringMatching(/^Ready to use\b/) }]);
+      expect((await probe.dom(`[data-library-grid] ${pluginLink}`)).elements).toHaveLength(1);
+      expect((await probe.dom('[data-testid="den-library"] [data-library-item-type="connection"]')).elements).toHaveLength(0);
+    });
+
+    await step("the plugin card opens its details and My Library returns to the inventory", async () => {
+      await user.click({ role: "link", label: new RegExp(world.pluginName) });
+      await user.see({ role: "heading", label: world.pluginName });
+      await user.see({ text: "MCP Servers" });
+      await user.see({ text: world.connection.name });
+      await user.notSee({ testId: "den-library" });
+      await user.click({ role: "link", label: "My Library" });
+      await user.see({ testId: "den-library" }, { timeoutMs: 90_000 });
+      await user.see({ text: world.connection.name });
+      expect((await probe.dom(`[data-library-grid] ${connectionLink}`)).elements).toHaveLength(1);
+      expect((await probe.dom(`[data-library-item-key="${pluginKey}"]`)).elements).toHaveLength(0);
+      await user.click({ role: "button", label: "Plugins" });
+      await user.see({ text: world.pluginName });
+      expect((await probe.dom(`[data-library-grid] ${pluginLink}`)).elements).toHaveLength(1);
+      expect((await probe.dom('[data-testid="den-library"] [data-library-item-type="connection"]')).elements).toHaveLength(0);
+    });
     await user.screenshot();
   });
 });


### PR DESCRIPTION
## Summary
Make Den's **My Library** follow the Desktop Library experience from #4902, without bringing device-only controls into the server dashboard.

**Stacked on #4902**, whose current head is `e94fcbd15`. This PR contains one additional signed commit (`13905bf70`) and four changed files. Merge #4902 first, then rebase/retarget this follow-up onto current `dev` and refresh its verification.

- Match neutral cards, compact list rows, status labels, toolbar tooltips, and empty-state recovery.
- Preserve real web links, sharing provenance, Cloud/Native transport information, and existing member/admin authoring boundaries.
- Keep Desktop's Advanced section, workspace MCP configuration, built-in runtimes, and local/hidden/disabled workspace states out of Den.

## UI/UX impact
Intentional changes, limited to Den **My Library**. Desktop and other dashboard pages are unchanged.

| Area | Change and reason |
| --- | --- |
| Cards | Use Desktop's icon-beside-content layout, neutral border/background, two-line descriptions, responsive auto-fill columns, and a text next action. Actual connected MCPs show a green **Connected** badge; available plugins show **Ready to use**, never a claim that their MCPs are connected. |
| List view | Compact rows with aligned icon/name/type slots, a small ready indicator, and the existing detail or sign-in destination. Narrow layouts scroll within the list rather than widening the page. |
| Provenance | Cloud/Native and person/team/catalog/organization attribution move from multiple chips into muted metadata; no access information or destination is removed. Directly shared Workflows retain their own type and detail links. |
| Tabs/search | Match the single-row status/search layout, state-count colors, zero-count visibility, and control sizing. **Needs setup** becomes **Ready to set up**. Den only exposes states supplied by its inventory, not a fabricated Disabled tab. |
| Add/view controls | Use hover/focus tooltips and the matching rounded view toggles. An unavailable Add control remains focusable and explains organization capability or administrator restrictions, with no navigable authoring destination. |
| Empty states | Match category/ready/search-empty wording and outlined recovery actions. **Clear filters** clears search and returns to Ready while retaining the kind. An empty status recovers to a populated one rather than another empty tab. |
| Loading/errors | Show layout-shaped loading placeholders. A failed initial load offers Refresh; a failed background refresh retains cached cards and shows a compact warning tooltip. |

The existing My Library title/header slot, MCPs/Skills/Plugins defaults, explicit saved list preference, role checks, API queries, grants, and connection/plugin/Workflow routes stay unchanged. No local files, credentials, databases, dependencies, or deployment configuration change.

## Verification
**Proof verdict: Incomplete.** Focused checks pass, but the extended real Den browser journey has not been run or published for this head. This is not a merge-readiness claim.

### Passed
At the committed candidate tree (`13905bf70`):
- From `ee/apps/den-web`: `pnpm exec bun test --conditions development tests/library-view.test.ts tests/remote-mcp-app-library.test.ts tests/program-plugin-marketplace.test.ts` — **28 passed, 0 failed, 0 skipped**.
- From `ee/apps/den-web`: `pnpm exec tsc --noEmit --pretty false --incremental false` — exit 0.
- `pnpm --dir evals typecheck` — **413 source files, no errors**, exit 0.
- `git diff --check` — exit 0.

### Failed / unresolved additional check
`COREPACK_ENABLE_NETWORK=0 pnpm --dir evals run lint:layers` exited 49 with 49 violations outside the changed journey. Examples include `worlds/sidebar-brand.ts` → `@openwork/testkit` (`worlds-use-seed-layer`) and `specs/workspace-engine-upgrade.e2e.test.ts` → `@openwork/behaviors` (`specs-use-testkit-only`). No diagnostic referenced `plugin-from-connector.e2e.test.ts`. This broader failure was not repaired or compared against a clean control; it is not being called pre-existing or passed.

### Deferred
- `pnpm evals:e2e plugin-from-connector` at the final head, followed by evidence publication.
- Manual browser/visual review and responsive-device validation.

The existing journey is extended, not duplicated: card/list persistence across reload, neutral connected-card status, empty Skills, search recovery, plugin detail navigation, and absence of Desktop-only controls. Existing connector-reuse, identity, and bundle/connection separation assertions remain intact.

## Risk and rollback
Presentation-only Den change plus an empty-state recovery correction. The main unverified risks are browser interaction and narrow-screen rendering. Revert this follow-up commit; no data migration or stored-format rollback is needed.
