### PR TITLE
fix(chat): retain Starting feedback until accepted work is observed

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1480,22 +1480,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const autoSending = (Boolean(autoSendPayload)
     || hasComposerAutoSend(props.sessionId))
     && !sessionModelUnavailable;
-  const status = useMemo((): ThreadStatus => {
-    if (evalThreadStatus) return evalThreadStatus;
-    if (liveStatus.type === "busy") {
-      return "streaming";
-    }
-
-    if (liveStatus.type === "retry") {
-      return "retrying";
-    }
-
-    if (sending || autoSending) {
-      return "submitted";
-    }
-
-    return "ready";
-  }, [autoSending, evalThreadStatus, liveStatus, sending]);
   const [evalMarkdownMessages, setEvalMarkdownMessages] = useState<UIMessage[]>(EMPTY_TRANSCRIPT);
   useEffect(() => {
     setEvalMarkdownMessages(EMPTY_TRANSCRIPT);
@@ -1909,6 +1893,26 @@ export function SessionSurface(props: SessionSurfaceProps) {
     hasActivePermission: Boolean(props.activePermission),
     hasSessionError: error !== null,
   }), [error, liveStatus.type, props.activePermission, props.activeQuestion, renderedMessages, sending]);
+  const status = useMemo((): ThreadStatus => {
+    if (evalThreadStatus) return evalThreadStatus;
+    if (liveStatus.type === "busy") {
+      return "streaming";
+    }
+
+    if (liveStatus.type === "retry") {
+      return "retrying";
+    }
+
+    if (sending || autoSending || (
+      queuedDrainState.phase.kind === "awaiting_observation"
+      && admissionOutcome === "unresolved"
+      && !admissionOutcomeUnresolved
+    )) {
+      return "submitted";
+    }
+
+    return "ready";
+  }, [admissionOutcome, admissionOutcomeUnresolved, autoSending, evalThreadStatus, liveStatus, queuedDrainState.phase.kind, sending]);
 
   useEffect(() => {
     if (!hasFullHistory || admissionOutcome !== "unresolved") {

--- a/apps/app/tests/composer-focus-continuity.test.tsx
+++ b/apps/app/tests/composer-focus-continuity.test.tsx
@@ -10,7 +10,7 @@ import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import type { NativeContextMenuRequest } from "../src/app/lib/desktop-types";
-import type { ComposerAttachment, ComposerDraft } from "../src/app/types";
+import type { ComposerAttachment, ComposerDraft, PendingPermission, PendingQuestion } from "../src/app/types";
 import type { CloudMcpSubmissionResult } from "../src/react-app/domains/connections/cloud-mcp-submit-readiness";
 import type {
   NewTaskComposerContext,
@@ -276,6 +276,8 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     return children(archived);
   }
 
+  let activePermission: PendingPermission | null = null;
+  let activeQuestion: PendingQuestion | null = null;
   const renderSurface = (opencodeBaseUrl = "http://127.0.0.1:1/opencode", activeSessionId = sessionId, isControlTarget = false) => root.render(
     <PlatformProvider value={platform}>
       <MemoryRouter>
@@ -286,6 +288,8 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
               <ArchiveOwner>{archived => (
               <SessionSurface
                 archived={archived}
+                activePermission={activePermission}
+                activeQuestion={activeQuestion}
                 client={client}
                 workspaceId={workspaceId}
                 workspaceRoot="/tmp/project-focus-continuity"
@@ -527,7 +531,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     const freshRead = Promise.withResolvers<OpenworkSessionSnapshot>();
     snapshotRead = freshRead.promise;
     fetchedSnapshot = createSnapshot({ type: "idle" }, 4);
-    await act(async () => { expect(await restoreShared()).toBe(true); });
+    await act(async () => { expect(await restoreShared()).toEqual({ kind: "done" }); });
     await waitFor(() => container.querySelector('[contenteditable="true"][data-lexical-editor="true"]') !== null, "shared Restore to enable the composer before refetch completes");
     expect(queryClient.getQueryState(key)?.fetchStatus).toBe("fetching");
     expect(container.querySelector('[data-testid="archived-session"]')).toBeNull();
@@ -849,14 +853,30 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
         role: "user",
         parts: [{ type: "text", text: "First message auto-send" }],
       }]);
-      submission.resolve({ outcome: "accepted" });
     });
+    await waitFor(() => Object.values(useComposerStateStore.getState().pendingMessages).flat()
+      .some((item) => item.serverMessageId === messageId), "the user message to be observed before acceptance returns");
+    expectStarting();
+    await act(async () => submission.resolve({ outcome: "accepted" }));
     expect(editor.textContent).toBe("");
     expect(container.textContent?.split("First message auto-send").length).toBe(2);
     expect(Object.values(useComposerStateStore.getState().pendingMessages).flat()).toHaveLength(0);
 
-    const { PromptAdmissionUnknownError } = await import("../src/app/lib/opencode");
+    expect(getQueuedDrainState(sessionId).phase.kind).toBe("awaiting_observation");
+    expectStarting();
+    await act(async () => queryClient.setQueryData(statusKey(workspaceId, sessionId), { type: "busy" }));
+    await waitFor(() => container.querySelector('[data-loading-message="working"]') !== null, "confirmed activity after accepted auto-send");
+    expect(container.querySelector('[data-loading-message="starting"]')).toBeNull();
+    await act(async () => queryClient.setQueryData(statusKey(workspaceId, sessionId), {
+      type: "retry", attempt: 1, message: "Retrying accepted request", next: Date.now() + 10_000,
+    }));
+    await waitFor(() => container.textContent?.includes("Retrying accepted request") === true, "retry feedback after accepted auto-send");
     expectSettled();
+    await act(async () => queryClient.setQueryData(statusKey(workspaceId, sessionId), { type: "idle" }));
+    await waitFor(() => getQueuedDrainState(sessionId).phase.kind === "ready", "the accepted auto-send to finish");
+    expectSettled();
+
+    const { PromptAdmissionUnknownError } = await import("../src/app/lib/opencode");
     submission = Promise.withResolvers<CloudMcpSubmissionResult>();
     await act(async () => useComposerStateStore.getState().setDraft(sessionId, "Uncertain send"));
     await act(async () => send());
@@ -869,6 +889,7 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     await act(async () => submission.reject(new PromptAdmissionUnknownError({ messageID: uncertainId })));
     expect(editor.textContent).toBe("Newer uncertain draft");
     expect(getQueuedDrainState(sessionId).phase).toMatchObject({ kind: "admission_unknown", messageID: uncertainId });
+    expectSettled();
     expect(Object.values(useComposerStateStore.getState().failedDrafts).flat()).toHaveLength(0);
     expect(useComposerStateStore.getState().queuedDrafts[sessionId]).toBeUndefined();
     await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [{
@@ -1010,7 +1031,8 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     // Native v2 returns admission without an ID and normalizes user turns to text only.
     const { createClientV2, v2PromptText } = await import("../src/app/lib/opencode-v2-adapter");
     const { draftToParts } = await import("../src/react-app/domains/session/sync/draft-parts");
-    const { snapshotToUIMessages } = await import("../src/react-app/domains/session/sync/usechat-adapter");
+    const { snapshotToUIMessages, createSessionErrorUIMessage } = await import("../src/react-app/domains/session/sync/usechat-adapter");
+    const { presentOpencodeSessionError } = await import("../src/react-app/domains/session/sync/session-error");
     const nativeBaseUrl = "http://127.0.0.1:1/opencode2";
     const nativeClient = createClientV2(nativeBaseUrl, "/tmp/project-focus-continuity", {});
     const nativeOwner = composerAutoSendScopeKey({ draftScope: "local", opencodeBaseUrl: nativeBaseUrl, workspaceId, sessionId });
@@ -1282,6 +1304,63 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     expect(queryClient.getQueryData<OpenworkSessionSnapshot>(snapshotKey(workspaceId, sessionId))?.status).toBeUndefined();
     expect(sentDrafts).toHaveLength(sendsBeforeProbe);
     expect(getQueuedDrainState(sessionId).lastResolution).toEqual({ itemId: "deferred-command-probe", resolution: "completed" });
+    expectSettled();
+
+    await act(async () => root.render(null));
+    await act(async () => {
+      fetchedSnapshot = createSnapshot({ type: "idle" }, 34);
+      queryClient.setQueryData(snapshotKey(workspaceId, sessionId), fetchedSnapshot);
+      queryClient.setQueryData(transcriptKey(workspaceId, sessionId), snapshotToUIMessages(fetchedSnapshot));
+      renderSession();
+    });
+    for (const outcome of ["answered", "failed", "stopped", "question", "permission", "unresolved"]) {
+      await act(async () => {
+        queryClient.setQueryData(transcriptKey(workspaceId, sessionId), snapshotToUIMessages(fetchedSnapshot));
+        dispatchQueuedDrain(sessionId, { type: "send_started", itemId: outcome });
+        dispatchQueuedDrain(sessionId, {
+          type: "send_result", itemId: outcome, outcome: "accepted", at: Date.now(),
+          deferredMessageID: "existing-user-message",
+        });
+      });
+      await waitFor(() => container.querySelector('[data-loading-message="starting"]') !== null, `${outcome} admission feedback`);
+      expectStarting();
+      if (outcome === "answered") {
+        await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [
+          ...snapshotToUIMessages(fetchedSnapshot),
+          { id: "completed-without-busy", role: "assistant", parts: [{ type: "text", text: "Completed without a busy event." }],
+            metadata: { opencode: { created: 35, completed: 36 } } },
+        ]));
+        await waitFor(() => container.textContent?.includes("Completed without a busy event.") === true, "the terminal reply without busy");
+      } else if (outcome === "failed") {
+        const presentation = presentOpencodeSessionError("Provider rejected the request.");
+        const failure = createSessionErrorUIMessage("failed-without-busy", presentation);
+        await act(async () => queryClient.setQueryData(transcriptKey(workspaceId, sessionId), [
+          ...snapshotToUIMessages(fetchedSnapshot), failure,
+        ]));
+        await waitFor(() => container.textContent?.includes(presentation.title) === true, "the terminal error without busy");
+      } else if (outcome === "stopped") {
+        await act(async () => dispatchQueuedDrain(sessionId, { type: "stop_confirmed" }));
+      } else if (outcome === "question") {
+        activeQuestion = { id: "question-without-busy", sessionID: sessionId, receivedAt: Date.now(),
+          questions: [{ header: "Choice", question: "Pick one", options: [{ label: "Yes", description: "Proceed" }] }] };
+        await act(async () => renderSession());
+      } else if (outcome === "permission") {
+        activePermission = { id: "permission-without-busy", sessionID: sessionId, receivedAt: Date.now(),
+          protocol: "legacy", permission: "read", patterns: ["/tmp/project-focus-continuity"], metadata: {}, always: [] };
+        await act(async () => renderSession());
+      } else {
+        await waitFor(() => container.querySelector('[data-testid="admission-outcome-unknown"]') !== null, "bounded admission recovery");
+      }
+      expectSettled();
+      expect(getQueuedDrainState(sessionId).phase.kind).toBe(outcome === "stopped" ? "ready" : "awaiting_observation");
+      await act(async () => {
+        dispatchQueuedDrain(sessionId, { type: "stop_confirmed" });
+        activeQuestion = null;
+        activePermission = null;
+        renderSession();
+      });
+    }
+    expect(sentDrafts).toHaveLength(sendsBeforeProbe);
 
     const { NewTaskComposer } = await import("../src/react-app/domains/session/chat/new-task-composer");
     let creation = Promise.withResolvers<void>();
@@ -1395,4 +1474,4 @@ test("composer focus, shared Restore, pending stops, and optimistic sends preser
     mock.restore();
     if (registeredDom) await GlobalRegistrator.unregister();
   }
-});
+}, 10_000);

--- a/evals/specs/session-archive-button.e2e.test.ts
+++ b/evals/specs/session-archive-button.e2e.test.ts
@@ -538,7 +538,7 @@ test("archiving exits only the viewed conversation, and working sessions require
 });
 
 test("accepted commands require exact engine admission before archive and never replay after Undo", async ({ world, user, agent, probe, step }) => {
-  const { a2, b1 } = world;
+  const { a1, a2, b1 } = world;
   const { aborts, open, send, archive, archived } = await archiveActions({ world, user, agent, probe });
   expect(await world.requests()).toHaveLength(0);
   expect(await aborts()).toHaveLength(0);
@@ -552,6 +552,61 @@ test("accepted commands require exact engine admission before archive and never 
       status: 200,
       body: { model: "session-archive-mock/mock-agent-workload-model", small_model: "session-archive-mock/mock-agent-workload-model" },
     });
+  });
+
+  await step("an accepted response keeps Starting visible until native busy, then Working clears at completion without another send", async () => {
+    await open(a1);
+    await world.holdRun();
+    await world.networkFault("accepted_command", a1.sessionId);
+    await agent.run("composer.set_text", { text: "/archive-witness" });
+    await user.see("composer", { text: "/archive-witness" });
+    await agent.run("composer.send");
+    const loading = `[data-session-surface-id="${a1.sessionId}"] [data-loading-message]`;
+    const startingUntil = Date.now() + 200;
+    do {
+      const rows = (await probe.dom(loading)).elements;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].text).toBe("Starting…");
+      expect(rows[0].rect.width).toBeGreaterThan(0);
+      expect(rows[0].rect.height).toBeGreaterThan(0);
+    } while (Date.now() < startingUntil);
+    const accepted = await world.facts();
+    const sends = accepted.requests.filter(request => ["command", "prompt_async"].includes(request.action));
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toMatchObject({ sessionId: a1.sessionId, action: "command", result: "accepted, not dispatched" });
+    expect(accepted.sessions.find(session => session.sessionId === a1.sessionId)?.status).toBe("idle");
+    expect(await world.requests()).toHaveLength(0);
+    expect((await probe.dom(`${loading}[data-loading-message="starting"]`)).elements).toHaveLength(1);
+    await world.releaseAbort();
+    await world.networkFault("none", a1.sessionId);
+    await probe.eventually(() => world.facts(), {
+      within: 30_000, label: "the single accepted command reaches native busy",
+      until: facts => facts.sessions.some(session => session.sessionId === a1.sessionId && session.status === "busy"),
+    });
+    await user.see({ text: "Working" });
+    expect((await probe.dom(`${loading}[data-loading-message="working"]`)).elements).toHaveLength(1);
+    expect((await probe.dom(`${loading}[data-loading-message="starting"]`)).elements).toHaveLength(0);
+    await world.releaseRun();
+    await user.see({ text: "Archive fixture reply." }, { timeoutMs: 60_000 });
+    await probe.eventually(() => world.facts(), {
+      within: 30_000, label: "the accepted command completes in the owning engine",
+      until: facts => facts.sessions.find(session => session.sessionId === a1.sessionId)?.status === "idle",
+    });
+    await user.notSee({ text: "Working" });
+    expect((await probe.dom(loading)).elements).toHaveLength(0);
+    const transcript = await world.transcript(a1);
+    expect(transcript.filter(message => message.role === "user")).toEqual([
+      expect.objectContaining({ id: sends[0].messageID, sessionId: a1.sessionId }),
+    ]);
+    expect(transcript).toEqual(expect.arrayContaining([
+      expect.objectContaining({ parentID: sends[0].messageID, role: "assistant", completed: expect.any(Number), pendingTools: false }),
+    ]));
+    const noReplayUntil = Date.now() + 1_500;
+    await probe.eventually(async () => {
+      expect((await world.facts()).requests.filter(request => ["command", "prompt_async"].includes(request.action))).toHaveLength(1);
+      expect(await world.requests()).toHaveLength(1);
+      return Date.now() >= noReplayUntil;
+    }, { within: 10_000, label: "completion never resubmits the accepted command" });
   });
 
   for (const queued of [false, true]) {

--- a/evals/specs/session-archive-button.e2e.test.ts
+++ b/evals/specs/session-archive-button.e2e.test.ts
@@ -135,7 +135,8 @@ test("archiving exits only the viewed conversation, and working sessions require
       }
       await archive(faultCandidate);
       await user.see({ text: "This session is still working" });
-      await user.see({ text: "Stop the current task and all its subtasks, cancel queued messages, and archive this conversation? Changes already made won't be undone. Actions already submitted to external services may still complete." });
+      await user.see({ text: "Stop the current task and archive?" });
+      expect(await world.archiveAccessibleDescription()).toBe("Stop the current task and archive?");
       await user.click({ role: "button", label: "Keep session open" });
       await world.networkFault("none", faultCandidate.sessionId);
       for (const observation of await world.faultObservation()) expect(observation.observed).toEqual(observation.actual);
@@ -537,7 +538,7 @@ test("archiving exits only the viewed conversation, and working sessions require
   });
 });
 
-test("accepted commands require exact engine admission before archive and never replay after Undo", async ({ world, user, agent, probe, step }) => {
+test("accepted commands require exact engine admission before archive and never replay after Undo", async ({ world, user, agent, probe, step, evidence }) => {
   const { a1, a2, b1 } = world;
   const { aborts, open, send, archive, archived } = await archiveActions({ world, user, agent, probe });
   expect(await world.requests()).toHaveLength(0);
@@ -555,32 +556,44 @@ test("accepted commands require exact engine admission before archive and never 
   });
 
   await step("an accepted response keeps Starting visible until native busy, then Working clears at completion without another send", async () => {
+    const prompt = "Suggest a simple plan for organizing a desk.";
     await open(a1);
     await world.holdRun();
-    await world.networkFault("accepted_command", a1.sessionId);
-    await agent.run("composer.set_text", { text: "/archive-witness" });
-    await user.see("composer", { text: "/archive-witness" });
+    await world.networkFault("accepted_prompt", a1.sessionId);
+    await agent.run("composer.set_text", { text: prompt });
+    await user.see("composer", { text: prompt });
     await agent.run("composer.send");
     const loading = `[data-session-surface-id="${a1.sessionId}"] [data-loading-message]`;
     const startingUntil = Date.now() + 200;
-    do {
-      const rows = (await probe.dom(loading)).elements;
-      expect(rows).toHaveLength(1);
-      expect(rows[0].text).toBe("Starting…");
-      expect(rows[0].rect.width).toBeGreaterThan(0);
-      expect(rows[0].rect.height).toBeGreaterThan(0);
-    } while (Date.now() < startingUntil);
+    try {
+      do {
+        const rows = (await probe.dom(loading)).elements;
+        expect(rows).toHaveLength(1);
+        expect(rows[0].text).toBe("Starting…");
+        expect(rows[0].rect.width).toBeGreaterThan(0);
+        expect(rows[0].rect.height).toBeGreaterThan(0);
+      } while (Date.now() < startingUntil);
+    } catch (error) {
+      const [diagnostics, facts, transcript, allLoading, statuses] = await Promise.all([
+        world.diagnostics(), world.facts(), world.transcript(a1),
+        probe.dom("[data-loading-message]"),
+        probe.dom(`[data-session-surface-id="${a1.sessionId}"] [role="status"]`),
+      ]);
+      evidence.recordJsonArtifact("Accepted prompt feedback failure", { sessionId: a1.sessionId, diagnostics, facts, transcript, allLoading, statuses });
+      await user.screenshot();
+      throw error;
+    }
     const accepted = await world.facts();
     const sends = accepted.requests.filter(request => ["command", "prompt_async"].includes(request.action));
     expect(sends).toHaveLength(1);
-    expect(sends[0]).toMatchObject({ sessionId: a1.sessionId, action: "command", result: "accepted, not dispatched" });
+    expect(sends[0]).toMatchObject({ sessionId: a1.sessionId, action: "prompt_async", result: "accepted, not dispatched" });
     expect(accepted.sessions.find(session => session.sessionId === a1.sessionId)?.status).toBe("idle");
     expect(await world.requests()).toHaveLength(0);
     expect((await probe.dom(`${loading}[data-loading-message="starting"]`)).elements).toHaveLength(1);
     await world.releaseAbort();
     await world.networkFault("none", a1.sessionId);
     await probe.eventually(() => world.facts(), {
-      within: 30_000, label: "the single accepted command reaches native busy",
+      within: 30_000, label: "the single accepted prompt reaches native busy",
       until: facts => facts.sessions.some(session => session.sessionId === a1.sessionId && session.status === "busy"),
     });
     await user.see({ text: "Working" });
@@ -589,14 +602,14 @@ test("accepted commands require exact engine admission before archive and never 
     await world.releaseRun();
     await user.see({ text: "Archive fixture reply." }, { timeoutMs: 60_000 });
     await probe.eventually(() => world.facts(), {
-      within: 30_000, label: "the accepted command completes in the owning engine",
+      within: 30_000, label: "the accepted prompt completes in the owning engine",
       until: facts => facts.sessions.find(session => session.sessionId === a1.sessionId)?.status === "idle",
     });
     await user.notSee({ text: "Working" });
     expect((await probe.dom(loading)).elements).toHaveLength(0);
     const transcript = await world.transcript(a1);
     expect(transcript.filter(message => message.role === "user")).toEqual([
-      expect.objectContaining({ id: sends[0].messageID, sessionId: a1.sessionId }),
+      expect.objectContaining({ id: sends[0].messageID, sessionId: a1.sessionId, text: prompt }),
     ]);
     expect(transcript).toEqual(expect.arrayContaining([
       expect.objectContaining({ parentID: sends[0].messageID, role: "assistant", completed: expect.any(Number), pendingTools: false }),
@@ -606,7 +619,7 @@ test("accepted commands require exact engine admission before archive and never 
       expect((await world.facts()).requests.filter(request => ["command", "prompt_async"].includes(request.action))).toHaveLength(1);
       expect(await world.requests()).toHaveLength(1);
       return Date.now() >= noReplayUntil;
-    }, { within: 10_000, label: "completion never resubmits the accepted command" });
+    }, { within: 10_000, label: "completion never resubmits the accepted prompt" });
   });
 
   for (const queued of [false, true]) {

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1414,7 +1414,7 @@ export async function commandPaletteSearch(seed: Seed) {
   return oneWorkspace(seed, `command-palette-search-${Date.now()}`);
 }
 
-type ArchiveFault = "none" | "false" | "error" | "timeout" | "unconfirmed" | "hold" | "retry" | "permission" | "question" | "prompt_error" | "hold_prompt" | "accepted_command" | "hold_archive";
+type ArchiveFault = "none" | "false" | "error" | "timeout" | "unconfirmed" | "hold" | "retry" | "permission" | "question" | "prompt_error" | "hold_prompt" | "accepted_command" | "accepted_prompt" | "hold_archive";
 type ArchiveRequest = {
   path: string; sessionId: string; action: string; messageID: string | null; result: string | number | null;
   command?: { name: string; arguments: string; model: string | null; agent: string | null };
@@ -1611,7 +1611,10 @@ export async function archiveActiveSessions(seed: Seed, { place }: { place: Plac
         await new Promise<void>(resolve => { state.release = resolve; });
         state.release = null;
       }
-      if (record?.action === "command" && target && state.mode === "accepted_command") {
+      if (record && target && (
+        (record.action === "command" && state.mode === "accepted_command")
+        || (record.action === "prompt_async" && state.mode === "accepted_prompt")
+      )) {
         record.result = "accepted, not dispatched";
         const admitted = new Request(request, { signal: new AbortController().signal });
         state.release = async () => {
@@ -1620,13 +1623,13 @@ export async function archiveActiveSessions(seed: Seed, { place }: { place: Plac
             const response = await original(admitted);
             record.result = response.status;
             record.responseBody = (await response.text()).slice(0, 2000);
-            if (!response.ok) throw new Error("Admitted command dispatch failed: " + response.status + " " + record.responseBody);
+            if (!response.ok) throw new Error("Admitted " + record.action + " dispatch failed: " + response.status + " " + record.responseBody);
           } catch (error) {
             record.dispatchError = error instanceof Error ? error.message : String(error);
             throw error;
           }
         };
-        return Response.json({ ok: true, accepted: true });
+        return record.action === "prompt_async" ? new Response(null, { status: 204 }) : Response.json({ ok: true, accepted: true });
       }
       if (record?.action === "prompt_async" && target && state.mode === "prompt_error") {
         record.result = 400;


### PR DESCRIPTION
## Summary
Keep Starting visible after an ordinary message is accepted while native execution has not yet been observed. Previously the submission promise could settle before native busy arrived, leaving the submitted message without loading feedback.

Reuse the existing admission lifecycle; native busy/retry, terminal results, explicit stop, questions, permissions, and bounded recovery retain their existing precedence. No synthetic busy status or replay is introduced.

## UI/UX impact
Starting no longer disappears between acceptance and confirmed work or existing bounded recovery. Existing labels, styling, layout, and confirmed-work timer behavior are unchanged.

## Verification
Verdict: Passed for the ordinary-message handoff on desktop/v1.
Exact head: 4bcbe393ed6754028bd607bfdc4327afefe80f41.

- Passed: cold Daytona desktop journey, 2 passed / 0 failed / 0 skipped, exit 0. Both sandboxes verified the exact source SHA.
- Command: OPENWORK_EVAL_REF=4bcbe393ed6754028bd607bfdc4327afefe80f41 pnpm evals:e2e session-archive-button --engine v1
- Accepted-admission coverage: Starting remains visible after HTTP 204 while upstream dispatch is held; native busy replaces it with Working; terminal completion clears loading; exactly one prompt and one user turn, no replay. Published evidence: https://github.com/different-ai/openwork/pull/4930#issuecomment-5642815903
- Companion archive journey passed its existing stop, cancellation, archive, Undo, and isolation checks. Updated its stale dialog-copy assertion to the current product wording; no dialog UI changed.
- Passed: focused composer continuity regression, 1 test / 539 assertions; app typecheck; evals typecheck (428 files); git diff --check.
- Required CI passed; no unresolved inline review comments at handoff.

Deferred: v2 runtime matrix, separate slash-command loading presentation, and visual judging (this change has no styling claim). Combined review-report upload was unavailable because OPENWORK_REVIEW_URL/authentication was not configured; the covering test was published through the supported GitHub evidence publisher instead.

Earlier attempts did not pass: one used an abbreviated source ref, one was interrupted during setup, and a prior test iteration exercised the separate slash-command path and a stale dialog-copy expectation. These are superseded by the exact-head run above, not counted as passing proof.

No merge, release, or deployment included.