### PR TITLE
fix(app): keep a queued message recoverable until the engine accepts it

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1124,7 +1124,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const updateQueuedDraftInStore = useComposerStateStore((state) => state.updateQueuedDraft);
   const reorderQueuedDrafts = useComposerStateStore((state) => state.reorderQueuedDrafts);
   const clearQueuedDrafts = useComposerStateStore((state) => state.clearQueuedDrafts);
-  const prependQueuedDrafts = useComposerStateStore((state) => state.prependQueuedDrafts);
   // Per-conversation model controls: each pane resolves its own remembered
   // model (falling back to the global default) and owns its picker open
   // state, so split panes never control each other's model picker.
@@ -2094,7 +2093,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return result;
     } catch (nextError) {
       if (isPromptAdmissionUnknown(nextError)) {
-        if (options.consumeQueuedItem) removeQueuedDraftFromStore(props.sessionId, itemId);
+        // Keep queued text recoverable until acceptance can be observed.
         dispatchQueuedDrain(props.sessionId, { type: "send_unknown", itemId, messageID: messageId, at: Date.now(), deferred: Boolean(nextDraft.command) });
         if (activeSessionOwnerRef.current === sessionOwner) setAwaitingAssistantBaseline(null);
         // A server that answered with a failure has explained itself: show that
@@ -2293,7 +2292,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Promote a queued follow-up to an immediate send (steer-style), instead of
   // waiting for the idle drain. Guarded against the drain effect so the same
   // draft cannot be delivered twice.
-  const sendingQueuedId = queuedDrainState.phase.kind === "sending"
+  const sendingQueuedId = queuedDrainState.phase.kind === "sending" || queuedDrainState.phase.kind === "admission_unknown"
     ? queuedDrainState.phase.itemId
     : undefined;
   const sendingQueued = Boolean(sendingQueuedId);
@@ -2307,7 +2306,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const generation = getQueuedSendGeneration(props.sessionId);
     try {
       const result = await sendDraft(target, item.id, undefined, { consumeQueuedItem: true });
-      if (result.outcome === "blocked" || result.outcome === "cancelled") {
+      if (result.outcome === "blocked" || result.outcome === "cancelled" || result.outcome === "unknown") {
         return;
       }
       target.attachments.forEach(revokeAttachmentPreview);
@@ -2371,6 +2370,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
     try {
       const admission = await readPromptAdmission(opencodeClient, props.sessionId, phase.messageID);
       if (admission === "accepted") {
+        getComposerQueuedDrafts(useComposerStateStore.getState(), props.sessionId)
+          .find((item) => item.id === phase.itemId)?.draft.attachments.forEach(revokeAttachmentPreview);
+        useComposerStateStore.getState().removeQueuedDraft(props.sessionId, phase.itemId);
         dispatchQueuedDrain(props.sessionId, {
           type: "admission_observed", itemId: phase.itemId, messageID: phase.messageID, at: Date.now(),
         });
@@ -2499,32 +2501,27 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!claimQueuedSend(props.sessionId, nextItem.id)) return;
     const generation = getQueuedSendGeneration(props.sessionId);
     drainingQueueRef.current = true;
-    removeQueuedDraftFromStore(props.sessionId, nextItem.id);
+    // Keep the durable queue mirror until acceptance, not merely the claim.
     void (async () => {
       try {
-        const result = await sendDraft(nextDraft, nextItem.id);
+        const result = await sendDraft(nextDraft, nextItem.id, undefined, { consumeQueuedItem: true });
         if (getQueuedSendGeneration(props.sessionId) !== generation) {
           nextDraft.attachments.forEach(revokeAttachmentPreview);
           return;
         }
         if (result.outcome === "blocked") {
           cloudQueueBlockedRef.current = true;
-          prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
-        } else if (result.outcome === "cancelled") {
-          prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
-        } else {
+        } else if (result.outcome !== "cancelled" && result.outcome !== "unknown") {
           nextDraft.attachments.forEach(revokeAttachmentPreview);
         }
       } catch {
-        if (getQueuedSendGeneration(props.sessionId) === generation) {
-          prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
-        }
+        // sendDraft halts admission; the unaccepted row remains recoverable.
       } finally {
         if (getQueuedSendGeneration(props.sessionId) !== generation) nextDraft.attachments.forEach(revokeAttachmentPreview);
         drainingQueueRef.current = false;
       }
     })();
-  }, [archived, archiveStateKnown, chatStreaming, cloudQueueRetryVersion, liveStatus.type, prependQueuedDrafts, props.opencodeBaseUrl, props.sessionId, queuedDrainState, queuedItems, removeQueuedDraftFromStore, sendDraft, sendingQueued]);
+  }, [archived, archiveStateKnown, chatStreaming, cloudQueueRetryVersion, liveStatus.type, props.opencodeBaseUrl, props.sessionId, queuedDrainState, queuedItems, sendDraft, sendingQueued]);
 
   useEffect(() => {
     if (props.cloudMcpSubmissionState.status !== "failed") {

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
@@ -206,6 +206,9 @@ function armObservationProbe(watched: WatchedSession) {
         const admission = await readPromptAdmission(client, watched.sessionId, phase.messageID);
         if (watchedSessions.get(watched.sessionId) !== watched) return;
         if (admission === "accepted") {
+          getComposerQueuedDrafts(useComposerStateStore.getState(), watched.sessionId)
+            .find((item) => item.id === phase.itemId)?.draft.attachments.forEach(revokeAttachmentPreview);
+          useComposerStateStore.getState().removeQueuedDraft(watched.sessionId, phase.itemId);
           dispatchQueuedDrain(watched.sessionId, {
             type: "admission_observed", itemId: phase.itemId, messageID: phase.messageID, at: Date.now(),
           });
@@ -365,11 +368,13 @@ async function attemptDrain(sessionId: string) {
   if (!claimQueuedSend(sessionId, nextItem.id)) return;
   const generation = getQueuedSendGeneration(sessionId);
   watched.sendInFlight = true;
-  useComposerStateStore.getState().removeQueuedDraft(sessionId, nextItem.id);
+  // The claim prevents another send; retain the row (and its durable mirror)
+  // until acceptance so a renderer restart can recover it as an unsent draft.
 
   try {
     const outcome = await submitAfterInterruption(context.opencodeBaseUrl, sessionId,
       () => performQueuedDraftSend(context, sessionId, draft, generation), draft.messageId);
+    if (outcome === "sent") useComposerStateStore.getState().removeQueuedDraft(sessionId, nextItem.id);
     dispatchQueuedDrain(sessionId, {
       type: "send_result",
       itemId: nextItem.id,
@@ -395,13 +400,12 @@ async function attemptDrain(sessionId: string) {
       dispatchQueuedDrain(sessionId, {
         type: "send_unknown", itemId: nextItem.id, messageID: draft.messageId, at: Date.now(), deferred: Boolean(draft.command),
       });
-      draft.attachments.forEach(revokeAttachmentPreview);
     } else if (getQueuedSendGeneration(sessionId) !== generation) {
       dispatchQueuedDrain(sessionId, { type: "send_result", itemId: nextItem.id, outcome: "cancelled", at: Date.now() });
       draft.attachments.forEach(revokeAttachmentPreview);
     } else {
       dispatchQueuedDrain(sessionId, { type: "send_error", itemId: nextItem.id });
-      useComposerStateStore.getState().prependQueuedDrafts(sessionId, [{ id: nextItem.id, draft }]);
+      // The unaccepted row is still queued for explicit retry or draft recovery.
     }
   } finally {
     watched.sendInFlight = false;

--- a/evals/specs/queued-messages-restart.e2e.test.ts
+++ b/evals/specs/queued-messages-restart.e2e.test.ts
@@ -96,11 +96,12 @@ test("queued follow-ups come back as an unsent draft after a renderer restart in
 test("a queued follow-up already admitted to the engine is neither duplicated nor restored after a reload", async ({ world, user, probe, step }) => {
   const userMessages = () => probe.dom('[data-message-role="user"]');
   const storedDrafts = () => probe.storage(draftsKey, (value) => readDrafts(value, world.session.sessionId));
+  await user.type("composer", world.running.prompt, { verify: true });
+  await user.press(enter);
+  await user.see({ text: "Building the release." });
+  await using transport = await world.observeQueuedTransport(false);
 
   await step("queue one follow-up, then let the running task finish so the drain admits it", async () => {
-    await user.type("composer", world.running.prompt, { verify: true });
-    await user.press(enter);
-    await user.see({ text: "Building the release." });
     await user.type("composer", world.queued.prompt, { verify: true });
     await user.press(enter);
     await user.see({ text: /1 queued/ });
@@ -128,5 +129,47 @@ test("a queued follow-up already admitted to the engine is neither duplicated no
     await world.releaseQueuedReply();
     await user.see({ text: /Notes published\./ });
     expect((await userMessages()).elements).toHaveLength(2);
+    const engine = await world.engineMessageCounts();
+    assertObserved("CD09: accepted queued message exists exactly once in native engine history", engine, engine.queued === 1 && engine.users === 2);
+    assertObserved("CD09: reply-held reload makes exactly one raw queued POST", transport.read(), transport.read().requests === 1);
+  });
+});
+
+test("CD10: a queued follow-up survives a pre-acceptance transport hold and reload as an unsent draft without a second POST", async ({ world, user, probe, step }) => {
+  await user.type("composer", world.running.prompt, { verify: true });
+  await user.press(enter);
+  await user.see({ text: "Building the release." });
+  await using transport = await world.observeQueuedTransport(true);
+
+  await step("queue one item and hold its POST before it reaches the engine", async () => {
+    await user.type("composer", world.queued.prompt, { verify: true });
+    await user.press(enter);
+    await user.see({ text: /1 queued/ });
+    await world.releaseRunningReply();
+    await probe.eventually(() => transport.read(), {
+      within: 15_000, label: "queued POST held at transport request stage",
+      until: (state) => state.held === 1,
+    });
+    expect(transport.read()).toEqual({ requests: 1, held: 1 });
+    expect(await world.engineMessageCounts()).toEqual({ users: 1, queued: 0 });
+  });
+
+  await step("destroy the renderer with prompt_async unresolved; recover without sending", async () => {
+    await user.reload();
+    await user.see({ text: world.running.prompt });
+    // A bounded idle observation catches any automatic drain in the new renderer.
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+    const engine = await world.engineMessageCounts();
+    const composer = (await probe.composer()).draftText;
+    const stored = await probe.storage(draftsKey, (value) => readDrafts(value, world.session.sessionId));
+    const requests = transport.read();
+    // Keep the three required oracles independent: a deduplicated DOM row is
+    // not native admission, durable recovery, or an exactly-once request count.
+    assertObserved("CD10(a): held queued message is absent from the engine (zero admissions)", engine, engine.queued === 0 && engine.users === 1);
+    assertObserved("CD10(c): reload never sends a second raw queued POST", requests, requests.requests === 1);
+    assertObserved("CD10(b): unaccepted queued text survives reload as an unsent persisted draft",
+      { composer, stored }, composer === world.queued.prompt
+        && stored.length === 1 && stored[0]!.text === world.queued.prompt && stored[0]!.queued.length === 0);
+    await user.notSee({ text: /queued/ });
   });
 });

--- a/evals/worlds/session-draft.ts
+++ b/evals/worlds/session-draft.ts
@@ -1,5 +1,80 @@
-import type { Seed } from "@openwork/env";
+import { browserScript, type Surface } from "@openwork/cdp";
+import { resolveEvalEngine, type Seed } from "@openwork/env";
 import { configureProvider } from "./chat.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Count actual queued POST attempts outside the renderer, across reloads.
+ * A request-stage hold never forwards the POST or produces an acceptance response.
+ * Only counts are retained: no headers, credentials, or prompt bodies.
+ */
+async function queuedTransport(app: Surface, sessionId: string, hold: boolean) {
+  const endpoint = app.client.webSocketDebuggerUrl;
+  if (!endpoint) throw new Error("Queue transport witness requires CDP");
+  const socket = new WebSocket(endpoint);
+  const pending = new Map<number, { resolve: () => void; reject: (error: Error) => void }>();
+  const held = new Set<string>();
+  let nextId = 0;
+  let requests = 0;
+  let failure: Error | null = null;
+  let disposed = false;
+  const command = async (method: string, params: Record<string, unknown> = {}) => {
+    const id = ++nextId;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => { pending.delete(id); reject(new Error(`Queue witness timed out: ${method}`)); }, 10_000);
+      pending.set(id, {
+        resolve: () => { clearTimeout(timer); resolve(); },
+        reject: (error) => { clearTimeout(timer); reject(error); },
+      });
+      socket.send(JSON.stringify({ id, method, params }));
+    });
+  };
+  socket.addEventListener("message", (event) => {
+    const message: unknown = JSON.parse(String(event.data));
+    if (!isRecord(message)) return;
+    if (typeof message.id === "number") {
+      const callback = pending.get(message.id);
+      pending.delete(message.id);
+      if (message.error) callback?.reject(new Error("Queue witness CDP command failed"));
+      else callback?.resolve();
+    }
+    if (message.method !== "Fetch.requestPaused" || !isRecord(message.params)) return;
+    const { requestId, request } = message.params;
+    if (typeof requestId !== "string" || !isRecord(request)) return;
+    if (request.method === "POST") {
+      requests += 1;
+      if (hold) { held.add(requestId); return; }
+    }
+    void command("Fetch.continueRequest", { requestId }).catch((error: Error) => { failure = error; });
+  });
+  socket.addEventListener("close", () => {
+    if (!disposed) failure = new Error("Queue transport witness disconnected");
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Queue witness connection timed out")), 10_000);
+    socket.addEventListener("open", () => { clearTimeout(timer); resolve(); }, { once: true });
+    socket.addEventListener("error", () => { clearTimeout(timer); reject(new Error("Queue witness connection failed")); }, { once: true });
+  });
+  await command("Fetch.enable", { patterns: [
+    { urlPattern: `*/session/${encodeURIComponent(sessionId)}/prompt_async*`, requestStage: "Request" },
+  ] });
+  return {
+    read() {
+      if (failure) throw failure;
+      return { requests, held: held.size };
+    },
+    async [Symbol.asyncDispose]() {
+      // A reload cancels its old request. Never release a held POST in teardown;
+      // abort any still-live request before disabling interception.
+      for (const requestId of held) {
+        await command("Fetch.failRequest", { requestId, errorReason: "Aborted" }).catch(() => undefined);
+      }
+      try { await command("Fetch.disable"); } finally { disposed = true; socket.close(); }
+    },
+  };
+}
 
 export async function existingSessionDraft(seed: Seed) {
   const history = { prompt: "Remember the release checklist", reply: "The release checklist is ready." };
@@ -75,6 +150,25 @@ export async function queuedFollowUps(seed: Seed) {
   });
   const session = await seed.session(app, { title: "Release build" });
   return { app, workspace, session, running, queued,
+    observeQueuedTransport: (hold: boolean) => queuedTransport(app, session.sessionId, hold),
+    engineMessageCounts: () => seed.evalIn(app, browserScript(async (workspaceId, sessionId, marker, engine) => {
+      const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
+      const mount = engine === "v2" ? "/opencode2/api" : "/opencode";
+      const response = await fetch(base + "/workspace/" + encodeURIComponent(workspaceId) + mount
+        + "/session/" + encodeURIComponent(sessionId) + "/message", {
+        headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") },
+      });
+      if (!response.ok) throw new Error("Native message count failed: HTTP " + response.status);
+      const body: unknown = await response.json();
+      if (!Array.isArray(body)) throw new Error("Expected native message array");
+      const users = body.filter((entry) => typeof entry === "object" && entry !== null
+        && "info" in entry && typeof entry.info === "object" && entry.info !== null
+        && "role" in entry.info && entry.info.role === "user");
+      const matching = users.filter((entry) => Array.isArray(entry.parts) && entry.parts.some((part: unknown) =>
+        typeof part === "object" && part !== null && "type" in part && part.type === "text"
+        && "text" in part && typeof part.text === "string" && part.text.includes(marker)));
+      return { users: users.length, queued: matching.length };
+    }, [workspace.workspaceId, session.sessionId, queued.prompt, resolveEvalEngine()]), { awaitPromise: true }),
     releaseRunningReply: () => mock.releaseAgentReply(running.prompt, 1),
     releaseQueuedReply: () => mock.releaseAgentReply(queued.prompt, 1),
     modelRequests: (promptMarker: string) => mock.agentRequests({ promptMarker }) };


### PR DESCRIPTION
## Change
Surface(s) touched: composer-drafts / Rows changed: CD10 (+ CD09) / Blanks introduced: none

Fix the pre-acceptance loss, rather than accept it. Foreground/background drainers retain the queued row and existing durable mirror until acceptance; the synchronous claim still prevents duplicate sends. Reload restores unsent text only, never an automatic send. No storage migration or #4928 changes.

## Proof — Passed (local appWeb, head 73210fc5e)
- `pnpm evals:e2e queued-messages-restart --local`: exit 0; 3 passed, 0 failed, 0 skipped.
- CD10 holds the actual POST at the CDP request boundary across reload: (a) queued engine messages **0** (one earlier user turn), (b) exact unsent text present in composer and persisted draft, (c) raw queued POST attempts **1**, never 2.
- Existing reply-held path: queued engine messages **1**, empty composer/no restore notice, raw queued POST attempts **1**.
- Revert only the production diff, keep tests: same command exits 1; 2 passed/1 failed. Only **CD10(b), unsent persisted draft recovery**, fails; native absence and request count remain green.
- `pnpm --filter @openwork/app typecheck` and `pnpm --dir evals typecheck`: exit 0.

Scope: renderer reload and text recovery, not native quit/crash or storage-failure durability. Lost acceptance responses can re-offer already-accepted text for review, never auto-send it. Signed and DCO-signed-off; do not merge.