### PR TITLE
fix(server): truncate long session.create titles instead of rejecting, and advertise the limit

### DIFF
--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -54,6 +54,7 @@ const createResultSchema = z.object({
   created: z.array(z.object({
     sessionId: z.string(),
     title: z.string(),
+    titleTruncated: z.boolean(),
     started: z.boolean(),
     model: sessionModelSchema.nullable(),
     route: z.string(),
@@ -62,6 +63,12 @@ const createResultSchema = z.object({
     title: z.string(),
     error: z.string(),
   })),
+});
+
+const argumentErrorSchema = z.object({
+  ok: z.literal(false),
+  error: z.string(),
+  issues: z.array(z.object({ path: z.string(), message: z.string() })),
 });
 
 const sendResultSchema = z.object({
@@ -676,7 +683,8 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(await search({ query: "a", createdAfter: 20, createdBefore: 60 })).toEqual(["ses_beta"]);
     expect(await search({ query: "a", archived: "exclude" })).toEqual(["ses_alpha", "ses_beta"]);
     expect(await search({ query: "a", archived: "only" })).toEqual(["ses_archive"]);
-    await expect(plugin.tool.openwork_query.execute({ id: "session.search", args: { query: "a", createdAfter: "yesterday-ish" } })).rejects.toThrow();
+    const invalid = argumentErrorSchema.parse(JSON.parse(await plugin.tool.openwork_query.execute({ id: "session.search", args: { query: "a", createdAfter: "yesterday-ish" } })));
+    expect(invalid.issues.map((issue) => issue.path)).toEqual(["createdAfter"]);
   });
 
   test("keeps search results when one workspace native mount is unavailable", async () => {
@@ -862,6 +870,57 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     ]));
   });
 
+  test.each([145, 120])("session.create accepts a %i-character title and echoes its final label", async (length) => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
+    const title = "T".repeat(length);
+    const expected = length > 120 ? `${title.slice(0, 119)}…` : title;
+    const output = await plugin.tool.openwork_execute.execute({
+      id: "session.create", args: { sessions: [{ title: `  ${title}  `, prompt: "Research dolphins." }] },
+    }, {});
+    const parsed = affordanceResultSchema("session.create", createResultSchema).parse(JSON.parse(output));
+    expect(parsed.result.created).toHaveLength(1);
+    expect(parsed.result.created[0]).toMatchObject({ title: expected, titleTruncated: length > 120 });
+    expect(parsed.result.created[0]?.title).toHaveLength(120);
+    expect(fake.requests.find((request) => request.method === "POST" && request.pathname.endsWith("/opencode/session"))?.body).toEqual({ title: expected });
+  });
+
+  test("session.create reports an empty title before creating anything", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+    const output = argumentErrorSchema.parse(JSON.parse(await plugin.tool.openwork_execute.execute({
+      id: "session.create", args: { sessions: [{ title: "  ", prompt: "Valid prompt" }] },
+    }, {})));
+    expect(output).toMatchObject({ ok: false, issues: [{ path: "sessions[0].title", message: expect.stringContaining("sessions[0].title:") }] });
+    expect(output.issues).toHaveLength(1);
+    expect(fake.requests).toEqual([]);
+  });
+
+  test("session.create reports every oversized prompt without partial creation", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+    const messages = ["sessions[1].prompt: 100,001 characters, max 100,000", "sessions[2].prompt: 100,412 characters, max 100,000"];
+    const output = argumentErrorSchema.parse(JSON.parse(await plugin.tool.openwork_execute.execute({
+      id: "session.create", args: { sessions: [
+        { title: "Valid", prompt: "Valid prompt" },
+        { title: "First invalid", prompt: "P".repeat(100_001) },
+        { title: "Second invalid", prompt: "P".repeat(100_412) },
+      ] },
+    }, {})));
+    expect(output).toMatchObject({ ok: false, error: messages.join("; "), issues: messages.map((message, index) => ({ path: `sessions[${index + 1}].prompt`, message })) });
+    expect(output.issues).toHaveLength(2);
+    expect(fake.requests).toEqual([]);
+  });
+
+  test.each(["session.search", "session.read", "session.send"])("%s returns structured argument issues without I/O", async (id) => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+    const tool = id === "session.send" ? plugin.tool.openwork_execute : plugin.tool.openwork_query;
+    const output = argumentErrorSchema.parse(JSON.parse(await tool.execute({ id, args: {} }, {})));
+    expect(output.issues.map((issue) => issue.path)).toEqual(id === "session.search" ? ["query"] : id === "session.read" ? ["sessionId"] : ["sessionId", "text"]);
+    expect(fake.requests).toEqual([]);
+  });
+
   test("session.create binds the requested model and reasoning effort at creation and on the first turn", async () => {
     const fake = startFakeOpenWorkServer();
     const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
@@ -921,10 +980,11 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     const fake = startFakeOpenWorkServer();
     const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
 
-    await expect(plugin.tool.openwork_execute.execute({
+    const output = argumentErrorSchema.parse(JSON.parse(await plugin.tool.openwork_execute.execute({
       id: "session.create",
       args: { model: { providerId: "lpr_test", variant: "high" }, sessions: [{ title: "Half a model", prompt: "Research nothing." }] },
-    }, { sessionID: "ses_origin" })).rejects.toThrow();
+    }, { sessionID: "ses_origin" })));
+    expect(output.issues.map((issue) => issue.path)).toEqual(["model.modelId"]);
     expect(fake.requests.filter((request) => request.method === "POST")).toEqual([]);
   });
 

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -185,6 +185,7 @@ type CreatedOpenWorkSessionResult = {
   ok: true;
   sessionId: string;
   title: string;
+  titleTruncated: boolean;
   started: boolean;
   /** The model the engine bound to the session, read from its create response. */
   model: OpenworkSessionModel | null;
@@ -193,6 +194,7 @@ type CreatedOpenWorkSessionResult = {
 type FailedOpenWorkSessionResult = {
   ok: false;
   title: string;
+  titleTruncated: boolean;
   error: string;
 };
 
@@ -245,6 +247,7 @@ function affordanceResult(
       ok: false,
       id,
       error: typeof result.error === "string" ? result.error : `${id} failed`,
+      ...(Array.isArray(result.issues) ? { issues: result.issues } : {}),
       code: "failed",
     };
   }
@@ -744,7 +747,9 @@ async function forEachWithConcurrency<T>(items: T[], concurrency: number, run: (
 }
 
 async function searchOpenWorkSessions(rawArgs: unknown): Promise<object> {
-  const args = sessionSearchArgsSchema.parse(rawArgs);
+  const parsed = sessionSearchArgsSchema.safeParse(rawArgs);
+  if (!parsed.success) return sessionArgumentError(parsed.error, rawArgs);
+  const args = parsed.data;
   const resultLimit = args.limit ?? SESSION_SEARCH_DEFAULT_LIMIT;
   const scanLimit = args.scanLimit ?? SESSION_SEARCH_DEFAULT_SCAN_LIMIT;
   const messageLimit = args.messageLimit ?? SESSION_SEARCH_DEFAULT_MESSAGE_LIMIT;
@@ -827,7 +832,9 @@ function readableMessages(messages: SessionMessage[]): ReadableMessage[] {
 }
 
 async function readOpenWorkSession(rawArgs: unknown): Promise<object> {
-  const args = sessionReadArgsSchema.parse(rawArgs);
+  const parsed = sessionReadArgsSchema.safeParse(rawArgs);
+  if (!parsed.success) return sessionArgumentError(parsed.error, rawArgs);
+  const args = parsed.data;
   const count = args.count ?? 30;
   const from = args.from ?? "end";
   const summary = args.summary ?? false;
@@ -933,7 +940,9 @@ type SendToOpenWorkSessionResult =
  * effort: the message is already sent if that fails).
  */
 async function sendToOpenWorkSession(rawArgs: unknown, context: OpenCodeContext): Promise<SendToOpenWorkSessionResult> {
-  const args = sessionSendArgsSchema.parse(rawArgs);
+  const parsed = sessionSendArgsSchema.safeParse(rawArgs);
+  if (!parsed.success) return sessionArgumentError(parsed.error, rawArgs);
+  const args = parsed.data;
   const located = await locateOpenWorkSession(args.sessionId, args.workspaceId);
   if ("error" in located) return { ok: false, error: located.error };
   const { workspace, session } = located;
@@ -1047,11 +1056,34 @@ function enginePromptModel(model: SessionModelArg) {
   return { model: { providerID: model.providerId, modelID: model.modelId }, ...(model.variant ? { variant: model.variant } : {}) };
 }
 
+function argumentAtPath(value: unknown, path: PropertyKey[]): unknown {
+  for (const key of path) {
+    value = typeof value === "object" && value !== null ? Reflect.get(value, key) : undefined;
+  }
+  return value;
+}
+
+function sessionArgumentError(error: z.ZodError, rawArgs: unknown): { ok: false; error: string; issues: Array<{ path: string; message: string }> } {
+  const issues = error.issues.map((issue) => {
+    const path = issue.path.map((key, index) => typeof key === "number" ? `[${key}]` : `${index ? "." : ""}${String(key)}`).join("");
+    const value = argumentAtPath(rawArgs, issue.path);
+    const detail = issue.code === "too_big" && issue.origin === "string" && typeof value === "string"
+      ? `${value.trim().length.toLocaleString("en-US")} characters, max ${issue.maximum.toLocaleString("en-US")}`
+      : issue.message;
+    return { path, message: `${path}: ${detail}` };
+  });
+  return { ok: false, error: issues.map((issue) => issue.message).join("; "), issues };
+}
+
 async function createOpenWorkSessions(rawArgs: unknown, context: OpenCodeContext): Promise<object> {
-  const args = sessionCreateArgsSchema.parse(rawArgs);
+  const parsed = sessionCreateArgsSchema.safeParse(rawArgs);
+  if (!parsed.success) return sessionArgumentError(parsed.error, rawArgs);
+  const args = parsed.data;
   const workspace = await resolveContextWorkspace(args.workspaceId, context);
   let createdOnEngine = false;
-  const results = await Promise.all(args.sessions.map(async (session): Promise<CreatedOpenWorkSessionResult | FailedOpenWorkSessionResult> => {
+  const results = await Promise.all(args.sessions.map(async (session, index): Promise<CreatedOpenWorkSessionResult | FailedOpenWorkSessionResult> => {
+    const inputTitle = argumentAtPath(rawArgs, ["sessions", index, "title"]);
+    const titleTruncated = typeof inputTitle === "string" && inputTitle.trim().length > 120;
     const model = session.model ?? args.model;
     try {
       const payload = sessionInfoSchema.parse(await postJson(
@@ -1066,7 +1098,8 @@ async function createOpenWorkSessions(rawArgs: unknown, context: OpenCodeContext
       return {
         ok: true,
         sessionId: payload.id,
-        title: payload.title?.trim() || session.title,
+        title: session.title,
+        titleTruncated,
         started: true,
         model: sessionModelOf(payload),
         route: `/workspace/${encodeURIComponent(workspace.id)}/session/${encodeURIComponent(payload.id)}`,
@@ -1075,6 +1108,7 @@ async function createOpenWorkSessions(rawArgs: unknown, context: OpenCodeContext
       return {
         ok: false,
         title: session.title,
+        titleTruncated,
         error: unknownErrorMessage(error),
       };
     }

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import { openworkFeatureContributionSchema } from "@openwork/types/openwork-provider";
 
 import { buildOpenworkProviderContributions, sessionAffordanceArgsSchemas } from "./openwork-provider-adapters.js";
+
+function stringMaxima(schema: unknown): number[] {
+  if (schema instanceof z.ZodString) {
+    return (schema._def.checks ?? []).flatMap((check) => {
+      const def = check._zod.def;
+      return def.check === "max_length" && "maximum" in def && typeof def.maximum === "number" ? [def.maximum] : [];
+    });
+  }
+  if (schema instanceof z.ZodObject) return Object.values(schema.shape).flatMap(stringMaxima);
+  if (schema instanceof z.ZodArray) return stringMaxima(schema.element);
+  if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable || schema instanceof z.ZodDefault) return stringMaxima(schema.unwrap());
+  if (schema instanceof z.ZodPipe) return stringMaxima(schema.in);
+  if (schema instanceof z.ZodUnion) return schema.options.flatMap(stringMaxima);
+  return [];
+}
 
 describe("OpenWork provider adapters", () => {
   test("every session affordance advertises exactly the arguments its schema accepts", () => {
@@ -15,7 +31,18 @@ describe("OpenWork provider adapters", () => {
     for (const [id, schema] of Object.entries(sessionAffordanceArgsSchemas)) {
       const advertised = affordances.find((affordance) => affordance.id === id)?.arguments.map((argument) => argument.name).sort();
       expect({ id, advertised }).toEqual({ id, advertised: Object.keys(schema.shape).sort() });
+      for (const [name, field] of Object.entries(schema.shape)) {
+        const description = affordances.find((affordance) => affordance.id === id)?.arguments.find((argument) => argument.name === name)?.description;
+        for (const maximum of stringMaxima(field)) expect(description).toContain(String(maximum));
+      }
     }
+  });
+
+  test("the bound walker reaches nested and optional strings, including transformed inputs", () => {
+    expect(stringMaxima(sessionAffordanceArgsSchemas["session.create"].shape.sessions)).toEqual([100_000, 60]);
+    expect(stringMaxima(z.object({ entries: z.array(z.object({ label: z.string().max(17).transform((value) => value).optional() })) }))).toEqual([17]);
+    const create = buildOpenworkProviderContributions([]).flatMap((entry) => entry.affordances).find((entry) => entry.id === "session.create");
+    expect(create?.arguments.find((argument) => argument.name === "sessions")?.description).toContain("title (≤120 chars, longer is clipped)");
   });
 
   test("normalizes sessions and extensions into semantic contributions", () => {

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
@@ -48,7 +48,7 @@ export const sessionModelArgSchema = openworkSessionModelSchema.extend({
 
 export const sessionCreateArgsSchema = z.object({
   sessions: z.array(z.object({
-    title: z.string().trim().min(1).max(120).describe("Short title shown in the OpenWork session list."),
+    title: z.string().trim().min(1).transform((title) => title.length > 120 ? `${title.slice(0, 119)}…` : title).describe("Short title shown in the OpenWork session list."),
     prompt: z.string().trim().min(1).max(100_000).describe("Self-contained task to start in the new session."),
     model: sessionModelArgSchema.optional().describe("Model and reasoning effort for this session. Overrides the top-level model."),
   })).min(1).describe("One entry per new session to create and start."),
@@ -181,9 +181,9 @@ function sessionContribution(): OpenworkFeatureContribution {
         description: "Create and start one or more sessions without navigating away. Pass `model` ({ providerId, modelId, variant }) to bind the sessions to a model and reasoning effort; it is applied at creation and to the first turn, and read back as `model` by session.read and session.list_sessions.",
         provider,
         arguments: [
-          argument("sessions", "array", true, "Session titles and self-contained prompts; an entry may carry its own `model`."),
+          argument("sessions", "array", true, "Array of { title (≤120 chars, longer is clipped), prompt (≤100000 chars), model? }. Each prompt is self-contained; model is { providerId, modelId, variant? (≤60 chars) }."),
           argument("workspaceId", "string", false, "Optional workspace id or name. Defaults to the requesting session's workspace."),
-          argument("model", "object", false, "Optional providerId, modelId and variant (reasoning effort) for every created session. Omit to use the engine default."),
+          argument("model", "object", false, "Optional providerId, modelId and variant (reasoning effort, ≤60 chars) for every created session. Omit to use the engine default."),
         ],
         effects: writeEffects,
       }),
@@ -195,7 +195,7 @@ function sessionContribution(): OpenworkFeatureContribution {
         provider,
         arguments: [
           argument("sessionId", "string", true, "Session id from session.search, session.read, or session.list_sessions."),
-          argument("text", "string", true, "Prompt text appended as a new user message."),
+          argument("text", "string", true, "Prompt text appended as a new user message (≤100000 chars)."),
           argument("workspaceId", "string", false, "Optional workspace id or name."),
           argument("reveal", "boolean", false, "true to also open that session in the person's focused pane after sending. Defaults to false."),
         ],

--- a/evals/specs/session-create-title-truncate.test.ts
+++ b/evals/specs/session-create-title-truncate.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { appWeb, eventually, needs, SkipError, test } from "@openwork/testkit";
+import { readHeadlessRuntimeManifest, resolveHeadlessWorldRuntimePaths } from "@openwork/world";
+import { OpenWorkExtensionsPreview } from "../../apps/server/src/opencode-plugins/openwork-extensions-preview";
+import { buildOpenworkProviderContributions } from "../../apps/server/src/opencode-plugins/openwork-provider-adapters";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function outputOf(output: string): Record<string, unknown> {
+  const value: unknown = JSON.parse(output);
+  if (!isRecord(value)) throw new Error("Expected an affordance response");
+  return value;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+test("session.create advertises clipping and returns every validation issue without creating sessions", async ({ evidence }) => {
+  const create = buildOpenworkProviderContributions([]).flatMap((entry) => entry.affordances).find((entry) => entry.id === "session.create");
+  const description = create?.arguments.find((argument) => argument.name === "sessions")?.description;
+  expect(description).toContain("title (≤120 chars, longer is clipped)");
+  expect(description).toContain("prompt (≤100000 chars)");
+  const plugin = await OpenWorkExtensionsPreview();
+  const output = outputOf(await plugin.tool.openwork_execute.execute({ id: "session.create", args: { sessions: [
+    { title: "", prompt: "Valid prompt" },
+    { title: "First", prompt: "P".repeat(100_001) },
+    { title: "Second", prompt: "P".repeat(100_412) },
+  ] } }, {}));
+  expect(output.ok).toBe(false);
+  expect(records(output.issues).map((issue) => issue.path)).toEqual(["sessions[0].title", "sessions[1].prompt", "sessions[2].prompt"]);
+  expect(records(output.issues)[2]?.message).toBe("sessions[2].prompt: 100,412 characters, max 100,000");
+  expect(output.created).toBeUndefined();
+  evidence.recordAssertionEvidence("Clipping is discoverable and validation reports all invalid entries", "The descriptor advertises 120/100000; one response contains the empty title and both oversized prompts, including measured lengths. No server is configured for this validation-only call.", records(output.issues).length === 3 && output.ok === false);
+});
+
+// This local headless world runs the real source UI, server, engine, and UI-control
+// mailbox. Only model inference is unnecessary: the claim is session creation,
+// not a model reply. An explicitly unconfigured model prevents external calls.
+test("session.create clips a 145-character title and session.list_sessions returns the persisted label", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun"] });
+  if (place.kind !== "local") throw new SkipError("this headless manifest proof uses the local lane");
+  const scratch = await realpath(await mkdtemp(join(tmpdir(), "session-title-cap-")));
+  const original = { url: process.env.OPENWORK_SERVER_URL, token: process.env.OPENWORK_SERVER_TOKEN };
+  try {
+    await using app = await appWeb({ name: "session-title-cap", workspacePath: scratch, place });
+    const paths = resolveHeadlessWorldRuntimePaths(fileURLToPath(new URL("../../", import.meta.url)), app.handle.name);
+    const runtime = await readHeadlessRuntimeManifest(paths.runtimeManifestPath);
+    if (!runtime || runtime.openworkUrl !== app.openworkUrl || runtime.workspace !== scratch) throw new Error("Could not identify the test-owned headless runtime");
+    process.env.OPENWORK_SERVER_URL = runtime.openworkUrl;
+    process.env.OPENWORK_SERVER_TOKEN = runtime.token;
+    const plugin = await OpenWorkExtensionsPreview({ directory: scratch });
+    const title = "T".repeat(145);
+    const clipped = `${title.slice(0, 119)}…`;
+    const boundary = "B".repeat(120);
+    const result = outputOf(await plugin.tool.openwork_execute.execute({
+      id: "session.create", args: {
+        model: { providerId: "title-test-unconfigured", modelId: "unused" },
+        sessions: [{ title, prompt: "Keep this label." }, { title: boundary, prompt: "Keep this other label." }],
+      },
+    }, {}));
+    expect(result.ok).toBe(true);
+    const created = isRecord(result.result) ? records(result.result.created) : [];
+    expect(created).toHaveLength(2);
+    expect(created[0]).toMatchObject({ ok: true, title: clipped, titleTruncated: true });
+    expect(created[1]).toMatchObject({ ok: true, title: boundary, titleTruncated: false });
+    expect(clipped).toHaveLength(120);
+
+    const listed = await eventually(async () => {
+      const output = outputOf(await plugin.tool.openwork_query.execute({ id: "session.list_sessions", args: {} }));
+      return records(output.result);
+    }, { within: 30_000, intervalMs: 250, label: "created labels visible through session.list_sessions", until: (entries) => created.every((session) => entries.some((entry) => entry.sessionId === session.sessionId)) });
+    expect(listed.find((entry) => entry.sessionId === created[0]?.sessionId)?.title).toBe(clipped);
+    expect(listed.find((entry) => entry.sessionId === created[1]?.sessionId)?.title).toBe(boundary);
+    expect(listed.some((entry) => entry.title === title)).toBe(false);
+    evidence.recordAssertionEvidence("Real headless affordances persist the clipped label and preserve a boundary label", "session.create accepted both labels: 145 → 120 characters ending in …, titleTruncated=true; 120 unchanged, titleTruncated=false. session.list_sessions returned those exact titles by their created IDs and never returned the original 145-character label.", listed.some((entry) => entry.sessionId === created[0]?.sessionId && entry.title === clipped) && listed.some((entry) => entry.sessionId === created[1]?.sessionId && entry.title === boundary));
+  } finally {
+    if (original.url === undefined) delete process.env.OPENWORK_SERVER_URL;
+    else process.env.OPENWORK_SERVER_URL = original.url;
+    if (original.token === undefined) delete process.env.OPENWORK_SERVER_TOKEN;
+    else process.env.OPENWORK_SERVER_TOKEN = original.token;
+    await rm(scratch, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Change
The RCA found **7/35 session.create calls failed (20%)** solely because titles exceeded 120 characters.

Before: long labels rejected the batch; constraints were hidden and validation threw raw Zod errors.
After: trim labels, clip to 119 characters + `…`, echo the final title and `titleTruncated`. Empty titles and prompts over 100,000 characters still reject. Responses list every issue with paths and measured lengths; search/read/send share this error shape. Descriptors advertise nested bounds; the drift walker also covers model.variant (60).

## Verification
- `pnpm --filter openwork-server typecheck` — exit 0.
- `pnpm --dir evals typecheck` — exit 0, 430 files.
- In apps/server: `bun test src/opencode-plugins/openwork-provider-adapters.test.ts src/opencode-plugins/openwork-extensions-preview.test.ts` — exit 0, 61 passed.
- `bun test src/opencode-plugins/` — exit 1, 197 passed, 1 known docs-string failure. Clean dev control cc4521467: same command/signature, 189 passed, 1 failed; intentionally untouched.

<!-- test-evidence -->
### Evidence — 703831c294f82aabbc313b2d0b348129737f4ea1
Local headless lane, cold boot; feature proof **Passed** (2 passed, 0 failed/skipped).
`pnpm evals:pr specs/session-create-title-truncate.test.ts` — exit 0.
- “session.create advertises clipping and returns every validation issue without creating sessions”: descriptor limits + all three invalid fields.
- “session.create clips a 145-character title and session.list_sessions returns the persisted label”: 145 → 120 ending `…`; 120 unchanged; final titles returned by created IDs, original long label absent.

Signed + DCO. RCA excluded. No merge.