### PR TITLE
fix(chat): refresh latest messages first when switching threads

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -980,14 +980,13 @@ export function SessionPage(props: SessionPageProps) {
     }, 5000);
     return () => window.clearTimeout(id);
   }, [pendingConversationHistoryNavigation]);
-  useEffect(() => {
+  const workbenchInventory = useMemo(() => {
     const workspaceGroup = props.sidebar.workspaceSessionGroups.find(
       (group) => group.workspace.id === props.selectedWorkspaceId,
     );
-    syncWorkbench({
+    return {
       workspaceId: props.selectedWorkspaceId,
       workspaceTitle: workspaceName,
-      primarySessionId: props.selectedSessionId,
       sessionsKnown: workspaceGroup?.status === "ready",
       archivedSessionIds: (workspaceGroup?.sessions ?? []).filter((session) => session.time?.archived).map((session) => session.id),
       sessions: (workspaceGroup?.sessions ?? []).map((session) => ({
@@ -996,14 +995,11 @@ export function SessionPage(props: SessionPageProps) {
         title: getDisplaySessionTitle(session.title),
         workspaceTitle: workspaceName,
       })),
-    });
-  }, [
-    props.selectedSessionId,
-    props.selectedWorkspaceId,
-    props.sidebar.workspaceSessionGroups,
-    syncWorkbench,
-    workspaceName,
-  ]);
+    };
+  }, [props.selectedWorkspaceId, props.sidebar.workspaceSessionGroups, workspaceName]);
+  useEffect(() => {
+    syncWorkbench({ ...workbenchInventory, primarySessionId: props.selectedSessionId });
+  }, [props.selectedSessionId, syncWorkbench, workbenchInventory]);
   useEffect(() => {
     props.onSessionTabsChange?.(sessionTabs);
   }, [sessionTabs, props.onSessionTabsChange]);

--- a/apps/app/src/react-app/domains/session/chat/workbench-store.ts
+++ b/apps/app/src/react-app/domains/session/chat/workbench-store.ts
@@ -98,7 +98,11 @@ export function syncWorkbenchSnapshot(
   input: SyncWorkbenchInput,
 ): WorkbenchSnapshot {
   const workspaceTitle = input.workspaceTitle?.trim() || input.workspaceId;
-  const available = input.sessions.map((session) => ({ ...session, workspaceTitle }));
+  const available = new Map<string, WorkbenchSessionTab>();
+  for (const session of input.sessions) {
+    const key = workbenchSessionKey(session);
+    if (!available.has(key)) available.set(key, { ...session, workspaceTitle });
+  }
   const archivedSessionIds = new Set(input.archivedSessionIds);
   // An index only covers one engine. Absence is not evidence of deletion:
   // retained tabs, like saved pairs, require an explicit close or archive.
@@ -110,14 +114,14 @@ export function syncWorkbenchSnapshot(
       || tab.sessionId === input.primarySessionId
     ))
     .map((tab) => {
-      const fresh = available.find((session) => isSameWorkbenchSession(session, tab));
+      const fresh = available.get(workbenchSessionKey(tab));
       return fresh ? { ...tab, ...fresh } : tab;
     });
 
   let primary: WorkbenchSessionTab | null = null;
   if (input.primarySessionId) {
     const ref = { workspaceId: input.workspaceId, sessionId: input.primarySessionId };
-    primary = findTab(available, ref) ?? findTab(tabs, ref) ?? { ...ref, workspaceTitle };
+    primary = available.get(workbenchSessionKey(ref)) ?? findTab(tabs, ref) ?? { ...ref, workspaceTitle };
     tabs = replaceOrAppendTab(tabs, primary);
   }
 

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1226,15 +1226,16 @@ function GlobalArchivedSessionItem({ group, session }: GlobalArchivedSessionEntr
 }
 
 function GlobalPinnedSessionTree({ group, sessionId }: GlobalPinnedSessionEntry) {
-  const pinnedIds = usePinnedSessionIds();
+  const pinnedIdList = useSessionManagementStore((state) => state.pinnedIds);
+  const pinnedIds = React.useMemo(() => new Set(pinnedIdList), [pinnedIdList]);
   const rootIds = React.useMemo(() => new Set([sessionId]), [sessionId]);
-  const rows = flattenSessionRows(
+  const rows = React.useMemo(() => flattenSessionRows(
     group.sessions,
     1,
     pinnedIds,
     [],
     { include: rootIds },
-  );
+  ), [group.sessions, pinnedIds, rootIds]);
 
   return rows.map((row) => (
     <SessionMenuItem
@@ -1404,7 +1405,8 @@ function WorkspaceSidebarGroup({
     return workspaceKindLabel(workspace);
   })();
 
-  const pinnedIds = usePinnedSessionIds();
+  const pinnedIdList = useSessionManagementStore((state) => state.pinnedIds);
+  const pinnedIds = React.useMemo(() => new Set(pinnedIdList), [pinnedIdList]);
   const orderIds = useSessionOrder(workspace.id);
   const { groups: wsGroups, assignments: wsAssignments } = useWorkspaceGroups(workspace.id);
   const store = useSessionManagementStore;
@@ -1413,13 +1415,13 @@ function WorkspaceSidebarGroup({
     () => partitionArchivedSessions(group.sessions),
     [group.sessions],
   );
-  const sessionRows = flattenSessionRows(
+  const sessionRows = React.useMemo(() => flattenSessionRows(
     group.sessions,
     wsGroups.length > 0 ? Number.MAX_SAFE_INTEGER : previewCount,
     EMPTY_PINNED_IDS,
     orderIds,
     { exclude: pinnedIds },
-  );
+  ), [group.sessions, orderIds, pinnedIds, previewCount, wsGroups.length]);
   const visibleRootIds = React.useMemo(
     () => sessionRows.map((row) => row.session.id),
     [sessionRows],

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -1,6 +1,9 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { CancelledError, queryOptions, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { LoaderCircle } from "lucide-react";
+import type { UIMessage } from "ai";
+import { applyHistorySourceChanges, mergeHistoryWindow, projectHistoryRead, reconcileHistoryRead, type LatestSessionHistory } from "./session-render-state";
+import { snapshotToUIMessages } from "../sync/usechat-adapter";
 import type { OpenworkSessionHistory } from "@/app/lib/openwork-server";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types";
 import { snapshotKey } from "../sync/session-sync";
@@ -49,6 +52,27 @@ type OpeningHistoryInput = {
 // prevent an in-flight speculative read surviving a credential change as a hit.
 const openingCredentials = new Map<string | null, number>();
 let nextOpeningCredential = 0;
+const hydratingTranscripts = new WeakSet<object>();
+const EMPTY_HISTORY: UIMessage[] = [];
+
+async function readLatestHistory<T>(read: (signal: AbortSignal) => Promise<T>, signal: AbortSignal) {
+  signal.throwIfAborted();
+  const deadline = new AbortController();
+  const readSignal = AbortSignal.any([signal, deadline.signal]);
+  let rejectAborted: (reason: unknown) => void = () => {};
+  const aborted = new Promise<never>((_resolve, reject) => { rejectAborted = reject; });
+  const onAbort = () => rejectAborted(readSignal.reason);
+  readSignal.addEventListener("abort", onAbort, { once: true });
+  const timer = setTimeout(() => deadline.abort(new Error("Latest history read timed out.")), 2_000);
+  try {
+    // Some transports cannot abort an already-dispatched request. The optional
+    // newest read must still release full-history loading at its deadline.
+    return await Promise.race([read(readSignal), aborted]);
+  } finally {
+    clearTimeout(timer);
+    readSignal.removeEventListener("abort", onAbort);
+  }
+}
 
 export function openingSessionHistoryOptions(input: OpeningHistoryInput, saved = getSessionScrollState(
   useSessionScrollStore.getState().sessions, input.sessionId, input.owner,
@@ -112,7 +136,10 @@ export function useSessionPrefetchIntent(intent: boolean, prefetch: () => void |
   return () => { committed.current = true; };
 }
 
-export function useOpeningSessionHistory(input: OpeningHistoryInput) {
+export function useOpeningSessionHistory(input: OpeningHistoryInput & {
+  transcriptQueryKey?: readonly unknown[];
+  readLatest?: (signal: AbortSignal) => Promise<Pick<OpenworkSessionHistory, "session" | "messages">>;
+}) {
   const client = useQueryClient();
   const hasLegacyPosition = useSessionScrollStore((state) => Boolean(state.sessions[input.sessionId]));
   const saved = useMemo(() => {
@@ -121,6 +148,95 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput) {
   const hasFullSnapshot = client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey)?.session.id === input.sessionId;
   const options = openingSessionHistoryOptions(input, saved);
   const query = useQuery({ ...options, enabled: !hasFullSnapshot });
+  const credential = options.queryKey[2];
+  const latestKey = useMemo(() => ["react-session-latest", ...input.snapshotQueryKey, input.owner, credential], [input.owner, input.sessionId, credential]);
+  const entry = useMemo<{
+    warm: boolean;
+    fullRead: { baseline: UIMessage[]; updateCount: number } | null;
+  }>(() => ({
+    warm: client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey)?.session.id === input.sessionId,
+    fullRead: null,
+  }), [client, input.owner, input.sessionId, credential]);
+  const readSource = useCallback(() => input.transcriptQueryKey
+    ? client.getQueryData<UIMessage[]>(input.transcriptQueryKey) ?? EMPTY_HISTORY : EMPTY_HISTORY,
+  [client, input.transcriptQueryKey]);
+  const latestQuery = useQuery({
+    queryKey: latestKey,
+    enabled: entry.warm && Boolean(input.readLatest),
+    queryFn: async ({ signal }): Promise<LatestSessionHistory> => {
+      const full = client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey);
+      if (!input.readLatest || !full) throw new Error("Latest conversation history is unavailable.");
+      const initial = client.getQueryData<LatestSessionHistory>(latestKey) ?? {
+        messages: mergeHistoryWindow(projectHistoryRead(full), readSource()), source: readSource(),
+      };
+      const history = await readLatestHistory(input.readLatest, signal);
+      signal.throwIfAborted();
+      if (history.session.id !== input.sessionId || history.messages.some(({ info, parts }) =>
+        info.sessionID !== input.sessionId || parts.some((part) =>
+          part.sessionID !== input.sessionId || part.messageID !== info.id))) {
+        throw new Error("Conversation history belongs to another session.");
+      }
+      const current = applyHistorySourceChanges(client.getQueryData<LatestSessionHistory>(latestKey) ?? initial, readSource());
+      if (history.session.revert?.messageID || client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey)?.session.revert?.messageID) return current;
+      return {
+        messages: reconcileHistoryRead(current.messages, projectHistoryRead({ ...full, messages: history.messages }), initial.messages),
+        source: current.source,
+      };
+    },
+    staleTime: Infinity,
+    gcTime: 0,
+    retry: false,
+    refetchOnMount: "always",
+    refetchOnReconnect: "always",
+    refetchOnWindowFocus: false,
+    structuralSharing: false,
+    networkMode: "always",
+  });
+  useEffect(() => {
+    if (!entry.warm || !input.readLatest) return;
+    const sourceKey = input.transcriptQueryKey;
+    const reconcile = () => client.setQueryData<LatestSessionHistory>(latestKey,
+      (current) => current ? applyHistorySourceChanges(current, readSource()) : current);
+    reconcile();
+    return client.getQueryCache().subscribe((event) => {
+      if (sourceKey && event.query.queryKey.length === sourceKey.length
+        && sourceKey.every((part, index) => part === event.query.queryKey[index])
+        && event.type === "updated" && event.action.type === "success"
+        && !hydratingTranscripts.has(client)) reconcile();
+    });
+  }, [client, entry, input.readLatest, input.transcriptQueryKey, latestKey, latestQuery.isSuccess, readSource]);
+  const readFullSnapshot = useCallback(async (signal: AbortSignal) => {
+    const cached = client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey);
+    const baseline = client.getQueryData<LatestSessionHistory>(latestKey)?.messages
+      ?? (cached ? snapshotToUIMessages(cached) : EMPTY_HISTORY);
+    const snapshot = await input.readSnapshot(signal);
+    signal.throwIfAborted();
+    entry.fullRead = { baseline, updateCount: (client.getQueryState(input.snapshotQueryKey)?.dataUpdateCount ?? 0) + 1 };
+    return snapshot;
+  }, [client, entry, input.readSnapshot, input.snapshotQueryKey, latestKey]);
+  const seedSnapshot = useCallback((snapshot: OpenworkSessionHistory, seed: () => void) => {
+    if (snapshot.session.id !== input.sessionId) return;
+    if (!entry.warm || !input.readLatest || !input.transcriptQueryKey) { seed(); return; }
+    if (latestQuery.isFetching) return;
+    const current = client.getQueryData<LatestSessionHistory>(latestKey);
+    hydratingTranscripts.add(client);
+    try {
+      seed();
+      if (!current) return;
+      const source = readSource();
+      const fullRead = entry.fullRead;
+      const baseline = fullRead && fullRead.updateCount === client.getQueryState(input.snapshotQueryKey)?.dataUpdateCount
+        ? fullRead.baseline : EMPTY_HISTORY;
+      client.setQueryData<LatestSessionHistory>(latestKey, {
+        messages: reconcileHistoryRead(current.messages, source, baseline),
+        source,
+      });
+    } finally {
+      hydratingTranscripts.delete(client);
+    }
+  }, [client, entry, input.readLatest, input.sessionId, input.snapshotQueryKey, input.transcriptQueryKey, latestKey, latestQuery.isFetching, readSource]);
+  const latestHistory = entry.warm ? latestQuery.data ?? null : null;
+  const fullReader = entry.warm ? readFullSnapshot : input.readSnapshot;
   const activeOwner = useRef<string | null>(input.owner);
   activeOwner.current = input.owner;
   useEffect(() => {
@@ -130,7 +246,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput) {
   const ensureFullSnapshot = useCallback(async () => {
     const options = {
       queryKey: input.snapshotQueryKey,
-      queryFn: ({ signal }: { signal: AbortSignal }) => input.readSnapshot(signal),
+      queryFn: ({ signal }: { signal: AbortSignal }) => fullReader(signal),
       networkMode: "always" as const,
     };
     try {
@@ -147,7 +263,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput) {
       if (!query || query.getObserversCount() === 0) throw error;
       return client.fetchQuery(options);
     }
-  }, [client, input.snapshotQueryKey, input.readSnapshot]);
+  }, [client, input.snapshotQueryKey, fullReader]);
   const runWithFullSnapshot = useCallback(async (
     action: (snapshot: OpenworkSessionHistory) => void | Promise<unknown>,
     options: { fresh?: boolean } = {},
@@ -185,11 +301,16 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput) {
     saved,
     options,
     snapshot,
+    latestHistory,
+    readFullSnapshot: fullReader,
+    seedSnapshot,
     // A newest window that came back shorter than its limit already holds the
     // whole conversation. Only a full window, a saved-position window, or an
     // unavailable preview can still be missing earlier messages.
     partial: snapshot === null || limit === undefined || snapshot.messages.length >= limit,
-    backgroundReady: hasFullSnapshot || backgroundOwner === input.owner,
+    backgroundReady: hasFullSnapshot
+      ? !entry.warm || !input.readLatest || !latestQuery.isFetching
+      : backgroundOwner === input.owner,
     ensureFullSnapshot,
     runWithFullSnapshot,
   };

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -24,16 +24,156 @@ export function resolveRenderedSessionSnapshot(input: {
   return null;
 }
 
+export type LatestSessionHistory = {
+  messages: UIMessage[];
+  source: UIMessage[];
+};
+
+const historyProjections = new WeakMap<OpenworkSessionHistory["messages"], UIMessage[]>();
+
+export function projectHistoryRead(snapshot: OpenworkSessionHistory) {
+  let projected = historyProjections.get(snapshot.messages);
+  if (!projected) {
+    const messages = snapshot.messages.every(({ info }) => Number.isFinite(info.time?.created))
+      ? snapshot.messages.toSorted((left, right) => left.info.time.created - right.info.time.created)
+      : snapshot.messages;
+    projected = snapshotToUIMessages({ ...snapshot, messages });
+    historyProjections.set(snapshot.messages, projected);
+  }
+  return projected;
+}
+
+const historyIndexes = new WeakMap<UIMessage[], Map<string, number>>();
+const historyValues = new WeakMap<object, string>();
+
+function historyIndex(messages: UIMessage[]) {
+  let index = historyIndexes.get(messages);
+  if (!index) {
+    index = new Map(messages.map((message, position) => [message.id, position]));
+    historyIndexes.set(messages, index);
+  }
+  return index;
+}
+
+function historyValue(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) return JSON.stringify(value);
+  let serialized = historyValues.get(value);
+  if (serialized === undefined) {
+    serialized = JSON.stringify(value);
+    historyValues.set(value, serialized);
+  }
+  return serialized;
+}
+
+function sameHistoryValue(left: unknown, right: unknown) {
+  return left === right || historyValue(left) === historyValue(right);
+}
+
+function historyPartKey(part: UIMessage["parts"][number], index: number) {
+  return part.type === "dynamic-tool" ? `tool:${part.toolCallId}` : `${part.type}:${index}`;
+}
+
+export function mergeHistoryWindow(history: UIMessage[], updates: UIMessage[]): UIMessage[] {
+  if (updates.length === 0) return history;
+  const positions = historyIndex(history);
+  const unique = [...new Map(updates.map((message) => [message.id, message])).values()];
+  const nextPositions = new Map<string, number>();
+  let next = history.length;
+  for (let index = unique.length - 1; index >= 0; index -= 1) {
+    const message = unique[index];
+    const position = positions.get(message.id);
+    if (position !== undefined) next = position;
+    else nextPositions.set(message.id, next);
+  }
+  let result = history;
+  const additions = new Map<number, UIMessage[]>();
+  let previous = -1;
+  for (const message of unique) {
+    const position = positions.get(message.id);
+    if (position !== undefined) {
+      previous = position;
+      if (history[position] === message) continue;
+      if (result === history) result = history.slice();
+      result[position] = message;
+    } else {
+      const following = nextPositions.get(message.id) ?? history.length;
+      const slot = following < history.length ? following : previous >= 0 ? previous + 1 : history.length;
+      const bucket = additions.get(slot) ?? [];
+      bucket.push(message);
+      additions.set(slot, bucket);
+    }
+  }
+  if (additions.size === 0) {
+    historyIndexes.set(result, positions);
+    return result;
+  }
+  return result.flatMap((message, index) => [...(additions.get(index) ?? []), message])
+    .concat(additions.get(history.length) ?? []);
+}
+
+function reconcileHistoryMessage(current: UIMessage, incoming: UIMessage, baseline?: UIMessage) {
+  const merged = mergeSnapshotAndLiveMessages([incoming], [current])[0];
+  const priorParts = new Map(baseline?.parts.map((part, index) => [historyPartKey(part, index), part]));
+  const changes = new Map<string, UIMessage["parts"][number]>();
+  current.parts.forEach((part, index) => {
+    const key = historyPartKey(part, index);
+    if (!sameHistoryValue(part, priorParts.get(key))) changes.set(key, part);
+  });
+  if (changes.size === 0 && sameHistoryValue(current.metadata, baseline?.metadata)) return merged;
+  const next: UIMessage = {
+    ...merged,
+    metadata: sameHistoryValue(current.metadata, baseline?.metadata) ? merged.metadata : current.metadata,
+    parts: merged.parts.map((part, index) => {
+      const change = changes.get(historyPartKey(part, index));
+      if (!change) return part;
+      if ((part.type === "text" || part.type === "reasoning") && change.type === part.type
+        && part.text.length > change.text.length) return part;
+      return change;
+    }),
+  };
+  return sameHistoryValue(next, current) ? current : next;
+}
+
+export function reconcileHistoryRead(current: UIMessage[], incoming: UIMessage[], baseline: UIMessage[] = []) {
+  const currentIndex = historyIndex(current);
+  const baselineIndex = historyIndex(baseline);
+  return mergeHistoryWindow(current, incoming.map((message) => {
+    const existing = current[currentIndex.get(message.id) ?? -1];
+    return existing ? reconcileHistoryMessage(existing, message, baseline[baselineIndex.get(message.id) ?? -1]) : message;
+  }));
+}
+
+export function applyHistorySourceChanges(history: LatestSessionHistory, source: UIMessage[]): LatestSessionHistory {
+  if (source === history.source) return history;
+  const before = historyIndex(history.source);
+  const displayed = historyIndex(history.messages);
+  const changes = source.flatMap((message) => {
+    const previous = history.source[before.get(message.id) ?? -1];
+    if (sameHistoryValue(message, previous)) return [];
+    const current = history.messages[displayed.get(message.id) ?? -1];
+    return [current ? reconcileHistoryMessage(message, current, previous) : message];
+  });
+  if (source.length === history.source.length && source.every((message, index) => message.id === history.source[index].id)) {
+    historyIndexes.set(source, before);
+  }
+  return { messages: mergeHistoryWindow(history.messages, changes), source };
+}
+
 export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
   snapshot: OpenworkSessionHistory | null | undefined;
   historyComplete?: boolean;
+  latestHistory?: LatestSessionHistory | null;
 }) {
   const revertMessageId = input.snapshot?.session.revert?.messageID ?? null;
   // Neither a newest window nor saved neighbors prove their position relative
   // to a revert cursor. Withhold them until the ordered full history arrives.
   if (input.historyComplete === false && revertMessageId) return [];
   const liveMessages = input.transcriptState ?? [];
+
+  if (input.latestHistory && input.historyComplete) {
+    return applyRevertCursor(input.latestHistory.messages, revertMessageId);
+  }
 
   const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
     ? snapshotToUIMessages(input.snapshot)

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1260,10 +1260,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
       markSessionSnapshotFetchStart(item, startedAt);
       return item;
   }, [props.opencodeBaseUrl, props.openworkToken, props.sessionId, sessionOwner, useDesktopLoopbackSnapshotRetry]);
-  const openingHistory = useOpeningSessionHistory({ owner: sessionOwner, sessionId: props.sessionId, authToken: props.openworkToken, snapshotQueryKey, readSnapshot });
+  const readLatest = useCallback(async (signal: AbortSignal) => {
+    const endpoint = { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken };
+    const [session, messages] = await Promise.all([
+      opencodeSessionNative.getNativeSession(endpoint, props.sessionId, { signal }),
+      opencodeSessionNative.getNativeSessionMessages(endpoint, props.sessionId, { signal, limit: 24 }),
+    ]);
+    return { session, messages };
+  }, [props.opencodeBaseUrl, props.openworkToken, props.sessionId]);
+  const openingHistory = useOpeningSessionHistory({ owner: sessionOwner, sessionId: props.sessionId, authToken: props.openworkToken, snapshotQueryKey, transcriptQueryKey, readSnapshot, readLatest });
   const snapshotQuery = useQuery<OpenworkSessionHistory>({
     queryKey: snapshotQueryKey,
-    queryFn: ({ signal }) => readSnapshot(signal),
+    queryFn: ({ signal }) => openingHistory.readFullSnapshot(signal),
     enabled: openingHistory.backgroundReady,
     staleTime: 500,
     networkMode: useDesktopLoopbackSnapshotRetry ? "always" : undefined,
@@ -1413,8 +1421,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     if (!currentSnapshot) return;
-    seedSessionState(props.workspaceId, currentSnapshot, { preview: !hasFullHistory });
-  }, [currentSnapshot, hasFullHistory, props.sessionId, props.workspaceId]);
+    openingHistory.seedSnapshot(currentSnapshot, () => seedSessionState(props.workspaceId, currentSnapshot, { preview: !hasFullHistory }));
+  }, [currentSnapshot, hasFullHistory, openingHistory.seedSnapshot, props.sessionId, props.workspaceId]);
 
   const snapshot = resolveRenderedSessionSnapshot({
     sessionId: props.sessionId,
@@ -1479,8 +1487,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId]);
 
   const baseRenderedMessages = useMemo(
-    () => deriveRenderedSessionMessages({ transcriptState, snapshot, historyComplete: hasFullHistory }),
-    [snapshot, transcriptState, hasFullHistory],
+    () => deriveRenderedSessionMessages({ transcriptState, snapshot, historyComplete: hasFullHistory, latestHistory: openingHistory.latestHistory }),
+    [snapshot, transcriptState, hasFullHistory, openingHistory.latestHistory],
   );
   const pendingMessages = useComposerStateStore((state) => state.pendingMessages[sessionOwner]);
   const [submittedMessage, setSubmittedMessage] = useState<{ owner: string; id: string } | null>(null);

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -29,6 +29,7 @@ import {
   STRUCTURED_OUTPUT_TOOL,
 } from "./parse-tool-parts";
 import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
+import type { LatestSessionHistory } from "../surface/session-render-state";
 import { applyRevertCursor, reconcileTranscriptMessages } from "./transcript-reconcile";
 import { isOrphanedInteraction, isTerminalToolPart, terminalToolCallIds, terminalTranscriptToolCallIds } from "./orphaned-interactions";
 import {
@@ -950,7 +951,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     // renderer derives the visible transcript from this cursor, so a revert
     // (or its cleanup on the next prompt) must reach the snapshot cache or
     // the transcript stays frozen on stale history.
-    queryClient.setQueryData<OpenworkSessionSnapshot>(
+    queryClient.setQueryData<OpenworkSessionHistory>(
       snapshotKey(workspaceId, update.sessionId),
       (current) => {
         if (!current) return current;
@@ -1201,10 +1202,19 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const props = (event.properties ?? {}) as { sessionID?: string; messageID?: string };
     if (!props.sessionID || !props.messageID) return;
     if (!isTrackedSession(entry, props.sessionID)) return;
+    const fullKey = snapshotKey(workspaceId, props.sessionID);
+    const latestKey = ["react-session-latest", ...fullKey];
+    void queryClient.cancelQueries({ queryKey: latestKey });
+    void queryClient.cancelQueries({ queryKey: fullKey, exact: true });
+    const keep = (message: UIMessage) => message.id !== props.messageID
+      && message.id !== `${SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX}${props.messageID}`;
+    queryClient.setQueriesData<LatestSessionHistory>({ queryKey: latestKey }, (current) => current ? {
+      messages: current.messages.filter(keep), source: current.source.filter(keep),
+    } : current);
     queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, props.sessionID), (current = []) =>
-      current.filter((message) => message.id !== props.messageID),
+      current.filter(keep),
     );
-    queryClient.setQueryData<OpenworkSessionSnapshot>(
+    queryClient.setQueryData<OpenworkSessionHistory>(
       snapshotKey(workspaceId, props.sessionID),
       (current) => {
         if (!current) return current;
@@ -1789,7 +1799,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
       };
     },
     onResolved: (sessionId, title) => {
-      getReactQueryClient().setQueryData<OpenworkSessionSnapshot>(
+      getReactQueryClient().setQueryData<OpenworkSessionHistory>(
         snapshotKey(input.workspaceId, sessionId),
         (current) => current
           ? { ...current, session: { ...current.session, title } }
@@ -2002,7 +2012,7 @@ export function applySessionRevert(workspaceId: string, session: Session) {
   const queryClient = getReactQueryClient();
   const revertMessageId = session.revert?.messageID ?? null;
 
-  queryClient.setQueryData<OpenworkSessionSnapshot>(
+  queryClient.setQueryData<OpenworkSessionHistory>(
     snapshotKey(workspaceId, session.id),
     (current) => (current ? { ...current, session: { ...current.session, revert: session.revert } } : current),
   );
@@ -2019,7 +2029,7 @@ export async function applySessionArchived(workspaceId: string, sessionId: strin
   const queryKey = snapshotKey(workspaceId, sessionId);
   // An older in-flight snapshot must not put the archived flag back after Restore.
   await queryClient.cancelQueries({ queryKey, exact: true });
-  queryClient.setQueryData<OpenworkSessionSnapshot>(queryKey, current => current ? {
+  queryClient.setQueryData<OpenworkSessionHistory>(queryKey, current => current ? {
     ...current,
     session: { ...current.session, time: { ...current.session.time, archived: archived ? Date.now() : 0 } },
   } : current);
@@ -2030,7 +2040,7 @@ export async function applySessionArchived(workspaceId: string, sessionId: strin
 export function applySessionUnrevert(workspaceId: string, sessionId: string) {
   const queryClient = getReactQueryClient();
   void queryClient.cancelQueries({ queryKey: snapshotKey(workspaceId, sessionId) });
-  queryClient.setQueryData<OpenworkSessionSnapshot>(
+  queryClient.setQueryData<OpenworkSessionHistory>(
     snapshotKey(workspaceId, sessionId),
     (current) => (current ? { ...current, session: { ...current.session, revert: undefined } } : current),
   );

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -271,6 +271,37 @@ describe("native OpenCode session operations", () => {
     expect(receivedEndpoint).toEqual(endpoint);
   });
 
+  test.each(["opencode", "opencode2"])("%s newest session/messages reads need no status or todos", async (engine) => {
+    const target = { ...endpoint, opencodeBaseUrl: endpoint.opencodeBaseUrl.replace("opencode", engine) };
+    const controller = new AbortController();
+    const history = Array.from({ length: 30 }, (_, index) => ({
+      info: { ...messages[0]!.info, id: `msg_${index}`, time: { created: index } },
+      parts: [],
+    }));
+    await withSessionFetch((request) => {
+      const url = new URL(request.url);
+      expect(request.headers.get("authorization")).toBe(`Bearer ${target.token}`);
+      if (url.pathname.endsWith(`/session/${session.id}`)) {
+        return Response.json(engine === "opencode2" ? { data: session } : session);
+      }
+      if (url.pathname.endsWith("/message")) {
+        expect(url.searchParams.get("limit")).toBe("24");
+        return Response.json(engine === "opencode2" ? {
+          data: history.slice(-24).map(({ info }) => ({ ...info, type: "user", content: [] })),
+        } : history.slice(-24));
+      }
+      throw new Error(`Unexpected newest-read dependency: ${url.pathname}`);
+    }, async (requests) => {
+      const [current, newest] = await Promise.all([
+        getNativeSession(target, session.id, { signal: controller.signal }),
+        getNativeSessionMessages(target, session.id, { signal: controller.signal, limit: 24 }),
+      ]);
+      expect(current.id).toBe(session.id);
+      expect(newest.map(({ info }) => info.id)).toEqual(history.slice(-24).map(({ info }) => info.id));
+      expect(requests).toHaveLength(2);
+    });
+  });
+
   test("composes get, messages, todo, and status in parallel with limit and signal", async () => {
     const calls: string[] = [];
     const controller = new AbortController();

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -4,14 +4,17 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, StrictMode, useEffect } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { QueryClientProvider, useQuery } from "@tanstack/react-query";
-import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import { notifyManager, onlineManager, QueryClientProvider, skipToken, useQuery } from "@tanstack/react-query";
+import type { UIMessage } from "ai";
+import type { OpenworkSessionHistory } from "../src/app/lib/openwork-server";
 import { openingHistoryWindow, openingSessionHistoryOptions, prefetchOpeningSessionHistory, sessionHistoryIdentity, SessionHistoryBoundary, SessionHistoryStatus, useOpeningSessionHistory, useSessionPrefetchIntent, type OpeningHistoryWindow } from "../src/react-app/domains/session/surface/session-history";
 import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
 import { flushSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
-import { applySessionUnrevert, seedSessionState, snapshotKey, transcriptKey } from "../src/react-app/domains/session/sync/session-sync";
-import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+import { __applySessionSyncEventForTest, __createWorkspaceSessionSyncForTest, applySessionRevert, applySessionUnrevert, seedSessionState, snapshotKey, trackWorkspaceSessionSync, transcriptKey } from "../src/react-app/domains/session/sync/session-sync";
+import type { OpencodeEvent } from "../src/app/types";
+import { deriveRenderedSessionMessages, type LatestSessionHistory } from "../src/react-app/domains/session/surface/session-render-state";
+import { snapshotToUIMessages } from "../src/react-app/domains/session/sync/usechat-adapter";
 import { resolveForkBoundaryId } from "../src/react-app/domains/session/sync/transcript-reconcile";
 
 const ownedDom = typeof window === "undefined";
@@ -24,6 +27,7 @@ let frameId = 0;
 
 beforeEach(() => {
   jest.useFakeTimers();
+  notifyManager.setScheduler(queueMicrotask);
   useSessionScrollStore.setState({ sessions: {} });
   spyOn(window, "requestAnimationFrame").mockImplementation((callback) => { frames.set(++frameId, callback); return frameId; });
   spyOn(window, "cancelAnimationFrame").mockImplementation((id) => { frames.delete(id); });
@@ -36,6 +40,7 @@ afterEach(async () => {
   mock.restore();
 });
 afterAll(async () => {
+  notifyManager.setScheduler((callback) => setTimeout(callback, 0));
   Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousAct);
   if (ownedDom) await GlobalRegistrator.unregister();
 });
@@ -43,15 +48,36 @@ afterAll(async () => {
 // A newest window that fills its limit may still be missing earlier messages.
 const fullWindow = Array.from({ length: 24 }, (_, index) => `w${index}`);
 
-function snapshot(id: string, title: string, ids: string[] = [], revert?: string): OpenworkSessionSnapshot {
+function snapshot(id: string, title: string, ids: string[] = [], revert?: string): OpenworkSessionHistory {
   return {
     session: { id, title, version: "1", time: { created: 1, updated: 1 }, revert: revert ? { messageID: revert } : undefined },
     messages: ids.map((messageId, index) => ({
       info: { id: messageId, sessionID: id, role: "user", time: { created: index + 1 } },
       parts: [{ id: `part-${messageId}`, sessionID: id, messageID: messageId, type: "text", text: messageId }],
     })),
-    todos: [], status: { type: "idle" },
   };
+}
+
+function sessionEvents() {
+  const input = { workspaceId: "workspace", baseUrl: "https://history.example/opencode", openworkToken: "history-test" };
+  const dispose = __createWorkspaceSessionSyncForTest(input);
+  const release = trackWorkspaceSessionSync(input, "a");
+  cleanups.push(async () => { release(); dispose(); });
+  return async (event: OpencodeEvent) => {
+    await act(async () => __applySessionSyncEventForTest(input, event));
+    await settle();
+  };
+}
+
+function historyTool(output: string, input = "initial", running = false) {
+  const history = snapshot("a", "Tools", ["old", "active"]);
+  history.messages[1].parts.push({
+    id: "tool-part", sessionID: "a", messageID: "active", type: "tool", tool: "bash", callID: "call",
+    state: running
+      ? { status: "running", input: { command: input }, time: { start: 1 } }
+      : { status: "completed", input: { command: input }, output, title: "Done", metadata: {}, time: { start: 1, end: 2 } },
+  });
+  return history;
 }
 
 async function settle() {
@@ -75,11 +101,15 @@ function fixture() {
   let ensureFullSnapshot: (() => Promise<OpenworkSessionHistory>) | undefined;
   let runWithFullSnapshot: ReturnType<typeof useOpeningSessionHistory>["runWithFullSnapshot"] | undefined;
   const reads: { owner: string; authToken?: string; window?: OpeningHistoryWindow; signal: AbortSignal; resolve: (snapshot: OpenworkSessionHistory) => void; reject: (error: Error) => void }[] = [];
+  const latestReads: { owner: string; authToken?: string; signal: AbortSignal; resolve: (history: Pick<OpenworkSessionHistory, "session" | "messages">) => void; reject: (error: Error) => void }[] = [];
   function input(owner = "a", authToken?: string, cacheOwner = owner) {
     const readSnapshot = (signal: AbortSignal, window?: OpeningHistoryWindow) => new Promise<OpenworkSessionHistory>((resolve, reject) => {
       reads.push({ owner, authToken, window, signal, resolve, reject });
     });
-    return { owner: cacheOwner, sessionId: owner, authToken, snapshotQueryKey: snapshotKey("workspace", owner), readSnapshot };
+    const readLatest = (signal: AbortSignal) => new Promise<Pick<OpenworkSessionHistory, "session" | "messages">>((resolve, reject) => {
+      latestReads.push({ owner, authToken, signal, resolve, reject });
+    });
+    return { owner: cacheOwner, sessionId: owner, authToken, snapshotQueryKey: snapshotKey("workspace", owner), transcriptQueryKey: transcriptKey("workspace", owner), readSnapshot, readLatest };
   }
   function Harness({ options, onMount }: { options: ReturnType<typeof input>; onMount?: (ensure: () => Promise<OpenworkSessionHistory>) => void }) {
     const { sessionId: owner, owner: cacheOwner } = options;
@@ -90,16 +120,17 @@ function fixture() {
     runWithFullSnapshot = opening.runWithFullSnapshot;
     // The hero's one-step auto-send fires from a mount effect, before any read settled.
     useEffect(() => { onMount?.(opening.ensureFullSnapshot); }, [onMount, opening.ensureFullSnapshot]);
-    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => options.readSnapshot(signal), enabled: opening.backgroundReady, staleTime: 500, retry: false });
+    const full = useQuery({ queryKey: key, queryFn: ({ signal }) => opening.readFullSnapshot(signal), enabled: opening.backgroundReady, staleTime: 500, retry: false });
     const current = full.data ?? opening.snapshot;
     useEffect(() => {
-      if (current) seedSessionState(workspaceId, current, { preview: !full.data });
-    }, [workspaceId, current, full.data]);
-    const messages = deriveRenderedSessionMessages({ snapshot: current, transcriptState: client.getQueryData(transcriptKey(workspaceId, owner)), historyComplete: Boolean(full.data) });
+      if (current) opening.seedSnapshot(current, () => seedSessionState(workspaceId, current, { preview: !full.data }));
+    }, [workspaceId, current, full.data, opening.seedSnapshot]);
+    const transcript = useQuery<UIMessage[]>({ queryKey: transcriptKey(workspaceId, owner), queryFn: skipToken });
+    const messages = deriveRenderedSessionMessages({ snapshot: current, transcriptState: transcript.data, historyComplete: Boolean(full.data), latestHistory: opening.latestHistory });
     const pending = !current || (!full.data && Boolean(current.session.revert));
     const failed = full.isError && !full.isFetching;
     return <><span>Composer {owner}</span><input aria-label="Draft" /><div className="relative"><div data-thread-scroll><SessionHistoryBoundary owner={cacheOwner} pending={pending} saved={opening.saved} failed={failed}>
-      <div>{current?.session.title}</div>{messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.id}</div>)}
+      <div>{current?.session.title}</div>{messages.map((message) => <div key={message.id} data-message-id={message.id}>{message.parts.map((part) => part.type === "text" ? part.text : part.type === "dynamic-tool" ? `${part.state}:${JSON.stringify({ input: part.input, output: "output" in part ? part.output : null })}` : "").join(" ")}</div>)}
     </SessionHistoryBoundary></div><SessionHistoryStatus key={cacheOwner} complete={Boolean(full.data)} pending={pending} loading={full.isFetching && opening.partial} failed={failed} onRetry={() => full.refetch()} /></div></>;
   }
   async function renderInput(options: ReturnType<typeof input>, mount: { strict?: boolean; onMount?: (ensure: () => Promise<OpenworkSessionHistory>) => void } = {}) {
@@ -108,7 +139,20 @@ function fixture() {
   }
   cleanups.push(async () => { await act(async () => root.unmount()); client.clear(); host.remove(); });
   return {
-    reads, host, client, input, renderInput,
+    reads, latestReads, host, client, input, renderInput,
+    startSharedRead(owner = "a") {
+      const options = input(owner);
+      void client.fetchQuery({ queryKey: options.snapshotQueryKey, queryFn: ({ signal }) => options.readSnapshot(signal), retry: false }).catch(() => undefined);
+    },
+    async startOwnedRead(owner = "a") {
+      const query = client.getQueryCache().find({ queryKey: snapshotKey("workspace", owner), exact: true });
+      if (!query) throw new Error("History is not mounted");
+      await act(async () => { void query.fetch().catch(() => undefined); });
+    },
+    async resolveLatest(index: number, history: Pick<OpenworkSessionHistory, "session" | "messages">) {
+      await act(async () => latestReads[index].resolve(history));
+      await settle();
+    },
     get runWithFullSnapshot() {
       if (!runWithFullSnapshot) throw new Error("History is not mounted");
       return runWithFullSnapshot;
@@ -415,10 +459,13 @@ describe("opening a thread", () => {
     const view = fixture();
     const cached = snapshot("a", "Cached through B", ["A", "B"]);
     view.client.setQueryData(snapshotKey("workspace", "a"), cached, { updatedAt: Date.now() - (backgroundRead ? 1_000 : 0) });
+    if (backgroundRead) view.startSharedRead();
     await view.render();
     const precedingReads = backgroundRead ? 1 : 0;
     expect(view.reads).toHaveLength(precedingReads);
-    view.client.setQueryData(transcriptKey("workspace", "a"), ["A", "B", "C", "D"].map((id) => ({ id, role: "assistant", parts: [] })));
+    await view.resolveLatest(0, snapshot("a", "Newest through C", ["A", "B", "C"]));
+    expect(view.host.querySelector('[data-message-id="C"]')).not.toBeNull();
+    await act(async () => view.client.setQueryData(transcriptKey("workspace", "a"), ["A", "B", "C", "D"].map((id) => ({ id, role: "assistant", parts: [] }))));
     // Sends retain their original cache-hit behavior, even during a full read.
     expect((await view.ensureFullSnapshot()).messages.map(({ info }) => info.id)).toEqual(["A", "B"]);
     expect(view.reads).toHaveLength(precedingReads);
@@ -491,7 +538,7 @@ describe("opening a thread", () => {
     await settle();
     expect(restore).toHaveBeenCalledTimes(1);
     expect(view.client.getQueryState(snapshotKey("workspace", "a"))).toMatchObject({ status: "success", fetchStatus: "idle" });
-    expect(view.client.getQueryData<OpenworkSessionSnapshot>(snapshotKey("workspace", "a"))?.session.revert).toBeUndefined();
+    expect(view.client.getQueryData<OpenworkSessionHistory>(snapshotKey("workspace", "a"))?.session.revert).toBeUndefined();
     expect(view.host.querySelectorAll("[data-message-id]").length).toBe(3);
     expect(view.host.querySelector('[role="status"]')).toBeNull();
     expect(view.host.querySelector("input")).toBe(composer);
@@ -573,7 +620,7 @@ describe("opening a thread", () => {
     // the simulated unmount removes the surface's only observer and TanStack
     // cancels that read. The send must still receive complete history.
     const view = fixture();
-    let send: Promise<{ snapshot: OpenworkSessionSnapshot } | { error: unknown }> | null = null;
+    let send: Promise<{ snapshot: OpenworkSessionHistory } | { error: unknown }> | null = null;
     await view.renderInput(view.input(), { strict: true, onMount: (ensure) => {
       send ??= ensure().then((snapshot) => ({ snapshot }), (error: unknown) => ({ error }));
     } });
@@ -629,6 +676,7 @@ describe("opening a thread", () => {
     expect(short.host.querySelector("[data-thread-history-status]")).toBeNull();
     expect(short.host.querySelectorAll("[data-message-id]")).toHaveLength(2);
     await short.resolve(1, snapshot("a", "Whole conversation", ["first", "second"]));
+    expect(short.latestReads).toHaveLength(0);
     expect(short.host.querySelector("[data-thread-history-status]")).toBeNull();
     await cleanups.pop()?.();
 
@@ -680,7 +728,7 @@ describe("opening a thread", () => {
     expect(view.reads.filter((read) => read.window === undefined).map((read) => read.owner)).toEqual(["b"]);
   });
 
-  test("warm full snapshots skip previews, and old anchors do not require persisted neighbors", async () => {
+  test("warm full snapshots skip speculative previews but refresh the selected tail", async () => {
     expect(openingHistoryWindow({ mode: "manual", scrollTop: 500, anchor: { messageId: "legacy", offset: 0 }, topClippedMessageId: null }))
       .toEqual({ messageIds: ["legacy"] });
     expect(openingHistoryWindow({ mode: "manual", scrollTop: 500, anchor: { messageId: "turn:steps", offset: -20 }, topClippedMessageId: null }))
@@ -694,6 +742,357 @@ describe("opening a thread", () => {
     await view.render();
     expect(view.host.textContent).toContain("Cached history");
     expect(view.host.querySelector('[role="status"]')).toBeNull();
+    expect(view.reads).toHaveLength(0);
+    expect(view.latestReads).toHaveLength(1);
+    await view.resolveLatest(0, snapshot("a", "Fresh", ["tail"]));
+    expect(view.host.textContent).toContain("tail");
     expect(view.reads.map((read) => read.window)).toEqual([undefined]);
+  });
+
+  test("a selected warm return shows a persisted tail before a held full read without replacing complete history", async () => {
+    const view = fixture();
+    const ids = ["first", ...fullWindow, "anchor"];
+    const cached = snapshot("a", "Cached history", ids);
+    const complete = snapshot("a", "Updated history", [...ids, "new-tail"]);
+    const key = snapshotKey("workspace", "a");
+    view.client.setQueryData(key, cached, { updatedAt: Date.now() - 1_000 });
+    view.startSharedRead();
+    await view.render("b");
+    await view.render();
+    const composer = view.host.querySelector("input");
+    expect(view.latestReads).toHaveLength(1);
+    const fullRead = view.reads.findIndex((read) => read.owner === "a" && !read.window);
+    expect(fullRead).toBeGreaterThanOrEqual(0);
+    await view.resolveLatest(0, { session: complete.session, messages: complete.messages.slice(-24) });
+    expect(view.host.textContent).toContain("new-tail");
+    expect([...view.host.querySelectorAll("[data-message-id]")].map((item) => item.getAttribute("data-message-id"))).toEqual([...ids, "new-tail"]);
+    expect(view.host.querySelector("input")).toBe(composer);
+    expect(view.host.querySelector("[data-thread-loading]")).toBeNull();
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.client.getQueryData(key)).toBe(cached);
+    expect(view.client.getQueryData<UIMessage[]>(transcriptKey("workspace", "a"))?.map((item) => item.id)).toEqual(ids);
+    expect(await view.ensureFullSnapshot()).toBe(cached);
+    await view.resolve(fullRead, cached);
+    expect(view.host.textContent).toContain("new-tail");
+    await act(async () => { void view.client.refetchQueries({ queryKey: key, exact: true }); });
+    await act(async () => view.reads.at(-1)!.reject(new Error("Full refresh unavailable")));
+    await settle();
+    expect(view.host.textContent).toContain("new-tail");
+    expect(view.client.getQueryData(key)).toBe(cached);
+    await view.render();
+    await view.render();
+    expect(view.latestReads).toHaveLength(1);
+    await act(async () => { void view.client.refetchQueries({ queryKey: key, exact: true }); });
+    const refreshed = view.reads.length - 1;
+    expect(view.reads[refreshed].window).toBeUndefined();
+    const replacement = snapshot("a", "New authoritative history", [...ids, "new-tail"]);
+    replacement.messages.at(-1)!.parts = [{ id: "new-text", sessionID: "a", messageID: "new-tail", type: "text", text: "confirmed" }];
+    await view.resolve(refreshed, replacement);
+    expect(view.host.textContent).toContain("confirmed");
+    expect(view.host.textContent).not.toContain("new-tail");
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(ids.length + 1);
+  });
+
+  test("newest and delayed full results cannot duplicate or roll back newer live text and tool completion", async () => {
+    const view = fixture();
+    const cached = snapshot("a", "Cached", ["old", "active"]);
+    const active = cached.messages[1];
+    active.parts.push({
+      id: "tool-part", sessionID: "a", messageID: "active", type: "tool", tool: "bash", callID: "call",
+      state: { status: "running", input: {}, time: { start: 1 } },
+    });
+    const key = snapshotKey("workspace", "a");
+    view.client.setQueryData(key, cached, { updatedAt: Date.now() - 1_000 });
+    const initial = snapshotToUIMessages(cached);
+    view.client.setQueryData(transcriptKey("workspace", "a"), initial);
+    await view.render();
+    await view.startOwnedRead();
+    expect(view.reads).toHaveLength(1);
+    const live: UIMessage[] = [initial[0], {
+      ...initial[1],
+      parts: [
+        { type: "text", text: "newer streaming text", state: "streaming" },
+        { type: "dynamic-tool", toolName: "bash", toolCallId: "call", state: "output-available", input: {}, output: "newer live result" },
+      ],
+    }];
+    await act(async () => view.client.setQueryData(transcriptKey("workspace", "a"), live));
+    const latest = snapshot("a", "Latest", ["old", "active", "persisted-tail"]);
+    latest.messages[1].parts.push({
+      ...active.parts[1],
+      type: "tool", tool: "bash", callID: "call",
+      state: { status: "completed", input: {}, output: "older persisted result", title: "Done", metadata: {}, time: { start: 1, end: 2 } },
+    });
+    await view.resolveLatest(0, latest);
+    const assertLive = () => {
+      expect(view.host.textContent).toContain("newer streaming text");
+      expect(view.host.textContent).toContain("newer live result");
+      expect(view.host.textContent).not.toContain("older persisted result");
+      expect([...view.host.querySelectorAll("[data-message-id]")].map((item) => item.getAttribute("data-message-id"))).toEqual(["old", "active", "persisted-tail"]);
+    };
+    assertLive();
+    const staleFull = { ...cached, messages: [cached.messages[0], latest.messages[1]] };
+    await view.resolve(0, staleFull);
+    assertLive();
+    expect(view.client.getQueryData<OpenworkSessionHistory>(key)?.messages).toEqual(staleFull.messages);
+  });
+
+  test("warm refresh leaves manual scroll state and the mounted anchor untouched", async () => {
+    const view = fixture();
+    const cached = snapshot("a", "Reading history", ["before", "anchor", ...fullWindow]);
+    view.client.setQueryData(snapshotKey("workspace", "a"), cached, { updatedAt: Date.now() - 1_000 });
+    const store = useSessionScrollStore.getState();
+    store.setManualScroll("a", 800, null, { messageId: "anchor", offset: -20 }, "a");
+    const saved = useSessionScrollStore.getState().sessions;
+    await view.render();
+    const scroller = view.host.querySelector<HTMLDivElement>("[data-thread-scroll]");
+    if (!scroller) throw new Error("Missing scroll viewport");
+    scroller.scrollTop = 800;
+    const anchor = scroller.querySelector('[data-message-id="anchor"]');
+    const latest = snapshot("a", "Latest", ["before", "anchor", ...fullWindow, "new-tail"]);
+    await view.resolveLatest(0, { session: latest.session, messages: latest.messages.slice(-24) });
+    expect(view.host.textContent).toContain("new-tail");
+    expect(scroller.scrollTop).toBe(800);
+    expect(scroller.querySelector('[data-message-id="anchor"]')).toBe(anchor);
+    expect(useSessionScrollStore.getState().sessions).toBe(saved);
+  });
+
+  test("warm refresh is owner and credential scoped, cancels obsolete reads, and never touches a neighbor", async () => {
+    const view = fixture();
+    const key = snapshotKey("workspace", "a");
+    const cached = snapshot("a", "Cached a", ["cached"]);
+    const neighbor = snapshot("b", "Neighbor", ["neighbor"]);
+    view.client.setQueryData(key, cached);
+    view.client.setQueryData(snapshotKey("workspace", "b"), neighbor);
+    await view.render("a", "old-credential");
+    const oldKey = view.client.getQueryCache().find({ queryKey: ["react-session-latest"], exact: false })?.queryKey;
+    expect(JSON.stringify(oldKey)).not.toContain("old-credential");
+    await view.render("a", "new-credential");
+    expect(view.latestReads[0].signal.aborted).toBe(true);
+    await view.resolveLatest(0, snapshot("a", "Old", ["obsolete-credential"]));
+    expect(view.host.textContent).not.toContain("obsolete-credential");
+    await view.render("a", "new-credential", "other-owner");
+    expect(view.latestReads[1].signal.aborted).toBe(true);
+    await view.resolveLatest(1, snapshot("a", "Old", ["obsolete-owner"]));
+    expect(view.host.textContent).not.toContain("obsolete-owner");
+    await view.resolveLatest(2, snapshot("a", "Current", ["current-tail"]));
+    expect(view.host.textContent).toContain("current-tail");
+    expect(view.client.getQueryData(key)).toBe(cached);
+    expect(view.client.getQueryData(snapshotKey("workspace", "b"))).toBe(neighbor);
+    await view.render("b");
+    expect(view.host.textContent).not.toContain("current-tail");
+    await cleanups.pop()?.();
+    expect(view.latestReads[3].signal.aborted).toBe(true);
+    await act(async () => view.latestReads[3].resolve(snapshot("b", "Late", ["late-unmounted"])));
+    expect(view.client.getQueryCache().findAll({ queryKey: ["react-session-latest"] })).toHaveLength(0);
+  });
+
+  test("failed or foreign warm reads retain cached content; reconnect retries only the selected entry", async () => {
+    const view = fixture();
+    const cached = snapshot("a", "Cached history", ["old"]);
+    const key = snapshotKey("workspace", "a");
+    view.client.setQueryData(key, cached);
+    await view.render();
+    await act(async () => view.latestReads[0].reject(new Error("Newest unavailable")));
+    await settle();
+    expect(view.host.textContent).toContain("old");
+    expect(view.host.querySelector('[role="alert"]')).toBeNull();
+    expect(view.client.getQueryData(key)).toBe(cached);
+    const reconnect = async () => {
+      await act(async () => { onlineManager.setOnline(false); onlineManager.setOnline(true); });
+      await settle();
+    };
+    await reconnect();
+    expect(view.latestReads).toHaveLength(2);
+    await view.resolveLatest(1, snapshot("a", "New", ["old", "fresh"]));
+    expect(view.host.textContent).toContain("fresh");
+    await reconnect();
+    await act(async () => view.latestReads[2].reject(new Error("Still unavailable")));
+    await settle();
+    expect(view.host.textContent).toContain("fresh");
+    await reconnect();
+    await view.resolveLatest(3, snapshot("b", "Foreign", ["foreign"]));
+    expect(view.host.textContent).not.toContain("foreign");
+    expect(view.host.textContent).toContain("fresh");
+    await reconnect();
+    const malformed = snapshot("a", "Foreign part", ["foreign-part"]);
+    malformed.messages[0].parts[0].sessionID = "b";
+    await view.resolveLatest(4, malformed);
+    expect(view.host.textContent).not.toContain("foreign-part");
+    expect(view.host.textContent).toContain("fresh");
+    expect(view.client.getQueryData(key)).toBe(cached);
+    expect(view.host.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  for (const shared of [false, true]) test(`overlapping full hydration cannot roll newest terminal B back to A without a stream event (shared=${shared})`, async () => {
+    const view = fixture();
+    const cached = historyTool("terminal-A");
+    const key = snapshotKey("workspace", "a");
+    view.client.setQueryData(key, cached, { updatedAt: Date.now() - 1_000 });
+    if (shared) view.startSharedRead();
+    await view.render();
+    if (!shared) await view.startOwnedRead();
+    expect(view.reads).toHaveLength(1);
+    expect(view.reads[0].window).toBeUndefined();
+    await view.resolveLatest(0, historyTool("terminal-B"));
+    expect(view.host.textContent).toContain("terminal-B");
+    const oldFull = historyTool("terminal-A");
+    oldFull.messages.push(snapshot("a", "Added history", ["full-only"]).messages[0]);
+    await view.resolve(0, oldFull);
+    expect(view.host.textContent).toContain("terminal-B");
+    expect(view.host.textContent).not.toContain("terminal-A");
+    expect(view.host.textContent).toContain("full-only");
+    expect(view.client.getQueryData<OpenworkSessionHistory>(key)?.messages).toEqual(oldFull.messages);
+    expect(JSON.stringify(view.client.getQueryData(transcriptKey("workspace", "a")))).toContain("terminal-A");
+    await view.render();
+    expect(view.host.textContent).toContain("terminal-B");
+  });
+
+  for (const cachedTool of [false, true]) test(`full reads started after newest advance tools without SSE through completion and later correction (cached tool=${cachedTool})`, async () => {
+    const view = fixture();
+    const key = snapshotKey("workspace", "a");
+    const cached = cachedTool ? historyTool("cached-terminal") : snapshot("a", "Before tool", ["old"]);
+    view.client.setQueryData(key, cached, { updatedAt: Date.now() - 1_000 });
+    await view.render();
+    expect(view.reads).toHaveLength(0);
+    await view.resolveLatest(0, historyTool("newest-terminal", "initial", !cachedTool));
+    expect(view.host.textContent).toContain(cachedTool ? "newest-terminal" : "input-streaming");
+    expect(view.client.getQueryData(key)).toBe(cached);
+    expect(view.reads).toHaveLength(1);
+    const outputs = ["first-completion", "first-completion", "forward-correction"];
+    for (const [index, output] of outputs.entries()) {
+      if (index > 0) {
+        await act(async () => { void view.client.refetchQueries({ queryKey: key, exact: true }); });
+      }
+      expect(view.reads).toHaveLength(index + 1);
+      expect(view.reads[index].window).toBeUndefined();
+      await view.resolve(index, historyTool(output));
+      expect(view.host.textContent).toContain("output-available");
+      expect(view.host.textContent).toContain(output);
+      expect(view.host.textContent).not.toContain("input-streaming");
+      expect(view.host.textContent).not.toContain("newest-terminal");
+      expect(view.host.querySelectorAll('[data-message-id="active"]')).toHaveLength(1);
+      expect(view.host.querySelector('[data-message-id="old"]')).not.toBeNull();
+      expect(view.latestReads).toHaveLength(1);
+    }
+    expect(view.host.textContent).not.toContain("first-completion");
+  });
+
+  test("an existing full read finishing before newest does not turn its hydration into a live update", async () => {
+    const view = fixture();
+    view.client.setQueryData(snapshotKey("workspace", "a"), historyTool("terminal-A"), { updatedAt: Date.now() - 1_000 });
+    view.startSharedRead();
+    await view.render();
+    const full = historyTool("terminal-A2");
+    full.session.title = "Finished full";
+    await view.resolve(0, full);
+    expect(view.client.getQueryData<OpenworkSessionHistory>(snapshotKey("workspace", "a"))?.session.title).toBe("Finished full");
+    await view.resolveLatest(0, historyTool("terminal-B"));
+    expect(view.host.textContent).toContain("terminal-B");
+    expect(view.host.textContent).not.toContain("terminal-A2");
+  });
+
+  for (const running of [false, true]) test(`live corrections after stale full hydration replace preserved tool data (running=${running})`, async () => {
+    const view = fixture();
+    const event = sessionEvents();
+    const cached = historyTool("terminal-A", "input-A", running);
+    view.client.setQueryData(snapshotKey("workspace", "a"), cached, { updatedAt: Date.now() - 1_000 });
+    view.startSharedRead();
+    await view.render();
+    await view.resolveLatest(0, historyTool("terminal-B", "input-B", running));
+    const oldFull = historyTool("terminal-A", "input-A", running);
+    oldFull.session.title = "Hydrated";
+    await view.resolve(0, oldFull);
+    expect(view.host.textContent).toContain("input-B");
+    for (const version of ["C", "D"]) {
+      const correction = historyTool(`terminal-${version}`, `input-${version}`, running).messages[1].parts[1];
+      await event({ type: "message.part.updated", properties: { part: correction } });
+      expect(view.host.textContent).toContain(`input-${version}`);
+      expect(view.host.textContent).not.toContain("input-B");
+      if (!running) expect(view.host.textContent).toContain(`terminal-${version}`);
+      await view.render();
+      expect(view.host.textContent).toContain(`input-${version}`);
+    }
+  });
+
+  for (const resolved of [false, true]) for (const reverted of [false, true]) test(`confirmed removal cannot be resurrected by newest or late full reads (resolved=${resolved}, revert cleanup=${reverted})`, async () => {
+    const view = fixture();
+    const event = sessionEvents();
+    const cached = snapshot("a", "Cached", ["old", "M", "after"]);
+    const key = snapshotKey("workspace", "a");
+    view.client.setQueryData(key, cached, { updatedAt: Date.now() - 1_000 });
+    view.client.setQueryData(snapshotKey("workspace", "b"), snapshot("b", "Neighbor", ["M"]));
+    view.startSharedRead();
+    await view.render();
+    if (resolved) await view.resolveLatest(0, snapshot("a", "Newest", ["M", "after", "tail"]));
+    if (reverted) {
+      await act(async () => applySessionRevert("workspace", { ...cached.session, revert: { messageID: "M" } }));
+      await settle();
+    }
+    await event({ type: "message.removed", properties: { sessionID: "a", messageID: "M" } });
+    expect(view.reads[0].signal.aborted).toBe(true);
+    if (!resolved) {
+      expect(view.latestReads[0].signal.aborted).toBe(true);
+      await view.resolveLatest(0, snapshot("a", "Late newest", ["M", "after", "late-tail"]));
+    }
+    await view.resolve(0, cached);
+    if (reverted) {
+      await act(async () => applySessionUnrevert("workspace", "a"));
+      await settle();
+    }
+    expect(view.host.querySelector('[data-message-id="M"]')).toBeNull();
+    expect(view.host.querySelector('[data-message-id="after"]')).not.toBeNull();
+    if (resolved) expect(view.host.querySelector('[data-message-id="tail"]')).not.toBeNull();
+    expect(view.client.getQueryData<OpenworkSessionHistory>(key)?.messages.some(({ info }) => info.id === "M")).toBe(false);
+    for (const query of view.client.getQueryCache().findAll({ queryKey: ["react-session-latest", ...key] })) {
+      const latest = view.client.getQueryData<LatestSessionHistory>(query.queryKey);
+      expect(latest?.messages.some((message) => message.id === "M") ?? false).toBe(false);
+    }
+    await event({ type: "message.updated", properties: { info: { id: "unrelated", sessionID: "a", role: "assistant" } } });
+    expect(view.host.querySelector('[data-message-id="M"]')).toBeNull();
+    expect(view.client.getQueryData<OpenworkSessionHistory>(snapshotKey("workspace", "b"))?.messages[0].info.id).toBe("M");
+  });
+
+  test("a transport that ignores cancellation cannot hold full history behind the newest deadline", async () => {
+    const view = fixture();
+    const cached = snapshot("a", "Cached", ["old"]);
+    view.client.setQueryData(snapshotKey("workspace", "a"), cached, { updatedAt: Date.now() - 1_000 });
+    await view.render();
+    expect(view.latestReads).toHaveLength(1);
+    expect(view.reads).toHaveLength(0);
+    await act(async () => { jest.advanceTimersByTime(2_000); });
+    await settle();
+    expect(view.latestReads[0].signal.aborted).toBe(true);
+    expect(view.reads.map((read) => read.window)).toEqual([undefined]);
+    await view.resolve(0, snapshot("a", "Complete", ["old", "confirmed"]));
+    expect(view.host.textContent).toContain("confirmed");
+    // The underlying request can finish even though its caller stopped waiting.
+    await view.resolveLatest(0, snapshot("a", "Too late", ["old", "obsolete-tail"]));
+    expect(view.host.textContent).not.toContain("obsolete-tail");
+    expect(view.host.textContent).toContain("confirmed");
+  });
+
+  test("absence from a bounded window is not deletion, and a credential change cannot reuse its scoped data", async () => {
+    const view = fixture();
+    const cached = snapshot("a", "Cached", ["M", ...fullWindow]);
+    view.client.setQueryData(snapshotKey("workspace", "a"), cached);
+    await view.render("a", "first-credential");
+    await view.resolveLatest(0, snapshot("a", "Window", [...fullWindow, "private-tail"]));
+    expect(view.host.querySelector('[data-message-id="M"]')).not.toBeNull();
+    expect(view.host.textContent).toContain("private-tail");
+    await view.render("a", "second-credential");
+    expect(view.host.textContent).not.toContain("private-tail");
+    expect(view.client.getQueryData(snapshotKey("workspace", "a"))).toBe(cached);
+  });
+
+  test("warm reverted history never uses a partial tail or restores a cursor from it", async () => {
+    const view = fixture();
+    const cached = snapshot("a", "Reverted", ["before", "cursor", "hidden"], "cursor");
+    const key = snapshotKey("workspace", "a");
+    view.client.setQueryData(key, cached);
+    await view.render();
+    await view.resolveLatest(0, snapshot("a", "Unreverted partial", ["hidden", "new-hidden"]));
+    expect([...view.host.querySelectorAll("[data-message-id]")].map((item) => item.getAttribute("data-message-id"))).toEqual(["before"]);
+    expect(view.client.getQueryData(key)).toBe(cached);
+    expect((await view.ensureFullSnapshot()).session.revert?.messageID).toBe("cursor");
   });
 });

--- a/apps/app/tests/session-render-state.test.ts
+++ b/apps/app/tests/session-render-state.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
-import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+import { applyHistorySourceChanges, deriveRenderedSessionMessages, mergeHistoryWindow, projectHistoryRead, reconcileHistoryRead, type LatestSessionHistory } from "../src/react-app/domains/session/surface/session-render-state";
 import { resolveForkBoundaryId } from "../src/react-app/domains/session/sync/transcript-reconcile";
 import {
   mergeSnapshotAndLiveMessages,
@@ -308,5 +308,92 @@ describe("session render state", () => {
     expect(second[2]).toBe(first[2]);
     expect(second[3]).not.toBe(first[3]);
     expect(second[3]?.parts).toEqual([{ type: "text", text: "chunk-1 chunk-2 ", state: "done" }]);
+  });
+});
+
+describe("warm history reconciliation", () => {
+  test("newest-first native reads are projected in chronological order once per immutable messages array", () => {
+    const snapshot = snapshotWithHistory();
+    snapshot.messages = snapshot.messages.toReversed();
+    const first = projectHistoryRead(snapshot);
+    expect(first.map((message) => message.id)).toEqual(["historical-user", "historical-assistant"]);
+    expect(projectHistoryRead(snapshot)).toBe(first);
+    expect(projectHistoryRead({ ...snapshot, session: { ...snapshot.session, title: "Updated title" } })).toBe(first);
+  });
+
+  test("content-equivalent hydration is not a live change and field-level live changes do not revert another part", () => {
+    const cached: UIMessage = { id: "active", role: "assistant", parts: [
+      { type: "text", text: "old", state: "done" },
+      { type: "dynamic-tool", toolName: "bash", toolCallId: "call", state: "output-available", input: {}, output: "A" },
+    ] };
+    const newest: UIMessage = { ...cached, parts: [cached.parts[0], {
+      type: "dynamic-tool", toolName: "bash", toolCallId: "call", state: "output-available", input: {}, output: "B",
+    }] };
+    const hydrated: UIMessage = { ...cached, parts: cached.parts.map((part) => ({ ...part })) };
+    let history: LatestSessionHistory = { messages: reconcileHistoryRead([hydrated], [newest], [cached]), source: [hydrated] };
+    expect(history.messages[0].parts[1]).toMatchObject({ output: "B" });
+    const streamed: UIMessage = { ...hydrated, parts: [{ type: "text", text: "longer streamed text", state: "streaming" }, hydrated.parts[1]] };
+    history = applyHistorySourceChanges(history, [streamed]);
+    expect(history.messages[0].parts[0]).toMatchObject({ text: "longer streamed text" });
+    expect(history.messages[0].parts[1]).toMatchObject({ output: "B" });
+    const corrected: UIMessage = { ...streamed, parts: [streamed.parts[0], {
+      type: "dynamic-tool", toolName: "bash", toolCallId: "call", state: "output-available", input: { command: "corrected" }, output: "C",
+    }] };
+    history = applyHistorySourceChanges(history, [corrected]);
+    expect(history.messages[0].parts[1]).toMatchObject({ input: { command: "corrected" }, output: "C" });
+  });
+
+  test("known IDs keep full-history positions and only genuinely new IDs are inserted once", () => {
+    const base = ["z-first", "a-middle", "m-last"].map((id) => message(id, "user", id, 1));
+    const changed = { ...base[1], parts: [{ type: "text", text: "changed" }] } satisfies UIMessage;
+    const inserted = message("new", "assistant", "new", 1);
+    const tail = message("tail", "assistant", "tail", 1);
+    const updated = mergeHistoryWindow(base, [base[0], inserted, changed, base[2], tail, tail]);
+    expect(updated.map((item) => item.id)).toEqual(["z-first", "new", "a-middle", "m-last", "tail"]);
+    expect(updated[0]).toBe(base[0]);
+    expect(updated[2]).toBe(changed);
+    expect(updated[3]).toBe(base[2]);
+    expect(mergeHistoryWindow(updated, [changed, tail])).toBe(updated);
+  });
+
+  for (const size of [200, 800, 3200]) for (const timestamps of ["tied", "missing"]) test(`newest-24 and sparse token updates stay linear over ${size} ${timestamps}-timestamp messages`, () => {
+    let idReads = 0;
+    let timestampReads = 0;
+    let projections = 0;
+    const base: UIMessage[] = Array.from({ length: size }, (_, index) => ({
+      get id() { idReads += 1; return `message-${index}`; },
+      role: "assistant",
+      metadata: timestamps === "tied" ? { opencode: { get created() { timestampReads += 1; return 1; } } } : undefined,
+      parts: [{ type: "text", text: `content-${index}`, state: "done" }],
+    }));
+    const tail = message("new-tail", "assistant", "persisted tail", 1);
+    const newest = [...base.slice(-23), tail];
+    idReads = 0;
+    let history: LatestSessionHistory = { messages: reconcileHistoryRead(base, newest, base), source: base };
+    expect(idReads).toBeLessThanOrEqual(size * 8 + 200);
+    const fixture = snapshotWithHistory();
+    const snapshot = { ...fixture, get messages() { projections += 1; return fixture.messages; } };
+    let source = base;
+    for (let token = 1; token <= 6; token += 1) {
+      const active = message(`message-${size - 1}`, "assistant", `content-${size - 1} ${"x".repeat(token)}`, 1);
+      if (timestamps === "missing") delete active.metadata;
+      source = [...source.slice(0, -1), active];
+      idReads = 0;
+      history = applyHistorySourceChanges(history, source);
+      expect(idReads).toBeLessThanOrEqual(size * 12 + 200);
+      idReads = 0;
+      timestampReads = 0;
+      const rendered = deriveRenderedSessionMessages({ snapshot, transcriptState: source, historyComplete: true, latestHistory: history });
+      expect(rendered).toBe(history.messages);
+      expect(idReads).toBe(0);
+      expect(timestampReads).toBe(0);
+      expect(projections).toBe(0);
+      expect(rendered).toHaveLength(size + 1);
+      expect(rendered[0]).toBe(base[0]);
+      expect(rendered[size - 2]).toBe(base[size - 2]);
+      expect(rendered[size - 1].parts).toEqual(active.parts);
+      expect(rendered[size]).toBe(tail);
+    }
+    expect(history.messages.map((item) => item.id)).toEqual([...base.map((item) => item.id), "new-tail"]);
   });
 });

--- a/apps/app/tests/session-sidebar-utils.test.ts
+++ b/apps/app/tests/session-sidebar-utils.test.ts
@@ -57,6 +57,33 @@ describe("sidebar session rows", () => {
     expect(rows.map((row) => row.session.id)).toEqual(["session-b"]);
   });
 
+  test("keeps large-inventory preview counts, manual order, and original session identities", () => {
+    const inventory: SidebarSessionItem[] = Array.from({ length: 10_000 }, (_, index) => ({
+      id: `session-${index}`, title: `Session ${index}`,
+    }));
+    const pinned = inventory[9_999]!;
+    const ordered = inventory[9_998]!;
+    const pinnedIds = new Set([pinned.id]);
+    const input = [
+      { id: "archived", title: "Archived", time: { archived: 1 } },
+      { id: "child", title: "Child", parentID: pinned.id },
+      ...inventory,
+    ];
+    const rows = flattenSessionRows(input, 6, new Set(), [ordered.id], { exclude: pinnedIds });
+    const pinnedRows = flattenSessionRows(input, 1, pinnedIds, [], { include: pinnedIds });
+
+    expect(rows).toHaveLength(6);
+    expect(rows.map((row) => row.session.id)).toEqual([ordered.id, ...inventory.slice(0, 5).map((session) => session.id)]);
+    expect(rows[0]!.session).toBe(ordered);
+    expect(rows[1]!.session).toBe(inventory[0]);
+    expect(pinnedRows).toHaveLength(1);
+    expect(pinnedRows[0]!.session).toBe(pinned);
+    const expanded = flattenSessionRows(input, Number.MAX_SAFE_INTEGER, new Set(), [ordered.id], { exclude: pinnedIds });
+    expect(expanded).toHaveLength(inventory.length - 1);
+    expect(expanded.slice(0, rows.length)).toEqual(rows);
+    expect(expanded.at(-1)!.session).toBe(inventory[9_997]);
+  });
+
   test("hides a child even when its parent is archived or outside the list", () => {
     const orphaned: SidebarSessionItem[] = [
       { id: "session-c", title: "Orphan child", parentID: "missing-parent" },

--- a/apps/app/tests/session-snapshot-owner-flip.test.tsx
+++ b/apps/app/tests/session-snapshot-owner-flip.test.tsx
@@ -8,7 +8,7 @@ import { createRoot } from "react-dom/client";
 
 import type { FieldsResult } from "../src/app/lib/opencode";
 import type { NativeSessionOperations, NativeSessionSnapshotTarget } from "../src/app/lib/opencode-session-native";
-import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import type { Platform } from "../src/react-app/kernel/platform";
 
 const workspaceId = "workspace-snapshot-owner-flip";
@@ -144,6 +144,7 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
 
   const readEndpoints: string[] = [];
   const historyWindows: Array<number | undefined> = [];
+  const readLimits: (number | undefined)[] = [];
   let releaseRetry: (() => void) | null = null;
   const snapshot = createSnapshot();
   const operationsFor = (endpoint: { opencodeBaseUrl: string }): NativeSessionOperations => {
@@ -172,15 +173,18 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
     composeNativeSessionHistoryWithRetry: (
       expectedOwner: string,
       readCurrentTarget: () => NativeSessionSnapshotTarget,
-      options: { signal?: AbortSignal },
-    ) => composeWithRetry(expectedOwner, readCurrentTarget, options, {
-      createOperations: operationsFor,
-      // The first (v1) read parks here until the test flips the owner.
-      waitForSnapshotRetry: (_delayMs, signal) => new Promise<void>((resolve, reject) => {
-        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
-        releaseRetry = resolve;
-      }),
-    }),
+      options: { signal?: AbortSignal; limit?: number },
+    ) => {
+      readLimits.push(options.limit);
+      return composeWithRetry(expectedOwner, readCurrentTarget, options, {
+        createOperations: operationsFor,
+        // The first (v1) read parks here until the test flips the owner.
+        waitForSnapshotRetry: (_delayMs, signal) => new Promise<void>((resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          releaseRetry = resolve;
+        }),
+      });
+    },
   }));
   const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
   const { snapshotKey } = await import("../src/react-app/domains/session/sync/session-sync");
@@ -257,6 +261,10 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
     // The abandoned owner must never retry or populate either result.
     expect(readEndpoints).toEqual([v1BaseUrl, v2BaseUrl, v2BaseUrl]);
     expect(historyWindows).toEqual([24, 24, undefined]);
+    expect(readLimits).toEqual([24, 24, undefined]);
+    const cached = queryClient.getQueryData<OpenworkSessionHistory>(key);
+    expect(cached?.status).toBeUndefined();
+    expect(cached?.todos).toBeUndefined();
   } finally {
     await act(async () => root.unmount());
     useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });

--- a/apps/app/tests/workbench-store.test.ts
+++ b/apps/app/tests/workbench-store.test.ts
@@ -77,8 +77,76 @@ describe("workbench store", () => {
     state = openWorkbenchTab(state, { workspaceId: "workspace-b", sessionId: "session-shared" });
     state = setWorkbenchSplit(state, { workspaceId: "workspace-b", sessionId: "session-shared" });
 
+    const sideChats = state.sideChats;
+    state = syncWorkbenchSnapshot(state, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-shared",
+      sessionsKnown: true,
+      sessions: [
+        { workspaceId: "workspace-b", sessionId: "session-shared", title: "Other workspace" },
+        { workspaceId: "workspace-a", sessionId: "session-shared", title: "First match" },
+        { workspaceId: "workspace-a", sessionId: "session-shared", title: "Later duplicate" },
+      ],
+    });
+
     expect(state.tabs).toHaveLength(2);
-    expect(state.secondary?.workspaceId).toBe("workspace-b");
+    expect(state.tabs.map((tab) => tab.title)).toEqual(["First match", "Other workspace"]);
+    expect(state.primary?.title).toBe("First match");
+    expect(state.secondary).toMatchObject({ workspaceId: "workspace-b", title: "Other workspace" });
+    expect(state.sideChats).toBe(sideChats);
+    expect(state.focusedPane).toBe("secondary");
+  });
+
+  test("keeps workspace and session key separators distinct during metadata refresh", () => {
+    const owner = { workspaceId: "workspace:a", sessionId: "shared", title: "Owner" };
+    const side = { workspaceId: "workspace", sessionId: "a:shared", title: "Side" };
+    const input = {
+      workspaceId: owner.workspaceId, primarySessionId: owner.sessionId,
+      sessionsKnown: true, sessions: [owner, side],
+    };
+    let state = syncWorkbenchSnapshot(emptyWorkbench, input);
+    state = setWorkbenchSplit(openWorkbenchTab(state, side), side);
+    const refreshed = syncWorkbenchSnapshot(state, input);
+
+    expect(refreshed.primary).toMatchObject(owner);
+    expect(refreshed.secondary).toMatchObject(side);
+    expect(refreshed.tabs.map((tab) => tab.title)).toEqual(["Owner", "Side"]);
+    expect(refreshed.sideChats).toBe(state.sideChats);
+  });
+
+  test("bounds retained identity reads with a large inventory and preserves no-op snapshot identity", () => {
+    const sessions = Array.from({ length: 10_000 }, (_, index) => ({
+      workspaceId: "workspace-a", sessionId: `session-${index}`, title: `Session ${index}`,
+    }));
+    let identityReads = 0;
+    const tabs = sessions.slice(-128).map((session) => ({
+      ...session,
+      workspaceTitle: "Workspace A",
+      get workspaceId() { identityReads++; return session.workspaceId; },
+      get sessionId() { identityReads++; return session.sessionId; },
+    }));
+    const current: WorkbenchSnapshot = { ...emptyWorkbench, primary: tabs[0]!, tabs };
+    const input = {
+      workspaceId: "workspace-a", workspaceTitle: "Workspace A",
+      primarySessionId: sessions[sessions.length - tabs.length]!.sessionId,
+      sessionsKnown: true, sessions,
+    };
+    const unchanged = syncWorkbenchSnapshot(current, input);
+
+    expect(identityReads).toBeLessThanOrEqual(tabs.length * 12);
+    expect(unchanged).toBe(current);
+    expect(unchanged.tabs).toBe(tabs);
+    identityReads = 0;
+    const switchedInput = { ...input, primarySessionId: sessions.at(-1)!.sessionId };
+    const switched = syncWorkbenchSnapshot(current, switchedInput);
+
+    expect(identityReads).toBeLessThanOrEqual(tabs.length * 12);
+    expect(switched.primary?.sessionId).toBe(switchedInput.primarySessionId);
+    expect(switched.tabs).toHaveLength(tabs.length);
+    expect(switched.tabs.map((tab) => tab.sessionId)).toEqual(sessions.slice(-128).map((session) => session.sessionId));
+    expect(switched.revision).toBe(current.revision + 1);
+    expect(switched.sideChats).toBe(current.sideChats);
+    expect(syncWorkbenchSnapshot(switched, switchedInput)).toBe(switched);
   });
 
   test("focuses and closes a secondary by its full workspace reference", () => {
@@ -243,6 +311,8 @@ describe("workbench store", () => {
       sessions: [],
     });
 
+    expect(loading).toBe(state);
+    expect(loading.sideChats).toBe(state.sideChats);
     expect(loading.tabs.map((tab) => tab.sessionId)).toEqual(["session-a", "session-b"]);
     expect(loading.secondary?.sessionId).toBe("session-b");
   });

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -5,10 +5,13 @@ import {
   longHistoryCount,
   longHistoryFirst,
   longHistoryLast,
+  longHistoryOtherTitle,
   longHistoryTitle,
+  warmCachedLongHistory,
 } from "../worlds/chat.ts";
 
 const test = spec.world((seed) => longHistory(seed, { holdAncillaryReads: true }), { timeout: 600_000 });
+const warmTest = spec.world(warmCachedLongHistory, { timeout: 600_000 });
 
 /** The page size the transcript read used to request; OpenCode returns the newest n. */
 const oldPageSize = 140;
@@ -217,5 +220,137 @@ test("opening a long conversation shows the latest and full history while ancill
     const source = await probe.desktopApi(messagesPath);
     expect(source.status).toBe(200);
     expect(messageTexts(source.body)).toHaveLength(longHistoryCount);
+  });
+});
+
+warmTest("returning to a fully cached conversation refreshes its persisted tail before the uncapped read completes", async ({ user, agent, probe, step, world }) => {
+  const messagesPath = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/opencode/session/${encodeURIComponent(world.session.sessionId)}/message`;
+  const surface = `[data-session-surface-id="${world.session.sessionId}"]`;
+  const historyDom = async () => {
+    const { elements } = await probe.dom(`${surface} [data-thread-scroll], ${surface} [data-message-id]`);
+    return { viewport: elements[0], rows: elements.slice(1) };
+  };
+  const persisted = await step("the complete tail is persisted before reload, without submitting a prompt", async () => {
+    const stored = await probe.desktopApi(messagesPath);
+    expect(stored.status).toBe(200);
+    const texts = messageTexts(stored.body);
+    expect(texts).toHaveLength(longHistoryCount);
+    expect(texts[0]).toBe(longHistoryFirst);
+    expect(texts.at(-1)).toBe(longHistoryLast);
+    const latest = await probe.desktopApi(`${messagesPath}?limit=24`);
+    expect(latest.status).toBe(200);
+    expect(messageTexts(latest.body)).toEqual(texts.slice(-24));
+    await user.reload();
+    await user.see({ role: "button", label: new RegExp(`^${longHistoryOtherTitle}`) }, { timeoutMs: 60_000 });
+    expect((await probe.dom(surface)).elements).toHaveLength(0);
+    return texts;
+  });
+
+  await using fault = await world.startHistoryFault();
+  const cached = await step("an earlier uncapped response fills the full cache but omits the already persisted last message", async () => {
+    await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });
+    const initial = await probe.eventually(() => fault.read(), {
+      within: 60_000,
+      label: "the earlier full snapshot is cached and idle",
+      until: (value) => value.snapshot?.sessionId === world.session.sessionId && value.snapshot.count === longHistoryCount - 1
+        && value.snapshot.status === "success" && value.snapshot.fetchStatus === "idle",
+    });
+    expect(initial.reads).toContainEqual({
+      warm: false, limit: null, nativeCount: longHistoryCount, count: longHistoryCount - 1, hasTail: false, delivered: true,
+    });
+    expect(initial).toMatchObject({ armed: false, released: false, expired: false, held: 0, mutations: 0 });
+    expect(renderedCount(await agent.run("session.read_transcript", { count: 1 }))).toBe(longHistoryCount - 1);
+    await probe.eventually(() => probe.dom(`${surface} [data-thread-history-complete="true"]`), {
+      within: 30_000, label: "all earlier history is mounted", until: (value) => value.elements.length === 1,
+    });
+    const { rows } = await historyDom();
+    expect(rows).toHaveLength(longHistoryCount - 1);
+    rows.forEach((row, index) => expect(row.text).toContain(persisted[index]));
+    expect(rows.some((row) => row.text.includes(longHistoryLast))).toBe(false);
+    expect((await probe.dom(`${surface} [data-lexical-editor="true"]`)).elements.map((element) => element.text)).toEqual([""]);
+
+    await agent.run("session.scroll_top");
+    let previous = Number.NaN;
+    let stable = 0;
+    const anchor = await probe.eventually(async () => {
+      const { viewport, rows } = await historyDom();
+      const first = rows[0];
+      expect(first.text).toContain(longHistoryFirst);
+      expect(first.rect.height).toBeGreaterThan(0);
+      const offset = first.rect.top - viewport.rect.top;
+      stable = offset >= 0 && offset < viewport.rect.height && Math.abs(offset - previous) <= 1 ? stable + 1 : 0;
+      previous = offset;
+      return { offset, stable };
+    }, { within: 30_000, intervalMs: 100, label: "manual reading anchor settled at the first message", until: (value) => value.stable >= 3 });
+    return { texts: rows.map((row) => row.text), offset: anchor.offset };
+  });
+
+  let maxAnchorDrift = 0;
+  const observeReturn = async () => {
+    const { viewport, rows } = await historyDom();
+    const first = rows.find((row) => row.text.includes(longHistoryFirst));
+    if (first && viewport && first.rect.height > 0) {
+      maxAnchorDrift = Math.max(maxAnchorDrift, Math.abs(first.rect.top - viewport.rect.top - cached.offset));
+    }
+    return { viewport, rows };
+  };
+  const refreshed = await step("the warm newest-24 read adds the missing tail while the uncapped response stays held", async () => {
+    await user.click({ role: "button", label: new RegExp(`^${longHistoryOtherTitle}`) });
+    await probe.eventually(() => probe.dom(surface), {
+      within: 30_000, label: "the long conversation is unmounted, not reloaded", until: (value) => value.elements.length === 0,
+    });
+    await fault.arm();
+    await user.click({ role: "button", label: new RegExp(`^${longHistoryTitle}`) });
+    const returned = await probe.eventually(async () => {
+      const dom = await observeReturn();
+      const state = await fault.read();
+      return { ...dom, state };
+    }, {
+      within: 30_000,
+      label: "persisted tail rendered before delivery of any warm uncapped response",
+      until: ({ rows, state }) => rows.length === longHistoryCount && rows.some((row) => row.text.includes(longHistoryLast)) && state.held > 0,
+    });
+    expect(returned.state).toMatchObject({
+      armed: true, released: false, expired: false, mutations: 0,
+      snapshot: { sessionId: world.session.sessionId, count: longHistoryCount - 1, status: "success", fetchStatus: "fetching" },
+    });
+    expect(returned.state.reads).toContainEqual({ warm: true, limit: "24", nativeCount: 24, count: 24, hasTail: true, delivered: true });
+    expect(returned.state.reads).toContainEqual({ warm: true, limit: null, nativeCount: longHistoryCount, count: longHistoryCount, hasTail: true, delivered: false });
+    expect(returned.state.reads.filter((read) => read.warm && read.limit === null && read.delivered)).toHaveLength(0);
+    expect(renderedCount(await agent.run("session.read_transcript", { count: 1 }))).toBe(longHistoryCount);
+    expect(returned.rows.slice(0, -1).map((row) => row.text)).toEqual(cached.texts);
+    expect(returned.rows.filter((row) => row.text.includes(longHistoryLast))).toHaveLength(1);
+    expect(returned.rows.at(-1)?.text).toContain(longHistoryLast);
+    expect(returned.rows[0].rect.top).toBeGreaterThanOrEqual(returned.viewport.rect.top);
+    expect(returned.rows[0].rect.bottom).toBeLessThanOrEqual(returned.viewport.rect.bottom);
+    expect(maxAnchorDrift).toBeLessThanOrEqual(1);
+    expect((await fault.read()).held).toBeGreaterThan(0);
+    return returned.rows.map((row) => row.text);
+  });
+
+  await step("releasing full history neither duplicates nor rolls back messages or the manual anchor", async () => {
+    await fault.release();
+    let historyChanged = false;
+    const complete = await probe.eventually(async () => {
+      const dom = await observeReturn();
+      historyChanged ||= dom.rows.length !== refreshed.length || dom.rows.some((row, index) => row.text !== refreshed[index]);
+      return { ...dom, state: await fault.read() };
+    }, {
+      within: 30_000,
+      label: "the released full snapshot is applied without losing the fresh tail",
+      until: ({ state }) => state.held === 0 && state.snapshot?.count === longHistoryCount && state.snapshot.fetchStatus === "idle",
+    });
+    expect(complete.state).toMatchObject({ released: true, expired: false, mutations: 0 });
+    expect(complete.state.reads).toContainEqual({ warm: true, limit: null, nativeCount: longHistoryCount, count: longHistoryCount, hasTail: true, delivered: true });
+    expect(historyChanged).toBe(false);
+    expect(complete.rows.map((row) => row.text)).toEqual(refreshed);
+    expect(renderedCount(await agent.run("session.read_transcript", { count: 1 }))).toBe(longHistoryCount);
+    expect((await probe.dom(`${surface} [data-thread-history-complete="true"]`)).elements).toHaveLength(1);
+    expect((await probe.dom(`${surface} [data-thread-loading]`)).elements).toHaveLength(0);
+    const stored = await probe.desktopApi(messagesPath);
+    expect(stored.status).toBe(200);
+    expect(messageTexts(stored.body)).toEqual(persisted);
+    expect((await observeReturn()).rows.map((row) => row.text)).toEqual(refreshed);
+    expect(maxAnchorDrift).toBeLessThanOrEqual(1);
   });
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -19,6 +19,26 @@ declare global {
     __modelEffortRequests?: unknown[];
     __openworkSubmissionFault?: { attempts: number; release: () => void };
     __openworkLongHistoryFault?: { dispose: () => void };
+    __openworkWarmHistoryFault?: {
+      state: {
+        armed: boolean;
+        released: boolean;
+        expired: boolean;
+        held: number;
+        mutations: number;
+        reads: {
+          warm: boolean;
+          limit: string | null;
+          nativeCount: number;
+          count: number;
+          hasTail: boolean;
+          delivered: boolean;
+        }[];
+      };
+      arm: () => void;
+      release: () => void;
+      dispose: () => void;
+    };
     __openworkStoppingFault?: {
       state: {
         attempts: number;
@@ -2080,6 +2100,139 @@ export async function longHistory(seed: Seed, options: { holdAncillaryReads?: bo
       if (!ancillaryFault) return;
       try { await evalIn(app, () => window.__openworkLongHistoryFault?.dispose(), { timeoutMs: 5_000, reattachAttempts: 0 }); }
       finally { await ancillaryFault.dispose(); }
+    },
+  };
+}
+
+export async function warmCachedLongHistory(seed: Seed) {
+  if (resolveEvalEngine() !== "v1") throw new SkipError("native v1 stored history (OPENWORK_EVAL_ENGINE=v1)");
+  const base = await longHistory(seed, { holdAncillaryReads: false });
+  return {
+    ...base,
+    startHistoryFault: () => warmHistoryFault(seed, base.app, base.workspace.workspaceId, base.session.sessionId),
+  };
+}
+
+async function warmHistoryFault(seed: Seed, app: Surface, workspaceId: string, sessionId: string) {
+  await seed.evalIn(app, browserScript((workspaceId, sessionId, tail) => {
+    if (window.__openworkWarmHistoryFault) throw new Error("A warm history fault is already active");
+    const port = localStorage.getItem("openwork.server.port");
+    if (!port) throw new Error("Warm history fault requires the local server port");
+    const origin = `http://127.0.0.1:${port}`;
+    const paths = ["workspace", "w"].map((mount) =>
+      `/${mount}/${encodeURIComponent(workspaceId)}/opencode/session/${encodeURIComponent(sessionId)}`);
+    const originalFetch = window.fetch;
+    const state: NonNullable<Window["__openworkWarmHistoryFault"]>["state"] = {
+      armed: false, released: false, expired: false, held: 0, mutations: 0, reads: [],
+    };
+    const pending = new Set<() => void>();
+    let expiry: ReturnType<typeof setTimeout>;
+    const release = () => {
+      state.released = true;
+      clearTimeout(expiry);
+      for (const resume of pending) resume();
+    };
+    const dispose = () => {
+      release();
+      if (window.fetch === wrappedFetch) window.fetch = originalFetch;
+    };
+    const expire = () => { state.expired = true; dispose(); };
+    const hasTail = (message: unknown) => {
+      if (!message || typeof message !== "object" || !("parts" in message) || !Array.isArray(message.parts)) return false;
+      return message.parts.some((part: unknown) => part && typeof part === "object"
+        && "type" in part && part.type === "text" && "text" in part && part.text === tail);
+    };
+    const wrappedFetch: typeof window.fetch = async (...args) => {
+      const [input, init] = args;
+      const url = new URL(input instanceof Request ? input.url : String(input), location.href);
+      const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+      const owned = url.origin === origin && paths.some((path) => url.pathname === path || url.pathname.startsWith(`${path}/`));
+      if (owned && method !== "GET") state.mutations += 1;
+      if (state.released || !owned || method !== "GET" || !paths.some((path) => url.pathname === `${path}/message`)) {
+        return originalFetch.apply(window, args);
+      }
+      const warm = state.armed;
+      const signal = init?.signal !== undefined ? init.signal : input instanceof Request ? input.signal : undefined;
+      const response = await originalFetch.apply(window, args);
+      if (!response.ok) throw new Error(`Warm history read failed: HTTP ${response.status}`);
+      const messages: unknown = await response.clone().json();
+      signal?.throwIfAborted();
+      if (!Array.isArray(messages)) throw new Error("Warm history read did not return native messages");
+      const returned = warm ? messages : messages.filter((message: unknown) => !hasTail(message));
+      const read = {
+        warm, limit: url.searchParams.get("limit"), nativeCount: messages.length,
+        count: returned.length, hasTail: returned.some(hasTail), delivered: false,
+      };
+      state.reads.push(read);
+      if (warm && read.limit === null && !state.released) {
+        state.held += 1;
+        try {
+          await new Promise<void>((resolveHold, rejectHold) => {
+            const cleanup = () => { pending.delete(resume); signal?.removeEventListener("abort", abort); };
+            const resume = () => { cleanup(); resolveHold(); };
+            const abort = () => { cleanup(); rejectHold(signal?.reason ?? new DOMException("Aborted", "AbortError")); };
+            pending.add(resume);
+            signal?.addEventListener("abort", abort, { once: true });
+            if (signal?.aborted) abort();
+          });
+        } finally {
+          state.held -= 1;
+        }
+      }
+      signal?.throwIfAborted();
+      read.delivered = true;
+      if (warm) return response;
+      const headers = new Headers(response.headers);
+      headers.delete("content-length");
+      headers.delete("content-encoding");
+      return new Response(JSON.stringify(returned), { status: response.status, statusText: response.statusText, headers });
+    };
+    window.fetch = wrappedFetch;
+    expiry = setTimeout(expire, 120_000);
+    window.__openworkWarmHistoryFault = {
+      state,
+      arm: () => {
+        if (state.armed || state.released) throw new Error("Warm history fault cannot be armed again");
+        state.armed = true;
+        clearTimeout(expiry);
+        expiry = setTimeout(expire, 120_000);
+      },
+      release,
+      dispose,
+    };
+  }, [workspaceId, sessionId, longHistoryLast]));
+
+  return {
+    read: () => seed.evalIn(app, () => {
+      const fault = window.__openworkWarmHistoryFault;
+      if (!fault) throw new Error("Warm history fault lost its document");
+      const composer: unknown = window.__openwork?.slice("composer");
+      const snapshot = composer && typeof composer === "object" && "snapshotQuery" in composer ? composer.snapshotQuery : null;
+      return {
+        ...fault.state,
+        snapshot: snapshot && typeof snapshot === "object" ? {
+          sessionId: "dataSessionId" in snapshot && typeof snapshot.dataSessionId === "string" ? snapshot.dataSessionId : null,
+          count: "dataMessageCount" in snapshot && typeof snapshot.dataMessageCount === "number" ? snapshot.dataMessageCount : null,
+          status: "status" in snapshot && typeof snapshot.status === "string" ? snapshot.status : null,
+          fetchStatus: "fetchStatus" in snapshot && typeof snapshot.fetchStatus === "string" ? snapshot.fetchStatus : null,
+        } : null,
+      };
+    }),
+    arm: () => seed.evalIn(app, () => {
+      const fault = window.__openworkWarmHistoryFault;
+      if (!fault) throw new Error("Warm history fault lost its document");
+      fault.arm();
+    }),
+    release: () => seed.evalIn(app, () => {
+      const fault = window.__openworkWarmHistoryFault;
+      if (!fault || fault.state.held < 1 || fault.state.expired) throw new Error("No uncapped history response is held");
+      fault.release();
+    }),
+    async [Symbol.asyncDispose]() {
+      await seed.evalIn(app, () => {
+        window.__openworkWarmHistoryFault?.dispose();
+        delete window.__openworkWarmHistoryFault;
+      });
     },
   };
 }


### PR DESCRIPTION
## Problem

Returning to a cached conversation can show old information until an uncapped history refresh finishes. Thread selection also repeats full-inventory projection and per-tab linear searches, making large workspaces more expensive to navigate.

## Changes

- Revalidate the selected warm conversation's newest 24 messages using metadata/message reads only. Keep cached history visible and start the ordinary full refresh after that optional read, with a two-second deadline even when transport cancellation is ignored.
- Keep the newest display separate from the authoritative full snapshot. Reconcile subsequent full reads and live updates without reverting newer tool results, freezing forward progress, duplicating messages, or resurrecting confirmed removals. Full-history send/branch/revert paths remain separate.
- Use composite-key indexing for retained-tab metadata, memoize the selection-independent inventory projection, and reuse sidebar row derivations when their inputs have not changed. Preserve order, pins, archived-thread behavior, and cross-workspace identity.
- Extend the existing history-opening journey with an earlier stale full response followed by a warm newest-window response while the uncapped response is held. Assert retained history, manual-anchor continuity, and consistency after release.

## UI/UX impact

Latest persisted messages and tool results become readable earlier on warm return. No changes to layout, styling, labels, icons, controls, thread order, or scrolling policy. Drafts, retained tabs, background execution, and complete history are preserved by the implementation; native layout/interaction proof remains outstanding.

## Verification — Incomplete

Candidate: `bfdbd703ca1083ea4996a71d9fbb006ed0770de9`, rebased on `dev@b352470e755c05229e85fcd5d5c60e401f6a65b1` after #4921 merged.

Conflict resolution preserves the history-only `OpenworkSessionHistory` contract and independent status/todo hydration from #4921 alongside this PR's warm-read deadline and latest-message reconciliation. Both ancillary-held and warm/full-held journey assertions remain; their fault setups are isolated. The resolution introduces no additional UI/UX changes.

### Passed — affected checks after conflict resolution

The following were run separately from `apps/app` with `bun test --no-install ./tests/<file>` (Bun 1.3.4):

| File | Passed |
| --- | ---: |
| `session-history.test.tsx` | 44 |
| `session-render-state.test.ts` | 45 |
| `opencode-session-native.test.ts` | 50 |
| `session-snapshot-owner-flip.test.tsx` | 1 |
| `session-sync-tool-parts.test.ts` | 21 |

Total: **161 passed, 0 failed, 0 skipped**. Every invocation exited 0.

- App `pnpm typecheck`: exit 0.
- `pnpm --dir evals typecheck`: exit 0, 424 source files.
- `git diff --check origin/dev...HEAD`: exit 0.

The unchanged workbench/sidebar tests previously passed 24 tests on `f4a188f53`; they were not rerun for this history-contract conflict resolution.

### Historical failed check — reproduced on clean dev

Before this rebase, `pnpm evals:check-browser` exited 1 on `f4a188f53` and a clean control at `12637c34f4af7cbde9286b8f53cea570190d5be7`, with the same four diagnostics in unchanged files. It was not rerun in this conflict-resolution pass:

- `inference-gateway-client-isolation.test.ts:385–386`: raw browser code strings.
- `inference-gateway-transport-security.test.ts:275`: two captures of `count`.

No edits to those unrelated files are included. Passing component tests also emit duplicate-key and unavailable-storage warnings; their origin has not been classified with a clean control.

### Deferred / missing proof

- The extended real-app journey has **not run**. Reproduction: `pnpm evals:e2e session-full-history-on-open --engine v1`.
- Exact-head cold-boot runtime evidence and its publication are missing. The new journey fixture covers native v1; native v2 is covered here only by focused read-adapter tests, not a real-app journey.
- Large-workspace desktop latency, browser geometry, and memory measurements remain unverified. Operation-count regressions are not measured end-user speedups.

The separate cold-history/activity/readiness refactor (#4921) is now in the base and is preserved, not duplicated in this PR's diff. Broad polling/reconnect scheduling changes and a new virtualizer remain out of scope. No installed-app or release change is claimed.
