### PR TITLE
ci: fail pull requests that add a real-looking secret (Betterleaks, diff-scoped)

### DIFF
--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -1,0 +1,44 @@
+title = "OpenWork diff-scoped secret policy"
+betterleaksMinVersion = "v1.8.1"
+
+# Betterleaks 1.8.1 uses Expr; true means skip. Keep the unresolved report
+# outside all path exemptions. Its security disposition is a separate review.
+prefilter = '''
+attributes["path"] != "evals/results/first-connection-windows-20260721/report.md" &&
+matchesAny(attributes["path"], [
+  // Unit/integration fixtures in test directories.
+  `(?:^|/)test/`,
+  // Unit/integration fixtures in tests directories.
+  `(?:^|/)tests/`,
+  // Static synthetic test data.
+  `(?:^|/)testdata/`,
+  // Colocated test modules.
+  `(?:^|/)[^/]*\.test\.[^/]*$`,
+  // Colocated end-to-end modules.
+  `(?:^|/)[^/]*\.e2e\.[^/]*$`,
+  // Evaluation fixtures and harnesses (unresolved report excepted above).
+  `^evals/`,
+  // Example configuration, including **/.env.example.
+  `(?:^|/)[^/]*\.example$`,
+  // Local Compose defaults, not production credentials.
+  `(?:^|/)docker-compose[^/]*\.yml$`,
+  // Helm example values.
+  `^packaging/(?:.*/)?values[^/]*\.yaml$`,
+  // Packaging instructions, including packaging/docker/README.md.
+  `^packaging/(?:.*/)?README\.md$`,
+  // Synthetic database credentials used to build the sandbox image.
+  `^scripts/build-microsandbox-openwork-image\.sh$`,
+  // Retain the default JavaScript lockfile exclusion.
+  `(?:^|/)(?:deno\.lock|npm-shrinkwrap\.json|package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$`
+])
+'''
+
+# Exact instructional literals, never substring matches against issued tokens.
+# The URI exception is restricted to the postgres:postgres tuple on loopback.
+filter = '''
+matchesAny(finding["secret"], [`^(?:changeme|example|YOUR_TOKEN|YOUR_API_KEY|YOUR_PASSWORD)$`]) ||
+matchesAny(finding["match"], [`^postgres(?:ql)?://postgres:postgres@(?:localhost|127\.0\.0\.1)(?::[0-9]+)?(?:[/\s'"\x60]|$)`])
+'''
+
+[extend]
+useDefault = true

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -51,11 +51,13 @@ jobs:
             [[ "$sha" =~ ^[0-9a-f]{40}$ && "$sha" != 0000000000000000000000000000000000000000 ]]
             git cat-file -e "$sha^{commit}"
           done
-          # Never load policy from the PR head. Missing initial policy means no exclusions.
+          # Established policy always comes from the base. Only the initial
+          # installation bootstraps from the head; Ben reviews that policy here.
           if git cat-file -e "$BASE_SHA:.betterleaks.toml" 2>/dev/null; then
             git show "$BASE_SHA:.betterleaks.toml" > "$RUNNER_TEMP/secret-scan.toml"
           else
-            printf '[extend]\nuseDefault = true\n' > "$RUNNER_TEMP/secret-scan.toml"
+            printf '%s\n' '::notice::Bootstrapping initial policy; maintainer review required.'
+            git show "$HEAD_SHA:.betterleaks.toml" > "$RUNNER_TEMP/secret-scan.toml"
           fi
           # A fresh bare clone has no PR-controlled worktree config or ignore files.
           # Run from RUNNER_TEMP too: no ignore file is read from the checkout.

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -52,18 +52,13 @@ jobs:
             git cat-file -e "$sha^{commit}"
           done
           # Never load policy from the PR head. Missing initial policy means no exclusions.
-          if git cat-file -e "$BASE_SHA:.gitleaks.toml" 2>/dev/null; then
-            git show "$BASE_SHA:.gitleaks.toml" > "$RUNNER_TEMP/secret-scan.toml"
+          if git cat-file -e "$BASE_SHA:.betterleaks.toml" 2>/dev/null; then
+            git show "$BASE_SHA:.betterleaks.toml" > "$RUNNER_TEMP/secret-scan.toml"
           else
             printf '[extend]\nuseDefault = true\n' > "$RUNNER_TEMP/secret-scan.toml"
           fi
-          if git cat-file -e "$BASE_SHA:.betterleaksignore" 2>/dev/null; then
-            git show "$BASE_SHA:.betterleaksignore" > "$RUNNER_TEMP/accepted-fingerprints"
-          else
-            : > "$RUNNER_TEMP/accepted-fingerprints"
-          fi
-          # An explicit -i does NOT disable source-directory ignore discovery.
           # A fresh bare clone has no PR-controlled worktree config or ignore files.
+          # Run from RUNNER_TEMP too: no ignore file is read from the checkout.
           git clone --quiet --bare --no-local . "$RUNNER_TEMP/secret-scan.git"
 
       - name: Scan only the introduced commits
@@ -76,13 +71,13 @@ jobs:
           scan_exit=0
           ./betterleaks git "$RUNNER_TEMP/secret-scan.git" \
             --config="$RUNNER_TEMP/secret-scan.toml" \
-            --gitleaks-ignore-path="$RUNNER_TEMP/accepted-fingerprints" \
             --ignore-gitleaks-allow --validation=false --git-workers=0 \
             --log-opts="$BASE_SHA..$HEAD_SHA" \
-            --redact=100 --log-level=info --no-color --exit-code=2 \
+            --redact=100 --log-level=info --no-color --exit-code=1 \
             --report-format=sarif --report-path=secret-scan.raw.sarif || scan_exit=$?
-          # Scan errors fail closed; do not publish a partial report as a complete scan.
-          if [[ "$scan_exit" != 0 && "$scan_exit" != 2 ]]; then
+          # Findings and some scanner errors both return 1; missing/invalid SARIF
+          # also fails closed below. Uploading results never clears a scan failure.
+          if [[ "$scan_exit" != 0 && "$scan_exit" != 1 ]]; then
             exit "$scan_exit"
           fi
           python3 - <<'PY'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -59,7 +59,11 @@ jobs:
           fi
           # A fresh bare clone has no PR-controlled worktree config or ignore files.
           # Run from RUNNER_TEMP too: no ignore file is read from the checkout.
-          git clone --quiet --bare --no-local . "$RUNNER_TEMP/secret-scan.git"
+          # Copy all fetched objects, including a base reachable only via a remote
+          # ref when checkout detached HEAD. Transport cloning can omit that base.
+          git clone --quiet --bare --no-hardlinks . "$RUNNER_TEMP/secret-scan.git"
+          git -C "$RUNNER_TEMP/secret-scan.git" cat-file -e "$BASE_SHA^{commit}"
+          git -C "$RUNNER_TEMP/secret-scan.git" cat-file -e "$HEAD_SHA^{commit}"
 
       - name: Scan only the introduced commits
         id: scan

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,113 @@
+name: Secret scan
+
+on:
+  pull_request:
+    # Recheck when edited, including a change to the target branch.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Newly introduced secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    env:
+      BETTERLEAKS_VERSION: 1.8.1
+      BETTERLEAKS_SHA256: efa407244e1ea8e35f582b8a42becdeac08bdead04f68eb752adda722d583c2a
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install checksum-pinned Betterleaks
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/betterleaks.tar.gz"
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            "https://github.com/betterleaks/betterleaks/releases/download/v${BETTERLEAKS_VERSION}/betterleaks_${BETTERLEAKS_VERSION}_linux_x64.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$BETTERLEAKS_SHA256" "$archive" | sha256sum --check --strict
+          tar -xzf "$archive" -C "$RUNNER_TEMP" betterleaks
+          "$RUNNER_TEMP/betterleaks" version
+
+      - name: Prepare trusted policy and isolated Git history
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          for sha in "$BASE_SHA" "$HEAD_SHA"; do
+            [[ "$sha" =~ ^[0-9a-f]{40}$ && "$sha" != 0000000000000000000000000000000000000000 ]]
+            git cat-file -e "$sha^{commit}"
+          done
+          # Never load policy from the PR head. Missing initial policy means no exclusions.
+          if git cat-file -e "$BASE_SHA:.gitleaks.toml" 2>/dev/null; then
+            git show "$BASE_SHA:.gitleaks.toml" > "$RUNNER_TEMP/secret-scan.toml"
+          else
+            printf '[extend]\nuseDefault = true\n' > "$RUNNER_TEMP/secret-scan.toml"
+          fi
+          if git cat-file -e "$BASE_SHA:.betterleaksignore" 2>/dev/null; then
+            git show "$BASE_SHA:.betterleaksignore" > "$RUNNER_TEMP/accepted-fingerprints"
+          else
+            : > "$RUNNER_TEMP/accepted-fingerprints"
+          fi
+          # An explicit -i does NOT disable source-directory ignore discovery.
+          # A fresh bare clone has no PR-controlled worktree config or ignore files.
+          git clone --quiet --bare --no-local . "$RUNNER_TEMP/secret-scan.git"
+
+      - name: Scan only the introduced commits
+        id: scan
+        shell: bash
+        working-directory: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          umask 077
+          scan_exit=0
+          ./betterleaks git "$RUNNER_TEMP/secret-scan.git" \
+            --config="$RUNNER_TEMP/secret-scan.toml" \
+            --gitleaks-ignore-path="$RUNNER_TEMP/accepted-fingerprints" \
+            --ignore-gitleaks-allow --validation=false --git-workers=0 \
+            --log-opts="$BASE_SHA..$HEAD_SHA" \
+            --redact=100 --log-level=info --no-color --exit-code=2 \
+            --report-format=sarif --report-path=secret-scan.raw.sarif || scan_exit=$?
+          # Scan errors fail closed; do not publish a partial report as a complete scan.
+          if [[ "$scan_exit" != 0 && "$scan_exit" != 2 ]]; then
+            exit "$scan_exit"
+          fi
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("secret-scan.raw.sarif").read_text())
+          for run in report["runs"]:
+              for result in run["results"]:
+                  # --redact does not redact commit messages or other context secrets.
+                  result.pop("partialFingerprints", None)
+                  result.pop("properties", None)
+                  result["message"] = {"text": "Potential secret detected (redacted)."}
+                  for location in result["locations"]:
+                      physical = location["physicalLocation"]
+                      physical.pop("contextRegion", None)
+                      physical["region"]["snippet"] = {"text": "REDACTED"}
+          Path("secret-scan.sarif").write_text(json.dumps(report))
+          PY
+          printf 'sarif=true\n' >> "$GITHUB_OUTPUT"
+          exit "$scan_exit"
+
+      - name: Upload redacted results to code scanning
+        if: ${{ !cancelled() && steps.scan.outputs.sarif == 'true' }}
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4
+        with:
+          sarif_file: ${{ runner.temp }}/secret-scan.sarif
+          category: betterleaks

--- a/docs/security/secret-scanning.md
+++ b/docs/security/secret-scanning.md
@@ -1,165 +1,130 @@
 # Secret scanning
 
-## Scope and rollout
+## What runs
 
-`.github/workflows/secret-scan.yml` runs the MIT-licensed
-[Betterleaks CLI 1.8.1](https://github.com/betterleaks/betterleaks/releases/tag/v1.8.1).
-The release version and Linux x64 archive SHA-256 are pinned in the workflow;
-the checksum is verified before extraction. Actions are pinned to commit SHAs.
-No scanner license key, package-manager installation, or provider credential is
-required. The Gitleaks Action is not used: its organization license can be free,
-but its proprietary EULA is distinct from the MIT scanner's license.
+`.github/workflows/secret-scan.yml` runs checksum-pinned, MIT-licensed
+[Betterleaks 1.8.1](https://github.com/betterleaks/betterleaks/releases/tag/v1.8.1)
+on pull requests (opened, synchronize, reopened, ready_for_review, edited) and
+pushes to `dev`. Actions are SHA-pinned. No license key is required.
 
-This preparation does **not** establish a reviewed history baseline. Do not
-publish an ignore file or claim rollout complete until security review accepts
-its individual entries and both enforcement proof runs are complete.
+The gate scans ordinary Git commit patches in `base..head` for PRs and
+`before..sha` for pushes, including intermediate commits. A secret added then
+removed within that range still fails. Commits already reachable from the base
+are not scanned. Missing or invalid SHAs fail closed. Exit 0 means no findings;
+exit 1 means findings or an error, and every nonzero exit fails CI.
 
-The job runs on PR opened/synchronize/reopened/ready_for_review/edited events
-(including retargeting a PR) and pushes to `dev`. It scans Git patches in the
-exclusive `base..head` range: the PR base
-and head SHAs, or the push's before and after SHAs. This includes intermediate
-commits, not only the final working tree; adding then removing a secret in the
-same PR still fails. Commits already reachable from the base are not rescanned.
-Missing/invalid commit objects fail closed rather than silently skipping a scan.
+The job uses `--redact=100`, disables live credential validation, and uploads
+sanitized SARIF to GitHub's Security tab, including when findings fail the job.
+Sanitization removes commit metadata, finding properties, match context and
+fingerprints, and replaces messages/snippets with fixed redacted text. Raw
+reports are not uploaded as artifacts. Permissions are `contents: read` and
+`security-events: write`; no repository secrets or PR comments are needed.
+This workflow does not configure required branch checks or push protection.
 
-This is a commit-patch check, not exhaustive secret-novelty analysis. Standard
-Git log patches do not include merge-resolution-only changes. We deliberately
-do not expand merges against each parent: doing so can report old base content
-as new. Separate merge-resolution coverage needs a validated parser strategy;
-this initial job does not claim it. Reintroduced content in a new ordinary
-commit can also be detected again.
+## Policy and review
 
-Exit status 0 means clean, 2 means findings, and other nonzero statuses mean a
-scanner/setup error; all nonzero statuses fail CI. The repository has active
-CodeQL code-scanning analyses, so sanitized SARIF is uploaded to the Security
-tab even when findings fail the scan. The job requests only `contents: read`
-and `security-events: write`; it never uses `pull_request_target`, PR comments,
-or repository secrets. The scanner check does not itself configure required
-branch-protection checks.
+CI loads `.betterleaks.toml` from the **base commit**, not the PR head. Until the
+policy first lands, CI uses embedded defaults without repository exemptions.
+Policy changes require review and take effect after merging into the base.
+A bare clone and a temporary working directory prevent PR-controlled config or
+ignore-file discovery. Inline allow comments are ignored. No repository code,
+hooks or dependencies are executed. Workflow edits remain subject to ordinary
+GitHub Actions PR semantics and require Ben's review; trusted policy is not a
+replacement for protecting workflow changes.
 
-## Trusted policy and accepted fingerprints
+The config extends the default rules without disabling `generic-password` or
+`generic-credential-uri`. Its global `prefilter` and `filter` use Betterleaks
+1.8.1's **Expr** syntax (not CEL); `true` means discard. These global expressions
+replace the corresponding default expressions; the JavaScript lockfile exclusion
+is retained explicitly, and default per-rule filters remain enabled.
 
-The policy names are `.gitleaks.toml` (Betterleaks-compatible TOML) and
-`.betterleaksignore`. CI reads both from the **base commit**, never the PR head.
-Before policy is first introduced, it uses embedded default rules with no
-fingerprint exclusions. An existing malformed policy fails rather than falling
-back. Policy updates take effect only after they land in the trusted base.
+Reviewed path classes are annotated individually in the config:
 
-The default extension syntax is:
+- `**/test/**`, `**/tests/**`, `**/testdata/**`, `**/*.test.*`, `**/*.e2e.*`:
+  synthetic test data and test modules.
+- `evals/**`: evaluation harnesses/fixtures, **except the unresolved report**.
+- `**/*.example` (including `**/.env.example`): instructional configuration.
+- `**/docker-compose*.yml`, `packaging/**/values*.yaml`: local deployment defaults.
+- `packaging/**/README.md` (including `packaging/docker/README.md`): deployment
+  instructions.
+- `scripts/build-microsandbox-openwork-image.sh`: sandbox-image build defaults.
 
-```toml
-[extend]
-useDefault = true
-```
+Path exclusions are deliberately broad and can hide actual secrets in those
+classes; never put live credentials in fixtures. The historical July token is
+outside this PR's commit range, remains untouched and explicitly not path-exempt,
+and its disposition belongs to Ben on Monday.
 
-Betterleaks' preferred ignore filename is `.betterleaksignore`; it also supports
-`.gitleaksignore`. The explicit flag is still `--gitleaks-ignore-path=PATH` (`-i`).
-CI supplies a base-derived file under the runner's temporary directory. A bare
-clone is the scan target because an explicit `-i` does **not** prevent automatic
-loading of the target directory's own ignore file. The PR's TOML, Expr filters,
-ignore files and inline allow comments cannot weaken this job's scanner policy.
-No repository scripts, dependencies or hooks are executed. The workflow itself
-remains PR-editable under ordinary GitHub Actions semantics: trusted scanner
-policy is not a substitute for protected workflow changes and maintainer review.
-Changes under `.github/` require Ben's review.
+The literal filter accepts only `changeme`, `example`, `YOUR_TOKEN`,
+`YOUR_API_KEY`, `YOUR_PASSWORD`, and the `postgres:postgres` URI tuple on
+`localhost`/`127.0.0.1`. It does not accept strings merely containing those words.
+To propose an exception, add a narrowly anchored path class or exact literal
+with a one-line rationale, request review, and rerun the positive and negative
+controls below. Never add an issued credential to the filter. There is no ignore
+file, fingerprint list or baseline.
 
-After individual security review, record one emitted, commit-qualified
-fingerprint per line in `.betterleaksignore`:
+## Reading a failure
 
-```text
-<full-commit-sha>:<repository-relative-file>:<rule-id>:<start-line>
-```
+1. Check the job status and Security findings for file, line and rule. An error
+   or missing SARIF is not a clean scan.
+2. If potentially real, report only location/rule privately using
+   [SECURITY.md](../../SECURITY.md). Do not paste values into PRs, issues or logs.
+3. Have the owner revoke/rotate the credential, update consumers through their
+   secret store, and check issuer audit logs. Do not probe it for validity.
+4. Remove exposures in a separately reviewed change. Deleting current content
+   does not remove history, forks or caches. Do not rewrite history in this PR.
+5. If synthetic, prefer nonmatching placeholders or a reviewed policy change;
+   do not silence a whole rule to get a green run.
 
-Use the actual fingerprint, not a secret hash or value. Deduplicate identical
-fingerprints: multiple findings on one line can share one fingerprint. Include
-the commit; do not use the broader commit-independent `file:rule:line` form.
-Blank lines and whole-line `#` comments are supported; trailing inline comments
-are not. LF and CRLF are accepted. Document each accepted entry's fixture/false-
-positive rationale without copying credentials, private metadata or scan logs.
-Never generate the accepted file automatically from every finding.
+The private pre-existing 619-row inventory is not an accepted baseline: 455 rows
+match the reviewed path classes, while 164 remain unexempted before literal
+filtering (52 URI, 102 password, 7 PostHog project-key, 3 generic-key findings).
+These are **to triage**, not a declaration that they are live or all false
+positives. Redacted historical rows alone do not establish exact literal values.
 
-## Synthetic fixtures
+## Local reproduction
 
-Prefer unmistakable noncredential placeholders. Betterleaks' default
-`generic-api-key` Expr filter includes token-efficiency checks; ordinary words
-may be rejected automatically. That reduces some generic false positives but
-does not classify all findings: the scanner also has URI/password rules.
+Use the pinned CLI in ignored `tmp/`, verifying the release archive checksum.
+The macOS arm64 archive SHA-256 is
+`8e80f33b5f2a7426b390347b9fd466033723cb94b6bdffa7572632e2eaec964e`;
+the Linux x64 checksum is pinned in the workflow. Keep raw reports owner-only:
+redaction covers detected values, not every possible secret in surrounding text.
 
-For local scans, a `gitleaks:allow` or `betterleaks:allow` comment on the matching
-line suppresses that line. **CI passes `--ignore-gitleaks-allow`**, so an inline
-comment alone cannot make a PR pass. For CI fixtures, request a narrow,
-reviewed `.gitleaks.toml` exception in the trusted base first, or use a clearly
-nonmatching synthetic value. Prefer exact anchored secret regexes/stopwords,
-ideally scoped to the relevant rule, over a whole-file exception when a file
-mixes fixtures and production code. Never exclude an entire tests tree.
-Retain default lockfile handling rather than duplicating broad exclusions.
-
-`reports/` is Git-excluded; untracked local reports are not Git-history inputs.
-Git ignore rules do not remove files already committed. A tracked report must
-be reviewed like any other tracked file, not treated as automatically safe.
-
-## Investigating a finding and rotating credentials
-
-1. Stop publication if a finding might be a real credential. Report only the
-   file, line, rule and commit through the private channel in
-   [SECURITY.md](../../SECURITY.md); do not copy the value into an issue or PR.
-2. Have the credential owner revoke/rotate it at the issuer, update consumers
-   through their secret store, and check access/audit logs. Do not validate a
-   discovered credential against a provider without explicit authorization.
-3. Remove the exposed value from current code or reports in a separately
-   reviewed change. Deletion does **not** remove the credential from Git
-   history, caches, forks or published artifacts. Do not rewrite shared history
-   as part of this CI change.
-4. Do not add real credentials to the ignore file. A deletion that already
-   landed in the base avoids those old commits in subsequent range scans, but
-   a full-history scan will still report them. Do not claim that history is
-   clean or accept a real finding merely to obtain a green baseline run.
-5. For an actual fixture/false positive, review the exact fingerprint and
-   rationale, update the accepted file, and rerun the same range and synthetic
-   positive-control proofs. Re-review findings when upgrading scanner versions;
-   rule/filter changes can change the finding set and fingerprints.
-
-## Local inspection and proof
-
-Use the workflow's pinned release binary in an ignored temporary directory and
-verify the platform-specific SHA-256 from the pinned release. The macOS arm64
-1.8.1 archive SHA-256 is
-`8e80f33b5f2a7426b390347b9fd466033723cb94b6bdffa7572632e2eaec964e`.
-Never use a floating `latest` binary to reproduce CI.
-
-The CI scan command, after preparing the base-derived policy and bare clone, is:
+After preparing a bare clone and copying the reviewed policy to a private
+temporary directory, run from that directory:
 
 ```sh
 betterleaks git "$HISTORY_REPO" \
   --config="$TRUSTED_CONFIG" \
-  --gitleaks-ignore-path="$TRUSTED_IGNORE" \
   --ignore-gitleaks-allow --validation=false --git-workers=0 \
   --log-opts="$BASE_SHA..$HEAD_SHA" \
-  --redact=100 --log-level=info --no-color --exit-code=2 \
-  --report-format=sarif --report-path="$PRIVATE_REPORT"
+  --redact=100 --log-level=info --no-color --exit-code=1 \
+  --report-format=sarif --report-path=secret-scan.raw.sarif
 ```
 
-Full-history triage instead uses `--log-opts='--full-history HEAD'` and a private
-redacted JSON report, in a detached worktree. It is a separate review, not the
-PR gate. There is no tracked JSON baseline. Keep raw reports in ignored,
-owner-only storage: `--redact=100` redacts detected secrets, **not all metadata**.
-Never use debug/trace logs or live validation. The workflow strips commit
-metadata, finding properties and match context, and forces redacted snippets
-before uploading SARIF; paths and rule identifiers necessarily remain visible.
-It does not upload the raw report as an Actions artifact.
+Required proofs use the pinned **local binary**, not a hosted service:
 
-Before rollout, use a disposable, signed synthetic-secret commit in a
-non-allowlisted file. Run the exact CI range command and assert exit 2 plus the
-expected finding, remove the disposable commit without rewriting a published
-branch, and assert exit 0 for the intended clean range with accepted policy.
-Capture commands, exit codes and redacted finding counts, not secret values.
-Test scanner errors separately so a missing report cannot become a successful
-scan. Full-history findings are never evidence of a passing clean-range proof.
+1. A disposable signed commit containing a synthetic AWS key pair and GitHub PAT
+   in a nonexempt path: exit 1, both rule IDs, redacted; then reset that unpublished
+   commit. AWS's literal `EXAMPLE` suffix is ignored by default, so use an
+   unissued synthetic ID of the same shape and its required paired secret.
+2. The same command on `origin/dev~5..origin/dev`: exit 0.
+3. A synthetic credential URI under `tests/`: exit 0; identical nonexempt content
+   must still be detected.
+4. `tmp/betterleaks config check --config .betterleaks.toml`: exit 0.
 
-## Runtime redaction is separate
+`pnpm evals:pr specs/ci-secret-scan.test.ts` automates these controls using
+isolated repositories; set `BETTERLEAKS_BIN` if the verified binary is elsewhere.
 
-CI detects committed material; runtime redaction protects user data in logs,
-diagnostics and tool results before publication. The in-flight
-[`feat/shared-secret-redaction`](https://github.com/different-ai/openwork/tree/feat/shared-secret-redaction)
-work adds `packages/secret-redaction`. Neither runtime redaction nor this
-heuristic CI scanner replaces credential rotation or review of exported data.
+## Boundaries and follow-ups
+
+This is not a full-history scan, a live-secret validity check, or exhaustive
+secret detection. Plain Git log patches miss merge-resolution-only changes.
+No scheduled job is added. Follow-ups, **not implemented here**:
+
+- Weekly full-history **reporting** scan.
+- Ben: disposition of the July report (also tracked as the 2026-07-22 report)
+  and archived sandbox; this PR does not modify either.
+- Guillaume: GitHub push-protection toggle.
+- Runtime redaction: `packages/secret-redaction` on sibling branch
+  [`feat/shared-secret-redaction`](https://github.com/different-ai/openwork/tree/feat/shared-secret-redaction).
+  Runtime output protection and committed-secret scanning serve different roles.

--- a/docs/security/secret-scanning.md
+++ b/docs/security/secret-scanning.md
@@ -23,9 +23,11 @@ This workflow does not configure required branch checks or push protection.
 
 ## Policy and review
 
-CI loads `.betterleaks.toml` from the **base commit**, not the PR head. Until the
-policy first lands, CI uses embedded defaults without repository exemptions.
-Policy changes require review and take effect after merging into the base.
+CI loads an established `.betterleaks.toml` from the **base commit**, not the PR
+head. Only the initial installation, when the base has no policy, bootstraps
+from the head and emits a maintainer-review notice. Ben must review that initial
+policy with this workflow. Later policy changes require review and take effect
+after merging into the base. Missing or malformed bootstrap policy fails closed.
 A bare clone and a temporary working directory prevent PR-controlled config or
 ignore-file discovery. Inline allow comments are ignored. No repository code,
 hooks or dependencies are executed. Workflow edits remain subject to ordinary

--- a/docs/security/secret-scanning.md
+++ b/docs/security/secret-scanning.md
@@ -1,0 +1,165 @@
+# Secret scanning
+
+## Scope and rollout
+
+`.github/workflows/secret-scan.yml` runs the MIT-licensed
+[Betterleaks CLI 1.8.1](https://github.com/betterleaks/betterleaks/releases/tag/v1.8.1).
+The release version and Linux x64 archive SHA-256 are pinned in the workflow;
+the checksum is verified before extraction. Actions are pinned to commit SHAs.
+No scanner license key, package-manager installation, or provider credential is
+required. The Gitleaks Action is not used: its organization license can be free,
+but its proprietary EULA is distinct from the MIT scanner's license.
+
+This preparation does **not** establish a reviewed history baseline. Do not
+publish an ignore file or claim rollout complete until security review accepts
+its individual entries and both enforcement proof runs are complete.
+
+The job runs on PR opened/synchronize/reopened/ready_for_review/edited events
+(including retargeting a PR) and pushes to `dev`. It scans Git patches in the
+exclusive `base..head` range: the PR base
+and head SHAs, or the push's before and after SHAs. This includes intermediate
+commits, not only the final working tree; adding then removing a secret in the
+same PR still fails. Commits already reachable from the base are not rescanned.
+Missing/invalid commit objects fail closed rather than silently skipping a scan.
+
+This is a commit-patch check, not exhaustive secret-novelty analysis. Standard
+Git log patches do not include merge-resolution-only changes. We deliberately
+do not expand merges against each parent: doing so can report old base content
+as new. Separate merge-resolution coverage needs a validated parser strategy;
+this initial job does not claim it. Reintroduced content in a new ordinary
+commit can also be detected again.
+
+Exit status 0 means clean, 2 means findings, and other nonzero statuses mean a
+scanner/setup error; all nonzero statuses fail CI. The repository has active
+CodeQL code-scanning analyses, so sanitized SARIF is uploaded to the Security
+tab even when findings fail the scan. The job requests only `contents: read`
+and `security-events: write`; it never uses `pull_request_target`, PR comments,
+or repository secrets. The scanner check does not itself configure required
+branch-protection checks.
+
+## Trusted policy and accepted fingerprints
+
+The policy names are `.gitleaks.toml` (Betterleaks-compatible TOML) and
+`.betterleaksignore`. CI reads both from the **base commit**, never the PR head.
+Before policy is first introduced, it uses embedded default rules with no
+fingerprint exclusions. An existing malformed policy fails rather than falling
+back. Policy updates take effect only after they land in the trusted base.
+
+The default extension syntax is:
+
+```toml
+[extend]
+useDefault = true
+```
+
+Betterleaks' preferred ignore filename is `.betterleaksignore`; it also supports
+`.gitleaksignore`. The explicit flag is still `--gitleaks-ignore-path=PATH` (`-i`).
+CI supplies a base-derived file under the runner's temporary directory. A bare
+clone is the scan target because an explicit `-i` does **not** prevent automatic
+loading of the target directory's own ignore file. The PR's TOML, Expr filters,
+ignore files and inline allow comments cannot weaken this job's scanner policy.
+No repository scripts, dependencies or hooks are executed. The workflow itself
+remains PR-editable under ordinary GitHub Actions semantics: trusted scanner
+policy is not a substitute for protected workflow changes and maintainer review.
+Changes under `.github/` require Ben's review.
+
+After individual security review, record one emitted, commit-qualified
+fingerprint per line in `.betterleaksignore`:
+
+```text
+<full-commit-sha>:<repository-relative-file>:<rule-id>:<start-line>
+```
+
+Use the actual fingerprint, not a secret hash or value. Deduplicate identical
+fingerprints: multiple findings on one line can share one fingerprint. Include
+the commit; do not use the broader commit-independent `file:rule:line` form.
+Blank lines and whole-line `#` comments are supported; trailing inline comments
+are not. LF and CRLF are accepted. Document each accepted entry's fixture/false-
+positive rationale without copying credentials, private metadata or scan logs.
+Never generate the accepted file automatically from every finding.
+
+## Synthetic fixtures
+
+Prefer unmistakable noncredential placeholders. Betterleaks' default
+`generic-api-key` Expr filter includes token-efficiency checks; ordinary words
+may be rejected automatically. That reduces some generic false positives but
+does not classify all findings: the scanner also has URI/password rules.
+
+For local scans, a `gitleaks:allow` or `betterleaks:allow` comment on the matching
+line suppresses that line. **CI passes `--ignore-gitleaks-allow`**, so an inline
+comment alone cannot make a PR pass. For CI fixtures, request a narrow,
+reviewed `.gitleaks.toml` exception in the trusted base first, or use a clearly
+nonmatching synthetic value. Prefer exact anchored secret regexes/stopwords,
+ideally scoped to the relevant rule, over a whole-file exception when a file
+mixes fixtures and production code. Never exclude an entire tests tree.
+Retain default lockfile handling rather than duplicating broad exclusions.
+
+`reports/` is Git-excluded; untracked local reports are not Git-history inputs.
+Git ignore rules do not remove files already committed. A tracked report must
+be reviewed like any other tracked file, not treated as automatically safe.
+
+## Investigating a finding and rotating credentials
+
+1. Stop publication if a finding might be a real credential. Report only the
+   file, line, rule and commit through the private channel in
+   [SECURITY.md](../../SECURITY.md); do not copy the value into an issue or PR.
+2. Have the credential owner revoke/rotate it at the issuer, update consumers
+   through their secret store, and check access/audit logs. Do not validate a
+   discovered credential against a provider without explicit authorization.
+3. Remove the exposed value from current code or reports in a separately
+   reviewed change. Deletion does **not** remove the credential from Git
+   history, caches, forks or published artifacts. Do not rewrite shared history
+   as part of this CI change.
+4. Do not add real credentials to the ignore file. A deletion that already
+   landed in the base avoids those old commits in subsequent range scans, but
+   a full-history scan will still report them. Do not claim that history is
+   clean or accept a real finding merely to obtain a green baseline run.
+5. For an actual fixture/false positive, review the exact fingerprint and
+   rationale, update the accepted file, and rerun the same range and synthetic
+   positive-control proofs. Re-review findings when upgrading scanner versions;
+   rule/filter changes can change the finding set and fingerprints.
+
+## Local inspection and proof
+
+Use the workflow's pinned release binary in an ignored temporary directory and
+verify the platform-specific SHA-256 from the pinned release. The macOS arm64
+1.8.1 archive SHA-256 is
+`8e80f33b5f2a7426b390347b9fd466033723cb94b6bdffa7572632e2eaec964e`.
+Never use a floating `latest` binary to reproduce CI.
+
+The CI scan command, after preparing the base-derived policy and bare clone, is:
+
+```sh
+betterleaks git "$HISTORY_REPO" \
+  --config="$TRUSTED_CONFIG" \
+  --gitleaks-ignore-path="$TRUSTED_IGNORE" \
+  --ignore-gitleaks-allow --validation=false --git-workers=0 \
+  --log-opts="$BASE_SHA..$HEAD_SHA" \
+  --redact=100 --log-level=info --no-color --exit-code=2 \
+  --report-format=sarif --report-path="$PRIVATE_REPORT"
+```
+
+Full-history triage instead uses `--log-opts='--full-history HEAD'` and a private
+redacted JSON report, in a detached worktree. It is a separate review, not the
+PR gate. There is no tracked JSON baseline. Keep raw reports in ignored,
+owner-only storage: `--redact=100` redacts detected secrets, **not all metadata**.
+Never use debug/trace logs or live validation. The workflow strips commit
+metadata, finding properties and match context, and forces redacted snippets
+before uploading SARIF; paths and rule identifiers necessarily remain visible.
+It does not upload the raw report as an Actions artifact.
+
+Before rollout, use a disposable, signed synthetic-secret commit in a
+non-allowlisted file. Run the exact CI range command and assert exit 2 plus the
+expected finding, remove the disposable commit without rewriting a published
+branch, and assert exit 0 for the intended clean range with accepted policy.
+Capture commands, exit codes and redacted finding counts, not secret values.
+Test scanner errors separately so a missing report cannot become a successful
+scan. Full-history findings are never evidence of a passing clean-range proof.
+
+## Runtime redaction is separate
+
+CI detects committed material; runtime redaction protects user data in logs,
+diagnostics and tool results before publication. The in-flight
+[`feat/shared-secret-redaction`](https://github.com/different-ai/openwork/tree/feat/shared-secret-redaction)
+work adds `packages/secret-redaction`. Neither runtime redaction nor this
+heuristic CI scanner replaces credential rotation or review of exported data.

--- a/evals/specs/ci-secret-scan.test.ts
+++ b/evals/specs/ci-secret-scan.test.ts
@@ -15,7 +15,7 @@ const githubToken = ["ghp_", "q7N4r2W6t", "3Y5u2I7o9", "P8a1S6d4F", "3g2H5j8K9"]
 const uriPassword = ["q7N4r2", "W6t3Y5u2"].join("");
 const credentialUri = `postgresql://scan_user:${uriPassword}@db.scan.invalid:5432/service`;
 
-function run(command: string, args: string[], cwd: string) {
+function run(command: string, args: string[], cwd: string, extraEnv: Record<string, string> = {}) {
   const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
   return spawnSync(command, args, {
     cwd,
@@ -31,6 +31,7 @@ function run(command: string, args: string[], cwd: string) {
       GIT_AUTHOR_EMAIL: "secret-scan@openwork.invalid",
       GIT_COMMITTER_NAME: "Secret scan fixture",
       GIT_COMMITTER_EMAIL: "secret-scan@openwork.invalid",
+      ...extraEnv,
     },
   });
 }
@@ -242,6 +243,38 @@ test("CI secret scan sanitizes SARIF metadata and context with the exact workflo
         region: { startLine: 3, snippet: { text: "REDACTED" } },
       } }],
     }] }] });
+  });
+});
+
+test("CI secret scan bootstraps once then uses base policy and preserves detached base objects", async () => {
+  await withScratch(async (directory) => {
+    needs({ commands: ["bash"] });
+    const workflow = await readFile(join(repository, ".github/workflows/secret-scan.yml"), "utf8");
+    const step = workflow.indexOf("      - name: Prepare trusted policy");
+    const start = workflow.indexOf("        run: |\n", step);
+    const end = workflow.indexOf("      - name: Scan only", start);
+    expect(step >= 0 && start > step && end > start).toBe(true);
+    const script = workflow.slice(start + "        run: |\n".length, end)
+      .split("\n").map((line) => line.replace(/^          /, "")).join("\n");
+    const { repo, base } = await fixtureRepository(directory);
+    const policy = await readFile(config, "utf8");
+    const installed = await commitFile(repo, ".betterleaks.toml", policy);
+    async function prepare(name: string, baseSha: string, headSha: string) {
+      const temp = join(directory, name);
+      await mkdir(temp);
+      const result = run("bash", ["-c", script], repo, { RUNNER_TEMP: temp, BASE_SHA: baseSha, HEAD_SHA: headSha });
+      expect(result.status).toBe(0);
+      expect(await readFile(join(temp, "secret-scan.toml"), "utf8")).toBe(policy);
+      expect(git(join(temp, "secret-scan.git"), ["cat-file", "-t", baseSha])).toBe("commit");
+      return result;
+    }
+    expect((await prepare("bootstrap", base, installed)).stdout.includes("Bootstrapping")).toBe(true);
+    const trusted = await commitFile(repo, "trusted.txt", "trusted-base\n");
+    git(repo, ["update-ref", "refs/remotes/origin/review-base", trusted]);
+    git(repo, ["checkout", "--detach", installed]);
+    const head = await commitFile(repo, ".betterleaks.toml", "[extend]\nuseDefault = true\n");
+    git(repo, ["branch", "-D", "main"]);
+    expect((await prepare("established", trusted, head)).stdout.includes("Bootstrapping")).toBe(false);
   });
 });
 

--- a/evals/specs/ci-secret-scan.test.ts
+++ b/evals/specs/ci-secret-scan.test.ts
@@ -3,6 +3,7 @@ import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promise
 import { devNull, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { currentTestEvidence } from "@openwork/test-evidence";
 import { needs, test } from "@openwork/testkit";
 import { expect } from "vitest";
 
@@ -52,6 +53,11 @@ async function withScratch(check: (directory: string) => Promise<void>) {
     expect(version.status, "Betterleaks version command must succeed").toBe(0);
     expect(version.stdout.trim() === "1.8.1", "use pinned Betterleaks 1.8.1 via BETTERLEAKS_BIN or tmp/betterleaks").toBe(true);
     await check(directory);
+    currentTestEvidence()?.recordAssertionEvidence(
+      "The named pinned-binary proof completed every observable assertion",
+      "Local Betterleaks 1.8.1; explicit exit-code, rule, path, policy or redaction assertions in this test all passed. Reproduce: pnpm evals:pr specs/ci-secret-scan.test.ts. No live validation or historical credential access.",
+      true,
+    );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/evals/specs/ci-secret-scan.test.ts
+++ b/evals/specs/ci-secret-scan.test.ts
@@ -1,0 +1,256 @@
+import { spawnSync } from "node:child_process";
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { devNull, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { needs, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const repository = fileURLToPath(new URL("../..", import.meta.url));
+const config = join(repository, ".betterleaks.toml");
+const binary = resolve(repository, process.env.BETTERLEAKS_BIN || "tmp/betterleaks");
+const awsId = ["AKIA", "Q7N4R2W6T3Y5U2I7"].join("");
+const awsSecret = ["q7N4r2W6t3", "Y5u2I7o9P8", "a1S6d4F3g2", "H5j8K9l0Zx"].join("");
+const githubToken = ["ghp_", "q7N4r2W6t", "3Y5u2I7o9", "P8a1S6d4F", "3g2H5j8K9"].join("");
+const uriPassword = ["q7N4r2", "W6t3Y5u2"].join("");
+const credentialUri = `postgresql://scan_user:${uriPassword}@db.scan.invalid:5432/service`;
+
+function run(command: string, args: string[], cwd: string) {
+  const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
+  return spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: 60_000,
+    maxBuffer: 8 * 1024 * 1024,
+    env: {
+      ...env,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: devNull,
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_AUTHOR_NAME: "Secret scan fixture",
+      GIT_AUTHOR_EMAIL: "secret-scan@openwork.invalid",
+      GIT_COMMITTER_NAME: "Secret scan fixture",
+      GIT_COMMITTER_EMAIL: "secret-scan@openwork.invalid",
+    },
+  });
+}
+
+function git(cwd: string, args: string[]): string {
+  const result = run("git", args, cwd);
+  expect(result.error === undefined, "git fixture command must start and finish within its timeout").toBe(true);
+  expect(result.status, "git fixture command must succeed").toBe(0);
+  return result.stdout.trim();
+}
+
+async function withScratch(check: (directory: string) => Promise<void>) {
+  needs({ commands: ["git", binary] });
+  await access(config);
+  const directory = await mkdtemp(join(tmpdir(), "openwork-secret-scan-"));
+  try {
+    const version = run(binary, ["version"], directory);
+    expect(version.status, "Betterleaks version command must succeed").toBe(0);
+    expect(version.stdout.trim() === "1.8.1", "use pinned Betterleaks 1.8.1 via BETTERLEAKS_BIN or tmp/betterleaks").toBe(true);
+    await check(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function fixtureRepository(directory: string) {
+  const repo = join(directory, "source");
+  await mkdir(repo);
+  git(repo, ["init", "--initial-branch=main"]);
+  git(repo, ["commit", "--allow-empty", "-m", "Initialize isolated scan fixture"]);
+  return { repo, base: git(repo, ["rev-parse", "HEAD"]) };
+}
+
+async function commitFile(repo: string, path: string, content: string) {
+  const destination = join(repo, path);
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, content, { mode: 0o600 });
+  git(repo, ["add", "--", path]);
+  git(repo, ["commit", "-m", "Add isolated scan fixture"]);
+  return git(repo, ["rev-parse", "HEAD"]);
+}
+
+async function scan(directory: string, source: string, base: string, head: string, name: string) {
+  const bare = join(directory, `${name}.git`);
+  git(directory, ["clone", "--bare", "--no-hardlinks", source, bare]);
+  const report = join(directory, `${name}.sarif`);
+  await writeFile(report, "", { mode: 0o600 });
+  const result = run(binary, [
+    "git", bare,
+    `--config=${config}`,
+    "--ignore-gitleaks-allow",
+    "--validation=false",
+    "--git-workers=0",
+    `--log-opts=${base}..${head}`,
+    "--redact=100",
+    "--log-level=info",
+    "--no-color",
+    "--exit-code=1",
+    "--report-format=sarif",
+    `--report-path=${report}`,
+  ], directory);
+  expect(result.error === undefined, "Betterleaks must start and finish within its timeout").toBe(true);
+  return { status: result.status, output: result.stdout + result.stderr, report };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function syntheticFindings(result: Awaited<ReturnType<typeof scan>>, secrets: string[]) {
+  const report = await readFile(result.report, "utf8");
+  expect(secrets.every((secret) => !report.includes(secret) && !result.output.includes(secret)), "synthetic secrets must be fully redacted in SARIF and logs").toBe(true);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(report);
+  } catch {
+    throw new Error("Betterleaks synthetic report must be valid SARIF JSON; contents withheld");
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.runs)) throw new Error("SARIF must contain runs");
+  const findings: { ruleId: string; paths: string[] }[] = [];
+  for (const run of parsed.runs) {
+    if (!isRecord(run) || !Array.isArray(run.results)) throw new Error("SARIF run must contain results");
+    for (const finding of run.results) {
+      if (!isRecord(finding) || typeof finding.ruleId !== "string" || !Array.isArray(finding.locations)) {
+        throw new Error("SARIF finding must contain ruleId and locations");
+      }
+      const paths: string[] = [];
+      for (const location of finding.locations) {
+        if (!isRecord(location) || !isRecord(location.physicalLocation)
+          || !isRecord(location.physicalLocation.artifactLocation)
+          || typeof location.physicalLocation.artifactLocation.uri !== "string") {
+          throw new Error("SARIF finding must contain artifact URI");
+        }
+        paths.push(location.physicalLocation.artifactLocation.uri);
+      }
+      findings.push({ ruleId: finding.ruleId, paths });
+    }
+  }
+  if (findings.length > 0) {
+    expect(report.includes("REDACTED"), "positive synthetic SARIF must contain redaction markers").toBe(true);
+  }
+  return findings;
+}
+
+test("CI secret scan validates the actual Betterleaks configuration", async () => {
+  await withScratch(async (directory) => {
+    const result = run(binary, ["config", "check", "--config", config], directory);
+    expect(result.error === undefined, "config check must start and finish within its timeout").toBe(true);
+    expect(result.status, "actual .betterleaks.toml must validate").toBe(0);
+  });
+});
+
+test("CI secret scan rejects paired AWS credentials and GitHub PATs outside exempt paths", async () => {
+  await withScratch(async (directory) => {
+    expect(/^AKIA[A-Z2-7]{16}$/.test(awsId) && !awsId.endsWith("EXAMPLE")).toBe(true);
+    expect(awsSecret.length).toBe(40);
+    expect(/^ghp_[A-Za-z0-9]{36}$/.test(githubToken)).toBe(true);
+    const { repo, base } = await fixtureRepository(directory);
+    const head = await commitFile(repo, "src/credentials.env", [
+      `AWS_ACCESS_KEY_ID=${awsId}`,
+      `AWS_SECRET_ACCESS_KEY=${awsSecret}`,
+      `GITHUB_TOKEN=${githubToken}`,
+      "",
+    ].join("\n"));
+    const result = await scan(directory, repo, base, head, "provider-credentials");
+    expect(result.status, "synthetic provider credentials must fail the CI gate").toBe(1);
+    const findings = await syntheticFindings(result, [awsId, awsSecret, githubToken]);
+    expect(findings.some((finding) => finding.ruleId === "aws-access-token" && finding.paths.includes("src/credentials.env"))).toBe(true);
+    expect(findings.some((finding) => finding.ruleId === "github-pat" && finding.paths.includes("src/credentials.env"))).toBe(true);
+  });
+});
+
+test("CI secret scan excludes credential URI fixtures only at exempt paths", async () => {
+  await withScratch(async (directory) => {
+    const { repo, base } = await fixtureRepository(directory);
+    const content = `DATABASE_URL=${credentialUri}\n`;
+    const exemptHead = await commitFile(repo, "tests/database.env", content);
+    const exempt = await scan(directory, repo, base, exemptHead, "exempt-uri");
+    expect(exempt.status, "credential URI in tests/ must not fail the CI gate").toBe(0);
+    expect((await syntheticFindings(exempt, [uriPassword])).length).toBe(0);
+    const head = await commitFile(repo, "src/database.env", content);
+    const detected = await scan(directory, repo, base, head, "nonexempt-uri");
+    expect(detected.status, "identical credential URI outside tests/ must fail the CI gate").toBe(1);
+    const findings = await syntheticFindings(detected, [uriPassword]);
+    expect(findings.some((finding) => finding.ruleId === "generic-credential-uri" && finding.paths.includes("src/database.env"))).toBe(true);
+    expect(findings.some((finding) => finding.paths.includes("tests/database.env"))).toBe(false);
+  });
+});
+
+test("CI secret scan keeps the held report path detectable without reading historical content", async () => {
+  await withScratch(async (directory) => {
+    const { repo, base } = await fixtureRepository(directory);
+    const path = "evals/results/first-connection-windows-20260721/report.md";
+    const head = await commitFile(repo, path, `DATABASE_URL=${credentialUri}\n`);
+    const result = await scan(directory, repo, base, head, "held-path-synthetic-only");
+    expect(result.status).toBe(1);
+    const findings = await syntheticFindings(result, [uriPassword]);
+    expect(findings.some((finding) => finding.ruleId === "generic-credential-uri" && finding.paths.includes(path))).toBe(true);
+  });
+});
+
+test("CI secret scan limits literal exceptions to exact placeholders and loopback defaults", async () => {
+  await withScratch(async (directory) => {
+    const { repo, base } = await fixtureRepository(directory);
+    for (const password of ["changeme", "example", "YOUR_TOKEN", "YOUR_API_KEY", "YOUR_PASSWORD"]) {
+      await commitFile(repo, `src/${password}.env`, `DATABASE_URL=postgresql://scan_user:${password}@db.scan.invalid/service\n`);
+    }
+    const cleanHead = await commitFile(repo, "src/loopback.env", "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/service\n");
+    const clean = await scan(directory, repo, base, cleanHead, "literal-exempt");
+    expect(clean.status).toBe(0);
+    expect((await syntheticFindings(clean, [])).length).toBe(0);
+    const head = await commitFile(repo, "src/real-shaped.env", [
+      "DATABASE_URL=postgresql://postgres:postgres@db.scan.invalid/service",
+      `DATABASE_URL=postgresql://scan_user:changeme${uriPassword}@db.scan.invalid/service`,
+      "",
+    ].join("\n"));
+    const detected = await scan(directory, repo, cleanHead, head, "literal-boundary");
+    expect(detected.status).toBe(1);
+    expect((await syntheticFindings(detected, [uriPassword])).filter((finding) => finding.ruleId === "generic-credential-uri").length).toBe(2);
+  });
+});
+
+test("CI secret scan sanitizes SARIF metadata and context with the exact workflow block", async () => {
+  await withScratch(async (directory) => {
+    needs({ commands: ["python3"] });
+    const workflow = await readFile(join(repository, ".github/workflows/secret-scan.yml"), "utf8");
+    const start = workflow.indexOf("          python3 - <<'PY'\n");
+    const end = workflow.indexOf("          PY\n", start);
+    expect(start >= 0 && end > start).toBe(true);
+    const script = workflow.slice(start + "          python3 - <<'PY'\n".length, end)
+      .split("\n").map((line) => line.replace(/^          /, "")).join("\n");
+    await writeFile(join(directory, "secret-scan.raw.sarif"), JSON.stringify({ runs: [{ results: [{
+      ruleId: "github-pat", partialFingerprints: { commitSha: githubToken },
+      properties: { commitMessage: githubToken }, message: { text: githubToken },
+      locations: [{ physicalLocation: {
+        artifactLocation: { uri: "src/synthetic.env" },
+        contextRegion: { snippet: { text: githubToken } },
+        region: { startLine: 3, snippet: { text: githubToken } },
+      } }],
+    }] }] }), { mode: 0o600 });
+    const result = run("python3", ["-c", script], directory);
+    expect(result.status).toBe(0);
+    const sanitized = await readFile(join(directory, "secret-scan.sarif"), "utf8");
+    expect(sanitized.includes(githubToken)).toBe(false);
+    expect(JSON.parse(sanitized)).toEqual({ runs: [{ results: [{
+      ruleId: "github-pat", message: { text: "Potential secret detected (redacted)." },
+      locations: [{ physicalLocation: {
+        artifactLocation: { uri: "src/synthetic.env" },
+        region: { startLine: 3, snippet: { text: "REDACTED" } },
+      } }],
+    }] }] });
+  });
+});
+
+test("CI secret scan accepts only the bounded origin/dev five-commit range from a bare clone", async () => {
+  await withScratch(async (directory) => {
+    const head = git(repository, ["rev-parse", "--verify", "origin/dev^{commit}"]);
+    const base = git(repository, ["rev-parse", "--verify", `${head}~5^{commit}`]);
+    expect(git(repository, ["rev-list", "--count", "--first-parent", `${base}..${head}`])).toBe("5");
+    const result = await scan(directory, repository, base, head, "bounded-origin-dev");
+    expect(result.status, "bounded origin/dev~5..origin/dev range must be clean; report contents withheld").toBe(0);
+  });
+});


### PR DESCRIPTION
Public repository, no secret gate today; one historical stray was escalated.

Checksum-pinned Betterleaks 1.8.1 scans PR `base..head` / dev-push `before..sha`; redacted, sanitized SARIF; SHA-pinned actions/minimal permissions. Base policy is authoritative after explicitly reviewed first-install bootstrapping. No baseline, ignore file, fingerprints, history job, or disabled generic rules.

**Exemptions:** `**/test/**`, `**/tests/**`, `**/testdata/**`, `**/*.test.*`, `**/*.e2e.*`, `evals/**`: synthetic fixtures/harnesses. `**/*.example`, `**/.env.example`: examples. `**/docker-compose*.yml`, `packaging/**/values*.yaml`: local defaults. `packaging/**/README.md`, `packaging/docker/README.md`: instructions. `scripts/build-microsandbox-openwork-image.sh`: sandbox defaults. Lockfiles retained.

Exact literals: `changeme`, `example`, `YOUR_TOKEN`, `YOUR_API_KEY`, `YOUR_PASSWORD`; `postgres:postgres` only in loopback URIs.

The historical July token is outside this PR range, untouched and explicitly not path-exempt; Ben decides Monday.

**To triage:** 164/619 historical rows remain before literal filtering: generic-credential-uri 52, generic-password 102, posthog-project-api-key 7, generic-api-key 3; [location-only inventory](https://github.com/different-ai/openwork/pull/4940#issuecomment-5644603295). No acceptance of these findings.

**Local proofs — pinned binary**, common workflow command (private bare clone/config/report):
```sh
S(){ betterleaks git "$R" --config="$C" --ignore-gitleaks-allow --validation=false --git-workers=0 --log-opts="$1" --redact=100 --log-level=info --no-color --exit-code=1 --report-format=sarif --report-path="$O"; }
```
- `S 4cdab98b4..1aa839fec`: exit 1; AWS+GitHub findings, redacted; signed throwaway reset.
- `S origin/dev~5..origin/dev`: exit 0; no leaks.
- `S "$fixtureBase..$fixtureHead"`: tests/ URI exit 0; identical nonexempt URI exit 1.
- `betterleaks config check --config .betterleaks.toml`: exit 0, 417 rules.
- `pnpm evals:pr specs/ci-secret-scan.test.ts`: 8 passed, 0 failed/skipped; final PR range also exit 0; [8 head-matched receipts](https://github.com/different-ai/openwork/pull/4940#issuecomment-5644603259). GitHub Secret scan: SUCCESS.

Follow-ups: weekly history reporting; 2026-07-22 report/archived sandbox disposition (Ben); push protection (Guillaume); `packages/secret-redaction`, `feat/shared-secret-redaction`. No history/live-verification/merge-resolution-only coverage.

Surface(s) touched: ci-secret-scan (new) / Rows changed: n/a / Blanks introduced: none

Reviewer: @benjaminshafii (.github/) — for Monday
