### PR TITLE
fix(app): keep queued composer messages across restart as an unsent draft

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -127,6 +127,8 @@ export default {
   "composer.queued_send_now_hint": "Send this message now instead of waiting for the agent to finish",
   "composer.queued_reorder": "Drag to reorder",
   "composer.queued_edit": "Edit queued message",
+  "composer.queue_restored_as_draft_one": "1 message waiting to be sent was kept as a draft during the restart. Review it and send it when you're ready.",
+  "composer.queue_restored_as_draft_other": "{count} messages waiting to be sent were kept as a draft during the restart. Review them and send when you're ready.",
   "composer.escape_to_stop": "Hit Escape again to stop the agent",
   "composer.skill_source": "Skill",
   "composer.stop": "Stop",

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1055,14 +1055,30 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
     const currentState = useComposerStateStore.getState();
     const currentDraft = getComposerDraft(currentState, props.sessionId);
-    const nextDraft = persistedDraftSnapshot?.text ?? "";
-    const needsHydration = composerDraftNeedsHydration({
+    const storedDraft = persistedDraftSnapshot?.text ?? "";
+    // Follow-ups that were still waiting behind a running task when the last
+    // renderer went away come back as unsent composer text, ahead of whatever
+    // was typed after them. They are never re-queued: across a restart nobody
+    // can vouch that "the agent finished" still means what it meant, so the
+    // person reviews and sends. A queue this renderer already holds for the
+    // conversation is the live truth and its mirror is left alone.
+    const restoredQueue = getComposerQueuedDrafts(currentState, props.sessionId).length === 0
+      ? persistedDraftSnapshot?.queued ?? []
+      : [];
+    const nextDraft = restoredQueue.length > 0
+      ? [...restoredQueue, storedDraft].filter((text) => text.length > 0).join("\n\n")
+      : storedDraft;
+    const needsHydration = restoredQueue.length > 0 || composerDraftNeedsHydration({
       claimedScopeKey,
       nextScopeKey: persistedDraftKey,
       currentText: currentDraft,
       storedText: nextDraft,
     });
 
+    if (restoredQueue.length > 0) {
+      persistDraft({ text: nextDraft, mode: persistedDraftSnapshot?.mode ?? "prompt", queued: [] });
+      toast.info(t("composer.queue_restored_as_draft", { count: restoredQueue.length }));
+    }
     if (needsHydration) {
       for (const attachment of getComposerAttachments(currentState, props.sessionId)) {
         revokeAttachmentPreview(attachment);
@@ -1070,7 +1086,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       hydrateComposerDraft(props.sessionId, nextDraft);
     }
     setHydratedDraftScopeKey(persistedDraftKey);
-  }, [hydrateComposerDraft, persistedDraftKey, persistedDraftSnapshot, props.sessionId]);
+  }, [hydrateComposerDraft, persistDraft, persistedDraftKey, persistedDraftSnapshot, props.sessionId]);
   // Queued follow-up drafts live in the shared composer store keyed by session
   // id. That keeps a queued message in session A from being drained into
   // session B when the route swaps the same surface component to another

--- a/apps/app/src/react-app/domains/session/sync/draft-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-store.ts
@@ -6,6 +6,13 @@ import type { PromptMode } from "../../../../app/types";
 export type SessionDraftSnapshot = {
   text: string;
   mode: PromptMode;
+  /**
+   * Text of the follow-ups queued behind a running task ("Send when agent
+   * finishes"), in send order. Present only while at least one is waiting.
+   * Kept beside the composer text so a restart can hand them back as an
+   * unsent draft instead of dropping them or sending them unattended.
+   */
+  queued?: string[];
 };
 
 export type SessionDraftIdentity = {
@@ -18,7 +25,10 @@ export type SessionDraftWriteResult =
   | { status: "conflict"; snapshot: SessionDraftSnapshot | null }
   | { status: "unavailable"; snapshot: SessionDraftSnapshot | null };
 
-type StoredDraft = SessionDraftSnapshot & {
+type StoredDraft = {
+  text: string;
+  mode: PromptMode;
+  queued: string[];
   revision: number;
 };
 
@@ -69,6 +79,12 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const normalizedOpaqueId = (value: string) => encodeURIComponent(value.trim());
 
+const parseQueued = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === "string" && item.length > 0) : [];
+
+const isEmptyStoredDraft = (draft: Pick<StoredDraft, "text" | "mode" | "queued">) =>
+  !draft.text && draft.mode === "prompt" && draft.queued.length === 0;
+
 export function cloudSessionDraftScope(identity: SessionDraftIdentity | null | undefined): string | null {
   const principalId = identity?.principalId.trim() ?? "";
   const organizationId = identity?.organizationId.trim() ?? "";
@@ -111,8 +127,9 @@ function parseDocument(raw: string | null): DraftDocument {
     for (const [key, value] of Object.entries(parsed.drafts)) {
       if (!key || !isRecord(value) || typeof value.text !== "string" || !isPromptMode(value.mode)) continue;
       if (typeof value.revision !== "number" || !Number.isSafeInteger(value.revision) || value.revision < 1) continue;
-      if (!value.text && value.mode === "prompt") continue;
-      drafts[key] = { text: value.text, mode: value.mode, revision: value.revision };
+      const queued = parseQueued(value.queued);
+      if (isEmptyStoredDraft({ text: value.text, mode: value.mode, queued })) continue;
+      drafts[key] = { text: value.text, mode: value.mode, queued, revision: value.revision };
       highestRevision = Math.max(highestRevision, value.revision);
     }
 
@@ -136,7 +153,9 @@ function sameStoredDraft(left: StoredDraft | undefined, right: StoredDraft | und
   if (!left || !right) return left === right;
   return left.revision === right.revision
     && left.text === right.text
-    && left.mode === right.mode;
+    && left.mode === right.mode
+    && left.queued.length === right.queued.length
+    && left.queued.every((item, index) => item === right.queued[index]);
 }
 
 function documentFingerprint(document: DraftDocument) {
@@ -223,9 +242,49 @@ export function createSessionDraftStore(options: DraftStoreOptions) {
     if (!stored) return null;
     const existing = visibleSnapshots.get(stored);
     if (existing) return existing;
-    const snapshot = { text: stored.text, mode: stored.mode };
+    const snapshot: SessionDraftSnapshot = stored.queued.length > 0
+      ? { text: stored.text, mode: stored.mode, queued: [...stored.queued] }
+      : { text: stored.text, mode: stored.mode };
     visibleSnapshots.set(stored, snapshot);
     return snapshot;
+  };
+
+  /**
+   * Replace one stored entry under the same compare-and-swap guard as `save`.
+   * `next` returning null deletes the entry.
+   */
+  const replaceEntry = (
+    key: string,
+    next: (latest: StoredDraft | undefined, revision: number) => StoredDraft | null,
+  ): SessionDraftWriteResult => {
+    const expected = loadCache().drafts[key];
+    const latestDocument = parseDocument(readRaw());
+    const latest = latestDocument.drafts[key];
+    if (!sameStoredDraft(expected, latest)) {
+      replaceCache(latestDocument);
+      return { status: "conflict", snapshot: currentSnapshot(key) };
+    }
+    const entry = next(latest, latestDocument.nextRevision);
+    if (entry === null && !latest) return { status: "saved", snapshot: null };
+    if (entry !== null && latest && sameStoredDraft({ ...entry, revision: latest.revision }, latest)) {
+      return { status: "saved", snapshot: currentSnapshot(key) };
+    }
+
+    const drafts = { ...latestDocument.drafts };
+    if (entry === null) delete drafts[key];
+    else drafts[key] = entry;
+    const oldest = Object.entries(drafts)
+      .sort((left, right) => left[1].revision - right[1].revision)
+      .slice(0, Math.max(0, Object.keys(drafts).length - MAX_SESSION_DRAFT_COUNT));
+    for (const [oldestKey] of oldest) delete drafts[oldestKey];
+
+    const nextDocument: DraftDocument = {
+      version: 2,
+      nextRevision: entry === null ? latestDocument.nextRevision : entry.revision + 1,
+      drafts,
+    };
+    if (!write(nextDocument)) return { status: "unavailable", snapshot: currentSnapshot(key) };
+    return { status: "saved", snapshot: currentSnapshot(key) };
   };
 
   const get = (
@@ -237,6 +296,10 @@ export function createSessionDraftStore(options: DraftStoreOptions) {
     return key ? currentSnapshot(key) : null;
   };
 
+  /**
+   * Forget the composer text. Follow-ups still waiting to be sent are not
+   * composer text and stay stored until their own queue mutation removes them.
+   */
   const clear = (
     scopeId: string | null | undefined,
     workspaceId: string,
@@ -244,21 +307,10 @@ export function createSessionDraftStore(options: DraftStoreOptions) {
   ): SessionDraftWriteResult => {
     const key = sessionDraftScopeKey(scopeId, workspaceId, sessionId);
     if (!key) return { status: "unavailable", snapshot: null };
-
-    const expected = loadCache().drafts[key];
-    const latestDocument = parseDocument(readRaw());
-    const latest = latestDocument.drafts[key];
-    if (!sameStoredDraft(expected, latest)) {
-      replaceCache(latestDocument);
-      return { status: "conflict", snapshot: currentSnapshot(key) };
-    }
-    if (!latest) return { status: "saved", snapshot: null };
-
-    const drafts = { ...latestDocument.drafts };
-    delete drafts[key];
-    const nextDocument: DraftDocument = { ...latestDocument, drafts };
-    if (!write(nextDocument)) return { status: "unavailable", snapshot: currentSnapshot(key) };
-    return { status: "saved", snapshot: null };
+    return replaceEntry(key, (latest, revision) => {
+      if (!latest || latest.queued.length === 0) return null;
+      return { text: "", mode: "prompt", queued: latest.queued, revision };
+    });
   };
 
   const save = (
@@ -269,44 +321,26 @@ export function createSessionDraftStore(options: DraftStoreOptions) {
   ): SessionDraftWriteResult => {
     const key = sessionDraftScopeKey(scopeId, workspaceId, sessionId);
     if (!key) return { status: "unavailable", snapshot: null };
-    if (!snapshot.text && snapshot.mode === "prompt") {
-      return clear(scopeId, workspaceId, sessionId);
-    }
+    return replaceEntry(key, (latest, revision) => {
+      const entry = { text: snapshot.text, mode: snapshot.mode, queued: snapshot.queued ?? latest?.queued ?? [], revision };
+      return isEmptyStoredDraft(entry) ? null : entry;
+    });
+  };
 
-    const expected = loadCache().drafts[key];
-    const latestDocument = parseDocument(readRaw());
-    const latest = latestDocument.drafts[key];
-    if (!sameStoredDraft(expected, latest)) {
-      replaceCache(latestDocument);
-      return { status: "conflict", snapshot: currentSnapshot(key) };
-    }
-    if (latest?.text === snapshot.text && latest.mode === snapshot.mode) {
-      return { status: "saved", snapshot: currentSnapshot(key) };
-    }
-
-    const revision = latestDocument.nextRevision;
-    const drafts = {
-      ...latestDocument.drafts,
-      [key]: { text: snapshot.text, mode: snapshot.mode, revision },
-    };
-    const oldest = Object.entries(drafts)
-      .sort((left, right) => left[1].revision - right[1].revision)
-      .slice(0, Math.max(0, Object.keys(drafts).length - MAX_SESSION_DRAFT_COUNT));
-    for (const [oldestKey] of oldest) delete drafts[oldestKey];
-
-    const nextDocument: DraftDocument = {
-      version: 2,
-      nextRevision: revision + 1,
-      drafts,
-    };
-    const normalized = { text: snapshot.text, mode: snapshot.mode };
-    if (!write(nextDocument)) return { status: "unavailable", snapshot: currentSnapshot(key) };
-    return { status: "saved", snapshot: normalized };
+  /** Mirror the follow-ups waiting behind a running task under an already
+   * composed draft key, leaving the composer text untouched. */
+  const saveQueued = (key: string, queued: readonly string[]): SessionDraftWriteResult => {
+    if (!key) return { status: "unavailable", snapshot: null };
+    return replaceEntry(key, (latest, revision) => {
+      const entry = { text: latest?.text ?? "", mode: latest?.mode ?? "prompt", queued: [...queued], revision };
+      return isEmptyStoredDraft(entry) ? null : entry;
+    });
   };
 
   return {
     get,
     save,
+    saveQueued,
     clear,
     subscribe(listener: () => void) {
       listeners.add(listener);
@@ -372,6 +406,10 @@ export const clearSessionDraft = (
 ) => getBrowserStore()?.clear(scopeId, workspaceId, sessionId)
   ?? { status: "unavailable", snapshot: null };
 
+/** `scopeKey` is a composed `sessionDraftScopeKey`, the form the composer store records per session. */
+export const saveSessionQueuedDrafts = (scopeKey: string, queued: readonly string[]) =>
+  getBrowserStore()?.saveQueued(scopeKey, queued) ?? { status: "unavailable", snapshot: null };
+
 export function useSessionDraftState(
   scopeId: string | null | undefined,
   workspaceId: string,
@@ -393,7 +431,9 @@ export function useSessionDraftState(
     if (!serializedSnapshot) return null;
     const parsed: unknown = JSON.parse(serializedSnapshot);
     if (!isRecord(parsed) || typeof parsed.text !== "string" || !isPromptMode(parsed.mode)) return null;
-    return { text: parsed.text, mode: parsed.mode };
+    const queued = parseQueued(parsed.queued);
+    const snapshot: SessionDraftSnapshot = { text: parsed.text, mode: parsed.mode };
+    return queued.length > 0 ? { ...snapshot, queued } : snapshot;
   }, [serializedSnapshot]);
 
   const save = useCallback(

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer-bridge.tsx
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer-bridge.tsx
@@ -3,8 +3,10 @@ import { useEffect } from "react";
 
 import { useEnterpriseActivationRequired } from "@/react-app/domains/cloud/enterprise-activation-gate";
 import { startGlobalQueueDrainer } from "./global-queue-drainer";
+import { startQueuedDraftPersistence } from "./queued-draft-persistence";
 
 export function GlobalQueueDrainerBridge() {
+  useEffect(() => startQueuedDraftPersistence(), []);
   if (useEnterpriseActivationRequired()) return null;
   return <ActivatedGlobalQueueDrainerBridge />;
 }

--- a/apps/app/src/react-app/domains/session/sync/queued-draft-persistence.ts
+++ b/apps/app/src/react-app/domains/session/sync/queued-draft-persistence.ts
@@ -1,0 +1,37 @@
+import {
+  getComposerSessionDraftScope,
+  persistableComposerDraftText,
+  useComposerStateStore,
+  type QueuedComposerItem,
+} from "../surface/composer-state-store";
+import { saveSessionQueuedDrafts } from "./draft-store";
+
+/**
+ * Follow-ups queued behind a running task live in the in-memory composer
+ * store, which a renderer reload or app restart empties. Mirror their text
+ * into the persisted draft entry of their conversation on every queue change,
+ * including drains for conversations that are not in view, so the next launch
+ * can hand them back as an unsent draft. Attachments hold live File objects
+ * and are not persisted, exactly like composer drafts.
+ */
+export function queuedDraftTexts(items: readonly QueuedComposerItem[]): string[] {
+  return items
+    .map((item) => persistableComposerDraftText(item.draft.text).trim())
+    .filter((text) => text.length > 0);
+}
+
+export function startQueuedDraftPersistence(save: typeof saveSessionQueuedDrafts = saveSessionQueuedDrafts): () => void {
+  let previous = useComposerStateStore.getState().queuedDrafts;
+  return useComposerStateStore.subscribe((state) => {
+    const next = state.queuedDrafts;
+    if (next === previous) return;
+    const sessionIds = new Set([...Object.keys(previous), ...Object.keys(next)]);
+    for (const sessionId of sessionIds) {
+      if (next[sessionId] === previous[sessionId]) continue;
+      const scopeKey = getComposerSessionDraftScope(sessionId);
+      if (!scopeKey) continue;
+      save(scopeKey, queuedDraftTexts(next[sessionId] ?? []));
+    }
+    previous = next;
+  });
+}

--- a/apps/app/tests/draft-store.test.ts
+++ b/apps/app/tests/draft-store.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_SESSION_DRAFT_COUNT,
   resolveSessionDraftScope,
   SESSION_DRAFT_STORAGE_KEY,
+  sessionDraftScopeKey,
 } from "../src/react-app/domains/session/sync/draft-store";
 
 type StorageMutation = { key: string | null; newValue: string | null };
@@ -236,6 +237,44 @@ describe("session draft storage v2", () => {
     }).status).toBe("saved");
     expect(() => JSON.parse(shared.values.get(SESSION_DRAFT_STORAGE_KEY) ?? "")).not.toThrow();
     expect(store.get(aliceOps, "workspace-a", "session-a")?.text).toBe("recovered");
+  });
+
+  test("keeps queued follow-ups beside the composer text and hands them back only while they wait", () => {
+    const shared = sharedStorageContexts();
+    const writer = createSessionDraftStore(shared.context("writer"));
+    const key = sessionDraftScopeKey(aliceOps, "workspace-a", "session-a");
+
+    writer.save(aliceOps, "workspace-a", "session-a", { text: "typed later", mode: "prompt" });
+    expect(writer.saveQueued(key, ["first follow-up", "second follow-up"]).status).toBe("saved");
+    expect(writer.get(aliceOps, "workspace-a", "session-a")).toEqual({
+      text: "typed later", mode: "prompt", queued: ["first follow-up", "second follow-up"],
+    });
+
+    // Composer edits and clears never touch the waiting follow-ups.
+    writer.save(aliceOps, "workspace-a", "session-a", { text: "edited", mode: "prompt" });
+    expect(writer.get(aliceOps, "workspace-a", "session-a")?.queued).toEqual(["first follow-up", "second follow-up"]);
+    expect(writer.clear(aliceOps, "workspace-a", "session-a").status).toBe("saved");
+    expect(writer.get(aliceOps, "workspace-a", "session-a")).toEqual({
+      text: "", mode: "prompt", queued: ["first follow-up", "second follow-up"],
+    });
+
+    // A relaunch reads the same entry, and an explicit queued: [] retires it.
+    writer.dispose();
+    const relaunched = createSessionDraftStore(shared.context("relaunch"));
+    expect(relaunched.get(aliceOps, "workspace-a", "session-a")?.queued).toEqual(["first follow-up", "second follow-up"]);
+    expect(relaunched.save(aliceOps, "workspace-a", "session-a", {
+      text: "first follow-up\n\nsecond follow-up", mode: "prompt", queued: [],
+    }).status).toBe("saved");
+    expect(relaunched.get(aliceOps, "workspace-a", "session-a")).toEqual({
+      text: "first follow-up\n\nsecond follow-up", mode: "prompt",
+    });
+
+    // Draining the last follow-up with no composer text removes the entry entirely.
+    relaunched.saveQueued(key, ["only"]);
+    relaunched.clear(aliceOps, "workspace-a", "session-a");
+    expect(relaunched.saveQueued(key, []).status).toBe("saved");
+    expect(relaunched.get(aliceOps, "workspace-a", "session-a")).toBeNull();
+    expect(relaunched.get(bobOps, "workspace-a", "session-a")).toBeNull();
   });
 
   test("never crashes when reads, migration, or quota-limited writes fail", () => {

--- a/apps/app/tests/queued-draft-persistence.test.ts
+++ b/apps/app/tests/queued-draft-persistence.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ComposerDraft } from "../src/app/types";
+import {
+  claimComposerSessionDraftScope,
+  getComposerQueuedDrafts,
+  useComposerStateStore,
+} from "../src/react-app/domains/session/surface/composer-state-store";
+import { startQueuedDraftPersistence } from "../src/react-app/domains/session/sync/queued-draft-persistence";
+
+function draft(text: string): ComposerDraft {
+  return { mode: "prompt", parts: [{ type: "text", text }], attachments: [], text, resolvedText: text, command: undefined };
+}
+
+describe("queued draft persistence", () => {
+  const writes: { scopeKey: string; queued: readonly string[] }[] = [];
+  let stop = () => {};
+
+  beforeEach(() => {
+    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {} });
+    writes.length = 0;
+    stop();
+    stop = startQueuedDraftPersistence((scopeKey, queued) => {
+      writes.push({ scopeKey, queued: [...queued] });
+      return { status: "saved", snapshot: null };
+    });
+  });
+
+  test("mirrors every queue mutation of a claimed conversation, in order, and only that conversation", () => {
+    claimComposerSessionDraftScope("session-a", "local|ws|session-a");
+    claimComposerSessionDraftScope("session-b", "local|ws|session-b");
+    const store = useComposerStateStore.getState();
+
+    store.appendQueuedDraft("session-a", draft("first [attachment shot.png] follow-up"));
+    store.appendQueuedDraft("session-a", draft("second follow-up"));
+    store.appendQueuedDraft("session-b", draft("other conversation"));
+    expect(writes).toEqual([
+      { scopeKey: "local|ws|session-a", queued: ["first  follow-up"] },
+      { scopeKey: "local|ws|session-a", queued: ["first  follow-up", "second follow-up"] },
+      { scopeKey: "local|ws|session-b", queued: ["other conversation"] },
+    ]);
+
+    // The background drain removes the head item without any surface mounted.
+    const head = getComposerQueuedDrafts(useComposerStateStore.getState(), "session-a")[0];
+    if (!head) throw new Error("missing head item");
+    store.removeQueuedDraft("session-a", head.id);
+    expect(writes.at(-1)).toEqual({ scopeKey: "local|ws|session-a", queued: ["second follow-up"] });
+
+    // A failed send re-queues it at the front; Stop clears the whole queue.
+    store.prependQueuedDrafts("session-a", [head]);
+    expect(writes.at(-1)).toEqual({ scopeKey: "local|ws|session-a", queued: ["first  follow-up", "second follow-up"] });
+    store.clearQueuedDrafts("session-a");
+    expect(writes.at(-1)).toEqual({ scopeKey: "local|ws|session-a", queued: [] });
+    expect(writes.filter((write) => write.scopeKey === "local|ws|session-b")).toHaveLength(1);
+  });
+
+  test("ignores composer edits and conversations whose draft scope is unknown", () => {
+    const store = useComposerStateStore.getState();
+    store.appendQueuedDraft("session-unclaimed", draft("nowhere to store"));
+    store.setDraft("session-unclaimed", "typing");
+    expect(writes).toEqual([]);
+
+    claimComposerSessionDraftScope("session-c", "local|ws|session-c");
+    store.appendQueuedDraft("session-c", draft("stored"));
+    store.setDraft("session-c", "typing more");
+    store.setAttachments("session-c", []);
+    expect(writes).toEqual([{ scopeKey: "local|ws|session-c", queued: ["stored"] }]);
+  });
+});

--- a/evals/specs/queued-messages-restart.e2e.test.ts
+++ b/evals/specs/queued-messages-restart.e2e.test.ts
@@ -1,0 +1,132 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { currentTestEvidence } from "@openwork/test-evidence";
+import { queuedFollowUps } from "../worlds/session-draft.ts";
+
+const test = spec.world(queuedFollowUps, {
+  resources: { surfaces: ["appWeb"], services: ["mock"] },
+  timeout: 240_000,
+});
+
+function assertObserved(assertion: string, observed: Record<string, unknown>, passed: boolean) {
+  currentTestEvidence()?.recordAssertionEvidence(assertion, JSON.stringify(observed), passed);
+  expect(passed, assertion).toBe(true);
+}
+
+// Busy Enter queues ("Send when agent finishes"); Cmd/Ctrl+Enter would steer.
+const enter = "Enter";
+const draftsKey = "openwork.session-drafts.v2";
+
+type StoredDrafts = { text: string; queued: string[] }[];
+
+function readDrafts(value: unknown, sessionId: string): StoredDrafts {
+  if (typeof value !== "object" || value === null || !("drafts" in value) || typeof value.drafts !== "object" || value.drafts === null) return [];
+  return Object.entries(value.drafts).filter(([key]) => key.includes(sessionId)).map(([, entry]) => {
+    const record: Record<string, unknown> = typeof entry === "object" && entry !== null ? { ...entry } : {};
+    const queued = Array.isArray(record.queued) ? record.queued.filter((item): item is string => typeof item === "string") : [];
+    return { text: typeof record.text === "string" ? record.text : "", queued };
+  });
+}
+
+test("queued follow-ups come back as an unsent draft after a renderer restart instead of vanishing or auto-sending", async ({ world, user, probe, step }) => {
+  const second = "Also tag the build";
+  const draft = "Draft typed after queueing";
+  const userMessages = () => probe.dom('[data-message-role="user"]');
+  const storedDrafts = () => probe.storage(draftsKey, (value) => readDrafts(value, world.session.sessionId));
+
+  await step("start a long task and queue two follow-ups while it runs", async () => {
+    await user.type("composer", world.running.prompt, { verify: true });
+    await user.press(enter);
+    await user.see({ text: "Building the release." });
+    await user.type("composer", world.queued.prompt, { verify: true });
+    await user.press(enter);
+    await user.see({ text: /1 queued/ });
+    await user.type("composer", second, { verify: true });
+    await user.press(enter);
+    await user.see({ text: /2 queued/ });
+    await user.see("composer", { editable: true, text: "" });
+    const rows = (await userMessages()).elements;
+    assertObserved("Queued follow-ups wait in the panel and are not sent while the task runs",
+      { rows: rows.length, queuedRequests: (await world.modelRequests(world.queued.prompt)).length },
+      rows.length === 1 && (await world.modelRequests(world.queued.prompt)).length === 0);
+  });
+
+  await step("type a draft after queueing; storage keeps both the draft and the queue", async () => {
+    await user.type("composer", draft, { verify: true });
+    const stored = await probe.eventually(storedDrafts, {
+      within: 10_000, label: "draft and queue persisted for this conversation",
+      until: (entries) => entries.length === 1 && entries[0]!.text === draft && entries[0]!.queued.length === 2,
+    });
+    assertObserved("The persisted draft entry records the composer text and both queued messages in order",
+      { stored, expected: { text: draft, queued: [world.queued.prompt, second] } },
+      stored.length === 1 && stored[0]!.text === draft
+        && stored[0]!.queued[0] === world.queued.prompt && stored[0]!.queued[1] === second);
+    await user.screenshot();
+  });
+
+  await step("reload the renderer while the task is still running", async () => {
+    await user.reload();
+    await user.see({ text: world.running.prompt });
+    await user.see("composer", { editable: true, text: /Then publish the release notes[\s\S]*Also tag the build[\s\S]*Draft typed after queueing/ });
+    await user.notSee({ text: /queued/ });
+    const composer = (await probe.composer()).draftText;
+    const rows = (await userMessages()).elements;
+    const stored = await storedDrafts();
+    const toast = (await probe.dom("[data-sonner-toast]")).elements.map((element) => element.text).join(" | ");
+    assertObserved("After reload the queue is folded into the composer in order, nothing was sent, and the person is told",
+      { composer, rows: rows.length, stored, toast, queuedRequests: (await world.modelRequests(world.queued.prompt)).length },
+      composer.startsWith(world.queued.prompt) && composer.includes(second) && composer.endsWith(draft)
+        && rows.length === 1 && stored.length === 1 && stored[0]!.queued.length === 0
+        && /2 messages waiting to be sent/.test(toast) && /kept as a draft/.test(toast));
+    await user.screenshot();
+  });
+
+  await step("finishing the task afterwards does not send the restored text on its own", async () => {
+    await world.releaseRunningReply();
+    await user.see({ text: /Build finished\./ });
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+    const rows = (await userMessages()).elements;
+    const composer = (await probe.composer()).draftText;
+    assertObserved("Idle after restart never drains a restored queue: one user turn, text still in the composer, no model call for it",
+      { rows: rows.length, composer, queuedRequests: (await world.modelRequests(world.queued.prompt)).length },
+      rows.length === 1 && composer.includes(world.queued.prompt) && (await world.modelRequests(world.queued.prompt)).length === 0);
+  });
+});
+
+test("a queued follow-up already admitted to the engine is neither duplicated nor restored after a reload", async ({ world, user, probe, step }) => {
+  const userMessages = () => probe.dom('[data-message-role="user"]');
+  const storedDrafts = () => probe.storage(draftsKey, (value) => readDrafts(value, world.session.sessionId));
+
+  await step("queue one follow-up, then let the running task finish so the drain admits it", async () => {
+    await user.type("composer", world.running.prompt, { verify: true });
+    await user.press(enter);
+    await user.see({ text: "Building the release." });
+    await user.type("composer", world.queued.prompt, { verify: true });
+    await user.press(enter);
+    await user.see({ text: /1 queued/ });
+    await world.releaseRunningReply();
+    await user.see({ text: /Build finished\./ });
+    await user.see({ text: "Publishing the notes." });
+    await user.notSee({ text: /1 queued/ });
+    const rows = (await userMessages()).elements;
+    const stored = await storedDrafts();
+    assertObserved("Admission moves the follow-up into the transcript and out of persisted queue storage",
+      { rows: rows.length, stored }, rows.length === 2 && stored.every((entry) => entry.queued.length === 0));
+  });
+
+  await step("reload while the admitted follow-up is still running", async () => {
+    await user.reload();
+    await user.see({ text: world.queued.prompt });
+    await user.see("composer", { editable: true, text: "" });
+    await user.notSee({ text: /queued/ });
+    const rows = (await userMessages()).elements;
+    const matching = rows.filter((row) => row.text.includes(world.queued.prompt)).length;
+    const toasts = (await probe.dom("[data-sonner-toast]")).elements.length;
+    assertObserved("The admitted follow-up appears exactly once, is not re-queued, not restored as a draft, and raises no restore notice",
+      { rows: rows.length, matching, composer: (await probe.composer()).draftText, toasts },
+      rows.length === 2 && matching === 1 && toasts === 0);
+    await world.releaseQueuedReply();
+    await user.see({ text: /Notes published\./ });
+    expect((await userMessages()).elements).toHaveLength(2);
+  });
+});

--- a/evals/worlds/session-draft.ts
+++ b/evals/worlds/session-draft.ts
@@ -36,3 +36,46 @@ export async function existingSessionDraft(seed: Seed) {
   return { app, workspace, reference, neighbor, session, history, followup,
     releaseReply: () => mock.releaseAgentReply(followup.prompt, 1) };
 }
+
+/**
+ * A conversation whose first turn stays busy until released, so follow-ups
+ * typed meanwhile are queued ("Send when agent finishes") rather than sent.
+ * The queued follow-up's own reply is held too, so an admitted queued turn can
+ * be observed mid-run across a renderer reload.
+ */
+export async function queuedFollowUps(seed: Seed) {
+  const running = { prompt: "Start the long release build", reply: "Building the release. Build finished." };
+  const queued = { prompt: "Then publish the release notes", reply: "Publishing the notes. Notes published." };
+  const workspacePath = seed.tmpPath("busy-follow-ups");
+  const app = await seed.appWeb({
+    name: "busy-follow-ups",
+    workspacePath,
+    mocks: { agent: seed.mock({
+      isolatedProcessEnv: true,
+      agentWorkloads: [
+        { promptMarker: running.prompt, latestUserTurn: true, finalReply: running.reply,
+          finalReplyChunks: ["Building the release.", " Build finished."], finalReplyInitiallyReleasedChunks: 1, steps: [] },
+        { promptMarker: queued.prompt, latestUserTurn: true, finalReply: queued.reply,
+          finalReplyChunks: ["Publishing the notes.", " Notes published."], finalReplyInitiallyReleasedChunks: 1, steps: [] },
+      ],
+    }) },
+  });
+  const mock = app.mocks.agent;
+  if (!mock) throw new Error("Missing queued follow-up model witness");
+  const workspace = await seed.workspace(app, workspacePath);
+  await configureProvider(seed, app, workspace.workspaceId, "queue-mock", "queue-model", {
+    provider: {
+      "queue-mock": {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Queued follow-up mock",
+        options: { baseURL: `${mock.url}/v1`, apiKey: "sk-queue-fixture" },
+        models: { "queue-model": { name: "Queued follow-up model" } },
+      },
+    },
+  });
+  const session = await seed.session(app, { title: "Release build" });
+  return { app, workspace, session, running, queued,
+    releaseRunningReply: () => mock.releaseAgentReply(running.prompt, 1),
+    releaseQueuedReply: () => mock.releaseAgentReply(queued.prompt, 1),
+    modelRequests: (promptMarker: string) => mock.agentRequests({ promptMarker }) };
+}


### PR DESCRIPTION
## Problem
Follow-ups queued with **Send when agent finishes** ("1 queued" panel) live only in the in-memory composer store (`composer-state-store.ts`, plain zustand). A renderer reload, **Restart to update**, or quit drops them silently, while the composer draft right next to them survives through `openwork.session-drafts.v2`. Nothing in the updater or quit path counts them. Verified on `origin/dev` `679784ef6` with a testkit run: after reload `{"queuedVisible":false,"composer":"Draft typed after queueing"}`, and once the task finished `{"rows":1,"requests":0}` — the queued message was never sent.

## Change (renderer only)
- `draft-store.ts`: each persisted draft entry gains an optional `queued: string[]` beside `text`/`mode`, under the same scope key, CAS guard, eviction and versioning. `save()` preserves it, `clear()` keeps an entry alive while follow-ups wait, new `saveQueued(scopeKey, texts)`.
- `queued-draft-persistence.ts`: a store subscription mirrors every `queuedDrafts` mutation (append, remove at admission, re-queue on error, reorder, Stop) for every conversation — including background drains for sessions not in view — into that entry. Started from `GlobalQueueDrainerBridge`.
- `session-surface.tsx` hydration: on a renderer that holds no in-memory queue for the conversation but finds one persisted, the queued texts are folded into the composer **ahead of** any later draft, the mirror is cleared in the same write, and a toast says *"N messages waiting to be sent were kept as a draft during the restart. Review them and send when you're ready."*
- Restored text is **never re-queued or auto-sent**. Across a restart nobody can vouch that "the agent finished" still means what it meant (desktop task recovery from #4636 may be resuming the interrupted run), so the person reviews and presses Enter — which re-queues in one keystroke if the task is busy again.
- Already-admitted items are not touched: the mirror drops an item at claim time, so a reload during its run shows it exactly once in the transcript and restores nothing.

Attachments hold live `File` objects and are not persisted, same as composer drafts. A follow-up PR (stacked, draft) adds the waiting-message count to both Restart-to-update dialogs; its Electron proof is blocked by a pre-existing `restartUpdateTaskWorld` arrangement failure.

## Verification: Passed
Head `9d5109b4f0cd6464a9543ffd03640bf85480295f`, signed + DCO sign-off. Lane: **Daytona**, cold boot, `--strict-ref` (sandboxSha = runner HEAD, `refMismatch: false`).

- `OPENWORK_EVAL_REF=9d5109b4f… pnpm evals:e2e queued-messages-restart --daytona --strict-ref` → exit 0; **2 passed, 0 failed, 0 skipped**.
  - *queued follow-ups come back as an unsent draft after a renderer restart instead of vanishing or auto-sending* — storage records `{text:"Draft typed after queueing", queued:["Then publish the release notes","Also tag the build"]}`; after reload composer = `Q1\n\nQ2\n\nDraft`, one user turn, `queued: []`, toast present, 0 model requests for the queued prompt; after the task finishes still one user turn and 0 requests.
  - *a queued follow-up already admitted to the engine is neither duplicated nor restored after a reload* — admission leaves `queued: []`; after reload the follow-up appears exactly once, composer empty, no toast.
- Same spec locally (`--local`) → 2 passed. Baseline spec on unmodified `origin/dev` reproduced the loss (quoted above).
- `pnpm --filter @openwork/app typecheck` → exit 0.
- `bun test tests/draft-store.test.ts tests/queued-draft-persistence.test.ts tests/composer-state-store.test.ts tests/queued-drain-admission-wedge.test.ts tests/electron-updater-install-policy.test.ts` → 40 pass, 0 fail.

Test evidence for both runs is published below.

## Known limits
- A queued item removed at admission whose `prompt_async` had not yet reached the engine when the renderer died is lost (not duplicated) — same sub-second window as today; the admission-unknown recovery machinery does not persist either.
- Two windows/tabs sharing one profile on the same conversation: the second window restores the first window's still-live queue as a draft (drafts already share this cross-tab model).
- Shell-mode and slash-command queued items come back as plain composer text.
