### PR TITLE
fix(composer): restore IME input after adding attachment chips

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -990,13 +990,23 @@ function SyncPlugin(props: {
       setPrompt(props.value, props.mentions, props.pastedText, props.attachments);
       // $getRoot().selectEnd() doesn't work when the last node is a
       // token (chip) — Lexical can't position a cursor inside a token,
-      // so the selection collapses to position 0. Use element-level
-      // selection instead: place the cursor *after* the last child of
-      // the last paragraph.
+      // so the selection collapses to position 0. However, a bare
+      // element-level selection after a non-editable token breaks IME
+      // composition (e.g. Chinese/Japanese). Append a trailing space
+      // text node and place the cursor in it to ensure a valid TextNode exists.
       const lastParagraph = $getRoot().getLastChild();
       if ($isElementNode(lastParagraph)) {
-        const childCount = lastParagraph.getChildrenSize();
-        lastParagraph.select(childCount, childCount);
+        const lastChild = lastParagraph.getLastChild();
+        if (isComposerInlineTokenNode(lastChild)) {
+          const spaceNode = $createTextNode(" ");
+          lastParagraph.append(spaceNode);
+          spaceNode.select(1, 1);
+        } else if ($isTextNode(lastChild)) {
+          lastChild.select();
+        } else {
+          const childCount = lastParagraph.getChildrenSize();
+          lastParagraph.select(childCount, childCount);
+        }
       } else {
         $getRoot().selectEnd();
       }


### PR DESCRIPTION
## Summary
- Fixes Chinese (and other CJK) IME input failure in the composer after adding an attachment or inline token chip.
- Appends a trailing whitespace `TextNode(" ")` and places the selection inside it when the paragraph ends with an inline token node, replacing the bare element-level selection.

## Why
- When an attachment chip (`ComposerAttachmentNode`) is appended as the last child of the paragraph, `SyncPlugin` previously fell back to an element-level selection via `lastParagraph.select(childCount, childCount)`.
- Because token chips have `contenteditable="false"` and `canInsertTextAfter(): false`, an element-level selection leaves the cursor directly against an uneditable element with no trailing text node.
- Chromium's IME subsystem requires an editable `TextNode` anchor to start composition; without it, `compositionstart` fails to trigger, completely breaking Chinese/CJK input until the editor is blurred and refocused.

## Issue
- Closes #4932

## Scope
- `apps/app/src/react-app/domains/session/surface/composer/editor.tsx` (`SyncPlugin` selection normalization logic).

## Out of scope
- Any changes to token rendering, keyboard navigation plugins, or file upload handlers.

## Testing
### Ran
- `pnpm typecheck`

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: expected to pass
- code-related failures: none
- external/env/auth blockers: none

## Manual verification
1. Open the composer in a session with an empty draft.
2. Click the attachment button and select an image file via the system file picker.
3. Once the attachment chip appears, immediately type Chinese using an IME (e.g. Pinyin `nihao`).
4. Verified that the IME candidate popup opens normally and Chinese characters commit as expected.
5. Verified that English typing, slash commands, and skills continue to behave normally.

## Evidence
- Verified locally. IME candidate window pops up immediately upon typing after file selection. (Attach screenshot/GIF here if you have one, otherwise write `Verified locally`)

## Risk
- Low. Only affects the fallback selection behavior when the last node in the composer paragraph is an inline token.

## Rollback
- Revert this commit via `git revert <commit-hash>`.