### PR TITLE
fix(app): redact quoted secret values in crash diagnostics (regression from #4820)

### DIFF
--- a/apps/app/src/app/lib/crash-diagnostics.ts
+++ b/apps/app/src/app/lib/crash-diagnostics.ts
@@ -1,7 +1,7 @@
 import { sanitizeDiagnosticString } from "./diagnostic-sanitizer";
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>()]+/gi;
-const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=[^&\s"'<>()]+/gi;
+const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=(?:"[^"]*"|'[^']*'|[^&\s"'<>()]+)/gi;
 const FALLBACK_MESSAGE = "An unexpected error occurred.";
 
 /**

--- a/apps/app/tests/crash-diagnostics.test.ts
+++ b/apps/app/tests/crash-diagnostics.test.ts
@@ -85,6 +85,24 @@ test("userinfo cut by the work bound before its @ cannot survive into any bounde
   expect(redactCrashText(exact)).toBe(exact);
 });
 
+test.each([
+  ["double-quoted value", 'token="DEMO_SECRET"', "token=[redacted]"],
+  ["single-quoted value", "key='abc'", "key=[redacted]"],
+  ["double-quoted value containing & and )", 'secret="a&b)")', "secret=[redacted])"],
+  ["single-quoted value containing & and )", "code='x&y)')", "code=[redacted])"],
+  ["unquoted value followed by )", "grant=abc)", "grant=[redacted])"],
+  ["unquoted value followed by ) in a stack frame", "at fn (file?token=abc)", "at fn (file?token=[redacted])"],
+])("redacts %s", (_label, input, expected) => {
+  expect(redactCrashText(input)).toBe(expected);
+  expect(redactCrashText(input)).not.toContain("DEMO_SECRET");
+  expect(redactCrashText(input)).not.toContain("abc");
+});
+
+test("JSON colon syntax is not widened to pair redaction (documented current behavior)", () => {
+  const json = '{"token":"abc"}';
+  expect(redactCrashText(json)).toBe(json);
+});
+
 test("long diagnostics are bounded after sanitizing, without masking ordinary text or HTML", () => {
   const diagnostic = formatCrashDiagnostic({ name: "N".repeat(50000), message: "m".repeat(50000), stack: "s".repeat(50000) });
   expect(diagnostic.name).toHaveLength(100);


### PR DESCRIPTION
## Regression from #4820

PR #4820 added `"'<>()` to the character exclusion in `SECRET_PAIR_PATTERN` so a trailing `)` from a stack frame is not swallowed. That also stops the match at the opening quote, so `token="DEMO_SECRET"` and `key='abc'` survive verbatim. `redactCrashText` feeds crash display, clipboard copy, and optional reporting — a credential leak.

## Fix

```diff
- const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=[^&\s"'<>()]+/gi;
+ const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=(?:"[^"]*"|'[^']*'|[^&\s"'<>()]+)/gi;
```

A value starting with a quote is matched through its closing quote; an unquoted value still stops at `&`/whitespace/`"'<>()` as before. The replacement keeps the key prefix and drops the quoted value.

## Inputs → output

| Input | Before | After |
|---|---|---|
| `token="DEMO_SECRET"` | `token="DEMO_SECRET"` | `token=[redacted]` |
| `key='abc'` | `key='abc'` | `key=[redacted]` |
| `grant=abc)` | `grant=[redacted])` | `grant=[redacted])` |

## Tests

New tests in `crash-diagnostics.test.ts`: `redacts double-quoted value`, `redacts single-quoted value`, `redacts double-quoted value containing & and )`, `redacts single-quoted value containing & and )`, `redacts unquoted value followed by )`, `redacts unquoted value followed by ) in a stack frame`, `JSON colon syntax is not widened to pair redaction`.

```
bun test --isolate tests/crash-diagnostics.test.ts
31 pass, 0 fail, 80 expect() calls
```

Reverting the source fix (keeping new tests): 4 quoted-value tests fail — `redacts double-quoted value` is the first.

Refs #4820.