### PR TITLE
test: stabilize provider sync checks and security fixtures

### DIFF
--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -499,8 +499,15 @@ describe("cloud provider sync gateway", () => {
       expect((await responseRecord(await fetch(`${base}/cloud-provider-sync/status`, { headers: clientHeaders() }), "status")))
         .toMatchObject({ hasSession: false, providers: [], lastRun: null });
       expect((await put("/den-session", "org_new")).status).toBe(204);
-      await waitForLastRun(base, "applied");
+      // Join delivery, then force the same no-op a 20 ms timer can complete before
+      // a status observer wakes. lastRun is not history; assert durable effects.
+      expect(["applied", "noop"]).toContain((await runSync(base, "identity-ready")).status);
+      expect(await runSync(base, "after-ready")).toEqual({ status: "noop" });
       expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeDefined();
+      expect((await new EnvService({ path: process.env.OPENWORK_ENV_STORE }).list())
+        .map(({ key, value }) => ({ key, value })))
+        .toEqual([{ key: "TEST_PROVIDER_API_KEY", value: provider.apiKey }]);
+      expect(engineRequests).toContain("PUT /auth/lpr_test");
       expect(denRequests).toContain("org_new /v1/llm-providers/lpr_test/connect");
     } finally {
       release.resolve();

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -501,7 +501,8 @@ describe("cloud provider sync gateway", () => {
       expect((await put("/den-session", "org_new")).status).toBe(204);
       // Join delivery, then force the same no-op a 20 ms timer can complete before
       // a status observer wakes. lastRun is not history; assert durable effects.
-      expect(["applied", "noop"]).toContain((await runSync(base, "identity-ready")).status);
+      expect(await runSync(base, "identity-ready"))
+        .toMatchObject({ status: expect.stringMatching(/^(applied|noop)$/) });
       expect(await runSync(base, "after-ready")).toEqual({ status: "noop" });
       expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_test).toBeDefined();
       expect((await new EnvService({ path: process.env.OPENWORK_ENV_STORE }).list())

--- a/ee/packages/utils/src/inference-bearer-key.test.ts
+++ b/ee/packages/utils/src/inference-bearer-key.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import {
+  createGatewayBearerKey,
+  GATEWAY_BEARER_KEY_RANDOM_BYTES,
+  gatewayBearerKey,
+  gatewayBearerKeyLookupDigest,
+  gatewayBearerKeyLookupDigests,
+  gatewayBearerKeyMatchesDigest,
+  gatewayBearerKeyStorageDigest,
+} from "./gateway-bearer-key"
+import {
   createInferenceBearerKey,
   INFERENCE_BEARER_KEY_RANDOM_BYTES,
   inferenceBearerKeyLookupDigest,
@@ -43,5 +52,50 @@ describe("inference bearer keys", () => {
     expect(hmacDigest).not.toBe(legacyDigest)
     expect(await inferenceBearerKeyStorageDigest(key)).toBe(legacyDigest)
     expect(await inferenceBearerKeyLookupDigests(key)).toEqual([hmacDigest, legacyDigest])
+  })
+})
+
+describe("gateway bearer keys", () => {
+  // Public known-answer fixture: bytes 0..31 encoded as canonical base64url.
+  const value = "ow_gw_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+  const lookupDigest = "8404a50a260519f5ca2a39218340a8ceebdaeb61b6937a44587bf85986880382"
+  const shaOnlyDigest = "1b1005c33dab8760fc1cf410cf265e806ce89373c8bdd921fcd54dc37ad0f7fd"
+
+  test("generates unique canonical bearer keys from 256 bits of CSPRNG output", () => {
+    const keys = Array.from({ length: 32 }, () => createGatewayBearerKey())
+
+    expect(new Set(keys.map((key) => key.value)).size).toBe(keys.length)
+    for (const key of keys) {
+      expect(key.purpose).toBe("gateway-bearer-key")
+      expect(gatewayBearerKey(key.value)).toEqual(key)
+      expect(Buffer.from(key.value.slice("ow_gw_".length), "base64url")).toHaveLength(GATEWAY_BEARER_KEY_RANDOM_BYTES)
+    }
+  })
+
+  test("pins domain-separated lookup and rejects SHA-only compatibility", async () => {
+    const key = gatewayBearerKey(value)
+
+    expect(await gatewayBearerKeyLookupDigest(key)).toBe(lookupDigest)
+    expect(await gatewayBearerKeyStorageDigest(key)).toBe(lookupDigest)
+    expect(await gatewayBearerKeyLookupDigests(key)).toEqual([lookupDigest])
+    // Hash the same bytes for the legacy negative control, not Models authentication.
+    expect(await legacyInferenceBearerKeyLookupDigest(inferenceBearerKey(value))).toBe(shaOnlyDigest)
+    expect(await gatewayBearerKeyMatchesDigest(key, lookupDigest)).toBe(true)
+    expect(await gatewayBearerKeyMatchesDigest(key, shaOnlyDigest)).toBe(false)
+    expect(await gatewayBearerKeyMatchesDigest(key, "0".repeat(64))).toBe(false)
+    expect(await gatewayBearerKeyMatchesDigest(key, lookupDigest.toUpperCase())).toBe(false)
+    expect(await gatewayBearerKeyMatchesDigest(key, lookupDigest.slice(1))).toBe(false)
+  })
+
+  test("rejects other key families and noncanonical encodings", () => {
+    for (const invalid of [
+      "",
+      value.replace("ow_gw_", "ow_inf_"),
+      value.slice(1),
+      `${value}=`,
+      `${value.slice(0, -1)}9`,
+    ]) {
+      expect(() => gatewayBearerKey(invalid)).toThrow("Invalid Gateway bearer key")
+    }
   })
 })

--- a/evals/packages/env/src/inference.ts
+++ b/evals/packages/env/src/inference.ts
@@ -9,6 +9,11 @@ import type { Place } from "./place.ts";
 import { ephemeralDatabaseName, localMysqlIsRunning } from "./place.ts";
 import { SkipError } from "./needs.ts";
 
+// Lookup witnesses use purpose-specific 256-bit bearer keys, not password hashing.
+// Keep the algorithms in the product helpers; fixed-vector tests pin their formats.
+export { gatewayBearerKey, gatewayBearerKeyLookupDigest } from "../../../../ee/packages/utils/src/gateway-bearer-key.ts";
+export { inferenceBearerKey, legacyInferenceBearerKeyLookupDigest } from "../../../../ee/packages/utils/src/inference-bearer-key.ts";
+
 const root = fileURLToPath(new URL("../../../..", import.meta.url));
 const encryptionSecret = "local-dev-db-encryption-key-please-change-1234567890";
 const exec = promisify(execFile);

--- a/evals/runner/openwork-server-cli.test.ts
+++ b/evals/runner/openwork-server-cli.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createServer, get, type IncomingMessage, type ServerResponse } from "node:http";
+import test from "node:test";
+import { close, listen, readBody, sendJson, sendMockError } from "../worlds/openwork-server-cli.ts";
+
+function getResponse(url: string): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    get(url, { agent: false, signal: AbortSignal.timeout(5_000) }, resolve).once("error", reject);
+  });
+}
+
+const sensitiveError = new Error("sensitive mock request message");
+sensitiveError.stack = "Error: sensitive mock request message\n    at sensitiveMockFrame (/internal/sensitive-provider.ts:42:9)";
+
+for (const { name, error } of [
+  { name: "an Error with a sensitive message and stack", error: sensitiveError },
+  { name: "a sensitive thrown string", error: "sensitive mock thrown string" },
+]) {
+  test(`sendMockError keeps ${name} server-side`, { timeout: 10_000 }, async t => {
+    const logger = t.mock.method(console, "error", () => {});
+    const server = createServer((_request, response) => {
+      try {
+        throw error;
+      } catch (caught) {
+        sendMockError(response, caught);
+      }
+    });
+    t.after(() => close(server));
+
+    const response = await getResponse(await listen(server));
+    const body = await readBody(response);
+
+    assert.equal(response.statusCode, 500);
+    assert.equal(response.headers["content-type"], "application/json");
+    assert.equal(response.headers["cache-control"], "no-store");
+    assert.equal(body, JSON.stringify({ error: "mock_request_failed" }));
+    assert.doesNotMatch(JSON.stringify({ headers: response.rawHeaders, body }), /sensitive/);
+    assert.equal(logger.mock.callCount(), 1);
+    assert.equal(logger.mock.calls[0]?.arguments[0], "[mock] Request failed");
+    assert.equal(logger.mock.calls[0]?.arguments[1], error);
+    assert.equal(logger.mock.calls[0]?.arguments.length, 2);
+  });
+}
+
+test("sendMockError closes an already-started response without a second header", { timeout: 10_000 }, async t => {
+  const logger = t.mock.method(console, "error", () => {});
+  const started = Promise.withResolvers<ServerResponse>();
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.write("already started");
+    started.resolve(response);
+  });
+  t.after(() => close(server));
+
+  const response = await getResponse(await listen(server));
+  const serverResponse = await started.promise;
+  const writeHead = t.mock.method(serverResponse, "writeHead");
+  let body = "";
+  response.setEncoding("utf8");
+  response.on("data", (chunk: string) => { body += chunk; });
+  const closed = new Promise<unknown>(resolve => {
+    let failure: unknown;
+    response.on("error", error => { failure = error; });
+    response.once("close", () => resolve(failure));
+  });
+  await once(response, "data");
+
+  sendMockError(serverResponse, sensitiveError);
+  const destroyedImmediately = serverResponse.destroyed;
+  const failure = await closed;
+
+  assert.equal(destroyedImmediately, true);
+  assert.equal(writeHead.mock.callCount(), 0);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["content-type"], "text/plain");
+  assert.equal(response.complete, false);
+  assert.equal(response.destroyed, true);
+  assert.ok(failure instanceof Error && "code" in failure);
+  assert.equal(failure.code, "ECONNRESET");
+  assert.equal(body, "already started");
+  assert.doesNotMatch(JSON.stringify({ headers: response.rawHeaders, body }), /sensitive|mock_request_failed/);
+  assert.equal(logger.mock.callCount(), 1);
+  assert.equal(logger.mock.calls[0]?.arguments[0], "[mock] Request failed");
+  assert.equal(logger.mock.calls[0]?.arguments[1], sensitiveError);
+  assert.equal(logger.mock.calls[0]?.arguments.length, 2);
+});
+
+test("sendJson preserves the supplied status and body without logging", { timeout: 10_000 }, async t => {
+  const logger = t.mock.method(console, "error", () => {});
+  const payload = { ok: true, data: [{ id: "mock" }], error: "intentional fixture payload" };
+  const server = createServer((_request, response) => {
+    sendJson(response, 201, payload);
+  });
+  t.after(() => close(server));
+
+  const response = await getResponse(await listen(server));
+  const body = await readBody(response);
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.headers["content-type"], "application/json");
+  assert.equal(response.headers["cache-control"], "no-store");
+  assert.equal(body, JSON.stringify(payload));
+  assert.equal(logger.mock.callCount(), 0);
+});

--- a/evals/specs/inference-gateway-lifecycle.test.ts
+++ b/evals/specs/inference-gateway-lifecycle.test.ts
@@ -1,8 +1,10 @@
-import { createHash, createHmac } from "node:crypto";
 import { createServer, type ServerResponse } from "node:http";
 import { expect } from "vitest";
 import { denFetch, type DenSession } from "@openwork/behaviors";
-import { eventually, localMysqlIsRunning, queryDenDatabase, server, test } from "@openwork/testkit";
+import {
+  eventually, gatewayBearerKey, gatewayBearerKeyLookupDigest, inferenceBearerKey,
+  legacyInferenceBearerKeyLookupDigest, localMysqlIsRunning, queryDenDatabase, server, test,
+} from "@openwork/testkit";
 
 const local = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL;
 const mysql = await localMysqlIsRunning();
@@ -107,7 +109,9 @@ test.skipIf(!local || !mysql)(title, { timeout: 600_000 }, async ({ place }) => 
   const sql = (statement: string, values: string[] = []) => queryDenDatabase(database, statement, values);
   const keys = (id = memberId) => sql("SELECT id, key_hash, status, encrypted_key FROM gateway_keys WHERE organization_id = ? AND org_membership_id = ? AND status = 'active' AND revoked_at IS NULL", [orgId, id]);
   const modelsKeys = () => sql("SELECT id, key_hash, status, encrypted_key FROM inference_keys WHERE organization_id = ? AND org_membership_id = ? AND status = 'active'", [orgId, memberId]);
-  const gatewayDigest = (key: string) => createHmac("sha256", "openwork-gateway-bearer-key-lookup-v1").update(key).digest("hex");
+  const gatewayDigest = (value: string) => gatewayBearerKeyLookupDigest(gatewayBearerKey(value));
+  // The legacy SHA-only digest is also the negative control for Gateway's domain separation.
+  const legacyDigest = (value: string) => legacyInferenceBearerKeyLookupDigest(inferenceBearerKey(value));
   // No Models tier and no /connect yet: join itself must provision exactly one key.
   const inferenceEnabled = record((await sql("SELECT JSON_EXTRACT(metadata, '$.inference.enabled') AS enabled FROM organization WHERE id = ?", [orgId]))[0]).enabled;
   expect(inferenceEnabled == null || inferenceEnabled === false || inferenceEnabled === "false").toBe(true);
@@ -152,8 +156,8 @@ test.skipIf(!local || !mysql)(title, { timeout: 600_000 }, async ({ place }) => 
   expect(key).toMatch(/^ow_gw_[A-Za-z0-9_-]{43}$/);
   expect(new Set(connections.map((entry) => entry.apiKey)).size).toBe(1);
   expect(await keys()).toHaveLength(1);
-  expect(record((await keys())[0]).key_hash).toBe(gatewayDigest(key));
-  expect(record((await keys())[0]).key_hash).not.toBe(createHash("sha256").update(key).digest("hex"));
+  expect(record((await keys())[0]).key_hash).toBe(await gatewayDigest(key));
+  expect(record((await keys())[0]).key_hash).not.toBe(await legacyDigest(key));
   expect(text(record((await keys())[0]).encrypted_key)).toMatch(/^enc:v1:/);
   const scopedEnv = `${sharedId.toUpperCase()}_ANTHROPIC_API_KEY`;
   expect(record(connections[0]?.providerConfig).env).toEqual([scopedEnv]);
@@ -178,7 +182,7 @@ test.skipIf(!local || !mysql)(title, { timeout: 600_000 }, async ({ place }) => 
   const gatewayBeforeModelsRepair = await keys();
   await sql("UPDATE inference_keys SET encrypted_key = NULL WHERE organization_id = ? AND org_membership_id = ? AND status = 'active'", [orgId, memberId]);
   expect(await modelsConnect()).toBe(modelsKey);
-  expect(record((await modelsKeys())[0]).key_hash).toBe(createHash("sha256").update(modelsKey).digest("hex"));
+  expect(record((await modelsKeys())[0]).key_hash).toBe(await legacyDigest(modelsKey));
   await sql("UPDATE inference_keys SET encrypted_key = NULL, key_hash = ? WHERE organization_id = ? AND org_membership_id = ? AND status = 'active'", ["0".repeat(64), orgId, memberId]);
   const rotatedModelsKey = await modelsConnect();
   expect(rotatedModelsKey).toMatch(/^ow_inf_[A-Za-z0-9_-]{43}$/);
@@ -197,7 +201,7 @@ test.skipIf(!local || !mysql)(title, { timeout: 600_000 }, async ({ place }) => 
   expect(repairedKey).not.toBe(rotatedModelsKey);
   expect(new Set(recovered.map((entry) => entry.apiKey)).size).toBe(1);
   expect(await keys()).toHaveLength(1);
-  expect(record((await keys())[0]).key_hash).toBe(gatewayDigest(repairedKey));
+  expect(record((await keys())[0]).key_hash).toBe(await gatewayDigest(repairedKey));
   expect((await connect()).apiKey).toBe(repairedKey);
   expect(await modelsConnect()).toBe(rotatedModelsKey);
   expect(await modelsKeys()).toEqual(modelsBeforeGatewayRepair);

--- a/evals/worlds/agent-session-send.ts
+++ b/evals/worlds/agent-session-send.ts
@@ -9,6 +9,7 @@ import {
   listen,
   readBody,
   sendJson,
+  sendMockError,
   sendStream,
   type ManagedOpenworkServer,
 } from "./openwork-server-cli.ts";
@@ -131,8 +132,7 @@ function mockProvider(
       }
       sendJson(response, 200, { object: "list", data: [] });
     })().catch((error: unknown) => {
-      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
-      else response.destroy(error instanceof Error ? error : undefined);
+      sendMockError(response, error);
     });
   });
 }

--- a/evals/worlds/agent-ui-context.ts
+++ b/evals/worlds/agent-ui-context.ts
@@ -9,6 +9,7 @@ import {
   listen,
   readBody,
   sendJson,
+  sendMockError,
   sendStream,
   type ManagedOpenworkServer,
 } from "./openwork-server-cli.ts";
@@ -81,8 +82,7 @@ function mockProvider(requests: AgentUiContextProviderRequest[]): Server {
       }
       sendJson(response, 200, { object: "list", data: [] });
     })().catch((error: unknown) => {
-      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
-      else response.destroy(error instanceof Error ? error : undefined);
+      sendMockError(response, error);
     });
   });
 }

--- a/evals/worlds/mcp-registration.ts
+++ b/evals/worlds/mcp-registration.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import { join } from "node:path";
 import type { Seed } from "@openwork/env";
 import { startMockMcp } from "@openwork/labs";
-import { bootManagedOpenworkServer, close, isRecord, listen, readBody, sendJson, sendStream } from "./openwork-server-cli.ts";
+import { bootManagedOpenworkServer, close, isRecord, listen, readBody, sendJson, sendMockError, sendStream } from "./openwork-server-cli.ts";
 
 function gate() {
   let release: () => void = () => {};
@@ -56,7 +56,7 @@ export async function mcpRegistration(seed: Seed) {
       });
       response.writeHead(upstream.status, Object.fromEntries(upstream.headers));
       response.end(await upstream.text());
-    } catch (error) { sendJson(response, 500, { error: String(error) }); }
+    } catch (error) { sendMockError(response, error); }
   });
   const mcpUrl = await listen(proxy);
   const provider = createServer(async (request, response) => {
@@ -75,7 +75,7 @@ export async function mcpRegistration(seed: Seed) {
         { id: "fixture", object: "chat.completion.chunk", choices: [{ index: 0, delta, finish_reason: null }] },
         { id: "fixture", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: call ? "tool_calls" : "stop" }] },
       ]);
-    } catch (error) { sendJson(response, 500, { error: String(error) }); }
+    } catch (error) { sendMockError(response, error); }
   });
   const providerUrl = await listen(provider);
   const mcpConfig = { type: "remote", url: mcpUrl, oauth: false, enabled: true };

--- a/evals/worlds/openwork-server-cli.ts
+++ b/evals/worlds/openwork-server-cli.ts
@@ -27,6 +27,15 @@ export function sendJson(response: ServerResponse, status: number, body: unknown
   response.end(JSON.stringify(body));
 }
 
+export function sendMockError(response: ServerResponse, error: unknown): void {
+  console.error("[mock] Request failed", error);
+  if (response.headersSent) {
+    response.destroy();
+    return;
+  }
+  sendJson(response, 500, { error: "mock_request_failed" });
+}
+
 export function sendStream(response: ServerResponse, chunks: unknown[]): void {
   response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
   for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);

--- a/evals/worlds/pdf-attachments.ts
+++ b/evals/worlds/pdf-attachments.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { SkipError } from "@openwork/env";
 import type { Seed } from "@openwork/env";
 import { buildTestPdf, pdfDataUrl } from "../../apps/server/src/pdf-attachments/pdf-fixture.test-helper.ts";
-import { bootManagedOpenworkServer, close, engineBinary, isRecord, listen, readBody, sendJson, sendStream } from "./openwork-server-cli.ts";
+import { bootManagedOpenworkServer, close, engineBinary, isRecord, listen, readBody, sendJson, sendMockError, sendStream } from "./openwork-server-cli.ts";
 
 // A PDF attached in chat must work with every model the engine can run. The
 // engine forwards a PDF part to the provider untouched, so a model without PDF
@@ -109,8 +109,7 @@ function mockProvider(workspace: string, requests: ProviderRequest[]): Server {
       }
       sendJson(response, 200, { object: "list", data: [] });
     })().catch((error: unknown) => {
-      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
-      else response.destroy(error instanceof Error ? error : undefined);
+      sendMockError(response, error);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Fix the provider-sync test race behind the two recent dev core-check timeouts. Join delivery and force a completed no-op before asserting durable configuration, credential, and engine-auth effects rather than trying to observe the transient `applied` status.
- Reuse the existing purpose-specific bearer-key lookup contracts in the inference lifecycle spec. Keep the SHA-only negative control and pin Gateway hashing, compatibility rejection, and canonical input handling with independent known-answer fixtures. Production key generation and hashing are unchanged.
- Keep unexpected mock-server exceptions in server-side diagnostics, returning a generic JSON failure or closing an already-started response. Keep ordinary and intentional redaction-fixture responses unchanged.

## Why these changes remain useful on dev
Rebased onto `b352470e755c05229e85fcd5d5c60e401f6a65b1`. Its build/core run passes, but the three bearer-hash CodeQL findings and the mock exception-disclosure finding remain open in recent dev analyses.

The earlier core failures in runs [34538978990](https://github.com/different-ai/openwork/actions/runs/34538978990) and [34534644082](https://github.com/different-ai/openwork/actions/runs/34534644082) were `Timed out waiting for provider sync status applied`, not compilation failures. Completing a legitimate no-op before the old status wait deterministically reproduces that exact timeout on the current implementation. The repaired case passes with that schedule and stronger durable assertions; no timeout was increased.

The database-migration failure was already corrected upstream by #4898. PR-triggered evidence-publisher attribution failures are separate and overlap #4708; neither is bundled here. This is not a claim to repair every intermittent CI failure.

## UI/UX impact
None — existing UI/UX preserved. Only tests and test infrastructure change; no production UI, authentication logic, migration, workflow, or check policy is changed.

## Verification — Incomplete
Candidate: `dd0de199ccf664a22e70b677fcb6d9b47334f18f`.

Passed on this exact head:
- `pnpm --filter openwork-server exec bun --conditions=development test src/cloud-provider-sync.e2e.test.ts --test-name-pattern "early identity cancels a previous provider fetch"` — 1 passed, 0 failed, 19 filtered out, 18 assertions.
- `pnpm --filter @openwork-ee/utils exec bun test src/inference-bearer-key.test.ts` — 7 passed, 0 failed, 215 assertions.
- `pnpm --dir evals exec node --test runner/openwork-server-cli.test.ts` — 4 passed, 0 failed, 0 skipped; real loopback HTTP checks.
- `pnpm --dir evals typecheck` — 425 evals source files, no errors.
- `pnpm --filter openwork-server build` — passed, including TypeScript and packaged plugin bundles.
- `git diff --check origin/dev...HEAD`.

The initial PR revision had a TypeScript constraint error in the new test assertion. The final assertion is type-safe; the exact server build and focused case were rerun successfully. Final-head GitHub verification: [CodeQL](https://github.com/different-ai/openwork/actions/runs/34655108633) reports zero findings in all three languages; the code-scanning check passes. [Build and core checks](https://github.com/different-ai/openwork/actions/runs/34655110758) passes, including the server bundles, Electron IPC typecheck, installed-desktop smoke test, core regressions, and required aggregate gate.

Failed, confirmed outside this patch:
- `pnpm --dir evals exec node scripts/spec-boundary-ratchet.mjs` exits 1 with 26 findings in 10 unrelated spec files. The identical command produces the same findings in a clean dev control at `12637c34f4af7cbde9286b8f53cea570190d5be7`. No baseline or assertion was relaxed.

Deferred:
- The full MySQL-backed inference lifecycle journey was not rerun. The local tests above do not claim complete Den/Desktop product-journey proof.



