### PR TITLE
perf(chat): load thread history independently of activity readiness

### DIFF
--- a/apps/app/src/app/lib/opencode-session-native.ts
+++ b/apps/app/src/app/lib/opencode-session-native.ts
@@ -3,7 +3,7 @@ import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/s
 import { closeSessionBrowserTabs } from "./desktop";
 import { createClient, unwrap, type FieldsResult } from "./opencode";
 import { createClientV2, isOpencodeV2BaseUrl } from "./opencode-v2-adapter";
-import type { OpenworkSessionSnapshot } from "./openwork-server";
+import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "./openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "./workspace-endpoint";
 
 type NativeSessionEndpoint = Pick<ResolvedWorkspaceEndpoint, "opencodeBaseUrl" | "token">;
@@ -112,13 +112,11 @@ export async function getNativeSessionMessages(
   return unwrapSessionResult(result, "session_not_found");
 }
 
-export async function composeNativeSessionSnapshot(
-  endpoint: NativeSessionEndpoint,
+async function readNativeSessionHistory(
+  operations: NativeSessionOperations,
   sessionId: string,
   options?: RequestOptions & { limit?: number; messageIds?: readonly string[] },
-  dependencies?: NativeSessionDependencies,
-): Promise<OpenworkSessionSnapshot> {
-  const operations = sessionOperations(endpoint, dependencies);
+): Promise<Pick<OpenworkSessionSnapshot, "session" | "messages">> {
   const readMessages = async () => {
     if (options?.messageIds === undefined) {
       return unwrapSessionResult(await operations.messages(sessionId, options?.limit, options), "session_not_found");
@@ -143,24 +141,52 @@ export async function composeNativeSessionSnapshot(
     }));
     return records.flat();
   };
-  const [sessionResult, messages, todoResult, statusResult] = await Promise.all([
+  const [sessionResult, messages] = await Promise.all([
     operations.get(sessionId, options),
     readMessages(),
+  ]);
+  options?.signal?.throwIfAborted();
+  const session = unwrapSessionResult(sessionResult, "session_not_found");
+  if (session.id !== sessionId || messages.some((record) => record.info.sessionID !== sessionId
+    || record.parts.some((part) => part.sessionID !== sessionId || part.messageID !== record.info.id))) {
+    throw new Error("Could not verify the session history owner.");
+  }
+  return { session, messages };
+}
+
+export async function composeNativeSessionHistory(
+  endpoint: NativeSessionEndpoint,
+  sessionId: string,
+  options?: RequestOptions & { limit?: number; messageIds?: readonly string[] },
+  dependencies?: NativeSessionDependencies,
+): Promise<OpenworkSessionHistory> {
+  return readNativeSessionHistory(sessionOperations(endpoint, dependencies), sessionId, options);
+}
+
+export async function composeNativeSessionSnapshot(
+  endpoint: NativeSessionEndpoint,
+  sessionId: string,
+  options?: RequestOptions & { limit?: number; messageIds?: readonly string[] },
+  dependencies?: NativeSessionDependencies,
+): Promise<OpenworkSessionSnapshot> {
+  const operations = sessionOperations(endpoint, dependencies);
+  const [history, todoResult, statusResult] = await Promise.all([
+    readNativeSessionHistory(operations, sessionId, options),
     operations.todo(sessionId, options),
     operations.status(options),
   ]);
-  const session = unwrapSessionResult(sessionResult, "session_not_found");
   const todos = unwrapSessionResult(todoResult, "session_not_found");
   const statuses = unwrapSessionResult(statusResult);
-  return { session, messages, todos, status: statuses[sessionId] ?? { type: "idle" } };
+  return { ...history, todos, status: statuses[sessionId] ?? { type: "idle" } };
 }
 
-export async function composeNativeSessionSnapshotWithRetry(
+async function readOwnedNativeSessionWithRetry<T>(
   expectedOwner: string,
   readCurrentTarget: () => NativeSessionSnapshotTarget,
   options: RequestOptions & { limit?: number; messageIds?: readonly string[] },
-  dependencies?: NativeSessionDependencies,
-): Promise<OpenworkSessionSnapshot> {
+  dependencies: NativeSessionDependencies | undefined,
+  read: (endpoint: NativeSessionEndpoint, sessionId: string, readOptions: RequestOptions & { limit?: number; messageIds?: readonly string[] }, dependencies?: NativeSessionDependencies) => Promise<T>,
+): Promise<T> {
   const signal = options.signal ?? new AbortController().signal;
   const waitForRetry = dependencies?.waitForSnapshotRetry ?? waitForSnapshotRetry;
   let attempt = 0;
@@ -168,7 +194,7 @@ export async function composeNativeSessionSnapshotWithRetry(
     signal.throwIfAborted();
     const target = readOwnedSnapshotTarget(expectedOwner, readCurrentTarget);
     try {
-      const snapshot = await composeNativeSessionSnapshot(
+      const snapshot = await read(
         target.endpoint,
         target.sessionId,
         options,
@@ -186,6 +212,24 @@ export async function composeNativeSessionSnapshotWithRetry(
       await waitForRetry(delayMs, signal);
     }
   }
+}
+
+export function composeNativeSessionHistoryWithRetry(
+  expectedOwner: string,
+  readCurrentTarget: () => NativeSessionSnapshotTarget,
+  options: RequestOptions & { limit?: number; messageIds?: readonly string[] },
+  dependencies?: NativeSessionDependencies,
+) {
+  return readOwnedNativeSessionWithRetry(expectedOwner, readCurrentTarget, options, dependencies, composeNativeSessionHistory);
+}
+
+export function composeNativeSessionSnapshotWithRetry(
+  expectedOwner: string,
+  readCurrentTarget: () => NativeSessionSnapshotTarget,
+  options: RequestOptions & { limit?: number; messageIds?: readonly string[] },
+  dependencies?: NativeSessionDependencies,
+) {
+  return readOwnedNativeSessionWithRetry(expectedOwner, readCurrentTarget, options, dependencies, composeNativeSessionSnapshot);
 }
 
 export async function deleteNativeSession(

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -267,6 +267,11 @@ export type OpenworkSessionSnapshot = {
     | { type: "retry"; attempt: number; message: string; next: number };
 };
 
+// Stored history is independently readable. Missing activity fields are not an
+// observed idle state or an empty todo list; live hydration owns those values.
+export type OpenworkSessionHistory = Pick<OpenworkSessionSnapshot, "session" | "messages">
+  & Partial<Pick<OpenworkSessionSnapshot, "status" | "todos">>;
+
 export type OpenworkPluginItem = {
   spec: string;
   source: "config" | "dir.project" | "dir.global";

--- a/apps/app/src/components/chat/progressive-message-list.tsx
+++ b/apps/app/src/components/chat/progressive-message-list.tsx
@@ -45,6 +45,7 @@ type MountState = {
 
 type Segment = { key: string; start: number; end: number; height: number; placeholder: boolean }
 type Plan = { keys: string[]; heights: number[]; segments: Segment[]; complete: boolean }
+type HeightPlan = { keys: string[]; scrollHeight: number | undefined; heights: number[]; totalHeight: number }
 type ReadingPosition = {
   reservedTop?: number
   element: HTMLElement | null
@@ -76,6 +77,10 @@ function sameStructure(a: Plan, b: Plan) {
       const other = b.segments[index]
       return segment.key === other.key && (!segment.placeholder || segment.height === other.height)
     })
+}
+
+function sameKeys(a: readonly string[], b: readonly string[]) {
+  return a === b || (a.length === b.length && a.every((key, index) => key === b[index]))
 }
 
 /** Whole groups mount once, then stay mounted. The key cancels work on a session switch. */
@@ -150,6 +155,7 @@ class ProgressiveGroups<T> extends React.Component<PreparedGroupsProps<T>, Mount
   private active = false
   private estimates = new Map<string, number>()
   private estimateScope = ""
+  private heightPlan: HeightPlan | null = null
 
   private cacheKey(width = this.state.width) {
     return JSON.stringify([this.props.viewport?.sessionKey, width])
@@ -363,27 +369,38 @@ class ProgressiveGroups<T> extends React.Component<PreparedGroupsProps<T>, Mount
 
   render() {
     const { groups, keys, renderGroup, viewport, header, children, className } = this.props
-    const cache = heightCache.get(this.cacheKey())
     const estimateScope = JSON.stringify([this.state.width, viewport?.historyComplete])
     if (estimateScope !== this.estimateScope) {
       this.estimateScope = estimateScope
       this.estimates = new Map()
+      this.heightPlan = null
     }
-    const known = keys.reduce((sum, key) => sum + (this.estimates.get(key) ?? cache?.get(key) ?? 0), 0)
-    const unknown = keys.filter((key) => !this.estimates.has(key) && !cache?.has(key)).length
-    const estimate = viewport?.historyComplete && viewport.scrollHeight && unknown > 0
-      ? Math.max(32, (viewport.scrollHeight - known - GROUP_GAP * Math.max(0, keys.length - 1)) / unknown)
-      : ESTIMATED_HEIGHT
-    // Freeze skipped geometry for this data/width scope. Learning a mounted
-    // group's size must not redistribute every other spacer during live reflow.
-    const heights = keys.map((key) => {
-      const height = this.estimates.get(key) ?? cache?.get(key) ?? estimate
-      this.estimates.set(key, height)
-      return height
-    })
+    let heightPlan = this.heightPlan
+    // Mount batches keep the same keys. Content-only parent updates may supply
+    // a new array with the same order, including after every group is mounted.
+    if (!heightPlan || heightPlan.scrollHeight !== viewport?.scrollHeight || !sameKeys(heightPlan.keys, keys)) {
+      const cache = heightCache.get(this.cacheKey())
+      const known = keys.reduce((sum, key) => sum + (this.estimates.get(key) ?? cache?.get(key) ?? 0), 0)
+      const unknown = keys.filter((key) => !this.estimates.has(key) && !cache?.has(key)).length
+      const estimate = viewport?.historyComplete && viewport.scrollHeight && unknown > 0
+        ? Math.max(32, (viewport.scrollHeight - known - GROUP_GAP * Math.max(0, keys.length - 1)) / unknown)
+        : ESTIMATED_HEIGHT
+      // Freeze skipped geometry for this data/width scope. Learning a mounted
+      // group's size must not redistribute every other spacer during live reflow.
+      let totalHeight = 0
+      const heights = keys.map((key) => {
+        const height = this.estimates.get(key) ?? cache?.get(key) ?? estimate
+        this.estimates.set(key, height)
+        totalHeight = totalHeight + height + GROUP_GAP
+        return height
+      })
+      heightPlan = { keys, scrollHeight: viewport?.scrollHeight, heights, totalHeight }
+      this.heightPlan = heightPlan
+    } else heightPlan.keys = keys
+    const { heights, totalHeight } = heightPlan
     const segments: Segment[] = []
     const reserved = viewport && !viewport.historyComplete
-      ? Math.max(0, (viewport.scrollHeight ?? 0) - heights.reduce((sum, height) => sum + height + GROUP_GAP, 0)) : 0
+      ? Math.max(0, (viewport.scrollHeight ?? 0) - totalHeight) : 0
     const leading = !viewport?.historyComplete ? viewport?.leadingHeight ?? reserved : 0
     const trailing = !viewport?.historyComplete ? viewport?.trailingHeight ?? 0 : 0
     if (leading > 0) segments.push({ key: "history-prefix", start: 0, end: 0, height: leading, placeholder: true })

--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -12,12 +12,23 @@ export type SessionWaitingKind = "permission" | "question";
 
 type SessionMessageRole = "assistant" | "system" | "user";
 
+type TranscriptActivity = {
+  startedAt: number;
+  latestUserId: string | null;
+  assistantOutput: boolean;
+  activeStartedAt: number;
+};
+
 type SessionActivityRecord = {
   status: SessionActivityStatus;
   runActive: boolean;
   retrying: boolean;
   runStatusAt: number;
   runStartedAt: number;
+  // Only an active run first discovered by a read may inherit persisted age.
+  // Live status/admission writes cancel this pending hydration, even on ties.
+  runHydrationAfter: number | null;
+  transcriptActivity: TranscriptActivity | null;
   lastProgressAt: number;
   progressRevision: string | null;
   progressParts: Record<string, string>;
@@ -59,7 +70,13 @@ type SessionActivityStore = {
     options?: { snapshotStartedAt?: number },
   ) => void;
   setRunStatus: (workspaceId: string, sessionId: string, status: unknown) => void;
-  observeTranscript: (workspaceId: string, sessionId: string, messages: UIMessage[], snapshot?: boolean) => void;
+  observeTranscript: (
+    workspaceId: string,
+    sessionId: string,
+    messages: UIMessage[],
+    snapshot?: boolean,
+    options?: { snapshotStartedAt?: number },
+  ) => void;
   markMessageRole: (workspaceId: string, sessionId: string, messageId: string, role: SessionMessageRole) => void;
   markAssistantOutput: (workspaceId: string, sessionId: string, messageId?: string, options?: { allowUnknownMessageRole?: boolean }) => void;
   setWaitingRequest: (workspaceId: string, sessionId: string, kind: "permission" | "question", requestId: string, waiting: boolean) => void;
@@ -76,6 +93,8 @@ const createRecord = (): SessionActivityRecord => ({
   retrying: false,
   runStatusAt: 0,
   runStartedAt: 0,
+  runHydrationAfter: null,
+  transcriptActivity: null,
   lastProgressAt: 0,
   progressRevision: null,
   progressParts: {},
@@ -176,6 +195,11 @@ function sameActivityRecord(
     && current.retrying === next.retrying
     && current.runStatusAt === next.runStatusAt
     && current.runStartedAt === next.runStartedAt
+    && current.runHydrationAfter === next.runHydrationAfter
+    && current.transcriptActivity?.startedAt === next.transcriptActivity?.startedAt
+    && current.transcriptActivity?.latestUserId === next.transcriptActivity?.latestUserId
+    && current.transcriptActivity?.assistantOutput === next.transcriptActivity?.assistantOutput
+    && current.transcriptActivity?.activeStartedAt === next.transcriptActivity?.activeStartedAt
     && current.lastProgressAt === next.lastProgressAt
     && current.progressRevision === next.progressRevision
     && current.latestActivity === next.latestActivity
@@ -245,6 +269,25 @@ function addValue(values: string[], value: string) {
   return values.includes(value) ? values : [...values, value];
 }
 
+function reconcileTranscriptActivity(record: SessionActivityRecord): SessionActivityRecord {
+  const snapshot = record.transcriptActivity;
+  if (!record.runActive || !snapshot) return record;
+  const hydrateRun = typeof record.runHydrationAfter === "number" && snapshot.startedAt > record.runHydrationAfter;
+  // Fresh history can reveal output for an already observed live run, but only
+  // a run first discovered by a read may inherit its persisted execution age.
+  const assistantOutput = record.assistantOutput
+    || ((hydrateRun || snapshot.startedAt > record.runStatusAt) && snapshot.assistantOutput);
+  if (!hydrateRun && assistantOutput === record.assistantOutput) return record;
+  return {
+    ...record,
+    assistantOutput,
+    runStartedAt: hydrateRun && snapshot.activeStartedAt > 0
+      ? Math.min(record.runStartedAt || snapshot.activeStartedAt, snapshot.activeStartedAt)
+      : record.runStartedAt,
+    runHydrationAfter: hydrateRun ? null : record.runHydrationAfter,
+  };
+}
+
 export const useSessionActivityStore = create<SessionActivityStore>((set, get) => ({
   recordsByWorkspaceId: {},
   statusesByWorkspaceId: {},
@@ -312,19 +355,23 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       // live spinner and stale busy cannot resurrect a run that already ended.
       if (typeof snapshotStartedAt === "number" && snapshotStartedAt < record.runStatusAt) return record;
       if (typeof snapshotStartedAt !== "number" && !runActive && record.status !== "idle") return record;
-      return {
+      return reconcileTranscriptActivity({
         ...record,
         runActive,
         runStatusAt: snapshotStartedAt ?? record.runStatusAt,
         retrying: normalized === "retry",
         runStartedAt: runActive && !record.runActive ? Date.now() : record.runStartedAt,
+        runHydrationAfter: !runActive ? null
+          : typeof snapshotStartedAt === "number" && (!record.runActive || record.runStatusAt === 0)
+            ? record.runStatusAt
+            : record.runHydrationAfter,
         assistantOutput: runActive && (assistantOutput ?? record.assistantOutput),
         errorActive: runActive ? false : record.errorActive,
         errorMessage: runActive ? null : record.errorMessage,
         compacting: runActive ? record.compacting : false,
         waitingPermissionIds: runActive ? record.waitingPermissionIds : [],
         waitingQuestionIds: runActive ? record.waitingQuestionIds : [],
-      };
+      });
     }));
   },
   setRunStatus: (workspaceId, sessionId, status) => {
@@ -338,6 +385,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
         ...record,
         runActive,
         runStatusAt: Date.now(),
+        runHydrationAfter: null,
         retrying: normalized === "retry",
         runStartedAt: runActive && !record.runActive ? Date.now() : record.runStartedAt,
         assistantOutput: runActive && record.runActive ? record.assistantOutput : false,
@@ -349,24 +397,50 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       };
     }));
   },
-  observeTranscript: (workspaceId, sessionId, messages, snapshot = false) => {
+  observeTranscript: (workspaceId, sessionId, messages, snapshot = false, options = {}) => {
     set((state) => updateRecord(state, workspaceId, sessionId, (record) => {
       const progress = transcriptProgress(messages, record.progressParts);
-      if (record.progressRevision === progress.revision) return record;
-      const hydratedActiveStartedAt = snapshot && record.progressRevision === null && record.runActive
+      const snapshotStartedAt = options.snapshotStartedAt;
+      const turnChanged = record.transcriptActivity !== null
+        && record.transcriptActivity.latestUserId !== progress.latestUserId;
+      const progressChanged = record.progressRevision !== progress.revision;
+      const observedAt = snapshot ? snapshotStartedAt ?? 0 : turnChanged || progressChanged ? Date.now() : 0;
+      const next = reconcileTranscriptActivity({
+        ...record,
+        ...(turnChanged ? {
+          assistantOutput: false,
+          runStartedAt: record.runActive
+            ? Math.max(record.runStartedAt, progress.latestUserCreated ?? (snapshot ? 0 : Date.now()))
+            : record.runStartedAt,
+          runHydrationAfter: null,
+          latestActivity: null,
+        } : {}),
+        transcriptActivity: {
+          startedAt: Math.max(turnChanged ? 0 : record.transcriptActivity?.startedAt ?? 0, observedAt),
+          latestUserId: progress.latestUserId,
+          assistantOutput: progress.assistantOutput,
+          activeStartedAt: progress.activeStartedAt,
+        },
+      });
+      // History may have established progress before status arrived. Activity
+      // enrichment must still run when its fingerprint is already known.
+      if (!progressChanged) return next;
+      const hydratedActiveStartedAt = snapshot && snapshotStartedAt === undefined
+        && record.progressRevision === null && next.runActive && next.runHydrationAfter !== null
         ? progress.activeStartedAt
         : 0;
       return {
-        ...record,
+        ...next,
         // Snapshot fetch time establishes ordering, not execution age. Only a
         // persisted in-flight part can move the first hydrated run anchor back;
         // old terminal transcript rows must not age a newer accepted run.
         runStartedAt: hydratedActiveStartedAt > 0
           ? Math.min(record.runStartedAt || hydratedActiveStartedAt, hydratedActiveStartedAt)
-          : record.runStartedAt,
+          : next.runStartedAt,
+        runHydrationAfter: hydratedActiveStartedAt > 0 ? null : next.runHydrationAfter,
         progressRevision: progress.revision,
         progressParts: progress.parts,
-        latestActivity: progress.label ?? record.latestActivity,
+        latestActivity: turnChanged && !progress.assistantOutput ? null : progress.label ?? next.latestActivity,
         lastProgressAt: progress.label
           ? Math.max(record.lastProgressAt, snapshot && record.progressRevision === null ? progress.timestamp : Date.now())
           : record.lastProgressAt,
@@ -429,6 +503,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       runActive: false,
       retrying: false,
       runStatusAt: Date.now(),
+      runHydrationAfter: null,
       assistantOutput: false,
       compacting: false,
     })));

--- a/apps/app/src/react-app/domains/session/status/session-progress.ts
+++ b/apps/app/src/react-app/domains/session/status/session-progress.ts
@@ -35,6 +35,9 @@ function safeToolActivity(part: UIMessage["parts"][number]): string {
 }
 
 type Progress = {
+  latestUserId: string | null;
+  latestUserCreated: number | null;
+  assistantOutput: boolean;
   revision: string;
   parts: Record<string, string>;
   label: string | null;
@@ -66,10 +69,16 @@ export function transcriptProgress(messages: UIMessage[], previousParts: Record<
   let label: string | null = null;
   let timestamp = 0;
   let activeStartedAt = 0;
+  let assistantOutput = false;
   let latestUserIndex = -1;
+  let latestUserCreated: number | null = null;
   for (let index = messages.length - 1; index >= 0; index--) {
     if (messages[index]?.role === "user") {
       latestUserIndex = index;
+      const metadata = messages[index].metadata;
+      const time = metadata && typeof metadata === "object" ? Reflect.get(metadata, "opencode") : undefined;
+      const created = time && typeof time === "object" ? Reflect.get(time, "created") : undefined;
+      if (typeof created === "number" && Number.isFinite(created)) latestUserCreated = created;
       break;
     }
   }
@@ -96,6 +105,7 @@ export function transcriptProgress(messages: UIMessage[], previousParts: Record<
         parts[key] = partFingerprint(part, () => [part.type, part.url]);
         activity = "File output received";
       } else continue;
+      if (messageIndex > latestUserIndex) assistantOutput = true;
       if (parts[key] !== previousParts[key]) label = activity;
       meaningful = true;
     }
@@ -115,7 +125,12 @@ export function transcriptProgress(messages: UIMessage[], previousParts: Record<
       activeStartedAt = activeStartedAt === 0 ? created : Math.min(activeStartedAt, created);
     }
   }
-  return { revision: fingerprint(parts), parts, label, timestamp, activeStartedAt };
+  return {
+    latestUserId: messages[latestUserIndex]?.id ?? null,
+    latestUserCreated,
+    assistantOutput,
+    revision: fingerprint(parts), parts, label, timestamp, activeStartedAt,
+  };
 }
 
 export function lastTaskProgressAt(

--- a/apps/app/src/react-app/domains/session/surface/debug-panel.tsx
+++ b/apps/app/src/react-app/domains/session/surface/debug-panel.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource react */
-import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
+import type { OpenworkSessionHistory } from "../../../../app/lib/openwork-server";
 import type { SessionRenderModel } from "../sync/transition-controller";
 
 export function SessionDebugPanel(props: {
   model: SessionRenderModel;
-  snapshot: OpenworkSessionSnapshot | null;
+  snapshot: OpenworkSessionHistory | null;
 }) {
   return (
     <div className="fixed bottom-20 right-4 z-30 w-[280px] rounded-2xl border border-dls-border bg-dls-surface/95 p-3 text-xs text-dls-secondary shadow-[var(--dls-card-shadow)] backdrop-blur-md">
@@ -14,9 +14,9 @@ export function SessionDebugPanel(props: {
         <div>renderedSessionId: <span className="text-dls-text">{props.model.renderedSessionId || "-"}</span></div>
         <div>transitionState: <span className="text-dls-text">{props.model.transitionState}</span></div>
         <div>renderSource: <span className="text-dls-text">{props.model.renderSource}</span></div>
-        <div>status: <span className="text-dls-text">{props.snapshot?.status.type ?? "-"}</span></div>
+        <div>status: <span className="text-dls-text">{props.snapshot?.status?.type ?? "-"}</span></div>
         <div>messages: <span className="text-dls-text">{props.snapshot?.messages.length ?? 0}</span></div>
-        <div>todos: <span className="text-dls-text">{props.snapshot?.todos.length ?? 0}</span></div>
+        <div>todos: <span className="text-dls-text">{props.snapshot?.todos?.length ?? 0}</span></div>
       </div>
     </div>
   );

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { CancelledError, queryOptions, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { LoaderCircle } from "lucide-react";
-import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
+import type { OpenworkSessionHistory } from "@/app/lib/openwork-server";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types";
 import { snapshotKey } from "../sync/session-sync";
 import { composerAutoSendScopeKey } from "./composer-auto-send";
@@ -42,7 +42,7 @@ type OpeningHistoryInput = {
   sessionId: string;
   authToken?: string | null;
   snapshotQueryKey: readonly unknown[];
-  readSnapshot: (signal: AbortSignal, window?: OpeningHistoryWindow) => Promise<OpenworkSessionSnapshot>;
+  readSnapshot: (signal: AbortSignal, window?: OpeningHistoryWindow) => Promise<OpenworkSessionHistory>;
 };
 
 // Opaque, bounded credential identities keep secrets out of query keys and
@@ -62,7 +62,7 @@ export function openingSessionHistoryOptions(input: OpeningHistoryInput, saved =
   }
   return queryOptions({
     queryKey: ["react-session-opening", input.owner, credential],
-    queryFn: async ({ signal }): Promise<{ snapshot: OpenworkSessionSnapshot | null }> => {
+    queryFn: async ({ signal }): Promise<{ snapshot: OpenworkSessionHistory | null }> => {
       try {
         const snapshot = await input.readSnapshot(signal, openingHistoryWindow(saved));
         signal.throwIfAborted();
@@ -85,7 +85,7 @@ export function openingSessionHistoryOptions(input: OpeningHistoryInput, saved =
 }
 
 export function prefetchOpeningSessionHistory(client: QueryClient, input: OpeningHistoryInput) {
-  if (client.getQueryData<OpenworkSessionSnapshot>(input.snapshotQueryKey)?.session.id === input.sessionId) return;
+  if (client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey)?.session.id === input.sessionId) return;
   // No queue and no neighboring reads: only one speculative opening at a time.
   if (client.isFetching({ queryKey: ["react-session-opening"] })) return;
   const options = openingSessionHistoryOptions(input);
@@ -118,7 +118,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput) {
   const saved = useMemo(() => {
     return getSessionScrollState(useSessionScrollStore.getState().sessions, input.sessionId, input.owner);
   }, [input.owner, input.sessionId, hasLegacyPosition]);
-  const hasFullSnapshot = client.getQueryData<OpenworkSessionSnapshot>(input.snapshotQueryKey)?.session.id === input.sessionId;
+  const hasFullSnapshot = client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey)?.session.id === input.sessionId;
   const options = openingSessionHistoryOptions(input, saved);
   const query = useQuery({ ...options, enabled: !hasFullSnapshot });
   const activeOwner = useRef<string | null>(input.owner);
@@ -149,7 +149,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput) {
     }
   }, [client, input.snapshotQueryKey, input.readSnapshot]);
   const runWithFullSnapshot = useCallback(async (
-    action: (snapshot: OpenworkSessionSnapshot) => void | Promise<unknown>,
+    action: (snapshot: OpenworkSessionHistory) => void | Promise<unknown>,
     options: { fresh?: boolean } = {},
   ) => {
     if (activeOwner.current !== input.owner) return;

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -1,6 +1,6 @@
 import type { UIMessage } from "ai";
 
-import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
+import type { OpenworkSessionHistory } from "../../../../app/lib/openwork-server";
 import { mergeSnapshotAndLiveMessages } from "../sync/message-merge";
 import { applyRevertCursor } from "../sync/transcript-reconcile";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
@@ -9,8 +9,8 @@ import { parseSlashCommandInvocation } from "./composer/slash-command";
 
 export function resolveRenderedSessionSnapshot(input: {
   sessionId: string;
-  currentSnapshot: OpenworkSessionSnapshot | null | undefined;
-  cachedRendered: { sessionId: string; snapshot: OpenworkSessionSnapshot } | null | undefined;
+  currentSnapshot: OpenworkSessionHistory | null | undefined;
+  cachedRendered: { sessionId: string; snapshot: OpenworkSessionHistory } | null | undefined;
 }) {
   if (input.currentSnapshot?.session.id === input.sessionId) {
     return input.currentSnapshot;
@@ -26,7 +26,7 @@ export function resolveRenderedSessionSnapshot(input: {
 
 export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
-  snapshot: OpenworkSessionSnapshot | null | undefined;
+  snapshot: OpenworkSessionHistory | null | undefined;
   historyComplete?: boolean;
 }) {
   const revertMessageId = input.snapshot?.session.revert?.messageID ?? null;

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -24,7 +24,7 @@ import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { useSessionDraftState } from "@/react-app/domains/session/sync/draft-store";
 import type {
   OpenworkServerClient,
-  OpenworkSessionSnapshot,
+  OpenworkSessionHistory,
 } from "@/app/lib/openwork-server";
 import { isLoopbackOpenworkServerUrl } from "@/app/lib/openwork-server";
 import type {
@@ -107,6 +107,7 @@ import {
   markSessionSnapshotFetchStart,
   reconcileFailureDegradedThreshold,
   seedSessionState,
+  seedSessionStatus,
   statusKey as reactStatusKey,
   transcriptKey as reactTranscriptKey,
   useWorkspaceSyncStreamStore,
@@ -707,10 +708,10 @@ function resolveFindOwnerSessionId() {
   return firstMountedSessionSurfaceId();
 }
 
-function statusLabel(snapshot: OpenworkSessionSnapshot | undefined, busy: boolean) {
+function statusLabel(status: SessionStatus, busy: boolean) {
   if (busy) return "Running...";
-  if (snapshot?.status.type === "busy") return "Running...";
-  if (snapshot?.status.type === "retry") return `Retrying: ${snapshot.status.message}`;
+  if (status.type === "busy") return "Running...";
+  if (status.type === "retry") return `Retrying: ${status.message}`;
   return "Ready";
 }
 
@@ -997,7 +998,7 @@ function composerSessionHasContent(state: ComposerSessionState | undefined) {
   ));
 }
 
-function hiddenMessageCount(snapshot: OpenworkSessionSnapshot, revertMessageId: string): number {
+function hiddenMessageCount(snapshot: OpenworkSessionHistory, revertMessageId: string): number {
   const index = snapshot.messages.findIndex((message) => message.info.id === revertMessageId);
   return index < 0 ? snapshot.messages.length : snapshot.messages.length - index;
 }
@@ -1177,7 +1178,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Terminal invariant: an accepted admission that reached idle with no
   // assistant result surfaces a bounded recovery card instead of plain idle.
   const [admissionOutcomeUnresolved, setAdmissionOutcomeUnresolved] = useState(false);
-  const [rendered, setRendered] = useState<{ owner: string; sessionId: string; snapshot: OpenworkSessionSnapshot } | null>(null);
+  const [rendered, setRendered] = useState<{ owner: string; sessionId: string; snapshot: OpenworkSessionHistory } | null>(null);
   const [toolSkills, setToolSkills] = useState<SkillCard[]>([]);
   const [toolMcpServers, setToolMcpServers] = useState<McpServerEntry[]>([]);
   const [toolMcpStatus, setToolMcpStatus] = useState<string | null>(null);
@@ -1246,12 +1247,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
       // The preview is bounded; the second read MUST remain uncapped. A preview
       // is never written to the authoritative snapshot cache as complete history.
       const item = useDesktopLoopbackSnapshotRetry
-        ? await opencodeSessionNative.composeNativeSessionSnapshotWithRetry(
+        ? await opencodeSessionNative.composeNativeSessionHistoryWithRetry(
           sessionOwner,
           () => snapshotTargetRef.current,
           { ...window, signal },
         )
-        : await opencodeSessionNative.composeNativeSessionSnapshot(
+        : await opencodeSessionNative.composeNativeSessionHistory(
           { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
           props.sessionId,
           { ...window, signal },
@@ -1260,7 +1261,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return item;
   }, [props.opencodeBaseUrl, props.openworkToken, props.sessionId, sessionOwner, useDesktopLoopbackSnapshotRetry]);
   const openingHistory = useOpeningSessionHistory({ owner: sessionOwner, sessionId: props.sessionId, authToken: props.openworkToken, snapshotQueryKey, readSnapshot });
-  const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
+  const snapshotQuery = useQuery<OpenworkSessionHistory>({
     queryKey: snapshotQueryKey,
     queryFn: ({ signal }) => readSnapshot(signal),
     enabled: openingHistory.backgroundReady,
@@ -2409,6 +2410,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useEffect(() => {
     const probeAt = nextObservationProbeAt(queuedDrainState, lastObservationProbeAtRef.current);
     if (probeAt === null) return;
+    const controller = new AbortController();
     const timer = window.setTimeout(() => {
       const startedAt = Date.now();
       lastObservationProbeAtRef.current = startedAt;
@@ -2419,9 +2421,19 @@ export function SessionSurface(props: SessionSurfaceProps) {
             await checkUnknownAdmission();
             return;
           }
-          const result = await snapshotQuery.refetch();
-          const probed = result.data?.session.id === props.sessionId ? result.data.status : null;
-          if (!probed) return;
+          // Admission still needs a fresh observed status. History deliberately
+          // carries no activity fields; never infer completion from their absence.
+          const [result, statusResult] = await Promise.all([
+            snapshotQuery.refetch(),
+            opencodeClient.session.status(undefined, { signal: controller.signal }),
+          ]);
+          if (controller.signal.aborted || snapshotTargetRef.current.owner !== sessionOwner
+            || result.isError || result.data?.session.id !== props.sessionId) return;
+          const statuses = unwrap(statusResult);
+          const record = useSessionActivityStore.getState().recordsByWorkspaceId[props.workspaceId]?.[props.sessionId];
+          if (record && record.runStatusAt >= startedAt) return;
+          const probed = statuses[props.sessionId] ?? IDLE_STATUS;
+          seedSessionStatus(props.workspaceId, props.sessionId, probed, { snapshotStartedAt: startedAt });
           if (probed.type === "idle") {
             const phase = getQueuedDrainState(props.sessionId).phase;
             if (result.data) sessionHasPendingSubmission(props.opencodeBaseUrl, props.sessionId, result.data.messages);
@@ -2436,12 +2448,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
           // Probe failed (for example the local server was briefly
           // unreachable); the version bump below re-arms a spaced retry.
         } finally {
-          setObservationProbeVersion((version) => version + 1);
+          if (!controller.signal.aborted) setObservationProbeVersion((version) => version + 1);
         }
       })();
     }, Math.max(0, probeAt - Date.now()));
-    return () => window.clearTimeout(timer);
-  }, [checkUnknownAdmission, observationProbeVersion, props.opencodeBaseUrl, props.sessionId, queuedDrainState, snapshotQuery.refetch]);
+    return () => { window.clearTimeout(timer); controller.abort(); };
+  }, [checkUnknownAdmission, observationProbeVersion, opencodeClient, props.opencodeBaseUrl, props.sessionId, props.workspaceId, queuedDrainState, sessionOwner, snapshotQuery.refetch]);
 
   useEffect(() => {
     if (drainingQueueRef.current || sendingQueued) return;
@@ -3412,7 +3424,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         modelUnavailable={sessionModelUnavailable}
         modelUnavailableMessage={sessionModelUnavailable ? props.modelUnavailableMessage : null}
         organizationModelsEmpty={props.organizationModelsEmpty}
-        statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
+        statusLabel={statusLabel(liveStatus, chatStreaming)}
         modelPickerOpen={modelPickerOpen}
         selectedModel={sessionModel.selectedModel}
         openWorkModelsEntitled={props.openWorkModelsEntitled}
@@ -3500,7 +3512,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         </>}
       </div>
       {/* Error display moved inline into the session conversation area */}
-      {props.developerMode ? <SessionDebugPanel model={model} snapshot={snapshot} /> : null}
+      {props.developerMode ? <SessionDebugPanel model={model} snapshot={snapshot ? { ...snapshot, status: liveStatus, todos: props.todos ?? [] } : null} /> : null}
     </div>
     </DevProfiler>
   );

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -28,7 +28,7 @@ import {
   parseStructuredOutputUIPart,
   STRUCTURED_OUTPUT_TOOL,
 } from "./parse-tool-parts";
-import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
+import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
 import { applyRevertCursor, reconcileTranscriptMessages } from "./transcript-reconcile";
 import { isOrphanedInteraction, isTerminalToolPart, terminalToolCallIds, terminalTranscriptToolCallIds } from "./orphaned-interactions";
 import {
@@ -118,8 +118,8 @@ type DeltaFlushScheduler = (
 
 const idleStatus: SessionStatus = { type: "idle" };
 const syncs = new Map<string, SyncEntry>();
-const sessionSnapshotFetchStarts = new WeakMap<OpenworkSessionSnapshot, number>();
-const todoSnapshotFirstSeen = new WeakMap<OpenworkSessionSnapshot, number>();
+const sessionSnapshotFetchStarts = new WeakMap<OpenworkSessionHistory, number>();
+const todoSnapshotFirstSeen = new WeakMap<OpenworkSessionHistory, number>();
 const workspaceSyncDisposeGraceMs = 2_000;
 const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
@@ -238,7 +238,7 @@ const defaultDeltaFlushScheduler: DeltaFlushScheduler = (lane, run) => {
 
 let deltaFlushScheduler = defaultDeltaFlushScheduler;
 
-export function markSessionSnapshotFetchStart(snapshot: OpenworkSessionSnapshot, startedAt: number) {
+export function markSessionSnapshotFetchStart(snapshot: OpenworkSessionHistory, startedAt: number) {
   sessionSnapshotFetchStarts.set(snapshot, startedAt);
 }
 
@@ -418,25 +418,6 @@ function getSessionCreatedInfo(event: OpencodeEvent): Session | null {
 
 function isLiveStatus(status: SessionStatus | null | undefined) {
   return status?.type === "busy" || status?.type === "retry";
-}
-
-function messageHasVisibleAssistantOutput(message: UIMessage) {
-  if (message.role !== "assistant") return false;
-  return message.parts.some((part) => {
-    if ("text" in part && typeof part.text === "string") return part.text.trim().length > 0;
-    return part.type === "dynamic-tool" || part.type === "file";
-  });
-}
-
-function assistantOutputAfterLatestUser(messages: UIMessage[]) {
-  let lastUserIndex = -1;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index]?.role === "user") {
-      lastUserIndex = index;
-      break;
-    }
-  }
-  return messages.slice(lastUserIndex + 1).some(messageHasVisibleAssistantOutput);
 }
 
 function sessionIdFromProperties(properties: unknown) {
@@ -1031,6 +1012,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       stopTrackingLiveSession(entry, sessionId);
       if (isTrackedSession(entry, sessionId)) {
         flushSessionDeltas(entry, workspaceId, sessionId);
+        void refreshSessionTodos(workspaceId, sessionId);
         // The activity store treats session.error as terminal (setError
         // lowers runActive), but the chat surface derives its thread status
         // from this react-query cache. An engine that errors without a
@@ -1522,6 +1504,7 @@ function applySessionRunStatus(
     const shouldRecordTerminal = wasLive || runStartedAt !== null;
     const shouldConvergeTerminal = shouldRecordTerminal || options.terminalEvent === true;
     if (shouldConvergeTerminal) void reconcileSessionPermissions(entry, sessionId);
+    if (tracked && shouldConvergeTerminal) void refreshSessionTodos(workspaceId, sessionId);
     if (tracked && shouldConvergeTerminal) {
       flushSessionDeltas(entry, workspaceId, sessionId);
       void getReactQueryClient().invalidateQueries({
@@ -1603,6 +1586,7 @@ async function reconcileSessionRunStatuses(
     const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId] ?? {};
     for (const sessionId of new Set([...Object.keys(records), ...entry.trackedSessionRefs.keys()])) {
       void reconcileSessionPermissions(entry, sessionId);
+      void refreshSessionTodos(input.workspaceId, sessionId);
     }
   }
   let statuses: Record<string, SessionStatus>;
@@ -1854,7 +1838,62 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   }, workspaceSyncDisposeGraceMs);
 }
 
-export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionSnapshot, options: { preview?: boolean } = {}) {
+export function seedSessionStatus(
+  workspaceId: string,
+  sessionId: string,
+  incomingStatus: SessionStatus,
+  options: { snapshotStartedAt: number },
+) {
+  const queryClient = getReactQueryClient();
+  const { snapshotStartedAt } = options;
+  const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+  // A read cannot supersede a live edge from the same clock tick either.
+  if (record && snapshotStartedAt <= record.runStatusAt) return;
+  const currentStatus = queryClient.getQueryData<SessionStatus>(statusKey(workspaceId, sessionId));
+  const terminal = [...syncs.values()].some((entry) => entry.input.workspaceId === workspaceId
+    && entry.nativeTerminalSessions.has(sessionId));
+  const status = incomingStatus.type === "busy" && currentStatus && (currentStatus.type === "retry" || terminal)
+    ? currentStatus : incomingStatus;
+  useSessionActivityStore.getState().seedSessionRun(
+    workspaceId,
+    sessionId,
+    status,
+    undefined,
+    { snapshotStartedAt },
+  );
+  queryClient.setQueryData(statusKey(workspaceId, sessionId), status);
+  if (isLiveStatus(status)) {
+    for (const entry of syncs.values()) {
+      if (entry.input.workspaceId === workspaceId) {
+        trackLiveSession(entry, sessionId, status, "snapshot");
+      }
+    }
+  }
+}
+
+export function seedSessionTodos(
+  workspaceId: string,
+  sessionId: string,
+  todos: Todo[],
+  options: { snapshotStartedAt: number },
+) {
+  const queryClient = getReactQueryClient();
+  const key = todoKey(workspaceId, sessionId);
+  const state = queryClient.getQueryState(key);
+  // Millisecond ties cannot establish that a snapshot is newer than live data.
+  if (state?.data === undefined || options.snapshotStartedAt > state.dataUpdatedAt) {
+    queryClient.setQueryData(key, todos, { updatedAt: options.snapshotStartedAt });
+  }
+}
+
+async function refreshSessionTodos(workspaceId: string, sessionId: string) {
+  const queryClient = getReactQueryClient();
+  const queryKey = [...todoKey(workspaceId, sessionId), "hydration"];
+  await queryClient.cancelQueries({ queryKey });
+  await queryClient.invalidateQueries({ queryKey });
+}
+
+export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionHistory, options: { preview?: boolean } = {}) {
   // A reverted window cannot establish which messages are still visible.
   if (options.preview && snapshot.session.revert?.messageID) return;
   const queryClient = getReactQueryClient();
@@ -1903,30 +1942,10 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   }
 
   const snapshotStartedAt = sessionSnapshotFetchStarts.get(snapshot);
-  if (typeof snapshotStartedAt === "number") {
-    const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[snapshot.session.id];
-    const currentStatus = queryClient.getQueryData<SessionStatus>(statusKey(workspaceId, snapshot.session.id));
-    const terminal = [...syncs.values()].some((entry) => entry.input.workspaceId === workspaceId
-      && entry.nativeTerminalSessions.has(snapshot.session.id));
-    const status = snapshot.status.type === "busy" && currentStatus && (currentStatus.type === "retry" || terminal)
-      ? currentStatus : snapshot.status;
-    useSessionActivityStore.getState().seedSessionRun(
-      workspaceId,
-      snapshot.session.id,
-      status,
-      assistantOutputAfterLatestUser(incoming),
-      { snapshotStartedAt },
-    );
-    if (snapshotStartedAt >= (record?.runStatusAt ?? 0)) {
-      queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), status);
-      if (isLiveStatus(status)) {
-        for (const entry of syncs.values()) {
-          if (entry.input.workspaceId === workspaceId) {
-            trackLiveSession(entry, snapshot.session.id, status, "snapshot");
-          }
-        }
-      }
-    }
+  if (snapshot.status !== undefined && typeof snapshotStartedAt === "number") {
+    seedSessionStatus(workspaceId, snapshot.session.id, snapshot.status, {
+      snapshotStartedAt,
+    });
   }
 
   // The snapshot's revert cursor is authoritative: messages at/after it are
@@ -1942,18 +1961,17 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   ));
   settleOrphanedInteractions(workspaceId, snapshot.session.id, terminalToolCallIds(snapshot.messages));
 
-  const todosKey = todoKey(workspaceId, snapshot.session.id);
-  // Remember first observation for unmarked snapshots too, so reselecting a
-  // cached object never makes it newer than a subsequent todo.updated event.
-  const todosStartedAt = snapshotStartedAt ?? todoSnapshotFirstSeen.get(snapshot) ?? Date.now();
-  todoSnapshotFirstSeen.set(snapshot, todosStartedAt);
-  const todosState = queryClient.getQueryState(todosKey);
-  // Millisecond ties cannot establish that a snapshot is newer than live data.
-  if (todosState?.data === undefined || todosStartedAt > todosState.dataUpdatedAt) {
-    queryClient.setQueryData(todosKey, snapshot.todos, { updatedAt: todosStartedAt });
+  if (snapshot.todos !== undefined) {
+    // Remember first observation for unmarked snapshots too, so reselecting a
+    // cached object never makes it newer than a subsequent todo.updated event.
+    const todosStartedAt = snapshotStartedAt ?? todoSnapshotFirstSeen.get(snapshot) ?? Date.now();
+    todoSnapshotFirstSeen.set(snapshot, todosStartedAt);
+    seedSessionTodos(workspaceId, snapshot.session.id, snapshot.todos, { snapshotStartedAt: todosStartedAt });
   }
-  useSessionActivityStore.getState().observeTranscript(workspaceId, snapshot.session.id,
-    queryClient.getQueryData<UIMessage[]>(key) ?? [], true);
+  const transcript = queryClient.getQueryData<UIMessage[]>(key) ?? [];
+  useSessionActivityStore.getState().observeTranscript(workspaceId, snapshot.session.id, transcript, true, {
+    snapshotStartedAt,
+  });
 }
 
 /**

--- a/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
+++ b/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
@@ -1,6 +1,7 @@
 // Pending interactions for a conversation and its descendants. Requests stay
 // owned by the session that asked; only their presentation bubbles to the parent.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { QueryObserver } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { unwrap } from "@/app/lib/opencode";
@@ -8,20 +9,86 @@ import { isOpencodeV2Client } from "@/app/lib/opencode-v2-adapter";
 import type { Client, PendingPermission, PendingQuestion, TodoItem } from "@/app/types";
 import { t } from "@/i18n";
 import { useQueryCacheArrayState, useQueryCacheState } from "@/react-app/infra/query-cache-state";
+import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { describeRouteError } from "@/react-app/shell/route-workspaces";
 import {
   permissionKey,
   questionKey,
   seedPermissionState,
   seedQuestionState,
+  seedSessionStatus,
+  seedSessionTodos,
   settleQuestionState,
   settlePermissionState,
+  statusKey,
   todoKey,
 } from "./session-sync";
 
 const emptyPendingPermissions: PendingPermission[] = [];
 const emptyPendingQuestions: PendingQuestion[] = [];
 const emptyTodos: TodoItem[] = [];
+const hydrationRetryDelaysMs = [100, 250, 500];
+const hydrationClients = new WeakMap<Client, number>();
+let nextHydrationClient = 0;
+
+function observeActivityRead(
+  client: Client,
+  key: readonly unknown[],
+  directory: string,
+  read: (signal: AbortSignal, startedAt: number) => Promise<void>,
+  recoverOnly = false,
+) {
+  let owner = hydrationClients.get(client);
+  if (owner === undefined) {
+    owner = ++nextHydrationClient;
+    hydrationClients.set(client, owner);
+  }
+  const observer = new QueryObserver(getReactQueryClient(), {
+    queryKey: [...key, "hydration", owner, directory],
+    queryFn: async ({ signal }) => {
+      for (let attempt = 0; ; attempt += 1) {
+        signal.throwIfAborted();
+        try {
+          await read(signal, Date.now());
+          return null;
+        } catch (error) {
+          signal.throwIfAborted();
+          const delay = hydrationRetryDelaysMs[attempt];
+          if (delay === undefined) throw error;
+          await new Promise<void>((resolve, reject) => {
+            const abort = () => { clearTimeout(timer); reject(signal.reason); };
+            const timer = setTimeout(() => {
+              signal.removeEventListener("abort", abort);
+              resolve();
+            }, delay);
+            signal.addEventListener("abort", abort, { once: true });
+          });
+        }
+      }
+    },
+    retry: false,
+    gcTime: 0,
+    networkMode: "always",
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+  const refresh = () => {
+    const result = observer.getCurrentResult();
+    if (result.isFetching || (recoverOnly && !result.isError)) return;
+    void observer.refetch({ cancelRefetch: false });
+  };
+  const onVisibilityChange = () => { if (document.visibilityState === "visible") refresh(); };
+  window.addEventListener("online", refresh);
+  window.addEventListener("focus", refresh);
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  return () => {
+    unsubscribe();
+    window.removeEventListener("online", refresh);
+    window.removeEventListener("focus", refresh);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  };
+}
 
 export type UseSessionInteractionsInput = {
   client: Client | null;
@@ -74,6 +141,24 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
     [sessionId, workspaceId],
   );
   const todos = useQueryCacheState<TodoItem[]>(todoQueryKey, emptyTodos);
+
+  useEffect(() => {
+    if (!client || !workspaceId || !sessionId) return;
+    return observeActivityRead(client, statusKey(workspaceId, sessionId), workspaceRoot, async (signal, snapshotStartedAt) => {
+      const statuses = unwrap(await client.session.status({ directory: workspaceRoot || undefined }, { signal }));
+      signal.throwIfAborted();
+      seedSessionStatus(workspaceId, sessionId, statuses[sessionId] ?? { type: "idle" }, { snapshotStartedAt });
+    }, true);
+  }, [client, workspaceId, sessionId, workspaceRoot]);
+
+  useEffect(() => {
+    if (!client || !workspaceId || !sessionId) return;
+    return observeActivityRead(client, todoKey(workspaceId, sessionId), workspaceRoot, async (signal, snapshotStartedAt) => {
+      const todos = unwrap(await client.session.todo({ sessionID: sessionId, directory: workspaceRoot || undefined }, { signal }));
+      signal.throwIfAborted();
+      seedSessionTodos(workspaceId, sessionId, todos, { snapshotStartedAt });
+    });
+  }, [client, workspaceId, sessionId, workspaceRoot]);
 
   useEffect(() => {
     if (!client || !workspaceId || interactionSessionIds.length === 0) return;

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -162,7 +162,7 @@ const snapshotMessageCache = new WeakMap<SnapshotMessages[number], UIMessage[]>(
 // Query snapshots are immutable. Share the projection between rendering and
 // hydration; a refreshed tail can also reuse unchanged historical messages.
 // Callers must copy before applying live updates to these cached messages.
-export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessage[] {
+export function snapshotToUIMessages(snapshot: Pick<OpenworkSessionSnapshot, "messages">): UIMessage[] {
   const cached = snapshotMessagesCache.get(snapshot.messages);
   if (cached) return cached;
   const messages = snapshot.messages.flatMap((message) => {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -19,7 +19,7 @@ import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
 import { createClient, isPromptAdmissionUnknown, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl, v2PromptText, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe, forkSession, listCommands, revertSession, shellInSession, unrevertSession } from "@/app/lib/opencode-session";
-import { composeNativeSessionSnapshot, getNativeSessionMessages } from "@/app/lib/opencode-session-native";
+import { composeNativeSessionHistory, getNativeSessionMessages } from "@/app/lib/opencode-session-native";
 import { prefetchOpeningSessionHistory, sessionHistoryIdentity } from "@/react-app/domains/session/surface/session-history";
 import { sendSessionCommand, sessionWorkHeld } from "@/app/lib/opencode-interruption";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -563,7 +563,7 @@ export function SessionRoute() {
       ...sessionHistoryIdentity({ draftScope: sessionDraftScope, opencodeBaseUrl: endpoint.opencodeBaseUrl, runtimeWorkspaceId: prefetchRuntimeWorkspaceId, sessionId }),
       sessionId,
       authToken: endpoint.token,
-      readSnapshot: (signal, window) => composeNativeSessionSnapshot(endpoint, sessionId, { ...window, signal }),
+      readSnapshot: (signal, window) => composeNativeSessionHistory(endpoint, sessionId, { ...window, signal }),
     });
     if (cancel) cancelOpeningPrefetchRef.current = cancel;
     return cancel;

--- a/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
+++ b/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
@@ -112,7 +112,7 @@ test("the composer stays editable when snapshot refresh fails or the model is un
   mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
   mock.module("@/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
   mock.module("@/app/lib/opencode-session-native", () => ({
-    composeNativeSessionSnapshot: async () => {
+    composeNativeSessionHistory: async () => {
       if (rejectSnapshot) throw new Error("snapshot refresh failed");
       return fetchedSnapshot;
     },

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -130,9 +130,14 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   const nativePromptTexts: string[] = [];
   const nativeMessages: { id: string; role: "user"; text: string }[] = [];
   const forkRequests: Request[] = [];
+  const admissionStatusRequests: Request[] = [];
   const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = new Request(input, init);
     const path = new URL(request.url).pathname;
+    if (request.method === "GET" && path.endsWith("/session/status")) {
+      admissionStatusRequests.push(request);
+      return Response.json({});
+    }
     if (request.method === "POST" && path.endsWith("/fork")) {
       forkRequests.push(request);
       await forkCompletion;
@@ -159,6 +164,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   window.localStorage.setItem("openwork.shell-config", JSON.stringify({ starterCards: false }));
   let fetchedSnapshot = createSnapshot({ type: "busy" }, 1);
   let snapshotRead: Promise<OpenworkSessionSnapshot> | null = null;
+  let historyOnly = false;
   const otherSessionId = `${sessionId}-other`;
   const otherSnapshot = createSnapshot({ type: "busy" }, 1, otherSessionId);
   const interruptionModule = await import("../src/app/lib/opencode-interruption");
@@ -173,7 +179,10 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
   const nativeSessionModule = await import("../src/app/lib/opencode-session-native");
   mock.module("@/app/lib/opencode-session-native", () => ({
     ...nativeSessionModule,
-    composeNativeSessionSnapshot: async (_target: unknown, id: string) => id === otherSessionId ? otherSnapshot : snapshotRead ?? fetchedSnapshot,
+    composeNativeSessionHistory: async (_target: unknown, id: string) => {
+      const value = await (id === otherSessionId ? otherSnapshot : snapshotRead ?? fetchedSnapshot);
+      return historyOnly ? { session: value.session, messages: value.messages } : value;
+    },
   }));
   const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
   const { snapshotKey, statusKey, transcriptKey } = await import("../src/react-app/domains/session/sync/session-sync");
@@ -1238,6 +1247,41 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Send now"]')?.click());
     expect(sentDrafts).toHaveLength(sendsBeforeQueue + 5);
     expect(getQueuedDrainState(sessionId).phase.kind).toBe("admission_unknown");
+
+    // A send without queued drafts must still recover a missed busy edge from
+    // fresh status plus a correlated terminal reply, not history.status.
+    await act(async () => {
+      resetQueuedDrainForTests();
+      useComposerStateStore.setState({ queuedDrafts: {}, pendingMessages: {}, failedDrafts: {} });
+      historyOnly = true;
+      fetchedSnapshot = createSnapshot({ type: "idle" }, 32);
+      fetchedSnapshot.messages.push({
+        info: {
+          id: "terminal-command-reply", sessionID: sessionId, role: "assistant", parentID: "existing-user-message",
+          time: { created: 32, completed: 33 }, finish: "stop", modelID: "test-model", providerID: "test",
+          mode: "build", agent: "build", path: { cwd: "/tmp/project-focus-continuity", root: "/tmp/project-focus-continuity" },
+          cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        parts: [],
+      });
+      queryClient.setQueryData(snapshotKey(workspaceId, sessionId), { session: fetchedSnapshot.session, messages: fetchedSnapshot.messages });
+      queryClient.setQueryData(statusKey(workspaceId, sessionId), { type: "idle" });
+      renderSurface();
+    });
+    const statusReadsBeforeProbe = admissionStatusRequests.length;
+    const sendsBeforeProbe = sentDrafts.length;
+    await act(async () => {
+      dispatchQueuedDrain(sessionId, { type: "send_started", itemId: "deferred-command-probe" });
+      dispatchQueuedDrain(sessionId, {
+        type: "send_result", itemId: "deferred-command-probe", outcome: "accepted", at: Date.now() - 20_000,
+        deferredMessageID: "existing-user-message",
+      });
+    });
+    await waitFor(() => getQueuedDrainState(sessionId).phase.kind === "ready", "a terminal command to settle from independent status and history");
+    expect(admissionStatusRequests.length).toBeGreaterThan(statusReadsBeforeProbe);
+    expect(queryClient.getQueryData<OpenworkSessionSnapshot>(snapshotKey(workspaceId, sessionId))?.status).toBeUndefined();
+    expect(sentDrafts).toHaveLength(sendsBeforeProbe);
+    expect(getQueuedDrainState(sessionId).lastResolution).toEqual({ itemId: "deferred-command-probe", resolution: "completed" });
 
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
     let creation = Promise.withResolvers<void>();

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -6,6 +6,8 @@ import { createClient, createPromptMessageID, hasAcceptedPromptMessage, PromptAd
 import { holdSessionWork, interruptSessionTurn, sendSessionCommand, sessionHasPendingSubmission, sessionNeedsStop, sessionWorkHeld, submitAfterInterruption, submitImmediateSessionTurn } from "../src/app/lib/opencode-interruption";
 import { createClientV2 } from "../src/app/lib/opencode-v2-adapter";
 import {
+  composeNativeSessionHistory,
+  composeNativeSessionHistoryWithRetry,
   composeNativeSessionSnapshot,
   composeNativeSessionSnapshotWithRetry,
   deleteNativeSession,
@@ -102,6 +104,71 @@ function turnMessages(sessionID: string, parts: ReturnType<typeof delegatedTool>
 }
 
 describe("native OpenCode session operations", () => {
+  test.each([undefined, { limit: 24 }, { messageIds: ["msg_1"] }])("history reads verify metadata/messages without reading activity (%j)", async (window) => {
+    const metadata = Promise.withResolvers<FieldsResult<Session>>();
+    const calls: string[] = [];
+    const controller = new AbortController();
+    let settled = false;
+    const history = composeNativeSessionHistory(endpoint, session.id, { ...window, signal: controller.signal }, {
+      createOperations: () => operations({
+        get: async (_id, options) => { expect(options?.signal).toBe(controller.signal); calls.push("get"); return metadata.promise; },
+        messages: async (_id, limit, options) => {
+          expect(limit).toBe(window && "limit" in window ? window.limit : undefined);
+          expect(options?.signal).toBe(controller.signal);
+          calls.push("messages"); return result(messages);
+        },
+        message: async (_id, _messageId, options) => {
+          expect(options?.signal).toBe(controller.signal);
+          calls.push("message"); return result(messages[0]!);
+        },
+        todo: async () => { calls.push("todo"); throw new Error("Todos unavailable"); },
+        status: async () => { calls.push("status"); throw new Error("Status unavailable"); },
+      }),
+    }).then((value) => { settled = true; return value; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    metadata.resolve(result(session));
+    expect(await history).toEqual({ session, messages });
+    expect(calls).toEqual(["get", window && "messageIds" in window ? "message" : "messages"]);
+  });
+
+  test("history-only reads reject mismatched metadata, messages, and parts", async () => {
+    const record = messages[0]!;
+    for (const overrides of [
+      { get: async () => result({ ...session, id: "ses_other" }) },
+      { messages: async () => result([{ ...record, info: { ...record.info, sessionID: "ses_other" } }]) },
+      { messages: async () => result([{ ...record, parts: record.parts.map((part) => ({ ...part, sessionID: "ses_other" })) }]) },
+      { messages: async () => result([{ ...record, parts: record.parts.map((part) => ({ ...part, messageID: "msg_other" })) }]) },
+    ]) {
+      await expect(composeNativeSessionHistory(endpoint, session.id, { limit: 24 }, {
+        createOperations: () => operations(overrides),
+      })).rejects.toThrow("verify the session history owner");
+    }
+  });
+
+  test.each(["abort", "owner"])("history retry cannot publish after its %s changes", async (change) => {
+    const pending = Promise.withResolvers<FieldsResult<Session>>();
+    const controller = new AbortController();
+    const aborted = new Error("history cancelled");
+    let owner = "owner-a";
+    let attempts = 0;
+    const history = composeNativeSessionHistoryWithRetry(owner, () => ({ owner, endpoint, sessionId: session.id }), {
+      limit: 24, signal: controller.signal,
+    }, {
+      createOperations: () => {
+        attempts += 1;
+        return operations({ get: async () => pending.promise });
+      },
+      waitForSnapshotRetry: async () => { throw new Error("Unexpected retry"); },
+    });
+    if (change === "abort") controller.abort(aborted);
+    else owner = "owner-b";
+    pending.resolve(result(session));
+    if (change === "abort") await expect(history).rejects.toBe(aborted);
+    else await expect(history).rejects.toThrow("Session snapshot owner changed");
+    expect(attempts).toBe(1);
+  });
+
   test("acceptance requires an exact native user-message GET, never absence or another message", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Request[] = [];
@@ -260,8 +327,10 @@ describe("native OpenCode session operations", () => {
       if (url.pathname.endsWith("/active")) return Response.json({ data: {} });
       throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
     }, async () => {
-      const preview = await composeNativeSessionSnapshot(target, session.id, { limit: 24 });
-      const full = await composeNativeSessionSnapshot(target, session.id);
+      const preview = await composeNativeSessionHistory(target, session.id, { limit: 24 });
+      const full = await composeNativeSessionHistory(target, session.id);
+      expect(preview.status).toBeUndefined();
+      expect(full.todos).toBeUndefined();
       const newestIds = history.slice(-24).map(({ info }) => info.id);
       const allIds = history.map(({ info }) => info.id);
       expect(preview.messages.map(({ info }) => info.id)).toEqual(engine === "opencode2" ? newestIds.toReversed() : newestIds);
@@ -293,7 +362,7 @@ describe("native OpenCode session operations", () => {
       if (path.endsWith("/active")) return Response.json({ data: {} });
       throw new Error(`Unexpected request: ${request.method} ${path}`);
     }, async (requests) => {
-      const snapshot = await composeNativeSessionSnapshot(target, session.id, { messageIds: ids, limit: 24, signal: controller.signal });
+      const snapshot = await composeNativeSessionHistory(target, session.id, { messageIds: ids, limit: 24, signal: controller.signal });
       expect(snapshot.messages.map(({ info }) => info.id)).toEqual(["msg_z", "msg_m"]);
       expect(snapshot.messages.every(({ info, parts }) => info.sessionID === session.id && parts.length === 1
         && parts.every((part) => part.sessionID === session.id && part.messageID === info.id))).toBe(true);
@@ -303,6 +372,7 @@ describe("native OpenCode session operations", () => {
       expect(requests.some((request) => new URL(request.url).pathname.endsWith("/message"))).toBe(false);
       for (const request of requests) {
         expect(request.method).toBe("GET");
+        expect(/\/(todo|status|active)$/.test(new URL(request.url).pathname)).toBe(false);
         expect(request.headers.get("Authorization")).toBe(`Bearer ${endpoint.token}`);
       }
     });

--- a/apps/app/tests/progressive-message-list.test.tsx
+++ b/apps/app/tests/progressive-message-list.test.tsx
@@ -66,6 +66,13 @@ function groups(count = 80): Group[] {
   return Array.from({ length: count }, (_, index) => ({ id: `g${index}`, messages: [{ id: `m${index}`, height: 240 }] }))
 }
 
+function trackHeightReads(data: readonly Group[]) {
+  const keys = new Set(data.map((group) => group.id))
+  const reads = spyOn(Map.prototype, "get")
+  // Height maps use raw group IDs; node tracking uses group:/placeholder: keys.
+  return () => reads.mock.calls.filter(([key]) => keys.has(key)).length
+}
+
 function fixture(initial = groups(), options: Partial<MessageListViewport> = {}, strict = false, fixedGeometry = false) {
   const container = document.createElement("div")
   document.body.append(container)
@@ -164,6 +171,123 @@ function fixture(initial = groups(), options: Partial<MessageListViewport> = {},
 }
 
 describe("progressive whole-group rendering", () => {
+  test.each([false, true])("reuses height planning across batches and fully mounted content updates (history complete: %s)", async (historyComplete) => {
+    const data = groups()
+    const view = fixture(data, { anchorMessageId: "m40", historyComplete, scrollHeight: 40_000 })
+    const heightReads = trackHeightReads(data)
+    await view.render()
+    const initialReads = heightReads()
+    expect(initialReads).toBeGreaterThan(0)
+    const tail = view.message("m79")
+    const anchor = view.message("m40")
+    const prefix = view.placeholders.find((node) => node.dataset.threadPlaceholder === "history-prefix")?.style.height
+    view.read("m40", -80)
+    // Measurements keep changing the shared cache, not the frozen height plan.
+    await act(async () => view.resize())
+    for (let index = 8; index < data.length; index += 8) {
+      await batch()
+      expect(heightReads()).toBe(initialReads)
+      expect(view.mounted).toHaveLength(Math.min(index + 8, data.length))
+      expect(view.position("m40")).toBeCloseTo(-80, 1)
+      expect(view.message("m40")).toBe(anchor)
+      expect(view.message("m79")).toBe(tail)
+    }
+    expect(view.complete).toBe(String(historyComplete))
+    expect(frames.size).toBe(0)
+    expect(view.placeholders.find((node) => node.dataset.threadPlaceholder === "history-prefix")?.style.height).toBe(prefix)
+    const next = data.map((group) => ({ ...group }))
+    next[79] = { ...next[79], messages: [...next[79].messages, { id: "live", height: 60 }] }
+    view.writes.length = 0
+    await view.render(next)
+    expect(heightReads()).toBe(initialReads)
+    expect(view.writes).toEqual([])
+    expect(view.message("m79")).toBe(tail)
+    expect(view.message("live")).toBeDefined()
+  })
+
+  test("rebuilds heights for added, reordered and removed keys without thawing existing estimates", async () => {
+    const data = groups(20)
+    for (const group of data) group.messages[0].height = 100
+    const prefix: Group = { id: "prefix", messages: [{ id: "prefix", height: 500 }] }
+    const view = fixture(data, { scrollHeight: 20 * 240 + 19 * 8 })
+    const heightReads = trackHeightReads([...data, prefix])
+    await view.render()
+    let previousReads = heightReads()
+    const tail = view.message("m19")
+    view.read("m16", -50)
+    await view.render([prefix, ...data], { scrollHeight: 20 * 240 + 500 + 20 * 8 })
+    expect(heightReads()).toBeGreaterThan(previousReads)
+    expect(view.placeholders[0].style.height).toBe(`${500 + 12 * 240 + 12 * 8}px`)
+    expect(view.position("m16")).toBeCloseTo(-50, 1)
+    previousReads = heightReads()
+    await view.render([data[19], ...data.slice(0, 12), prefix, ...data.slice(12, 19)])
+    expect(heightReads()).toBeGreaterThan(previousReads)
+    expect(view.placeholders[0].dataset.threadPlaceholder).toBe("placeholder:g0")
+    expect(view.placeholders[0].style.height).toBe(`${12 * 240 + 500 + 12 * 8}px`)
+    expect(view.message("m19")).toBe(tail)
+    previousReads = heightReads()
+    await view.render(data)
+    expect(heightReads()).toBeGreaterThan(previousReads)
+    expect(view.placeholders[0].style.height).toBe(`${12 * 240 + 11 * 8}px`)
+    expect(view.message("m19")).toBe(tail)
+    previousReads = heightReads()
+    await batch()
+    expect(heightReads()).toBe(previousReads)
+  })
+
+  test("invalidates width and history scopes while preserving measured geometry and the reading anchor", async () => {
+    const data = groups(20)
+    for (const group of data) group.messages[0].height = 100
+    const sessionKey = `planning-${++sessionId}`
+    const first = fixture(data, { sessionKey, revealAll: true })
+    await first.render()
+    await first.unmount()
+    const view = fixture(data, { sessionKey })
+    const heightReads = trackHeightReads(data)
+    await view.render()
+    expect(view.placeholders[0].style.height).toBe(`${12 * 100 + 11 * 8}px`)
+    view.read("m16", -50)
+    let previousReads = heightReads()
+    await act(async () => view.resize(900))
+    expect(heightReads()).toBeGreaterThan(previousReads)
+    expect(view.placeholders[0].style.height).toBe(`${12 * 240 + 11 * 8}px`)
+    expect(view.position("m16")).toBeCloseTo(-50, 1)
+    await act(async () => view.resize())
+    previousReads = heightReads()
+    await view.render(data, { historyComplete: false, scrollHeight: 8_000 })
+    expect(heightReads()).toBeGreaterThan(previousReads)
+    expect(view.placeholders.map((node) => node.style.height)).toEqual(["4160px", "2968px"])
+    expect(view.position("m16")).toBeCloseTo(-50, 1)
+    previousReads = heightReads()
+    await view.render(data, { historyComplete: true })
+    expect(heightReads()).toBeGreaterThan(previousReads)
+    expect(view.placeholders).toHaveLength(1)
+    expect(Number.parseFloat(view.placeholders[0].style.height)).toBeCloseTo(7_136, 1)
+    expect(view.position("m16")).toBeCloseTo(-50, 1)
+    previousReads = heightReads()
+    await batch()
+    expect(heightReads()).toBe(previousReads)
+  })
+
+  test("updates saved extent and explicit reserved regions without redistributing frozen group heights", async () => {
+    const data = groups(20)
+    const view = fixture(data, { historyComplete: false, scrollHeight: 8_000 })
+    const heightReads = trackHeightReads(data)
+    await view.render()
+    const previousReads = heightReads()
+    const skipped = view.placeholders[1].style.height
+    view.read("m16", -50)
+    await view.render(data, { scrollHeight: 9_000 })
+    expect(heightReads()).toBeGreaterThan(previousReads)
+    expect(view.placeholders.map((node) => node.style.height)).toEqual(["4040px", skipped])
+    expect(view.position("m16")).toBeCloseTo(-50, 1)
+    const geometryReads = heightReads()
+    await view.render(data, { leadingHeight: 1_000, trailingHeight: 500 })
+    expect(heightReads()).toBe(geometryReads)
+    expect(view.placeholders.map((node) => node.style.height)).toEqual(["1000px", skipped, "500px"])
+    expect(view.position("m16")).toBeCloseTo(-50, 1)
+  })
+
   for (const count of [80, 800, 1600]) {
     test(`invokes renderGroup only ${count} times while backfilling ${count} groups`, async () => {
       const data = groups(count)

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -5,7 +5,7 @@ import { act, StrictMode, useEffect } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
-import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { openingHistoryWindow, openingSessionHistoryOptions, prefetchOpeningSessionHistory, sessionHistoryIdentity, SessionHistoryBoundary, SessionHistoryStatus, useOpeningSessionHistory, useSessionPrefetchIntent, type OpeningHistoryWindow } from "../src/react-app/domains/session/surface/session-history";
 import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
 import { flushSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
@@ -72,16 +72,16 @@ function fixture() {
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
-  let ensureFullSnapshot: (() => Promise<OpenworkSessionSnapshot>) | undefined;
+  let ensureFullSnapshot: (() => Promise<OpenworkSessionHistory>) | undefined;
   let runWithFullSnapshot: ReturnType<typeof useOpeningSessionHistory>["runWithFullSnapshot"] | undefined;
-  const reads: { owner: string; authToken?: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionSnapshot) => void; reject: (error: Error) => void }[] = [];
+  const reads: { owner: string; authToken?: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionHistory) => void; reject: (error: Error) => void }[] = [];
   function input(owner = "a", authToken?: string, cacheOwner = owner) {
-    const readSnapshot = (signal: AbortSignal, window?: OpeningHistoryWindow) => new Promise<OpenworkSessionSnapshot>((resolve, reject) => {
+    const readSnapshot = (signal: AbortSignal, window?: OpeningHistoryWindow) => new Promise<OpenworkSessionHistory>((resolve, reject) => {
       reads.push({ owner, authToken, window, signal, resolve, reject });
     });
     return { owner: cacheOwner, sessionId: owner, authToken, snapshotQueryKey: snapshotKey("workspace", owner), readSnapshot };
   }
-  function Harness({ options, onMount }: { options: ReturnType<typeof input>; onMount?: (ensure: () => Promise<OpenworkSessionSnapshot>) => void }) {
+  function Harness({ options, onMount }: { options: ReturnType<typeof input>; onMount?: (ensure: () => Promise<OpenworkSessionHistory>) => void }) {
     const { sessionId: owner, owner: cacheOwner } = options;
     const key = options.snapshotQueryKey;
     const workspaceId = key[1];
@@ -102,7 +102,7 @@ function fixture() {
       <div>{current?.session.title}</div>{messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.id}</div>)}
     </SessionHistoryBoundary></div><SessionHistoryStatus key={cacheOwner} complete={Boolean(full.data)} pending={pending} loading={full.isFetching && opening.partial} failed={failed} onRetry={() => full.refetch()} /></div></>;
   }
-  async function renderInput(options: ReturnType<typeof input>, mount: { strict?: boolean; onMount?: (ensure: () => Promise<OpenworkSessionSnapshot>) => void } = {}) {
+  async function renderInput(options: ReturnType<typeof input>, mount: { strict?: boolean; onMount?: (ensure: () => Promise<OpenworkSessionHistory>) => void } = {}) {
     const tree = <QueryClientProvider client={client}><Harness options={options} onMount={mount.onMount} /></QueryClientProvider>;
     await act(async () => flushSync(() => root.render(mount.strict ? <StrictMode>{tree}</StrictMode> : tree)));
   }
@@ -118,7 +118,7 @@ function fixture() {
       return ensureFullSnapshot();
     },
     render(owner = "a", authToken?: string, cacheOwner = owner) { return renderInput(input(owner, authToken, cacheOwner)); },
-    async resolve(index: number, title: string | OpenworkSessionSnapshot) {
+    async resolve(index: number, title: string | OpenworkSessionHistory) {
       await act(async () => reads[index].resolve(typeof title === "string" ? snapshot(reads[index].owner, title) : title));
       await settle();
     },
@@ -126,6 +126,26 @@ function fixture() {
 }
 
 describe("opening a thread", () => {
+  test("preview and full history become readable without an activity snapshot", async () => {
+    const view = fixture();
+    await view.render();
+    const preview = snapshot("a", "Readable preview", ["msg_latest"]);
+    await view.resolve(0, { session: preview.session, messages: preview.messages });
+    expect(view.host.textContent).toContain("msg_latest");
+    expect(view.host.querySelector("[data-thread-loading]")).toBeNull();
+    expect(view.client.getQueryData(snapshotKey("workspace", "a"))).toBeUndefined();
+    await paint();
+    await paint();
+    const full = snapshot("a", "Readable full history", ["msg_old", "msg_latest"]);
+    await view.resolve(1, { session: full.session, messages: full.messages });
+    expect(view.host.textContent).toContain("msg_old");
+    expect(view.host.textContent).toContain("msg_latest");
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    const cached = view.client.getQueryData<OpenworkSessionHistory>(snapshotKey("workspace", "a"));
+    expect(cached?.status).toBeUndefined();
+    expect(cached?.todos).toBeUndefined();
+  });
+
   for (const openworkWorkspaceId of [undefined, "runtime-x"]) test(`remote sidebar alias shares runtime preview/full keys with click (explicit runtime ID=${Boolean(openworkWorkspaceId)})`, async () => {
     const sidebarWorkspaceId = "rem_x";
     const endpoint = resolveWorkspaceEndpoint({ id: sidebarWorkspaceId, workspaceType: "remote", baseUrl: "https://worker.example", openworkToken: "remote-token", openworkWorkspaceId }, { baseUrl: "http://localhost:7777", token: "local-token" });

--- a/apps/app/tests/session-snapshot-owner-flip.test.tsx
+++ b/apps/app/tests/session-snapshot-owner-flip.test.tsx
@@ -143,6 +143,7 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
   window.localStorage.setItem("openwork.shell-config", JSON.stringify({ starterCards: false }));
 
   const readEndpoints: string[] = [];
+  const historyWindows: Array<number | undefined> = [];
   let releaseRetry: (() => void) | null = null;
   const snapshot = createSnapshot();
   const operationsFor = (endpoint: { opencodeBaseUrl: string }): NativeSessionOperations => {
@@ -150,7 +151,10 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
     const v2 = endpoint.opencodeBaseUrl === v2BaseUrl;
     return {
       get: async () => (v2 ? ok(snapshot.session) : notFound()),
-      messages: async () => (v2 ? ok(snapshot.messages) : notFound()),
+      messages: async (_sessionId, limit) => {
+        historyWindows.push(limit);
+        return v2 ? ok(snapshot.messages) : notFound();
+      },
       todo: async () => (v2 ? ok(snapshot.todos) : notFound()),
       status: async () => ok({}),
       delete: async () => ok(true),
@@ -162,10 +166,10 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
   mock.module("@/components/chat/task-suggestions", () => ({ ...taskSuggestions, TaskSuggestions: () => null }));
   mock.module("../src/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
   // Bind the real implementation first: mocking rewires the loaded module's live bindings.
-  const composeWithRetry = sessionNative.composeNativeSessionSnapshotWithRetry;
+  const composeWithRetry = sessionNative.composeNativeSessionHistoryWithRetry;
   mock.module("@/app/lib/opencode-session-native", () => ({
     ...sessionNative,
-    composeNativeSessionSnapshotWithRetry: (
+    composeNativeSessionHistoryWithRetry: (
       expectedOwner: string,
       readCurrentTarget: () => NativeSessionSnapshotTarget,
       options: { signal?: AbortSignal },
@@ -244,11 +248,15 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
     await act(async () => root.render(surface(v2BaseUrl)));
     await act(async () => { releaseRetry?.(); });
 
-    await waitFor(() => container.textContent?.includes(transcriptText) === true, "the transcript read under the v2 owner");
+    await waitFor(() => container.textContent?.includes(transcriptText) === true
+      && queryClient.getQueryState(key)?.status === "success", "the full transcript read under the v2 owner");
     expect(queryClient.getQueryState(key)?.status).toBe("success");
     expect(queryClient.getQueryState(key)?.error).toBeNull();
     expect(container.textContent).not.toContain("owner changed");
-    expect(readEndpoints).toEqual([v1BaseUrl, v2BaseUrl]);
+    // The new owner's preview paints before its separate uncapped history read.
+    // The abandoned owner must never retry or populate either result.
+    expect(readEndpoints).toEqual([v1BaseUrl, v2BaseUrl, v2BaseUrl]);
+    expect(historyWindows).toEqual([24, 24, undefined]);
   } finally {
     await act(async () => root.unmount());
     useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
+import { afterEach, describe, expect, setSystemTime, spyOn, test } from "bun:test";
 import type { UIMessage } from "ai";
 import type { PermissionRequest, PermissionV2Request, QuestionRequest } from "@opencode-ai/sdk/v2/client";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
@@ -8,7 +8,7 @@ import { createRoot } from "react-dom/client";
 import { createClient } from "../src/app/lib/opencode";
 import { createClientV2 } from "../src/app/lib/opencode-v2-adapter";
 import { useSessionInteractions, type UseSessionInteractionsInput } from "../src/react-app/domains/session/sync/use-session-interactions";
-import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
 import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
@@ -121,13 +121,561 @@ function snapshotWithMessages(
   } as unknown as OpenworkSessionSnapshot;
 }
 
+async function withInteractionHydration(
+  fetchResponse: (request: Request) => Promise<Response>,
+  run: (harness: {
+    client: UseSessionInteractionsInput["client"];
+    calls: Request[];
+    container: HTMLDivElement;
+    render: (overrides?: Partial<UseSessionInteractionsInput>) => Promise<void>;
+    unmount: () => Promise<void>;
+    runRetry: (delay: number) => Promise<void>;
+    pendingRetryDelays: () => number[];
+  }) => Promise<void>,
+) {
+  GlobalRegistrator.register({ url: "http://localhost/" });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  // Leave React/DOM scheduling real; only hold the bounded hydration retries.
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const retries = new Map<ReturnType<typeof setTimeout>, { delay: number; run: () => void }>();
+  const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation((callback, delay, ...args) => {
+    if (typeof callback === "function" && (delay === 100 || delay === 250 || delay === 500)) {
+      const timer = originalSetTimeout(() => {}, 60_000);
+      retries.set(timer, { delay, run: () => callback(...args) });
+      return timer;
+    }
+    return originalSetTimeout(callback, delay, ...args);
+  });
+  const clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation((timer) => {
+    for (const key of retries.keys()) if (key === timer) retries.delete(key);
+    originalClearTimeout(timer);
+  });
+  const originalFetch = globalThis.fetch;
+  const calls: Request[] = [];
+  const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    calls.push(request);
+    const path = new URL(request.url).pathname;
+    if (path.endsWith("/permission")) return Response.json(path.includes("/api/session/") ? { data: [] } : []);
+    if (path.endsWith("/question")) return Response.json([]);
+    return fetchResponse(request);
+  };
+  Object.defineProperty(globalThis, "fetch", { configurable: true, writable: true, value: fetchStub });
+  const client = createClient("http://localhost/opencode", "/project");
+  function Interactions(props: UseSessionInteractionsInput) {
+    const interactions = useSessionInteractions(props);
+    return createElement("div", null, interactions.todos.map((todo) => todo.content).join(", "));
+  }
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  let mounted = true;
+  const unmount = async () => {
+    if (!mounted) return;
+    mounted = false;
+    await act(async () => root.unmount());
+  };
+  try {
+    await run({
+      client, calls, container, unmount,
+      pendingRetryDelays: () => [...retries.values()].map((retry) => retry.delay),
+      runRetry: async (delay) => {
+        const next = retries.entries().next().value;
+        if (!next) throw new Error("Missing hydration retry");
+        const [timer, retry] = next;
+        expect(retry.delay).toBe(delay);
+        retries.delete(timer);
+        originalClearTimeout(timer);
+        setSystemTime(Date.now() + delay);
+        await act(async () => { retry.run(); });
+      },
+      render: async (overrides = {}) => {
+        await act(async () => root.render(createElement(Interactions, {
+          client, workspaceId: "workspace-a", workspaceRoot: "/project", sessionId: "session-a", ...overrides,
+        })));
+      },
+    });
+  } finally {
+    await unmount();
+    for (const timer of retries.keys()) originalClearTimeout(timer);
+    timeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+    Object.defineProperty(globalThis, "fetch", { configurable: true, writable: true, value: originalFetch });
+    await GlobalRegistrator.unregister();
+  }
+}
+
 afterEach(() => {
   __setWorkspaceSessionSyncPermissionFetcherForTest(null);
   __setWorkspaceSessionSyncStatusFetcherForTest(null);
   setSystemTime();
   getReactQueryClient().clear();
-  for (const sessionId of ["session-a", "session-b", "session-child"]) {
-    useSessionActivityStore.getState().removeSession("workspace-a", sessionId);
+  for (const workspaceId of ["workspace-a", "workspace-b"]) {
+    for (const sessionId of ["session-a", "session-b", "session-child"]) {
+      useSessionActivityStore.getState().removeSession(workspaceId, sessionId);
+    }
+  }
+});
+
+describe("independent session status and todo hydration", () => {
+  test("initial status failure recovers with bounded retries even without a workspace sync", async () => {
+    let statusReads = 0;
+    await withInteractionHydration(async (request) => {
+      if (!new URL(request.url).pathname.endsWith("/status")) return Response.json([]);
+      statusReads += 1;
+      return statusReads === 1 ? Response.json({ message: "starting" }, { status: 503 })
+        : Response.json({ "session-a": { type: "busy" } });
+    }, async ({ render, runRetry, pendingRetryDelays, calls }) => {
+      setSystemTime(100);
+      await render();
+      expect(getReactQueryClient().getQueryData(statusKey("workspace-a", "session-a"))).toBeUndefined();
+      expect(pendingRetryDelays()).toEqual([100]);
+      await runRetry(100);
+      expect(statusReads).toBe(2);
+      expect(getReactQueryClient().getQueryData(statusKey("workspace-a", "session-a"))).toEqual({ type: "busy" });
+      expect(pendingRetryDelays()).toEqual([]);
+      expect(calls.some((request) => /\/(message|messages|snapshot)$/.test(new URL(request.url).pathname))).toBe(false);
+    });
+  });
+
+  test("status recovery is bounded, coalesces wake events, and cancels on unmount", async () => {
+    let statusReads = 0;
+    let failing = true;
+    const held = Promise.withResolvers<Response>();
+    await withInteractionHydration(async (request) => {
+      if (!new URL(request.url).pathname.endsWith("/status")) return Response.json([]);
+      statusReads += 1;
+      return failing ? Response.json({ message: "offline" }, { status: 503 }) : held.promise;
+    }, async ({ render, runRetry, pendingRetryDelays, unmount }) => {
+      await render();
+      for (const delay of [100, 250, 500]) await runRetry(delay);
+      expect(statusReads).toBe(4);
+      expect(pendingRetryDelays()).toEqual([]);
+      failing = false;
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+        window.dispatchEvent(new Event("online"));
+        window.dispatchEvent(new Event("focus"));
+      });
+      expect(statusReads).toBe(5);
+      await unmount();
+      await act(async () => { held.resolve(Response.json({ "session-a": { type: "busy" } })); });
+      expect(getReactQueryClient().getQueryData(statusKey("workspace-a", "session-a"))).toBeUndefined();
+      expect(pendingRetryDelays()).toEqual([]);
+    });
+  });
+
+  test("navigation cancels a scheduled initial status retry", async () => {
+    let statusReads = 0;
+    await withInteractionHydration(async (request) => {
+      if (!new URL(request.url).pathname.endsWith("/status")) return Response.json([]);
+      statusReads += 1;
+      return statusReads === 1 ? Response.json({ message: "offline" }, { status: 503 }) : Response.json({});
+    }, async ({ render, pendingRetryDelays }) => {
+      await render();
+      expect(pendingRetryDelays()).toEqual([100]);
+      await render({ sessionId: "session-b" });
+      expect(pendingRetryDelays()).toEqual([]);
+      expect(statusReads).toBe(2);
+      expect(getReactQueryClient().getQueryData(statusKey("workspace-a", "session-a"))).toBeUndefined();
+      expect(getReactQueryClient().getQueryData(statusKey("workspace-a", "session-b"))).toEqual({ type: "idle" });
+    });
+  });
+
+  for (const terminal of ["idle", "error", "native-success", "native-cancel", "poll", "reconnect"]) {
+    test(`${terminal} reconciliation repairs a missed todo event without focus or history`, async () => {
+      const input = { workspaceId: "workspace-a", baseUrl: terminal.startsWith("native") ? "http://localhost/opencode2" : "http://localhost/opencode", openworkToken: "token" };
+      const cleanup = __createWorkspaceSessionSyncForTest(input);
+      const release = trackWorkspaceSessionSync(input, "session-a");
+      __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+      __setWorkspaceSessionSyncPermissionFetcherForTest(async () => []);
+      let completed = false;
+      let todoReads = 0;
+      try {
+        await withInteractionHydration(async (request) => {
+          if (new URL(request.url).pathname.endsWith("/status")) return Response.json({});
+          todoReads += 1;
+          return Response.json([{ id: "task", content: completed ? "Completed task" : "Running task", status: completed ? "completed" : "in_progress", priority: "high" }]);
+        }, async ({ render, container, runRetry, calls }) => {
+          setSystemTime(100);
+          await render();
+          expect(container.textContent).toBe("Running task");
+          setSystemTime(150);
+          if (terminal !== "reconnect") {
+            __applySessionSyncEventForTest(input, { type: "session.status", properties: { sessionID: "session-a", status: { type: "busy" } } });
+          }
+          completed = true;
+          setSystemTime(200);
+          if (terminal === "poll") await runRetry(250);
+          else await act(async () => {
+            if (terminal === "reconnect") __revalidateWorkspaceSyncsForTest();
+            else if (terminal === "error") __applySessionSyncEventForTest(input, { type: "session.error", properties: { sessionID: "session-a", error: { name: "UnknownError", data: { message: "Stopped" } } } });
+            else if (terminal === "native-success") __applySessionSyncEventForTest(input, { type: "session.execution.succeeded", properties: { sessionID: "session-a", sequence: 2 } });
+            else if (terminal === "native-cancel") __applySessionSyncEventForTest(input, { type: "session.execution.interrupted", properties: { sessionID: "session-a", sequence: 2, reason: "user" } });
+            else __applySessionSyncEventForTest(input, { type: "session.idle", properties: { sessionID: "session-a" } });
+          });
+          expect(container.textContent).toBe("Completed task");
+          expect(todoReads).toBe(2);
+          expect(calls.some((request) => /\/(message|messages|snapshot)$/.test(new URL(request.url).pathname))).toBe(false);
+        });
+      } finally { release(); cleanup(); }
+    });
+  }
+
+  test("terminal todo reconciliation replaces an older in-flight initial read and ignores its late body", async () => {
+    const input = { workspaceId: "workspace-a", baseUrl: "http://localhost/opencode", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const release = trackWorkspaceSessionSync(input, "session-a");
+    const held = Promise.withResolvers<Response>();
+    let todoReads = 0;
+    try {
+      await withInteractionHydration(async (request) => {
+        if (new URL(request.url).pathname.endsWith("/status")) return Response.json({});
+        todoReads += 1;
+        return todoReads === 1 ? held.promise : Response.json([{ id: "done", content: "Completed task", status: "completed", priority: "high" }]);
+      }, async ({ render, container, client }) => {
+        if (!client) throw new Error("Missing client");
+        const reads = spyOn(client.session, "todo");
+        try {
+          setSystemTime(100);
+          await render();
+          const oldSignal = reads.mock.calls[0]?.[1]?.signal;
+          setSystemTime(200);
+          await act(async () => { __applySessionSyncEventForTest(input, { type: "session.idle", properties: { sessionID: "session-a" } }); });
+          expect(oldSignal?.aborted).toBe(true);
+          expect(todoReads).toBe(2);
+          expect(container.textContent).toBe("Completed task");
+          await act(async () => { held.resolve(Response.json([])); });
+          expect(container.textContent).toBe("Completed task");
+        } finally { reads.mockRestore(); }
+      });
+    } finally { release(); cleanup(); }
+  });
+
+  test("terminal todo retry preserves cached data on failure and rejects a same-clock live overwrite", async () => {
+    const input = { workspaceId: "workspace-a", baseUrl: "http://localhost/opencode", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const release = trackWorkspaceSessionSync(input, "session-a");
+    const held = Promise.withResolvers<Response>();
+    let reads = 0;
+    try {
+      await withInteractionHydration(async (request) => {
+        if (new URL(request.url).pathname.endsWith("/status")) return Response.json({});
+        reads += 1;
+        if (reads === 1) return Response.json([{ id: "task", content: "Cached task", status: "in_progress", priority: "high" }]);
+        if (reads === 2) return Response.json({ message: "offline" }, { status: 503 });
+        return held.promise;
+      }, async ({ render, container, runRetry, pendingRetryDelays }) => {
+        setSystemTime(100);
+        await render();
+        setSystemTime(200);
+        await act(async () => { __applySessionSyncEventForTest(input, { type: "session.idle", properties: { sessionID: "session-a" } }); });
+        expect(reads).toBe(2);
+        expect(container.textContent).toBe("Cached task");
+        expect(pendingRetryDelays()).toEqual([100]);
+        await runRetry(100);
+        expect(reads).toBe(3);
+        const live = [{ id: "task", content: "Live completed task", status: "completed", priority: "high" }];
+        await act(async () => { __applySessionSyncEventForTest(input, { type: "todo.updated", properties: { sessionID: "session-a", todos: live } }); });
+        setSystemTime(400);
+        await act(async () => { held.resolve(Response.json([])); });
+        expect(container.textContent).toBe("Live completed task");
+        expect(getReactQueryClient().getQueryState(todoKey("workspace-a", "session-a"))?.dataUpdatedAt).toBe(300);
+        expect(pendingRetryDelays()).toEqual([]);
+      });
+    } finally { release(); cleanup(); }
+  });
+
+  for (const terminal of ["error", "native-cancel"]) {
+    test(`retried status cannot overwrite a same-clock ${terminal}`, async () => {
+      const input = { workspaceId: "workspace-a", baseUrl: "http://localhost/opencode2", openworkToken: "token" };
+      const cleanup = __createWorkspaceSessionSyncForTest(input);
+      const release = trackWorkspaceSessionSync(input, "session-a");
+      __setWorkspaceSessionSyncPermissionFetcherForTest(async () => []);
+      const held = Promise.withResolvers<Response>();
+      let reads = 0;
+      try {
+        await withInteractionHydration(async (request) => {
+          if (!new URL(request.url).pathname.endsWith("/status")) return Response.json([]);
+          reads += 1;
+          return reads === 1 ? Response.json({ message: "offline" }, { status: 503 }) : held.promise;
+        }, async ({ render, runRetry }) => {
+          setSystemTime(100);
+          await render();
+          await runRetry(100);
+          await act(async () => {
+            if (terminal === "error") __applySessionSyncEventForTest(input, { type: "session.error", properties: { sessionID: "session-a", error: { name: "UnknownError", data: { message: "Stopped" } } } });
+            else __applySessionSyncEventForTest(input, { type: "session.execution.interrupted", properties: { sessionID: "session-a", sequence: 2, reason: "user" } });
+          });
+          setSystemTime(300);
+          await act(async () => { held.resolve(Response.json({ "session-a": { type: "busy" } })); });
+          expect(getReactQueryClient().getQueryData(statusKey("workspace-a", "session-a"))).toEqual({ type: "idle" });
+          expect(useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"])
+            .toMatchObject({ runActive: false, runStatusAt: 200, errorActive: terminal === "error" });
+        });
+      } finally { release(); cleanup(); }
+    });
+  }
+
+  test("a failed todo read retries independently with a fresh timestamp and recovers the cached list", async () => {
+    let todoReads = 0;
+    const fresh = [{ id: "fresh", content: "Recovered task", status: "completed", priority: "high" }];
+    await withInteractionHydration(async (request) => {
+      if (new URL(request.url).pathname.endsWith("/status")) return Response.json({});
+      todoReads += 1;
+      return todoReads === 1 ? Response.json({ message: "offline" }, { status: 503 }) : Response.json(fresh);
+    }, async ({ render, calls, container, runRetry }) => {
+      setSystemTime(100);
+      await render();
+      expect(todoReads).toBe(1);
+      setSystemTime(150);
+      await act(async () => {
+        getReactQueryClient().setQueryData(todoKey("workspace-a", "session-a"), [
+          { id: "cached", content: "Cached task", status: "pending", priority: "high" },
+        ]);
+      });
+      expect(container.textContent).toBe("Cached task");
+      await runRetry(100);
+      expect(todoReads).toBe(2);
+      expect(container.textContent).toBe("Recovered task");
+      expect(getReactQueryClient().getQueryData(todoKey("workspace-a", "session-a"))).toEqual(fresh);
+      expect(getReactQueryClient().getQueryState(todoKey("workspace-a", "session-a"))?.dataUpdatedAt).toBeGreaterThan(150);
+      expect(calls.filter((request) => new URL(request.url).pathname.endsWith("/status"))).toHaveLength(1);
+      expect(calls.some((request) => /\/(message|messages|snapshot)$/.test(new URL(request.url).pathname))).toBe(false);
+    });
+  });
+
+  for (const recovery of ["online", "focus"]) {
+    test(`todo retries are bounded and ${recovery} restarts recovery after exhaustion`, async () => {
+      let todoReads = 0;
+      let failing = true;
+      await withInteractionHydration(async (request) => {
+        if (new URL(request.url).pathname.endsWith("/status")) return Response.json({});
+        todoReads += 1;
+        return failing ? Response.json({ message: "offline" }, { status: 503 })
+          : Response.json([{ id: "recovered", content: "Recovered task", status: "pending", priority: "high" }]);
+      }, async ({ render, calls, container, unmount, runRetry, pendingRetryDelays }) => {
+        await render();
+        for (const delay of [100, 250, 500]) {
+          await runRetry(delay);
+        }
+        expect(todoReads).toBe(4);
+        expect(pendingRetryDelays()).toEqual([]);
+        failing = false;
+        await act(async () => { window.dispatchEvent(new Event(recovery)); });
+        expect(todoReads).toBe(5);
+        expect(container.textContent).toBe("Recovered task");
+        expect(calls.filter((request) => new URL(request.url).pathname.endsWith("/status"))).toHaveLength(1);
+        await unmount();
+        window.dispatchEvent(new Event(recovery));
+        expect(pendingRetryDelays()).toEqual([]);
+        expect(todoReads).toBe(5);
+      });
+    });
+  }
+
+  test("navigation cancels queued todo retries and recovery only reads the current owner", async () => {
+    const todoPaths: string[] = [];
+    await withInteractionHydration(async (request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/status")) return Response.json({});
+      todoPaths.push(path);
+      return path.includes("/session-a/") ? Response.json({ message: "offline" }, { status: 503 }) : Response.json([]);
+    }, async ({ render, pendingRetryDelays }) => {
+      await render();
+      expect(pendingRetryDelays()).toEqual([100]);
+      await render({ sessionId: "session-b" });
+      expect(pendingRetryDelays()).toEqual([]);
+      expect(todoPaths).toEqual(["/opencode/session/session-a/todo", "/opencode/session/session-b/todo"]);
+      await act(async () => { window.dispatchEvent(new Event("online")); });
+      expect(todoPaths).toEqual([
+        "/opencode/session/session-a/todo", "/opencode/session/session-b/todo", "/opencode/session/session-b/todo",
+      ]);
+      expect(getReactQueryClient().getQueryData(todoKey("workspace-a", "session-a"))).toBeUndefined();
+    });
+  });
+
+  test("a recovering todo read still cannot replace a newer live event", async () => {
+    const pending = Promise.withResolvers<Response>();
+    let todoReads = 0;
+    const input = { workspaceId: "workspace-a", baseUrl: "http://localhost/opencode", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const release = trackWorkspaceSessionSync(input, "session-a");
+    try {
+      await withInteractionHydration(async (request) => {
+        if (new URL(request.url).pathname.endsWith("/status")) return Response.json({});
+        todoReads += 1;
+        return todoReads === 1 ? Response.json({ message: "offline" }, { status: 503 }) : pending.promise;
+      }, async ({ render, runRetry }) => {
+        setSystemTime(100);
+        await render();
+        await runRetry(100);
+        expect(todoReads).toBe(2);
+        setSystemTime(300);
+        const live = [{ id: "live", content: "Live task", status: "completed", priority: "high" }];
+        await act(async () => {
+          __applySessionSyncEventForTest(input, { type: "todo.updated", properties: { sessionID: "session-a", todos: live } });
+          pending.resolve(Response.json([]));
+        });
+        expect(getReactQueryClient().getQueryData(todoKey("workspace-a", "session-a"))).toEqual(live);
+      });
+    } finally { release(); cleanup(); }
+  });
+
+  for (const first of ["status", "todos"]) {
+    test(`${first} hydrates while the other read is held and neither blocks history`, async () => {
+      const status = Promise.withResolvers<Response>();
+      const todos = Promise.withResolvers<Response>();
+      const queryClient = getReactQueryClient();
+      const cachedTodos = [{ id: "cached", content: "Cached task", status: "pending", priority: "high" }];
+      const freshTodos = [{ id: "fresh", content: "Fresh task", status: "completed", priority: "high" }];
+      setSystemTime(50);
+      queryClient.setQueryData(todoKey("workspace-a", "session-a"), cachedTodos);
+      await withInteractionHydration(async (request) => {
+        return new URL(request.url).pathname.endsWith("/status") ? status.promise : todos.promise;
+      }, async ({ calls, container, render }) => {
+        setSystemTime(100);
+        await render({ interactionSessionIds: ["session-child"] });
+        expect(calls.filter((request) => /\/(status|todo)$/.test(new URL(request.url).pathname))
+          .map((request) => new URL(request.url).pathname))
+          .toEqual(["/opencode/session/status", "/opencode/session/session-a/todo"]);
+        const { session, messages } = snapshotWithMessages([{ id: "answer", role: "assistant", text: "History is ready" }]);
+        const history: OpenworkSessionHistory = { session, messages };
+        markSessionSnapshotFetchStart(history, 100);
+        setSystemTime(150);
+        seedSessionState("workspace-a", history);
+        expect(queryClient.getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"))?.[0]?.parts[0])
+          .toMatchObject({ text: "History is ready" });
+        expect(queryClient.getQueryData(statusKey("workspace-a", "session-a"))).toBeUndefined();
+        expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toEqual(cachedTodos);
+        expect(useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"]?.runStatusAt).toBe(0);
+        setSystemTime(200);
+        await act(async () => {
+          if (first === "status") status.resolve(Response.json({}));
+          else todos.resolve(Response.json(freshTodos));
+        });
+        expect(queryClient.getQueryData(statusKey("workspace-a", "session-a")))
+          .toEqual(first === "status" ? { type: "idle" } : undefined);
+        expect(container.textContent).toBe(first === "todos" ? "Fresh task" : "Cached task");
+        setSystemTime(300);
+        await act(async () => {
+          if (first === "status") todos.resolve(Response.json(freshTodos));
+          else status.resolve(Response.json({}));
+        });
+        expect(queryClient.getQueryData(statusKey("workspace-a", "session-a"))).toEqual({ type: "idle" });
+        expect(useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"]?.runStatusAt).toBe(100);
+        expect(container.textContent).toBe("Fresh task");
+        expect(queryClient.getQueryData(todoKey("workspace-a", "session-child"))).toBeUndefined();
+        expect(queryClient.getQueryData(statusKey("workspace-a", "session-child"))).toBeUndefined();
+        // Changing the descendants only refreshes their interactions.
+        await render({ interactionSessionIds: ["session-b"] });
+        expect(calls.filter((request) => /\/(status|todo)$/.test(new URL(request.url).pathname))).toHaveLength(2);
+        expect(calls.some((request) => /\/(message|messages|snapshot|session)$/.test(new URL(request.url).pathname))).toBe(false);
+      });
+    });
+  }
+
+  for (const cached of [false, true]) {
+    test(`failed status and todo reads retain ${cached ? "cached" : "unobserved"} state`, async () => {
+      const queryClient = getReactQueryClient();
+      const cachedTodos = [{ id: "cached", content: "Keep this task", status: "pending", priority: "high" }];
+      setSystemTime(50);
+      if (cached) {
+        useSessionActivityStore.getState().setRunStatus("workspace-a", "session-a", { type: "busy" });
+        queryClient.setQueryData(statusKey("workspace-a", "session-a"), { type: "busy" });
+        queryClient.setQueryData(todoKey("workspace-a", "session-a"), cachedTodos);
+      }
+      await withInteractionHydration(async () => Response.json({ message: "unavailable" }, { status: 503 }), async ({ render }) => {
+        setSystemTime(100);
+        await render();
+        expect(queryClient.getQueryData(statusKey("workspace-a", "session-a"))).toEqual(cached ? { type: "busy" } : undefined);
+        expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toEqual(cached ? cachedTodos : undefined);
+        expect(useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"]?.runStatusAt ?? 0).toBe(cached ? 50 : 0);
+      });
+    });
+  }
+
+  for (const eventTime of [100, 200]) {
+    test(`status and todo events at ${eventTime} beat held reads started at 100`, async () => {
+      const status = Promise.withResolvers<Response>();
+      const todos = Promise.withResolvers<Response>();
+      const input = { workspaceId: "workspace-a", baseUrl: "http://localhost/opencode", openworkToken: "token" };
+      const cleanup = __createWorkspaceSessionSyncForTest(input);
+      const release = trackWorkspaceSessionSync(input, "session-a");
+      const liveTodos = [{ id: "live", content: "Live task", status: "completed", priority: "high" }];
+      try {
+        await withInteractionHydration(async (request) => {
+          return new URL(request.url).pathname.endsWith("/status") ? status.promise : todos.promise;
+        }, async ({ render }) => {
+          setSystemTime(100);
+          await render();
+          setSystemTime(eventTime);
+          await act(async () => {
+            __applySessionSyncEventForTest(input, {
+              type: "session.status", properties: { sessionID: "session-a", status: { type: "busy" } },
+            });
+            __applySessionSyncEventForTest(input, {
+              type: "todo.updated", properties: { sessionID: "session-a", todos: liveTodos },
+            });
+          });
+          setSystemTime(300);
+          await act(async () => {
+            status.resolve(Response.json({}));
+            todos.resolve(Response.json([]));
+          });
+          expect(getReactQueryClient().getQueryData(statusKey("workspace-a", "session-a"))).toEqual({ type: "busy" });
+          expect(getReactQueryClient().getQueryData(todoKey("workspace-a", "session-a"))).toEqual(liveTodos);
+          expect(useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"]?.runStatusAt).toBe(eventTime);
+        });
+      } finally { release(); cleanup(); }
+    });
+  }
+
+  for (const change of ["client", "workspace", "session", "unmount"]) {
+    test(`${change} cancels both independent reads and ignores late successful bodies`, async () => {
+      const status = Promise.withResolvers<Response>();
+      const todos = Promise.withResolvers<Response>();
+      let hold = true;
+      await withInteractionHydration(async (request) => {
+        const statusRead = new URL(request.url).pathname.endsWith("/status");
+        if (hold) return statusRead ? status.promise : todos.promise;
+        return Response.json(statusRead ? {} : []);
+      }, async ({ client, render, unmount }) => {
+        if (!client) throw new Error("Missing hydration client");
+        const statusSpy = spyOn(client.session, "status");
+        const todoSpy = spyOn(client.session, "todo");
+        try {
+          setSystemTime(100);
+          await render();
+          const statusSignal = statusSpy.mock.calls[0]?.[1]?.signal;
+          const todoSignal = todoSpy.mock.calls[0]?.[1]?.signal;
+          expect(statusSignal?.aborted).toBe(false);
+          expect(todoSignal?.aborted).toBe(false);
+          expect(statusSignal).not.toBe(todoSignal);
+          hold = false;
+          setSystemTime(200);
+          if (change === "client") await render({ client: createClient("http://localhost/opencode", "/project") });
+          else if (change === "workspace") await render({ workspaceId: "workspace-b" });
+          else if (change === "session") await render({ sessionId: "session-b" });
+          else await unmount();
+          expect(statusSignal?.aborted).toBe(true);
+          expect(todoSignal?.aborted).toBe(true);
+          const queryClient = getReactQueryClient();
+          const statusBefore = queryClient.getQueryState(statusKey("workspace-a", "session-a"));
+          const todosBefore = queryClient.getQueryState(todoKey("workspace-a", "session-a"));
+          setSystemTime(300);
+          await act(async () => {
+            status.resolve(Response.json({ "session-a": { type: "busy" } }));
+            todos.resolve(Response.json([{ id: "late", content: "Obsolete task", status: "pending", priority: "high" }]));
+          });
+          expect(queryClient.getQueryState(statusKey("workspace-a", "session-a"))).toBe(statusBefore);
+          expect(queryClient.getQueryState(todoKey("workspace-a", "session-a"))).toBe(todosBefore);
+        } finally {
+          statusSpy.mockRestore();
+          todoSpy.mockRestore();
+        }
+      });
+    });
   }
 });
 
@@ -147,6 +695,8 @@ describe("session permission sync", () => {
         calls.push(request);
         const path = new URL(request.url).pathname;
         if (path.endsWith("/api/session")) throw new Error("Unrelated session sweep must not run");
+        if (path.endsWith("/session/status")) return Response.json({});
+        if (path.endsWith("/session/active")) return Response.json({ data: {} });
         if (path.endsWith("/api/session/session-a/permission") && hold) return delayed.promise;
         if ((path.endsWith("/form/request") || path.endsWith("/question")) && hold) return delayedQuestion.promise;
         if (path.endsWith("/api/session/session-child/permission")) {
@@ -508,6 +1058,69 @@ describe("session question sync", () => {
 });
 
 describe("session transcript sync", () => {
+  test("history-only hydration and cached revisits preserve busy status and cached todos", () => {
+    const queryClient = getReactQueryClient();
+    const snapshot = snapshotWithMessages([{ id: "answer", role: "assistant", text: "Answer" }]);
+    snapshot.status = { type: "busy" };
+    snapshot.todos = [{ id: "todo", content: "Keep working", status: "in_progress", priority: "high" }];
+    setSystemTime(100);
+    markSessionSnapshotFetchStart(snapshot, 100);
+    seedSessionState("workspace-a", snapshot);
+    const statusBefore = queryClient.getQueryState(statusKey("workspace-a", "session-a"));
+    const todosBefore = queryClient.getQueryState(todoKey("workspace-a", "session-a"));
+    const { session, messages } = snapshotWithMessages([{ id: "answer", role: "assistant", text: "Answer continues" }]);
+    const history: OpenworkSessionHistory = { session, messages };
+    markSessionSnapshotFetchStart(history, 200);
+    for (const now of [200, 300]) {
+      setSystemTime(now);
+      seedSessionState("workspace-a", history);
+      expect(queryClient.getQueryState(statusKey("workspace-a", "session-a"))).toBe(statusBefore);
+      expect(queryClient.getQueryState(todoKey("workspace-a", "session-a"))).toBe(todosBefore);
+      expect(useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"])
+        .toMatchObject({ runActive: true, runStatusAt: 100 });
+    }
+    expect(queryClient.getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"))?.[0]?.parts[0])
+      .toMatchObject({ text: "Answer continues" });
+  });
+
+  test("full history without status or todos reconciles reverts, settles orphans, and observes transcript progress", () => {
+    const { session, messages } = snapshotWithMessages([
+      { id: "answer", role: "assistant", text: "Completed answer" },
+      { id: "reverted", role: "user", text: "Reverted prompt" },
+    ]);
+    const tool = { messageID: "answer", callID: "finished-call" };
+    messages[0]!.parts.push({
+      id: "finished-part", sessionID: session.id, messageID: "answer", type: "tool",
+      callID: tool.callID, tool: "lookup",
+      state: { status: "completed", input: {}, output: "Found it", title: "Lookup", metadata: {}, time: { start: 1, end: 2 } },
+    });
+    const history: OpenworkSessionHistory = { session: { ...session, revert: { messageID: "reverted" } }, messages };
+    seedPermissionState("workspace-a", "session-a", [{ ...permission("orphaned-permission", "session-a"), tool }]);
+    seedQuestionState("workspace-a", "session-a", [
+      { ...question("orphaned-question", "session-a"), tool },
+      question("still-pending", "session-a"),
+    ]);
+    const queryClient = getReactQueryClient();
+    queryClient.setQueryData(transcriptKey("workspace-a", "session-a"), [
+      uiMessage("answer", "assistant", "Completed"), uiMessage("reverted", "user", "Reverted prompt"),
+    ]);
+    markSessionSnapshotFetchStart(history, 100);
+    seedSessionState("workspace-a", history);
+    const transcript = queryClient.getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"));
+    expect(transcript?.map((message) => message.id)).toEqual(["answer"]);
+    expect(transcript?.[0]?.parts[0]).toMatchObject({ text: "Completed answer" });
+    expect(queryClient.getQueryData(permissionKey("workspace-a", "session-a"))).toEqual([]);
+    expect(queryClient.getQueryData(questionKey("workspace-a", "session-a"))).toMatchObject([{ id: "still-pending" }]);
+    expect(queryClient.getQueryData(statusKey("workspace-a", "session-a"))).toBeUndefined();
+    expect(queryClient.getQueryData(todoKey("workspace-a", "session-a"))).toBeUndefined();
+    const record = useSessionActivityStore.getState().recordsByWorkspaceId["workspace-a"]?.["session-a"];
+    expect(record?.runStatusAt).toBe(0);
+    expect(record?.progressRevision).not.toBeNull();
+    // Settlement watermarks also reject a later list containing the orphan.
+    seedQuestionState("workspace-a", "session-a", [{ ...question("orphaned-question", "session-a"), tool }]);
+    expect(queryClient.getQueryData(questionKey("workspace-a", "session-a"))).toEqual([]);
+  });
+
   test("coalesces token-sized deltas by transcript part", () => {
     const deltas = coalescePendingDeltas([
       { sessionId: "session-a", messageId: "msg-a", partId: "part-a", reasoning: false, delta: "hel" },

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, jest, setSystemTime, spyOn, test } from "bun:test";
 import type { PermissionV2Request, SessionStatus } from "@opencode-ai/sdk/v2/client";
 
-import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { markTaskRunStart, takeTaskRunStart } from "../src/app/lib/analytics";
 import * as notifications from "../src/react-app/shell/desktop-notifications";
 import { createClientV2, createV2EventTranslationState, translateV2Event } from "../src/app/lib/opencode-v2-adapter";
 import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import { hasNoNewActivity } from "../src/react-app/domains/session/status/session-progress";
 import {
   __applySessionSyncEventForTest,
   __createWorkspaceSessionSyncForTest,
@@ -26,6 +27,7 @@ import {
   seedPermissionState,
   seedQuestionState,
   seedSessionState,
+  seedSessionStatus,
   snapshotKey,
   statusKey,
   todoKey,
@@ -66,6 +68,27 @@ function createSnapshot(status: SessionStatus): OpenworkSessionSnapshot {
     messages: [],
     todos: [],
     status,
+  };
+}
+
+function createActiveHistory(kind: "text" | "tool" = "tool"): OpenworkSessionHistory {
+  const { session } = createSnapshot({ type: "busy" });
+  return {
+    session,
+    messages: [{
+      info: {
+        id: "persisted-assistant", sessionID: sessionId, role: "assistant", parentID: "persisted-user",
+        time: { created: 1_000 }, modelID: "test", providerID: "test", mode: "default", agent: "build",
+        path: { cwd: "/tmp/project-run-status", root: "/tmp/project-run-status" },
+        cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+      parts: kind === "text" ? [{
+        id: "persisted-part", sessionID: sessionId, messageID: "persisted-assistant", type: "text", text: "Already responding",
+      }] : [{
+        id: "persisted-part", sessionID: sessionId, messageID: "persisted-assistant", type: "tool", callID: "persisted-call", tool: "read",
+        state: { status: "running", input: { filePath: "/tmp/project-run-status/result.txt" }, time: { start: 1_000 } },
+      }],
+    }],
   };
 }
 
@@ -237,6 +260,28 @@ describe("native v2 run lifecycle", () => {
     } finally { globalThis.fetch = originalFetch; }
   });
 
+  test("independent status hydration cannot resurrect a native terminal or erase richer retry detail", () => {
+    jest.useFakeTimers();
+    __setWorkspaceSessionSyncPermissionFetcherForTest(async () => []);
+    const { emit } = nativeSync();
+    setSystemTime(100);
+    emit("session.execution.started", 1);
+    setSystemTime(200);
+    emit("session.retry.scheduled", 2, { attempt: 2, at: 1_000, error: { message: "Rate limited" } });
+    setSystemTime(350);
+    seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 300 });
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId)))
+      .toEqual({ type: "retry", attempt: 2, message: "Rate limited", next: 1_000 });
+    setSystemTime(400);
+    emit("session.execution.succeeded", 3);
+    setSystemTime(600);
+    for (const snapshotStartedAt of [300, 400, 500]) {
+      seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt });
+      expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+      expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(false);
+    }
+  });
+
   test.each(["user", "shutdown", "superseded", "unknown"])("%s interruption never reports completed or stops a newer execution", async (reason) => {
     jest.useFakeTimers();
     const notify = spyOn(notifications, "notifyDesktopEvent").mockImplementation(() => {});
@@ -292,6 +337,208 @@ describe("native v2 run lifecycle", () => {
 });
 
 describe("session run status ordering", () => {
+  for (const first of ["user", "status"]) {
+    for (const sameClock of [false, true]) {
+      test(`cached activity follows the latest user turn (${first} first, same clock=${sameClock})`, () => {
+        const { input } = createTestSync();
+        setSystemTime(60_000);
+        applyStatus(input, { type: "idle" });
+        const history = createActiveHistory();
+        markSessionSnapshotFetchStart(history, 61_000);
+        setSystemTime(62_000);
+        seedSessionState(workspaceId, history);
+        const userAt = sameClock ? 62_000 : 63_000;
+        const user = () => __applySessionSyncEventForTest(input, {
+          type: "message.updated", properties: { info: { id: "current-user", sessionID: sessionId, role: "user", time: { created: userAt } } },
+        });
+        const busy = () => seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 61_500 });
+        setSystemTime(userAt);
+        if (first === "user") { user(); busy(); }
+        else { busy(); user(); }
+        const readRecord = () => useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+        expect(readRecord()).toMatchObject({ runActive: true, assistantOutput: false, status: "thinking", latestActivity: null });
+        expect(readRecord()?.runStartedAt).toBeGreaterThanOrEqual(userAt);
+        const startedAt = readRecord()?.runStartedAt;
+        setSystemTime(64_000);
+        user();
+        seedSessionState(workspaceId, history);
+        seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 63_500 });
+        expect(readRecord()).toMatchObject({ assistantOutput: false, status: "thinking", runStartedAt: startedAt });
+        expect(hasNoNewActivity({ active: true, lastProgressAt: Math.max(readRecord()?.runStartedAt ?? 0, readRecord()?.lastProgressAt ?? 0), now: 64_000 })).toBe(false);
+        setSystemTime(65_000);
+        __applySessionSyncEventForTest(input, { type: "message.updated", properties: { info: { id: "current-assistant", sessionID: sessionId, role: "assistant", time: { created: 65_000 } } } });
+        __applySessionSyncEventForTest(input, { type: "message.part.updated", properties: { part: { id: "current-part", messageID: "current-assistant", sessionID: sessionId, type: "text", text: "Current answer" } } });
+        expect(readRecord()).toMatchObject({ assistantOutput: true, status: "responding", runStartedAt: startedAt });
+      });
+    }
+  }
+
+  test("a new snapshot turn uses its user timestamp without backdating a newer admission", () => {
+    const store = useSessionActivityStore.getState();
+    const history: Parameters<typeof store.observeTranscript>[2] = [
+      { id: "old-user", role: "user", parts: [], metadata: { opencode: { created: 500 } } },
+      { id: "old-assistant", role: "assistant", metadata: { opencode: { created: 1_000 } }, parts: [
+        { type: "dynamic-tool", toolName: "read", toolCallId: "old-call", state: "input-available", input: {} },
+      ] },
+    ];
+    setSystemTime(62_000);
+    store.seedSessionRun(workspaceId, sessionId, { type: "busy" }, undefined, { snapshotStartedAt: 62_000 });
+    store.observeTranscript(workspaceId, sessionId, history, true, { snapshotStartedAt: 61_000 });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runStartedAt).toBe(1_000);
+    setSystemTime(63_000);
+    history.push({ id: "new-user", role: "user", parts: [], metadata: { opencode: { created: 62_500 } } });
+    store.observeTranscript(workspaceId, sessionId, history, true, { snapshotStartedAt: 62_501 });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId])
+      .toMatchObject({ runStartedAt: 62_500, assistantOutput: false, status: "thinking" });
+    setSystemTime(64_000);
+    store.setRunStatus(workspaceId, sessionId, { type: "idle" });
+    store.setRunStatus(workspaceId, sessionId, { type: "busy" });
+    setSystemTime(65_000);
+    history.push({ id: "accepted-user", role: "user", parts: [], metadata: { opencode: { created: 63_500 } } });
+    store.observeTranscript(workspaceId, sessionId, history, true, { snapshotStartedAt: 64_500 });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId])
+      .toMatchObject({ runStartedAt: 64_000, assistantOutput: false, status: "thinking" });
+  });
+
+  test("metadata-only updates cannot make old history fresh enough to enrich a newer admission", () => {
+    const { input } = createTestSync();
+    const history = createActiveHistory();
+    markSessionSnapshotFetchStart(history, 61_000);
+    setSystemTime(62_000);
+    seedSessionState(workspaceId, history);
+    const store = useSessionActivityStore.getState();
+    store.markMessageRole(workspaceId, sessionId, "persisted-assistant", "assistant");
+    setSystemTime(63_000);
+    store.setRunStatus(workspaceId, sessionId, { type: "busy" });
+    const before = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+    setSystemTime(64_000);
+    __applySessionSyncEventForTest(input, {
+      type: "message.updated", properties: { info: {
+        id: "persisted-assistant", sessionID: sessionId, role: "assistant", time: { created: 1_000, completed: 2_000 },
+      } },
+    });
+    expect(store.getStatus(workspaceId, sessionId)).toBe("thinking");
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]).toBe(before);
+    setSystemTime(65_000);
+    seedSessionState(workspaceId, history);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]).toBe(before);
+  });
+
+  for (const first of ["status", "history"]) {
+    const kinds: Array<"text" | "tool"> = ["text", "tool"];
+    for (const kind of kinds) {
+      test(`${first} first hydrates persisted ${kind} activity without a new stream event`, () => {
+        const history = createActiveHistory(kind);
+        markSessionSnapshotFetchStart(history, 61_001);
+        setSystemTime(62_000);
+        if (first === "status") seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 61_000 });
+        else seedSessionState(workspaceId, history);
+        setSystemTime(63_000);
+        if (first === "status") seedSessionState(workspaceId, history);
+        else seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 61_000 });
+        const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+        expect(record).toMatchObject({ runActive: true, assistantOutput: true, status: "responding", runStatusAt: 61_000, lastProgressAt: 1_000 });
+        if (kind === "tool") {
+          expect(record?.runStartedAt).toBe(1_000);
+          expect(hasNoNewActivity({ active: true, lastProgressAt: Math.max(record?.runStartedAt ?? 0, record?.lastProgressAt ?? 0), now: 63_000 })).toBe(true);
+        }
+        const statusState = getReactQueryClient().getQueryState(statusKey(workspaceId, sessionId));
+        setSystemTime(130_000);
+        seedSessionState(workspaceId, history);
+        expect(getReactQueryClient().getQueryState(statusKey(workspaceId, sessionId))).toBe(statusState);
+        expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]).toBe(record);
+      });
+    }
+
+    test(`${first} first cannot backdate or enrich a newer admitted run with old persisted activity`, () => {
+      const history = createActiveHistory();
+      markSessionSnapshotFetchStart(history, 61_001);
+      setSystemTime(62_000);
+      if (first === "status") seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 61_000 });
+      else seedSessionState(workspaceId, history);
+      const store = useSessionActivityStore.getState();
+      setSystemTime(62_500);
+      store.setRunStatus(workspaceId, sessionId, { type: "idle" });
+      store.setRunStatus(workspaceId, sessionId, { type: "busy" });
+      setSystemTime(63_000);
+      if (first === "status") seedSessionState(workspaceId, history);
+      else seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 61_000 });
+      // A later successful poll still belongs to the admitted run, not the
+      // older persisted tool that happened to finish loading after admission.
+      seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 62_750 });
+      expect(store.getStatus(workspaceId, sessionId)).toBe("thinking");
+      const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId];
+      expect(record).toMatchObject({ runActive: true, assistantOutput: false, runStartedAt: 62_500, runStatusAt: 62_750 });
+      expect(hasNoNewActivity({ active: true, lastProgressAt: Math.max(record?.runStartedAt ?? 0, record?.lastProgressAt ?? 0), now: 63_000 })).toBe(false);
+    });
+  }
+
+  test("a live terminal edge between status and history prevents deferred activity enrichment", () => {
+    const { input } = createTestSync();
+    const history = createActiveHistory();
+    markSessionSnapshotFetchStart(history, 61_000);
+    setSystemTime(62_000);
+    seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 61_000 });
+    setSystemTime(62_500);
+    applyStatus(input, { type: "idle" });
+    const statusState = getReactQueryClient().getQueryState(statusKey(workspaceId, sessionId));
+    setSystemTime(63_000);
+    seedSessionState(workspaceId, history);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId])
+      .toMatchObject({ runActive: false, assistantOutput: false, runStatusAt: 62_500, runStartedAt: 62_000 });
+    expect(getReactQueryClient().getQueryState(statusKey(workspaceId, sessionId))).toBe(statusState);
+  });
+
+  test("a same-clock admission cancels pending age hydration even when the busy status is unchanged", () => {
+    const history = createActiveHistory();
+    markSessionSnapshotFetchStart(history, 62_000);
+    setSystemTime(62_000);
+    seedSessionStatus(workspaceId, sessionId, { type: "busy" }, { snapshotStartedAt: 62_000 });
+    useSessionActivityStore.getState().setRunStatus(workspaceId, sessionId, { type: "busy" });
+    setSystemTime(63_000);
+    seedSessionState(workspaceId, history);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId])
+      .toMatchObject({ runActive: true, assistantOutput: false, runStartedAt: 62_000, runStatusAt: 62_000 });
+  });
+
+  test("fresh history can reveal output after a live busy edge without backdating that observed run", () => {
+    const { input } = createTestSync();
+    setSystemTime(62_000);
+    applyStatus(input, { type: "busy" });
+    const history = createActiveHistory();
+    markSessionSnapshotFetchStart(history, 62_001);
+    setSystemTime(63_000);
+    seedSessionState(workspaceId, history);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId])
+      .toMatchObject({ runActive: true, assistantOutput: true, status: "responding", runStartedAt: 62_000, runStatusAt: 62_000 });
+  });
+
+  for (const todosPresent of [false, true]) {
+    test(`${todosPresent ? "todos-only" : "history-only"} hydration does not establish observed idle`, () => {
+      const { session, messages } = createSnapshot({ type: "idle" });
+      const history: OpenworkSessionHistory = { session, messages, ...(todosPresent ? { todos: [] } : {}) };
+      setSystemTime(100);
+      markSessionSnapshotFetchStart(history, 100);
+      seedSessionState(workspaceId, history);
+      expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toBeUndefined();
+      expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runStatusAt ?? 0).toBe(0);
+      expect(getReactQueryClient().getQueryData(todoKey(workspaceId, sessionId))).toEqual(todosPresent ? [] : undefined);
+    });
+  }
+
+  test("status-only history seeds the observed status without clearing cached todos", () => {
+    const { session, messages } = createSnapshot({ type: "idle" });
+    const history: OpenworkSessionHistory = { session, messages, status: { type: "idle" } };
+    const todos = [{ id: "keep", content: "Keep this task", status: "pending", priority: "high" }];
+    getReactQueryClient().setQueryData(todoKey(workspaceId, sessionId), todos);
+    const todosBefore = getReactQueryClient().getQueryState(todoKey(workspaceId, sessionId));
+    markSessionSnapshotFetchStart(history, 100);
+    seedSessionState(workspaceId, history);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runStatusAt).toBe(100);
+    expect(getReactQueryClient().getQueryState(todoKey(workspaceId, sessionId))).toBe(todosBefore);
+  });
+
   test("preserves the activity snapshot when workspace seeds are unchanged", () => {
     const store = useSessionActivityStore.getState();
     store.seedWorkspaceSessions(workspaceId, [{ id: sessionId, status: { type: "idle" } }]);

--- a/apps/server/src/opencode-proxy.e2e.test.ts
+++ b/apps/server/src/opencode-proxy.e2e.test.ts
@@ -1,9 +1,12 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { proxyOpencodeRequest, startServer } from "./server.js";
+import * as engineV2Preview from "./engine-v2-preview.js";
+import { ApiError } from "./errors.js";
+import { managedDesktopPolicy } from "./managed-desktop-policy.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
 type Served = {
@@ -35,7 +38,7 @@ function auth(token: string) {
   return { Authorization: `Bearer ${token}` };
 }
 
-function startMockOpencode(input?: { holdCommand?: Promise<void>; foreignSessionDirectory?: string; recovery?: { active: boolean; turn: number } }) {
+function startMockOpencode(input?: { holdCommand?: Promise<void>; foreignSessionDirectory?: string; nativeV2Directory?: string; recovery?: { active: boolean; turn: number } }) {
   const requests: Array<{ pathname: string; search: string; directory: string | null; method: string; body?: unknown }> = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -45,14 +48,35 @@ function startMockOpencode(input?: { holdCommand?: Promise<void>; foreignSession
       const record: { pathname: string; search: string; directory: string | null; method: string; body?: unknown } = {
         pathname: url.pathname,
         search: url.search,
-        directory: request.headers.get("x-opencode-directory"),
+        directory: input?.nativeV2Directory ? url.searchParams.get("location[directory]") : request.headers.get("x-opencode-directory"),
         method: request.method,
       };
-      if (request.method === "POST") {
+      if (!["GET", "HEAD"].includes(request.method)) {
         const text = await request.text();
         if (text) record.body = JSON.parse(text);
       }
       requests.push(record);
+
+      if (input?.nativeV2Directory) {
+        const sessionId = url.pathname.match(/^\/api\/session\/(ses_[^/]+)$/)?.[1];
+        if (sessionId) {
+          if (sessionId === "ses_missing") return Response.json({ code: "not_found" }, { status: 404 });
+          if (sessionId === "ses_unavailable") return Response.json({ code: "storage_unavailable" }, { status: 503 });
+          const directory = sessionId === "ses_foreign" ? input.foreignSessionDirectory
+            : sessionId === "ses_unscoped" ? undefined : input.nativeV2Directory;
+          return Response.json({ data: { info: { id: sessionId, location: { directory }, title: "Stored thread" } } });
+        }
+        const messageSession = url.pathname.match(/^\/api\/session\/(ses_[^/]+)\/message(?:\/(msg_[^/]+))?$/);
+        if (messageSession) {
+          const message = { info: { id: "msg_1", sessionID: messageSession[1], role: "assistant" },
+            parts: [{ id: "prt_1", type: "text", text: "Stored history" }] };
+          return Response.json({ data: messageSession[2] ? message : [message] });
+        }
+        if (["/api/mcp", "/api/skill", "/api/session"].includes(url.pathname)) return Response.json({ data: [] });
+        if (url.pathname === "/api/session/ses_1/instructions/entries/openwork.context"
+          || url.pathname === "/api/session/ses_1/prompt") return Response.json({ data: { accepted: true } });
+        return Response.json({ code: "not_found" }, { status: 404 });
+      }
 
       if (input?.recovery) {
         if (url.pathname === "/session/ses_1/prompt_async") {
@@ -229,6 +253,57 @@ function deferred() {
   return { promise, resolve };
 }
 
+function readinessGate() {
+  const entered = deferred();
+  const released = deferred();
+  let failure: ApiError | undefined;
+  const calls: string[][] = [];
+  return {
+    calls,
+    entered: entered.promise,
+    release: released.resolve,
+    fail() {
+      failure = new ApiError(503, "fixture_readiness_failed", "Execution readiness failed");
+      released.resolve();
+    },
+    async wait(...args: string[]) {
+      calls.push(args);
+      entered.resolve();
+      await released.promise;
+      if (failure) throw failure;
+    },
+  };
+}
+
+async function startV2Proxy() {
+  const workspaceRoot = await createWorkspaceRoot();
+  const secondWorkspaceRoot = await createWorkspaceRoot();
+  const engine = startMockOpencode({ nativeV2Directory: workspaceRoot, foreignSessionDirectory: secondWorkspaceRoot });
+  const provider = readinessGate();
+  const mcp = readinessGate();
+  const status = () => ({ enabled: true, chatRouting: true, running: true,
+    mirroredProviderIds: [], skippedProviderIds: [], catalogModelIds: [] });
+  // Hold only execution preparation; requests still cross the real HTTP server,
+  // auth/policy checks, native proxy and ownership lookup into a loopback witness.
+  const preview = spyOn(engineV2Preview, "createEngineV2Preview").mockReturnValue({
+    start() {}, status, setEnabled: async () => status(), setChatRouting: async () => status(),
+    connection: () => ({ url: `http://127.0.0.1:${engine.server.port}`, username: "opencode", password: "fixture" }),
+    ensureWorkspaceReady: provider.wait, syncWorkspaceMcp: mcp.wait, stop: async () => {},
+  });
+  try {
+    const openwork = await startOpenworkServer({ workspaceRoot, secondWorkspaceRoot, readOnly: false });
+    stops.push(() => { provider.release(); mcp.release(); });
+    const base = `http://127.0.0.1:${openwork.server.port}`;
+    const request = (path: string, init: RequestInit = {}, workspaceId = "ws_1") => fetch(
+      `${base}/workspace/${workspaceId}/opencode2${path}`,
+      { signal: AbortSignal.timeout(2_000), headers: auth(openwork.token), ...init },
+    );
+    return { ...openwork, base, request, engine, provider, mcp, workspaceRoot, secondWorkspaceRoot };
+  } finally {
+    preview.mockRestore();
+  }
+}
+
 async function waitUntil(predicate: () => boolean) {
   for (let index = 0; index < 20; index++) {
     if (predicate()) return true;
@@ -238,6 +313,145 @@ async function waitUntil(predicate: () => boolean) {
 }
 
 describe("workspace OpenCode proxy", () => {
+  test.serial("v2 stored history responds while provider and MCP readiness are held; prompts wait for both", async () => {
+    const fixture = await startV2Proxy();
+    let promptSettled = false;
+    const prompt = fixture.request("/api/session/ses_1/prompt", { method: "POST", body: JSON.stringify({ parts: [] }) })
+      .finally(() => { promptSettled = true; });
+    for (const gate of [fixture.provider, fixture.mcp]) {
+      await gate.entered;
+      const before = fixture.engine.requests.length;
+      for (const suffix of ["", "/message", "/message/msg_1"]) {
+        const query = new URLSearchParams({ "location[directory]": fixture.secondWorkspaceRoot,
+          "location[project]": "foreign", location: "foreign", limit: "50" });
+        query.append("location[directory]", "another-directory");
+        const response = await fixture.request(`/api/session/ses_1${suffix}?${query}`, {
+          headers: { ...auth(fixture.token), "x-opencode-directory": fixture.secondWorkspaceRoot },
+        });
+        expect(response.status).toBe(200);
+        const payload = await response.json();
+        expect(JSON.stringify(payload)).toContain(suffix ? "Stored history" : "Stored thread");
+      }
+      const reads = fixture.engine.requests.slice(before);
+      expect(reads.map((item) => item.pathname)).toEqual([
+        "/api/session/ses_1", "/api/session/ses_1",
+        "/api/session/ses_1", "/api/session/ses_1/message",
+        "/api/session/ses_1", "/api/session/ses_1/message/msg_1",
+      ]);
+      for (const read of reads) {
+        expect(read.method).toBe("GET");
+        expect(read.directory).toBe(fixture.workspaceRoot);
+        const query = new URLSearchParams(read.search);
+        expect([...query.keys()].filter((key) => key.startsWith("location"))).toEqual(["location[directory]"]);
+      }
+      expect(promptSettled).toBe(false);
+      gate.release();
+    }
+    expect((await prompt).status).toBe(200);
+    expect(fixture.provider.calls).toEqual([[fixture.workspaceRoot]]);
+    expect(fixture.mcp.calls).toEqual([["ws_1", fixture.workspaceRoot]]);
+    expect(fixture.engine.requests.slice(-5).map((item) => `${item.method} ${item.pathname}`)).toEqual([
+      "GET /api/session/ses_1", "GET /api/mcp", "GET /api/skill",
+      "PUT /api/session/ses_1/instructions/entries/openwork.context", "POST /api/session/ses_1/prompt",
+    ]);
+  });
+
+  for (const failingGate of ["provider", "mcp"]) {
+    test.serial(`v2 history survives failed ${failingGate} readiness without admitting other reads or mutations`, async () => {
+      const fixture = await startV2Proxy();
+      if (failingGate === "provider") { fixture.provider.fail(); fixture.mcp.release(); }
+      else { fixture.provider.release(); fixture.mcp.fail(); }
+      const guarded: Array<[string, string]> = [
+        ["GET", "/api/session"], ["GET", "/api/session/status"], ["GET", "/api/session/active"],
+        ["GET", "/api/session/ses_1/todo"], ["GET", "/api/session/ses_1/permission"],
+        ["GET", "/api/permission"], ["GET", "/api/form/request"], ["GET", "/api/provider"],
+        ["GET", "/api/session/ses_1/unknown"], ["GET", "/api/session/status/message"],
+        ["GET", "/api/session/ses_1/messages"], ["GET", "/api/session/ses_1/message/"],
+        ["GET", "/api/session/ses_1/message/msg_1/part/prt_1"],
+        ["GET", "/apix/session/ses_1/message"], ["GET", "/api/%73ession/ses_1/message"],
+        ["GET", "/api/session/%73es_1/message"], ["GET", "/api/session/ses_1/%6dessage"],
+        ["GET", "/api/session/ses_1/message/%6dsg_1"],
+        ["GET", "/api/session/ses_1%2Fprompt/message"], ["GET", "/api/session/ses_1%252Fprompt/message"],
+        ["GET", "/api/session/ses_1/message/msg_1%2F..%2Fprompt"],
+        ["GET", "/api/session/ses_1/message/%2e%2e/prompt"],
+        ["HEAD", "/api/session/ses_1/message"],
+        ["POST", "/api/session"], ["POST", "/api/session/ses_1/prompt"],
+        ["POST", "/api/session/ses_1/command"], ["POST", "/api/session/ses_1/generate"],
+        ["POST", "/api/session/ses_1/message"], ["PUT", "/api/session/ses_1/message/msg_1"],
+        ["PATCH", "/api/session/ses_1"], ["DELETE", "/api/session/ses_1/message/msg_1"],
+      ];
+      for (const [method, path] of guarded) {
+        const response = await fixture.request(path, { method });
+        expect({ method, path, status: response.status }).toEqual({ method, path, status: 503 });
+        if (method !== "HEAD") await expect(response.json()).resolves.toMatchObject({ code: "fixture_readiness_failed" });
+      }
+      expect(fixture.engine.requests).toEqual([]);
+      expect(fixture.provider.calls).toHaveLength(guarded.length);
+      expect(fixture.mcp.calls).toHaveLength(failingGate === "provider" ? 0 : guarded.length);
+      for (const suffix of ["", "/message", "/message/msg_1"]) {
+        const response = await fixture.request(`/api/session/ses_1${suffix}`);
+        expect(response.status).toBe(200);
+        expect(JSON.stringify(await response.json())).toContain(suffix ? "Stored history" : "Stored thread");
+      }
+      expect(fixture.provider.calls).toHaveLength(guarded.length);
+      expect(fixture.mcp.calls).toHaveLength(failingGate === "provider" ? 0 : guarded.length);
+    });
+  }
+
+  test.serial("v2 history preserves authentication, token revocation, policy and workspace ownership while readiness is held", async () => {
+    const fixture = await startV2Proxy();
+    for (const suffix of ["", "/message", "/message/msg_1"]) {
+      for (const headers of [{}, auth("invalid-token")]) {
+        expect((await fixture.request(`/api/session/ses_1${suffix}`, { headers })).status).toBe(401);
+      }
+    }
+    expect(fixture.engine.requests).toEqual([]);
+
+    const issued = await fetch(`${fixture.base}/tokens`, {
+      method: "POST", headers: { "x-openwork-host-token": fixture.config.hostToken }, body: JSON.stringify({ scope: "viewer" }),
+    });
+    expect(issued.status).toBe(201);
+    const viewer = await issued.json();
+    expect((await fixture.request("/api/session/ses_1/message", { headers: auth(viewer.token) })).status).toBe(200);
+    fixture.engine.requests.length = 0;
+    expect((await fixture.request("/api/session/ses_1/message", { method: "POST", headers: auth(viewer.token) })).status).toBe(403);
+    const revoked = await fetch(`${fixture.base}/tokens/${viewer.id}`, {
+      method: "DELETE", headers: { "x-openwork-host-token": fixture.config.hostToken },
+    });
+    expect(revoked.status).toBe(200);
+    for (const suffix of ["", "/message", "/message/msg_1"]) {
+      expect((await fixture.request(`/api/session/ses_1${suffix}`, { headers: auth(viewer.token) })).status).toBe(401);
+    }
+    expect(fixture.engine.requests).toEqual([]);
+
+    const deniedSessions: Array<[string, number]> = [["ses_foreign", 404], ["ses_missing", 404], ["ses_unavailable", 503], ["ses_unscoped", 404]];
+    for (const [sessionId, status] of deniedSessions) {
+      for (const suffix of ["", "/message", "/message/msg_1"]) {
+        const response = await fixture.request(`/api/session/${sessionId}${suffix}`);
+        expect(response.status).toBe(status);
+        expect(JSON.stringify(await response.json())).not.toContain("Stored history");
+      }
+    }
+    expect(fixture.engine.requests.every((item) => !item.pathname.includes("/message"))).toBe(true);
+    const owner = await fixture.request("/api/session/ses_foreign/message", {}, "ws_2");
+    expect(owner.status).toBe(200);
+    expect(JSON.stringify(await owner.json())).toContain("Stored history");
+    fixture.engine.requests.length = 0;
+
+    const policy = spyOn(managedDesktopPolicy(fixture.config), "assertRequest")
+      .mockRejectedValue(new ApiError(403, "organization_policy_denied", "Fixture policy denied"));
+    try {
+      for (const suffix of ["", "/message", "/message/msg_1"]) {
+        const response = await fixture.request(`/api/session/ses_1${suffix}`);
+        expect(response.status).toBe(403);
+        await expect(response.json()).resolves.toMatchObject({ code: "organization_policy_denied" });
+      }
+    } finally { policy.mockRestore(); }
+    expect(fixture.engine.requests).toEqual([]);
+    expect(fixture.provider.calls).toEqual([]);
+    expect(fixture.mcp.calls).toEqual([]);
+  });
+
   test("desktop-owned recovery survives a server restart and admits one continuation through the authenticated proxy", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const recovery = { active: false, turn: 0 };

--- a/apps/server/src/opencode-proxy.e2e.test.ts
+++ b/apps/server/src/opencode-proxy.e2e.test.ts
@@ -288,7 +288,9 @@ async function startV2Proxy() {
   const preview = spyOn(engineV2Preview, "createEngineV2Preview").mockReturnValue({
     start() {}, status, setEnabled: async () => status(), setChatRouting: async () => status(),
     connection: () => ({ url: `http://127.0.0.1:${engine.server.port}`, username: "opencode", password: "fixture" }),
-    ensureWorkspaceReady: provider.wait, syncWorkspaceMcp: mcp.wait, stop: async () => {},
+    ensureWorkspaceReady: provider.wait, syncWorkspaceMcp: mcp.wait,
+    syncCloudSkills: async () => ({ root: join(workspaceRoot, "cloud-skills"), state: { root: null, skills: [] } }),
+    stop: async () => {},
   });
   try {
     const openwork = await startOpenworkServer({ workspaceRoot, secondWorkspaceRoot, readOnly: false });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -889,10 +889,17 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           }
           proxyService = "opencode";
           proxyBaseUrl = connection.url;
-          await engineV2Preview.ensureWorkspaceReady(workspace.path);
-          // Reconcile through v2's runtime MCP API before the next call. The
-          // ordinary connection routes remain authoritative; v1 is untouched.
-          await engineV2Preview.syncWorkspaceMcp(workspace.id, workspace.path);
+          // Only exact native history reads may skip execution readiness. Keep
+          // IDs literal (no encoded separators or route-prefix matches), and
+          // still verify session ownership in proxyOpencodeV2Request below.
+          const isSessionHistoryRead = request.method === "GET"
+            && /^\/opencode2\/api\/session\/ses_[A-Za-z0-9_-]+(?:\/message(?:\/msg_[A-Za-z0-9_-]+)?)?$/.test(mount.restPath);
+          if (!isSessionHistoryRead) {
+            await engineV2Preview.ensureWorkspaceReady(workspace.path);
+            // Reconcile through v2's runtime MCP API before execution admission.
+            // The ordinary connection routes remain authoritative.
+            await engineV2Preview.syncWorkspaceMcp(workspace.id, workspace.path);
+          }
           const send = () => proxyOpencodeV2Request({
             config,
             request,

--- a/evals/specs/opencode-v2-provider-hot-inject.test.ts
+++ b/evals/specs/opencode-v2-provider-hot-inject.test.ts
@@ -1,9 +1,9 @@
 import { randomBytes } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { createServer, type IncomingMessage } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { eventually, test } from "@openwork/testkit";
+import { eventually, mcpMock, needs, test } from "@openwork/testkit";
 import { expect } from "vitest";
 
 import {
@@ -47,6 +47,207 @@ function sessionId(payload: unknown): string | undefined {
   if (!isRecord(payload) || !isRecord(payload.data)) return undefined;
   return typeof payload.data.id === "string" ? payload.data.id : undefined;
 }
+
+// Complements the real HTTP proxy + fake readiness cases in opencode-proxy.e2e:
+// this crosses the pinned native engine's storage boundary, not the proxy gate.
+test("V2-STORED-01: cold stored reads survive pending catalog and MCP readiness", { timeout: 60_000 }, async ({ evidence, place }) => {
+  needs({ placement: "local", env: ["OPENWORK_EVAL_OPENCODE2_BIN"] });
+  const binary = process.env.OPENWORK_EVAL_OPENCODE2_BIN;
+  if (!binary) throw new Error("A pre-cached native-v2 binary is required; this case never installs one");
+  expect((await stat(binary)).isFile()).toBe(true);
+  const rootDir = await mkdtemp(join(tmpdir(), "oc2-stored-reads-"));
+  const directory = join(rootDir, "workspace");
+  const foreignDirectory = join(rootDir, "foreign-workspace");
+  const home = join(rootDir, "home");
+  const env = {
+    HOME: home,
+    XDG_CACHE_HOME: join(home, "cache"),
+    XDG_CONFIG_HOME: join(home, "config"),
+    XDG_DATA_HOME: join(home, "data"),
+    XDG_STATE_HOME: join(home, "state"),
+    XDG_RUNTIME_DIR: join(home, "run"),
+    OPENCODE_CONFIG: join(rootDir, "fixture.json"),
+  };
+  await Promise.all([directory, foreignDirectory, ...Object.values(env).filter((path) => path !== env.OPENCODE_CONFIG)]
+    .map((path) => mkdir(path, { recursive: true })));
+  // The managed launcher allowlists OS variables and accepts only explicit
+  // OPENCODE_CONFIG/MODELS_URL; inherited OPENCODE_*, credentials and DB paths
+  // cannot enter this child. HOME, XDG paths, config and DB are fixture-owned.
+  const { handle: mcp } = await mcpMock({ allowUnauthenticatedMcp: true, isolatedProcessEnv: true, tools: [] }).boot(place);
+  const catalogPending = new Set<ServerResponse>();
+  const mcpPending = new Set<ServerResponse>();
+  const unexpected: string[] = [];
+  let providerRequests = 0;
+  let server: ManagedOpencodeV2Server | undefined;
+  const hold = (pending: Set<ServerResponse>, response: ServerResponse) => {
+    pending.add(response);
+    response.once("close", () => pending.delete(response));
+  };
+  // mcpMock owns the protocol; this loopback fault holds its initialize reply.
+  // Neither gate is released before the stored-read assertions finish.
+  const witness = createServer(async (request, response) => {
+    try {
+      if (request.url === "/seed/api.json") {
+        response.writeHead(200, { "content-type": "application/json" }).end("{}");
+        return;
+      }
+      if (request.url === "/cold/api.json") {
+        hold(catalogPending, response);
+        return;
+      }
+      if (request.url?.split("?")[0] === "/mcp") {
+        const body = request.method === "POST" ? await readRequestBody(request) : undefined;
+        const reply = await fetch(mcp.mcpUrl, {
+          method: request.method,
+          headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+          body: body === undefined ? undefined : JSON.stringify(body),
+          signal: AbortSignal.timeout(3_000),
+        });
+        const text = await reply.text();
+        if (isRecord(body) && body.method === "initialize" && reply.ok) {
+          hold(mcpPending, response);
+          return;
+        }
+        response.writeHead(reply.status, { "content-type": reply.headers.get("content-type") ?? "application/json" }).end(text);
+        return;
+      }
+      if (request.url?.startsWith("/provider/")) providerRequests += 1;
+      else unexpected.push(`${request.method} ${request.url}`);
+      response.writeHead(503).end();
+    } catch {
+      unexpected.push("witness forwarding failed");
+      response.writeHead(500).end();
+    }
+  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      witness.once("error", reject);
+      witness.listen(0, "127.0.0.1", resolve);
+    });
+    const address = witness.address();
+    if (address === null || typeof address === "string") throw new Error("Stored-read witness did not bind");
+    const witnessUrl = `http://127.0.0.1:${address.port}`;
+    const model = { providerID: "stored-read-witness", id: "stored-model" };
+    const config = {
+      providers: {
+        [model.providerID]: {
+          package: "@opencode-ai/ai/providers/openai-compatible",
+          settings: { baseURL: `${witnessUrl}/provider/v1`, apiKey: "fixture-only" },
+          models: { [model.id]: { name: "Stored model", limit: { context: 4096, output: 512 } } },
+        },
+      },
+    };
+    await writeFile(env.OPENCODE_CONFIG, JSON.stringify(config));
+    server = await createManagedOpencodeV2Server({
+      bin: binary, rootDir, bootTimeoutMs: 10_000,
+      env: { ...env, OPENCODE_MODELS_URL: `${witnessUrl}/seed` },
+    });
+    const firstHealth = await server.health();
+    expect(firstHealth.version).toBe("0.0.0-beta-19086");
+    const time = 1_700_000_000_000;
+    const transcript = (id: string, workspace: string, marker: string) => ({
+      location: { directory: workspace },
+      info: {
+        id, projectID: "global", title: marker, location: { directory: workspace },
+        agent: "build", model, cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        time: { created: time, updated: time + 2, idle: time + 2 }, outcome: "succeeded",
+        metadata: { fixture: marker },
+      },
+      messages: [
+        { id: `msg_${marker}_user`, type: "user", text: `Stored question ${marker}`, time: { created: time } },
+        { id: `msg_${marker}_answer`, type: "assistant", agent: "build", model,
+          content: [{ type: "text", text: `Stored answer ${marker}` }], finish: "stop",
+          time: { created: time + 1, completed: time + 2 } },
+      ],
+    });
+    const owned = transcript("ses_stored_owner", directory, "owner");
+    const foreign = transcript("ses_stored_foreign", foreignDirectory, "foreign");
+    const imported = [];
+    for (const body of [owned, foreign]) {
+      const result = await server.fetchJson("/api/session/import", { method: "POST", body, timeoutMs: 3_000 });
+      expect(result.status, JSON.stringify(result.json)).toBe(200);
+      expect(result.json).toMatchObject({ data: { id: body.info.id, location: body.location, metadata: body.info.metadata } });
+      imported.push(result.json);
+    }
+    await server.close();
+    expect(server.exitCode).not.toBeNull();
+    const database = await stat(join(rootDir, "opencode.db"));
+    expect(database.size).toBeGreaterThan(0);
+    await writeFile(env.OPENCODE_CONFIG, JSON.stringify({ ...config, mcp: { servers: {
+      "pending-witness": { type: "remote", url: `${witnessUrl}/mcp`, oauth: false, timeout: { startup: 30_000 } },
+    } } }));
+    // Same DB, new process and catalog source key: no prior location runtime or
+    // catalog cache can satisfy this cold startup. The launcher waits on health only.
+    server = await createManagedOpencodeV2Server({
+      bin: binary, rootDir, bootTimeoutMs: 10_000,
+      env: { ...env, OPENCODE_MODELS_URL: `${witnessUrl}/cold` },
+    });
+    const health = await server.health();
+    expect(health.version).toBe("0.0.0-beta-19086");
+    expect(health.pid).toBe(server.childPid);
+    expect(health.pid).not.toBe(firstHealth.pid);
+    expect((await stat(join(rootDir, "opencode.db"))).ino).toBe(database.ino);
+    // Start location-dependent readiness, never a prompt. Observe the actual
+    // native requests reaching the held witnesses rather than relying on sleep.
+    const catalogSnapshot = await server.fetchJson("/api/model", { directory, timeoutMs: 15_000 });
+    expect(catalogSnapshot.status).toBe(200);
+    await eventually(() => ({ catalog: catalogPending.size, mcp: mcpPending.size, unexpected }), {
+      within: 5_000, intervalMs: 20, label: "native catalog and MCP initialization at local gates",
+      until: (state) => state.catalog > 0 && state.mcp > 0,
+    });
+    const assertPending = async () => {
+      const nativeMcp = await server!.fetchJson("/api/mcp", { directory, timeoutMs: 1_000 });
+      expect(nativeMcp.status).toBe(200);
+      expect(nativeMcp.json).toMatchObject({ data: [{ name: "pending-witness", status: { status: "pending" } }] });
+      expect(catalogPending.size).toBeGreaterThan(0);
+      expect(mcpPending.size).toBeGreaterThan(0);
+      expect(providerRequests).toBe(0);
+      expect(unexpected).toEqual([]);
+    };
+    await assertPending();
+    const timings: Record<string, number> = {};
+    const read = async (label: string, path: string) => {
+      await assertPending();
+      const start = Date.now();
+      const result = await server!.fetchJson(path, { directory, timeoutMs: 1_000 });
+      timings[label] = Date.now() - start;
+      await assertPending();
+      return result;
+    };
+    const metadata = await read("metadata", `/api/session/${owned.info.id}`);
+    expect(metadata.status).toBe(200);
+    expect(metadata.json).toEqual(imported[0]);
+    // Small settled transcript only: this does not prove the adapter paginates >50.
+    const messages = await read("messages", `/api/session/${owned.info.id}/message?order=asc&limit=10`);
+    expect(messages.status).toBe(200);
+    expect(messages.json).toMatchObject({ data: owned.messages });
+    if (!isRecord(messages.json) || !Array.isArray(messages.json.data)) throw new Error("Missing native message list");
+    expect(messages.json.data).toHaveLength(2);
+    const single = await read("single", `/api/session/${owned.info.id}/message/${owned.messages[1].id}`);
+    expect(single.status).toBe(200);
+    expect(single.json).toEqual({ data: owned.messages[1] });
+    const foreignExists = await read("foreign-owner", `/api/session/${foreign.info.id}/message/${foreign.messages[1].id}`);
+    expect(foreignExists.status).toBe(200);
+    expect(foreignExists.json).toEqual({ data: foreign.messages[1] });
+    const refused = await read("foreign-refused", `/api/session/${owned.info.id}/message/${foreign.messages[1].id}`);
+    expect(refused.status).toBe(404);
+    expect(JSON.stringify(refused.json)).not.toContain("Stored answer foreign");
+    expect(server.exitCode).toBeNull();
+    evidence.recordAssertionEvidence(
+      "V2-STORED-01 native cold storage reads before location readiness",
+      `Native version ${health.version}; seed PID ${firstHealth.pid}, cold PID ${health.pid}, child PID ${server.childPid}; placement ${place.kind}. Cold-restarted the same isolated DB after HTTP import. Exact metadata, two settled messages and single-message reads completed within 1s each while catalog/MCP replies remained held and the native MCP status remained pending; /api/model returned its nonblocking snapshot. A foreign message existed under its owner but returned 404 under the other session. Provider requests: 0. Read timings (ms): ${JSON.stringify(timings)}. Direct native boundary only; proxy gate and >50 adapter pagination are not exercised.`,
+      true,
+    );
+  } finally {
+    await server?.close();
+    for (const response of [...catalogPending, ...mcpPending]) response.destroy();
+    witness.closeAllConnections();
+    await new Promise<void>((resolve) => witness.close(() => resolve()));
+    await mcp.stop();
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
 
 test("opencode v2 injects providers at runtime without an engine reload", { timeout: 240_000 }, async ({ evidence }) => {
   const binary = await resolveOpencodeV2Bin();

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -8,7 +8,7 @@ import {
   longHistoryTitle,
 } from "../worlds/chat.ts";
 
-const test = spec.world(longHistory, { timeout: 600_000 });
+const test = spec.world((seed) => longHistory(seed, { holdAncillaryReads: true }), { timeout: 600_000 });
 
 /** The page size the transcript read used to request; OpenCode returns the newest n. */
 const oldPageSize = 140;
@@ -32,15 +32,76 @@ function renderedCount(value: unknown): number {
   return value.messageCount;
 }
 
-test("opening a long conversation shows the latest first and preserves access to its entire history", async ({ user, agent, probe, step, world }) => {
+function ancillaryReads(value: unknown) {
+  if (!Array.isArray(value)) throw new Error("Ancillary request identities are missing");
+  return value.map((read) => {
+    if (!isRecord(read) || typeof read.id !== "number" || typeof read.startedAt !== "number"
+      || (read.kind !== "status" && read.kind !== "todo")
+      || (read.openedAt !== null && typeof read.openedAt !== "number")
+      || (read.settledAt !== null && typeof read.settledAt !== "number")
+      || typeof read.sameTurnAbort !== "boolean") throw new Error(`Invalid ancillary request: ${JSON.stringify(read)}`);
+    return {
+      id: read.id, kind: read.kind, openedAt: read.openedAt, startedAt: read.startedAt,
+      settledAt: read.settledAt, outcome: read.outcome, abortName: read.abortName, sameTurnAbort: read.sameTurnAbort,
+    };
+  });
+}
+
+function ancillaryFault(value: unknown) {
+  if (!isRecord(value) || !isRecord(value.status) || !isRecord(value.todo) || !isRecord(value.history)
+    || !isRecord(value.opening) || (value.opening.openedAt !== null && typeof value.opening.openedAt !== "number")) {
+    throw new Error(`Long history ancillary fault did not publish its witness: ${JSON.stringify(value)}`);
+  }
+  return {
+    workspaceId: value.workspaceId, sessionId: value.sessionId, documentId: value.documentId,
+    released: value.released, expired: value.expired,
+    status: value.status, todo: value.todo, history: value.history, reads: ancillaryReads(value.reads),
+    opening: {
+      openedAt: value.opening.openedAt, trusted: value.opening.trusted,
+      first: value.opening.first, latest: value.opening.latest, full: value.opening.full,
+    },
+  };
+}
+
+function openingPaint(value: unknown, openedAt: number | null, deadlineMs: number) {
+  if (!isRecord(value) || typeof value.at !== "number" || typeof value.elapsedMs !== "number" || openedAt === null) {
+    throw new Error(`The trusted opening did not produce a frame witness: ${JSON.stringify(value)}`);
+  }
+  expect(value.elapsedMs, JSON.stringify(value)).toBeLessThan(deadlineMs);
+  expect(value.elapsedMs).toBeGreaterThanOrEqual(0);
+  expect(value.at - openedAt).toBe(value.elapsedMs);
+  expect(value).toMatchObject({ latestVisible: true, released: false, expired: false });
+  const reads = ancillaryReads(value.reads).filter((read) => read.openedAt === openedAt);
+  for (const read of reads) {
+    expect(read.startedAt).toBeGreaterThanOrEqual(openedAt);
+    expect(read.startedAt).toBeLessThanOrEqual(value.at);
+    if (read.sameTurnAbort) {
+      expect(read).toMatchObject({ outcome: "aborted", abortName: "AbortError" });
+      if (read.settledAt === null) throw new Error("A mount cancellation has no settlement timestamp");
+      expect(read.settledAt - read.startedAt).toBeLessThan(50);
+    } else {
+      expect(read, JSON.stringify(value)).toMatchObject({ outcome: "pending", settledAt: null });
+    }
+  }
+  const originals = ["status", "todo"].map((kind) => {
+    const original = reads.find((read) => read.kind === kind && !read.sameTurnAbort);
+    if (!original) throw new Error(`No original post-click ${kind} read was pending at the frame: ${JSON.stringify(value)}`);
+    return original;
+  });
+  return { ...value, at: value.at, elapsedMs: value.elapsedMs, originals };
+}
+
+test("opening a long conversation shows the latest and full history while ancillary reads remain pending", async ({ user, agent, probe, step, world, evidence }) => {
   const messagesPath = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/opencode/session/${encodeURIComponent(world.session.sessionId)}/message`;
   const surface = `[data-session-surface-id="${world.session.sessionId}"]`;
+  const sidebarTarget = { testId: `sidebar-session-${world.session.sessionId}` };
   const latestVisible = async () => {
     const { elements } = await probe.dom(`${surface} [data-thread-scroll], ${surface} [data-message-id]`);
     const viewport = elements[0];
     const latest = elements.slice(1).find((element) => element.text.includes(longHistoryLast));
     return Boolean(viewport && latest && latest.rect.height > 0 && latest.rect.bottom > viewport.rect.top && latest.rect.top < viewport.rect.bottom);
   };
+  const readFault = () => probe.storage(world.ancillaryFaultKey, ancillaryFault);
 
   await step("the engine stores more messages than one newest-first page holds", async () => {
     const stored = await probe.desktopApi(messagesPath);
@@ -58,20 +119,45 @@ test("opening a long conversation shows the latest first and preserves access to
     expect(pageTexts).toHaveLength(oldPageSize);
     expect(pageTexts).not.toContain(longHistoryFirst);
     expect(pageTexts.at(-1)).toBe(longHistoryLast);
+    evidence.recordAssertionEvidence(
+      "Stored history is read through the real native desktop",
+      JSON.stringify({ kind: world.app.handle.kind, host: world.app.handle.hostKind, pid: world.app.handle.pid,
+        profileDir: world.app.handle.profileDir, profileOwner: world.app.handle.meta?.profileOwner, workspaceRoot: world.app.workspaceRoot,
+        storedMessages: texts.length, pageMessages: pageTexts.length }),
+      true,
+    );
   });
 
   await step("a cold start lands on the other session with no transcript cached for the long one", async () => {
     await user.reload();
-    await user.see({ role: "button", label: new RegExp(`^${longHistoryTitle}`) }, { timeoutMs: 60_000 });
+    await user.see({ ...sidebarTarget, role: "button", label: new RegExp(`^${longHistoryTitle}`) }, { timeoutMs: 60_000 });
     await user.notSee({ text: longHistoryLast });
     await user.notSee({ text: longHistoryFirst });
+    expect((await probe.dom(`[data-session-surface-id="${world.other.sessionId}"]`)).elements).toHaveLength(1);
+    const fault = await readFault();
+    expect(fault).toMatchObject({
+      released: false, expired: false, opening: { openedAt: null, trusted: false, first: null, latest: null, full: null },
+      todo: { attempts: 0 }, history: { limited: 0, full: 0, fullSucceeded: 0 },
+    });
+    expect(fault.reads.every((read) => read.openedAt === null)).toBe(true);
   });
 
-  await step("clicking the long conversation renders every stored message", async () => {
-    await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });
-    // Read-only geometry: `user.see` may scroll a target into view and would
-    // conceal a regression where opening incorrectly lands at the first row.
-    await probe.eventually(latestVisible, { within: 60_000, label: "latest message visible without scrolling", until: Boolean });
+  await step("clicking the long conversation renders latest and full history before ancillary reads settle", async () => {
+    await user.click(sidebarTarget);
+    await probe.eventually(readFault, {
+      within: 2_000, label: "trusted click reaches the exact sidebar session",
+      until: (fault) => fault.opening.trusted === true,
+    });
+    const visible = await probe.eventually(readFault, {
+      within: 15_000, label: "first transcript frame and latest message after the trusted click",
+      until: (fault) => isRecord(fault.opening.first) && isRecord(fault.opening.latest),
+    });
+    expect(visible.opening.trusted).toBe(true);
+    const first = openingPaint(visible.opening.first, visible.opening.openedAt, 2_000);
+    const latest = openingPaint(visible.opening.latest, visible.opening.openedAt, 2_000);
+    const originalIds = first.originals.map((read) => read.id);
+    expect(latest.originals.map((read) => read.id)).toEqual(originalIds);
+    expect(await latestVisible()).toBe(true);
     const rendered = await probe.eventually(async () => renderedCount(await agent.run("session.read_transcript", { count: 1 })), {
       within: 60_000,
       label: "rendered transcript length",
@@ -84,6 +170,28 @@ test("opening a long conversation shows the latest first and preserves access to
       return (await probe.dom(`${surface} [data-thread-history-complete="true"]`)).elements.length;
     }, { within: 30_000, label: "background history mounting preserves the latest viewport", until: (count) => count === 1 });
     expect((await probe.dom(`${surface} [data-thread-loading]`)).elements).toHaveLength(0);
+    expect((await probe.dom(`${surface} [data-message-id]`)).elements).toHaveLength(longHistoryCount);
+    const fault = await probe.eventually(readFault, {
+      within: 15_000, label: "full history frame recorded without replacing the original held reads",
+      until: (value) => isRecord(value.opening.full),
+    });
+    expect(fault).toMatchObject({ workspaceId: world.workspace.workspaceId, sessionId: world.session.sessionId, released: false, expired: false });
+    const full = openingPaint(fault.opening.full, fault.opening.openedAt, 5_000);
+    expect(full).toMatchObject({ messageCount: longHistoryCount, historyComplete: true });
+    expect(full.originals.map((read) => read.id)).toEqual(originalIds);
+    for (const original of full.originals) {
+      const current = fault.reads.find((read) => read.id === original.id);
+      expect(current?.startedAt).toBe(original.startedAt);
+      if (current?.settledAt !== null) expect(current?.settledAt).toBeGreaterThan(full.at);
+    }
+    expect(fault.history.full).toBeGreaterThan(0);
+    expect(fault.history.fullSucceeded).toBeGreaterThan(0);
+    expect((await probe.dom(`${surface} [data-testid="session-error-card"]`)).elements).toHaveLength(0);
+    evidence.recordAssertionEvidence(
+      "The cold transcript appears before the original post-click ancillary reads settle, not after a timeout and retry",
+      JSON.stringify({ documentId: fault.documentId, opening: fault.opening, reads: fault.reads, history: fault.history, originalIds }),
+      true,
+    );
   });
 
   await step("the first message is reachable at the top of the transcript", async () => {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -18,6 +18,7 @@ declare global {
   interface Window {
     __modelEffortRequests?: unknown[];
     __openworkSubmissionFault?: { attempts: number; release: () => void };
+    __openworkLongHistoryFault?: { dispose: () => void };
     __openworkStoppingFault?: {
       state: {
         attempts: number;
@@ -1847,10 +1848,27 @@ export const longHistoryFirst = "LONG-HISTORY-FIRST-MESSAGE 7c31";
 export const longHistoryLast = "LONG-HISTORY-LAST-MESSAGE 7c31";
 
 /** A long stored conversation opened cold, from another selected session. */
-export async function longHistory(seed: Seed) {
+export async function longHistory(seed: Seed, options: { holdAncillaryReads?: boolean } = {}) {
+  if (resolveEvalEngine() !== "v1") throw new SkipError("native v1 stored history (OPENWORK_EVAL_ENGINE=v1)");
   const app = await seed.desktop({ name: "session-full-history" });
   const workspace = await seed.workspace(app, seed.tmpPath("session-full-history"));
-  const session = await seedSessionRetry(seed, app, { title: longHistoryTitle });
+  const createStoredSession = (title: string) => seed.evalIn(app, browserScript(async (workspaceId, title) => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) throw new Error("Long history arrangement requires the owned local server");
+    const response = await fetch(`http://127.0.0.1:${port}/workspace/${encodeURIComponent(workspaceId)}/opencode/session`, {
+      method: "POST", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ title }), signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) throw new Error(`Long history session creation failed: ${response.status}`);
+    const body: unknown = await response.json();
+    if (!body || typeof body !== "object" || !("id" in body) || typeof body.id !== "string"
+      || !("title" in body) || body.title !== title) throw new Error("Native session did not preserve its seeded title");
+    return { sessionId: body.id, title };
+  }, [workspace.workspaceId, title]), { timeoutMs: 20_000 });
+  const session = options.holdAncillaryReads
+    ? await createStoredSession(longHistoryTitle)
+    : await seedSessionRetry(seed, app, { title: longHistoryTitle });
   // TODO(primitive): store many engine messages without a model turn.
   const seeded = await seed.evalIn(app, browserScript(async (workspaceId, sessionId, count, first, last) => {
     const port = localStorage.getItem("openwork.server.port");
@@ -1875,8 +1893,195 @@ export async function longHistory(seed: Seed) {
     return Array.isArray(storedMessages) ? storedMessages.length : "stored:not-an-array";
   }, [workspace.workspaceId, session.sessionId, longHistoryCount, longHistoryFirst, longHistoryLast]), { awaitPromise: true, timeoutMs: 180_000 });
   if (seeded !== longHistoryCount) throw new Error(`Long history was not stored: ${String(seeded)}`);
-  const other = await seedSessionRetry(seed, app, { title: longHistoryOtherTitle });
-  return { app, workspace, session, other };
+  const other = options.holdAncillaryReads
+    ? await createStoredSession(longHistoryOtherTitle)
+    : await seedSessionRetry(seed, app, { title: longHistoryOtherTitle });
+  if (options.holdAncillaryReads) {
+    await seed.evalIn(app, browserScript((workspaceId, sessionId) => {
+      location.hash = `/workspace/${encodeURIComponent(workspaceId)}/session/${encodeURIComponent(sessionId)}`;
+    }, [workspace.workspaceId, other.sessionId]));
+  }
+  const ancillaryFaultKey = `openwork.eval.long-history-ancillary.${session.sessionId}`;
+  const ancillaryFault = options.holdAncillaryReads
+    ? await addInitScript(app.client, browserScript((workspaceId, sessionId, storageKey, count, last) => {
+      if (window.top !== window) return;
+      const port = localStorage.getItem("openwork.server.port");
+      if (!port || !/^\d+$/.test(port)) throw new Error("Long history fault requires the owned local server port");
+      const serverOrigin = `http://127.0.0.1:${port}`;
+      const paths = ["workspace", "w"].map((mount) => `/${mount}/${encodeURIComponent(workspaceId)}/opencode/session`);
+      const statusPaths = new Set(paths.map((path) => `${path}/status`));
+      const todoPaths = new Set(paths.map((path) => `${path}/${encodeURIComponent(sessionId)}/todo`));
+      const messagePaths = new Set(paths.map((path) => `${path}/${encodeURIComponent(sessionId)}/message`));
+      const originalFetch = window.fetch;
+      type Read = {
+        id: number;
+        kind: "status" | "todo";
+        openedAt: number | null;
+        startedAt: number;
+        settledAt: number | null;
+        outcome: "pending" | "aborted" | "failed";
+        abortName: string | null;
+        sameTurnAbort: boolean;
+      };
+      type Paint = {
+        at: number;
+        elapsedMs: number;
+        messageCount: number;
+        latestVisible: boolean;
+        historyComplete: boolean;
+        reads: Read[];
+        released: boolean;
+        expired: boolean;
+      };
+      const reads: Read[] = [];
+      const opening: { openedAt: number | null; trusted: boolean; first: Paint | null; latest: Paint | null; full: Paint | null } = {
+        openedAt: null, trusted: false, first: null, latest: null, full: null,
+      };
+      const state = {
+        workspaceId, sessionId, documentId: performance.timeOrigin, opening, reads,
+        status: { attempts: 0, pending: 0, aborted: 0, failed: 0 },
+        todo: { attempts: 0, pending: 0, aborted: 0, failed: 0 },
+        history: { limited: 0, full: 0, fullSucceeded: 0 },
+        released: false,
+        expired: false,
+      };
+      const publish = () => localStorage.setItem(storageKey, JSON.stringify(state));
+      let frame = 0;
+      const sample = () => {
+        if (opening.openedAt === null || state.released) return;
+        const root = document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`);
+        const viewport = root?.querySelector<HTMLElement>("[data-thread-scroll]")?.getBoundingClientRect();
+        if (root && viewport && document.visibilityState === "visible") {
+          const messages = [...root.querySelectorAll<HTMLElement>("[data-message-id]")];
+          const visible = (element: HTMLElement) => {
+            const rect = element.getBoundingClientRect();
+            const style = getComputedStyle(element);
+            return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none"
+              && rect.bottom > Math.max(0, viewport.top) && rect.top < Math.min(innerHeight, viewport.bottom)
+              && rect.right > Math.max(0, viewport.left) && rect.left < Math.min(innerWidth, viewport.right);
+          };
+          const latest = messages.find((message) => message.textContent?.includes(last));
+          const at = performance.now();
+          const paint: Paint = {
+            at, elapsedMs: at - opening.openedAt, messageCount: messages.length,
+            latestVisible: Boolean(latest && visible(latest)),
+            historyComplete: Boolean(root.querySelector('[data-thread-history-complete="true"]')),
+            reads: reads.map((read) => ({ ...read })), released: state.released, expired: state.expired,
+          };
+          let changed = false;
+          if (!opening.first && messages.some(visible)) { opening.first = paint; changed = true; }
+          if (!opening.latest && paint.latestVisible) { opening.latest = paint; changed = true; }
+          if (!opening.full && paint.messageCount === count && paint.historyComplete && messages.some(visible)) {
+            opening.full = paint;
+            changed = true;
+          }
+          if (changed) publish();
+        }
+        if (!opening.first || !opening.latest || !opening.full) frame = requestAnimationFrame(sample);
+      };
+      const captureOpen = (event: MouseEvent) => {
+        if (opening.openedAt !== null || !event.isTrusted) return;
+        const button = event.composedPath().find((node): node is HTMLElement => node instanceof HTMLElement
+          && node.getAttribute("data-testid") === `sidebar-session-${sessionId}`);
+        if (!button || button.closest("[data-sidebar-session-workspace-id]")?.getAttribute("data-sidebar-session-workspace-id") !== workspaceId) return;
+        opening.openedAt = performance.now();
+        opening.trusted = true;
+        publish();
+        frame = requestAnimationFrame(sample);
+      };
+      window.addEventListener("click", captureOpen, true);
+      const pending = new Set<() => void>();
+      const wrappedFetch: typeof window.fetch = async (input, init) => {
+        const url = new URL(input instanceof Request ? input.url : String(input), location.href);
+        const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+        if (method !== "GET" || url.origin !== serverOrigin) return originalFetch.call(window, input, init);
+        const kind = statusPaths.has(url.pathname) ? "status" : todoPaths.has(url.pathname) ? "todo" : null;
+        if (!kind) {
+          const historyRead = messagePaths.has(url.pathname);
+          const full = historyRead && !url.searchParams.has("limit");
+          if (historyRead) {
+            if (full) state.history.full += 1;
+            else state.history.limited += 1;
+            publish();
+          }
+          const response = await originalFetch.call(window, input, init);
+          if (full && response.ok) { state.history.fullSucceeded += 1; publish(); }
+          return response;
+        }
+        const counter = state[kind];
+        const read: Read = {
+          id: reads.length + 1, kind, openedAt: opening.openedAt, startedAt: performance.now(),
+          settledAt: null, outcome: "pending", abortName: null, sameTurnAbort: false,
+        };
+        reads.push(read);
+        counter.attempts += 1;
+        const unavailable = () => new Response(JSON.stringify({ message: "Long history ancillary read unavailable" }), {
+          status: 503, headers: { "content-type": "application/json" },
+        });
+        if (state.released) {
+          read.outcome = "failed";
+          read.settledAt = performance.now();
+          counter.failed += 1;
+          publish();
+          return unavailable();
+        }
+        counter.pending += 1;
+        publish();
+        return new Promise<Response>((resolve, reject) => {
+          const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+          let sameTurn = true;
+          queueMicrotask(() => { sameTurn = false; });
+          const settle = (aborted: boolean) => {
+            if (read.settledAt !== null) return;
+            read.settledAt = performance.now();
+            read.outcome = aborted ? "aborted" : "failed";
+            read.abortName = aborted && signal?.reason instanceof Error ? signal.reason.name : null;
+            read.sameTurnAbort = aborted && sameTurn && read.abortName === "AbortError"
+              && read.settledAt - read.startedAt < 50 && opening.first === null;
+            signal?.removeEventListener("abort", onAbort);
+            pending.delete(fail);
+            counter.pending -= 1;
+            if (aborted) counter.aborted += 1;
+            else counter.failed += 1;
+            publish();
+            if (aborted) reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+            else resolve(unavailable());
+          };
+          const onAbort = () => settle(true);
+          const fail = () => settle(false);
+          pending.add(fail);
+          signal?.addEventListener("abort", onAbort, { once: true });
+          if (signal?.aborted) onAbort();
+        });
+      };
+      const release = () => {
+        state.released = true;
+        cancelAnimationFrame(frame);
+        for (const fail of pending) fail();
+        publish();
+      };
+      const expiry = window.setTimeout(() => { state.expired = true; release(); }, 180_000);
+      const dispose = () => {
+        window.clearTimeout(expiry);
+        release();
+        if (window.fetch === wrappedFetch) window.fetch = originalFetch;
+        window.removeEventListener("pagehide", dispose);
+        window.removeEventListener("click", captureOpen, true);
+      };
+      window.__openworkLongHistoryFault = { dispose };
+      window.addEventListener("pagehide", dispose, { once: true });
+      window.fetch = wrappedFetch;
+      publish();
+    }, [workspace.workspaceId, session.sessionId, ancillaryFaultKey, longHistoryCount, longHistoryLast]))
+    : null;
+  return {
+    app, workspace, session, other, ancillaryFaultKey,
+    async [Symbol.asyncDispose]() {
+      if (!ancillaryFault) return;
+      try { await evalIn(app, () => window.__openworkLongHistoryFault?.dispose(), { timeoutMs: 5_000, reattachAttempts: 0 }); }
+      finally { await ancillaryFault.dispose(); }
+    },
+  };
 }
 
 export async function taskActivity(seed: Seed) {


### PR DESCRIPTION
## Summary

Opening a conversation should not wait for live status, todos, or connector startup before stored messages become readable.

- Read verified metadata and messages independently for the opening preview and subsequent history read. Partial previews never establish complete history or observed idle.
- Hydrate status and todos separately with bounded retries, cancellation, and terminal/reconnect reconciliation. Preserve newer live events, current-turn activity, and explicit send-completion checks.
- Let only exact native-v2 history GET routes bypass provider/MCP readiness. Authentication, managed policy, workspace/session ownership, and execution admission remain enforced.
- Reuse frozen group-height plans during background mounting instead of repeating height-map calculations for each batch. Keep the existing mounting order, geometry, and full-history behavior.

## UI/UX impact

The intended change is earlier availability of readable history; status and todos can arrive independently. No changes to layout, controls, icons, labels, grouping, Find behavior, or intended scroll behavior. Existing live status/todo displays are preserved. Native desktop interaction proof remains incomplete.

## Verification

**Verdict: Incomplete.** This is not a measured desktop speedup or a merge-readiness sign-off. Exact-head desktop E2E evidence is missing. The last desktop attempt on the earlier candidate failed during native preparation, as detailed below.

Head: `c532d73635a38f8bf8c883934833570080833f6b`
Base: `12637c34f4af7cbde9286b8f53cea570190d5be7`
Both included commits are signed and carry the configured author sign-off.

### Passed on the reconciled candidate

- App and server no-emit typechecks; `pnpm evals:typecheck` checked 424 eval sources without errors; diff whitespace checks passed.
- App focused checks, run separately with `bun test --no-install ./tests/<file>` from `apps/app`: `session-history` 25, `session-sync-run-status` 64, `session-sync-permissions` 62, and `session-attention-rollup` 6. **157 passed, 0 failed, 0 skipped.**
- From `apps/server`: `bun --conditions=development test src/opencode-proxy.e2e.test.ts` — **16 passed, 0 failed**, 315 assertions. The real HTTP proxy uses controlled readiness and engine witnesses, including negative authorization and ownership cases.
- On the committed head: `OPENWORK_EVAL_ENGINE=v2 OPENWORK_EVAL_OPENCODE2_BIN=<cached-beta-19086-binary> pnpm evals:pr specs/opencode-v2-provider-hot-inject.test.ts -t V2-STORED-01` — **1 selected test passed**, exit 0. The other case was filtered out, not executed. Actual native v2 cold-restarted an isolated database and served stored metadata/messages while catalog and MCP initialization replies remained pending, with zero model requests. This proves the direct native storage boundary, not the desktop transport or changed proxy end-to-end.

### Earlier candidate checks

279 app tests and 16 proxy tests passed before the publication rebase, covering cancellation, live ordering, send completion, scroll restoration, and progressive mounting. These historical results are not exact-head desktop evidence. The rebase preserves the newer history-announcement and session-attention behavior; the proxy fixture was updated for the new native skill synchronization contract.

### Failed / missing desktop proof

`pnpm evals:e2e session-full-history-on-open --local --engine v1` last exited 1 during sidecar preparation: macOS codesigning reported `internal error in Code Signing subsystem`. Earlier click-target, teardown, and seeding fixture failures were corrected, but the complete journey has not passed. No signing bypass was used.

The journey now requires first/latest/full frame witnesses tied to the original pending ancillary request identities, so timeout-then-retry cannot masquerade as nonblocking loading. These assertions are not yet passing runtime evidence.

Remaining: rerun that desktop journey on this head, verify native scrolling/loading timings, and publish its evidence. Large mixed assistant groups and v2 history pagination beyond the existing page boundary are not proven or redesigned here. Component runs emitted duplicate-key/storage warnings; no clean-control or unrelated repair claim is made. Required CI remains unchanged.
