### PR TITLE
fix(chat): keep submitted text visible during native acknowledgement

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -1488,6 +1488,7 @@ export interface RunSyncHealth {
 
 interface MessageListProps {
   messages: UIMessage[]
+  messageIdReplacements?: ReadonlyMap<string, string>
   status: ThreadStatus
   activityStatus: SessionActivityStatus
   retryStatus?: RetryStatus | null
@@ -1509,7 +1510,7 @@ export function shouldShowRunReconnecting(status: ThreadStatus, syncDegraded: bo
   return status === "submitted" || status === "streaming" || status === "retrying"
 }
 
-export function MessageList({ messages, status, activityStatus, retryStatus, syncHealth, viewport }: MessageListProps) {
+export function MessageList({ messages, messageIdReplacements, status, activityStatus, retryStatus, syncHealth, viewport }: MessageListProps) {
   const { workspaceId, sessionId } = useMessageList()
   const workspace = useWorkspaceMaybe()
   const tasks = React.useMemo(() => activeDelegatedTasks(messages), [messages])
@@ -1599,6 +1600,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus, syn
     >
       <ProgressiveMessageList
         groups={items}
+        groupKeyReplacements={messageIdReplacements}
         viewport={viewport}
         className="@container/message-list"
         getGroupKey={(item) => isMessageGroup(item) ? item.messages[0]?.message.id ?? "empty-assistant-group" : item.message.id}

--- a/apps/app/src/components/chat/progressive-message-list.tsx
+++ b/apps/app/src/components/chat/progressive-message-list.tsx
@@ -20,6 +20,7 @@ interface ProgressiveMessageListProps<T> {
   groups: readonly T[]
   getGroupKey: (group: T) => string
   getMessageIds: (group: T) => readonly string[]
+  groupKeyReplacements?: ReadonlyMap<string, string>
   renderGroup: (group: T, index: number) => React.ReactNode
   viewport?: MessageListViewport
   className?: string
@@ -115,10 +116,13 @@ class ProgressiveGroups<T> extends React.Component<PreparedGroupsProps<T>, Mount
   static getDerivedStateFromProps<T>(props: PreparedGroupsProps<T>, state: MountState): MountState | null {
     const { keys, anchorIndex } = props
     if (!keys.length) return null
-    let mounted = state.mounted
+    const replacements = [...(props.groupKeyReplacements ?? [])]
+      .filter(([key, previous]) => state.mounted.has(previous) && !state.mounted.has(key) && keys.includes(key))
+      .map(([key]) => key)
+    let mounted = replacements.length ? new Set([...state.mounted, ...replacements]) : state.mounted
     const last = keys[keys.length - 1]
     if (!props.viewport || props.viewport.revealAll) {
-      if (keys.every((key) => mounted.has(key))) return null
+      if (keys.every((key) => state.mounted.has(key))) return null
       mounted = new Set(keys)
     } else if (!state.initialized || (anchorIndex >= 0 && (state.anchorPending || !mounted.has(keys[anchorIndex])))) {
       // Include the live tail without allowing the first mount to exceed eight groups.
@@ -133,7 +137,7 @@ class ProgressiveGroups<T> extends React.Component<PreparedGroupsProps<T>, Mount
       mounted = nearby
     } else if (!mounted.has(last)) {
       mounted = new Set([...mounted, last])
-    } else return null
+    } else if (mounted === state.mounted) return null
     return { ...state, mounted, initialized: true, anchorPending: state.anchorPending && anchorIndex < 0 && !props.viewport?.historyComplete }
   }
 

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1486,6 +1486,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const failedDraft = useComposerStateStore((state) => state.failedDrafts[sessionOwner]?.[0]);
   const pendingReconciliation = useMemo(() => {
     const matchedIds = new Set<string>();
+    const messageIdReplacements = new Map<string, string>();
     const messages = [...baseRenderedMessages];
     const remaining = (pendingMessages ?? []).flatMap((item) => {
       const { draft: pending, previousMessageIds } = item;
@@ -1503,6 +1504,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         return [item];
       }
       matchedIds.add(match.id);
+      if (match.id !== pending.messageId) messageIdReplacements.set(match.id, pending.messageId);
       messages[messages.indexOf(match)] = { ...match, parts };
       const textReady = !text.trim()
         || match.parts.some((part) => part.type === "text" && part.text.trim());
@@ -1511,7 +1513,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     });
     // A server turn can acknowledge only one pending send, even when two
     // consecutive prompts have identical text and v2 assigns its own IDs.
-    return { messages, remaining: remaining.map((item) => {
+    return { messages, messageIdReplacements, remaining: remaining.map((item) => {
       const claimed = [...matchedIds].filter((id) => id !== item.serverMessageId && !item.previousMessageIds.includes(id));
       return claimed.length ? { ...item, previousMessageIds: [...item.previousMessageIds, ...claimed] } : item;
     }) };
@@ -3287,6 +3289,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       onMcpRetry={handleMcpRetry}
                     >
                       <MessageList
+                        messageIdReplacements={pendingReconciliation.messageIdReplacements}
                         viewport={messageViewport}
                         messages={renderedMessages}
                         status={status}

--- a/apps/app/tests/progressive-message-list.test.tsx
+++ b/apps/app/tests/progressive-message-list.test.tsx
@@ -131,11 +131,12 @@ function fixture(initial = groups(), options: Partial<MessageListViewport> = {},
   cleanups.push(unmount)
   return {
     container, ready, writes, rendered, key, ids, unmount,
-    async render(next = data, update: Partial<MessageListViewport> = {}, renderer?: (group: Group, index: number) => ReactNode) {
+    async render(next = data, update: Partial<MessageListViewport> = {}, renderer?: (group: Group, index: number) => ReactNode, groupKeyReplacements?: ReadonlyMap<string, string>) {
       data = next
       viewport = { ...viewport, ...update }
       const list = <ProgressiveMessageList
         groups={data} viewport={viewport} getGroupKey={key} getMessageIds={ids}
+        groupKeyReplacements={groupKeyReplacements}
         renderGroup={(group, index) => {
           rendered.push(index)
           if (renderer) return renderer(group, index)
@@ -309,6 +310,57 @@ describe("progressive whole-group rendering", () => {
     await view.render([...next, { id: "new-user", messages: [{ id: "new-user", height: 60 }] }])
     expect(view.message("new-user")).toBeDefined()
     expect(view.message("m79")).toBe(tail)
+  })
+
+  test.each([false, true])("keeps submitted text mounted when its native ID arrives with assistant already present: %s", async (assistantAlreadyPresent) => {
+    const history = groups()
+    const pending = { id: "pending-user", messages: [{ id: "pending-user", height: 60 }] }
+    const native = { id: "native-user", messages: [{ id: "native-user", height: 60 }] }
+    const assistant = { id: "assistant", messages: [{ id: "assistant", height: 60 }] }
+    const text = "Keep this submitted message visible."
+    const render = (group: Group) => group.messages.map((message) =>
+      <div key={message.id} data-message-id={message.id}>{group === pending || group === native ? text : message.id}</div>)
+    const view = fixture([...history, pending])
+    await view.render(undefined, {}, render)
+    const expectOneSubmission = () => expect(view.container.textContent?.split(text).length).toBe(2)
+    expectOneSubmission()
+    view.read("pending-user")
+    if (assistantAlreadyPresent) {
+      await view.render([...history, pending, assistant], {}, render)
+      expectOneSubmission()
+    }
+    await view.render([...history, native, assistant], {}, render, new Map([[native.id, pending.id]]))
+    expectOneSubmission()
+    expect(view.message("native-user")).toBeDefined()
+    expect(view.mounted).not.toContain("pending-user")
+    expect(view.mounted).not.toContain("g0")
+    await act(async () => runFrame())
+    expectOneSubmission()
+    await act(async () => runFrame())
+    expectOneSubmission()
+    await view.render([...history, native, assistant], {}, render)
+    expectOneSubmission()
+  })
+
+  test("replacement admission stays scoped to mounted groups in the same session, not new history", async () => {
+    const data = groups()
+    const view = fixture(data, { anchorMessageId: "m40" })
+    await view.render()
+    view.read("m40")
+    const next = data.map((group) => group.id === "g0" || group.id === "g40" ? { ...group, id: `native-${group.id}` } : group)
+    next.unshift({ id: "older-history", messages: [{ id: "older-history", height: 240 }] })
+    const replacements = new Map([["native-g0", "g0"], ["native-g40", "g40"]])
+    await view.render(next, { anchorMessageId: undefined }, undefined, replacements)
+    expect(view.mounted).toContain("native-g40")
+    expect(view.mounted).not.toContain("native-g0")
+    expect(view.mounted).not.toContain("older-history")
+    expect(view.mounted).toHaveLength(8)
+    await view.render(next)
+    expect(view.mounted).toContain("native-g40")
+    await view.render(next, { sessionKey: `replacement-${++sessionId}` }, undefined, replacements)
+    expect(view.mounted).not.toContain("native-g40")
+    expect(view.mounted).not.toContain("native-g0")
+    expect(view.mounted).toHaveLength(8)
   })
 
   test("keeps the exact visible message offset while estimates above it are replaced", async () => {

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -513,6 +513,7 @@ continuityTest("CONT-01 restores the exact cumulative prefix while one answer st
   });
 
   await step("one real send admits once and renders only the initially released first bullet", async () => {
+    await using transcript = await observeTranscript(probe, [{ role: "user", text: streamedContinuityPrompt }]);
     await user.type("composer", streamedContinuityPrompt);
     await user.click("Run task");
     await user.see({ text: streamedContinuityPrompt }, { timeoutMs: 2_000 });
@@ -533,6 +534,9 @@ continuityTest("CONT-01 restores the exact cumulative prefix while one answer st
     await expectOneUserAdmission();
     expect(await promptPosts()).toBe(1);
     expect(await world.providerFinalRequests()).toHaveLength(1);
+    const admission = await transcript.finish();
+    evidence.recordJsonArtifact("CONT-01 submitted user text continuity", admission);
+    expect(admission).toMatchObject({ seen: [true], violations: [], stopped: false });
   });
 
   await step("B remains empty while bullet two and partial bullet three advance only in A", async () => {


### PR DESCRIPTION
## Problem

Submitted user text can disappear briefly when the native engine replaces the optimistic message ID, especially when an assistant group already follows it. The new ID loses progressive mount admission and becomes a history placeholder until the next batch.

This is the separate transcript-continuity follow-up to #4881. It targets dev directly and contains no Cloud skill changes.

## Change

- Carry the existing pending-to-native ID match through the message list.
- Transfer mount admission only from a group that was already mounted in the same session.
- Keep native IDs authoritative and preserve deferred history/backfill behavior.
- Extend the existing CONT-01 journey with frame-by-frame submitted-user-text continuity. No assertion is weakened.

## Verification

Head: `218b80ca267ddacd11a28cb148dfac5d6a284fe0`; base: `3b6db1dca072ec1d38131ac608e5be2b0c9a8a62`.

**Verdict: Incomplete for hosted evidence publication; focused checks passed.**

- Deterministic reproduction before the fix: both assistant-ordering cases failed.
- After the fix: progressive-message-list component tests, 26 passed / 0 failed (154 assertions), including history/session isolation.
- App and evals typechecks passed during development.
- On final head: `pnpm evals:e2e streamed-markdown-answer --local --engine v2 --case CONT-01` exited 0: 1 passed / 0 failed / 0 selected skips; 3 other cases filtered out. Fresh isolated app-web, real v2 engine, mock provider. The user-text observer remained present without duplicate or disappearance violations.
- Optional layers audit reported 51 violations outside the changed files; no clean control was run, so this is not classified as pre-existing.
- Hosted evidence publication is pending terminal credential setup. Electron/Daytona and the Cloud01-specific timing trace were not exercised in this PR. The component regression proves the mount-admission defect; CONT-01 checks continuity across the real v2 app path.

## UI/UX impact

Submitted text stays visible during native acknowledgement instead of briefly disappearing. No layout, icon, color, label, control, or historical-backfill changes.