### PR TITLE
fix(chat): finish loading earlier messages across owner changes

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -55,7 +55,7 @@ let nextOpeningCredential = 0;
 const hydratingTranscripts = new WeakSet<object>();
 const EMPTY_HISTORY: UIMessage[] = [];
 
-async function readHistoryWithDeadline<T>(read: (signal: AbortSignal) => Promise<T>, signal: AbortSignal, timeoutMs: number, timeoutMessage: string) {
+async function readLatestHistory<T>(read: (signal: AbortSignal) => Promise<T>, signal: AbortSignal) {
   signal.throwIfAborted();
   const deadline = new AbortController();
   const readSignal = AbortSignal.any([signal, deadline.signal]);
@@ -63,8 +63,10 @@ async function readHistoryWithDeadline<T>(read: (signal: AbortSignal) => Promise
   const aborted = new Promise<never>((_resolve, reject) => { rejectAborted = reject; });
   const onAbort = () => rejectAborted(readSignal.reason);
   readSignal.addEventListener("abort", onAbort, { once: true });
-  const timer = setTimeout(() => deadline.abort(new Error(timeoutMessage)), timeoutMs);
+  const timer = setTimeout(() => deadline.abort(new Error("Latest history read timed out.")), 2_000);
   try {
+    // Some transports cannot abort an already-dispatched request. The optional
+    // newest read must still release full-history loading at its deadline.
     return await Promise.race([read(readSignal), aborted]);
   } finally {
     clearTimeout(timer);
@@ -167,7 +169,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
       const initial = client.getQueryData<LatestSessionHistory>(latestKey) ?? {
         messages: mergeHistoryWindow(projectHistoryRead(full), readSource()), source: readSource(),
       };
-      const history = await readHistoryWithDeadline(input.readLatest, signal, 2_000, "Latest history read timed out.");
+      const history = await readLatestHistory(input.readLatest, signal);
       signal.throwIfAborted();
       if (history.session.id !== input.sessionId || history.messages.some(({ info, parts }) =>
         info.sessionID !== input.sessionId || parts.some((part) =>
@@ -207,7 +209,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
     const cached = client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey);
     const baseline = client.getQueryData<LatestSessionHistory>(latestKey)?.messages
       ?? (cached ? snapshotToUIMessages(cached) : EMPTY_HISTORY);
-    const snapshot = await readHistoryWithDeadline(input.readSnapshot, signal, 30_000, "Conversation history read timed out.");
+    const snapshot = await input.readSnapshot(signal);
     signal.throwIfAborted();
     entry.fullRead = { baseline, updateCount: (client.getQueryState(input.snapshotQueryKey)?.dataUpdateCount ?? 0) + 1 };
     return snapshot;
@@ -234,6 +236,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
     }
   }, [client, entry, input.readLatest, input.sessionId, input.snapshotQueryKey, input.transcriptQueryKey, latestKey, latestQuery.isFetching, readSource]);
   const latestHistory = entry.warm ? latestQuery.data ?? null : null;
+  const fullReader = entry.warm ? readFullSnapshot : input.readSnapshot;
   const activeOwner = useRef<string | null>(input.owner);
   activeOwner.current = input.owner;
   useEffect(() => {
@@ -243,7 +246,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
   const ensureFullSnapshot = useCallback(async () => {
     const options = {
       queryKey: input.snapshotQueryKey,
-      queryFn: ({ signal }: { signal: AbortSignal }) => readFullSnapshot(signal),
+      queryFn: ({ signal }: { signal: AbortSignal }) => fullReader(signal),
       networkMode: "always" as const,
     };
     try {
@@ -260,7 +263,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
       if (!query || query.getObserversCount() === 0) throw error;
       return client.fetchQuery(options);
     }
-  }, [client, input.snapshotQueryKey, readFullSnapshot]);
+  }, [client, input.snapshotQueryKey, fullReader]);
   const runWithFullSnapshot = useCallback(async (
     action: (snapshot: OpenworkSessionHistory) => void | Promise<unknown>,
     options: { fresh?: boolean } = {},
@@ -299,7 +302,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
     options,
     snapshot,
     latestHistory,
-    readFullSnapshot,
+    readFullSnapshot: fullReader,
     seedSnapshot,
     // A newest window that came back shorter than its limit already holds the
     // whole conversation. Only a full window, a saved-position window, or an

--- a/apps/app/src/react-app/domains/session/surface/session-history.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-history.tsx
@@ -55,7 +55,7 @@ let nextOpeningCredential = 0;
 const hydratingTranscripts = new WeakSet<object>();
 const EMPTY_HISTORY: UIMessage[] = [];
 
-async function readLatestHistory<T>(read: (signal: AbortSignal) => Promise<T>, signal: AbortSignal) {
+async function readHistoryWithDeadline<T>(read: (signal: AbortSignal) => Promise<T>, signal: AbortSignal, timeoutMs: number, timeoutMessage: string) {
   signal.throwIfAborted();
   const deadline = new AbortController();
   const readSignal = AbortSignal.any([signal, deadline.signal]);
@@ -63,10 +63,8 @@ async function readLatestHistory<T>(read: (signal: AbortSignal) => Promise<T>, s
   const aborted = new Promise<never>((_resolve, reject) => { rejectAborted = reject; });
   const onAbort = () => rejectAborted(readSignal.reason);
   readSignal.addEventListener("abort", onAbort, { once: true });
-  const timer = setTimeout(() => deadline.abort(new Error("Latest history read timed out.")), 2_000);
+  const timer = setTimeout(() => deadline.abort(new Error(timeoutMessage)), timeoutMs);
   try {
-    // Some transports cannot abort an already-dispatched request. The optional
-    // newest read must still release full-history loading at its deadline.
     return await Promise.race([read(readSignal), aborted]);
   } finally {
     clearTimeout(timer);
@@ -169,7 +167,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
       const initial = client.getQueryData<LatestSessionHistory>(latestKey) ?? {
         messages: mergeHistoryWindow(projectHistoryRead(full), readSource()), source: readSource(),
       };
-      const history = await readLatestHistory(input.readLatest, signal);
+      const history = await readHistoryWithDeadline(input.readLatest, signal, 2_000, "Latest history read timed out.");
       signal.throwIfAborted();
       if (history.session.id !== input.sessionId || history.messages.some(({ info, parts }) =>
         info.sessionID !== input.sessionId || parts.some((part) =>
@@ -209,7 +207,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
     const cached = client.getQueryData<OpenworkSessionHistory>(input.snapshotQueryKey);
     const baseline = client.getQueryData<LatestSessionHistory>(latestKey)?.messages
       ?? (cached ? snapshotToUIMessages(cached) : EMPTY_HISTORY);
-    const snapshot = await input.readSnapshot(signal);
+    const snapshot = await readHistoryWithDeadline(input.readSnapshot, signal, 30_000, "Conversation history read timed out.");
     signal.throwIfAborted();
     entry.fullRead = { baseline, updateCount: (client.getQueryState(input.snapshotQueryKey)?.dataUpdateCount ?? 0) + 1 };
     return snapshot;
@@ -236,7 +234,6 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
     }
   }, [client, entry, input.readLatest, input.sessionId, input.snapshotQueryKey, input.transcriptQueryKey, latestKey, latestQuery.isFetching, readSource]);
   const latestHistory = entry.warm ? latestQuery.data ?? null : null;
-  const fullReader = entry.warm ? readFullSnapshot : input.readSnapshot;
   const activeOwner = useRef<string | null>(input.owner);
   activeOwner.current = input.owner;
   useEffect(() => {
@@ -246,7 +243,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
   const ensureFullSnapshot = useCallback(async () => {
     const options = {
       queryKey: input.snapshotQueryKey,
-      queryFn: ({ signal }: { signal: AbortSignal }) => fullReader(signal),
+      queryFn: ({ signal }: { signal: AbortSignal }) => readFullSnapshot(signal),
       networkMode: "always" as const,
     };
     try {
@@ -263,7 +260,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
       if (!query || query.getObserversCount() === 0) throw error;
       return client.fetchQuery(options);
     }
-  }, [client, input.snapshotQueryKey, fullReader]);
+  }, [client, input.snapshotQueryKey, readFullSnapshot]);
   const runWithFullSnapshot = useCallback(async (
     action: (snapshot: OpenworkSessionHistory) => void | Promise<unknown>,
     options: { fresh?: boolean } = {},
@@ -302,7 +299,7 @@ export function useOpeningSessionHistory(input: OpeningHistoryInput & {
     options,
     snapshot,
     latestHistory,
-    readFullSnapshot: fullReader,
+    readFullSnapshot,
     seedSnapshot,
     // A newest window that came back shorter than its limit already holds the
     // whole conversation. Only a full window, a saved-position window, or an

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { UIMessage } from "ai";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { hashKey, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 import { Check, CirclePause, Minimize2 } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
@@ -1304,7 +1304,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useEffect(() => {
     const previous = snapshotOwnerRef.current;
     snapshotOwnerRef.current = { queryKey: snapshotQueryKey, owner: sessionOwner };
-    if (previous.queryKey !== snapshotQueryKey || previous.owner === sessionOwner) return;
+    if (hashKey(previous.queryKey) !== hashKey(snapshotQueryKey) || previous.owner === sessionOwner) return;
     const filters = { queryKey: snapshotQueryKey, exact: true };
     void queryClient.cancelQueries(filters).then(() => queryClient.invalidateQueries(filters));
   }, [queryClient, sessionOwner, snapshotQueryKey]);
@@ -3344,7 +3344,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
             ) : null}
           </div>
         </div>
-        <SessionHistoryStatus key={sessionOwner} complete={hasFullHistory} pending={pendingSessionLoad}
+        <SessionHistoryStatus key={`history:${sessionOwner}`} complete={hasFullHistory} pending={pendingSessionLoad}
           loading={snapshotQuery.isFetching && openingHistory.partial}
           failed={snapshotQuery.isError && !snapshotQuery.isFetching} onRetry={() => snapshotQuery.refetch()} />
         <SessionScrollOverlay

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -213,7 +213,7 @@ describe("opening a thread", () => {
     expect(view.latestReads).toHaveLength(0);
   });
 
-  test("a stalled full history read releases loading for Retry without losing the active preview", async () => {
+  test("a failed long history read retries without losing the active preview", async () => {
     const view = fixture();
     const event = sessionEvents();
     const full = longHistory();
@@ -228,9 +228,8 @@ describe("opening a thread", () => {
     expect(view.reads).toHaveLength(2);
     expect(view.reads[1].window).toBeUndefined();
     expect(view.host.querySelector('[role="status"]')?.textContent).toBe("Loading earlier messages…");
-    await act(async () => { jest.advanceTimersByTime(30_000); });
+    await act(async () => view.reads[1].reject(new Error("Full read failed")));
     await settle();
-    expect(view.reads[1].signal.aborted).toBe(true);
     expect(view.client.getQueryState(snapshotKey("workspace", "a"))).toMatchObject({ status: "error", fetchStatus: "idle" });
     expect(view.host.querySelector('[role="alert"]')?.textContent).toContain("The rest of this conversation could not be loaded.");
     expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(24);
@@ -245,10 +244,8 @@ describe("opening a thread", () => {
     await act(async () => view.host.querySelector("button")?.click());
     expect(view.reads).toHaveLength(4);
     await view.resolve(3, full);
-    await view.resolve(1, snapshot("a", "Obsolete timed-out result", ["obsolete"]));
     expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(440);
     expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
-    expect(view.host.textContent).not.toContain("Obsolete timed-out result");
     expect(view.host.querySelector("input")).toBe(composer);
     expect(composer.value).toBe("Keep my unsent draft");
   });

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -58,9 +58,9 @@ function snapshot(id: string, title: string, ids: string[] = [], revert?: string
   };
 }
 
-function longHistory(): OpenworkSessionHistory {
+function longHistory(count = 440): OpenworkSessionHistory {
   const history = snapshot("a", "Long active conversation");
-  history.messages = Array.from({ length: 440 }, (_, index) => {
+  history.messages = Array.from({ length: count }, (_, index) => {
     const id = `message-${index}`;
     return {
       info: { id, sessionID: "a", role: "assistant", time: { created: index + 1 } },
@@ -69,7 +69,7 @@ function longHistory(): OpenworkSessionHistory {
         { id: `reasoning-${index}`, sessionID: "a", messageID: id, type: "reasoning", text: `Reasoning ${index}`, time: { start: 1 } },
         {
           id: `tool-${index}`, sessionID: "a", messageID: id, type: "tool", tool: "bash", callID: `call-${index}`,
-          state: index === 439
+          state: index === count - 1
             ? { status: "running", input: { command: "work" }, time: { start: 1 } }
             : { status: "completed", input: { command: "work" }, output: `Result ${index}`, title: "Done", metadata: {}, time: { start: 1, end: 2 } },
         },
@@ -210,6 +210,40 @@ describe("opening a thread", () => {
     expect(view.host.textContent).toContain("input-streaming");
     expect(view.client.getQueryData(statusKey("workspace", "a"))).toEqual({ type: "busy" });
     expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.latestReads).toHaveLength(0);
+  });
+
+  test("a 15 MB active history completes and structurally shares an equal full refresh", async () => {
+    const view = fixture();
+    const event = sessionEvents();
+    const full = longHistory(1467);
+    for (const [index, message] of full.messages.entries()) {
+      if (index < 214) message.parts.push({ id: `extra-${index}`, sessionID: "a", messageID: message.info.id, type: "text", text: "Additional persisted text" });
+      for (const part of message.parts) {
+        if (part.type === "tool" && part.state.status === "completed") part.state.output += "x".repeat(10_000);
+      }
+    }
+    const serialized = JSON.stringify(full);
+    expect(serialized.length).toBeGreaterThan(15_000_000);
+    expect(full.messages.reduce((count, message) => count + message.parts.length, 0)).toBe(4615);
+    await view.render();
+    await view.resolve(0, { session: full.session, messages: full.messages.slice(-24) });
+    await paint();
+    await paint();
+    await event({ type: "session.status", properties: { sessionID: "a", status: { type: "busy" } } });
+    await view.resolve(1, JSON.parse(serialized));
+    const key = snapshotKey("workspace", "a");
+    const cached = view.client.getQueryData<OpenworkSessionHistory>(key);
+    expect(cached?.messages).toHaveLength(1467);
+    expect(view.host.querySelectorAll("[data-message-id]").length).toBe(1467);
+    expect(view.host.querySelectorAll("[data-thread-history-status]").length).toBe(0);
+    await act(async () => { void view.client.refetchQueries({ queryKey: key, exact: true }); });
+    expect(view.reads).toHaveLength(3);
+    await view.resolve(2, JSON.parse(serialized));
+    expect(view.client.getQueryData(key) === cached).toBe(true);
+    expect(view.client.getQueryState(key)).toMatchObject({ status: "success", fetchStatus: "idle", dataUpdateCount: 2 });
+    expect(view.client.getQueryData(statusKey("workspace", "a"))).toEqual({ type: "busy" });
+    expect(view.host.querySelectorAll("[data-thread-history-status]").length).toBe(0);
     expect(view.latestReads).toHaveLength(0);
   });
 

--- a/apps/app/tests/session-history.test.tsx
+++ b/apps/app/tests/session-history.test.tsx
@@ -11,7 +11,7 @@ import { openingHistoryWindow, openingSessionHistoryOptions, prefetchOpeningSess
 import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
 import { flushSessionScrollState, useSessionScrollStore } from "../src/react-app/domains/session/surface/scroll-store";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
-import { __applySessionSyncEventForTest, __createWorkspaceSessionSyncForTest, applySessionRevert, applySessionUnrevert, seedSessionState, snapshotKey, trackWorkspaceSessionSync, transcriptKey } from "../src/react-app/domains/session/sync/session-sync";
+import { __applySessionSyncEventForTest, __createWorkspaceSessionSyncForTest, applySessionRevert, applySessionUnrevert, seedSessionState, snapshotKey, statusKey, trackWorkspaceSessionSync, transcriptKey } from "../src/react-app/domains/session/sync/session-sync";
 import type { OpencodeEvent } from "../src/app/types";
 import { deriveRenderedSessionMessages, type LatestSessionHistory } from "../src/react-app/domains/session/surface/session-render-state";
 import { snapshotToUIMessages } from "../src/react-app/domains/session/sync/usechat-adapter";
@@ -56,6 +56,27 @@ function snapshot(id: string, title: string, ids: string[] = [], revert?: string
       parts: [{ id: `part-${messageId}`, sessionID: id, messageID: messageId, type: "text", text: messageId }],
     })),
   };
+}
+
+function longHistory(): OpenworkSessionHistory {
+  const history = snapshot("a", "Long active conversation");
+  history.messages = Array.from({ length: 440 }, (_, index) => {
+    const id = `message-${index}`;
+    return {
+      info: { id, sessionID: "a", role: "assistant", time: { created: index + 1 } },
+      parts: [
+        { id: `text-${index}`, sessionID: "a", messageID: id, type: "text", text: `Text ${index}` },
+        { id: `reasoning-${index}`, sessionID: "a", messageID: id, type: "reasoning", text: `Reasoning ${index}`, time: { start: 1 } },
+        {
+          id: `tool-${index}`, sessionID: "a", messageID: id, type: "tool", tool: "bash", callID: `call-${index}`,
+          state: index === 439
+            ? { status: "running", input: { command: "work" }, time: { start: 1 } }
+            : { status: "completed", input: { command: "work" }, output: `Result ${index}`, title: "Done", metadata: {}, time: { start: 1, end: 2 } },
+        },
+      ],
+    };
+  });
+  return history;
 }
 
 function sessionEvents() {
@@ -170,6 +191,97 @@ function fixture() {
 }
 
 describe("opening a thread", () => {
+  test("a 440-message mixed-part history completes while the conversation stays active", async () => {
+    const view = fixture();
+    const event = sessionEvents();
+    const full = longHistory();
+    expect(full.messages.reduce((count, message) => count + message.parts.length, 0)).toBe(1320);
+    await view.render();
+    await view.resolve(0, { session: full.session, messages: full.messages.slice(-24) });
+    await paint();
+    await paint();
+    await event({ type: "session.status", properties: { sessionID: "a", status: { type: "busy" } } });
+    expect(view.host.querySelector('[role="status"]')?.textContent).toBe("Loading earlier messages…");
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(24);
+    await view.resolve(1, full);
+    expect(view.client.getQueryState(snapshotKey("workspace", "a"))).toMatchObject({ status: "success", fetchStatus: "idle" });
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(440);
+    expect(view.host.textContent).toContain("Text 0");
+    expect(view.host.textContent).toContain("input-streaming");
+    expect(view.client.getQueryData(statusKey("workspace", "a"))).toEqual({ type: "busy" });
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.latestReads).toHaveLength(0);
+  });
+
+  test("a stalled full history read releases loading for Retry without losing the active preview", async () => {
+    const view = fixture();
+    const event = sessionEvents();
+    const full = longHistory();
+    await view.render();
+    await view.resolve(0, { session: full.session, messages: full.messages.slice(-24) });
+    await paint();
+    await paint();
+    await event({ type: "session.status", properties: { sessionID: "a", status: { type: "busy" } } });
+    const composer = view.host.querySelector("input");
+    if (!composer) throw new Error("Missing composer");
+    composer.value = "Keep my unsent draft";
+    expect(view.reads).toHaveLength(2);
+    expect(view.reads[1].window).toBeUndefined();
+    expect(view.host.querySelector('[role="status"]')?.textContent).toBe("Loading earlier messages…");
+    await act(async () => { jest.advanceTimersByTime(30_000); });
+    await settle();
+    expect(view.reads[1].signal.aborted).toBe(true);
+    expect(view.client.getQueryState(snapshotKey("workspace", "a"))).toMatchObject({ status: "error", fetchStatus: "idle" });
+    expect(view.host.querySelector('[role="alert"]')?.textContent).toContain("The rest of this conversation could not be loaded.");
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(24);
+    expect(view.host.querySelector('[role="status"]')).toBeNull();
+    await act(async () => view.host.querySelector("button")?.click());
+    expect(view.reads).toHaveLength(3);
+    expect(view.reads[2].window).toBeUndefined();
+    expect(view.reads[2].signal.aborted).toBe(false);
+    await act(async () => view.reads[2].reject(new Error("Retry failed")));
+    await settle();
+    expect(view.host.querySelector("button")?.textContent).toBe("Retry");
+    await act(async () => view.host.querySelector("button")?.click());
+    expect(view.reads).toHaveLength(4);
+    await view.resolve(3, full);
+    await view.resolve(1, snapshot("a", "Obsolete timed-out result", ["obsolete"]));
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(440);
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.host.textContent).not.toContain("Obsolete timed-out result");
+    expect(view.host.querySelector("input")).toBe(composer);
+    expect(composer.value).toBe("Keep my unsent draft");
+  });
+
+  test("an engine switch abandons the old preview and completes the new engine's full history", async () => {
+    const view = fixture();
+    const identity = (opencodeBaseUrl: string) => sessionHistoryIdentity({
+      draftScope: "local", opencodeBaseUrl, runtimeWorkspaceId: "workspace", sessionId: "a",
+    });
+    const v1 = { ...view.input(), ...identity("http://localhost/opencode") };
+    const v2 = { ...view.input(), ...identity("http://localhost/opencode2") };
+    expect(v1.snapshotQueryKey).toEqual(v2.snapshotQueryKey);
+    expect(v1.owner).not.toBe(v2.owner);
+    await view.renderInput(v1);
+    await view.renderInput(v2);
+    expect(view.reads[0].signal.aborted).toBe(true);
+    await view.resolve(0, snapshot("a", "Old engine", ["obsolete"]));
+    expect(view.host.textContent).not.toContain("Old engine");
+    const full = longHistory();
+    await view.resolve(1, { session: full.session, messages: full.messages.slice(-24) });
+    await paint();
+    await paint();
+    expect(view.reads).toHaveLength(3);
+    expect(view.reads[2].window).toBeUndefined();
+    await view.resolve(2, full);
+    await act(async () => { jest.advanceTimersByTime(30_000); });
+    await settle();
+    expect(view.client.getQueryState(v2.snapshotQueryKey)).toMatchObject({ status: "success", fetchStatus: "idle" });
+    expect(view.host.querySelectorAll("[data-message-id]")).toHaveLength(440);
+    expect(view.host.querySelector("[data-thread-history-status]")).toBeNull();
+    expect(view.host.textContent).not.toContain("obsolete");
+  });
+
   test("preview and full history become readable without an activity snapshot", async () => {
     const view = fixture();
     await view.render();

--- a/apps/app/tests/session-snapshot-owner-flip.test.tsx
+++ b/apps/app/tests/session-snapshot-owner-flip.test.tsx
@@ -7,10 +7,11 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 
 import type { FieldsResult } from "../src/app/lib/opencode";
-import type { NativeSessionOperations, NativeSessionSnapshotTarget } from "../src/app/lib/opencode-session-native";
+import { composeNativeSessionHistoryWithRetry, type NativeSessionOperations, type NativeSessionSnapshotTarget } from "../src/app/lib/opencode-session-native";
 import type { OpenworkSessionHistory, OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import type { Platform } from "../src/react-app/kernel/platform";
 
+const composeWithRetry = composeNativeSessionHistoryWithRetry;
 const workspaceId = "workspace-snapshot-owner-flip";
 const sessionId = "ses_snapshot_owner_flip";
 const v1BaseUrl = "http://127.0.0.1:1/opencode";
@@ -93,7 +94,7 @@ async function waitFor(predicate: () => boolean, label: string) {
 // Reload of a v2 session: the surface mounts under the v1 URL before the chat
 // routing status resolves, the first owned read 404s on v1 and waits to retry,
 // and the routing flip changes the owner while that read is still in flight.
-test("a session snapshot read that loses its owner mid-flight is re-read under the new owner", async () => {
+for (const interruptFullRead of [false, true]) test(`a session snapshot read that loses its owner mid-flight is re-read under the new owner (full read=${interruptFullRead})`, async () => {
   const require = createRequire(import.meta.url);
   // Bun's isolated test loader cycles Lexical's ESM entries; use their real CJS entries before the app imports the editor.
   for (const moduleId of [
@@ -145,18 +146,29 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
   const readEndpoints: string[] = [];
   const historyWindows: Array<number | undefined> = [];
   const readLimits: (number | undefined)[] = [];
+  const readSignals: (AbortSignal | undefined)[] = [];
   let releaseRetry: (() => void) | null = null;
   const snapshot = createSnapshot();
+  if (interruptFullRead) {
+    const message = snapshot.messages[0];
+    snapshot.messages = Array.from({ length: 440 }, (_, index) => {
+      const id = `msg_history_${index}`;
+      return {
+        info: { ...message.info, id },
+        parts: message.parts.map((part) => ({ ...part, id: `part_history_${index}`, messageID: id })),
+      };
+    });
+  }
   const operationsFor = (endpoint: { opencodeBaseUrl: string }): NativeSessionOperations => {
     readEndpoints.push(endpoint.opencodeBaseUrl);
-    const v2 = endpoint.opencodeBaseUrl === v2BaseUrl;
+    const readable = endpoint.opencodeBaseUrl === v2BaseUrl || (interruptFullRead && readLimits.at(-1) === 24);
     return {
-      get: async () => (v2 ? ok(snapshot.session) : notFound()),
+      get: async () => (readable ? ok(snapshot.session) : notFound()),
       messages: async (_sessionId, limit) => {
         historyWindows.push(limit);
-        return v2 ? ok(snapshot.messages) : notFound();
+        return readable ? ok(limit === undefined ? snapshot.messages : snapshot.messages.slice(-limit)) : notFound();
       },
-      todo: async () => (v2 ? ok(snapshot.todos) : notFound()),
+      todo: async () => (readable ? ok(snapshot.todos) : notFound()),
       status: async () => ok({}),
       delete: async () => ok(true),
     };
@@ -166,8 +178,6 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
   const taskSuggestions = await import("../src/components/chat/task-suggestions");
   mock.module("@/components/chat/task-suggestions", () => ({ ...taskSuggestions, TaskSuggestions: () => null }));
   mock.module("../src/react-app/domains/session/surface/composer/workspace-run-mode-menu", () => ({ WorkspaceRunModeMenu: () => null }));
-  // Bind the real implementation first: mocking rewires the loaded module's live bindings.
-  const composeWithRetry = sessionNative.composeNativeSessionHistoryWithRetry;
   mock.module("@/app/lib/opencode-session-native", () => ({
     ...sessionNative,
     composeNativeSessionHistoryWithRetry: (
@@ -176,6 +186,7 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
       options: { signal?: AbortSignal; limit?: number },
     ) => {
       readLimits.push(options.limit);
+      readSignals.push(options.signal);
       return composeWithRetry(expectedOwner, readCurrentTarget, options, {
         createOperations: operationsFor,
         // The first (v1) read parks here until the test flips the owner.
@@ -187,10 +198,11 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
     },
   }));
   const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
-  const { snapshotKey } = await import("../src/react-app/domains/session/sync/session-sync");
+  const { snapshotKey, statusKey } = await import("../src/react-app/domains/session/sync/session-sync");
   const queryClient = getReactQueryClient();
   queryClient.clear();
   const key = snapshotKey(workspaceId, sessionId);
+  if (interruptFullRead) queryClient.setQueryData(statusKey(workspaceId, sessionId), { type: "busy" });
   const client = createOpenworkServerClient({ baseUrl: "http://127.0.0.1:1", token: "test-token" });
   const container = document.createElement("div");
   document.body.append(container);
@@ -246,25 +258,37 @@ test("a session snapshot read that loses its owner mid-flight is re-read under t
   try {
     await act(async () => root.render(surface(v1BaseUrl)));
     await waitFor(() => releaseRetry !== null, "the v1 read to 404 and park before its retry");
-    expect(readEndpoints).toEqual([v1BaseUrl]);
+    expect(readEndpoints).toEqual(interruptFullRead ? [v1BaseUrl, v1BaseUrl] : [v1BaseUrl]);
+    const previousStatus = container.querySelector("[data-thread-history-status]");
+    if (interruptFullRead) expect(previousStatus?.textContent).toContain("Loading earlier messages…");
+    else expect(previousStatus).toBeNull();
 
     // Routing status resolves: the same session is now owned by /opencode2.
     await act(async () => root.render(surface(v2BaseUrl)));
-    await act(async () => { releaseRetry?.(); });
+    if (!interruptFullRead) await act(async () => { releaseRetry?.(); });
 
     await waitFor(() => container.textContent?.includes(transcriptText) === true
       && queryClient.getQueryState(key)?.status === "success", "the full transcript read under the v2 owner");
-    expect(queryClient.getQueryState(key)?.status).toBe("success");
-    expect(queryClient.getQueryState(key)?.error).toBeNull();
+    expect(queryClient.getQueryState(key)).toMatchObject({ status: "success", fetchStatus: "idle", error: null });
+    expect(readSignals[interruptFullRead ? 1 : 0]?.aborted).toBe(true);
     expect(container.textContent).not.toContain("owner changed");
     // The new owner's preview paints before its separate uncapped history read.
     // The abandoned owner must never retry or populate either result.
-    expect(readEndpoints).toEqual([v1BaseUrl, v2BaseUrl, v2BaseUrl]);
-    expect(historyWindows).toEqual([24, 24, undefined]);
-    expect(readLimits).toEqual([24, 24, undefined]);
+    expect(readEndpoints).toEqual(interruptFullRead ? [v1BaseUrl, v1BaseUrl, v2BaseUrl, v2BaseUrl] : [v1BaseUrl, v2BaseUrl, v2BaseUrl]);
+    expect(historyWindows).toEqual(interruptFullRead ? [24, undefined, 24, undefined] : [24, 24, undefined]);
+    expect(readLimits).toEqual(historyWindows);
     const cached = queryClient.getQueryData<OpenworkSessionHistory>(key);
     expect(cached?.status).toBeUndefined();
     expect(cached?.todos).toBeUndefined();
+    expect(cached?.messages).toHaveLength(interruptFullRead ? 440 : 1);
+    expect(container.querySelectorAll("[data-thread-history-status]").length).toBe(0);
+    if (interruptFullRead) {
+      expect(previousStatus?.isConnected).toBe(false);
+      expect(queryClient.getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+    }
+    await act(async () => root.render(surface(v2BaseUrl)));
+    expect(container.querySelectorAll("[data-thread-history-status]").length).toBe(0);
+    expect(readLimits).toEqual(historyWindows);
   } finally {
     await act(async () => root.unmount());
     useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -230,7 +230,7 @@ test("opening a long conversation shows the latest and full history while ancill
   });
 });
 
-warmTest("returning to a fully cached conversation refreshes its persisted tail before the uncapped read completes", async ({ user, agent, probe, step, world }) => {
+warmTest("returning to a fully cached conversation refreshes its persisted tail before the uncapped read completes", async ({ user, agent, probe, step, world, evidence }) => {
   const messagesPath = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/opencode/session/${encodeURIComponent(world.session.sessionId)}/message`;
   const surface = `[data-session-surface-id="${world.session.sessionId}"]`;
   const historyDom = async () => {
@@ -359,5 +359,11 @@ warmTest("returning to a fully cached conversation refreshes its persisted tail 
     expect(messageTexts(stored.body)).toEqual(persisted);
     expect((await observeReturn()).rows.map((row) => row.text)).toEqual(refreshed);
     expect(maxAnchorDrift).toBeLessThanOrEqual(1);
+    evidence.recordAssertionEvidence(
+      "Warm history retains the refreshed tail, unchanged source, and manual anchor after full-read release",
+      JSON.stringify({ cachedMessages: cached.texts.length, refreshedMessages: refreshed.length, finalMessages: complete.rows.length,
+        persistedMessages: messageTexts(stored.body).length, historyChanged, maxAnchorDrift, state: complete.state }),
+      true,
+    );
   });
 });

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -203,7 +203,9 @@ test("opening a long conversation shows the latest and full history while ancill
     await probe.eventually(() => probe.dom(`${surface} [data-thread-history-status]`), {
       within: 10_000, label: "earlier-history status disappears at the first message", until: value => value.elements.length === 0,
     });
-    expect((await probe.dom(`${surface} [data-message-role="user"]`)).elements[0]?.text).toContain(longHistoryFirst);
+    const first = (await probe.dom(`${surface} [data-message-role="user"]`)).elements[0];
+    expect(first?.text).toContain(longHistoryFirst);
+    evidence.recordAssertionEvidence("The first stored user message renders without an earlier-history status", JSON.stringify({ first: first?.text, status: (await probe.dom(`${surface} [data-thread-history-status]`)).elements.length }), true);
     await user.looks([
       `The conversation transcript visibly starts with a user message reading "${longHistoryFirst}"`,
       "The transcript shows no loading indicator, error card, or empty-conversation placeholder",
@@ -212,6 +214,7 @@ test("opening a long conversation shows the latest and full history while ancill
 
   // Baseline branch coverage after full loading, not the delayed-preview race.
   await step("after full loading, branching at the first message excludes later history and leaves the source unchanged", async () => {
+    await user.hover({ text: longHistoryFirst });
     await user.click({ role: "button", label: "Branch in new chat", nth: 0 });
     // count limits returned messages; messageCount is the entire rendered transcript.
     await probe.eventually(async () => renderedCount(await agent.run("session.read_transcript", { count: 1 })), {

--- a/evals/specs/session-full-history-on-open.e2e.test.ts
+++ b/evals/specs/session-full-history-on-open.e2e.test.ts
@@ -200,6 +200,10 @@ test("opening a long conversation shows the latest and full history while ancill
   await step("the first message is reachable at the top of the transcript", async () => {
     await agent.run("session.scroll_top");
     await user.see({ text: longHistoryFirst }, { timeoutMs: 30_000 });
+    await probe.eventually(() => probe.dom(`${surface} [data-thread-history-status]`), {
+      within: 10_000, label: "earlier-history status disappears at the first message", until: value => value.elements.length === 0,
+    });
+    expect((await probe.dom(`${surface} [data-message-role="user"]`)).elements[0]?.text).toContain(longHistoryFirst);
     await user.looks([
       `The conversation transcript visibly starts with a user message reading "${longHistoryFirst}"`,
       "The transcript shows no loading indicator, error card, or empty-conversation placeholder",

--- a/evals/specs/session-history-loading-web.e2e.test.ts
+++ b/evals/specs/session-history-loading-web.e2e.test.ts
@@ -1,0 +1,126 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { mixedHistoryWeb } from "../worlds/session-history-loading.ts";
+
+const test = spec.world(mixedHistoryWeb, { timeout: 600_000, resources: { surfaces: ["appWeb"], services: [] } });
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function witness(value: unknown) {
+  if (!record(value) || !Array.isArray(value.opens) || !Array.isArray(value.reads)
+    || typeof value.installedAt !== "number" || typeof value.samples !== "number") throw new Error("Missing initial history observer");
+  return {
+    installedAt: value.installedAt, samples: value.samples, expired: value.expired,
+    opens: value.opens.map((opening: unknown) => {
+      if (!record(opening) || typeof opening.at !== "number" || typeof opening.samples !== "number") throw new Error("Invalid opening witness");
+      return { sessionId: opening.sessionId, at: opening.at, samples: opening.samples, trusted: opening.trusted, initialRows: opening.initialRows, statusSeen: opening.statusSeen };
+    }),
+    reads: value.reads.map((read: unknown) => {
+      if (!record(read) || typeof read.startedAt !== "number" || typeof read.parts !== "number" || typeof read.messages !== "number"
+        || typeof read.reasoning !== "number" || typeof read.tools !== "number"
+        || (read.deliveredAt !== null && typeof read.deliveredAt !== "number")) throw new Error("Invalid history read witness");
+      return { sessionId: read.sessionId, limit: read.limit, startedAt: read.startedAt, deliveredAt: read.deliveredAt, messages: read.messages, parts: read.parts, reasoning: read.reasoning, tools: read.tools };
+    }),
+  };
+}
+
+test("mixed active history clears its loading status and short history never announces earlier messages", async ({ user, agent, probe, step, world, evidence, place }) => {
+  const surface = `[data-session-surface-id="${world.long.sessionId}"]`;
+  const read = () => probe.storage(world.storageKey, witness);
+  const rows = () => probe.dom(`${surface} [data-message-role="user"]`);
+  await user.reload();
+  await user.see({ testId: `sidebar-session-${world.long.sessionId}` }, { timeoutMs: 60_000 });
+  expect((await read()).opens).toHaveLength(0);
+  expect((await probe.dom(surface)).elements).toHaveLength(0);
+
+  await step("more than 1000 mixed parts remain active while the uncapped read is held", async () => {
+    await user.click({ testId: `sidebar-session-${world.long.sessionId}` });
+    await probe.eventually(async () => {
+      const state = await read();
+      expect(state.expired).toBe(false);
+      return state.reads.find(item => item.sessionId === world.long.sessionId && item.limit === null);
+    }, { within: 15_000, label: "uncapped mixed history request starts", until: value => Boolean(value) });
+    const state = await read();
+    const full = state.reads.find(item => item.sessionId === world.long.sessionId && item.limit === null);
+    expect(full?.parts).toBeGreaterThan(1000);
+    expect(full?.reasoning).toBe(world.turns * 4);
+    expect(full?.tools).toBe(world.turns * 4 + 1);
+    expect(full?.messages).toBe(world.turns * 2);
+    expect(full?.deliveredAt).toBeNull();
+    expect((await rows()).elements.some(row => row.text.includes(world.first))).toBe(false);
+    await probe.eventually(() => probe.dom(`${surface} [data-thread-history-status]`), {
+      within: 5_000, label: "genuine earlier-history loading status is present", until: value => value.elements.length === 1,
+    });
+    await user.see({ role: "button", label: "Stop" });
+    evidence.recordAssertionEvidence("More than 1000 mixed tool/reasoning parts load for an active session", JSON.stringify(state), true);
+  });
+
+  await step("switching away from pending history never shows its status in the short session's initial load", async () => {
+    await user.click({ testId: `sidebar-session-${world.short.sessionId}` });
+    const shortSurface = `[data-session-surface-id="${world.short.sessionId}"]`;
+    await probe.eventually(read, {
+      within: 10_000, label: "short initial preview and uncapped read are both observed", until: state => {
+        const reads = state.reads.filter(item => item.sessionId === world.short.sessionId);
+        const opening = state.opens.find(item => item.sessionId === world.short.sessionId);
+        return reads.some(item => item.limit === 24 && item.deliveredAt !== null)
+          && reads.some(item => item.limit === null && item.deliveredAt !== null) && Boolean(opening && opening.samples >= 30);
+      },
+    });
+    await user.see({ text: world.shortText });
+    expect((await probe.dom(`${shortSurface} [data-thread-history-status]`)).elements).toHaveLength(0);
+    expect((await probe.dom(`${shortSurface} [data-message-role="user"]`)).elements).toHaveLength(1);
+    expect((await probe.dom(`${shortSurface} [data-message-id]`)).elements.some(row => row.text.includes(world.first))).toBe(false);
+    const state = await read();
+    const opening = state.opens.find(item => item.sessionId === world.short.sessionId);
+    if (!opening) throw new Error("Short opening was not observed");
+    expect(opening).toMatchObject({ trusted: true, initialRows: 0, statusSeen: false });
+    expect(opening.at).toBeGreaterThan(state.installedAt);
+    const shortReads = state.reads.filter(item => item.sessionId === world.short.sessionId);
+    expect(shortReads.every(item => item.startedAt >= opening.at)).toBe(true);
+    expect(state.reads.filter(item => item.sessionId === world.long.sessionId && item.limit === null).every(item => item.deliveredAt === null)).toBe(true);
+    expect(state.expired).toBe(false);
+    evidence.recordAssertionEvidence("Short session never renders history status during initial preview or full loading", JSON.stringify(state), true);
+  });
+
+  await user.click({ testId: `sidebar-session-${world.long.sessionId}` });
+  await probe.eventually(() => probe.dom(`${surface} [data-thread-history-status]`), {
+    within: 5_000, label: "returning to pending long history resumes loading", until: value => value.elements.length === 1,
+  });
+  await step("scrolling to the top clears the status within 10 seconds and renders the first user row", async () => {
+    await agent.run("session.scroll_top");
+    await world.release();
+    const complete = await probe.eventually(async () => {
+      const status = await probe.dom(`${surface} [data-thread-history-status], ${surface} [data-thread-loading], ${surface} [data-testid="session-error-card"]`);
+      const history = await rows();
+      const mounted = await probe.dom(`${surface} [data-thread-history-complete="true"]`);
+      return { status: status.elements.length, users: history.elements.length, first: history.elements[0]?.text, complete: mounted.elements.length };
+    }, { within: 10_000, label: "earliest user row without orphaned history status", until: value => value.status === 0 && value.complete === 1 && value.users === world.turns && Boolean(value.first?.includes(world.first)) });
+    await agent.run("session.scroll_top");
+    await probe.eventually(() => probe.dom(`${surface} [data-thread-scroll], ${surface} [data-message-role="user"]`), {
+      within: 5_000, label: "first user row is visible at the top", until: ({ elements }) => {
+        const [viewport, first] = elements;
+        return Boolean(viewport && first && first.text.includes(world.first) && first.rect.height > 0 && first.rect.top >= viewport.rect.top && first.rect.top < viewport.rect.bottom);
+      },
+    });
+    expect((await read()).opens[0]).toMatchObject({ trusted: true, statusSeen: true, initialRows: 0 });
+    evidence.recordAssertionEvidence("History status disappears within 10 seconds and the first user row renders", JSON.stringify({ complete, witness: await read() }), true);
+  });
+
+  await step("PageUp and Find do not resurrect history loading or lose earlier messages", async () => {
+    await user.press(place.kind === "local" && process.platform === "darwin" ? "Meta+f" : "Control+f");
+    await user.type({ placeholder: "Find in conversation" }, "Mixed history user 120", { replace: true });
+    await user.see({ text: /^Mixed history user 120$/ });
+    await user.click({ role: "button", label: "Close find" });
+    await user.click({ text: /^Mixed history user 120$/ });
+    const before = (await rows()).elements[119];
+    if (!before) throw new Error("Find did not retain user 120");
+    await user.press("PageUp");
+    const after = await probe.eventually(rows, { within: 5_000, label: "PageUp moves the reading position above its Find anchor", until: ({ elements }) => (elements[119]?.rect.top ?? 0) > before.rect.top + 16 });
+    expect(after.elements).toHaveLength(world.turns);
+    const status = (await probe.dom(`${surface} [data-thread-history-status]`)).elements.length;
+    expect(status).toBe(0);
+    evidence.recordAssertionEvidence("PageUp and Find retain earlier messages without reviving history status", JSON.stringify({ users: after.elements.length, before: before.rect.top, after: after.elements[119]?.rect.top, status }), true);
+  });
+});

--- a/evals/specs/session-history-loading-web.e2e.test.ts
+++ b/evals/specs/session-history-loading-web.e2e.test.ts
@@ -111,16 +111,52 @@ test("mixed active history clears its loading status and short history never ann
   await step("PageUp and Find do not resurrect history loading or lose earlier messages", async () => {
     await user.press(place.kind === "local" && process.platform === "darwin" ? "Meta+f" : "Control+f");
     await user.type({ placeholder: "Find in conversation" }, "Mixed history user 120", { replace: true });
-    await user.see({ text: /^Mixed history user 120$/ });
+    const reading = async () => {
+      const { elements } = await probe.dom(`${surface} [data-thread-scroll], ${surface} [data-message-role="user"]`);
+      const [viewport, ...users] = elements;
+      const row = users[119];
+      if (!viewport || !row) throw new Error("Find did not retain user 120");
+      return { text: row.text, offset: row.rect.top - viewport.rect.top, users: users.length,
+        visible: row.rect.width > 0 && row.rect.height > 0 && row.rect.top >= viewport.rect.top && row.rect.bottom <= viewport.rect.bottom };
+    };
+    let previous = Number.NaN;
+    let stable = 0;
+    const found = await probe.eventually(async () => {
+      const current = await reading();
+      stable = current.visible ? Math.abs(current.offset - previous) <= 1 ? stable + 1 : 1 : 0;
+      previous = current.offset;
+      return current;
+    }, { within: 5_000, intervalMs: 100, label: "Find passively reveals user 120 at a settled offset", until: current => current.visible && current.text.includes("Mixed history user 120") && stable >= 3 });
     await user.click({ role: "button", label: "Close find" });
+    let maxCloseDrift = 0;
+    stable = 0;
+    const closed = await probe.eventually(async () => {
+      const current = await reading();
+      expect(current.text).toBe(found.text);
+      maxCloseDrift = Math.max(maxCloseDrift, Math.abs(current.offset - found.offset));
+      stable = current.visible ? Math.abs(current.offset - previous) <= 1 ? stable + 1 : 1 : 0;
+      previous = current.offset;
+      return current;
+    }, { within: 5_000, intervalMs: 100, label: "Close Find retains the same visible message and offset", until: current => current.visible && stable >= 3 });
+    expect(maxCloseDrift).toBeLessThanOrEqual(2);
+    evidence.recordAssertionEvidence("Closing Find retains the exact visible user row within 2px", JSON.stringify({ found, closed, maxCloseDrift }), true);
     await user.click({ text: /^Mixed history user 120$/ });
-    const before = (await rows()).elements[119];
-    if (!before) throw new Error("Find did not retain user 120");
+    const before = await reading();
+    expect(before.text).toBe(found.text);
+    expect(Math.abs(before.offset - closed.offset)).toBeLessThanOrEqual(2);
     await user.press("PageUp");
-    const after = await probe.eventually(rows, { within: 5_000, label: "PageUp moves the reading position above its Find anchor", until: ({ elements }) => (elements[119]?.rect.top ?? 0) > before.rect.top + 16 });
-    expect(after.elements).toHaveLength(world.turns);
+    previous = Number.NaN;
+    stable = 0;
+    const after = await probe.eventually(async () => {
+      const current = await reading();
+      expect(current.text).toBe(found.text);
+      stable = current.offset > before.offset + 16 ? Math.abs(current.offset - previous) <= 1 ? stable + 1 : 1 : 0;
+      previous = current.offset;
+      return current;
+    }, { within: 5_000, intervalMs: 100, label: "PageUp moves above the Find anchor and settles for three polls within 1px", until: current => current.offset > before.offset + 16 && stable >= 3 });
+    expect(after.users).toBe(world.turns);
     const status = (await probe.dom(`${surface} [data-thread-history-status]`)).elements.length;
     expect(status).toBe(0);
-    evidence.recordAssertionEvidence("PageUp and Find retain earlier messages without reviving history status", JSON.stringify({ users: after.elements.length, before: before.rect.top, after: after.elements[119]?.rect.top, status }), true);
+    evidence.recordAssertionEvidence("PageUp and Find retain earlier messages without reviving history status", JSON.stringify({ before, after, stablePolls: stable, status }), true);
   });
 });

--- a/evals/worlds/session-history-loading.ts
+++ b/evals/worlds/session-history-loading.ts
@@ -1,0 +1,137 @@
+import { addInitScript, browserScript } from "@openwork/cdp";
+import { resolveEvalEngine, SkipError, type Seed } from "@openwork/env";
+
+export async function mixedHistoryWeb(seed: Seed) {
+  if (resolveEvalEngine() !== "v1") throw new SkipError("synthetic native v1 history (OPENWORK_EVAL_ENGINE=v1)");
+  const workspacePath = seed.tmpPath("mixed-history-loading");
+  const app = await seed.appWeb({ name: "mixed-history-loading", workspacePath });
+  const workspace = await seed.workspace(app, workspacePath);
+  const [long, short, landing] = await seed.sessions(app, ["Mixed active history", "Short history control", "History landing"]);
+  if (!long || !short || !landing) throw new Error("History fixture sessions were not created");
+  const first = "MIXED-HISTORY-FIRST-USER";
+  const last = "MIXED-HISTORY-LATEST-ANSWER";
+  const shortText = "SHORT-HISTORY-ONLY-USER";
+  const storageKey = "openwork.eval.mixed-history-observation";
+  const releaseKey = "openwork.eval.mixed-history-release";
+  const turns = 160;
+  const fixture = await addInitScript(app.client, browserScript((workspaceId, longId, shortId, first, last, shortText, turns, storageKey, releaseKey) => {
+    if (window.top !== window) return;
+    const port = localStorage.getItem("openwork.server.port");
+    if (!port) throw new Error("History fixture requires its isolated server");
+    const origin = `http://127.0.0.1:${port}`;
+    const mounts = ["workspace", "w"].map(mount => `/${mount}/${encodeURIComponent(workspaceId)}/opencode/session`);
+    const created = Date.now() - 1_000_000;
+    const makeMessages = (sessionID: string, count: number) => Array.from({ length: count }, (_, index) => {
+      const userId = `msg_history_${String(index * 2).padStart(6, "0")}`;
+      const assistantId = `msg_history_${String(index * 2 + 1).padStart(6, "0")}`;
+      const time = created + index * 1000;
+      const text = sessionID === shortId ? shortText : index === 0 ? first : `Mixed history user ${index + 1}`;
+      const user = {
+        info: { id: userId, sessionID, role: "user", time: { created: time }, agent: "build", model: { providerID: "fixture", modelID: "fixture" } },
+        parts: [{ id: `prt_${userId}`, sessionID, messageID: userId, type: "text", text }],
+      };
+      const mixed = sessionID === longId ? Array.from({ length: 4 }, (_, partIndex) => [
+        { id: `prt_${assistantId}_reason_${partIndex}`, sessionID, messageID: assistantId, type: "reasoning", text: `Review checkpoint ${index + 1}.${partIndex + 1}`, time: { start: time, end: time + 100 } },
+        { id: `prt_${assistantId}_tool_${partIndex}`, sessionID, messageID: assistantId, type: "tool", tool: "read", callID: `call_${index}_${partIndex}`,
+          state: { status: "completed", input: { filePath: "fixture.txt" }, output: `Safe fixture result ${index + 1}.${partIndex + 1}`, title: "Read fixture", metadata: {}, time: { start: time + 100, end: time + 200 } } },
+      ]).flat() : [];
+      const active = sessionID === longId && index === count - 1;
+      const assistant = {
+        info: { id: assistantId, sessionID, parentID: userId, role: "assistant", agent: "build", mode: "build", providerID: "fixture", modelID: "fixture",
+          path: { cwd: "/fixture", root: "/fixture" }, cost: 0, tokens: { input: 1, output: 1, reasoning: 1, cache: { read: 0, write: 0 } },
+          time: { created: time + 1, ...(active ? {} : { completed: time + 900 }) }, ...(active ? {} : { finish: "stop" }) },
+        parts: [...mixed, { id: `prt_${assistantId}_text`, sessionID, messageID: assistantId, type: "text", text: active ? last : `Checkpoint ${index + 1} recorded.` },
+          ...(active ? [{ id: `prt_${assistantId}_active`, sessionID, messageID: assistantId, type: "tool", tool: "read", callID: "call_active",
+            state: { status: "running", input: { filePath: "pending-fixture.txt" }, title: "Read pending fixture", metadata: {}, time: { start: time + 950 } } }] : [])],
+      };
+      return [user, assistant];
+    }).flat();
+    const longMessages = makeMessages(longId, turns);
+    const shortMessages = makeMessages(shortId, 1);
+    type HistoryRead = { sessionId: string; limit: number | null; startedAt: number; deliveredAt: number | null; messages: number; parts: number; reasoning: number; tools: number };
+    const opens: { sessionId: string; at: number; trusted: boolean; statusSeen: boolean; initialRows: number; samples: number }[] = [];
+    const reads: HistoryRead[] = [];
+    const state = {
+      installedAt: performance.now(), documentId: performance.timeOrigin, samples: 0, mutations: 0, opens, reads,
+      expired: false,
+    };
+    localStorage.removeItem(releaseKey);
+    const publish = () => localStorage.setItem(storageKey, JSON.stringify(state));
+    const sample = (records: MutationRecord[] = []) => {
+      state.samples += 1;
+      state.mutations += records.length;
+      const opening = state.opens.at(-1);
+      if (opening) {
+        opening.samples += 1;
+        const selector = `[data-session-surface-id="${opening.sessionId}"] [data-thread-history-status]`;
+        opening.statusSeen ||= Boolean(document.querySelector(selector)) || records.some(record => [...record.addedNodes].some(node => {
+          if (!(node instanceof Element)) return false;
+          const scoped = record.target instanceof Element && record.target.closest(`[data-session-surface-id="${opening.sessionId}"]`);
+          return node.matches(selector) || Boolean(node.querySelector(selector))
+            || Boolean(scoped && (node.matches("[data-thread-history-status]") || node.querySelector("[data-thread-history-status]")));
+        }));
+      }
+      publish();
+    };
+    const observer = new MutationObserver(sample);
+    observer.observe(document, { subtree: true, childList: true, attributes: true, attributeFilter: ["data-thread-history-status", "data-session-surface-id"] });
+    const capture = (event: MouseEvent) => {
+      const button = event.composedPath().find((node): node is HTMLElement => node instanceof HTMLElement
+        && [longId, shortId].some(id => node.getAttribute("data-testid") === `sidebar-session-${id}`));
+      if (!button) return;
+      const sessionId = button.getAttribute("data-testid")?.slice("sidebar-session-".length);
+      if (!sessionId) return;
+      state.opens.push({ sessionId, at: performance.now(), trusted: event.isTrusted, statusSeen: false,
+        initialRows: document.querySelectorAll(`[data-session-surface-id="${sessionId}"] [data-message-id]`).length, samples: 0 });
+      sample();
+    };
+    window.addEventListener("click", capture, true);
+    const timer = setInterval(sample, 20);
+    const originalFetch = window.fetch;
+    window.fetch = async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), location.href);
+      const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+      if (url.origin !== origin || method !== "GET") return originalFetch.call(window, input, init);
+      if (mounts.some(mount => url.pathname === `${mount}/status`)) {
+        return Response.json({ [longId]: { type: "busy" } });
+      }
+      const sessionId = [longId, shortId].find(id => mounts.some(mount => url.pathname === `${mount}/${encodeURIComponent(id)}/message`));
+      if (!sessionId) return originalFetch.call(window, input, init);
+      const all = sessionId === longId ? longMessages : shortMessages;
+      const limit = url.searchParams.has("limit") ? Number(url.searchParams.get("limit")) : null;
+      const messages = limit === null ? all : all.slice(-limit);
+      const partTypes = messages.flatMap(message => message.parts.map(part => part.type));
+      const read: HistoryRead = { sessionId, limit, startedAt: performance.now(), deliveredAt: null, messages: messages.length,
+        parts: partTypes.length, reasoning: partTypes.filter(type => type === "reasoning").length, tools: partTypes.filter(type => type === "tool").length };
+      state.reads.push(read);
+      publish();
+      const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+      if (sessionId === longId && limit === null) {
+        const deadline = performance.now() + 30_000;
+        while (localStorage.getItem(releaseKey) !== "released") {
+          signal?.throwIfAborted();
+          if (performance.now() > deadline) { state.expired = true; publish(); throw new Error("Mixed history gate expired"); }
+          await new Promise(resolve => setTimeout(resolve, 20));
+        }
+      } else {
+        await new Promise(resolve => setTimeout(resolve, limit === null ? 500 : 150));
+      }
+      signal?.throwIfAborted();
+      read.deliveredAt = performance.now();
+      publish();
+      return Response.json(messages);
+    };
+    window.addEventListener("pagehide", () => {
+      observer.disconnect();
+      clearInterval(timer);
+      window.removeEventListener("click", capture, true);
+      window.fetch = originalFetch;
+    }, { once: true });
+    publish();
+  }, [workspace.workspaceId, long.sessionId, short.sessionId, first, last, shortText, turns, storageKey, releaseKey]));
+  return {
+    app, workspace, long, short, landing, first, last, shortText, turns, storageKey,
+    release: () => seed.evalIn(app, browserScript(key => { localStorage.setItem(key, "released"); }, [releaseKey])),
+    async [Symbol.asyncDispose]() { await fixture.dispose(); },
+  };
+}


### PR DESCRIPTION
## Summary
- Give the earlier-history status its own React sibling key. Previously it shared Find's owner key and could remain mounted after a successful full read.
- Compare TanStack query hashes, not array references, when deciding whether an owner transition must cancel/refetch the same history query.
- Add independently mutation-killed production-surface coverage, large mixed-part active-history tests, and local Testkit browser proof with a short-session initial-load negative control and measured Find/PageUp navigation.

**Three production lines changed**, including the import. No server/pagination change. The speculative deadline checkpoint was explicitly withdrawn; it is absent from the final diff. No hunk of #4921 is undone.

Surface(s) touched: history-reading / Rows changed: H07,H28,H29,H30,H31,H32 / Blanks introduced: none

## RCA and attribution
A read-only live sample returned **1,467 messages / 4,615 parts / 15,321,981 bytes**, HTTP200 application/json, chunked, fully received in **84.50ms** (24/140-message reads:6.45/12.96ms). No stalled HTTP body in that sample. No live data is in fixtures/evidence.

In `session-surface.tsx:3347–3358`, status and Find had the same `sessionOwner` key. The production-component test reproduces a connected old loading node **after success/idle with all440 messages cached**. At :1307, reference equality also skipped recovery because :1167 reconstructs the logical query-key array when owner changes.

Merge-diff/blame attribution: duplicate key introduced by **#4855**, reference guard by **#4797**. **#4921 introduced neither**; its independent history/activity reads remain intact. No parent-vs-#4921 runtime bisect performed. These mechanisms are proved in the component; attribution to the precise reported live renderer remains inferred because no live owner-transition trace was captured.

## Recent PRs / overlap
| PR | Addresses this exact stall? |
|---|---|
| #4838 | Broad full-history availability; staging assertion only, no owner transition. |
| #4845 | No, settled-group rendering reuse. |
| #4846 | No, loading-time reading navigation/owner isolation. |
| #4855 | Loading presentation/Retry; introduced duplicate sibling key. Its completion assertion mounts a hook harness without Find, so it cannot establish production-sibling cleanup. |
| #4869 | No, engine-owned navigation/inventory; one-turn no-tool fixture misses active backfill. |
| #4921 | Different blocker: stored history must not wait on activity/todos/connectors. Its150-message held-ancillary assertion misses owner-key reconciliation; body already disclosed duplicate-key warnings. |
| #4742 | No, PageUp/focus settling. |
| #4780 | No, Find spacer/anchor retention. |

Searched open PRs with `gh pr list --state open --search "history OR earlier OR scroll" --limit100`; inspected #4930/#4601/#4599/#4843; no matching fix. User-supplied Slack audit of #bug at03:40EDT Sept12 found no previous matching report (phrase searches afterSept5, loading afterSept7, last40 messages backSept8). Ben's Sept11 v2 alignment, empty-composer flash, and implementation-detail rendering reports were different bugs (p1789167605599519/p1789168189846209/p1789175006483529). No Slack post.

## Matrix / exact proof boundaries
Historical H02 is filled only for150 messages, not an unlimited contract; not a lying cell within that boundary. H26 was partial with a retained-tail oracle; current source already corrects it to `world.history`, and this PR does not claim a new chosen-anchor cold run.

| Row | Assertion / boundary |
|---|---|
| H29 | Web mixed active1601part/320message fixture: `expect(full?.parts).toBeGreaterThan(1000)`; bounded completion predicate status0,complete1,160user rows,first sentinel; first row visibly at top. Unit stress additionally1467messages/4615parts/>15MB. |
| H30 | Actual surface owner transition: query `{status:"success",fetchStatus:"idle",error:null}`, windows `[24,undefined,24,undefined]`,440cached messages,zero status nodes,`expect(previousStatus?.isConnected).toBe(false)`. **Restoring duplicate key alone fails zero-node assertion; restoring ref guard alone times out.** Happy DOM/native-operation injection, not full engine-switch E2E. |
| H31 | Failure/Retry helper: error/idle,alert instead of spinner,explicit click issues third read,440messages/status absent; preview/draft retained. |
| H32 | Short browser initial load: observer installed before trusted opening; `statusSeen:false`,initialRows0,>=30samples,both preview/full delivered,other long read still pending. |
| H07/H28 | PageUp moves565px and settles3polls within1px; Find close preserves exact requested visible text and offset within2px (observed0px drift), without user.see scrolling before measurement. |

**Negative space:** short/no status = H32 browser pass; failed+Retry reissue = H31 helper pass; engine switch mid-load = H30 component pass/mutation-killed; PageUp settle = H07 browser pass; Find anchor = H28 bounded browser pass. Remaining P0 extensions explicitly unfilled: native same-query engine switch, browser owner-switch-during-Retry, H14 late-backfill focus, H18/H19 short/sticky Find, H20 stale Find, H04 stale anchor,H22 cache expiry. Their required oracle is new read/old-node disconnection plus exact requested message/offset retained, not spinner absence alone.

## Verification — final head f33761b88e10e7420b1fead2c16d201d933497e0
Local lane explicitly allowed by requester. pnpm11.4/bun1.4/node24.20.
- `pnpm --config.verify-deps-before-run=never exec bun test --isolate ./tests/session-history.test.tsx ./tests/session-snapshot-owner-flip.test.tsx ./tests/progressive-message-list.test.tsx ./tests/session-render-state.test.ts ./tests/opencode-session-native.test.ts ./tests/session-scroll.test.tsx ./tests/find-bar.test.tsx` (apps/app): exit0,**216passed/0failed/0skipped**,7770assertions.
- `pnpm --config.verify-deps-before-run=never typecheck` (apps/app): exit0. Server untouched.
- `pnpm evals:e2e session-history-loading-web --local --engine v1 --surface web`: exit0,**1passed/0failed/0skipped**.
- `pnpm evals:e2e session-full-history-on-open --local --engine v1`: exit0,**2passed/0failed/0skipped**; two original cold-case visual judgments pending publication.
- `git diff --check`: exit0.

Global eval typecheck fails TS2345 at unchanged session-attention-rollup.test.ts:27; exact clean-origin/dev control e1cf5e74f reproduces it. Browser lint reports4inference-gateway diagnostics and layer lint52violations; clean control matches counts/categories, not independently verified full-set equivalence. No unrelated fixes bundled. Initial dependency failures and a repaired branch-action hover timeout are not passed evidence.

**Publication verdict: Incomplete until head-bound evidence is attached and pending judgments resolved.** Draft only for that reason; no `.github/` or `warden.toml` changes. Merge requires required-test gate, diff-warden approval, no failed checks/unresolved threads, and head-bound evidence.
