### PR TITLE
fix(app): restore the offline loaded-workspace reset and drop stale sessionsLoaded fixtures (follow-up to #4889)

### DIFF
--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -554,6 +554,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         setWorkspaces(orderedDesktopWorkspaces);
         sessionsByWorkspaceIdRef.current = {};
         setSessionsByWorkspaceId({});
+        loadedWorkspaceIdsRef.current = new Set();
         setErrorsByWorkspaceId({});
         setLegacySelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "");
         return;

--- a/apps/app/tests/archived-session-sort.test.ts
+++ b/apps/app/tests/archived-session-sort.test.ts
@@ -11,7 +11,6 @@ function group(id: string, sessions: SessionListItem[]): WorkspaceSessionGroup {
   return {
     workspace: { id, name: id, path: `/work/${id}`, preset: "starter", workspaceType: "local" },
     sessions,
-    sessionsLoaded: true,
     status: "ready",
   };
 }

--- a/apps/app/tests/use-workspace-route-state.test.tsx
+++ b/apps/app/tests/use-workspace-route-state.test.tsx
@@ -187,7 +187,8 @@ for (const staleCompletesFirst of [true, false]) {
     await act(async () => {
       initial.find((request) => request.workspaceId === "ws_2")?.response.resolve([session("ws_2", "cached-v1")]);
     });
-    expect(route().loadedWorkspaceIds.has("ws_2")).toBe(true);
+    expect(route().sessionsByWorkspaceId.ws_2.map((item) => item.id)).toEqual(["cached-v1"]);
+    expect(route().retryingWorkspaceIds).not.toContain("ws_2");
     const stale = initial.filter((request) => request.workspaceId === "ws_1");
 
     localStatus = deferred();
@@ -207,9 +208,8 @@ for (const staleCompletesFirst of [true, false]) {
       await finishStale();
       expect(route().sessionsByWorkspaceId.ws_1).toEqual([]);
       expect(route().sessionsByWorkspaceId.ws_2.map((item) => item.id)).toEqual(["cached-v1"]);
-      expect(route().loadedWorkspaceIds.has("ws_1")).toBe(false);
-      expect(route().loadedWorkspaceIds.has("ws_2")).toBe(false);
       expect(route().retryingWorkspaceIds).toContain("ws_1");
+      expect(route().retryingWorkspaceIds).toContain("ws_2");
     }
     await act(async () => {
       for (const request of fresh) request.response.resolve([session(request.workspaceId, "fresh")]);
@@ -218,9 +218,55 @@ for (const staleCompletesFirst of [true, false]) {
     expect(route().sessionsByWorkspaceId.ws_1.map((item) => item.id)).toEqual(["fresh"]);
     expect(route().sessionsByWorkspaceId.ws_2.map((item) => item.id)).toEqual(["fresh"]);
     expect(route().retryingWorkspaceIds).not.toContain("ws_1");
-    expect(route().loadedWorkspaceIds.has("ws_2")).toBe(true);
+    expect(route().retryingWorkspaceIds).not.toContain("ws_2");
   });
 }
+
+test("offline recovery reloads cleared inventories even when the unselected remote scope is unchanged", async () => {
+  await mount();
+  await publishRouting(false);
+  const initial = [...requests];
+  expect(initial.map((request) => request.workspaceId).sort()).toEqual(["remote", "ws_1", "ws_2"]);
+  await act(async () => {
+    for (const request of initial) request.response.resolve([session(request.workspaceId, "cached")]);
+  });
+  for (const workspace of workspaces) {
+    expect(route().sessionsByWorkspaceId[workspace.id].map((item) => item.id)).toEqual(["cached"]);
+  }
+  // Healthy refreshes must not reload already-loaded, unselected inventories.
+  await act(async () => { await route().refreshRouteState({ supersede: true }); });
+  expect(requests).toHaveLength(3);
+
+  // Web disconnect clears inventory; transient desktop gaps retain it instead.
+  const onlineConnection = connection;
+  connection = { baseUrl: "", token: "" };
+  await act(async () => { await route().refreshRouteState({ supersede: true }); });
+  expect(route().sessionsByWorkspaceId).toEqual({});
+  expect(requests).toHaveLength(3);
+  expect(route().selectedWorkspaceId).toBe("ws_1");
+
+  connection = onlineConnection;
+  await act(async () => { await route().refreshRouteState({ supersede: true }); });
+  const recovered = requests.slice(initial.length);
+  expect(recovered.map((request) => request.workspaceId).sort()).toEqual(["remote", "ws_1", "ws_2"]);
+  const remoteBefore = initial.find((request) => request.workspaceId === "remote");
+  const remoteAfter = recovered.find((request) => request.workspaceId === "remote");
+  if (!remoteBefore || !remoteAfter) throw new Error("Expected remote inventory before and after recovery");
+  expect(remoteAfter.engine).toBe(remoteBefore.engine);
+  expect(remoteAfter.endpoint.baseUrl).toBe(remoteBefore.endpoint.baseUrl);
+  expect(remoteAfter.endpoint.token).toBe(remoteBefore.endpoint.token);
+  expect(remoteAfter.endpoint.workspaceId).toBe(remoteBefore.endpoint.workspaceId);
+  expect(route().sessionsByWorkspaceId.rem_remote).toEqual([]);
+  expect(route().retryingWorkspaceIds).toContain("rem_remote");
+  await act(async () => {
+    for (const request of recovered) request.response.resolve([session(request.workspaceId, "recovered")]);
+  });
+  for (const workspace of workspaces) {
+    expect(route().sessionsByWorkspaceId[workspace.id].map((item) => item.id)).toEqual(["recovered"]);
+    expect(route().retryingWorkspaceIds).not.toContain(workspace.id);
+  }
+  expect(requests).toHaveLength(6);
+});
 
 test("a rotated endpoint waits for its own routing and rejects the old endpoint's late inventory", async () => {
   await mount();

--- a/evals/specs/workspace-inventory-recovery.test.ts
+++ b/evals/specs/workspace-inventory-recovery.test.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { needs, test } from "@openwork/testkit";
+
+const appDirectory = fileURLToPath(new URL("../../apps/app/", import.meta.url));
+
+// Run the mounted hook in its native Bun/Happy DOM runtime, retaining its
+// assertions and output in the PR evidence lane without exposing private refs.
+test("workspace inventories recover after disconnect and retain count-free fixture compatibility", async ({ evidence }) => {
+  needs({ commands: ["bun"], placement: "local" });
+  const files = ["tests/archived-session-sort.test.ts", "tests/use-workspace-route-state.test.tsx"];
+  const result = spawnSync("bun", ["test", ...files], {
+    cwd: appDirectory,
+    encoding: "utf8",
+    timeout: 30_000,
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  const output = result.stdout + result.stderr;
+  expect(result.error).toBeUndefined();
+  expect(result.status, output).toBe(0);
+  expect(output).toMatch(/\b13 pass/);
+  expect(output).toMatch(/\b0 fail/);
+  expect(output).not.toMatch(/\b[1-9]\d* (skip|todo|filtered out)/);
+  evidence.recordAssertionEvidence(
+    "C05/C07: unchanged remote scope reloads after offline clearing; healthy refresh stays cached; archive and routing consumers use the retained contract",
+    `bun test ${files.join(" ")}\nExit: ${result.status}\n${output}`,
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
Surface(s) touched: history-reading (inventory) / Rows changed: C05, C07 / Blanks introduced: none

- Restore only the private loaded-ID reset alongside disconnected inventory clearing. Counts remain removed.
- C05 is necessary: the mounted hook regression fails without this line because recovery skips the unchanged, unselected remote scope; local scope invalidation alone is insufficient. Healthy refresh retains cached inventories. Current desktop transient gaps retain display state; the clearing branch exercised here is web disconnect.
- C07 escaped tsc because apps/app/tsconfig.json excludes tests/. --listFilesOnly confirms both fixtures absent, public type present. The literal has an explicit return type, not widening. Remove the stale fixture field and replace removed hook-export assertions with inventory/loading assertions; do not widen the public type.

## Verification
Passed locally on dc0a4f144 (requested Bun/renderer lane):
- `bun test tests/archived-session-sort.test.ts tests/use-workspace-route-state.test.tsx` (apps/app): exit 0; 13 passed, 0 failed/skipped.
- `pnpm evals:pr specs/workspace-inventory-recovery.test.ts`: exit 0; 1 passed, 0 failed/skipped, wrapping the 13 assertions-backed tests.
- `pnpm --filter @openwork/app typecheck`: exit 0.
- Before reset: focused offline regression failed, missing remote reload. Clean origin/dev also reproduced two stale-hook-consumer failures.

Reviewed #4816 file list: no deleted file, badge, count string/i18n, Archived count UI, or public field restored. Only shared production hook changes, by one line. Signed and signed off; do not merge.