### PR TITLE
Fix Models label in command palette

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -743,7 +743,6 @@ export function AdvancedOpencodeSection(props: AdvancedOpencodeSectionProps) {
 export function AdvancedWorkspaceRunModeSection() {
   const { workspaceRunModeEnabled, toggleWorkspaceRunMode } = useFeatureFlagsPreferences();
   const restricted = useDesktopRestriction("allowControlSettings");
-  if (!isDesktopRuntime()) return null;
   return (
     <LayoutSection id="advanced-workspace-run-mode">
       <LayoutSectionHeader>
@@ -757,7 +756,13 @@ export function AdvancedWorkspaceRunModeSection() {
             Choose when OpenWork asks before acting, using the icon beside attachments. Off by default. Available with the standard desktop engine.
           </LayoutSectionItemDescription>
           <LayoutSectionItemHeaderActions>
-            <Switch data-testid="workspace-run-mode-flag" aria-label="Show workspace run mode" checked={workspaceRunModeEnabled} disabled={restricted} onCheckedChange={toggleWorkspaceRunMode} />
+            <Switch
+              data-testid="workspace-run-mode-flag"
+              aria-label="Show workspace run mode"
+              checked={workspaceRunModeEnabled}
+              disabled={restricted || !isDesktopRuntime()}
+              onCheckedChange={toggleWorkspaceRunMode}
+            />
           </LayoutSectionItemHeaderActions>
         </LayoutSectionItemHeader>
         <LayoutSectionItemFootnote>

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -116,7 +116,6 @@ export type CommandPaletteProps = {
   selectedModel?: ModelRef;
   selectedModelBehavior?: string | null;
   onSelectModel?: (model: ModelRef, behavior: string | null) => void;
-  selectedModelLabel?: string;
   /** Optional — open a URL in the user's browser. Falls back to window.open. */
   onOpenUrl?: (url: string) => void;
   /** Optional: current session servers/artifacts exposed through Cmd/Ctrl+K. */
@@ -278,7 +277,6 @@ export function CommandPalette(props: CommandPaletteProps) {
           id: "models",
           title: "Models",
           detail: "Choose the LLM that runs your next prompts",
-          meta: props.selectedModelLabel ?? t("session.default_model"),
           searchText: "model models llm provider openai anthropic claude gpt gemini switch pick select default",
           group: ACTIONS_GROUP,
           action: () => {
@@ -686,11 +684,7 @@ export function CommandPalette(props: CommandPaletteProps) {
         ) : null}
       </div>
       {item.shortcut || item.meta ? (
-        <CommandShortcut
-          className={item.id === "models" && item.meta ? "max-w-[50%] shrink-0 truncate whitespace-nowrap tracking-normal" : undefined}
-        >
-          {item.shortcut ?? item.meta}
-        </CommandShortcut>
+        <CommandShortcut>{item.shortcut ?? item.meta}</CommandShortcut>
       ) : null}
     </CommandItem>
   );

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -276,7 +276,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     ...(hasNestedModelPicker || props.onOpenModelPicker
       ? [{
           id: "models",
-          title: "Switch model",
+          title: "Models",
           detail: "Choose the LLM that runs your next prompts",
           meta: props.selectedModelLabel ?? t("session.default_model"),
           searchText: "model models llm provider openai anthropic claude gpt gemini switch pick select default",
@@ -686,7 +686,11 @@ export function CommandPalette(props: CommandPaletteProps) {
         ) : null}
       </div>
       {item.shortcut || item.meta ? (
-        <CommandShortcut>{item.shortcut ?? item.meta}</CommandShortcut>
+        <CommandShortcut
+          className={item.id === "models" && item.meta ? "max-w-[50%] shrink-0 truncate whitespace-nowrap tracking-normal" : undefined}
+        >
+          {item.shortcut ?? item.meta}
+        </CommandShortcut>
       ) : null}
     </CommandItem>
   );

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -3871,7 +3871,6 @@ export function SessionRoute() {
       onSelectModel={(next, behavior) => {
         applySessionRouteModelSelection(next, selectedSessionId || null, { value: behavior });
       }}
-      selectedModelLabel={modelLabel}
       accessibleTargets={paletteAccessibleTargets}
       onOpenAccessibleTarget={(target) => {
         try {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2797,7 +2797,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           modelPicker.setRecentProviderIds(new Set());
           window.requestAnimationFrame(() => modelPicker.setOpen(true));
         }}
-        selectedModelLabel={defaultModelLabel}
         sessions={paletteSessionOptions}
         extraItems={checkDesktopRestriction({ restriction: "allowControlSettings" }) ? [] : [developerModePaletteItem]}
       />

--- a/apps/app/tests/command-palette-search.test.ts
+++ b/apps/app/tests/command-palette-search.test.ts
@@ -66,7 +66,7 @@ describe("command palette search", () => {
     const items = [
       item({
         id: "models",
-        title: "Switch model",
+        title: "Models",
         detail: "Choose the LLM that runs your next prompts",
         searchText: "model models llm provider openai anthropic claude gpt gemini switch pick select default",
       }),

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -221,7 +221,7 @@ test("command palette searches settings by alias, navigates, records recents, an
         const readSwitch = () => probe.eval(browserScript(() => {
           const control = document.querySelector<HTMLButtonElement>('[data-testid="workspace-run-mode-flag"]');
           return control ? { disabled: control.disabled, checked: control.getAttribute("aria-checked") } : null;
-        }));
+        }, []));
         const before = await readSwitch();
         expect(before?.disabled).toBe(true);
         await expect(user.click({ role: "switch", label: "Show workspace run mode" })).rejects.toThrow("Refused to click disabled");

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -216,6 +216,17 @@ test("command palette searches settings by alias, navigates, records recents, an
         label: `${section.title} is focused and in view`,
         until: (value) => value === true,
       })).toBe(true);
+      if (section.id === "workspace-run-mode") {
+        await user.see({ role: "switch", label: "Show workspace run mode" });
+        const readSwitch = () => probe.eval(browserScript(() => {
+          const control = document.querySelector<HTMLButtonElement>('[data-testid="workspace-run-mode-flag"]');
+          return control ? { disabled: control.disabled, checked: control.getAttribute("aria-checked") } : null;
+        }));
+        const before = await readSwitch();
+        expect(before?.disabled).toBe(true);
+        await expect(user.click({ role: "switch", label: "Show workspace run mode" })).rejects.toThrow("Refused to click disabled");
+        expect(await readSwitch()).toEqual(before);
+      }
       await user.notSee(paletteInput);
     });
   }

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -3,7 +3,10 @@ import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { commandPaletteSearch } from "../worlds/session-shell.ts";
 
-const test = spec.world(commandPaletteSearch);
+const test = spec.world(commandPaletteSearch, {
+  timeout: 420_000,
+  resources: { surfaces: ["appWeb"], services: [] },
+});
 const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
 
 function stringArray(value: unknown): string[] {
@@ -12,8 +15,13 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
-test("command palette searches settings by alias, navigates, records recents, and filters actions", async ({ world, user, probe, step }) => {
+test("command palette searches settings by alias, navigates, records recents, and filters actions", async ({ world, user, probe, step, evidence }) => {
   const workspaceId = world.workspace.workspaceId;
+  const draft = "Keep this draft while checking Models.";
+  const runtime = await world.runtimeFacts();
+  expect(runtime.browser).toContain("HeadlessChrome");
+  expect(runtime.electronBridge).toBe(false);
+  evidence.recordJsonArtifact("command palette web runtime", runtime);
   const macPlatform = await probe.eval(() => (/Mac|iPhone|iPad|iPod/.test(navigator.platform)));
   const paletteShortcut = macPlatform ? "Meta+K" : "Control+K";
   const waitForPaletteClose = () => probe.eventually(() => probe.has("Arrow keys to navigate"), {
@@ -22,8 +30,11 @@ test("command palette searches settings by alias, navigates, records recents, an
     until: (open) => !open,
   });
 
+  await user.type("composer", draft);
+  const initialComposer = await probe.composer();
+
   await step("the empty palette offers actions and settings without recents", async () => {
-    expect(await probe.hash()).toContain(workspaceId);
+    expect(await world.location()).toContain(workspaceId);
     await user.press(paletteShortcut);
     await user.see(paletteInput);
     await user.see({ text: "Actions" });
@@ -33,24 +44,62 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.screenshot();
   });
 
+  await step("Models stays readable beside long selected-model metadata and preserves composer state", async () => {
+    await user.type(paletteInput, "models", { replace: true });
+    await user.screenshot();
+    await user.see({ role: "option", label: /^Models/ });
+    const row = await probe.dom('[data-command-palette-item="models"]');
+    const label = await probe.dom('[data-command-palette-item="models"] > div:first-child');
+    const metadata = await probe.dom('[data-command-palette-item="models"] > [data-slot="command-shortcut"]');
+    expect(row.elements).toHaveLength(1);
+    expect(label.elements).toHaveLength(1);
+    expect(metadata.elements).toHaveLength(1);
+    expect(label.elements[0]!.text).toContain("Models");
+    expect(label.elements[0]!.rect.width).toBeGreaterThan(80);
+    expect(metadata.elements[0]!.rect.height).toBeLessThanOrEqual(20);
+    expect(label.elements[0]!.rect.right).toBeLessThanOrEqual(metadata.elements[0]!.rect.left);
+    evidence.recordJsonArtifact("Models row geometry", {
+      row: row.elements[0],
+      label: label.elements[0],
+      metadata: metadata.elements[0],
+      longModelId: world.longModelId,
+    });
+    await user.looks([
+      "The visible command palette row is clearly labeled Models.",
+      "The selected-model metadata is a single unobtrusive trailing line and does not overlap, replace, or garble the Models label.",
+    ]);
+    await user.press("Enter");
+    await user.see({ placeholder: "Search models..." });
+    await user.press("Escape");
+    await user.see(paletteInput);
+    await user.press("Escape");
+    await waitForPaletteClose();
+    await user.see("composer", { text: draft });
+    const currentComposer = await probe.composer();
+    expect(currentComposer.selectedModelLabel).toBe(initialComposer.selectedModelLabel);
+    expect(currentComposer.draftText).toBe(initialComposer.draftText);
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+  });
+
   await step("folders ranks Permissions first and Enter navigates there", async () => {
     await user.type(paletteInput, "folders", { replace: true });
     await user.see({ role: "option", label: /^Permissions/ });
     await user.notSee({ text: "Sessions" });
     await user.screenshot();
     await user.press("Enter");
-    const hash = await probe.eventually(() => probe.hash(), {
+    const location = await probe.eventually(() => world.location(), {
       within: 15_000,
       label: "Permissions settings route",
       until: (value) => value.endsWith("/settings/permissions"),
     });
-    expect(hash).toContain(workspaceId);
-    expect(hash).toMatch(/\/settings\/permissions$/);
-    expect(hash).not.toMatch(/\/settings\/general$/);
-    expect(hash).not.toMatch(/\/settings\/preferences$/);
+    expect(location).toContain(workspaceId);
+    expect(location).toMatch(/\/settings\/permissions$/);
+    expect(location).not.toMatch(/\/settings\/general$/);
+    expect(location).not.toMatch(/\/settings\/preferences$/);
   });
 
-  await step("reopening the palette shows Permissions as the sole recent item", async () => {
+  await step("reopening the palette shows the chosen Models and Permissions recents", async () => {
     await user.see({ text: /Authorized folders/ });
     // Settings closes route-owned overlays just after its content appears; let that
     // transition settle so it does not immediately close the newly opened palette.
@@ -59,8 +108,9 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.see(paletteInput);
     await user.see({ text: "Recent" });
     await user.see({ role: "option", label: /^Permissions/ });
+    await user.see({ role: "option", label: /^Models/ });
     const storedRecents = stringArray(await probe.storage("openwork.react.command-palette.recents"));
-    expect(storedRecents).toEqual(["settings:permissions"]);
+    expect(storedRecents).toEqual(["settings:permissions", "models"]);
     expect(storedRecents).not.toContain("settings:appearance");
     await user.screenshot();
   });
@@ -70,14 +120,14 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.see({ role: "option", label: /^Appearance/ });
     await user.screenshot();
     await user.press("Enter");
-    const hash = await probe.eventually(() => probe.hash(), {
+    const location = await probe.eventually(() => world.location(), {
       within: 15_000,
       label: "Appearance settings route",
       until: (value) => value.endsWith("/settings/appearance"),
     });
-    expect(hash).toContain(workspaceId);
-    expect(hash).toMatch(/\/settings\/appearance$/);
-    expect(hash).not.toMatch(/\/settings\/permissions$/);
+    expect(location).toContain(workspaceId);
+    expect(location).toMatch(/\/settings\/appearance$/);
+    expect(location).not.toMatch(/\/settings\/permissions$/);
     await probe.eventually(() => probe.has("Arrow keys to navigate"), {
       within: 15_000,
       label: "command palette closes after choosing Appearance",
@@ -107,9 +157,9 @@ test("command palette searches settings by alias, navigates, records recents, an
       until: (open) => !open,
     });
     await user.notSee(paletteInput);
-    const hash = await probe.hash();
-    expect(hash).toContain(workspaceId);
-    expect(hash).toMatch(/\/settings\/appearance$/);
+    const location = await world.location();
+    expect(location).toContain(workspaceId);
+    expect(location).toMatch(/\/settings\/appearance$/);
   });
 
   await step("developer mode surfaces Advanced sections without a search", async () => {
@@ -149,12 +199,12 @@ test("command palette searches settings by alias, navigates, records recents, an
         label: section.id === "experimental-engine" ? /^Organization server/ : /^Experimental engine/,
       });
       await user.click({ role: "option", label: new RegExp(`^${section.title}`) });
-      const sectionHash = await probe.eventually(() => probe.hash(), {
+      const sectionLocation = await probe.eventually(() => world.location(), {
         within: 15_000,
         label: `${section.title} section route`,
         until: (value) => value.endsWith(`/settings/advanced/${section.id}`),
       });
-      expect(sectionHash).toBe(`#/workspace/${workspaceId}/settings/advanced/${section.id}`);
+      expect(sectionLocation).toBe(`/workspace/${workspaceId}/settings/advanced/${section.id}`);
       await waitForPaletteClose();
       expect(await probe.eventually(() => probe.eval(browserScript((id) => {
         const section = document.getElementById(id);

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -41,12 +41,14 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.see({ role: "option", label: /^Permissions/ });
     await user.notSee({ text: "Recent" });
     await user.notSee({ role: "option", label: /^Experimental engine/ });
-    await user.screenshot();
+    await user.looks([
+      "The command palette is visibly open with its search field, result groups, and keyboard footer intact.",
+      "The empty-query palette visibly offers actions and settings, including Permissions, without a Recent group.",
+    ]);
   });
 
   await step("Models stays readable without exposing internal model metadata and preserves composer state", async () => {
     await user.type(paletteInput, "models", { replace: true });
-    await user.screenshot();
     await user.see({ role: "option", label: /^Models/ });
     const row = await probe.dom('[data-command-palette-item="models"]');
     const label = await probe.dom('[data-command-palette-item="models"] > div:first-child');
@@ -85,7 +87,10 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.type(paletteInput, "folders", { replace: true });
     await user.see({ role: "option", label: /^Permissions/ });
     await user.notSee({ text: "Sessions" });
-    await user.screenshot();
+    await user.looks([
+      "After searching for folders, Permissions is the visible highlighted first result.",
+      "No Sessions result group is displayed for the folders query.",
+    ]);
     await user.press("Enter");
     const location = await probe.eventually(() => world.location(), {
       within: 15_000,
@@ -111,13 +116,19 @@ test("command palette searches settings by alias, navigates, records recents, an
     const storedRecents = stringArray(await probe.storage("openwork.react.command-palette.recents"));
     expect(storedRecents).toEqual(["settings:permissions", "models"]);
     expect(storedRecents).not.toContain("settings:appearance");
-    await user.screenshot();
+    await user.looks([
+      "The Recent group visibly contains both Permissions and Models.",
+      "Appearance is not shown in the Recent group.",
+    ]);
   });
 
   await step("dark mode ranks Appearance first and Enter navigates there", async () => {
     await user.type(paletteInput, "dark mode", { replace: true });
     await user.see({ role: "option", label: /^Appearance/ });
-    await user.screenshot();
+    await user.looks([
+      "After searching for dark mode, Appearance is the visible highlighted first result.",
+      "The Appearance result remains readable with its settings context and description.",
+    ]);
     await user.press("Enter");
     const location = await probe.eventually(() => world.location(), {
       within: 15_000,
@@ -145,7 +156,10 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.see({ role: "option", label: /^Toggle sidebar/ });
     await user.notSee({ role: "option", label: /^Appearance/ });
     await user.notSee({ role: "option", label: /^Permissions/ });
-    await user.screenshot();
+    await user.looks([
+      "With the greater-than action filter, Toggle sidebar is visibly available.",
+      "Settings entries such as Appearance and Permissions are not displayed in the filtered results.",
+    ]);
   });
 
   await step("Escape closes the palette without navigating", async () => {
@@ -174,7 +188,10 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.see({ role: "option", label: /^Experimental engine/ });
     await user.see({ role: "option", label: /^Workspace run mode/ });
     await user.see({ role: "option", label: /^Developer/ });
-    await user.screenshot();
+    await user.looks([
+      "With Developer Mode enabled, the command palette visibly lists the advanced settings destinations.",
+      "Organization server, Runtime, Agent access diagnostics, OpenCode config sources, Experimental engine, Workspace run mode, and Developer remain readable and distinct.",
+    ]);
     await user.type(paletteInput, "Disable Developer Mode", { replace: true });
     await user.click({ role: "option", label: /^Disable Developer Mode/ });
     await waitForPaletteClose();

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -44,7 +44,7 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.screenshot();
   });
 
-  await step("Models stays readable beside long selected-model metadata and preserves composer state", async () => {
+  await step("Models stays readable without exposing internal model metadata and preserves composer state", async () => {
     await user.type(paletteInput, "models", { replace: true });
     await user.screenshot();
     await user.see({ role: "option", label: /^Models/ });
@@ -53,20 +53,19 @@ test("command palette searches settings by alias, navigates, records recents, an
     const metadata = await probe.dom('[data-command-palette-item="models"] > [data-slot="command-shortcut"]');
     expect(row.elements).toHaveLength(1);
     expect(label.elements).toHaveLength(1);
-    expect(metadata.elements).toHaveLength(1);
+    expect(metadata.elements).toHaveLength(0);
     expect(label.elements[0]!.text).toContain("Models");
     expect(label.elements[0]!.rect.width).toBeGreaterThan(80);
-    expect(metadata.elements[0]!.rect.height).toBeLessThanOrEqual(20);
-    expect(label.elements[0]!.rect.right).toBeLessThanOrEqual(metadata.elements[0]!.rect.left);
+    expect(row.elements[0]!.text.toLowerCase()).not.toContain(world.longModelId);
     evidence.recordJsonArtifact("Models row geometry", {
       row: row.elements[0],
       label: label.elements[0],
-      metadata: metadata.elements[0],
+      metadataCount: metadata.elements.length,
       longModelId: world.longModelId,
     });
     await user.looks([
       "The visible command palette row is clearly labeled Models.",
-      "The selected-model metadata is a single unobtrusive trailing line and does not overlap, replace, or garble the Models label.",
+      "No internal selected-model identifier or garbled model metadata is displayed in the Models row.",
     ]);
     await user.press("Enter");
     await user.see({ placeholder: "Search models..." });

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -219,8 +219,11 @@ test("command palette searches settings by alias, navigates, records recents, an
       if (section.id === "workspace-run-mode") {
         await user.see({ role: "switch", label: "Show workspace run mode" });
         const readSwitch = () => probe.eval(browserScript(() => {
-          const control = document.querySelector<HTMLButtonElement>('[data-testid="workspace-run-mode-flag"]');
-          return control ? { disabled: control.disabled, checked: control.getAttribute("aria-checked") } : null;
+          const control = document.querySelector<HTMLElement>('[data-testid="workspace-run-mode-flag"]');
+          return control ? {
+            disabled: control.matches(":disabled") || control.getAttribute("aria-disabled") === "true",
+            checked: control.getAttribute("aria-checked"),
+          } : null;
         }, []));
         const before = await readSwitch();
         expect(before?.disabled).toBe(true);

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -43,7 +43,7 @@ test("command palette searches settings by alias, navigates, records recents, an
     await user.notSee({ role: "option", label: /^Experimental engine/ });
     await user.looks([
       "The command palette is visibly open with its search field, result groups, and keyboard footer intact.",
-      "The empty-query palette visibly offers actions and settings, including Permissions, without a Recent group.",
+      "The empty-query palette visibly shows Settings including Permissions, without a Recent group.",
     ]);
   });
 

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -6,6 +6,7 @@ import { resolveEvalEngine, SkipError } from "@openwork/env";
 import type { Place, Seed } from "@openwork/env";
 import { daytonaSandbox, defaultDaytonaExec, desktop as launchDesktop, execInSandbox, startMockOnSandbox } from "@openwork/hosts";
 import { startMockMcp } from "@openwork/labs";
+import { configureProvider } from "./chat.ts";
 
 const stormProviderId = "active-session-storm-mock";
 const stormModelId = "mock-agent-workload-model";
@@ -1411,7 +1412,38 @@ export async function pinnedSessions(seed: Seed) {
 }
 
 export async function commandPaletteSearch(seed: Seed) {
-  return oneWorkspace(seed, `command-palette-search-${Date.now()}`);
+  const name = `command-palette-search-${Date.now()}`;
+  const workspacePath = seed.tmpPath(name);
+  const longModelId = "gwm_01m292tscteantqy79spgyvbcs_01m292tsbxehmvrpjxfn7m4n86_01m292tsbgey6s6q4hbnvd6a8h";
+  const providerId = "palette-model-witness";
+  const app = await seed.appWeb({ name, workspacePath });
+  const workspace = await seed.workspace(app, workspacePath);
+  await configureProvider(seed, app, workspace.workspaceId, providerId, longModelId, {
+    model: `${providerId}/${longModelId}`,
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Palette model witness",
+        options: { baseURL: "http://127.0.0.1:9/v1", apiKey: "palette-model-fixture" },
+        models: { [longModelId]: { name: longModelId } },
+      },
+    },
+  });
+  await waitFor(app, () => Boolean(window.__openworkControl), {
+    timeoutMs: 60_000,
+    label: "reloaded app-web command palette is interactive",
+  });
+  return {
+    app,
+    workspace,
+    workspacePath,
+    longModelId,
+    location: () => seed.evalIn(app, () => window.location.pathname),
+    runtimeFacts: () => seed.evalIn(app, () => ({
+      browser: navigator.userAgent,
+      electronBridge: Boolean(window.__OPENWORK_ELECTRON__),
+    })),
+  };
 }
 
 type ArchiveFault = "none" | "false" | "error" | "timeout" | "unconfirmed" | "hold" | "retry" | "permission" | "question" | "prompt_error" | "hold_prompt" | "accepted_command" | "accepted_prompt" | "hold_archive";


### PR DESCRIPTION
## Summary
- label the Cmd+K model entry as Models and remove internal selected-model IDs from the row
- migrate the existing command-palette journey to appWeb with HeadlessChrome/no-Electron coverage for readability, no metadata leakage, keyboard back/close behavior, search/navigation, recents, and draft/model preservation

## Web migration prerequisite
- keep the advertised Workspace run mode destination mounted and focusable on web
- keep its desktop-only switch disabled on web and assert a click is refused without changing state

## Testing
- `pnpm --filter @openwork/app exec bun test --isolate tests/command-palette-search.test.ts tests/command-palette-models.test.ts tests/command-palette-settings.test.ts` (14 passed)
- `pnpm --filter @openwork/app typecheck`
- `pnpm evals:e2e command-palette-search --engine v2 --surface web --with-llm-vision` (1 passed; 7/7 visual artifacts and 14/14 expectations passed; 0 unvalidated/failed/pending; SHA `86f9f740125e30303f4292fb2db7389a058f13d1`)
- `pnpm evals:e2e composer-model-picker-no-subscribe-promo --engine v2 --case MODEL-01 --surface web` (selected case 1 passed, 0 failed, 0 skipped; one non-selected legacy sibling not run; SHA `86f9f740125e30303f4292fb2db7389a058f13d1`)
- pre-fix appWeb run pinned to `030d0fe08` fails the Models assertion and retains screenshot evidence

Linear: OPE-50