### PR TITLE
fix(app): roll descendant activity and unknown inventory up to the parent's status, not only waiting attention

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -151,6 +151,7 @@ export type SessionPageSidebarProps = {
   developerMode: boolean;
   sessionStatusById: Record<string, string>;
   sessionAttentionLabelById?: Record<string, string>;
+  sessionAttentionSourceById?: Record<string, "child" | "descendant">;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   newTaskDisabled: boolean;
@@ -1369,6 +1370,7 @@ export function SessionPage(props: SessionPageProps) {
           showSessionActions={Boolean(props.onRenameSession || props.onDeleteSession || props.onArchiveSession)}
           sessionStatusById={props.sidebar.sessionStatusById}
           sessionAttentionLabelById={props.sidebar.sessionAttentionLabelById}
+          sessionAttentionSourceById={props.sidebar.sessionAttentionSourceById}
           connectingWorkspaceId={props.sidebar.connectingWorkspaceId}
           workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
           newTaskDisabled={props.sidebar.newTaskDisabled}

--- a/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
+++ b/apps/app/src/react-app/domains/session/control/list-control-sessions.ts
@@ -1,7 +1,8 @@
-import type { OpenworkSessionModel } from "@openwork/types/openwork-affordance";
+import type { OpenworkSessionActivityInventory, OpenworkSessionModel } from "@openwork/types/openwork-affordance";
 
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { SessionActivityStatus } from "../status/session-activity-store";
+import { selectSessionAttention, type SessionAttention } from "../status/session-attention";
 
 export type ControlSessionWorkspace = {
   id: string;
@@ -29,11 +30,12 @@ export type ControlSessionLike = {
   time?: {
     updated?: number;
     created?: number;
+    archived?: number;
   };
   model?: ControlSessionEngineModel | null;
 };
 
-export type ListedControlSession = {
+export type ListedControlSession = OpenworkSessionActivityInventory & {
   sessionId: string;
   title: string;
   workspace: string;
@@ -41,8 +43,6 @@ export type ListedControlSession = {
   pinned: boolean;
   /** Live activity, the same source as the sidebar indicator. */
   status: SessionActivityStatus;
-  /** True while a turn, subtask, compaction, permission, or question is still open. */
-  working: boolean;
   /** Model and reasoning effort the session is bound to; null before any model is bound. */
   model: OpenworkSessionModel | null;
 };
@@ -52,6 +52,7 @@ export type ListControlSessionsState = {
   sessionsByWorkspaceId: Record<string, ControlSessionLike[]>;
   pinnedIds: readonly string[];
   statusFor: (workspaceId: string, sessionId: string) => SessionActivityStatus;
+  attentionFor?: (workspaceId: string, sessionId: string) => SessionAttention | undefined;
 };
 
 /** Anything but a finished or failed turn still needs Stop before archive. */
@@ -100,18 +101,27 @@ export function listControlSessions(args: unknown, state: ListControlSessionsSta
   const out: ListedControlSession[] = [];
   for (const workspace of state.workspaces) {
     if (workspaceQuery && !matchesWorkspace(workspace, workspaceQuery)) continue;
-    for (const session of state.sessionsByWorkspaceId[workspace.id] ?? []) {
+    const sessions = state.sessionsByWorkspaceId[workspace.id] ?? [];
+    const attention = state.attentionFor ? undefined : selectSessionAttention(
+      sessions.flatMap((session) => session.id ? [{ ...session, id: session.id }] : []),
+      (id) => state.statusFor(workspace.id, id),
+      () => undefined,
+    );
+    for (const session of sessions) {
       const sessionId = session.id?.trim() ?? "";
       if (!sessionId) continue;
-      const status = state.statusFor(workspace.id, sessionId);
+      const activity = state.attentionFor?.(workspace.id, sessionId) ?? attention?.get(sessionId);
+      if (!activity) continue;
       out.push({
         sessionId,
         title: getDisplaySessionTitle(session.title ?? ""),
         workspace: controlWorkspaceLabel(workspace),
         updatedAt: session.time?.updated ?? session.time?.created ?? 0,
         pinned: state.pinnedIds.includes(sessionId),
-        status,
-        working: isWorkingStatus(status),
+        status: activity.status,
+        working: activity.working,
+        descendantActivity: activity.descendantActivity,
+        inventoryComplete: activity.inventoryComplete,
         model: controlSessionModel(session),
       });
     }

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -102,7 +102,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const listSessionsControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.list_sessions",
     label: "List available sessions",
-    description: "Return every loaded session across workspaces (pinned first, then newest). Entries include `pinned`, `status` (idle, thinking, responding, waiting, compacting, error), `working` (true while a turn, subtask, permission, or question is still open) and `model` ({ providerId, modelId, variant }: the model and reasoning effort the session is bound to, null before any model is bound). Check `working` before session.archive. Pass `limit` to cap the count or `workspaceId` to narrow to one workspace.",
+    description: "Return every loaded session across workspaces (pinned first, then newest). Entries include `pinned`, `status` (idle, thinking, responding, waiting, compacting, error), `working` (own work or known busy/waiting descendants), `descendantActivity` ({ busy, waiting, unknown } counts), `inventoryComplete` (false when referenced descendant activity is unreadable; unknown alone does not imply working) and `model` ({ providerId, modelId, variant }: the model and reasoning effort the session is bound to, null before any model is bound). Check `working` before session.archive. Pass `limit` to cap the count or `workspaceId` to narrow to one workspace.",
     kind: "query",
     effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
@@ -111,15 +111,14 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
       { name: "workspaceId", type: "string", required: false, description: "Workspace ID or display name. Omit to include every workspace." },
     ],
     execute: (args) => {
-      // Same roll-up as the sidebar: a delegated child's pending permission
-      // or question makes its parent `waiting`, not `thinking`.
       const activity = useSessionActivityStore.getState();
       const attentionByWorkspaceId = new Map<string, ReturnType<typeof selectSessionAttention>>();
       return listControlSessions(args, {
         workspaces,
         sessionsByWorkspaceId,
         pinnedIds,
-        statusFor: (workspaceId, sessionId) => {
+        statusFor: activity.getStatus,
+        attentionFor: (workspaceId, sessionId) => {
           let attention = attentionByWorkspaceId.get(workspaceId);
           if (!attention) {
             const runtimeId = endpointForWorkspace(workspaces.find((workspace) => workspace.id === workspaceId))?.workspaceId;
@@ -128,10 +127,11 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
               (sessionsByWorkspaceId[workspaceId] ?? []).flatMap((session) => (session.id ? [{ ...session, id: session.id }] : [])),
               (id) => ids.map((wid) => activity.statusesByWorkspaceId[wid]?.[id]).find((status) => status !== undefined),
               (id) => ids.map((wid) => activity.waitingByWorkspaceId[wid]?.[id]).find((kind) => kind !== undefined),
+              (id) => ids.flatMap((wid) => activity.recordsByWorkspaceId[wid]?.[id]?.childSessionIds ?? []),
             );
             attentionByWorkspaceId.set(workspaceId, attention);
           }
-          return attention.get(sessionId)?.status ?? activity.getStatus(workspaceId, sessionId);
+          return attention.get(sessionId);
         },
       });
     },

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -11,6 +11,7 @@ export type SidebarContextValue = {
   sessionStatusById?: Record<string, string>;
   /** Why a row needs the person when a delegated child, not the session itself, is asking. */
   sessionAttentionLabelById?: Record<string, string>;
+  sessionAttentionSourceById?: Record<string, "child" | "descendant">;
   newTaskDisabled: boolean;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -227,6 +227,7 @@ interface SessionStatusIndicatorProps {
   isUnread: boolean;
   /** Names the delegated child asking, e.g. "Needs permission: Audit four open PRs". */
   attentionLabel?: string;
+  attentionSource?: "child" | "descendant";
 }
 
 function ShowMoreSessionsButton({
@@ -251,7 +252,7 @@ function ShowMoreSessionsButton({
 }
 
 /** Activity and outcomes share the fixed glyph slot before the session title. */
-function SessionStatusIndicator({ status, isActiveWork, isUnread, attentionLabel }: SessionStatusIndicatorProps) {
+function SessionStatusIndicator({ status, isActiveWork, isUnread, attentionLabel, attentionSource }: SessionStatusIndicatorProps) {
   return (
     <SidebarGlyphSlot>
       {isActiveWork ? (
@@ -259,14 +260,14 @@ function SessionStatusIndicator({ status, isActiveWork, isUnread, attentionLabel
           ? getSessionActivityStatusLabel(status)
           : t("workspace_list.session_streaming")} />
       ) : (
-        <SessionOutcomeIndicator status={status} isUnread={isUnread} attentionLabel={attentionLabel} />
+        <SessionOutcomeIndicator status={status} isUnread={isUnread} attentionLabel={attentionLabel} attentionSource={attentionSource} />
       )}
     </SidebarGlyphSlot>
   );
 }
 
 /** Orange = needs you, green = unread result, none = read/idle. */
-function SessionOutcomeIndicator({ status, isUnread, attentionLabel }: { status?: string; isUnread: boolean; attentionLabel?: string }) {
+function SessionOutcomeIndicator({ status, isUnread, attentionLabel, attentionSource }: Omit<SessionStatusIndicatorProps, "isActiveWork">) {
   if (isNeedsAttentionSessionStatus(status)) {
     const title = attentionLabel
       ?? (isSessionActivityStatus(status)
@@ -275,7 +276,7 @@ function SessionOutcomeIndicator({ status, isUnread, attentionLabel }: { status?
     return (
       <span
         data-session-attention-indicator
-        data-session-attention-source={attentionLabel ? "child" : "self"}
+        data-session-attention-source={attentionSource ?? "self"}
         className="size-2 shrink-0 rounded-full"
         style={{ backgroundColor: OUTCOME_DOT_NEEDS_ACTION }}
         title={title}
@@ -762,7 +763,13 @@ function SessionSideChatControl({ workspaceId, sessionId, title }: {
       }}
     >
       {isActiveWork || isNeedsAttentionSessionStatus(status) || isUnread
-        ? <SessionStatusIndicator status={status} isActiveWork={isActiveWork} isUnread={isUnread} />
+        ? <SessionStatusIndicator
+            status={status}
+            isActiveWork={isActiveWork}
+            isUnread={isUnread}
+            attentionLabel={sideChat ? ctx.sessionAttentionLabelById?.[sideChat.sessionId] : undefined}
+            attentionSource={sideChat ? ctx.sessionAttentionSourceById?.[sideChat.sessionId] : undefined}
+          />
         : <Plus className="size-3" />}
       {sideChat ? <span>{t("session_management.split_view")}</span> : null}
     </button>
@@ -778,6 +785,7 @@ export type AppSidebarProps = {
   showSessionActions?: boolean;
   sessionStatusById?: Record<string, string>;
   sessionAttentionLabelById?: Record<string, string>;
+  sessionAttentionSourceById?: Record<string, "child" | "descendant">;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   newTaskDisabled: boolean;
@@ -892,6 +900,7 @@ export function AppSidebar(props: AppSidebarProps) {
     showSessionActions: props.showSessionActions,
     sessionStatusById: props.sessionStatusById,
     sessionAttentionLabelById: props.sessionAttentionLabelById,
+    sessionAttentionSourceById: props.sessionAttentionSourceById,
     newTaskDisabled: props.newTaskDisabled,
     connectingWorkspaceId: props.connectingWorkspaceId,
     workspaceConnectionStateById: props.workspaceConnectionStateById,
@@ -2173,6 +2182,7 @@ function SessionMenuItem({
       isActiveWork={resolvedActiveWork}
       isUnread={isUnread}
       attentionLabel={sessionAttentionLabel}
+      attentionSource={ctx.sessionAttentionSourceById?.[session.id]}
     />
   );
 

--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import { create } from "zustand";
-import type { UIMessage } from "ai";
+import { isToolUIPart, type UIMessage } from "ai";
+import { isTaskToolPart, taskChildSessionId } from "../../../../lib/build-in-tools";
 import { transcriptProgress } from "./session-progress";
 
 import { t } from "../../../../i18n";
@@ -40,6 +41,7 @@ type SessionActivityRecord = {
   waitingPermissionIds: string[];
   waitingQuestionIds: string[];
   messageRoles: Record<string, SessionMessageRole>;
+  childSessionIds: string[];
   updatedAt: number;
 };
 
@@ -106,6 +108,7 @@ const createRecord = (): SessionActivityRecord => ({
   waitingPermissionIds: [],
   waitingQuestionIds: [],
   messageRoles: {},
+  childSessionIds: [],
   updatedAt: 0,
 });
 
@@ -209,7 +212,8 @@ function sameActivityRecord(
     && current.compacting === next.compacting
     && sameStrings(current.waitingPermissionIds, next.waitingPermissionIds)
     && sameStrings(current.waitingQuestionIds, next.waitingQuestionIds)
-    && sameMessageRoles(current.messageRoles, next.messageRoles);
+    && sameMessageRoles(current.messageRoles, next.messageRoles)
+    && sameStrings(current.childSessionIds, next.childSessionIds);
 }
 
 type SessionActivityDerivedState = Pick<SessionActivityStore, "recordsByWorkspaceId" | "statusesByWorkspaceId" | "waitingByWorkspaceId">;
@@ -400,6 +404,15 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
   observeTranscript: (workspaceId, sessionId, messages, snapshot = false, options = {}) => {
     set((state) => updateRecord(state, workspaceId, sessionId, (record) => {
       const progress = transcriptProgress(messages, record.progressParts);
+      const childSessionIds = new Set(record.childSessionIds);
+      for (const message of messages) {
+        if (message.role !== "assistant") continue;
+        for (const part of message.parts) {
+          if (!isToolUIPart(part) || !isTaskToolPart(part)) continue;
+          const childId = taskChildSessionId(part);
+          if (childId) childSessionIds.add(childId);
+        }
+      }
       const snapshotStartedAt = options.snapshotStartedAt;
       const turnChanged = record.transcriptActivity !== null
         && record.transcriptActivity.latestUserId !== progress.latestUserId;
@@ -407,6 +420,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
       const observedAt = snapshot ? snapshotStartedAt ?? 0 : turnChanged || progressChanged ? Date.now() : 0;
       const next = reconcileTranscriptActivity({
         ...record,
+        childSessionIds: childSessionIds.size === record.childSessionIds.length ? record.childSessionIds : [...childSessionIds],
         ...(turnChanged ? {
           assistantOutput: false,
           runStartedAt: record.runActive

--- a/apps/app/src/react-app/domains/session/status/session-attention.ts
+++ b/apps/app/src/react-app/domains/session/status/session-attention.ts
@@ -1,3 +1,4 @@
+import type { OpenworkSessionActivityInventory } from "@openwork/types/openwork-affordance";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import { t } from "../../../../i18n";
 import type { SessionActivityStatus, SessionWaitingKind } from "./session-activity-store";
@@ -6,75 +7,85 @@ type AttentionSession = {
   id: string;
   parentID?: string | null;
   title?: string | null;
+  time?: { archived?: number | null };
 };
 
-/** The descendant whose unanswered request blocks an ancestor. */
 export type SessionAttentionSource = {
   sessionId: string;
   title: string;
   kind: SessionWaitingKind;
+  relationship: "child" | "descendant";
 };
 
-export type SessionAttention = {
+export type SessionAttention = OpenworkSessionActivityInventory & {
   status: SessionActivityStatus;
-  /** Set only when `status` is "waiting" because of a delegated child, not the session's own request. */
   blockedBy: SessionAttentionSource | null;
 };
 
-/**
- * The status a person (or an agent asking `session.list_sessions`) should see
- * for each session. A delegated child's pending permission or question lives
- * on the child's activity record, so the parent's own status stays "thinking"
- * while nothing can move until someone answers. This rolls that request up
- * every parentID hop so the sidebar, notifications, and agent-visible status
- * agree with the transcript's inline "Needs permission" treatment.
- *
- * Precedence: error > waiting (own or descendant) > compacting > thinking /
- * responding > idle. `ownStatus` already orders everything but the descendant
- * case. Cyclic or dangling parent data stops at the first repeated hop.
- */
 export function selectSessionAttention(
   sessions: readonly AttentionSession[],
   ownStatus: (sessionId: string) => SessionActivityStatus | undefined,
   waitingKind: (sessionId: string) => SessionWaitingKind | undefined,
+  childIds: (sessionId: string) => readonly string[] = () => [],
 ): Map<string, SessionAttention> {
-  const parentOf = new Map<string, string>();
-  for (const session of sessions) {
-    const id = session.id.trim();
-    const parentID = session.parentID?.trim();
-    if (id && parentID && parentID !== id) parentOf.set(id, parentID);
-  }
-
-  const blockedBy = new Map<string, SessionAttentionSource>();
-  for (const session of sessions) {
-    const id = session.id.trim();
-    const kind = id ? waitingKind(id) : undefined;
-    if (!kind) continue;
-    const source: SessionAttentionSource = { sessionId: id, title: getDisplaySessionTitle(session.title ?? ""), kind };
-    const visited = new Set([id]);
-    for (let parent = parentOf.get(id); parent && !visited.has(parent); parent = parentOf.get(parent)) {
-      visited.add(parent);
-      if (!blockedBy.has(parent)) blockedBy.set(parent, source);
-    }
+  const inventory = new Map(sessions.map((session) => [session.id.trim(), session]));
+  const children = new Map<string, Set<string>>();
+  const link = (parent: string, child: string) => {
+    if (!parent || !child || parent === child) return;
+    const ids = children.get(parent) ?? new Set<string>();
+    ids.add(child);
+    children.set(parent, ids);
+  };
+  for (const [id, session] of inventory) {
+    link(session.parentID?.trim() ?? "", id);
+    for (const child of childIds(id)) link(id, child.trim());
   }
 
   const attention = new Map<string, SessionAttention>();
-  for (const session of sessions) {
-    const id = session.id.trim();
+  for (const [id, session] of inventory) {
     if (!id) continue;
-    const own = ownStatus(id) ?? "idle";
-    if (own === "error" || own === "waiting") {
-      attention.set(id, { status: own, blockedBy: null });
-      continue;
+    const descendantActivity = { busy: 0, waiting: 0, unknown: 0 };
+    let blockedBy: SessionAttentionSource | null = null;
+    const visited = new Set([id]);
+    const queue = session.time?.archived ? [] : [...children.get(id) ?? []];
+    for (let index = 0; index < queue.length; index += 1) {
+      const childId = queue[index];
+      if (visited.has(childId)) continue;
+      visited.add(childId);
+      const child = inventory.get(childId);
+      if (child?.time?.archived) continue;
+      const status = ownStatus(childId);
+      const kind = waitingKind(childId);
+      if (!child || status === undefined && !kind) descendantActivity.unknown += 1;
+      else if (status !== "error" && (kind || status === "waiting")) {
+        descendantActivity.waiting += 1;
+        if (!blockedBy && kind) blockedBy = {
+          sessionId: childId,
+          title: getDisplaySessionTitle(child.title ?? ""),
+          kind,
+          relationship: children.get(id)?.has(childId) ? "child" : "descendant",
+        };
+      } else if (status !== "idle" && status !== "error") descendantActivity.busy += 1;
+      queue.push(...children.get(childId) ?? []);
     }
-    const source = blockedBy.get(id);
-    attention.set(id, source ? { status: "waiting", blockedBy: source } : { status: own, blockedBy: null });
+    const own = ownStatus(id) ?? "idle";
+    const ownWins = own === "error" || own === "waiting";
+    attention.set(id, {
+      status: !ownWins && descendantActivity.waiting > 0 ? "waiting" : own,
+      blockedBy: ownWins ? null : blockedBy,
+      working: own !== "idle" && own !== "error" || descendantActivity.busy > 0 || descendantActivity.waiting > 0,
+      descendantActivity,
+      inventoryComplete: descendantActivity.unknown === 0,
+    });
   }
   return attention;
 }
 
-/** Tooltip / accessible name for the orange "needs you" dot when a child is the reason. */
-export function sessionAttentionLabel(source: SessionAttentionSource): string {
+export function sessionAttentionSidebarStatus(attention: SessionAttention): SessionActivityStatus {
+  return attention.status === "idle" && attention.descendantActivity.busy > 0 ? "thinking" : attention.status;
+}
+
+export function sessionAttentionLabel(source: Omit<SessionAttentionSource, "relationship">): string {
   const prefix = source.kind === "permission"
     ? t("session.subagent_permission_needed")
     : t("session.subagent_question_pending");

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -121,7 +121,7 @@ import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-co
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
 import { ReactSessionRuntime } from "@/react-app/domains/session/sync/runtime-sync";
 import { useSessionActivityStore } from "@/react-app/domains/session/status/session-activity-store";
-import { selectSessionAttention, sessionAttentionLabel } from "@/react-app/domains/session/status/session-attention";
+import { selectSessionAttention, sessionAttentionLabel, sessionAttentionSidebarStatus } from "@/react-app/domains/session/status/session-attention";
 import { buildOpenworkSessionSystemContext } from "@/react-app/domains/session/sync/env-context";
 import {
   applySessionRevert,
@@ -818,6 +818,7 @@ export function SessionRoute() {
   const seedWorkspaceActivitySessions = useSessionActivityStore((state) => state.seedWorkspaceSessions);
   const sessionActivityByWorkspaceId = useSessionActivityStore((state) => state.statusesByWorkspaceId);
   const sessionWaitingByWorkspaceId = useSessionActivityStore((state) => state.waitingByWorkspaceId);
+  const sessionRecordsByWorkspaceId = useSessionActivityStore((state) => state.recordsByWorkspaceId);
 
   useEffect(() => {
     for (const group of workspaceSessionGroups) {
@@ -829,12 +830,10 @@ export function SessionRoute() {
     }
   }, [seedWorkspaceActivitySessions, workspaceSessionGroups]);
 
-  // A delegated child's pending permission or question rolls up to its parent
-  // row: the person must answer before anything moves, so the parent shows
-  // "needs you" instead of the working spinner.
   const sidebarSessionAttention = useMemo(() => {
     const statusById: Record<string, string> = {};
     const labelById: Record<string, string> = {};
+    const sourceById: Record<string, "child" | "descendant"> = {};
     for (const group of workspaceSessionGroups) {
       const serverId = workspaceServerId(group.workspace);
       const workspaceStatuses = {
@@ -849,16 +848,23 @@ export function SessionRoute() {
         group.sessions,
         (sessionId) => workspaceStatuses[sessionId],
         (sessionId) => workspaceWaiting[sessionId],
+        (sessionId) => [
+          ...(sessionRecordsByWorkspaceId[group.workspace.id]?.[sessionId]?.childSessionIds ?? []),
+          ...(serverId ? sessionRecordsByWorkspaceId[serverId]?.[sessionId]?.childSessionIds ?? [] : []),
+        ],
       );
       for (const session of group.sessions) {
         const entry = attention.get(session.id);
-        if (!entry || (!workspaceStatuses[session.id] && !entry.blockedBy)) continue;
-        statusById[session.id] = entry.status;
-        if (entry.blockedBy) labelById[session.id] = sessionAttentionLabel(entry.blockedBy);
+        if (!entry) continue;
+        statusById[session.id] = sessionAttentionSidebarStatus(entry);
+        if (entry.blockedBy) {
+          labelById[session.id] = sessionAttentionLabel(entry.blockedBy);
+          sourceById[session.id] = entry.blockedBy.relationship;
+        }
       }
     }
-    return { statusById, labelById };
-  }, [sessionActivityByWorkspaceId, sessionWaitingByWorkspaceId, workspaceSessionGroups]);
+    return { statusById, labelById, sourceById };
+  }, [sessionActivityByWorkspaceId, sessionWaitingByWorkspaceId, sessionRecordsByWorkspaceId, workspaceSessionGroups]);
   const sidebarSessionStatusById = sidebarSessionAttention.statusById;
 
   const sidebarActiveWorkspaceId = useMemo(() => {
@@ -3511,6 +3517,7 @@ export function SessionRoute() {
         developerMode: false,
         sessionStatusById: sidebarSessionStatusById,
         sessionAttentionLabelById: sidebarSessionAttention.labelById,
+        sessionAttentionSourceById: sidebarSessionAttention.sourceById,
         connectingWorkspaceId: null,
         workspaceConnectionStateById,
         newTaskDisabled: !canCreateTask,

--- a/apps/app/tests/session-attention-rollup.test.ts
+++ b/apps/app/tests/session-attention-rollup.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-
-import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
-import { selectSessionAttention, sessionAttentionLabel } from "../src/react-app/domains/session/status/session-attention";
+import { useSessionActivityStore, type SessionActivityStatus } from "../src/react-app/domains/session/status/session-activity-store";
+import { selectSessionAttention, sessionAttentionLabel, sessionAttentionSidebarStatus } from "../src/react-app/domains/session/status/session-attention";
+import { listControlSessions } from "../src/react-app/domains/session/control/list-control-sessions";
 
 const workspaceId = "ws-rollup";
-const parent = { id: "ses-parent", title: "Slop audit (Astra high)" };
-const child = { id: "ses-child", title: "Audit four open PRs", parentID: parent.id };
-const grandchild = { id: "ses-grandchild", title: "Read den-web", parentID: child.id };
+const parent = { id: "ses-parent", title: "Review changes" };
+const child = { id: "ses-child", title: "Review tests", parentID: parent.id };
+const grandchild = { id: "ses-grandchild", title: "Read server", parentID: child.id };
 const unrelated = { id: "ses-other", title: "Unrelated root" };
 const sessions = [parent, child, grandchild, unrelated];
 
@@ -16,91 +16,133 @@ function attentionFor(sessionId: string) {
     sessions,
     (id) => state.statusesByWorkspaceId[workspaceId]?.[id],
     (id) => state.waitingByWorkspaceId[workspaceId]?.[id],
+    (id) => state.recordsByWorkspaceId[workspaceId]?.[id]?.childSessionIds ?? [],
   ).get(sessionId);
 }
 
-describe("delegated child attention roll-up", () => {
+const empty = { busy: 0, waiting: 0, unknown: 0 };
+
+describe("descendant attention inventory", () => {
   beforeEach(() => {
     useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {}, waitingByWorkspaceId: {} });
+    for (const session of sessions) useSessionActivityStore.getState().setRunStatus(workspaceId, session.id, "idle");
   });
 
-  test("RCA: the store keeps the parent's own status at thinking while its child waits on a permission", () => {
+  test("a busy child keeps an idle parent working without fabricating own activity", () => {
+    const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, child.id, "running");
+    expect(store.getStatus(workspaceId, parent.id)).toBe("idle");
+    const listed = listControlSessions({}, {
+      workspaces: [{ id: workspaceId }], sessionsByWorkspaceId: { [workspaceId]: sessions }, pinnedIds: [],
+      statusFor: store.getStatus, attentionFor: (_workspace, id) => attentionFor(id),
+    });
+    expect(listed.find((session) => session.sessionId === parent.id)?.working).toBe(true);
+    const attention = attentionFor(parent.id);
+    expect(attention).toEqual({ status: "idle", blockedBy: null, working: true, descendantActivity: { ...empty, busy: 1 }, inventoryComplete: true });
+    expect(attention && sessionAttentionSidebarStatus(attention)).toBe("thinking");
+    expect(attentionFor(unrelated.id)).toEqual({ status: "idle", blockedBy: null, working: false, descendantActivity: empty, inventoryComplete: true });
+  });
+
+  test("a busy grandchild reaches every hop once even with duplicate session rows", () => {
+    const attention = selectSessionAttention([...sessions, grandchild], (id) => id === grandchild.id ? "responding" : "idle", () => undefined);
+    expect(attention.get(parent.id)?.descendantActivity).toEqual({ ...empty, busy: 1 });
+    expect(attention.get(child.id)?.descendantActivity).toEqual({ ...empty, busy: 1 });
+    expect(attention.get(grandchild.id)?.descendantActivity).toEqual(empty);
+  });
+
+  test("waiting wins over a busy descendant and normal own running", () => {
     const store = useSessionActivityStore.getState();
     store.setRunStatus(workspaceId, parent.id, "running");
     store.setRunStatus(workspaceId, child.id, "running");
-    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
-
-    // The child's record carries the request; the parent's does not.
-    expect(store.getStatus(workspaceId, child.id)).toBe("waiting");
-    expect(store.getStatus(workspaceId, parent.id)).toBe("thinking");
-    expect(useSessionActivityStore.getState().waitingByWorkspaceId[workspaceId]).toEqual({ [child.id]: "permission" });
-
-    // The roll-up is what the sidebar, list_sessions, and notifications read.
-    expect(attentionFor(parent.id)).toEqual({
-      status: "waiting",
-      blockedBy: { sessionId: child.id, title: child.title, kind: "permission" },
-    });
-    expect(attentionFor(child.id)).toEqual({ status: "waiting", blockedBy: null });
-    expect(attentionFor(unrelated.id)).toEqual({ status: "idle", blockedBy: null });
-  });
-
-  test("answering the request returns the parent to its own working status", () => {
-    const store = useSessionActivityStore.getState();
-    store.setRunStatus(workspaceId, parent.id, "running");
-    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
-    expect(attentionFor(parent.id)?.status).toBe("waiting");
-
-    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", false);
-    expect(useSessionActivityStore.getState().waitingByWorkspaceId[workspaceId]).toEqual({});
-    expect(attentionFor(parent.id)).toEqual({ status: "thinking", blockedBy: null });
-  });
-
-  test("a grandchild's question reaches every ancestor and names the grandchild", () => {
-    const store = useSessionActivityStore.getState();
-    store.setRunStatus(workspaceId, parent.id, "running");
     store.setWaitingRequest(workspaceId, grandchild.id, "question", "q-1", true);
-
-    const source = { sessionId: grandchild.id, title: grandchild.title, kind: "question" as const };
-    expect(attentionFor(parent.id)).toEqual({ status: "waiting", blockedBy: source });
-    expect(attentionFor(child.id)).toEqual({ status: "waiting", blockedBy: source });
-    expect(sessionAttentionLabel(source)).toBe("Waiting for your answer: Read den-web");
-    expect(sessionAttentionLabel({ sessionId: child.id, title: child.title, kind: "permission" }))
-      .toBe("Needs permission: Audit four open PRs");
+    const attention = attentionFor(parent.id);
+    expect(attention).toEqual({
+      status: "waiting", working: true, inventoryComplete: true,
+      descendantActivity: { busy: 1, waiting: 1, unknown: 0 },
+      blockedBy: { sessionId: grandchild.id, title: grandchild.title, kind: "question", relationship: "descendant" },
+    });
+    expect(attention && sessionAttentionSidebarStatus(attention)).toBe("waiting");
+    expect(attentionFor(child.id)?.blockedBy?.relationship).toBe("child");
+    expect(attention?.blockedBy && sessionAttentionLabel(attention.blockedBy)).toBe("Waiting for your answer: Read server");
   });
 
-  test("precedence: the parent's own error or own request wins over a descendant's request", () => {
+  test("answering a child request releases waiting but keeps known work", () => {
     const store = useSessionActivityStore.getState();
+    store.setRunStatus(workspaceId, parent.id, "running");
     store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
-
-    store.setError(workspaceId, parent.id, "boom");
-    expect(attentionFor(parent.id)).toEqual({ status: "error", blockedBy: null });
-
-    store.clearError(workspaceId, parent.id);
-    store.setRunStatus(workspaceId, parent.id, "running");
-    store.setWaitingRequest(workspaceId, parent.id, "question", "q-own", true);
-    expect(attentionFor(parent.id)).toEqual({ status: "waiting", blockedBy: null });
+    expect(attentionFor(parent.id)?.blockedBy).toEqual({ sessionId: child.id, title: child.title, kind: "permission", relationship: "child" });
+    expect(sessionAttentionLabel({ sessionId: child.id, title: child.title, kind: "permission" })).toBe("Needs permission: Review tests");
+    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", false);
+    expect(attentionFor(parent.id)).toEqual({ status: "thinking", blockedBy: null, working: true, descendantActivity: empty, inventoryComplete: true });
   });
 
-  test("a child that is compacting or idle does not roll anything up; a removed child releases the parent", () => {
+  const statuses: SessionActivityStatus[] = ["error", "waiting", "compacting", "thinking", "responding", "idle"];
+  for (const own of statuses) {
+    test(`own ${own} precedence is preserved with busy and waiting descendants`, () => {
+      const busy = selectSessionAttention(sessions, (id) => id === parent.id ? own : "thinking", () => undefined).get(parent.id);
+      expect(busy?.status).toBe(own);
+      expect(busy?.working).toBe(true);
+      const waiting = selectSessionAttention(sessions, (id) => id === parent.id ? own : "waiting", () => "permission").get(parent.id);
+      expect(waiting?.status).toBe(own === "error" || own === "waiting" ? own : "waiting");
+      expect(waiting?.blockedBy === null).toBe(own === "error" || own === "waiting");
+    });
+  }
+
+  test("compacting descendants count as busy; idle and errored descendants do not", () => {
     const store = useSessionActivityStore.getState();
-    store.setRunStatus(workspaceId, parent.id, "running");
     store.setCompacting(workspaceId, child.id, true);
-    expect(attentionFor(parent.id)).toEqual({ status: "thinking", blockedBy: null });
-
-    store.setWaitingRequest(workspaceId, child.id, "permission", "per-1", true);
-    expect(attentionFor(parent.id)?.status).toBe("waiting");
-    store.removeSession(workspaceId, child.id);
-    expect(useSessionActivityStore.getState().waitingByWorkspaceId[workspaceId]).toEqual({});
-    expect(attentionFor(parent.id)).toEqual({ status: "thinking", blockedBy: null });
+    store.setError(workspaceId, grandchild.id, "failed");
+    expect(attentionFor(parent.id)?.descendantActivity).toEqual({ ...empty, busy: 1 });
   });
 
-  test("cyclic parent data terminates", () => {
-    const cyclic = [
-      { id: "a", title: "A", parentID: "b" },
-      { id: "b", title: "B", parentID: "a" },
-    ];
-    const attention = selectSessionAttention(cyclic, () => "thinking", (id) => (id === "a" ? "permission" : undefined));
-    expect(attention.get("a")).toEqual({ status: "thinking", blockedBy: null });
-    expect(attention.get("b")).toEqual({ status: "waiting", blockedBy: { sessionId: "a", title: "A", kind: "permission" } });
+  test("an archived branch contributes neither activity nor unknown descendants", () => {
+    const attention = selectSessionAttention([parent, { ...child, time: { archived: 1 } }, grandchild],
+      (id) => id === parent.id ? "idle" : "thinking", () => "permission", (id) => id === grandchild.id ? ["missing"] : []);
+    expect(attention.get(parent.id)).toEqual({ status: "idle", blockedBy: null, working: false, descendantActivity: empty, inventoryComplete: true });
+  });
+
+  test("missing activity for a known child is unknown, not idle or working", () => {
+    const attention = selectSessionAttention([parent, child], (id) => id === parent.id ? "idle" : undefined, () => undefined).get(parent.id);
+    expect(attention).toEqual({ status: "idle", blockedBy: null, working: false, descendantActivity: { ...empty, unknown: 1 }, inventoryComplete: false });
+  });
+
+  test("a task child absent from the app inventory is unknown even with a stale busy status", () => {
+    const store = useSessionActivityStore.getState();
+    store.observeTranscript(workspaceId, parent.id, [{
+      id: "msg-task", role: "assistant", parts: [{
+        type: "dynamic-tool", toolName: "task", toolCallId: "call-task", state: "input-available",
+        input: { description: "Inspect", prompt: "Inspect tests", subagent_type: "general" },
+        callProviderMetadata: { openwork: { childSessionId: "missing-child" } },
+      }],
+    }]);
+    store.setRunStatus(workspaceId, "missing-child", "running");
+    const attention = attentionFor(parent.id);
+    expect(attention?.descendantActivity).toEqual({ ...empty, unknown: 1 });
+    expect(attention?.working).toBe(false);
+    expect(attention?.inventoryComplete).toBe(false);
+  });
+
+  test("unknown never erases known busy/waiting descendants", () => {
+    const attention = selectSessionAttention(sessions, (id) => id === child.id ? "thinking" : "idle",
+      (id) => id === grandchild.id ? "question" : undefined, (id) => id === child.id ? ["missing"] : []).get(parent.id);
+    expect(attention).toMatchObject({ status: "waiting", working: true, inventoryComplete: false, descendantActivity: { busy: 1, waiting: 1, unknown: 1 } });
+  });
+
+  test("cyclic and duplicate graph references terminate without counting the root", () => {
+    const cyclic = [{ id: "a", parentID: "b" }, { id: "b", parentID: "a" }];
+    const attention = selectSessionAttention(cyclic, () => "thinking", () => undefined, () => ["a", "b", "b"]);
+    expect(attention.get("a")?.descendantActivity).toEqual({ ...empty, busy: 1 });
+    expect(attention.get("b")?.descendantActivity).toEqual({ ...empty, busy: 1 });
+  });
+
+  test("list_sessions projects the complete rollup including unknown and own error", () => {
+    const attention = selectSessionAttention(sessions, (id) => id === parent.id ? "error" : "thinking", () => undefined, (id) => id === parent.id ? ["missing"] : []);
+    const listed = listControlSessions({}, {
+      workspaces: [{ id: workspaceId }], sessionsByWorkspaceId: { [workspaceId]: sessions }, pinnedIds: [],
+      statusFor: () => "idle", attentionFor: (_workspace, id) => attention.get(id),
+    });
+    expect(listed.find((session) => session.sessionId === parent.id)).toMatchObject({
+      status: "error", working: true, descendantActivity: { busy: 2, waiting: 0, unknown: 1 }, inventoryComplete: false,
+    });
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
+import { openworkSessionActivityInventorySchema } from "@openwork/types/openwork-affordance";
 
 import { OpenWorkExtensionsPreview } from "./openwork-extensions-preview.js";
 import * as OpenWorkExtensionsPreviewEntry from "./openwork-extensions-preview.js";
@@ -37,6 +38,8 @@ const sessionModelSchema = z.object({
 }).strict();
 
 const readResultSchema = z.object({
+  ...openworkSessionActivityInventorySchema.shape,
+  status: z.string(),
   ok: z.literal(true),
   workspaceId: z.string(),
   sessionId: z.string(),
@@ -123,7 +126,12 @@ async function transformedSystem(plugin: Awaited<ReturnType<typeof OpenWorkExten
   return output.system.join("\n");
 }
 
-function startFakeOpenWorkServer(options: { failPromptText?: string; failSessionListWorkspaceId?: string } = {}) {
+function startFakeOpenWorkServer(options: {
+  failPromptText?: string;
+  failSessionListWorkspaceId?: string;
+  activityResponses?: Record<string, unknown>;
+  failedActivityPaths?: string[];
+} = {}) {
   const requests: Array<{ pathname: string; search: string; authorization: string | null; method: string; body?: unknown }> = [];
   const uiControlRequests: Array<{ authorization: string | null; body: unknown }> = [];
   let createdCount = 0;
@@ -225,6 +233,12 @@ function startFakeOpenWorkServer(options: { failPromptText?: string; failSession
           return Response.json({ message: "Remote worker unavailable" }, { status: 503 });
         }
         return Response.json([sessionArchive]);
+      }
+
+      const activityPath = url.pathname.replace("/workspace/ws_1/opencode", "");
+      if (options.failedActivityPaths?.includes(activityPath)) return Response.json({ message: "Unavailable" }, { status: 503 });
+      if (options.activityResponses && Object.hasOwn(options.activityResponses, activityPath)) {
+        return Response.json(options.activityResponses[activityPath]);
       }
 
       // Live activity: alpha is mid-turn, beta waits on a permission, archive is idle.
@@ -495,8 +509,107 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(await read("ses_gamma")).toMatchObject({ status: "waiting", working: true });
     // An unrelated busy root is untouched by another tree's request.
     expect(await read("ses_alpha")).toMatchObject({ status: "busy", working: true });
-    expect(sessionActivityFrom({ ses_p: { type: "busy" } }, [{ sessionID: "ses_c" }], [], "ses_p", ["ses_c"])).toEqual({ status: "waiting", working: true });
-    expect(sessionActivityFrom({ ses_p: { type: "busy" } }, [{ sessionID: "ses_c" }], [], "ses_p")).toEqual({ status: "busy", working: true });
+    expect(sessionActivityFrom({ ses_p: { type: "busy" } }, [{ sessionID: "ses_c" }], [], "ses_p", ["ses_c"])).toMatchObject({ status: "waiting", working: true, descendantActivity: { busy: 0, waiting: 1, unknown: 0 }, inventoryComplete: true });
+    expect(sessionActivityFrom({ ses_p: { type: "busy" } }, [{ sessionID: "ses_c" }], [], "ses_p")).toMatchObject({ status: "busy", working: true, descendantActivity: { busy: 0, waiting: 0, unknown: 0 }, inventoryComplete: true });
+  });
+
+  async function readActivity(sessionId = "ses_alpha", summary = false) {
+    const plugin = await OpenWorkExtensionsPreview();
+    return affordanceResultSchema("session.read", openworkSessionActivityInventorySchema.extend({ status: z.string() }))
+      .parse(JSON.parse(await plugin.tool.openwork_query.execute({ id: "session.read", args: { sessionId, count: 1, summary } }))).result;
+  }
+
+  test("session.read counts a busy child and grandchild once at every hop, including summary", async () => {
+    startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": { ses_gamma_grandchild: { type: "busy" } },
+      "/permission": [], "/question": [],
+      "/session/ses_alpha/children": [{ id: "ses_gamma" }, { id: "ses_gamma" }],
+    } });
+    expect(await readActivity()).toEqual({ status: "idle", working: true, descendantActivity: { busy: 1, waiting: 0, unknown: 0 }, inventoryComplete: true });
+    expect(await readActivity("ses_gamma", true)).toEqual({ status: "idle", working: true, descendantActivity: { busy: 1, waiting: 0, unknown: 0 }, inventoryComplete: true });
+  });
+
+  test("session.read counts direct busy/retrying/compacting descendants independently", async () => {
+    startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": { ses_busy: { type: "busy" }, ses_retry: { type: "retry" }, ses_compact: { type: "compacting" } },
+      "/session/ses_alpha/children": [{ id: "ses_busy" }, { id: "ses_retry" }, { id: "ses_compact" }],
+    } });
+    expect(await readActivity()).toEqual({ status: "idle", working: true, descendantActivity: { busy: 3, waiting: 0, unknown: 0 }, inventoryComplete: true });
+  });
+
+  test("session.read does not traverse or count archived branches", async () => {
+    const fake = startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": { ses_gamma: { type: "busy" } },
+      "/session/ses_alpha/children": [{ id: "ses_gamma", time: { archived: 1 } }],
+    } });
+    expect(await readActivity()).toEqual({ status: "idle", working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 0 }, inventoryComplete: true });
+    expect(fake.requests.some((request) => request.pathname.endsWith("/ses_gamma/children"))).toBe(false);
+  });
+
+  test("session.read failed root and child hops report unresolved branches without fabricated activity", async () => {
+    startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": {}, "/permission": [], "/question": [],
+    }, failedActivityPaths: ["/session/ses_alpha/children", "/session/ses_gamma_child/children"] });
+    expect(await readActivity()).toEqual({ status: "idle", working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 1 }, inventoryComplete: false });
+    expect(await readActivity("ses_gamma")).toEqual({ status: "idle", working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 1 }, inventoryComplete: false });
+  });
+
+  test("session.read malformed child inventory is unknown", async () => {
+    startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": {}, "/session/ses_alpha/children": [{ parentID: "ses_alpha" }],
+    } });
+    expect(await readActivity()).toMatchObject({ working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 1 }, inventoryComplete: false });
+  });
+
+  test("session.read unknown hops do not erase known busy or waiting work", async () => {
+    startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": { ses_gamma: { type: "busy" } },
+      "/session/ses_alpha/children": [{ id: "ses_gamma" }],
+    }, failedActivityPaths: ["/session/ses_gamma_grandchild/children"] });
+    expect(await readActivity()).toEqual({ status: "waiting", working: true, descendantActivity: { busy: 1, waiting: 1, unknown: 1 }, inventoryComplete: false });
+  });
+
+  test("session.read cyclic child responses cannot count the root or a child twice", async () => {
+    startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": { ses_gamma: { type: "busy" } },
+      "/session/ses_alpha/children": [{ id: "ses_gamma" }, { id: "ses_gamma" }, { id: "ses_alpha" }],
+      "/session/ses_gamma/children": [{ id: "ses_alpha" }],
+    } });
+    expect(await readActivity()).toEqual({ status: "idle", working: true, descendantActivity: { busy: 1, waiting: 0, unknown: 0 }, inventoryComplete: true });
+  });
+
+  test("session.read traversal cap reports omitted inventory instead of silently complete", async () => {
+    const fake = startFakeOpenWorkServer({ activityResponses: {
+      "/session/status": {},
+      "/session/ses_alpha/children": Array.from({ length: 260 }, (_, index) => ({ id: `ses_cap_${index}` })),
+    } });
+    expect(await readActivity()).toEqual({ status: "idle", working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 5 }, inventoryComplete: false });
+    expect(fake.requests.filter((request) => request.pathname.endsWith("/children"))).toHaveLength(256);
+  });
+
+  for (const own of ["error", "waiting", "compacting", "thinking", "responding", "busy", "retry", "idle"]) {
+    test(`session.read preserves own ${own} precedence against descendant waiting`, async () => {
+      startFakeOpenWorkServer({ activityResponses: {
+        "/session/status": { ses_alpha: { type: own }, ses_gamma: { type: "busy" } },
+        "/session/ses_alpha/children": [{ id: "ses_gamma" }],
+      } });
+      expect(await readActivity()).toEqual({ status: own === "error" ? "error" : "waiting", working: true, descendantActivity: { busy: 1, waiting: 1, unknown: 0 }, inventoryComplete: true });
+    });
+  }
+
+  for (const path of ["/session/status", "/permission", "/question"]) {
+    test(`session.read exposes unknown after ${path} failure without fabricating busy`, async () => {
+      startFakeOpenWorkServer({ activityResponses: {
+        "/session/status": {}, "/permission": [], "/question": [],
+        "/session/ses_alpha/children": [{ id: "ses_child" }],
+      }, failedActivityPaths: [path] });
+      expect(await readActivity()).toEqual({ status: "unknown", working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 1 }, inventoryComplete: false });
+    });
+  }
+
+  test("session.read retains observed busy work when another core probe fails", async () => {
+    startFakeOpenWorkServer({ failedActivityPaths: ["/permission"] });
+    expect(await readActivity()).toEqual({ status: "busy", working: true, descendantActivity: { busy: 0, waiting: 0, unknown: 0 }, inventoryComplete: false });
   });
 
   test("session.read exposes the session's bound model and reasoning effort from the engine record", async () => {
@@ -513,12 +626,12 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(await read("ses_archive")).toBeNull();
   });
 
-  test("an unreadable activity probe never reports a session as safe to archive", () => {
-    expect(sessionActivityFrom(null, [], [], "ses_x")).toEqual({ status: "busy", working: true });
-    expect(sessionActivityFrom({}, null, [], "ses_x")).toEqual({ status: "busy", working: true });
-    expect(sessionActivityFrom({ ses_x: { type: "retry" } }, [], [], "ses_x")).toEqual({ status: "retry", working: true });
-    expect(sessionActivityFrom({ ses_x: { type: "idle" } }, [], [{ sessionID: "ses_x" }], "ses_x")).toEqual({ status: "waiting", working: true });
-    expect(sessionActivityFrom({ ses_other: { type: "busy" } }, [{ sessionID: "ses_other" }], [], "ses_x")).toEqual({ status: "idle", working: false });
+  test("unreadable core probes report unknown instead of fabricated work", () => {
+    expect(sessionActivityFrom(null, [], [], "ses_x")).toEqual({ status: "unknown", working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 0 }, inventoryComplete: false });
+    expect(sessionActivityFrom({}, null, [], "ses_x")).toEqual({ status: "unknown", working: false, descendantActivity: { busy: 0, waiting: 0, unknown: 0 }, inventoryComplete: false });
+    expect(sessionActivityFrom({ ses_x: { type: "retry" } }, [], [], "ses_x")).toMatchObject({ status: "retry", working: true, inventoryComplete: true });
+    expect(sessionActivityFrom({ ses_x: { type: "idle" } }, [], [{ sessionID: "ses_x" }], "ses_x")).toMatchObject({ status: "waiting", working: true, inventoryComplete: true });
+    expect(sessionActivityFrom({ ses_other: { type: "busy" } }, [{ sessionID: "ses_other" }], [], "ses_x")).toMatchObject({ status: "idle", working: false, inventoryComplete: true });
   });
 
   test("session.read returns session metadata and per-message timestamps", async () => {
@@ -560,7 +673,8 @@ describe("OpenWorkExtensionsPreview session tools", () => {
       lastAssistant: z.object({ id: z.string(), role: z.string(), text: z.string() }).passthrough().nullable(),
     }).strict().extend({
       workspaceId: z.string(), workspace: z.string(), title: z.string(), createdAt: z.number(), updatedAt: z.number(),
-      archived: z.boolean(), parentId: z.string().nullable(), status: z.string(), working: z.boolean(),
+      archived: z.boolean(), parentId: z.string().nullable(), status: z.string(),
+      ...openworkSessionActivityInventorySchema.shape,
       model: z.object({ providerId: z.string(), modelId: z.string(), variant: z.string().nullable() }).nullable(),
     })).parse(JSON.parse(output));
 

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -701,28 +701,48 @@ async function readWorkspaceSession(workspace: OpenWorkWorkspace, sessionId: str
 }
 
 const MAX_SESSION_DESCENDANTS = 256;
-const sessionChildrenSchema = z.array(z.object({ id: z.string() }).passthrough());
+const sessionChildrenSchema = z.array(z.object({
+  id: z.string().trim().min(1),
+  time: z.object({ archived: z.number().optional() }).optional(),
+}).passthrough());
 
-/** Every delegated descendant of a session, breadth first; a failed hop ends the walk there. */
-async function readSessionDescendantIds(base: string, sessionId: string): Promise<string[]> {
-  const ids = [sessionId];
-  for (let index = 0; index < ids.length && ids.length <= MAX_SESSION_DESCENDANTS; index += 1) {
+async function readSessionDescendantIds(base: string, sessionId: string): Promise<{ ids: string[]; unknown: number }> {
+  const queue = [sessionId];
+  const seen = new Set(queue);
+  const ids: string[] = [];
+  let unknown = 0;
+  let index = 0;
+  for (; index < queue.length && index < MAX_SESSION_DESCENDANTS; index += 1) {
     const parsed = sessionChildrenSchema.safeParse(
-      await serverGet(`${base}/session/${encodeURIComponent(ids[index])}/children`).catch(() => null),
+      await serverGet(`${base}/session/${encodeURIComponent(queue[index])}/children`).catch(() => null),
     );
-    if (!parsed.success) continue;
-    for (const child of parsed.data) if (!ids.includes(child.id)) ids.push(child.id);
+    if (!parsed.success) {
+      unknown += 1;
+      continue;
+    }
+    for (const child of parsed.data) {
+      if (seen.has(child.id)) continue;
+      seen.add(child.id);
+      if (child.time?.archived) continue;
+      if (queue.length >= MAX_SESSION_DESCENDANTS) {
+        unknown += 1;
+        continue;
+      }
+      ids.push(child.id);
+      queue.push(child.id);
+    }
   }
-  return ids.slice(1);
+  return { ids, unknown };
 }
 
-async function readSessionActivity(workspace: OpenWorkWorkspace, sessionId: string): Promise<SessionActivity> {
+async function readSessionActivity(workspace: OpenWorkWorkspace, session: SessionInfo): Promise<SessionActivity> {
   const base = `/workspace/${encodeURIComponent(workspace.id)}/opencode`;
   const probe = (path: string) => serverGet(`${base}${path}`).catch(() => null);
-  const [statuses, permissions, questions, descendantIds] = await Promise.all([
-    probe("/session/status"), probe("/permission"), probe("/question"), readSessionDescendantIds(base, sessionId),
+  const [statuses, permissions, questions, descendants] = await Promise.all([
+    probe("/session/status"), probe("/permission"), probe("/question"),
+    session.time?.archived ? { ids: [], unknown: 0 } : readSessionDescendantIds(base, session.id),
   ]);
-  return sessionActivityFrom(statuses, permissions, questions, sessionId, descendantIds);
+  return sessionActivityFrom(statuses, permissions, questions, session.id, descendants.ids, descendants.unknown);
 }
 
 // The engine returns the newest `limit` messages; without a limit it returns
@@ -850,13 +870,12 @@ async function readOpenWorkSession(rawArgs: unknown): Promise<object> {
       const needsFullTranscript = summary || from === "start";
       const [messages, activity] = await Promise.all([
         readSessionMessages(workspace, args.sessionId, needsFullTranscript ? undefined : count),
-        readSessionActivity(workspace, args.sessionId),
+        readSessionActivity(workspace, session),
       ]);
       const readable = readableMessages(messages);
       const metadata = {
         ...sessionMetadata(workspace, session),
-        status: activity.status,
-        working: activity.working,
+        ...activity,
       };
       if (summary) {
         return {

--- a/apps/server/src/opencode-plugins/session-activity.ts
+++ b/apps/server/src/opencode-plugins/session-activity.ts
@@ -1,36 +1,51 @@
+import type { OpenworkSessionActivityInventory } from "@openwork/types/openwork-affordance";
 import { z } from "zod";
 
 const engineSessionStatusesSchema = z.record(z.string(), z.object({ type: z.string() }).passthrough());
 const enginePendingRequestsSchema = z.array(z.object({ sessionID: z.string() }).passthrough());
 
-/** Engine vocabulary; `working` is the cross-surface contract agents key decisions on. */
-export type SessionActivity = { status: "idle" | "busy" | "retry" | "waiting"; working: boolean };
+export type SessionActivity = OpenworkSessionActivityInventory & {
+  status: "idle" | "busy" | "retry" | "waiting" | "error" | "compacting" | "thinking" | "responding" | "unknown";
+};
 
-/**
- * Live activity for one session from the engine: its run status plus any
- * unanswered permission or question addressed to it or to one of its
- * delegated descendants (a blocked child blocks the parent, and the person
- * answers from the parent). An unreadable probe reports working=true with
- * status "busy" so a caller never archives on a guess.
- */
 export function sessionActivityFrom(
   statuses: unknown,
   permissions: unknown,
   questions: unknown,
   sessionId: string,
   descendantIds: readonly string[] = [],
+  unknownDescendants = 0,
 ): SessionActivity {
   const parsedStatuses = engineSessionStatusesSchema.safeParse(statuses);
   const parsedPermissions = enginePendingRequestsSchema.safeParse(permissions);
   const parsedQuestions = enginePendingRequestsSchema.safeParse(questions);
-  if (!parsedStatuses.success || !parsedPermissions.success || !parsedQuestions.success) {
-    return { status: "busy", working: true };
+  const probesComplete = parsedStatuses.success && parsedPermissions.success && parsedQuestions.success;
+  const waiting = new Set([
+    ...parsedPermissions.success ? parsedPermissions.data.map((request) => request.sessionID) : [],
+    ...parsedQuestions.success ? parsedQuestions.data.map((request) => request.sessionID) : [],
+  ]);
+  const statusFor = (id: string): SessionActivity["status"] => {
+    const type = parsedStatuses.success ? parsedStatuses.data[id]?.type : undefined;
+    if (type === "error") return "error";
+    if (waiting.has(id) || type === "waiting") return "waiting";
+    if (type === "busy" || type === "running") return "busy";
+    if (type === "retry" || type === "compacting" || type === "thinking" || type === "responding") return type;
+    return probesComplete && (type === undefined || type === "idle") ? "idle" : "unknown";
+  };
+  const descendantActivity = { busy: 0, waiting: 0, unknown: unknownDescendants };
+  for (const id of new Set(descendantIds)) {
+    if (id === sessionId) continue;
+    const status = statusFor(id);
+    if (status === "unknown") descendantActivity.unknown += 1;
+    else if (status === "waiting") descendantActivity.waiting += 1;
+    else if (status !== "idle" && status !== "error") descendantActivity.busy += 1;
   }
-  const tree = new Set([sessionId, ...descendantIds]);
-  const waiting = [...parsedPermissions.data, ...parsedQuestions.data].some((request) => tree.has(request.sessionID));
-  if (waiting) return { status: "waiting", working: true };
-  const type = parsedStatuses.data[sessionId]?.type;
-  if (type === "busy" || type === "running") return { status: "busy", working: true };
-  if (type === "retry") return { status: "retry", working: true };
-  return { status: "idle", working: false };
+  const own = statusFor(sessionId);
+  return {
+    status: own !== "error" && descendantActivity.waiting > 0 ? "waiting" : own,
+    working: own !== "idle" && own !== "error" && own !== "unknown"
+      || descendantActivity.busy > 0 || descendantActivity.waiting > 0,
+    descendantActivity,
+    inventoryComplete: probesComplete && own !== "unknown" && descendantActivity.unknown === 0,
+  };
 }

--- a/evals/specs/session-attention-rollup.test.ts
+++ b/evals/specs/session-attention-rollup.test.ts
@@ -37,6 +37,7 @@ function listed() {
     sessionsByWorkspaceId: { [workspaceId]: sessions },
     pinnedIds: [],
     statusFor: (_workspace, sessionId) => rolled.get(sessionId)?.status ?? "idle",
+    attentionFor: (_workspace, sessionId) => rolled.get(sessionId),
   }).map((entry) => [entry.sessionId, entry]));
 }
 
@@ -50,12 +51,12 @@ test("the activity store keeps a delegating parent at thinking while its child's
   const rolled = attention();
   expect(own).toBe("thinking");
   expect(store.getStatus(workspaceId, child.id)).toBe("waiting");
-  expect(rolled.get(parent.id)).toEqual({
+  expect(rolled.get(parent.id)).toMatchObject({
     status: "waiting",
     blockedBy: { sessionId: child.id, title: child.title, kind: "permission" },
   });
-  expect(rolled.get(child.id)).toEqual({ status: "waiting", blockedBy: null });
-  expect(rolled.get(unrelated.id)).toEqual({ status: "idle", blockedBy: null });
+  expect(rolled.get(child.id)).toMatchObject({ status: "waiting", blockedBy: null });
+  expect(rolled.get(unrelated.id)).toMatchObject({ status: "idle", blockedBy: null });
   expect(sessionAttentionLabel({ sessionId: child.id, title: child.title, kind: "permission" }))
     .toBe(`Needs permission: ${child.title}`);
   evidence.recordAssertionEvidence(
@@ -93,13 +94,13 @@ test("the parent's own error or own request outranks a descendant's request", as
   store.setWaitingRequest(workspaceId, child.id, "permission", "per_1", true);
   store.setError(workspaceId, parent.id, "Provider failed");
   const errored = attention().get(parent.id);
-  expect(errored).toEqual({ status: "error", blockedBy: null });
+  expect(errored).toMatchObject({ status: "error", blockedBy: null });
 
   store.clearError(workspaceId, parent.id);
   store.setRunStatus(workspaceId, parent.id, "running");
   store.setWaitingRequest(workspaceId, parent.id, "question", "que_own", true);
   const own = attention().get(parent.id);
-  expect(own).toEqual({ status: "waiting", blockedBy: null });
+  expect(own).toMatchObject({ status: "waiting", blockedBy: null });
   evidence.recordAssertionEvidence(
     "Precedence is error > own waiting > descendant waiting",
     `With a child permission pending, an errored parent reports ${errored?.status}; a parent with its own question reports ${own?.status} with blockedBy ${String(own?.blockedBy)}.`,

--- a/evals/specs/sidebar-child-attention-rollup.e2e.test.ts
+++ b/evals/specs/sidebar-child-attention-rollup.e2e.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 import { browserScript } from "@openwork/cdp";
 import { spec } from "@openwork/testkit";
-import { parentChildPermissionWorld } from "../worlds/first-run.ts";
+import { parentChildHeldToolWorld, parentChildPermissionWorld } from "../worlds/first-run.ts";
 
 // A delegated child's pending permission lives on the child's activity
 // record. The parent row must show the orange "needs you" dot naming that
@@ -67,6 +67,129 @@ test("a delegated child's pending permission turns the parent's sidebar row oran
       until: (entry) => isRecord(entry) && entry.status !== "waiting",
     });
     expect(parent).toMatchObject({ sessionId: parentId, status: "thinking", working: true });
+    await user.screenshot();
+  });
+});
+
+const heldToolTest = spec.world(parentChildHeldToolWorld, { timeout: 600_000 });
+
+heldToolTest("an idle parent's sidebar spinner and descendantActivity follow a real child's held MCP tool", { timeout: 240_000 }, async ({ world, user, agent, probe, step }) => {
+  const parentId = world.session.sessionId;
+  const sinceIso = new Date().toISOString();
+  const v2 = world.engine === "v2";
+  const record = (value: unknown): Record<string, unknown> => isRecord(value) ? value : {};
+  const records = (value: unknown): Record<string, unknown>[] => Array.isArray(value) ? value.filter(isRecord) : [];
+  const read = async (path: string) => {
+    const response = await probe.desktopApi(world.mount + path);
+    expect(response.status, path).toBe(200);
+    return v2 ? record(response.body).data : response.body;
+  };
+  const transcript = async (id: string) => records(await read(`/session/${encodeURIComponent(id)}/${v2 ? "context" : "message?limit=50"}`))
+    .flatMap((message) => {
+      const info = v2 ? message : record(message.info);
+      if (info[v2 ? "type" : "role"] !== "assistant") return [];
+      const parts = records(v2 ? message.content : message.parts);
+      return [{
+        id: info.id, completed: typeof record(info.time).completed === "number",
+        text: parts.filter((part) => part.type === "text").map((part) => part.text).join(""),
+        tools: parts.filter((part) => part.type === "tool").map((part) => ({
+          name: part[v2 ? "name" : "tool"], status: record(part.state).status, metadata: record(part.state).metadata,
+        })),
+      }];
+    });
+  const nativeStatuses = async () => {
+    const statuses = await read(v2 ? "/session/active" : "/session/status");
+    expect(isRecord(statuses) && !Array.isArray(statuses)).toBe(true);
+    return record(statuses);
+  };
+  const statusOf = (statuses: Record<string, unknown>, id: string) => id in statuses ? record(statuses[id]).type : "idle";
+  const listedParent = async () => {
+    const listed = await agent.run("session.list_sessions");
+    expect(Array.isArray(listed)).toBe(true);
+    return records(listed).find((entry) => entry.sessionId === parentId);
+  };
+  const rowIndicator = () => probe.eval(browserScript((id) => {
+    const row = document.querySelector<HTMLElement>('[data-sidebar-session-id="' + id + '"]');
+    return {
+      exists: Boolean(row),
+      spinner: Boolean(row?.querySelector("[data-session-loading-indicator]")),
+      attention: Boolean(row?.querySelector("[data-session-attention-indicator]")),
+    };
+  }, [parentId]));
+  const childId = await step("real delegation completes and leaves the parent natively idle", async () => {
+    await user.type("composer", world.prompt, { verify: true });
+    await user.press("Enter");
+    await user.see({ text: world.reply }, { timeoutMs: 60_000 });
+    const children = records(await read("/session?limit=100")).filter((entry) => entry.parentID === parentId);
+    expect(children).toHaveLength(1);
+    const child = children[0];
+    if (!child || typeof child.id !== "string") throw new Error("Real delegation did not create a child session");
+    const id = child.id;
+    expect(id).not.toBe(parentId);
+    await probe.eventually(async () => ({ messages: await transcript(parentId), statuses: await nativeStatuses() }), {
+      within: 30_000, label: "the real task completes before independently resuming its child",
+      until: ({ messages, statuses }) => messages.some((message) => message.completed && message.text.includes(world.reply))
+        && statusOf(statuses, parentId) === "idle" && statusOf(statuses, id) === "idle",
+    });
+    expect((await transcript(parentId)).flatMap((message) => message.tools)).toContainEqual({
+      name: world.delegationTool, status: "completed",
+      metadata: expect.objectContaining(v2 ? { sessionID: id } : { sessionId: id }),
+    });
+    const parent = await probe.eventually(listedParent, {
+      within: 15_000, label: "the idle parent initially has no busy descendants",
+      until: (entry) => entry?.working === false && record(entry.descendantActivity).busy === 0,
+    });
+    expect(parent).toMatchObject({ status: "idle", working: false, descendantActivity: { busy: 0 } });
+    expect(await rowIndicator()).toEqual({ exists: true, spinner: false, attention: false });
+    return id;
+  });
+  const parentBefore = await transcript(parentId);
+
+  await step("only the resumed child runs while its idle parent shows descendant work", async () => {
+    const sent = await agent.desktopApi(`${world.mount}/session/${encodeURIComponent(childId)}/${v2 ? "prompt" : "prompt_async"}`, {
+      method: "POST", body: world.promptBody,
+    });
+    expect(sent.status).toBe(v2 ? 200 : 204);
+    await probe.eventually(world.heldTool, {
+      within: 45_000, label: "the child's actual MCP response is held at the witness",
+      until: (state) => state.held === 1,
+    });
+    expect(await world.mock.toolCalls({ name: "hold", sinceIso })).toEqual([
+      expect.objectContaining({ name: "hold", args: { marker: world.marker } }),
+    ]);
+    const active = await probe.eventually(async () => ({
+      statuses: await nativeStatuses(), messages: await transcript(childId), parent: await listedParent(), indicator: await rowIndicator(),
+    }), {
+      within: 15_000, label: "native child tool activity rolls up without making the parent engine busy",
+      until: ({ statuses, messages, parent, indicator }) => statusOf(statuses, parentId) === "idle"
+        && statusOf(statuses, childId) === (v2 ? "running" : "busy")
+        && messages.some((message) => message.tools.some((tool) => tool.name === world.toolName && tool.status === "running"))
+        && parent?.working === true && record(parent.descendantActivity).busy === 1 && indicator.spinner,
+    });
+    expect(active.parent).toMatchObject({ sessionId: parentId, working: true, descendantActivity: { busy: 1 } });
+    expect(active.indicator).toEqual({ exists: true, spinner: true, attention: false });
+    expect(world.heldTool()).toEqual({ held: 1, released: false, timedOut: false, delivered: 0 });
+    expect(await transcript(parentId)).toEqual(parentBefore);
+    expect(await probe.hash()).toContain(`/session/${parentId}`);
+    await user.screenshot();
+  });
+
+  await step("explicit release completes the child and clears the parent's spinner and busy inventory", async () => {
+    world.release();
+    const settled = await probe.eventually(async () => ({
+      statuses: await nativeStatuses(), messages: await transcript(childId), parent: await listedParent(), indicator: await rowIndicator(),
+    }), {
+      within: 45_000, label: "the successful child tool and native idle state clear descendant activity",
+      until: ({ statuses, messages, parent, indicator }) => statusOf(statuses, parentId) === "idle" && statusOf(statuses, childId) === "idle"
+        && messages.some((message) => message.completed && message.text.includes(world.toolReply))
+        && messages.some((message) => message.tools.some((tool) => tool.name === world.toolName && tool.status === "completed"))
+        && parent?.working === false && record(parent.descendantActivity).busy === 0 && !indicator.spinner,
+    });
+    expect(settled.parent).toMatchObject({ sessionId: parentId, status: "idle", working: false, descendantActivity: { busy: 0 } });
+    expect(settled.indicator).toEqual({ exists: true, spinner: false, attention: false });
+    expect(world.heldTool()).toEqual({ held: 1, released: true, timedOut: false, delivered: 1 });
+    expect(await transcript(parentId)).toEqual(parentBefore);
+    expect(await probe.hash()).toContain(`/session/${parentId}`);
     await user.screenshot();
   });
 });

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1,5 +1,6 @@
 import { browserScript, listTargets } from "@openwork/cdp";
 import { spawn } from "node:child_process";
+import { createServer } from "node:http";
 import { chmod, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -22,6 +23,7 @@ import {
 import { startEgressLab, startMockMcp } from "@openwork/labs";
 import { diagnoseEgressLabProduct } from "@openwork/behaviors";
 import { configureProvider } from "./chat.ts";
+import { close, listen, readBody, sendJson, sendMockError } from "./openwork-server-cli.ts";
 import { matchVerdictExpectations } from "@openwork/matchers";
 import {
   assignPluginToMarketplace,
@@ -253,6 +255,91 @@ export async function parentChildPermissionWorld(seed: Seed) {
     throw new Error(`Child permission seed failed: ${JSON.stringify(seeded)}`);
   }
   return base;
+}
+
+export async function parentChildHeldToolWorld(seed: Seed, { place }: { place: Place }) {
+  if (place.kind !== "local") throw new SkipError("The held MCP response witness needs local placement (--local).");
+  const engine = resolveEvalEngine();
+  const providerId = "descendant-mock";
+  const modelId = "descendant-model";
+  const delegationTool = engine === "v2" ? "subagent" : "task";
+  const toolName = "descendant_hold";
+  const marker = `descendant-${Date.now()}-${process.pid}`;
+  const prompt = "Delegate preparing an isolated investigation, then confirm it is ready.";
+  const childPrompt = "Prepare the isolated investigation.";
+  const followup = "Run the held investigation tool, then report its result.";
+  const reply = "The delegated investigation is ready.";
+  const toolReply = `Investigation released ${marker}.`;
+  await using setup = new AsyncDisposableStack();
+  const mock = setup.use(await startMockMcp({
+    port: await allocateFreePort(), isolatedProcessEnv: true, allowUnauthenticatedMcp: true,
+    tools: [{ name: "hold", description: "Run the held investigation", inputSchema: {
+      type: "object", properties: { marker: { type: "string" } }, required: ["marker"],
+    }, result: { content: [{ type: "text", text: toolReply }] } }],
+    agentWorkloads: [
+      { promptMarker: prompt, latestUserTurn: true, finalReply: reply, steps: [{ tool: delegationTool, arguments: {
+        description: "Prepare isolated investigation", prompt: childPrompt,
+        ...(engine === "v2" ? { agent: "general", background: false } : { subagent_type: "general" }),
+      } }] },
+      { promptMarker: childPrompt, latestUserTurn: true, finalReply: "Investigation prepared.", steps: [] },
+      { promptMarker: followup, latestUserTurn: true, finalReply: toolReply, finalReplyFrom: "last-tool-text",
+        steps: [{ tool: toolName, arguments: { marker } }] },
+    ],
+  }));
+  const gate = Promise.withResolvers<void>();
+  const state = { held: 0, released: false, timedOut: false, delivered: 0 };
+  const release = () => { state.released = true; gate.resolve(); };
+  const proxy = createServer(async (request, response) => {
+    try {
+      if (request.method !== "POST") return sendJson(response, 405, {});
+      const raw = await readBody(request);
+      const body: unknown = JSON.parse(raw);
+      const held = isRecord(body) && body.method === "tools/call" && isRecord(body.params)
+        && body.params.name === "hold" && isRecord(body.params.arguments) && body.params.arguments.marker === marker;
+      const upstream = await fetch(mock.mcpUrl, {
+        method: "POST", headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+        body: raw, signal: AbortSignal.timeout(15_000),
+      });
+      const text = await upstream.text();
+      if (held) {
+        state.held += 1;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([gate.promise, new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              state.timedOut = true;
+              reject(new Error("Descendant MCP response was not explicitly released"));
+            }, 90_000);
+          })]);
+        } finally { clearTimeout(timer); }
+      }
+      response.writeHead(upstream.status, Object.fromEntries(upstream.headers));
+      response.end(text);
+      if (held) state.delivered += 1;
+    } catch (error) { sendMockError(response, error); }
+  });
+  const mcpUrl = await listen(proxy);
+  setup.defer(async () => { release(); await close(proxy); });
+  const app = await seed.desktop({ name: "descendant-held-tool" });
+  const workspace = await seed.workspace(app, seed.tmpPath("descendant-held-tool"), { create: true });
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    permission: { task: "allow", "descendant_*": "allow" },
+    mcp: { descendant: { type: "remote", url: mcpUrl, enabled: true, oauth: false, timeout: 120_000 } },
+    provider: { [providerId]: { npm: "@ai-sdk/openai-compatible", name: "Descendant mock",
+      options: { baseURL: `${mock.url}/v1`, apiKey: "sk-descendant-fixture" },
+      models: { [modelId]: { name: "Descendant model" } },
+    } },
+  }, engine);
+  const session = await seed.session(app, { title: "Idle parent with delegated work" });
+  const resources = setup.move();
+  return {
+    app, workspace, session, engine, delegationTool, toolName, marker, prompt, followup, reply, toolReply, mock,
+    mount: `/workspace/${encodeURIComponent(workspace.workspaceId)}/${engine === "v2" ? "opencode2/api" : "opencode"}`,
+    promptBody: engine === "v2" ? { text: followup }
+      : { model: { providerID: providerId, modelID: modelId }, parts: [{ type: "text", text: followup }] },
+    heldTool: () => ({ ...state }), release,
+    [Symbol.asyncDispose]: () => resources.disposeAsync(),
+  };
 }
 
 export async function scopedPermissionRefreshWorld(seed: Seed) {

--- a/packages/types/src/openwork-affordance.ts
+++ b/packages/types/src/openwork-affordance.ts
@@ -75,6 +75,17 @@ export const openworkSessionModelSchema = z.object({
 })
 export type OpenworkSessionModel = z.infer<typeof openworkSessionModelSchema>
 
+export const openworkSessionActivityInventorySchema = z.object({
+  working: z.boolean(),
+  descendantActivity: z.object({
+    busy: z.number().int().nonnegative(),
+    waiting: z.number().int().nonnegative(),
+    unknown: z.number().int().nonnegative(),
+  }),
+  inventoryComplete: z.boolean(),
+})
+export type OpenworkSessionActivityInventory = z.infer<typeof openworkSessionActivityInventorySchema>
+
 /**
  * Where a request came from: the conversation (session) whose agent issued
  * it. Set by the OpenWork bridge, never by the agent, so UI commands such as


### PR DESCRIPTION
## Scope
Surface(s) touched: session-affordances / Rows changed: S23 / Blanks introduced: none

Roll up `{descendantActivity:{busy,waiting,unknown}, inventoryComplete}` in sidebar/list/read. Known descendant work sets working; unknown alone never does. Preserve own-status precedence, waiting-over-spinner, truthful child/descendant sources, and exclude archived branches. Failed/malformed/capped server walks expose incomplete inventory. Unknown counts unresolved branches, not an unseen-descendant census. No S02/S06/S32/S40 promotion.

## Proof
Local lane, signed head 2d013171c:
- App + server typecheck: exit 0.
- Selector/sync/cache/sidebar/server Bun suites: 275 passed, 0 failed.
- Testkit attention + inventory specs: 8 passed.
- `pnpm evals:e2e sidebar-child-attention-rollup --local --engine v1`: 2 passed, 0 skipped. Real delegated child resumes into a held MCP tool while parent stays natively idle; spinner and busy=1 appear, then clear on release. v2 not claimed.
- Targeted selector mutant removing busy propagation: “a busy child keeps an idle parent working without fabricating own activity” fails (`list_sessions.working`: expected true, received false); restored passes. This is a behavioral mutant, not a full-commit revert.

## Boundaries
Archive gate, modal, requester metadata, and #4903 channel behavior untouched. #4879 closed/unmerged; only explicitly cleared two-line sidebar prop adapter touches session-page.tsx, no header/breadcrumb/subagent-overview edits. Root install missed evals; one evals install repaired it. Head-matching evidence follows in comments. Do not merge.