### PR TITLE
fix(app): hide default thinking label in composer

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -332,6 +332,7 @@ export function ModelSelect({
   const nextFavorite = nextFavoriteModel(favorites, value);
   const showBehavior = !hideValue
     && selectedThinkingOptions.length > 0
+    && (selectedOption ? selectedOption.behaviorValue != null : behaviorValue != null)
     && Boolean(effectiveBehaviorLabel);
 
   const applyModel = (option: ModelOption, behavior?: string | null) => {

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -65,18 +65,26 @@ effortTest("MODEL-01 selected reasoning effort survives reload and reaches the n
   const catalog = await world.readNative(`${prefix}/model`);
   expect(catalog.status).toBe(200);
   expect(catalog.body).toMatchObject({ data: expect.arrayContaining([
-    expect.objectContaining({ id: world.modelId, providerID: world.providerId, variants: [{ id: "low" }, { id: "high" }, { id: "CustomExact" }] }),
+    expect.objectContaining({ id: world.modelId, providerID: world.providerId, variants: [{ id: "low" }, { id: "high" }, { id: "CustomExact" }, { id: "auto" }] }),
     expect.objectContaining({ id: "standard", providerID: world.providerId, variants: [] }),
   ]) });
   expect(JSON.stringify(catalog.body)).not.toMatch(/synthetic-effort-key|"settings":|"providerOptions":|"headers":/);
   evidence.recordJsonArtifact("MODEL-01 native catalog", catalog);
+  await step("Default leaves the closed trigger showing only the model", async () => {
+    await user.looks([
+      "The closed composer model trigger shows Reasoning witness with a dropdown chevron, without a Default label or a middle-dot separator next to the model name.",
+    ]);
+    await user.see({ role: "button", label: "Change model" }, { text: /^Reasoning witness$/ });
+  });
   await user.click({ role: "button", label: "Change model" });
   await step("only advertised effort choices are selectable", async () => {
     await user.click({ role: "button", label: /^Effort/ });
+    await user.see({ role: "button", label: "Default" });
     await user.see({ role: "button", label: "Low" });
     await user.notSee({ role: "button", label: /^Hidden/ });
     await user.click({ role: "button", label: "High" });
     await user.see({ role: "button", label: "Change model" }, { text: /High/ });
+    await user.looks(["The closed composer model trigger shows Reasoning witness followed by a middle-dot separator and High, with a dropdown chevron."]);
   });
   await user.press("Escape");
   await user.type("composer", world.prompt);
@@ -150,5 +158,38 @@ effortTest("MODEL-01 selected reasoning effort survives reload and reaches the n
     expect(native.body).toMatchObject({ data: { model: { id: "standard", providerID: world.providerId, variant: "default" } } });
     evidence.recordJsonArtifact("MODEL-01 unsupported model request and native session", { requests, modelRequests, native });
     await user.see("Run task", { timeoutMs: 30_000 });
+  });
+  await step("returning to Default removes the suffix and persists after reload", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ role: "button", label: /^Model\s+Standard witness/ });
+    await user.type({ placeholder: "Search models..." }, "Reasoning witness");
+    await user.click({ role: "option", label: /^Reasoning witness/ });
+    await user.click({ role: "button", label: "High" });
+    await user.see({ role: "button", label: "Change model" }, { text: /High/ });
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ role: "button", label: /^Effort/ });
+    await user.click({ role: "button", label: "Default" });
+    await user.see({ role: "button", label: "Change model" }, { text: /^Reasoning witness$/ });
+    await user.reload();
+    await user.see("Run task", { timeoutMs: 60_000 });
+    await user.see({ role: "button", label: "Change model" }, { text: /^Reasoning witness$/ });
+    await user.looks(["The closed composer model trigger shows Reasoning witness and its dropdown chevron, with no Default label and no middle-dot separator next to the model name."]);
+    const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
+    expect(native.body).toMatchObject({ data: { model: { id: world.modelId, providerID: world.providerId, variant: "default" } } });
+    evidence.recordJsonArtifact("MODEL-01 Default after reload", native);
+    await user.click({ role: "button", label: "Change model" });
+    await user.see({ role: "button", label: /^Effort\s+Default/ });
+    await user.click({ role: "button", label: /^Effort/ });
+    await user.see({ role: "button", label: "Default" });
+    await user.looks(["The effort picker is open and retains a selectable Default choice alongside Low, High, Auto, and CustomExact."]);
+    await user.click({ role: "button", label: "Auto" });
+    await user.see({ role: "button", label: "Change model" }, { text: /^Reasoning witness\s*· Auto$/ });
+    await user.reload();
+    await user.see("Run task", { timeoutMs: 60_000 });
+    await user.see({ role: "button", label: "Change model" }, { text: /^Reasoning witness\s*· Auto$/ });
+    await user.looks(["The closed composer model trigger shows Reasoning witness followed by a middle-dot separator and Auto, with a dropdown chevron."]);
+    const explicit = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
+    expect(explicit.body).toMatchObject({ data: { model: { id: world.modelId, providerID: world.providerId, variant: "auto" } } });
+    evidence.recordJsonArtifact("MODEL-01 explicit auto variant after reload", explicit);
   });
 });

--- a/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
+++ b/evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts
@@ -174,6 +174,11 @@ effortTest("MODEL-01 selected reasoning effort survives reload and reaches the n
     await user.see("Run task", { timeoutMs: 60_000 });
     await user.see({ role: "button", label: "Change model" }, { text: /^Reasoning witness$/ });
     await user.looks(["The closed composer model trigger shows Reasoning witness and its dropdown chevron, with no Default label and no middle-dot separator next to the model name."]);
+    await user.type("composer", world.prompt);
+    await user.click("Run task");
+    await probe.eventually(() => world.requests(), { within: 90_000, label: "Default reaches provider after reload", until: (requests) => requests.length === 5 });
+    expect((await world.requests())[4]).toMatchObject({ model: world.modelId, reasoningEffort: null });
+    await user.see("Run task", { timeoutMs: 30_000 });
     const native = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
     expect(native.body).toMatchObject({ data: { model: { id: world.modelId, providerID: world.providerId, variant: "default" } } });
     evidence.recordJsonArtifact("MODEL-01 Default after reload", native);
@@ -188,6 +193,11 @@ effortTest("MODEL-01 selected reasoning effort survives reload and reaches the n
     await user.see("Run task", { timeoutMs: 60_000 });
     await user.see({ role: "button", label: "Change model" }, { text: /^Reasoning witness\s*· Auto$/ });
     await user.looks(["The closed composer model trigger shows Reasoning witness followed by a middle-dot separator and Auto, with a dropdown chevron."]);
+    await user.type("composer", world.prompt);
+    await user.click("Run task");
+    await probe.eventually(() => world.requests(), { within: 90_000, label: "explicit Auto reaches provider after reload", until: (requests) => requests.length === 6 });
+    expect((await world.requests())[5]).toMatchObject({ model: world.modelId, reasoningEffort: "low" });
+    await user.see("Run task", { timeoutMs: 30_000 });
     const explicit = await world.readNative(`${prefix}/session/${world.session.sessionId}`);
     expect(explicit.body).toMatchObject({ data: { model: { id: world.modelId, providerID: world.providerId, variant: "auto" } } });
     evidence.recordJsonArtifact("MODEL-01 explicit auto variant after reload", explicit);

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -648,6 +648,7 @@ export async function modelPickerEffortWeb(seed: Seed) {
         [modelId]: { name: "Reasoning witness", reasoning: true, variants: {
           low: { reasoningEffort: "low" }, high: { reasoningEffort: "high" },
           CustomExact: { reasoningEffort: "low" },
+          auto: { reasoningEffort: "low" },
           hidden: { disabled: true, reasoningEffort: "high" },
         } },
         standard: { name: "Standard witness", reasoning: false },


### PR DESCRIPTION
## Summary
- OPE-49: hide Default and its separator on the closed composer trigger, using the selected behavior identity rather than label text.
- Keep the picker Default choice and explicit provider variant labels unchanged.
- Extend existing MODEL-01; preserve High/CustomExact native request coverage and add Default/Auto reload checks with synthetic provider requests.

## Final-head verification
Commit: 3bb3b43cb2600749e2b8f4d0949082de2e2903ce
- Pinned Daytona appWeb/HeadlessChrome/v2 MODEL-01: 1 passed, 0 failed, 0 selected skips; unrelated Electron case not executed.
- Five screenshots: 5/5 automated visual expectations passed, zero pending/unvalidated; all five independently opened and inspected firsthand.
- App typecheck and whitespace check passed.
- Live build/core/required CI and Warden passed on this exact SHA; Warden reports no blocking findings.
- Final evidence with screenshots: https://github.com/different-ai/openwork/pull/4947#issuecomment-5649250438
- Historical red and incomplete runs retained: https://github.com/different-ai/openwork/pull/4947#issuecomment-5649255153

## Typecheck control
Both local eval typecheck failures reproduce with the tracked source tree restored exactly to baseline 91a7459a691179437fab6b9a09ffc9e21529a64e, verified by git diff against that SHA, in this same worktree with identical Node 24/pnpm dependencies. No second worktree or main-checkout changes. Final-head files restored afterward.
- Canonical eval typecheck: exit 1 on baseline and head, one TS2345 in session-attention-rollup.test.ts:27.
- Spec-layer typecheck: exit 2 on baseline and head, same 12 TS1294/TS2550 diagnostics from existing compiler flags/library coverage.
No unrelated fixes included. These remain known baseline check failures, not passing checks.

## Reproduce
With the vision key supplied securely, run:

OPENWORK_EVAL_REF=3bb3b43cb2600749e2b8f4d0949082de2e2903ce pnpm evals:e2e composer-model-picker-no-subscribe-promo --engine v2 --case MODEL-01 --surface web --with-llm-vision --strict-ref

No merge authorized or performed.