### PR TITLE
fix(composer): follow the caret for mention suggestions

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -294,15 +294,15 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     return plugins;
   };
 
-  const handleInsertMention = (kind: ComposerMentionKind, value: string) => {
+  const handleInsertMention = (kind: ComposerMentionKind, value: string, nextDraft?: string) => {
     // @agent mentions switch the pending task's agent instead of inserting a
     // mention token (mirrors the session composer, #2101).
     if (kind === "agent") {
-      updateDraft(continuationHolderRef.current.state.draft.replace(/@([^\s@]*)$/, ""));
+      updateDraft(nextDraft ?? continuationHolderRef.current.state.draft.replace(/@([^\s@]*)$/, ""));
       context?.onSelectAgent(value);
       return;
     }
-    updateDraft(continuationHolderRef.current.state.draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
+    updateDraft(nextDraft ?? continuationHolderRef.current.state.draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
     updateMentions({ ...continuationHolderRef.current.state.mentions, [value]: kind });
   };
 

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -104,7 +104,7 @@ type ComposerProps = {
   onOpenSettingsSection?: (section: ComposerSettingsSection) => void;
   recentFiles: string[];
   searchFiles: (query: string) => Promise<string[]>;
-  onInsertMention: (kind: ComposerMentionKind, value: string) => void;
+  onInsertMention: (kind: ComposerMentionKind, value: string, draft?: string) => void;
   /** Sent-prompt history (oldest first) recalled with ArrowUp/ArrowDown (#2012). */
   inputHistory?: string[];
   onPasteText: (text: string) => void;
@@ -248,6 +248,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
   const [toolMenuLayout, setToolMenuLayout] = useState<ToolMenuLayout | null>(null);
   const [toolMenuSection, setToolMenuSection] = useState<ToolMenuSection>("commands");
   const [mentionItems, setMentionItems] = useState<MentionItem[]>([]);
+  const [activeMentionQuery, setActiveMentionQuery] = useState<string | null>(null);
   const [mentionOpen, setMentionOpen] = useState(false);
   const [menuIndex, setMenuIndex] = useState(0);
   const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -366,9 +367,8 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
   const slashCommandQuery = getSlashCommandQuery(props.draft);
   const slashOpenNext = slashCommandQuery !== null;
   const slashQuery = slashCommandQuery ?? "";
-  const mentionMatch = props.draft.match(/@([^\s@]*)$/);
-  const mentionOpenNext = Boolean(mentionMatch);
-  const mentionQuery = mentionMatch?.[1] ?? "";
+  const mentionOpenNext = activeMentionQuery !== null;
+  const mentionQuery = activeMentionQuery ?? "";
   const nonDefaultAgents = useMemo(() => agents.filter(isNonDefaultAgent), [agents]);
   const showAgentPicker = props.selectedAgent !== null;
 
@@ -960,6 +960,14 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
     props.onOpenSettingsSection?.(composerConfigureSectionForMenu(toolMenuSection));
   };
 
+  const applyMentionSelection = (item: MentionItem) => {
+    const draft = editorRef.current?.insertMentionAtSelection(item.kind, item.value);
+    if (draft == null) return false;
+    props.onInsertMention(item.kind, item.value, draft);
+    setMentionOpen(false);
+    return true;
+  };
+
   const acceptActiveItem = () => {
     if (!activeItems.length) return false;
     if (activeMenu === "slash") {
@@ -971,9 +979,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
     if (activeMenu === "mention") {
       const item = mentionFiltered[menuIndex];
       if (!item) return false;
-      props.onInsertMention(item.kind, item.value);
-      setMentionOpen(false);
-      return true;
+      return applyMentionSelection(item);
     }
     return false;
   };
@@ -1252,8 +1258,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                   className={`flex w-full items-start gap-3 rounded-[16px] px-3 py-2.5 text-left transition-colors hover:bg-gray-2/70 ${activeMenu === "mention" && mentionFiltered[menuIndex]?.id === item.id ? "bg-gray-3 text-gray-12" : "text-gray-11"}`}
                   onMouseEnter={() => setMenuIndex(index)}
                   onClick={() => {
-                    props.onInsertMention(item.kind, item.value);
-                    setMentionOpen(false);
+                    applyMentionSelection(item);
                   }}
                 >
                   {item.kind === "computer" ? (
@@ -1336,6 +1341,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
               submitDisabled={props.disabled}
               placeholder={t("composer.placeholder")}
               onChange={props.onDraftChange}
+              onMentionQueryChange={setActiveMentionQuery}
               onSubmit={handleEditorSubmit}
               onExpandPastedText={handleExpandPastedText}
               onExpandAttachment={setExpandedAttachmentId}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -59,6 +59,7 @@ type EditorProps = {
   submitDisabled: boolean;
   placeholder: string;
   onChange: (value: string) => void;
+  onMentionQueryChange?: (query: string | null) => void;
   onSubmit: (options: { queue: boolean }) => void | Promise<void>;
   onExpandPastedText?: (label: string) => void;
   onExpandAttachment?: (id: string) => void;
@@ -72,6 +73,7 @@ type EditorProps = {
 
 export type LexicalPromptEditorHandle = {
   insertSkillAtSelection: (skillName: string, skillToken?: string) => void;
+  insertMentionAtSelection: (kind: ComposerMentionKind, value: string) => string | null;
 };
 
 type SerializedComposerMentionNode = Spread<
@@ -880,6 +882,41 @@ function setPrompt(
   }
 }
 
+function mentionAtSelection() {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
+  let node = selection.anchor.getNode();
+  let end = selection.anchor.offset;
+  if ($isElementNode(node)) {
+    const previous = node.getChildAtIndex(end - 1);
+    if (!$isTextNode(previous)) return null;
+    node = previous;
+    end = node.getTextContentSize();
+  }
+  if (!$isTextNode(node) || isComposerInlineTokenNode(node)) return null;
+  const text = node.getTextContent();
+  const match = text.slice(0, end).match(/@([^\s@]*)$/);
+  if (!match) return null;
+  const remaining = text.slice(end).match(/^[^\s@]*/)?.[0] ?? "";
+  return { node, start: end - match[0].length, end: end + remaining.length, query: match[1] ?? "" };
+}
+
+function insertMentionAtSelection(kind: ComposerMentionKind, value: string) {
+  const match = mentionAtSelection();
+  if (!match) return false;
+  const end = match.end + (kind !== "agent" && match.node.getTextContent()[match.end] === " " ? 1 : 0);
+  const selection = match.node.select(match.start, end);
+  if (kind === "agent") {
+    selection.removeText();
+    return true;
+  }
+  const mention = $createComposerMentionNode(value, kind);
+  const space = $createTextNode(" ");
+  selection.insertNodes([mention, space]);
+  space.selectEnd();
+  return true;
+}
+
 function appendSkillAtEnd(skillName: string, skillToken?: string) {
   const root = $getRoot();
   const lastChild = root.getLastChild();
@@ -1293,6 +1330,13 @@ function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEd
       editor.update(() => insertSkillAtSelection(skillName, skillToken));
       editor.focus();
     },
+    insertMentionAtSelection(kind: ComposerMentionKind, value: string) {
+      let draft: string | null = null;
+      editor.update(() => {
+        if (insertMentionAtSelection(kind, value)) draft = serializePromptFromRoot();
+      }, { discrete: true });
+      return draft;
+    },
   }), [editor]);
 
   return null;
@@ -1347,6 +1391,7 @@ function AttachmentChipPlugin(props: { onRemoveAttachment?: (id: string) => void
 export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorProps>(function LexicalPromptEditor(props, ref) {
   const valueRef = useRef(props.value);
   const onChangeRef = useRef(props.onChange);
+  const onMentionQueryChangeRef = useRef(props.onMentionQueryChange);
 
   useEffect(() => {
     valueRef.current = props.value;
@@ -1354,7 +1399,8 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
 
   useEffect(() => {
     onChangeRef.current = props.onChange;
-  }, [props.onChange]);
+    onMentionQueryChangeRef.current = props.onMentionQueryChange;
+  }, [props.onChange, props.onMentionQueryChange]);
 
   const initialConfig = useMemo(
     () => ({
@@ -1374,6 +1420,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
   const syncPromptFromEditorState = useCallback(
     (state: Parameters<NonNullable<React.ComponentProps<typeof OnChangePlugin>["onChange"]>>[0]) => {
       state.read(() => {
+        onMentionQueryChangeRef.current?.(mentionAtSelection()?.query ?? null);
         const next = serializePromptFromRoot();
         if (next === valueRef.current) return;
         valueRef.current = next;

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2583,18 +2583,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setComposerDraft(props.sessionId, draft.replaceAll(`[attachment ${id}]`, ""));
   }, [attachments, draft, props.sessionId, setComposerAttachments, setComposerDraft]);
 
-  const handleInsertMention = useCallback((kind: ComposerMentionKind, value: string) => {
+  const handleInsertMention = useCallback((kind: ComposerMentionKind, value: string, nextDraft?: string) => {
     // @agent mentions switch the session agent instead of inserting an agent
     // part. Agent parts are treated as *subagent* (task tool) calls by the
     // engine, which silently fails for primary agents and left every reply
     // coming from the default agent (#2101).
     if (kind === "agent") {
-      setComposerDraft(props.sessionId, draft.replace(/@([^\s@]*)$/, ""));
+      setComposerDraft(props.sessionId, nextDraft ?? draft.replace(/@([^\s@]*)$/, ""));
       props.onSelectAgent(value);
       toast.success(t("composer.agent_selected", { agent: value }));
       return;
     }
-    setComposerDraft(props.sessionId, draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
+    setComposerDraft(props.sessionId, nextDraft ?? draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
     setComposerMentions(props.sessionId, { ...mentions, [value]: kind });
     // Pre-flight Computer Use permissions when an app is mentioned so missing
     // Accessibility / Screen Recording grants surface before send, not as a

--- a/apps/app/tests/composer-mention-results.test.tsx
+++ b/apps/app/tests/composer-mention-results.test.tsx
@@ -1,0 +1,370 @@
+import { afterAll, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { createRequire } from "node:module";
+import { act, useState, type ComponentProps, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { encodeComposerMentionValue } from "../src/react-app/domains/session/surface/composer/mention-encoding";
+
+GlobalRegistrator.register({ url: "http://localhost/" });
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+Object.defineProperty(document, "compatMode", { configurable: true, value: "CSS1Compat" });
+const network = mock(async () => { throw new Error("Network is not available in composer tests"); });
+Object.defineProperty(globalThis, "fetch", { configurable: true, value: network });
+Object.defineProperty(window, "fetch", { configurable: true, value: network });
+
+const require = createRequire(import.meta.url);
+for (const name of [
+  "lexical",
+  "@lexical/react/LexicalComposer.js",
+  "@lexical/react/LexicalPlainTextPlugin.js",
+  "@lexical/react/LexicalContentEditable.js",
+  "@lexical/react/LexicalErrorBoundary.js",
+  "@lexical/react/LexicalOnChangePlugin.js",
+  "@lexical/react/LexicalHistoryPlugin.js",
+  "@lexical/react/LexicalComposerContext.js",
+]) {
+  const exports = require(name);
+  mock.module(name, () => exports);
+}
+
+let runningApps: string[] = [];
+const connections = {
+  connections: [], loading: false, loaded: true, error: null, connectingId: null,
+  refresh: async () => {}, connect: async () => {},
+};
+mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
+mock.module("@/components/chat/image-lightbox", () => ({ ImageLightbox: () => null }));
+mock.module("@/react-app/domains/connections/use-org-mcp-connections", () => ({ useOrgMcpConnections: () => connections }));
+mock.module("@/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
+mock.module("@/react-app/shell/dev-profiler", () => ({ DevProfiler: ({ children }: { children: ReactNode }) => children }));
+mock.module("../src/react-app/domains/session/surface/composer/app-mentions", () => ({ listRunningAppsForMention: async () => runningApps }));
+
+const { ReactSessionComposer } = await import("../src/react-app/domains/session/surface/composer/composer");
+const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
+const { $createRangeSelection, $getRoot, $getSelection, $isElementNode, $isRangeSelection, $isTextNode, $setSelection, getNearestEditorFromDOMNode, SKIP_DOM_SELECTION_TAG } = await import("lexical");
+type Props = ComponentProps<typeof ReactSessionComposer>;
+const defaultAgents: Awaited<ReturnType<Props["listAgents"]>> = [{ name: "openwork", mode: "primary", options: {}, permission: [] }];
+
+async function mounted(options: {
+  draft?: string;
+  files?: string[];
+  apps?: string[];
+  mentions?: Props["mentions"];
+  attachments?: Props["attachments"];
+  search?: Props["searchFiles"];
+  newTask?: boolean;
+} = {}) {
+  runningApps = options.apps ?? [];
+  const queries: string[] = [];
+  const selectedAgent = mock((value: string | null) => {});
+  const sent = mock(() => {});
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  let currentDraft = options.draft ?? "";
+  const searchFiles = async (query: string) => {
+    queries.push(query);
+    return options.search ? options.search(query) : options.files ?? ["notes.md", "docs/start.md", "src/openwork.ts", "docs/cloud-notes.md"];
+  };
+  const listAgents = async () => defaultAgents;
+  const listCommands = async () => [];
+  const attachments = options.attachments ?? [];
+  const recentFiles: string[] = [];
+  function Harness() {
+    const [draft, setDraft] = useState(currentDraft);
+    const [mentions, setMentions] = useState(options.mentions ?? {});
+    const updateDraft = (value: string) => { currentDraft = value; setDraft(value); };
+    const context = {
+      client: null,
+      workspaceId: null,
+      selectedModel: { providerID: "fixture", modelID: "fixture" },
+      modelPickerOpen: false,
+      onModelPickerOpenChange: () => {},
+      onModelChange: () => {},
+      modelVariantLabel: "Default",
+      modelVariant: null,
+      onModelVariantChange: () => {},
+      agentLabel: "OpenWork",
+      selectedAgent: null,
+      listAgents,
+      onSelectAgent: selectedAgent,
+      listCommands,
+      searchFiles,
+      isRemoteWorkspace: false,
+      isSandboxWorkspace: false,
+    };
+    if (options.newTask) {
+      return <NewTaskComposer draft={draft} onDraftChange={updateDraft} onRunTask={sent} busy={false} context={context} />;
+    }
+    return <ReactSessionComposer
+      {...context}
+      draft={draft}
+      mentions={mentions}
+      onDraftChange={updateDraft}
+      onSend={sent}
+      onSteer={() => {}}
+      onQueue={() => {}}
+      onStop={() => {}}
+      busy={false}
+      steering={false}
+      submissionPreparing={false}
+      queuedCount={0}
+      disabled={false}
+      statusLabel=""
+      attachments={attachments}
+      onAttachFiles={() => {}}
+      onRemoveAttachment={() => {}}
+      attachmentsEnabled={false}
+      attachmentsDisabledReason={null}
+      recentFiles={recentFiles}
+      onInsertMention={(kind, value, nextDraft) => {
+        updateDraft(nextDraft ?? draft.replace(/@([^\s@]*)$/, kind === "agent" ? "" : `@${encodeComposerMentionValue(value)} `));
+        if (kind === "agent") selectedAgent(value);
+        else setMentions((previous) => ({ ...previous, [value]: kind }));
+      }}
+      onPasteText={() => {}}
+      onUnsupportedFileLinks={() => {}}
+      pastedText={[]}
+      onExpandPastedText={() => {}}
+      onRemovePastedText={() => {}}
+    />;
+  }
+  await act(async () => root.render(<Harness />));
+  const element = container.querySelector<HTMLElement>("[contenteditable='true'][data-lexical-editor='true']");
+  if (!element) throw new Error("Composer editor did not mount");
+  const editor = getNearestEditorFromDOMNode(element);
+  if (!editor) throw new Error("Lexical editor is unavailable");
+  await act(async () => editor.update(() => { $getRoot().selectEnd(); }, { discrete: true }));
+  const buttons = () => Array.from(container.querySelectorAll("button")).filter((button) => button.textContent?.startsWith("@"));
+  return {
+    queries, selectedAgent, sent,
+    draft: () => currentDraft,
+    labels: () => buttons().map((button) => button.textContent ?? ""),
+    tokenTitles: () => Array.from(element.querySelectorAll("span[contenteditable='false'][title]")).map((node) => node.getAttribute("title")),
+    async type(text: string) {
+      await act(async () => editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) throw new Error("Typing requires a range selection");
+        selection.insertText(text);
+      }, { discrete: true }));
+    },
+    async removeText(value: string, start: number, end: number) {
+      await act(async () => editor.update(() => {
+        const node = $getRoot().getAllTextNodes().find((candidate) => candidate.getTextContent() === value);
+        if (!node) throw new Error("Text node is unavailable");
+        node.select(start, end).removeText();
+      }, { discrete: true }));
+    },
+    async caret(offset: number, paragraphIndex = 0, end = offset) {
+      await act(async () => editor.update(() => {
+        const paragraph = $getRoot().getChildAtIndex(paragraphIndex);
+        if (!$isElementNode(paragraph)) throw new Error("Paragraph is unavailable");
+        const selection = $createRangeSelection();
+        const setPoint = (point: typeof selection.anchor, position: number) => {
+          let remaining = position;
+          for (const node of paragraph.getChildren()) {
+            const size = node.getTextContentSize();
+            if ($isTextNode(node) && remaining <= size) {
+              point.set(node.getKey(), remaining, "text");
+              return;
+            }
+            remaining -= size;
+          }
+          throw new Error(`Caret offset ${position} is outside paragraph ${paragraphIndex}`);
+        };
+        setPoint(selection.anchor, offset);
+        setPoint(selection.focus, end);
+        $setSelection(selection);
+      }, { discrete: true, ...(end === offset ? {} : { tag: SKIP_DOM_SELECTION_TAG }) }));
+    },
+    async beforeToken(value: string) {
+      await act(async () => editor.update(() => {
+        const paragraph = $getRoot().getFirstChild();
+        if (!$isElementNode(paragraph)) throw new Error("Paragraph is unavailable");
+        const token = paragraph.getChildren().find((node) => node.getTextContent() === value);
+        if (!token) throw new Error("Token is unavailable");
+        const offset = token.getIndexWithinParent();
+        paragraph.select(offset, offset);
+      }, { discrete: true }));
+    },
+    async press(key: string) {
+      await act(async () => {
+        element.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+      });
+    },
+    async choose(prefix: string) {
+      const button = buttons().find((candidate) => candidate.textContent?.startsWith(prefix));
+      if (!button) throw new Error(`Mention ${prefix} is unavailable`);
+      await act(async () => {
+        button.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+        button.click();
+      });
+    },
+    async close() {
+      await act(async () => root.unmount());
+      container.remove();
+      expect(network).not.toHaveBeenCalled();
+    },
+  };
+}
+
+test("end-of-draft queries retain the available default agent and matching files", async () => {
+  const composer = await mounted();
+  try {
+    for (const character of "@openwork") await composer.type(character);
+    expect(composer.queries.at(-1)).toBe("openwork");
+    expect(composer.labels()[0]?.startsWith("@openwork")).toBe(true);
+    expect(composer.labels().some((label) => label.startsWith("@src/openwork.ts"))).toBe(true);
+    expect(composer.labels().some((label) => label.startsWith("@notes.md"))).toBe(false);
+    await composer.type(" summarize");
+    expect(composer.labels()).toEqual([]);
+  } finally { await composer.close(); }
+});
+
+for (const newTask of [false, true]) {
+  for (const method of ["Enter", "Tab", "mouse"]) {
+    test(`${newTask ? "new-task" : "session composer"} ${method} replaces the mention at the caret and preserves later text`, async () => {
+      const composer = await mounted({ draft: "@openwork @notes", newTask });
+      try {
+        await composer.caret("@openwork".length);
+        await composer.type(" @cl");
+        expect(composer.queries.at(-1)).toBe("cl");
+        expect(composer.labels()[0]?.startsWith("@cloud")).toBe(true);
+        expect(composer.labels().some((label) => label.startsWith("@notes.md"))).toBe(false);
+        if (method === "mouse") await composer.choose("@cloud");
+        else await composer.press(method);
+        expect(composer.draft()).toBe("@openwork @cloud @notes");
+        expect(composer.tokenTitles()).toContain("@cloud");
+        expect(composer.labels()).toEqual([]);
+        expect(composer.sent).not.toHaveBeenCalled();
+        await composer.type("continue ");
+        expect(composer.draft()).toBe("@openwork @cloud continue @notes");
+        expect(composer.sent).not.toHaveBeenCalled();
+      } finally { await composer.close(); }
+    });
+  }
+}
+
+test("accepting within a plain-text mention replaces its remaining characters", async () => {
+  const composer = await mounted({ draft: "Use @cloud before @notes" });
+  try {
+    await composer.caret("Use @cl".length);
+    expect(composer.queries.at(-1)).toBe("cl");
+    await composer.press("Tab");
+    expect(composer.draft()).toBe("Use @cloud before @notes");
+    await composer.type("this ");
+    expect(composer.draft()).toBe("Use @cloud this before @notes");
+    expect(composer.sent).not.toHaveBeenCalled();
+  } finally { await composer.close(); }
+});
+
+test("selection-only movement refreshes the active query and a range selection closes suggestions", async () => {
+  const composer = await mounted({ draft: "@cl @notes" });
+  try {
+    expect(composer.queries.at(-1)).toBe("notes");
+    await composer.caret(3);
+    expect(composer.queries.at(-1)).toBe("cl");
+    expect(composer.labels()[0]?.startsWith("@cloud")).toBe(true);
+    expect(composer.draft()).toBe("@cl @notes");
+    await composer.caret(0);
+    expect(composer.labels()).toEqual([]);
+    await composer.caret("@cl @notes".length);
+    expect(composer.queries.at(-1)).toBe("notes");
+    expect(composer.labels().some((label) => label.startsWith("@notes.md"))).toBe(true);
+    await composer.caret(0, 0, 3);
+    expect(composer.labels()).toEqual([]);
+    expect(composer.draft()).toBe("@cl @notes");
+  } finally { await composer.close(); }
+});
+
+test("encoded mention and attachment nodes do not shift replacement across paragraph breaks", async () => {
+  const file = "docs/100% plan.md";
+  const prefix = `@${encodeComposerMentionValue(file)} [attachment document] @openwork`;
+  const composer = await mounted({
+    draft: `First\n\n${prefix} @notes\nLast`,
+    mentions: { [file]: "file" },
+    attachments: [{ id: "document", name: "report.pdf", mimeType: "application/pdf", size: 1, kind: "file" }],
+  });
+  try {
+    await composer.caret(prefix.length, 2);
+    await composer.type(" @cl");
+    expect(composer.queries.at(-1)).toBe("cl");
+    await composer.press("Tab");
+    expect(composer.draft()).toBe(`First\n\n${prefix} @cloud @notes\nLast`);
+    expect(composer.tokenTitles()).toContain(`@${file}`);
+    expect(composer.tokenTitles()).toContain("@cloud");
+    await composer.type("continue ");
+    expect(composer.draft()).toBe(`First\n\n${prefix} @cloud continue @notes\nLast`);
+    expect(composer.sent).not.toHaveBeenCalled();
+  } finally { await composer.close(); }
+});
+
+test("an element caret before an attachment targets the preceding plain-text mention", async () => {
+  const composer = await mounted({
+    draft: "@cl [attachment document] @notes",
+    attachments: [{ id: "document", name: "report.pdf", mimeType: "application/pdf", size: 1, kind: "file" }],
+  });
+  try {
+    await composer.removeText("@cl ", 3, 4);
+    expect(composer.draft()).toBe("@cl[attachment document] @notes");
+    await composer.beforeToken("[attachment document]");
+    expect(composer.labels()[0]?.startsWith("@cloud")).toBe(true);
+    await composer.press("Tab");
+    expect(composer.draft()).toBe("@cloud [attachment document] @notes");
+    await composer.type("continue ");
+    expect(composer.draft()).toBe("@cloud continue [attachment document] @notes");
+    expect(composer.sent).not.toHaveBeenCalled();
+  } finally { await composer.close(); }
+});
+
+for (const newTask of [false, true]) {
+  test(`${newTask ? "new-task" : "session composer"} agent selection removes only the active mention`, async () => {
+    const composer = await mounted({ draft: "Use @openw before @notes", newTask });
+    try {
+      await composer.caret("Use @openw".length);
+      expect(composer.labels()[0]?.startsWith("@openwork")).toBe(true);
+      await composer.press("Enter");
+      expect(composer.draft()).toBe("Use  before @notes");
+      expect(composer.selectedAgent).toHaveBeenCalledWith("openwork");
+      expect(composer.sent).not.toHaveBeenCalled();
+      await composer.type("this");
+      expect(composer.draft()).toBe("Use this before @notes");
+    } finally { await composer.close(); }
+  });
+}
+
+test("file values keep their encoding and later mention tokens intact", async () => {
+  const file = "docs/100% plan.md";
+  const composer = await mounted({ draft: "Use @100 before @notes", files: [file, "notes.md"] });
+  try {
+    await composer.caret("Use @100".length);
+    await composer.press("Enter");
+    expect(composer.draft()).toBe(`Use @${encodeComposerMentionValue(file)} before @notes`);
+    expect(composer.tokenTitles()).toContain(`@${file}`);
+    expect(composer.sent).not.toHaveBeenCalled();
+  } finally { await composer.close(); }
+});
+
+test("ordinary text after an existing semantic app mention does not reopen suggestions", async () => {
+  const composer = await mounted({ draft: "@OpenWork ", mentions: { OpenWork: "app" }, apps: ["OpenWork"] });
+  try {
+    await composer.type("summarize");
+    expect(composer.labels()).toEqual([]);
+    expect(composer.queries).toEqual([]);
+  } finally { await composer.close(); }
+});
+
+test("a delayed previous query cannot replace newer mention results", async () => {
+  const oldFiles = Promise.withResolvers<string[]>();
+  const composer = await mounted({ search: (query) => query === "openwork" ? oldFiles.promise : Promise.resolve(["docs/cloud-notes.md"]) });
+  try {
+    await composer.type("@openwork");
+    await composer.type(" @cl");
+    await act(async () => { oldFiles.resolve(["src/openwork.ts"]); });
+    expect(composer.queries.at(-1)).toBe("cl");
+    expect(composer.labels()[0]?.startsWith("@cloud")).toBe(true);
+    expect(composer.labels().some((label) => label.includes("src/openwork.ts"))).toBe(false);
+  } finally { oldFiles.resolve([]); await composer.close(); }
+});
+
+afterAll(() => GlobalRegistrator.unregister());

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -5,8 +5,22 @@ import { computerMentions } from "../worlds/chat.ts";
 const test = spec.world(computerMentions);
 
 test("computer mentions steer tasks through Connect and Automations names the computer", async ({ world, user, probe, step, evidence }) => {
+  await step("mention selection follows the caret and preserves later draft text", async () => {
+    for (const method of ["Enter", "Tab", "mouse"]) {
+      await user.type("composer", "@openwork @cl @notes", { replace: true });
+      for (let index = 0; index < " @notes".length; index += 1) await user.press("ArrowLeft");
+      await user.see({ role: "button", label: /^@cloud/ });
+      await user.notSee({ role: "button", label: /^@desktop/ });
+      if (method === "mouse") await user.click({ role: "button", label: /^@cloud/ });
+      else await user.press(method);
+      await user.see("composer", { text: "@openwork @cloud @notes" });
+      expect((await probe.composer()).userMessageCount).toBe(0);
+    }
+    evidence.recordAssertionEvidence("Mention acceptance preserves the draft suffix", "Selection-only caret movement offers cloud for the middle @cl mention. Enter, Tab, and mouse replace that mention without changing the later @notes text or sending a message.", true);
+  });
+
   await step("the mention menu explains both computers without starting a task", async () => {
-    await user.type("composer", "@");
+    await user.type("composer", "@", { replace: true });
     await user.see({ text: "Start a task on your cloud computer" });
     await user.see({ text: "Start a task on your connected desktop computer" });
     await user.screenshot();


### PR DESCRIPTION
## Problem

When editing a mention in the middle of a draft, suggestions were derived from the last mention in the entire draft. Accepting a result could therefore replace the wrong text. For example, a caret after the middle `@cl` in `@openwork @cl @notes` queried `notes` instead of `cl`.

Refs ENG-14. Scope is the reproduced caret-targeting condition; file-ranking rules and available agent/app candidates are unchanged.

## What changed

- Derive the active mention from the Lexical selection, including selection-only caret movement.
- Replace that mention directly in the editor for Enter, Tab, and mouse acceptance. Preserve later text, semantic tokens, paragraph boundaries, and the insertion position.
- Replace remaining characters when accepting inside a plain-text mention, avoiding duplicated suffixes.
- Use the resulting draft in both existing-session and new-task composers while preserving mention metadata and agent selection.
- Add focused component regressions and extend the existing computer-task-mentions journey; no new journey file.

## Verification

**Verdict: Incomplete — the extended Den/Electron journey has not been executed.**

Checked head: `b9e76a1a0787163180eb99d7ef4b5b988ef43a52`, rebased onto `dev` at `155e4585c5b326537a29229f00892b3d15aefab1`.

### Passed on this head

- `COREPACK_ENABLE_NETWORK=0 corepack pnpm@11.4.0 --filter @openwork/app exec bun test --isolate ./tests/composer-mention-results.test.tsx ./tests/mention-encoding.test.ts ./tests/composer-line-boundary-keys.test.ts` — 23 passed, 0 failed, 159 assertions.
- `COREPACK_ENABLE_NETWORK=0 corepack pnpm@11.4.0 --filter @openwork/app typecheck` — passed.
- `git diff --check origin/dev...HEAD` — passed.

The regressions failed before the corresponding repairs: the original caret-targeting assertions were red, and the within-word assertion received `Use @cloud oud before @notes` instead of preserving `Use @cloud before @notes`.

### Failed earlier checks

Before the final rebase, `pnpm --dir evals typecheck` reported six TS7006 diagnostics in untouched evidence-review/test-artifacts files, and `pnpm --dir evals lint:layers` reported 51 violations outside this change. These failures were not baseline-controlled, repaired, or rerun on the final head; they are not claimed as passing checks.

### Not run

- `pnpm evals:e2e computer-task-mentions` — Den/Electron runtime evidence remains missing.

## UI/UX impact

- Suggestions follow the mention at the caret and close outside an active mention or for a range selection.
- Accepting a suggestion replaces only the active mention and keeps subsequent typing at the insertion point instead of changing later draft text.
- Layout, styling, icons, labels, file ranking, agent availability, slash behavior, keyboard bindings, and send behavior are preserved.
