### PR TITLE
fix(app): redact JSON and header credentials in crash diagnostics and prove every sink uses it

### DIFF
--- a/apps/app/src/app/lib/crash-diagnostics.ts
+++ b/apps/app/src/app/lib/crash-diagnostics.ts
@@ -1,7 +1,9 @@
 import { sanitizeDiagnosticString } from "./diagnostic-sanitizer";
 
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>()]+/gi;
-const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=(?:"[^"]*"|'[^']*'|[^&\s"'<>()]+)/gi;
+// Quoted values also end at the work cutoff; an absent closing quote must fail closed.
+const SECRET_PAIR_PATTERN = /(token|grant|code|secret|key)=(?:"(?:\\[\s\S]?|[^"\\])*(?:"|$)|'(?:\\[\s\S]?|[^'\\])*(?:'|$)|[^&\s"'<>()]+)/gi;
+const SECRET_JSON_PAIR_PATTERN = /((["'])(?:token|grant|code|secret|key|password|authorization)\2\s*:\s*)(?:"(?:\\[\s\S]?|[^"\\])*(?:"|$)|'(?:\\[\s\S]?|[^'\\])*(?:'|$)|[^,\s"'{}\[\]]+)/gi;
 const FALLBACK_MESSAGE = "An unexpected error occurred.";
 
 /**
@@ -33,7 +35,9 @@ export function redactCrashText(text: string): string {
     return withoutUserinfo.slice(0, cut) + position;
   });
   // URLs first: masking a query pair first could eat its frame's :line:column.
-  return sanitizeDiagnosticString(urlsRemoved).replace(SECRET_PAIR_PATTERN, "$1=[redacted]");
+  return sanitizeDiagnosticString(urlsRemoved)
+    .replace(SECRET_JSON_PAIR_PATTERN, '$1"[redacted]"')
+    .replace(SECRET_PAIR_PATTERN, "$1=[redacted]");
 }
 
 /** Read each field defensively, without recursive inspection or string coercion. */

--- a/apps/app/tests/app-error-boundary.test.tsx
+++ b/apps/app/tests/app-error-boundary.test.tsx
@@ -143,6 +143,111 @@ test("the revealed technical details show the redacted message, never the query 
   }
 });
 
+function quotedCrash(sink: string) {
+  const fields = ["token", "grant", "code", "secret", "key"];
+  const opaque = ["q7Vm2pR8", "b4Nx9wL3", "h6Zd1sK5", "v8Jc3rT2", "m5Yf7aP9"];
+  const canaries: string[] = [];
+  function assignments(part: string) {
+    return fields.map((field, index) => {
+      const values = [0, 1, 2, 3].map((variant) => `${sink}${part}${opaque[index]}${variant}`);
+      canaries.push(...values);
+      return `${field}="${values[0]}" ${field}='${values[1]}' "${field}":"${values[2]}" '${field}':'${values[3]}'`;
+    }).join(" ");
+  }
+  const error = new Error(`Recovery failed: ${assignments("m")} status=502`);
+  error.stack = `Error: recovery trace ${assignments("s")}\n    at restoreSession (session-route.tsx:42:7)`;
+  return { error, canaries };
+}
+
+test("revealed DOM redacts complete quoted assignments in a caught error message and stack", async () => {
+  const ownedDom = typeof window === "undefined";
+  if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const logError = spyOn(console, "error").mockImplementation(() => {});
+  const { error, canaries } = quotedCrash("d");
+  function Throws(): ReactNode {
+    throw error;
+  }
+  try {
+    await act(async () => {
+      root.render(<AppErrorBoundary><Throws /></AppErrorBoundary>);
+    });
+    const toggle = Array.from(container.querySelectorAll("button")).find((button) => /technical details/i.test(button.textContent ?? ""));
+    if (!toggle) throw new Error("Technical details toggle is missing");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector("pre")).toBeNull();
+    await act(async () => { toggle.click(); });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    const stack = container.querySelector("pre");
+    const message = stack?.previousElementSibling;
+    expect(message?.textContent).toContain("Recovery failed:");
+    expect(message?.textContent).toContain("status=502");
+    expect(stack?.textContent).toContain("Error: recovery trace");
+    expect(stack?.textContent).toContain("at restoreSession (session-route.tsx:42:7)");
+    for (const canary of canaries) expect(container.textContent).not.toContain(canary);
+    expect(message?.textContent?.match(/\[redacted\]/g)).toHaveLength(20);
+    expect(stack?.textContent?.match(/\[redacted\]/g)).toHaveLength(20);
+  } finally {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    logError.mockRestore();
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+    if (ownedDom) await GlobalRegistrator.unregister();
+  }
+});
+
+test("Copy details writes redacted quoted assignments from a caught error to the clipboard", async () => {
+  const ownedDom = typeof window === "undefined";
+  if (ownedDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const logError = spyOn(console, "error").mockImplementation(() => {});
+  const writeText = spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+  const { error, canaries } = quotedCrash("c");
+  function Throws(): ReactNode {
+    throw error;
+  }
+  try {
+    await act(async () => {
+      root.render(<AppErrorBoundary><Throws /></AppErrorBoundary>);
+    });
+    const toggle = Array.from(container.querySelectorAll("button")).find((button) => /technical details/i.test(button.textContent ?? ""));
+    if (!toggle) throw new Error("Technical details toggle is missing");
+    await act(async () => { toggle.click(); });
+    const copy = Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "Copy details");
+    if (!copy) throw new Error("Copy details button is missing");
+    expect(writeText).not.toHaveBeenCalled();
+    await act(async () => { copy.click(); });
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const payload = writeText.mock.calls[0][0];
+    const parts = payload.split("\n\n");
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toContain("OpenWork ");
+    expect(parts[1]).toContain("Recovery failed:");
+    expect(parts[1]).toContain("status=502");
+    expect(parts[2]).toContain("Error: recovery trace");
+    expect(parts[2]).toContain("at restoreSession (session-route.tsx:42:7)");
+    for (const canary of canaries) expect(payload).not.toContain(canary);
+    expect(parts[1].match(/\[redacted\]/g)).toHaveLength(20);
+    expect(parts[2].match(/\[redacted\]/g)).toHaveLength(20);
+    expect(copy.textContent).toBe("Copied");
+  } finally {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    writeText.mockRestore();
+    logError.mockRestore();
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
+    if (ownedDom) await GlobalRegistrator.unregister();
+  }
+});
+
 test("children render untouched when nothing throws", () => {
   const html = renderToStaticMarkup(
     <AppErrorBoundary>

--- a/apps/app/tests/crash-diagnostics.test.ts
+++ b/apps/app/tests/crash-diagnostics.test.ts
@@ -98,9 +98,43 @@ test.each([
   expect(redactCrashText(input)).not.toContain("abc");
 });
 
-test("JSON colon syntax is not widened to pair redaction (documented current behavior)", () => {
-  const json = '{"token":"abc"}';
-  expect(redactCrashText(json)).toBe(json);
+test("JSON colon syntax redacts the value while retaining the key", () => {
+  expect(redactCrashText('{"token":"abc"}')).toBe('{"token":"[redacted]"}');
+});
+
+test.each(["token", "grant", "code", "secret", "key", "password", "authorization"])("JSON redacts %s across quote and scalar forms", (key) => {
+  for (const quote of ['"', "'"]) {
+    for (const value of ['"OPAQUE_VALUE"', "'OPAQUE_VALUE'", "OPAQUE_VALUE", "123", "false", '""']) {
+      const prefix = `{${quote}${key.toUpperCase()}${quote} : `;
+      const clean = redactCrashText(`${prefix}${value}, "status":"useful"}`);
+      expect(clean).toBe(`${prefix}"[redacted]", "status":"useful"}`);
+      expect(redactCrashText(clean)).toBe(clean);
+    }
+  }
+});
+
+test("JSON quoted secrets include escaped quotes and do not mask unrelated keys", () => {
+  expect(redactCrashText(String.raw`{"token":"opaque\"remainder", "status":"useful"}`))
+    .toBe('{"token":"[redacted]", "status":"useful"}');
+  expect(redactCrashText(String.raw`{'secret':'opaque\'remainder', 'status':'useful'}`))
+    .toBe(`{'secret':"[redacted]", 'status':'useful'}`);
+  expect(redactCrashText('{"tokenCount":3,"monkey":"useful"}')).toBe('{"tokenCount":3,"monkey":"useful"}');
+});
+
+test.each(["Authorization: Bearer", "authorization: bEaReR", "Bearer"])("redacts %s header credentials", (prefix) => {
+  const clean = redactCrashText(`${prefix} OPAQUE_HEADER+/==`);
+  expect(clean).toBe(`${prefix.replace(/bearer/i, "Bearer")} [REDACTED]`);
+});
+
+test.each(['"', "'"])("quoted secrets with %s closing beyond the work cutoff fail closed", (quote) => {
+  for (const prefix of [`token=${quote}`, `{"token":${quote}`]) {
+    const source = prefix + "OPAQUE_CUTOFF_" + "x".repeat(17000) + quote;
+    expect(source.lastIndexOf(quote)).toBeGreaterThan(16000);
+    const expected = prefix.startsWith("{") ? '{"token":"[redacted]"' : "token=[redacted]";
+    expect(redactCrashText(source)).toBe(expected);
+    expect(formatCrashDiagnostic({ name: source, message: source, stack: source }))
+      .toEqual({ name: expected, message: expected, stack: expected });
+  }
 });
 
 test("long diagnostics are bounded after sanitizing, without masking ordinary text or HTML", () => {
@@ -111,5 +145,12 @@ test("long diagnostics are bounded after sanitizing, without masking ordinary te
   const html = '<img src=x onerror="synthetic()"><script>synthetic()</script>';
   expect(redactCrashText(html)).toBe(html);
   expect(redactCrashText("Useful error: loading model, status=502" )).toBe("Useful error: loading model, status=502");
-  expect(redactCrashText("x".repeat(995) + " Bearer FAKE_TRAILING_TOKEN").slice(0, 1000)).not.toContain("FAKE_");
+  const prefix = "x".repeat(940) + ' token="';
+  const source = prefix + "OPAQUE_RETAINED_" + "s".repeat(200) + '" useful suffix ' + "z".repeat(2000);
+  expect(source.indexOf("OPAQUE_RETAINED_")).toBeLessThan(1000);
+  expect(source.lastIndexOf('"')).toBeGreaterThan(1000);
+  const message = formatCrashDiagnostic({ message: source }).message;
+  expect(message).toBe(("x".repeat(940) + " token=[redacted] useful suffix " + "z".repeat(2000)).slice(0, 1000));
+  expect(message).toHaveLength(1000);
+  expect(message).not.toContain("OPAQUE_RETAINED_");
 });

--- a/apps/app/tests/error-monitoring.test.ts
+++ b/apps/app/tests/error-monitoring.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
 
 import {
   buildSentryEnvelope,
@@ -8,6 +10,7 @@ import {
   sanitizePageUrl,
   shouldMonitorWebErrors,
   startWebErrorMonitoring,
+  type WebErrorEvent,
 } from "../src/app/lib/error-monitoring";
 import { AppErrorBoundary } from "../src/react-app/shell/app-error-boundary";
 
@@ -135,8 +138,13 @@ describe("reportCaughtWebError", () => {
   // driven at runtime. Module state only opens once, so desktop runs first.
   // The boundary's componentDidCatch is the real caller, so the hand-off and
   // its redaction are exercised through it.
-  test("a boundary-caught error produces exactly one envelope on web and none on desktop", async () => {
+  test("boundary-caught errors redact quoted identity, message and stack in web envelopes, dedupe, and stay inert on desktop", async () => {
     GlobalRegistrator.register({ url: "https://app.openworklabs.com/signin?grant=secret-grant" });
+    const actEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
     const bodies: string[] = [];
     const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
       bodies.push(String(init?.body));
@@ -171,7 +179,62 @@ describe("reportCaughtWebError", () => {
       // Neither the page URL's grant nor the thrown URL's token leaves the page.
       expect(bodies[0]).not.toContain("secret-grant");
       expect(bodies[0]).not.toContain("eval-secret-token");
+
+      const fields = ["token", "grant", "code", "secret", "key"];
+      const opaque = ["r4Lb8xM2", "z7Qn3cV9", "p2Hs6wJ5", "f9Tk4aD7", "y3Bg8uN6"];
+      for (const [index, field] of fields.entries()) {
+        const canaries: string[] = [];
+        function assignments(part: string, selected: string[]) {
+          return selected.map((key, position) => {
+            const values = [0, 1, 2, 3].map((variant) => `${part}${index}${opaque[position]}${variant}`);
+            canaries.push(...values);
+            return `${key}="${values[0]}" ${key}='${values[1]}' "${key}":"${values[2]}" '${key}':'${values[3]}'`;
+          }).join(" ");
+        }
+        const error = new Error(`Recovery ${index} failed: ${assignments("m", fields)} status=502`);
+        error.name = `E ${assignments("n", [field])} end`;
+        error.stack = `Error: recovery trace ${assignments("s", fields)}\n    at restoreSession (session-route.tsx:42:7)`;
+        function Throws(): ReactNode {
+          throw error;
+        }
+        for (const attempt of [0, 1]) {
+          await act(async () => {
+            root.render(createElement(AppErrorBoundary, { key: `${index}-${attempt}` }, createElement(Throws)));
+          });
+          expect(container.textContent).toContain("OpenWork hit an unexpected error");
+          expect(bodies).toHaveLength(index + 2);
+        }
+        const body = bodies[index + 1];
+        const lines = body.split("\n");
+        expect(lines).toHaveLength(3);
+        const reported: WebErrorEvent = JSON.parse(lines[2]);
+        const identity = reported.exception.values[0].type;
+        const message = reported.exception.values[0].value;
+        const stack = reported.extra?.stack;
+        expect(identity).toStartWith("E ");
+        expect(identity).toEndWith(" end");
+        expect(message).toContain(`Recovery ${index} failed:`);
+        expect(message).toContain("status=502");
+        expect(stack).toContain("Error: recovery trace");
+        expect(stack).toContain("at restoreSession (session-route.tsx:42:7)");
+        expect(reported.tags).toEqual({ boot_phase: "runtime" });
+        expect(reported.request).toEqual({ url: "https://app.openworklabs.com/signin" });
+        for (const canary of canaries) {
+          expect(body).not.toContain(canary);
+          expect(identity).not.toContain(canary);
+          expect(message).not.toContain(canary);
+          expect(stack).not.toContain(canary);
+        }
+        expect(body).not.toContain("secret-grant");
+        expect(identity.match(/\[redacted\]/g)).toHaveLength(4);
+        expect(message.match(/\[redacted\]/g)).toHaveLength(20);
+        expect(stack?.match(/\[redacted\]/g)).toHaveLength(20);
+      }
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
     } finally {
+      await act(async () => { root.unmount(); });
+      container.remove();
+      Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", actEnvironment);
       fetchSpy.mockRestore();
       logError.mockRestore();
       if (previous.deployment === undefined) delete process.env.VITE_OPENWORK_DEPLOYMENT;

--- a/evals/specs/crash-redaction.test.ts
+++ b/evals/specs/crash-redaction.test.ts
@@ -22,14 +22,15 @@ for (const [claim, file] of cases) {
       env: { ...process.env, NO_COLOR: "1" },
     });
     const output = result.stdout + result.stderr;
-    evidence.recordAssertionEvidence(
-      `Crash redaction: ${claim}`,
-      `bun test ${file}\nExit: ${result.status}\n${output}`,
-    );
     expect(result.error).toBeUndefined();
     expect(result.status, output).toBe(0);
     expect(output).toMatch(/[1-9]\d* pass/);
     expect(output).toMatch(/\b0 fail/);
     expect(output).not.toMatch(/\b[1-9]\d* (skip|todo)/);
+    evidence.recordAssertionEvidence(
+      `Crash redaction: ${claim}`,
+      `bun test ${file}\nExit: ${result.status}\n${output}`,
+      true,
+    );
   });
 }

--- a/evals/specs/crash-redaction.test.ts
+++ b/evals/specs/crash-redaction.test.ts
@@ -1,0 +1,35 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { needs, test } from "@openwork/testkit";
+
+// Keep the Bun/Happy DOM component tests in their native runtime while publishing
+// their actual exit status and assertion output through the PR evidence lane.
+const appDirectory = fileURLToPath(new URL("../../apps/app/", import.meta.url));
+const cases = [
+  ["JSON, headers, work cutoff and sanitize-before-output-cap", "tests/crash-diagnostics.test.ts"],
+  ["caught-error display and clipboard sinks", "tests/app-error-boundary.test.tsx"],
+  ["caught-error optional report sink", "tests/error-monitoring.test.ts"],
+];
+
+for (const [claim, file] of cases) {
+  test(`crash redaction protects ${claim}`, async ({ evidence }) => {
+    needs({ commands: ["bun"], placement: "local" });
+    const result = spawnSync("bun", ["test", file], {
+      cwd: appDirectory,
+      encoding: "utf8",
+      timeout: 30_000,
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+    const output = result.stdout + result.stderr;
+    evidence.recordAssertionEvidence(
+      `Crash redaction: ${claim}`,
+      `bun test ${file}\nExit: ${result.status}\n${output}`,
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, output).toBe(0);
+    expect(output).toMatch(/[1-9]\d* pass/);
+    expect(output).toMatch(/\b0 fail/);
+    expect(output).not.toMatch(/\b[1-9]\d* (skip|todo)/);
+  });
+}


### PR DESCRIPTION
## Changes
Redact quoted JSON credential keys (case-insensitive; single quotes and scalar values included), preserve keys, and fail closed when the 16,000-character work cutoff removes a closing quote. Handle escaped quotes. Bearer headers already redacted; explicit assertions now cover them.

All three requested sinks already route through the shared formatter: no routing bug or sink production change. Mounted recovery tests inspect revealed DOM, clipboard write arguments, and intercepted optional-report bodies, including identity/message/stack. The separate pre-boot sender (R40) remains out of scope.

Surface(s) touched: redaction / Rows changed: R06, R12, R15, R21, R22, R23 / Blanks introduced: none

- R06, R15: partial→filled.
- R12, R21–R23: blank→filled (bounded helper/component/handler scope).
- Private matrix report untouched and uncommitted.

## Verification — Passed
Local lane; Daytona API key unavailable. All commands exit 0, no skipped tests:
- From `apps/app`: `bun test tests/crash-diagnostics.test.ts` — 44 passed.
- `bun test tests/app-error-boundary.test.tsx` — 16 passed.
- `bun test tests/error-monitoring.test.ts` — 12 passed.
- `pnpm evals:pr specs/crash-redaction.test.ts` — 3 passed; publishes native test assertion output.
- `pnpm --filter @openwork/app typecheck` — passed.

Intentional mutations all exit 1: remove JSON replacement → JSON-colon test fails; restore closing-quote-only pattern → both cutoff tests fail; cap-only or cap-before-sanitize → rewritten long-diagnostics test fails; remove quoted-assignment protection → all three sink tests fail. Every mutation restored; final signed head retested.