### PR TITLE
fix(app): roll a delegated child's pending permission or question up to the parent's sidebar status

### DIFF
--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -114,7 +114,7 @@ export function SubagentRunLine({ part, className, parentActive = true }: Subage
   const agent = agentName(part.input?.subagent_type ?? "")
   const status = permissionPending
     ? t("session.subagent_permission_needed")
-    : questionPending ? "Waiting for your answer"
+    : questionPending ? t("session.subagent_question_pending")
     : activity === "retrying" ? "Retrying"
     : activity === "failed" ? "Task reported an error"
     : activity === "waiting-result" ? "Waiting for task result"

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1322,6 +1322,7 @@ export default {
   "session.permission_title_read": "Read files?",
   "session.permission_title_task": "Start a subtask?",
   "session.subagent_permission_needed": "Needs permission",
+  "session.subagent_question_pending": "Waiting for your answer",
   "session.subagent_task": "Sub-agent task",
   "session.permission_decision_hint": "Allow once for this request, or allow for session when you trust this scope.",
   "session.redo_aria_label": "Redo last reverted message",

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -150,6 +150,7 @@ export type SessionPageSidebarProps = {
   selectedSessionId: string | null;
   developerMode: boolean;
   sessionStatusById: Record<string, string>;
+  sessionAttentionLabelById?: Record<string, string>;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   newTaskDisabled: boolean;
@@ -1371,6 +1372,7 @@ export function SessionPage(props: SessionPageProps) {
           selectedSessionId={props.sidebar.selectedSessionId}
           showSessionActions={Boolean(props.onRenameSession || props.onDeleteSession || props.onArchiveSession)}
           sessionStatusById={props.sidebar.sessionStatusById}
+          sessionAttentionLabelById={props.sidebar.sessionAttentionLabelById}
           connectingWorkspaceId={props.sidebar.connectingWorkspaceId}
           workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
           newTaskDisabled={props.sidebar.newTaskDisabled}

--- a/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
+++ b/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
@@ -11,6 +11,8 @@ export type ControlSessionWorkspace = {
 export type ControlSessionLike = {
   id?: string;
   title?: string;
+  /** Set on delegated (sub-agent) sessions; their pending requests roll up to this parent. */
+  parentID?: string | null;
   time?: {
     updated?: number;
     created?: number;

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -9,6 +9,7 @@ import { useControlAction, type OpenworkControlAction } from "../../../shell/con
 import { useSessionManagementStore } from "../sidebar/session-management-store";
 import type { ArchiveSessionOptions, ArchiveSessionOutcome } from "../sidebar/use-session-archive";
 import { useSessionActivityStore } from "../status/session-activity-store";
+import { selectSessionAttention } from "../status/session-attention";
 import { isSameWorkbenchSession, useWorkbenchStore } from "../chat/workbench-store";
 import { controlWorkspaceLabel as workspaceLabel, listControlSessions, type ControlSessionLike as SessionLike } from "./list-control-sessions";
 
@@ -108,13 +109,32 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
       { name: "limit", type: "number", required: false, description: "Maximum sessions to return. Omit to return all loaded sessions." },
       { name: "workspaceId", type: "string", required: false, description: "Workspace ID or display name. Omit to include every workspace." },
     ],
-    execute: (args) => listControlSessions(args, {
-      workspaces,
-      sessionsByWorkspaceId,
-      pinnedIds,
-      statusFor: (workspaceId, sessionId) => useSessionActivityStore.getState().getStatus(workspaceId, sessionId),
-    }),
-  }), [pinnedIds, sessionsByWorkspaceId, workspaces]);
+    execute: (args) => {
+      // Same roll-up as the sidebar: a delegated child's pending permission
+      // or question makes its parent `waiting`, not `thinking`.
+      const activity = useSessionActivityStore.getState();
+      const attentionByWorkspaceId = new Map<string, ReturnType<typeof selectSessionAttention>>();
+      return listControlSessions(args, {
+        workspaces,
+        sessionsByWorkspaceId,
+        pinnedIds,
+        statusFor: (workspaceId, sessionId) => {
+          let attention = attentionByWorkspaceId.get(workspaceId);
+          if (!attention) {
+            const runtimeId = endpointForWorkspace(workspaces.find((workspace) => workspace.id === workspaceId))?.workspaceId;
+            const ids = runtimeId && runtimeId !== workspaceId ? [workspaceId, runtimeId] : [workspaceId];
+            attention = selectSessionAttention(
+              (sessionsByWorkspaceId[workspaceId] ?? []).flatMap((session) => (session.id ? [{ ...session, id: session.id }] : [])),
+              (id) => ids.map((wid) => activity.statusesByWorkspaceId[wid]?.[id]).find((status) => status !== undefined),
+              (id) => ids.map((wid) => activity.waitingByWorkspaceId[wid]?.[id]).find((kind) => kind !== undefined),
+            );
+            attentionByWorkspaceId.set(workspaceId, attention);
+          }
+          return attention.get(sessionId)?.status ?? activity.getStatus(workspaceId, sessionId);
+        },
+      });
+    },
+  }), [endpointForWorkspace, pinnedIds, sessionsByWorkspaceId, workspaces]);
   useControlAction(listSessionsControlAction);
 
   const openSessionControlAction = useMemo<OpenworkControlAction>(() => ({

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -9,6 +9,8 @@ export type SidebarContextValue = {
   developerMode: boolean;
   showSessionActions?: boolean;
   sessionStatusById?: Record<string, string>;
+  /** Why a row needs the person when a delegated child, not the session itself, is asking. */
+  sessionAttentionLabelById?: Record<string, string>;
   newTaskDisabled: boolean;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -225,6 +225,8 @@ interface SessionStatusIndicatorProps {
   status?: string;
   isActiveWork: boolean;
   isUnread: boolean;
+  /** Names the delegated child asking, e.g. "Needs permission: Audit four open PRs". */
+  attentionLabel?: string;
 }
 
 function ShowMoreSessionsButton({
@@ -249,7 +251,7 @@ function ShowMoreSessionsButton({
 }
 
 /** Activity and outcomes share the fixed glyph slot before the session title. */
-function SessionStatusIndicator({ status, isActiveWork, isUnread }: SessionStatusIndicatorProps) {
+function SessionStatusIndicator({ status, isActiveWork, isUnread, attentionLabel }: SessionStatusIndicatorProps) {
   return (
     <SidebarGlyphSlot>
       {isActiveWork ? (
@@ -257,21 +259,23 @@ function SessionStatusIndicator({ status, isActiveWork, isUnread }: SessionStatu
           ? getSessionActivityStatusLabel(status)
           : t("workspace_list.session_streaming")} />
       ) : (
-        <SessionOutcomeIndicator status={status} isUnread={isUnread} />
+        <SessionOutcomeIndicator status={status} isUnread={isUnread} attentionLabel={attentionLabel} />
       )}
     </SidebarGlyphSlot>
   );
 }
 
 /** Orange = needs you, green = unread result, none = read/idle. */
-function SessionOutcomeIndicator({ status, isUnread }: { status?: string; isUnread: boolean }) {
+function SessionOutcomeIndicator({ status, isUnread, attentionLabel }: { status?: string; isUnread: boolean; attentionLabel?: string }) {
   if (isNeedsAttentionSessionStatus(status)) {
-    const title = isSessionActivityStatus(status)
-      ? getSessionActivityStatusLabel(status)
-      : t("workspace_list.session_needs_attention");
+    const title = attentionLabel
+      ?? (isSessionActivityStatus(status)
+        ? getSessionActivityStatusLabel(status)
+        : t("workspace_list.session_needs_attention"));
     return (
       <span
         data-session-attention-indicator
+        data-session-attention-source={attentionLabel ? "child" : "self"}
         className="size-2 shrink-0 rounded-full"
         style={{ backgroundColor: OUTCOME_DOT_NEEDS_ACTION }}
         title={title}
@@ -773,6 +777,7 @@ export type AppSidebarProps = {
   selectedSessionId: string | null;
   showSessionActions?: boolean;
   sessionStatusById?: Record<string, string>;
+  sessionAttentionLabelById?: Record<string, string>;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   newTaskDisabled: boolean;
@@ -886,6 +891,7 @@ export function AppSidebar(props: AppSidebarProps) {
     developerMode: props.developerMode,
     showSessionActions: props.showSessionActions,
     sessionStatusById: props.sessionStatusById,
+    sessionAttentionLabelById: props.sessionAttentionLabelById,
     newTaskDisabled: props.newTaskDisabled,
     connectingWorkspaceId: props.connectingWorkspaceId,
     workspaceConnectionStateById: props.workspaceConnectionStateById,
@@ -2097,6 +2103,7 @@ function SessionMenuItem({
   const displayTitle = getDisplaySessionTitle(session.title);
   const itemTitle = workspaceName ? `${displayTitle} — ${workspaceName}` : displayTitle;
   const sessionActivityStatus = ctx.sessionStatusById?.[session.id];
+  const sessionAttentionLabel = ctx.sessionAttentionLabelById?.[session.id];
   const resolvedActiveWork = isActiveWorkSessionStatus(sessionActivityStatus);
   const isUnread = unreadIds.has(session.id) && !isSelected;
   const isArchived = isSessionArchived(session);
@@ -2140,7 +2147,7 @@ function SessionMenuItem({
   const accessibleState = resolvedActiveWork && isSessionActivityStatus(sessionActivityStatus)
     ? `${displayTitle}, ${getSessionActivityStatusLabel(sessionActivityStatus)}`
     : isNeedsAttentionSessionStatus(sessionActivityStatus)
-      ? `${displayTitle}, ${t("workspace_list.session_needs_attention")}`
+      ? `${displayTitle}, ${sessionAttentionLabel ?? t("workspace_list.session_needs_attention")}`
       : isUnread
         ? `${displayTitle}, ${t("workspace_list.session_unread")}`
         : itemTitle;
@@ -2159,7 +2166,12 @@ function SessionMenuItem({
   // Pinned/archived rows identify their workspace via the tooltip title
   // only — no workspace color dot in these sections.
   const leading = (
-    <SessionStatusIndicator status={sessionActivityStatus} isActiveWork={resolvedActiveWork} isUnread={isUnread} />
+    <SessionStatusIndicator
+      status={sessionActivityStatus}
+      isActiveWork={resolvedActiveWork}
+      isUnread={isUnread}
+      attentionLabel={sessionAttentionLabel}
+    />
   );
 
   const trailing = (

--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -7,6 +7,9 @@ import { t } from "../../../../i18n";
 
 export type SessionActivityStatus = "idle" | "thinking" | "responding" | "error" | "compacting" | "waiting";
 
+/** What an unanswered request is asking the person for. */
+export type SessionWaitingKind = "permission" | "question";
+
 type SessionMessageRole = "assistant" | "system" | "user";
 
 type SessionActivityRecord = {
@@ -39,6 +42,12 @@ type SessionLike = {
 type SessionActivityStore = {
   recordsByWorkspaceId: Record<string, Record<string, SessionActivityRecord>>;
   statusesByWorkspaceId: Record<string, Record<string, SessionActivityStatus>>;
+  /**
+   * Sessions with an unanswered permission or question, by what they ask for.
+   * Derived like `statusesByWorkspaceId` so a parent roll-up can subscribe
+   * without re-rendering on every transcript progress write.
+   */
+  waitingByWorkspaceId: Record<string, Record<string, SessionWaitingKind>>;
   getStatus: (workspaceId: string, sessionId: string) => SessionActivityStatus;
   getSessionError: (workspaceId: string, sessionId: string) => string | null;
   seedWorkspaceSessions: (workspaceId: string, sessions: SessionLike[]) => void;
@@ -124,6 +133,26 @@ function updateWorkspaceStatus(
   };
 }
 
+function waitingKindForRecord(record: SessionActivityRecord): SessionWaitingKind | undefined {
+  if (record.waitingPermissionIds.length > 0) return "permission";
+  if (record.waitingQuestionIds.length > 0) return "question";
+  return undefined;
+}
+
+function updateWorkspaceWaiting(
+  waitingByWorkspaceId: Record<string, Record<string, SessionWaitingKind>>,
+  workspaceId: string,
+  sessionId: string,
+  kind: SessionWaitingKind | undefined,
+) {
+  const current = waitingByWorkspaceId[workspaceId] ?? {};
+  if (current[sessionId] === kind) return waitingByWorkspaceId;
+  const next = { ...current };
+  if (kind) next[sessionId] = kind;
+  else delete next[sessionId];
+  return { ...waitingByWorkspaceId, [workspaceId]: next };
+}
+
 function sameStrings(left: string[], right: string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
@@ -159,12 +188,14 @@ function sameActivityRecord(
     && sameMessageRoles(current.messageRoles, next.messageRoles);
 }
 
+type SessionActivityDerivedState = Pick<SessionActivityStore, "recordsByWorkspaceId" | "statusesByWorkspaceId" | "waitingByWorkspaceId">;
+
 function updateRecord(
-  state: Pick<SessionActivityStore, "recordsByWorkspaceId" | "statusesByWorkspaceId">,
+  state: SessionActivityDerivedState,
   workspaceId: string,
   sessionId: string,
   updater: (record: SessionActivityRecord) => SessionActivityRecord,
-) {
+): SessionActivityDerivedState {
   const workspaceRecords = state.recordsByWorkspaceId[workspaceId] ?? {};
   const currentRecord = workspaceRecords[sessionId];
   const nextRecord = updater(currentRecord ?? createRecord());
@@ -180,6 +211,7 @@ function updateRecord(
       },
     },
     statusesByWorkspaceId: updateWorkspaceStatus(state.statusesByWorkspaceId, workspaceId, sessionId, status),
+    waitingByWorkspaceId: updateWorkspaceWaiting(state.waitingByWorkspaceId, workspaceId, sessionId, waitingKindForRecord(nextRecord)),
   };
 }
 
@@ -216,6 +248,7 @@ function addValue(values: string[], value: string) {
 export const useSessionActivityStore = create<SessionActivityStore>((set, get) => ({
   recordsByWorkspaceId: {},
   statusesByWorkspaceId: {},
+  waitingByWorkspaceId: {},
   getStatus: (workspaceId, sessionId) => (
     get().statusesByWorkspaceId[workspaceId]?.[sessionId] ?? "idle"
   ),
@@ -239,7 +272,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
     const id = workspaceId.trim();
     if (!id) return;
     set((state) => {
-      let nextState: Pick<SessionActivityStore, "recordsByWorkspaceId" | "statusesByWorkspaceId"> = state;
+      let nextState: SessionActivityDerivedState = state;
       for (const session of sessions) {
         const sessionId = session.id.trim();
         if (!sessionId) continue;
@@ -443,6 +476,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
           ...state.statusesByWorkspaceId,
           [workspace]: nextStatuses,
         },
+        waitingByWorkspaceId: updateWorkspaceWaiting(state.waitingByWorkspaceId, workspace, session, undefined),
       };
     });
   },

--- a/apps/app/src/react-app/domains/session/status/session-attention.ts
+++ b/apps/app/src/react-app/domains/session/status/session-attention.ts
@@ -1,0 +1,82 @@
+import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
+import { t } from "../../../../i18n";
+import type { SessionActivityStatus, SessionWaitingKind } from "./session-activity-store";
+
+type AttentionSession = {
+  id: string;
+  parentID?: string | null;
+  title?: string | null;
+};
+
+/** The descendant whose unanswered request blocks an ancestor. */
+export type SessionAttentionSource = {
+  sessionId: string;
+  title: string;
+  kind: SessionWaitingKind;
+};
+
+export type SessionAttention = {
+  status: SessionActivityStatus;
+  /** Set only when `status` is "waiting" because of a delegated child, not the session's own request. */
+  blockedBy: SessionAttentionSource | null;
+};
+
+/**
+ * The status a person (or an agent asking `session.list_sessions`) should see
+ * for each session. A delegated child's pending permission or question lives
+ * on the child's activity record, so the parent's own status stays "thinking"
+ * while nothing can move until someone answers. This rolls that request up
+ * every parentID hop so the sidebar, notifications, and agent-visible status
+ * agree with the transcript's inline "Needs permission" treatment.
+ *
+ * Precedence: error > waiting (own or descendant) > compacting > thinking /
+ * responding > idle. `ownStatus` already orders everything but the descendant
+ * case. Cyclic or dangling parent data stops at the first repeated hop.
+ */
+export function selectSessionAttention(
+  sessions: readonly AttentionSession[],
+  ownStatus: (sessionId: string) => SessionActivityStatus | undefined,
+  waitingKind: (sessionId: string) => SessionWaitingKind | undefined,
+): Map<string, SessionAttention> {
+  const parentOf = new Map<string, string>();
+  for (const session of sessions) {
+    const id = session.id.trim();
+    const parentID = session.parentID?.trim();
+    if (id && parentID && parentID !== id) parentOf.set(id, parentID);
+  }
+
+  const blockedBy = new Map<string, SessionAttentionSource>();
+  for (const session of sessions) {
+    const id = session.id.trim();
+    const kind = id ? waitingKind(id) : undefined;
+    if (!kind) continue;
+    const source: SessionAttentionSource = { sessionId: id, title: getDisplaySessionTitle(session.title ?? ""), kind };
+    const visited = new Set([id]);
+    for (let parent = parentOf.get(id); parent && !visited.has(parent); parent = parentOf.get(parent)) {
+      visited.add(parent);
+      if (!blockedBy.has(parent)) blockedBy.set(parent, source);
+    }
+  }
+
+  const attention = new Map<string, SessionAttention>();
+  for (const session of sessions) {
+    const id = session.id.trim();
+    if (!id) continue;
+    const own = ownStatus(id) ?? "idle";
+    if (own === "error" || own === "waiting") {
+      attention.set(id, { status: own, blockedBy: null });
+      continue;
+    }
+    const source = blockedBy.get(id);
+    attention.set(id, source ? { status: "waiting", blockedBy: source } : { status: own, blockedBy: null });
+  }
+  return attention;
+}
+
+/** Tooltip / accessible name for the orange "needs you" dot when a child is the reason. */
+export function sessionAttentionLabel(source: SessionAttentionSource): string {
+  const prefix = source.kind === "permission"
+    ? t("session.subagent_permission_needed")
+    : t("session.subagent_question_pending");
+  return `${prefix}: ${source.title}`;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -121,6 +121,7 @@ import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-co
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
 import { ReactSessionRuntime } from "@/react-app/domains/session/sync/runtime-sync";
 import { useSessionActivityStore } from "@/react-app/domains/session/status/session-activity-store";
+import { selectSessionAttention, sessionAttentionLabel } from "@/react-app/domains/session/status/session-attention";
 import { buildOpenworkSessionSystemContext } from "@/react-app/domains/session/sync/env-context";
 import {
   applySessionRevert,
@@ -816,6 +817,7 @@ export function SessionRoute() {
   ));
   const seedWorkspaceActivitySessions = useSessionActivityStore((state) => state.seedWorkspaceSessions);
   const sessionActivityByWorkspaceId = useSessionActivityStore((state) => state.statusesByWorkspaceId);
+  const sessionWaitingByWorkspaceId = useSessionActivityStore((state) => state.waitingByWorkspaceId);
 
   useEffect(() => {
     for (const group of workspaceSessionGroups) {
@@ -827,21 +829,37 @@ export function SessionRoute() {
     }
   }, [seedWorkspaceActivitySessions, workspaceSessionGroups]);
 
-  const sidebarSessionStatusById = useMemo(() => {
-    const next: Record<string, string> = {};
+  // A delegated child's pending permission or question rolls up to its parent
+  // row: the person must answer before anything moves, so the parent shows
+  // "needs you" instead of the working spinner.
+  const sidebarSessionAttention = useMemo(() => {
+    const statusById: Record<string, string> = {};
+    const labelById: Record<string, string> = {};
     for (const group of workspaceSessionGroups) {
       const serverId = workspaceServerId(group.workspace);
       const workspaceStatuses = {
         ...(sessionActivityByWorkspaceId[group.workspace.id] ?? {}),
         ...(serverId ? sessionActivityByWorkspaceId[serverId] ?? {} : {}),
       };
+      const workspaceWaiting = {
+        ...(sessionWaitingByWorkspaceId[group.workspace.id] ?? {}),
+        ...(serverId ? sessionWaitingByWorkspaceId[serverId] ?? {} : {}),
+      };
+      const attention = selectSessionAttention(
+        group.sessions,
+        (sessionId) => workspaceStatuses[sessionId],
+        (sessionId) => workspaceWaiting[sessionId],
+      );
       for (const session of group.sessions) {
-        const status = workspaceStatuses[session.id];
-        if (status) next[session.id] = status;
+        const entry = attention.get(session.id);
+        if (!entry || (!workspaceStatuses[session.id] && !entry.blockedBy)) continue;
+        statusById[session.id] = entry.status;
+        if (entry.blockedBy) labelById[session.id] = sessionAttentionLabel(entry.blockedBy);
       }
     }
-    return next;
-  }, [sessionActivityByWorkspaceId, workspaceSessionGroups]);
+    return { statusById, labelById };
+  }, [sessionActivityByWorkspaceId, sessionWaitingByWorkspaceId, workspaceSessionGroups]);
+  const sidebarSessionStatusById = sidebarSessionAttention.statusById;
 
   const sidebarActiveWorkspaceId = useMemo(() => {
     const sessionId = selectedSessionId?.trim() ?? "";
@@ -3492,6 +3510,7 @@ export function SessionRoute() {
         selectedSessionId,
         developerMode: false,
         sessionStatusById: sidebarSessionStatusById,
+        sessionAttentionLabelById: sidebarSessionAttention.labelById,
         connectingWorkspaceId: null,
         workspaceConnectionStateById,
         newTaskDisabled: !canCreateTask,

--- a/apps/app/tests/session-attention-rollup.test.ts
+++ b/apps/app/tests/session-attention-rollup.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import { selectSessionAttention, sessionAttentionLabel } from "../src/react-app/domains/session/status/session-attention";
+
+const workspaceId = "ws-rollup";
+const parent = { id: "ses-parent", title: "Slop audit (Astra high)" };
+const child = { id: "ses-child", title: "Audit four open PRs", parentID: parent.id };
+const grandchild = { id: "ses-grandchild", title: "Read den-web", parentID: child.id };
+const unrelated = { id: "ses-other", title: "Unrelated root" };
+const sessions = [parent, child, grandchild, unrelated];
+
+function attentionFor(sessionId: string) {
+  const state = useSessionActivityStore.getState();
+  return selectSessionAttention(
+    sessions,
+    (id) => state.statusesByWorkspaceId[workspaceId]?.[id],
+    (id) => state.waitingByWorkspaceId[workspaceId]?.[id],
+  ).get(sessionId);
+}
+
+describe("delegated child attention roll-up", () => {
+  beforeEach(() => {
+    useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {}, waitingByWorkspaceId: {} });
+  });
+
+  test("RCA: the store keeps the parent's own status at thinking while its child waits on a permission", () => {
+    const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, parent.id, "running");
+    store.setRunStatus(workspaceId, child.id, "running");
+    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
+
+    // The child's record carries the request; the parent's does not.
+    expect(store.getStatus(workspaceId, child.id)).toBe("waiting");
+    expect(store.getStatus(workspaceId, parent.id)).toBe("thinking");
+    expect(useSessionActivityStore.getState().waitingByWorkspaceId[workspaceId]).toEqual({ [child.id]: "permission" });
+
+    // The roll-up is what the sidebar, list_sessions, and notifications read.
+    expect(attentionFor(parent.id)).toEqual({
+      status: "waiting",
+      blockedBy: { sessionId: child.id, title: child.title, kind: "permission" },
+    });
+    expect(attentionFor(child.id)).toEqual({ status: "waiting", blockedBy: null });
+    expect(attentionFor(unrelated.id)).toEqual({ status: "idle", blockedBy: null });
+  });
+
+  test("answering the request returns the parent to its own working status", () => {
+    const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, parent.id, "running");
+    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
+    expect(attentionFor(parent.id)?.status).toBe("waiting");
+
+    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", false);
+    expect(useSessionActivityStore.getState().waitingByWorkspaceId[workspaceId]).toEqual({});
+    expect(attentionFor(parent.id)).toEqual({ status: "thinking", blockedBy: null });
+  });
+
+  test("a grandchild's question reaches every ancestor and names the grandchild", () => {
+    const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, parent.id, "running");
+    store.setWaitingRequest(workspaceId, grandchild.id, "question", "q-1", true);
+
+    const source = { sessionId: grandchild.id, title: grandchild.title, kind: "question" as const };
+    expect(attentionFor(parent.id)).toEqual({ status: "waiting", blockedBy: source });
+    expect(attentionFor(child.id)).toEqual({ status: "waiting", blockedBy: source });
+    expect(sessionAttentionLabel(source)).toBe("Waiting for your answer: Read den-web");
+    expect(sessionAttentionLabel({ sessionId: child.id, title: child.title, kind: "permission" }))
+      .toBe("Needs permission: Audit four open PRs");
+  });
+
+  test("precedence: the parent's own error or own request wins over a descendant's request", () => {
+    const store = useSessionActivityStore.getState();
+    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
+
+    store.setError(workspaceId, parent.id, "boom");
+    expect(attentionFor(parent.id)).toEqual({ status: "error", blockedBy: null });
+
+    store.clearError(workspaceId, parent.id);
+    store.setRunStatus(workspaceId, parent.id, "running");
+    store.setWaitingRequest(workspaceId, parent.id, "question", "q-own", true);
+    expect(attentionFor(parent.id)).toEqual({ status: "waiting", blockedBy: null });
+  });
+
+  test("a child that is compacting or idle does not roll anything up; a removed child releases the parent", () => {
+    const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, parent.id, "running");
+    store.setCompacting(workspaceId, child.id, true);
+    expect(attentionFor(parent.id)).toEqual({ status: "thinking", blockedBy: null });
+
+    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
+    expect(attentionFor(parent.id)?.status).toBe("waiting");
+    store.removeSession(workspaceId, child.id);
+    expect(useSessionActivityStore.getState().waitingByWorkspaceId[workspaceId]).toEqual({});
+    expect(attentionFor(parent.id)).toEqual({ status: "thinking", blockedBy: null });
+  });
+
+  test("cyclic parent data terminates", () => {
+    const cyclic = [
+      { id: "a", title: "A", parentID: "b" },
+      { id: "b", title: "B", parentID: "a" },
+    ];
+    const attention = selectSessionAttention(cyclic, () => "thinking", (id) => (id === "a" ? "permission" : undefined));
+    expect(attention.get("a")).toEqual({ status: "thinking", blockedBy: null });
+    expect(attention.get("b")).toEqual({ status: "waiting", blockedBy: { sessionId: "a", title: "A", kind: "permission" } });
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -194,11 +194,17 @@ function startFakeOpenWorkServer(options: { failPromptText?: string; failSession
       }
 
       // Live activity: alpha is mid-turn, beta waits on a permission, archive is idle.
-      if (url.pathname === "/workspace/ws_1/opencode/session/status") return Response.json({ ses_alpha: { type: "busy" } });
+      // Gamma is a busy parent whose delegated grandchild waits on a question.
+      if (url.pathname === "/workspace/ws_1/opencode/session/status") return Response.json({ ses_alpha: { type: "busy" }, ses_gamma: { type: "busy" } });
       if (url.pathname === "/workspace/ws_1/opencode/permission") return Response.json([{ id: "per_1", sessionID: "ses_beta" }]);
-      if (url.pathname === "/workspace/ws_1/opencode/question") return Response.json([]);
+      if (url.pathname === "/workspace/ws_1/opencode/question") return Response.json([{ id: "que_1", sessionID: "ses_gamma_grandchild" }]);
       if (url.pathname === "/workspace/ws_2/opencode/session/status") return Response.json({});
       if (url.pathname === "/workspace/ws_2/opencode/permission" || url.pathname === "/workspace/ws_2/opencode/question") return Response.json([]);
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_gamma/children") return Response.json([{ id: "ses_gamma_child", parentID: "ses_gamma" }]);
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_gamma_child/children") return Response.json([{ id: "ses_gamma_grandchild", parentID: "ses_gamma_child" }]);
+      if (url.pathname.endsWith("/children")) return Response.json([]);
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_gamma") return Response.json({ id: "ses_gamma", title: "Gamma delegation", time: { created: 100, updated: 300 } });
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_gamma/message") return Response.json([]);
 
       if (url.pathname === "/workspace/ws_1/opencode/session/ses_alpha") return Response.json(sessionAlpha);
       if (url.pathname === "/workspace/ws_1/opencode/session/ses_beta") return Response.json(sessionBeta);
@@ -430,6 +436,21 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(await read("ses_alpha")).toMatchObject({ status: "busy", working: true });
     expect(await read("ses_beta")).toMatchObject({ status: "waiting", working: true });
     expect(await read("ses_archive")).toMatchObject({ status: "idle", working: false });
+  });
+
+  test("session.read rolls a delegated descendant's pending request up to the parent", async () => {
+    startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+    const read = async (sessionId: string) => affordanceResultSchema("session.read", readResultSchema)
+      .parse(JSON.parse(await plugin.tool.openwork_query.execute({ id: "session.read", args: { sessionId, count: 1 } })))
+      .result;
+
+    // The grandchild owns the question; the busy parent reports waiting, not busy.
+    expect(await read("ses_gamma")).toMatchObject({ status: "waiting", working: true });
+    // An unrelated busy root is untouched by another tree's request.
+    expect(await read("ses_alpha")).toMatchObject({ status: "busy", working: true });
+    expect(sessionActivityFrom({ ses_p: { type: "busy" } }, [{ sessionID: "ses_c" }], [], "ses_p", ["ses_c"])).toEqual({ status: "waiting", working: true });
+    expect(sessionActivityFrom({ ses_p: { type: "busy" } }, [{ sessionID: "ses_c" }], [], "ses_p")).toEqual({ status: "busy", working: true });
   });
 
   test("an unreadable activity probe never reports a session as safe to archive", () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -626,11 +626,29 @@ async function readWorkspaceSession(workspace: OpenWorkWorkspace, sessionId: str
   return session;
 }
 
+const MAX_SESSION_DESCENDANTS = 256;
+const sessionChildrenSchema = z.array(z.object({ id: z.string() }).passthrough());
+
+/** Every delegated descendant of a session, breadth first; a failed hop ends the walk there. */
+async function readSessionDescendantIds(base: string, sessionId: string): Promise<string[]> {
+  const ids = [sessionId];
+  for (let index = 0; index < ids.length && ids.length <= MAX_SESSION_DESCENDANTS; index += 1) {
+    const parsed = sessionChildrenSchema.safeParse(
+      await serverGet(`${base}/session/${encodeURIComponent(ids[index])}/children`).catch(() => null),
+    );
+    if (!parsed.success) continue;
+    for (const child of parsed.data) if (!ids.includes(child.id)) ids.push(child.id);
+  }
+  return ids.slice(1);
+}
+
 async function readSessionActivity(workspace: OpenWorkWorkspace, sessionId: string): Promise<SessionActivity> {
   const base = `/workspace/${encodeURIComponent(workspace.id)}/opencode`;
   const probe = (path: string) => serverGet(`${base}${path}`).catch(() => null);
-  const [statuses, permissions, questions] = await Promise.all([probe("/session/status"), probe("/permission"), probe("/question")]);
-  return sessionActivityFrom(statuses, permissions, questions, sessionId);
+  const [statuses, permissions, questions, descendantIds] = await Promise.all([
+    probe("/session/status"), probe("/permission"), probe("/question"), readSessionDescendantIds(base, sessionId),
+  ]);
+  return sessionActivityFrom(statuses, permissions, questions, sessionId, descendantIds);
 }
 
 async function readSessionMessages(workspace: OpenWorkWorkspace, sessionId: string, limit: number): Promise<SessionMessage[]> {

--- a/apps/server/src/opencode-plugins/session-activity.ts
+++ b/apps/server/src/opencode-plugins/session-activity.ts
@@ -8,15 +8,17 @@ export type SessionActivity = { status: "idle" | "busy" | "retry" | "waiting"; w
 
 /**
  * Live activity for one session from the engine: its run status plus any
- * unanswered permission or question addressed to it. An unreadable probe
- * reports working=true with status "busy" so a caller never archives on a
- * guess.
+ * unanswered permission or question addressed to it or to one of its
+ * delegated descendants (a blocked child blocks the parent, and the person
+ * answers from the parent). An unreadable probe reports working=true with
+ * status "busy" so a caller never archives on a guess.
  */
 export function sessionActivityFrom(
   statuses: unknown,
   permissions: unknown,
   questions: unknown,
   sessionId: string,
+  descendantIds: readonly string[] = [],
 ): SessionActivity {
   const parsedStatuses = engineSessionStatusesSchema.safeParse(statuses);
   const parsedPermissions = enginePendingRequestsSchema.safeParse(permissions);
@@ -24,7 +26,8 @@ export function sessionActivityFrom(
   if (!parsedStatuses.success || !parsedPermissions.success || !parsedQuestions.success) {
     return { status: "busy", working: true };
   }
-  const waiting = [...parsedPermissions.data, ...parsedQuestions.data].some((request) => request.sessionID === sessionId);
+  const tree = new Set([sessionId, ...descendantIds]);
+  const waiting = [...parsedPermissions.data, ...parsedQuestions.data].some((request) => tree.has(request.sessionID));
   if (waiting) return { status: "waiting", working: true };
   const type = parsedStatuses.data[sessionId]?.type;
   if (type === "busy" || type === "running") return { status: "busy", working: true };

--- a/evals/specs/session-attention-rollup.test.ts
+++ b/evals/specs/session-attention-rollup.test.ts
@@ -1,0 +1,108 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { useSessionActivityStore } from "../../apps/app/src/react-app/domains/session/status/session-activity-store";
+import { selectSessionAttention, sessionAttentionLabel } from "../../apps/app/src/react-app/domains/session/status/session-attention";
+import { listControlSessions } from "../../apps/app/src/react-app/domains/session/control/list-control-sessions";
+
+// The sidebar, session.list_sessions and the transcript all read the same
+// roll-up: a delegated child's unanswered permission or question makes its
+// parent "waiting" (orange, needs you) instead of "thinking" (spinner).
+
+const workspaceId = "ws_rollup";
+const parent = { id: "ses_parent", title: "Slop audit (Astra high)", time: { updated: 300 } };
+const child = { id: "ses_child", title: "Audit four open PRs", parentID: parent.id, time: { updated: 310 } };
+const grandchild = { id: "ses_grandchild", title: "Read den-web", parentID: child.id, time: { updated: 320 } };
+const unrelated = { id: "ses_other", title: "Unrelated root", time: { updated: 200 } };
+const sessions = [parent, child, grandchild, unrelated];
+
+function reset() {
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {}, waitingByWorkspaceId: {} });
+  return useSessionActivityStore.getState();
+}
+
+function attention() {
+  const state = useSessionActivityStore.getState();
+  return selectSessionAttention(
+    sessions,
+    (id) => state.statusesByWorkspaceId[workspaceId]?.[id],
+    (id) => state.waitingByWorkspaceId[workspaceId]?.[id],
+  );
+}
+
+function listed() {
+  const rolled = attention();
+  return new Map(listControlSessions(null, {
+    workspaces: [{ id: workspaceId, displayName: "Rollup" }],
+    sessionsByWorkspaceId: { [workspaceId]: sessions },
+    pinnedIds: [],
+    statusFor: (_workspace, sessionId) => rolled.get(sessionId)?.status ?? "idle",
+  }).map((entry) => [entry.sessionId, entry]));
+}
+
+test("the activity store keeps a delegating parent at thinking while its child's permission makes the roll-up waiting", async ({ evidence }) => {
+  const store = reset();
+  store.setRunStatus(workspaceId, parent.id, "running");
+  store.setRunStatus(workspaceId, child.id, "running");
+  store.setWaitingRequest(workspaceId, child.id, "permission", "per_1", true);
+
+  const own = store.getStatus(workspaceId, parent.id);
+  const rolled = attention();
+  expect(own).toBe("thinking");
+  expect(store.getStatus(workspaceId, child.id)).toBe("waiting");
+  expect(rolled.get(parent.id)).toEqual({
+    status: "waiting",
+    blockedBy: { sessionId: child.id, title: child.title, kind: "permission" },
+  });
+  expect(rolled.get(child.id)).toEqual({ status: "waiting", blockedBy: null });
+  expect(rolled.get(unrelated.id)).toEqual({ status: "idle", blockedBy: null });
+  expect(sessionAttentionLabel({ sessionId: child.id, title: child.title, kind: "permission" }))
+    .toBe(`Needs permission: ${child.title}`);
+  evidence.recordAssertionEvidence(
+    "A child's pending permission rolls up to the parent without touching unrelated roots",
+    `Parent own status ${own}; rolled-up parent status ${rolled.get(parent.id)?.status} naming ${rolled.get(parent.id)?.blockedBy?.title}; unrelated root ${rolled.get(unrelated.id)?.status}.`,
+    own === "thinking" && rolled.get(parent.id)?.status === "waiting" && rolled.get(unrelated.id)?.status === "idle",
+  );
+});
+
+test("session.list_sessions reports a blocked parent as waiting and returns it to working once the child is answered", async ({ evidence }) => {
+  const store = reset();
+  store.setRunStatus(workspaceId, parent.id, "running");
+  store.setWaitingRequest(workspaceId, grandchild.id, "question", "que_1", true);
+
+  const blocked = listed();
+  expect(blocked.get(parent.id)).toMatchObject({ status: "waiting", working: true });
+  expect(blocked.get(child.id)).toMatchObject({ status: "waiting", working: true });
+  expect(blocked.get(grandchild.id)).toMatchObject({ status: "waiting", working: true });
+  expect(blocked.get(unrelated.id)).toMatchObject({ status: "idle", working: false });
+
+  store.setWaitingRequest(workspaceId, grandchild.id, "question", "que_1", false);
+  const answered = listed();
+  expect(answered.get(parent.id)).toMatchObject({ status: "thinking", working: true });
+  expect(answered.get(child.id)).toMatchObject({ status: "idle", working: false });
+  expect(answered.get(grandchild.id)).toMatchObject({ status: "idle", working: false });
+  evidence.recordAssertionEvidence(
+    "Agents see the parent as waiting only while a descendant's request is unanswered",
+    `Blocked: parent ${blocked.get(parent.id)?.status}; answered: parent ${answered.get(parent.id)?.status}, unrelated ${answered.get(unrelated.id)?.status}.`,
+    blocked.get(parent.id)?.status === "waiting" && answered.get(parent.id)?.status === "thinking",
+  );
+});
+
+test("the parent's own error or own request outranks a descendant's request", async ({ evidence }) => {
+  const store = reset();
+  store.setWaitingRequest(workspaceId, child.id, "permission", "per_1", true);
+  store.setError(workspaceId, parent.id, "Provider failed");
+  const errored = attention().get(parent.id);
+  expect(errored).toEqual({ status: "error", blockedBy: null });
+
+  store.clearError(workspaceId, parent.id);
+  store.setRunStatus(workspaceId, parent.id, "running");
+  store.setWaitingRequest(workspaceId, parent.id, "question", "que_own", true);
+  const own = attention().get(parent.id);
+  expect(own).toEqual({ status: "waiting", blockedBy: null });
+  evidence.recordAssertionEvidence(
+    "Precedence is error > own waiting > descendant waiting",
+    `With a child permission pending, an errored parent reports ${errored?.status}; a parent with its own question reports ${own?.status} with blockedBy ${String(own?.blockedBy)}.`,
+    errored?.status === "error" && own?.status === "waiting" && own?.blockedBy === null,
+  );
+});

--- a/evals/specs/sidebar-child-attention-rollup.e2e.test.ts
+++ b/evals/specs/sidebar-child-attention-rollup.e2e.test.ts
@@ -25,7 +25,7 @@ test("a delegated child's pending permission turns the parent's sidebar row oran
     return {
       spinner: Boolean(row?.querySelector<HTMLElement>("[data-session-loading-indicator]")),
       dot: dot instanceof HTMLElement ? { title: dot.title, ariaLabel: dot.getAttribute("aria-label"), source: dot.dataset.sessionAttentionSource ?? null } : null,
-      ariaLabel: row?.getAttribute("aria-label") ?? null,
+      ariaLabel: row?.querySelector<HTMLElement>('[data-testid="sidebar-session-' + id + '"]')?.getAttribute("aria-label") ?? null,
     };
   }, [parentId]));
   const listedParent = async () => {

--- a/evals/specs/sidebar-child-attention-rollup.e2e.test.ts
+++ b/evals/specs/sidebar-child-attention-rollup.e2e.test.ts
@@ -1,0 +1,72 @@
+import { expect } from "vitest";
+import { browserScript } from "@openwork/cdp";
+import { spec } from "@openwork/testkit";
+import { parentChildPermissionWorld } from "../worlds/first-run.ts";
+
+// A delegated child's pending permission lives on the child's activity
+// record. The parent row must show the orange "needs you" dot naming that
+// child, not the working spinner, and agents asking list_sessions must see
+// the parent as waiting. Answering the request returns the spinner.
+
+const test = spec.world(parentChildPermissionWorld);
+
+const CHILD_TITLE = "Investigate the deployment failure";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+test("a delegated child's pending permission turns the parent's sidebar row orange and its agent-visible status to waiting", async ({ world, user, agent, probe, step }) => {
+  const parentId = world.session.sessionId;
+  // TODO(primitive): read a sidebar row's indicator through a first-class primitive.
+  const rowIndicator = () => probe.eval(browserScript((id) => {
+    const row = document.querySelector<HTMLElement>('[data-sidebar-session-id="' + id + '"]');
+    const dot = row?.querySelector<HTMLElement>("[data-session-attention-indicator]");
+    return {
+      spinner: Boolean(row?.querySelector<HTMLElement>("[data-session-loading-indicator]")),
+      dot: dot instanceof HTMLElement ? { title: dot.title, ariaLabel: dot.getAttribute("aria-label"), source: dot.dataset.sessionAttentionSource ?? null } : null,
+      ariaLabel: row?.getAttribute("aria-label") ?? null,
+    };
+  }, [parentId]));
+  const listedParent = async () => {
+    const listed = await agent.run("session.list_sessions");
+    if (!Array.isArray(listed)) throw new Error("list_sessions did not return a list");
+    return listed.find((entry) => isRecord(entry) && entry.sessionId === parentId);
+  };
+
+  await step("the parent row needs you and names the blocked child while the transcript shows the same request", async () => {
+    await user.see({ text: /Needs permission/ }, { timeoutMs: 30_000 });
+    await user.see({ text: new RegExp(`Requested by ${CHILD_TITLE}`) });
+    const indicator = await probe.eventually(rowIndicator, {
+      within: 15_000, label: "the parent's sidebar row shows the orange needs-you dot for its child",
+      until: (value) => value.dot?.source === "child",
+    });
+    expect(indicator).toEqual({
+      spinner: false,
+      dot: { title: `Needs permission: ${CHILD_TITLE}`, ariaLabel: `Needs permission: ${CHILD_TITLE}`, source: "child" },
+      ariaLabel: expect.stringContaining(`Needs permission: ${CHILD_TITLE}`),
+    });
+    const parent = await probe.eventually(listedParent, {
+      within: 15_000, label: "session.list_sessions reports the parent as waiting",
+      until: (entry) => isRecord(entry) && entry.status === "waiting",
+    });
+    expect(parent).toMatchObject({ sessionId: parentId, status: "waiting", working: true });
+    await user.screenshot();
+  });
+
+  await step("answering the child's request returns the parent row to the working spinner", async () => {
+    await user.click("Allow once");
+    await user.notSee({ text: new RegExp(`Requested by ${CHILD_TITLE}`) }, { timeoutMs: 15_000 });
+    const indicator = await probe.eventually(rowIndicator, {
+      within: 15_000, label: "the parent's sidebar row returns to the working spinner",
+      until: (value) => value.spinner && value.dot === null,
+    });
+    expect(indicator).toMatchObject({ spinner: true, dot: null });
+    const parent = await probe.eventually(listedParent, {
+      within: 15_000, label: "session.list_sessions reports the parent as working again",
+      until: (entry) => isRecord(entry) && entry.status !== "waiting",
+    });
+    expect(parent).toMatchObject({ sessionId: parentId, status: "thinking", working: true });
+    await user.screenshot();
+  });
+});


### PR DESCRIPTION
## Problem

A parent session that delegated to a subagent kept showing the **working spinner** on its sidebar row while it was actually blocked: the child's `Access an external folder?` permission had to be answered before anything could move. The transcript already knew (`childBlocked` in `message-list.tsx`, `Needs permission` in `subagent-run-line.tsx`), but the sidebar, `session.list_sessions` (#4903) and `session.read` did not.

## Root cause

`session-activity-store.ts` `statusForRecord()` returns `waiting` only when the **session's own** record has `waitingPermissionIds` / `waitingQuestionIds`. A delegated child's request lives on the **child's** record, so the parent stays `thinking` (runActive, waiting on the `task` tool) and the sidebar renders the spinner. The same gap applied to `list_sessions` / `session.read` `status` + `working`.

## Fix

One selector, used everywhere the parent's attention state is shown:

- `session-attention.ts` — `selectSessionAttention(sessions, ownStatus, waitingKind)` walks each session's `parentID` chain and reports `waiting` for every ancestor of a blocked descendant, naming that descendant. Precedence: `error` > `waiting` (own or descendant) > `compacting` > `thinking`/`responding` > `idle`. Cyclic/dangling parent data terminates.
- `session-activity-store.ts` — derives `waitingByWorkspaceId` alongside `statusesByWorkspaceId`, so the roll-up subscribes without re-rendering `SessionRoute` on every transcript progress write.
- Sidebar — parent row shows the orange needs-you dot with tooltip / `aria-label` `Needs permission: <child title>` (or `Waiting for your answer: …`), tagged `data-session-attention-source="child"`; the row button's accessible name carries the same text.
- `session.list_sessions` — `status` / `working` use the same roll-up.
- Server `session.read` — the activity probe walks `/session/:id/children` (bounded) so a descendant's request reports the parent as `waiting`.
- `subagent-run-line.tsx` — reuses the new `session.subagent_question_pending` key instead of a hardcoded string.

Permission semantics and who may answer are unchanged. Desktop notifications already fired for child permissions (they key on the event, not the status), so nothing changed there. #4879 (delegated work overview) touches only transcript/header files — no overlap.

## Proof

Lane: **Daytona** (`OPENWORK_EVAL_DAYTONA=1 --daytona --strict-ref`, sandbox built at the PR head, `refMismatch: false`).

| Test | Command | Result |
| --- | --- | --- |
| `evals/specs/sidebar-child-attention-rollup.e2e.test.ts` (new) | `OPENWORK_EVAL_REF=f486eb7 pnpm evals:e2e sidebar-child-attention-rollup --daytona --strict-ref` | **Passed** 1/1, 0 skipped |
| `evals/specs/session-attention-rollup.test.ts` (new, PR lane) | `pnpm evals:pr specs/session-attention-rollup.test.ts` | **Passed** 3/3 |
| `evals/specs/parent-child-permission-approval.e2e.test.ts` (existing, regression) | `OPENWORK_EVAL_REF=f486eb7 pnpm evals:e2e parent-child-permission-approval --daytona --strict-ref` | 2/4 passed — the two seeded parent/child tests pass; `permissionStopRecovery` and `delegatedQuestionHandoff` failed in **world setup** (`configureProvider` → `/engine/reload` 503 `opencode_engine_unreachable`) before their bodies ran, with all four worlds booting in one sandbox. Those worlds are not touched by this change. |
| `apps/app/tests/session-attention-rollup.test.ts` (new, bun) | `bun test --isolate tests/session-attention-rollup.test.ts` | 6/6 — includes the RCA witness: parent own status stays `thinking`, roll-up is `waiting` |
| `apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts` | `bun test src/opencode-plugins/openwork-extensions-preview.test.ts` | 33/33 (new `session.read` roll-up case) |
| `pnpm typecheck` in `apps/app` and `apps/server` | | clean |

Pre-existing, unrelated: `apps/app/tests/session-archive-agent-contract.test.tsx` has 3 red cases locally that are identical on a clean `origin/dev` worktree (archive hook returns `cancelled`); not touched here.

The e2e proves: parent row has the orange dot titled `Needs permission: Investigate the deployment failure` and **no** spinner while the child's request is pending; `session.list_sessions` reports the parent `status: waiting, working: true`; after **Allow once** the spinner returns and `list_sessions` reports `thinking`.

Fixes the report from audit session `ses_f745daa30ffeVievUjczeXNb78`. Related: #4812, #4723, #4798, #4840, #4903.
