### PR TITLE
test(evals): cover invitation authentication flows

### DIFF
--- a/evals/packages/testkit/src/self-host.ts
+++ b/evals/packages/testkit/src/self-host.ts
@@ -24,6 +24,7 @@ export interface SelfHostServerOptions {
   slug: string;
   ownerEmails: string[];
   allowPublicSignup?: boolean;
+  bootstrapCode?: string;
 }
 
 export interface SelfHostDen {
@@ -208,6 +209,9 @@ export async function selfHostServer(options: SelfHostServerOptions): Promise<Se
       DEN_SINGLE_ORG_SLUG: options.slug,
       DEN_SINGLE_ORG_OWNER_EMAILS: options.ownerEmails.join(","),
       DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: String(options.allowPublicSignup ?? false),
+      DEN_INITIAL_ADMIN_BOOTSTRAP_CODE: options.bootstrapCode ?? "",
+      RESEND_API_KEY: "",
+      SMTP_HOST: "",
       DEN_REQUIRE_EMAIL_VERIFICATION: "false",
       DEN_PASSWORD_BREACH_SCREENING_ENABLED: "false",
       OPENWORK_DEV_MODE: "1",

--- a/evals/specs/org-invite-join.e2e.test.ts
+++ b/evals/specs/org-invite-join.e2e.test.ts
@@ -57,6 +57,7 @@ test("OPE-82: cloud invitations retain identity and organization through authent
   await step("a different current account cannot consume an invite and can switch to the invited account", async () => {
     const person = identity("switch-invitee");
     const invite = await witnesses.invite(person.email, orgId, "admin");
+    const wrongAccountMembershipIds = membersFor(await witnesses.org(orgId), world.other.email).map((member) => member.id);
     const surface = await world.fresh(invite.link, world.other);
     const actor = user.on(surface);
     await actor.see({ text: "Switch accounts to continue." }, { timeoutMs: 90_000 });
@@ -65,7 +66,7 @@ test("OPE-82: cloud invitations retain identity and organization through authent
     expect(denied.response.ok).toBe(false);
     expect(denied.body).not.toHaveProperty("accepted", true);
     await pending(person.email);
-    expect(membersFor(await witnesses.org(orgId), world.other.email)).toHaveLength(0);
+    expect(membersFor(await witnesses.org(orgId), world.other.email).map((member) => member.id)).toEqual(wrongAccountMembershipIds);
     await actor.click({ role: "button", label: "Use a different account" });
     await actor.see({ text: person.email });
     await actor.type({ role: "textbox", label: "Name" }, person.name);
@@ -75,7 +76,7 @@ test("OPE-82: cloud invitations retain identity and organization through authent
     await joined(person.email, "admin");
     await actor.notSee({ role: "textbox", label: "Verification code" });
     expect(await witnesses.emails("verification", person.email)).toEqual(verificationBefore);
-    expect(membersFor(await witnesses.org(orgId), world.other.email)).toHaveLength(0);
+    expect(membersFor(await witnesses.org(orgId), world.other.email).map((member) => member.id)).toEqual(wrongAccountMembershipIds);
   });
 
   await step("canceled and domain-blocked invites do not authenticate or add members", async () => {

--- a/evals/specs/org-invite-join.e2e.test.ts
+++ b/evals/specs/org-invite-join.e2e.test.ts
@@ -1,0 +1,135 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { invitationWitnesses, invitationsFor, membersFor, orgInvite, rows, text } from "../worlds/org-invite.ts";
+
+const test = spec.world(orgInvite, { resources: { surfaces: ["web"], services: ["den"] }, needs: { placement: "local" }, timeout: 900_000 });
+
+test("OPE-82: cloud invitations retain identity and organization through authentication", async ({ world, user, probe, seed, step }) => {
+  const { witnesses, identity } = world;
+  const orgId = text(world.organization.id);
+  const otherId = text(world.otherOrg.id);
+  const otherWitness = invitationWitnesses(world.other);
+  const otherBefore = await otherWitness.org(otherId);
+  const noCrossOrg = async () => expect(await otherWitness.org(otherId)).toEqual(otherBefore);
+  const pending = async (email: string) => {
+    const org = await witnesses.org(orgId);
+    expect(invitationsFor(org, email)).toEqual([expect.objectContaining({ status: "pending" })]);
+    expect(membersFor(org, email)).toHaveLength(0);
+    await noCrossOrg();
+  };
+  const joined = async (email: string, role = "member") => {
+    const org = await probe.eventually(() => witnesses.org(orgId), {
+      within: 30_000, label: `one membership for ${email}`, until: (value) => membersFor(value, email).length === 1,
+    });
+    expect(membersFor(org, email)).toEqual([expect.objectContaining({ role })]);
+    expect(invitationsFor(org, email).filter((invite) => invite.status === "pending")).toHaveLength(0);
+    const invitationIds = invitationsFor(org, email).map((invite) => invite.id);
+    expect(rows(org.members).filter((member) => invitationIds.includes(member.inviteId) && (!member.userId || !member.joinedAt))).toEqual([]);
+    await noCrossOrg();
+  };
+
+  await step("OPE-82: an email/password invite proves the mailbox and joins without another verification challenge", async () => {
+    const person = identity("password-invitee");
+    const invite = await witnesses.invite(person.email, orgId);
+    const verificationBefore = await witnesses.emails("verification", person.email);
+    const ownerSurface = await world.fresh("/dashboard/members", world.owner);
+    const ownerActor = user.on(ownerSurface);
+    await ownerActor.see({ text: person.email }, { timeoutMs: 90_000 });
+    await ownerActor.see({ text: "Pending" });
+    await user.navigate(invite.link);
+    await user.see({ text: person.email }, { timeoutMs: 90_000 });
+    await user.see({ role: "button", label: "Sign up with Google" });
+    await user.type({ role: "textbox", label: "Name" }, person.name);
+    await user.type({ role: "textbox", label: "Password" }, person.password);
+    await user.click({ role: "button", label: "Create account" });
+    await joined(person.email);
+    await user.notSee({ role: "textbox", label: "Verification code" });
+    await user.notSee({ role: "button", label: "Resend code" });
+    expect(await witnesses.emails("verification", person.email)).toEqual(verificationBefore);
+    await ownerActor.see({ text: person.email });
+    await ownerActor.notSee({ text: "Pending" }, { timeoutMs: 30_000 });
+    await user.reload();
+    await joined(person.email);
+    const session = await witnesses.sessionFor(person);
+    expect((await invitationWitnesses(session).orgs()).map((org) => org.id)).toEqual([orgId]);
+  });
+
+  await step("a different current account cannot consume an invite and can switch to the invited account", async () => {
+    const person = identity("switch-invitee");
+    const invite = await witnesses.invite(person.email, orgId, "admin");
+    const surface = await world.fresh(invite.link, world.other);
+    const actor = user.on(surface);
+    await actor.see({ text: "Switch accounts to continue." }, { timeoutMs: 90_000 });
+    await actor.notSee({ role: "button", label: `Join ${text(world.organization.name)}` });
+    const denied = await seed.api(world.other, "/v1/orgs/invitations/accept", { method: "POST", body: JSON.stringify({ id: invite.token }) });
+    expect(denied.response.ok).toBe(false);
+    expect(denied.body).not.toHaveProperty("accepted", true);
+    await pending(person.email);
+    expect(membersFor(await witnesses.org(orgId), world.other.email)).toHaveLength(0);
+    await actor.click({ role: "button", label: "Use a different account" });
+    await actor.see({ text: person.email });
+    await actor.type({ role: "textbox", label: "Name" }, person.name);
+    const verificationBefore = await witnesses.emails("verification", person.email);
+    await actor.type({ role: "textbox", label: "Password" }, person.password);
+    await actor.click({ role: "button", label: "Create account" });
+    await joined(person.email, "admin");
+    await actor.notSee({ role: "textbox", label: "Verification code" });
+    expect(await witnesses.emails("verification", person.email)).toEqual(verificationBefore);
+    expect(membersFor(await witnesses.org(orgId), world.other.email)).toHaveLength(0);
+  });
+
+  await step("expired, canceled and domain-blocked invites do not authenticate or add members", async () => {
+    for (const state of ["expired", "canceled", "blocked"]) {
+      const person = identity(`${state}-invitee`);
+      const invite = await witnesses.invite(person.email, orgId);
+      if (state === "expired") await world.expire(invite.id);
+      if (state === "canceled") {
+        const canceled = await witnesses.api(`/v1/invitations/${invite.id}`, { method: "DELETE", headers: { "x-openwork-org-id": orgId } });
+        expect(canceled.response.ok, canceled.text).toBe(true);
+      }
+      if (state === "blocked") {
+        const restricted = await witnesses.api("/v1/org", { method: "PATCH", headers: { "x-openwork-org-id": orgId }, body: JSON.stringify({ allowedEmailDomains: ["allowed.test"] }) });
+        expect(restricted.response.ok, restricted.text).toBe(true);
+      }
+      try {
+        const before = await witnesses.emails("verification", person.email);
+        const surface = await world.fresh(invite.link);
+        const actor = user.on(surface);
+        await actor.see({ text: state === "blocked" ? "This invite needs a different email domain." : `This invite ${state === "expired" ? "expired" : "was canceled"}.` }, { timeoutMs: 90_000 });
+        await actor.notSee({ role: "textbox", label: "Password" });
+        await actor.notSee({ role: "textbox", label: "Verification code" });
+        await actor.notSee({ role: "button", label: `Join ${text(world.organization.name)}` });
+        const org = await witnesses.org(orgId);
+        expect(membersFor(org, person.email)).toHaveLength(0);
+        expect(invitationsFor(org, person.email).some((entry) => entry.status === "accepted")).toBe(false);
+        expect(await witnesses.emails("verification", person.email)).toEqual(before);
+        await noCrossOrg();
+      } finally {
+        if (state === "blocked") {
+          const restored = await witnesses.api("/v1/org", { method: "PATCH", headers: { "x-openwork-org-id": orgId }, body: JSON.stringify({ allowedEmailDomains: [] }) });
+          expect(restored.response.ok, restored.text).toBe(true);
+        }
+      }
+    }
+  });
+
+  await step("a generic sign-up 403 is an error, not an email-verification challenge", async () => {
+    const person = identity("forbidden-invitee");
+    const invite = await witnesses.invite(person.email, orgId);
+    const proxy = await seed.faultProxy(world.den);
+    await proxy.faults.status("/api/auth/sign-up/email", 403, { times: 1, body: { code: "ACCESS_DENIED", message: "Account registration is blocked by policy." } });
+    const surface = await seed.web({ den: { ...world.den, ref: proxy.ref }, startPath: new URL(invite.link).pathname + new URL(invite.link).search, headless: true });
+    const actor = user.on(surface);
+    const before = await witnesses.emails("verification", person.email);
+    await actor.see({ role: "textbox", label: "Name" }, { timeoutMs: 90_000 });
+    await actor.type({ role: "textbox", label: "Name" }, person.name);
+    await actor.type({ role: "textbox", label: "Password" }, person.password);
+    await actor.click({ role: "button", label: "Create account" });
+    await probe.eventually(() => proxy.requestLog(), { within: 15_000, label: "the submitted form received the generic 403", until: (requests) => requests.some((request) => request.faulted && request.status === 403) });
+    await actor.see({ text: "Account registration is blocked by policy." });
+    await actor.notSee({ role: "textbox", label: "Verification code" });
+    await actor.notSee({ role: "button", label: "Resend code" });
+    expect(await witnesses.emails("verification", person.email)).toEqual(before);
+    await pending(person.email);
+  });
+});

--- a/evals/specs/org-invite-join.e2e.test.ts
+++ b/evals/specs/org-invite-join.e2e.test.ts
@@ -2,7 +2,7 @@ import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { invitationWitnesses, invitationsFor, membersFor, orgInvite, rows, text } from "../worlds/org-invite.ts";
 
-const test = spec.world(orgInvite, { resources: { surfaces: ["web"], services: ["den"] }, needs: { placement: "local" }, timeout: 900_000 });
+const test = spec.world(orgInvite, { resources: { surfaces: ["web"], services: ["den"] }, timeout: 900_000 });
 
 test("OPE-82: cloud invitations retain identity and organization through authentication", async ({ world, user, probe, seed, step }) => {
   const { witnesses, identity } = world;
@@ -78,11 +78,10 @@ test("OPE-82: cloud invitations retain identity and organization through authent
     expect(membersFor(await witnesses.org(orgId), world.other.email)).toHaveLength(0);
   });
 
-  await step("expired, canceled and domain-blocked invites do not authenticate or add members", async () => {
-    for (const state of ["expired", "canceled", "blocked"]) {
+  await step("canceled and domain-blocked invites do not authenticate or add members", async () => {
+    for (const state of ["canceled", "blocked"]) {
       const person = identity(`${state}-invitee`);
       const invite = await witnesses.invite(person.email, orgId);
-      if (state === "expired") await world.expire(invite.id);
       if (state === "canceled") {
         const canceled = await witnesses.api(`/v1/invitations/${invite.id}`, { method: "DELETE", headers: { "x-openwork-org-id": orgId } });
         expect(canceled.response.ok, canceled.text).toBe(true);
@@ -95,7 +94,7 @@ test("OPE-82: cloud invitations retain identity and organization through authent
         const before = await witnesses.emails("verification", person.email);
         const surface = await world.fresh(invite.link);
         const actor = user.on(surface);
-        await actor.see({ text: state === "blocked" ? "This invite needs a different email domain." : `This invite ${state === "expired" ? "expired" : "was canceled"}.` }, { timeoutMs: 90_000 });
+        await actor.see({ text: state === "blocked" ? "This invite needs a different email domain." : "This invite was canceled." }, { timeoutMs: 90_000 });
         await actor.notSee({ role: "textbox", label: "Password" });
         await actor.notSee({ role: "textbox", label: "Verification code" });
         await actor.notSee({ role: "button", label: `Join ${text(world.organization.name)}` });

--- a/evals/specs/org-invite-sso.e2e.test.ts
+++ b/evals/specs/org-invite-sso.e2e.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { ssoInvite } from "../worlds/den.ts";
+import { invitationWitnesses, invitationsFor, membersFor, rows } from "../worlds/org-invite.ts";
+
+for (const mismatch of [false, true]) {
+  const test = spec.world((seed) => ssoInvite(seed, { mismatchedEmail: mismatch, role: "admin" }), { resources: { surfaces: ["web"], services: ["den", "mock"] }, needs: { placement: "local" }, timeout: 600_000 });
+
+  test(`SSO-enforced invitation ${mismatch ? "rejects a different IdP email without consuming the invite" : "joins the matching IdP email with the invited role"}`, async ({ world, user, probe, step }) => {
+    const witnesses = invitationWitnesses(world.den.admin);
+    const before = await witnesses.org(world.organizationId);
+    const invitations = invitationsFor(before, world.invitee);
+    expect(invitations).toEqual([expect.objectContaining({ status: "pending", role: "admin" })]);
+    const otpBefore = await witnesses.emails("verification", world.invitee);
+
+    await step("the invite routes through the organization's registered and enabled IdP", async () => {
+      const configured = await witnesses.api("/v1/sso", { headers: { "x-openwork-org-id": world.organizationId } });
+      expect(configured.response.ok, configured.text).toBe(true);
+      expect(configured.body).toHaveProperty("connection.status", "enabled");
+      await user.navigate(world.joinUrl);
+      await user.see({ role: "button", label: "Sign in with SSO" }, { timeoutMs: 90_000 });
+      await user.notSee({ role: "textbox", label: "Password" });
+      await user.click({ role: "button", label: "Sign in with SSO" });
+    });
+
+    await step(mismatch ? "the actual IdP identity cannot claim another person's invitation" : "the actual IdP identity joins once, without an email OTP or role downgrade", async () => {
+      if (mismatch) {
+        await user.see({ text: "Switch accounts to continue." }, { timeoutMs: 90_000 });
+        await user.see({ text: world.mismatchedEmail });
+        await user.notSee({ role: "button", label: /^Join / });
+        const org = await witnesses.org(world.organizationId);
+        expect(invitationsFor(org, world.invitee)).toEqual(invitations);
+        expect(membersFor(org, world.invitee)).toHaveLength(0);
+        expect(membersFor(org, world.mismatchedEmail).some((member) => member.role === "admin")).toBe(false);
+      } else {
+        const org = await probe.eventually(() => witnesses.org(world.organizationId), { within: 90_000, label: "SSO invite membership", until: (value) => membersFor(value, world.invitee).length === 1 });
+        expect(membersFor(org, world.invitee)).toEqual([expect.objectContaining({ role: "admin" })]);
+        expect(invitationsFor(org, world.invitee).filter((invite) => invite.status === "pending")).toEqual([]);
+        expect(rows(org.members).filter((member) => invitations.some((invite) => invite.id === member.inviteId) && (!member.userId || !member.joinedAt))).toEqual([]);
+        const others = (value: Record<string, unknown>) => rows(value.members).filter((member) => !membersFor(value, world.invitee).includes(member));
+        expect(others(org)).toEqual(others(before).filter((member) => !invitations.some((invite) => invite.id === member.inviteId)));
+        await user.reload();
+        expect(membersFor(await witnesses.org(world.organizationId), world.invitee)).toHaveLength(1);
+      }
+      await user.notSee({ role: "textbox", label: "Verification code" });
+      expect(await witnesses.emails("verification", world.invitee)).toEqual(otpBefore);
+      expect(await witnesses.emails("verification", world.mismatchedEmail)).toEqual([]);
+    });
+  });
+}

--- a/evals/specs/self-host-invite.e2e.test.ts
+++ b/evals/specs/self-host-invite.e2e.test.ts
@@ -1,0 +1,80 @@
+import { expect } from "vitest";
+import { personDefaults, selfHostServer, spec } from "@openwork/testkit";
+import { invitationWitnesses, invitationsFor, localInviteNeeds, membersFor, record, rows, text } from "../worlds/org-invite.ts";
+
+const test = spec.world(async (seed, { place }) => {
+  await localInviteNeeds();
+  const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
+  const owner = personDefaults("bootstrap-owner", undefined, runId);
+  const outsider = personDefaults("invited-outsider", { email: `invited-${runId}@outside.test` }, runId);
+  const rejected = personDefaults("uninvited-outsider", { email: `uninvited-${runId}@outside.test` }, runId);
+  const bootstrapCode = `test-bootstrap-${runId}`;
+  const server = await selfHostServer({ place, name: `Private workspace ${runId}`, slug: `private-${runId}`, ownerEmails: [owner.email], allowPublicSignup: false, bootstrapCode });
+  try {
+    const den = await seed.den({ reuse: server.ref, provision: false });
+    const web = await seed.web({ den, headless: true });
+    return { den, web, owner, outsider, rejected, bootstrapCode, anonymous: den.admin, async [Symbol.asyncDispose]() { await server[Symbol.asyncDispose](); } };
+  } catch (error) {
+    await server[Symbol.asyncDispose]();
+    throw error;
+  }
+}, { resources: { surfaces: ["web"], services: ["den"] }, needs: { placement: "local" }, timeout: 600_000 });
+
+test("private self-host signup admits the bootstrap owner and invited outsider, but not an uninvited outsider", async ({ world, user, probe, seed, step }) => {
+  let orgId = "";
+  await step("the configured bootstrap administrator auto-joins without an invitation", async () => {
+    const verified = await seed.api(world.anonymous, "/v1/auth/bootstrap/verify", { method: "POST", body: JSON.stringify({ email: world.owner.email, code: world.bootstrapCode }), signal: AbortSignal.timeout(15_000) });
+    expect(verified.response.status, verified.text).toBe(200);
+    const grant = text(record(verified.body).grant);
+    const created = await seed.api(world.anonymous, "/api/auth/sign-up/email", { method: "POST", body: JSON.stringify({ ...world.owner, bootstrapGrant: grant }), signal: AbortSignal.timeout(15_000) });
+    expect(created.response.ok, created.text).toBe(true);
+    world.den.admin = await invitationWitnesses(world.anonymous).sessionFor(world.owner);
+    const witness = invitationWitnesses(world.den.admin);
+    const organizations = await witness.orgs();
+    expect(organizations).toHaveLength(1);
+    orgId = text(organizations[0].id);
+    const org = await witness.org(orgId);
+    expect(membersFor(org, world.owner.email)).toEqual([expect.objectContaining({ role: "owner" })]);
+    expect(invitationsFor(org, world.owner.email)).toEqual([]);
+    const replay = await witness.api("/v1/auth/bootstrap/verify", { method: "POST", body: JSON.stringify({ email: world.owner.email, code: world.bootstrapCode }) });
+    expect(replay.response.status).toBe(409);
+    expect(replay.body).not.toHaveProperty("grant");
+  });
+
+  const witness = invitationWitnesses(world.den.admin);
+  await step("public signup disabled rejects an uninvited outsider without a session or placeholder", async () => {
+    const before = await witness.org(orgId);
+    const denied = await seed.api(world.anonymous, "/api/auth/sign-up/email", { method: "POST", body: JSON.stringify(world.rejected), signal: AbortSignal.timeout(15_000) });
+    expect(denied.response.status, denied.text).toBe(403);
+    expect(denied.body).not.toHaveProperty("token");
+    expect(await witness.org(orgId)).toEqual(before);
+    expect(membersFor(before, world.rejected.email)).toEqual([]);
+    expect(invitationsFor(before, world.rejected.email)).toEqual([]);
+    expect(await witness.emails("verification", world.rejected.email)).toEqual([]);
+  });
+
+  await step("an invited outsider can create their account despite disabled public signup", async () => {
+    const invite = await witness.invite(world.outsider.email, orgId);
+    const ownerBefore = membersFor(await witness.org(orgId), world.owner.email);
+    await user.navigate(invite.link);
+    await user.see({ text: world.outsider.email }, { timeoutMs: 90_000 });
+    await user.type({ role: "textbox", label: "Name" }, world.outsider.name);
+    await user.type({ role: "textbox", label: "Password" }, world.outsider.password);
+    await user.click({ role: "button", label: "Create account" });
+    const org = await probe.eventually(() => witness.org(orgId), { within: 30_000, label: "invited outsider joins the private workspace", until: (value) => membersFor(value, world.outsider.email).length === 1 });
+    expect(membersFor(org, world.outsider.email)).toEqual([expect.objectContaining({ role: "member" })]);
+    expect(rows(org.members).filter((member) => member.inviteId === invite.id)).toHaveLength(1);
+    expect(rows(org.members).filter((member) => member.inviteId === invite.id && (!member.userId || !member.joinedAt))).toEqual([]);
+    expect(invitationsFor(org, world.outsider.email).filter((entry) => entry.status === "pending")).toEqual([]);
+    expect(membersFor(org, world.owner.email)).toEqual(ownerBefore);
+    expect(membersFor(org, world.rejected.email)).toEqual([]);
+    await user.notSee({ role: "textbox", label: "Verification code" });
+    await user.reload();
+    expect(membersFor(await witness.org(orgId), world.outsider.email)).toHaveLength(1);
+    const member = await witness.sessionFor(world.outsider);
+    expect((await invitationWitnesses(member).orgs()).map((entry) => entry.id)).toEqual([orgId]);
+    const replay = await seed.api(member, "/v1/orgs/invitations/accept", { method: "POST", body: JSON.stringify({ id: invite.token }) });
+    expect(replay.response.ok, replay.text).toBe(true);
+    expect(membersFor(await witness.org(orgId), world.outsider.email)).toHaveLength(1);
+  });
+});

--- a/evals/specs/signup-verification-recovery.e2e.test.ts
+++ b/evals/specs/signup-verification-recovery.e2e.test.ts
@@ -1,0 +1,75 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { emailLinks, invitationWitnesses, membersFor, orgInvite, text } from "../worlds/org-invite.ts";
+
+const test = spec.world(orgInvite, { resources: { surfaces: ["web"], services: ["den"] }, needs: { placement: "local" }, timeout: 600_000 });
+
+test("cold cloud signup recovers from the verification email without an invitation", async ({ world, user, probe, step }) => {
+  const person = world.identity("cold-signup");
+  let currentCode = "";
+  let recoveryLink = "";
+  const noAuthentication = async () => {
+    expect(await world.sessionsFor(person.email)).toEqual([]);
+    expect(membersFor(await world.witnesses.org(text(world.organization.id)), person.email)).toEqual([]);
+    expect(membersFor(await invitationWitnesses(world.other).org(text(world.otherOrg.id)), person.email)).toEqual([]);
+    expect(await world.witnesses.emails("organizationInvite", person.email)).toEqual([]);
+  };
+
+  await step("signup sends an OTP but neither creates membership nor authenticates a wrong code", async () => {
+    await user.see({ role: "textbox", label: "Email" }, { timeoutMs: 90_000 });
+    await user.type({ role: "textbox", label: "Email" }, person.email);
+    await user.click({ role: "button", label: "Next" });
+    await user.type({ role: "textbox", label: "Name" }, person.name);
+    await user.type({ role: "textbox", label: "Password" }, person.password);
+    await user.click({ role: "button", label: "Sign up" });
+    await user.see({ role: "textbox", label: "Verification code" });
+    await probe.eventually(() => world.witnesses.emails("verification", person.email), { within: 15_000, label: "cold signup verification email", until: (emails) => emails.length > 0 });
+    currentCode = await world.witnesses.otp(person.email);
+    const wrongCode = currentCode === "000000" ? "000001" : "000000";
+    await user.type({ role: "textbox", label: "Verification code" }, wrongCode);
+    await user.click({ role: "button", label: "Verify email" });
+    await user.see({ text: /invalid.*(code|otp)|(code|otp).*invalid/i });
+    await user.notSee({ text: "Make it yours." });
+    await user.notSee({ testId: "den-org-sidebar" });
+    await noAuthentication();
+  });
+
+  await step("resend replaces the old OTP without allowing it to authenticate", async () => {
+    const oldCode = currentCode;
+    const before = await world.witnesses.emails("verification", person.email);
+    await user.click({ role: "button", label: "Resend code" });
+    await probe.eventually(() => world.witnesses.emails("verification", person.email), { within: 15_000, label: "resent verification email", until: (emails) => emails.length > before.length });
+    currentCode = await world.witnesses.otp(person.email);
+    expect(currentCode).not.toBe(oldCode);
+    await user.type({ role: "textbox", label: "Verification code" }, oldCode, { replace: true });
+    await user.click({ role: "button", label: "Verify email" });
+    await user.see({ text: /invalid.*(code|otp)|(code|otp).*invalid/i });
+    await user.notSee({ text: "Make it yours." });
+    await noAuthentication();
+  });
+
+  await step("the actual verification email contains a usable recovery link", async () => {
+    const html = await world.witnesses.lastEmail("verification", person.email);
+    const links = emailLinks(html).filter((link) => new URL(link).origin === new URL(world.den.ref.webUrl).origin);
+    expect(links, "Signup verification email must link back to code entry/recovery, not strand the person with only an OTP").not.toEqual([]);
+    recoveryLink = links[0];
+    expect(new URL(recoveryLink).searchParams.has("invite")).toBe(false);
+    expect(await world.witnesses.emails("organizationInvite", person.email)).toEqual([]);
+  });
+
+  await step("opening the email in a fresh browser resumes code entry without silently authenticating", async () => {
+    const surface = await world.fresh(recoveryLink);
+    const actor = user.on(surface);
+    await actor.see({ role: "textbox", label: "Verification code" }, { timeoutMs: 90_000 });
+    await actor.see({ text: person.email });
+    await actor.notSee({ testId: "den-org-sidebar" });
+    await actor.notSee({ text: "Make it yours." });
+    await noAuthentication();
+    await actor.type({ role: "textbox", label: "Verification code" }, currentCode);
+    await actor.click({ role: "button", label: "Verify email" });
+    await actor.see({ text: "Make it yours." }, { timeoutMs: 30_000 });
+    await actor.notSee({ role: "textbox", label: "Verification code" });
+    const session = await world.witnesses.sessionFor(person);
+    expect(await invitationWitnesses(session).orgs()).toEqual([]);
+  });
+});

--- a/evals/worlds/den.ts
+++ b/evals/worlds/den.ts
@@ -4,6 +4,7 @@ import type { Seed } from "@openwork/env";
 import { waitFor } from "@openwork/behaviors";
 import { navigate } from "@openwork/cdp";
 import { startMockIdpLab } from "@openwork/labs";
+import { localInviteNeeds } from "./org-invite.ts";
 
 function recordField(value: unknown, key: string): Record<string, unknown> | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
@@ -22,20 +23,24 @@ function booleanField(value: unknown, key: string): boolean {
   return Reflect.get(value, key) === true;
 }
 
-export async function ssoInvite(seed: Seed) {
+export async function ssoInvite(seed: Seed, options: { mismatchedEmail?: boolean; role?: string } = {}) {
+  await localInviteNeeds();
   if (!await localMysqlIsRunning()) throw new SkipError("MySQL on 127.0.0.1:3306");
 
   const stamp = Date.now();
   const domain = "sso-acme.test";
   const invitee = `sso-newcomer-${stamp}@${domain}`;
+  const mismatchedEmail = `sso-other-${stamp}@${domain}`;
   const idp = await startMockIdpLab({
     domain,
     defaultSubject: { email: invitee, name: "SSO Newcomer" },
+    knobs: { emailMismatch: options.mismatchedEmail ? mismatchedEmail : false },
   });
   try {
     const den = await seed.den({
       trustedOrigins: [new URL(idp.issuer).origin],
       org: { admin: { email: `sso-owner-${stamp}@${domain}` } },
+      env: { DEN_ORG_MODE: "multi_org", DEN_REQUIRE_EMAIL_VERIFICATION: "true", OPENWORK_DEV_MODE: "1", RESEND_API_KEY: "", SMTP_HOST: "" },
     });
     const organizationResult = await seed.api(den.admin, "/v1/org");
     const organizationId = stringField(recordField(organizationResult.body, "organization"), "id");
@@ -136,7 +141,7 @@ export async function ssoInvite(seed: Seed) {
 
     const invited = await seed.api(den.admin, "/v1/invitations", {
       method: "POST",
-      body: JSON.stringify({ email: invitee, role: "member" }),
+      body: JSON.stringify({ email: invitee, role: options.role ?? "member" }),
     });
     const inviteToken = stringField(invited.body, "inviteToken");
     if (!invited.response.ok || !inviteToken) throw new Error(`Could not invite the SSO member: HTTP ${invited.response.status}.`);
@@ -150,6 +155,10 @@ export async function ssoInvite(seed: Seed) {
     });
     return {
       web,
+      den,
+      organizationId,
+      inviteToken,
+      mismatchedEmail,
       invitee,
       joinUrl: `${webOrigin}/join-org?invite=${encodeURIComponent(inviteToken)}`,
       async [Symbol.asyncDispose]() {

--- a/evals/worlds/org-invite.ts
+++ b/evals/worlds/org-invite.ts
@@ -99,29 +99,14 @@ export async function orgInvite(seed: Seed, { place }: { place: { kind: "local" 
   const createdOrganization = await seed.api(owner, "/v1/org", { method: "POST", body: JSON.stringify({ name: `Invite workspace ${runId}` }) });
   if (!createdOrganization.response.ok) throw new Error(`Organization: HTTP ${createdOrganization.response.status}`);
   const organization = record(record(createdOrganization.body).organization);
-  const otherPerson = identity("other-owner");
-  const signUp = await denFetch(den.ref, "/api/auth/sign-up/email", {
-    method: "POST", body: JSON.stringify(otherPerson), signal: AbortSignal.timeout(15_000),
-  });
-  if (!signUp.response.ok) throw new Error(`Other owner sign-up: HTTP ${signUp.response.status}`);
-  const deadline = Date.now() + 15_000;
-  let otp: string | null = null;
-  while (Date.now() < deadline && !otp) {
-    try {
-      otp = await witnesses.otp(otherPerson.email);
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    }
-  }
-  if (!otp) throw new Error("Other owner verification email did not arrive");
-  const verified = await denFetch(den.ref, "/api/auth/email-otp/verify-email", {
-    method: "POST", body: JSON.stringify({ email: otherPerson.email, otp }), signal: AbortSignal.timeout(15_000),
-  });
-  if (!verified.response.ok) throw new Error(`Other owner verification: HTTP ${verified.response.status}`);
-  const other = await signIn(den.ref, otherPerson);
-  const createdOther = await seed.api(other, "/v1/org", { method: "POST", body: JSON.stringify({ name: `Other workspace ${runId}` }) });
+  const createdOther = await seed.api(owner, "/v1/org", { method: "POST", body: JSON.stringify({ name: `Other workspace ${runId}` }) });
   if (!createdOther.response.ok) throw new Error(`Second organization: HTTP ${createdOther.response.status}`);
   const otherOrg = record(record(createdOther.body).organization);
+  const selected = await seed.api(owner, "/v1/me/active-organization", {
+    method: "POST", body: JSON.stringify({ organizationId: text(organization.id) }),
+  });
+  if (!selected.response.ok) throw new Error(`Select organization: HTTP ${selected.response.status}`);
+  const other = owner;
   const web = await seed.web({ den, startPath: "/", headless: true });
   return {
     den, web, owner, other, organization, otherOrg, identity, witnesses,

--- a/evals/worlds/org-invite.ts
+++ b/evals/worlds/org-invite.ts
@@ -1,5 +1,5 @@
 import { denFetch, signIn, type DenSession } from "@openwork/behaviors";
-import { createAdmin, localMysqlIsRunning, localRedisIsRunning, needs, personDefaults, queryDenDatabase, SkipError, type Seed } from "@openwork/env";
+import { defaultReuseAdmin, localMysqlIsRunning, localRedisIsRunning, needs, personDefaults, queryDenDatabase, SkipError, type Seed } from "@openwork/env";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -82,35 +82,53 @@ export function invitationsFor(org: Record<string, unknown>, email: string) {
   return rows(org.invitations).filter((invitation) => invitation.email === email);
 }
 
-export async function orgInvite(seed: Seed) {
+export async function orgInvite(seed: Seed, { place }: { place: { kind: "local" | "daytona" } }) {
   const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
   const identity = (key: string) => personDefaults(key, undefined, runId);
   const den = await seed.den({
-    org: { name: `Invite workspace ${runId}`, admin: identity("invite-owner"), members: {} },
+    ...(place.kind === "daytona" ? { provision: false } : { seedProfile: "demo-org" }),
     env: {
       DEN_ORG_MODE: "multi_org", DEN_REQUIRE_EMAIL_VERIFICATION: "true",
       DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: "true", OPENWORK_DEV_MODE: "1",
       RESEND_API_KEY: "", SMTP_HOST: "", GOOGLE_CLIENT_ID: "invite-google-client", GOOGLE_CLIENT_SECRET: "invite-google-secret",
     },
   });
-  const owner = den.admin;
+  const owner = await signIn(den.ref, defaultReuseAdmin());
+  den.admin = owner;
   const witnesses = invitationWitnesses(owner);
-  const organization = record((await witnesses.org()).organization);
-  const other = await createAdmin(den, identity("other-owner"));
-  try {
-    const created = await seed.api(other, "/v1/org", { method: "POST", body: JSON.stringify({ name: `Other workspace ${runId}` }) });
-    if (!created.response.ok) throw new Error(`Second organization: HTTP ${created.response.status}`);
-    const otherOrg = record(record(created.body).organization);
-    const web = await seed.web({ den, startPath: "/", headless: true });
-    return {
-      den, web, owner, other, organization, otherOrg, identity, witnesses,
-      fresh: (startPath = "/", signedInAs?: DenSession) => seed.web({ den, startPath, signedInAs, headless: true }),
-      async sessionsFor(email: string) {
-        if (!den.database) throw new Error("Session witness requires the isolated Den database");
-        return queryDenDatabase(den.database.url, "SELECT session.id FROM session INNER JOIN user ON user.id = session.user_id WHERE user.email = ? AND session.expires_at > NOW()", [email]);
-      },
-    };
-  } finally {
-    den.admin = owner;
+  const createdOrganization = await seed.api(owner, "/v1/org", { method: "POST", body: JSON.stringify({ name: `Invite workspace ${runId}` }) });
+  if (!createdOrganization.response.ok) throw new Error(`Organization: HTTP ${createdOrganization.response.status}`);
+  const organization = record(record(createdOrganization.body).organization);
+  const otherPerson = identity("other-owner");
+  const signUp = await denFetch(den.ref, "/api/auth/sign-up/email", {
+    method: "POST", body: JSON.stringify(otherPerson), signal: AbortSignal.timeout(15_000),
+  });
+  if (!signUp.response.ok) throw new Error(`Other owner sign-up: HTTP ${signUp.response.status}`);
+  const deadline = Date.now() + 15_000;
+  let otp: string | null = null;
+  while (Date.now() < deadline && !otp) {
+    try {
+      otp = await witnesses.otp(otherPerson.email);
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
   }
+  if (!otp) throw new Error("Other owner verification email did not arrive");
+  const verified = await denFetch(den.ref, "/api/auth/email-otp/verify-email", {
+    method: "POST", body: JSON.stringify({ email: otherPerson.email, otp }), signal: AbortSignal.timeout(15_000),
+  });
+  if (!verified.response.ok) throw new Error(`Other owner verification: HTTP ${verified.response.status}`);
+  const other = await signIn(den.ref, otherPerson);
+  const createdOther = await seed.api(other, "/v1/org", { method: "POST", body: JSON.stringify({ name: `Other workspace ${runId}` }) });
+  if (!createdOther.response.ok) throw new Error(`Second organization: HTTP ${createdOther.response.status}`);
+  const otherOrg = record(record(createdOther.body).organization);
+  const web = await seed.web({ den, startPath: "/", headless: true });
+  return {
+    den, web, owner, other, organization, otherOrg, identity, witnesses,
+    fresh: (startPath = "/", signedInAs?: DenSession) => seed.web({ den, startPath, signedInAs, headless: true }),
+    async sessionsFor(email: string) {
+      if (!den.database) throw new Error("Session witness requires the isolated Den database");
+      return queryDenDatabase(den.database.url, "SELECT session.id FROM session INNER JOIN user ON user.id = session.user_id WHERE user.email = ? AND session.expires_at > NOW()", [email]);
+    },
+  };
 }

--- a/evals/worlds/org-invite.ts
+++ b/evals/worlds/org-invite.ts
@@ -1,0 +1,121 @@
+import { denFetch, signIn, type DenSession } from "@openwork/behaviors";
+import { createAdmin, localMysqlIsRunning, localRedisIsRunning, needs, personDefaults, queryDenDatabase, SkipError, type Seed } from "@openwork/env";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected an object witness");
+  return value;
+}
+
+export function text(value: unknown): string {
+  if (typeof value !== "string" || !value) throw new Error("Expected a nonempty string witness");
+  return value;
+}
+
+export function rows(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) throw new Error("Expected an array witness");
+  return value.map(record);
+}
+
+export async function localInviteNeeds() {
+  needs({ placement: "local" });
+  if (!await localMysqlIsRunning()) throw new SkipError("MySQL on 127.0.0.1:3306");
+  if (!await localRedisIsRunning()) throw new SkipError("Redis on 127.0.0.1:6379");
+}
+
+export function invitationWitnesses(admin: DenSession) {
+  const api = (path: string, init?: RequestInit) => denFetch(admin, path, {
+    ...init,
+    headers: { authorization: `Bearer ${admin.token}`, ...init?.headers },
+    signal: AbortSignal.timeout(15_000),
+  });
+  const read = async (path: string, orgId?: string) => {
+    const result = await api(path, { headers: orgId ? { "x-openwork-org-id": orgId } : {} });
+    if (!result.response.ok) throw new Error(`Witness ${path}: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+    return record(result.body);
+  };
+  const emails = async (template: string, email: string) => rows((await read(`/v1/dev/emails?template=${template}`)).emails).filter((entry) => entry.to === email);
+  const lastEmail = async (template: string, email: string) => {
+    const all = rows((await read(`/v1/dev/emails?template=${template}`)).emails);
+    if (all[0]?.to !== email) throw new Error(`Latest ${template} email does not belong to the isolated recipient ${email}`);
+    const result = await api(`/v1/dev/emails/last?template=${template}`);
+    if (!result.response.ok) throw new Error(`Email HTML: HTTP ${result.response.status}`);
+    return result.text;
+  };
+  return {
+    api, emails, lastEmail,
+    sessionFor: (person: { email: string; password: string }) => signIn(admin, person),
+    org: (id?: string) => read("/v1/org", id),
+    orgs: async () => rows((await read("/v1/me/orgs")).orgs),
+    async invite(email: string, orgId: string, role = "member") {
+      const result = await api("/v1/invitations", {
+        method: "POST", headers: { "x-openwork-org-id": orgId }, body: JSON.stringify({ email, role }),
+      });
+      if (!result.response.ok) throw new Error(`Create invitation: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+      const body = record(result.body);
+      const html = await lastEmail("organizationInvite", email);
+      const link = emailLinks(html).find((url) => new URL(url).pathname === "/join-org");
+      if (!link || new URL(link).searchParams.get("invite") !== body.inviteToken) throw new Error("Invitation email must contain the issued invitation link");
+      return { id: text(body.invitationId), token: text(body.inviteToken), link, email, role, orgId };
+    },
+    async otp(email: string) {
+      const html = await lastEmail("verification", email);
+      const code = html.replace(/<[^>]*>/g, " ").match(/\b\d{6}\b/)?.[0];
+      if (!code) throw new Error("Verification email has no six-digit code");
+      return code;
+    },
+  };
+}
+
+export function emailLinks(html: string): string[] {
+  return [...html.matchAll(/href=["'](https?:\/\/[^"']+)["']/g)].map((match) => match[1].replaceAll("&amp;", "&"));
+}
+
+export function membersFor(org: Record<string, unknown>, email: string) {
+  return rows(org.members).filter((member) => member.userId && member.joinedAt && member.user && record(member.user).email === email);
+}
+
+export function invitationsFor(org: Record<string, unknown>, email: string) {
+  return rows(org.invitations).filter((invitation) => invitation.email === email);
+}
+
+export async function orgInvite(seed: Seed) {
+  await localInviteNeeds();
+  const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
+  const identity = (key: string) => personDefaults(key, undefined, runId);
+  const den = await seed.den({
+    org: { name: `Invite workspace ${runId}`, admin: identity("invite-owner"), members: {} },
+    env: {
+      DEN_ORG_MODE: "multi_org", DEN_REQUIRE_EMAIL_VERIFICATION: "true",
+      DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: "true", OPENWORK_DEV_MODE: "1",
+      RESEND_API_KEY: "", SMTP_HOST: "", GOOGLE_CLIENT_ID: "invite-google-client", GOOGLE_CLIENT_SECRET: "invite-google-secret",
+    },
+  });
+  const owner = den.admin;
+  const witnesses = invitationWitnesses(owner);
+  const organization = record((await witnesses.org()).organization);
+  const other = await createAdmin(den, identity("other-owner"));
+  try {
+    const created = await seed.api(other, "/v1/org", { method: "POST", body: JSON.stringify({ name: `Other workspace ${runId}` }) });
+    if (!created.response.ok) throw new Error(`Second organization: HTTP ${created.response.status}`);
+    const otherOrg = record(record(created.body).organization);
+    const web = await seed.web({ den, startPath: "/", headless: true });
+    return {
+      den, web, owner, other, organization, otherOrg, identity, witnesses,
+      fresh: (startPath = "/", signedInAs?: DenSession) => seed.web({ den, startPath, signedInAs, headless: true }),
+      async sessionsFor(email: string) {
+        if (!den.database) throw new Error("Session witness requires the isolated Den database");
+        return queryDenDatabase(den.database.url, "SELECT session.id FROM session INNER JOIN user ON user.id = session.user_id WHERE user.email = ? AND session.expires_at > NOW()", [email]);
+      },
+      async expire(invitationId: string) {
+        if (!den.database) throw new Error("Invitation expiry fixture requires the isolated Den database");
+        await queryDenDatabase(den.database.url, "UPDATE invitation SET expires_at = DATE_SUB(NOW(), INTERVAL 1 DAY) WHERE id = ?", [invitationId]);
+      },
+    };
+  } finally {
+    den.admin = owner;
+  }
+}

--- a/evals/worlds/org-invite.ts
+++ b/evals/worlds/org-invite.ts
@@ -83,7 +83,6 @@ export function invitationsFor(org: Record<string, unknown>, email: string) {
 }
 
 export async function orgInvite(seed: Seed) {
-  await localInviteNeeds();
   const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
   const identity = (key: string) => personDefaults(key, undefined, runId);
   const den = await seed.den({
@@ -109,10 +108,6 @@ export async function orgInvite(seed: Seed) {
       async sessionsFor(email: string) {
         if (!den.database) throw new Error("Session witness requires the isolated Den database");
         return queryDenDatabase(den.database.url, "SELECT session.id FROM session INNER JOIN user ON user.id = session.user_id WHERE user.email = ? AND session.expires_at > NOW()", [email]);
-      },
-      async expire(invitationId: string) {
-        if (!den.database) throw new Error("Invitation expiry fixture requires the isolated Den database");
-        await queryDenDatabase(den.database.url, "UPDATE invitation SET expires_at = DATE_SUB(NOW(), INTERVAL 1 DAY) WHERE id = ?", [invitationId]);
       },
     };
   } finally {


### PR DESCRIPTION
## Summary
- add consolidated cloud invitation coverage for email signup, account switching, Google availability, canceled/domain-blocked invitations, and generic auth failures
- add focused SSO, self-hosted, and cold-signup verification recovery journeys
- add shared invitation witnesses and self-host bootstrap support
- make the cloud invitation journey runnable on Daytona

## Verification
- `pnpm --dir evals exec vitest list --config vitest.config.ts --project e2e specs/org-invite-join.e2e.test.ts specs/signup-verification-recovery.e2e.test.ts specs/org-invite-sso.e2e.test.ts specs/self-host-invite.e2e.test.ts` — 5 tests collected
- scoped dependency-cruiser check — pass
- `OPENWORK_EVAL_REF=$(git rev-parse HEAD) pnpm evals:e2e org-invite-join --daytona --strict-ref` at `41361eb7` — failed on the intended OPE-82 product assertion: the invitation page showed only `Create account` and did not offer `Sign up with Google`; 0 passed, 1 failed, 0 skipped
- Daytona sandbox and browser sandboxes cleaned up successfully
- `pnpm --dir evals typecheck` — blocked by the existing `session-attention-rollup.test.ts:27` error also present on clean `origin/dev`

Tracks OPE-82.