### PR TITLE
ci(review): redeploy the review app and keep report links on a stable alias

### DIFF
--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -1,0 +1,102 @@
+name: Review app deploy
+
+# Report links in PR comments point at vars.OPENWORK_REVIEW_URL. A Vercel
+# deployment URL is an immutable snapshot, so that variable must name a stable
+# alias. This workflow redeploys the review app from the default branch and
+# moves the alias to the new deployment, so existing report links always open
+# the current app.
+#
+# Required repository configuration:
+#   vars.OPENWORK_REVIEW_URL                 https://<stable-alias>.vercel.app
+#   vars.OPENWORK_REVIEW_VERCEL_ORG_ID       Vercel team id (team_...)
+#   vars.OPENWORK_REVIEW_VERCEL_PROJECT_ID   Vercel project id (prj_...)
+#   secrets.VERCEL_TOKEN                     Vercel token with access to the project
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - apps/review/**
+      - packages/review/**
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .github/workflows/review-app-deploy.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: review-app-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      github.repository == 'different-ai/openwork' &&
+      vars.OPENWORK_REVIEW_URL != '' &&
+      vars.OPENWORK_REVIEW_VERCEL_ORG_ID != '' &&
+      vars.OPENWORK_REVIEW_VERCEL_PROJECT_ID != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ vars.OPENWORK_REVIEW_VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.OPENWORK_REVIEW_VERCEL_PROJECT_ID }}
+      OPENWORK_REVIEW_URL: ${{ vars.OPENWORK_REVIEW_URL }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Resolve the stable review alias
+        id: alias
+        run: |
+          set -euo pipefail
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::Missing GitHub Actions secret VERCEL_TOKEN."
+            exit 1
+          fi
+          host="$(node -e 'const u = new URL(process.env.OPENWORK_REVIEW_URL); if (u.protocol !== "https:" || u.pathname !== "/" || u.search || u.hash) throw new Error("OPENWORK_REVIEW_URL must be an https origin"); console.log(u.hostname)')"
+          if [[ "$host" =~ -[a-z0-9]{9}-[a-z0-9-]+\.vercel\.app$ ]]; then
+            echo "::error::OPENWORK_REVIEW_URL ($host) looks like a single deployment URL. Point it at a stable alias so redeploys can replace it."
+            exit 1
+          fi
+          echo "host=$host" >> "$GITHUB_OUTPUT"
+      - name: Deploy the review app to the protected preview environment
+        id: deploy
+        run: |
+          set -euo pipefail
+          url="$(npx --yes vercel@48 deploy --target preview --yes --token "$VERCEL_TOKEN" --meta githubCommitSha="$GITHUB_SHA")"
+          case "$url" in
+            https://*) ;;
+            *) echo "::error::Unexpected deployment output: $url"; exit 1 ;;
+          esac
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed $url"
+      - name: Point the stable alias at the new deployment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          ALIAS_HOST: ${{ steps.alias.outputs.host }}
+        run: |
+          set -euo pipefail
+          npx --yes vercel@48 alias set "$DEPLOYMENT_URL" "$ALIAS_HOST" --token "$VERCEL_TOKEN"
+      - name: Verify the alias still requires Vercel Authentication
+        env:
+          ALIAS_HOST: ${{ steps.alias.outputs.host }}
+        run: |
+          set -euo pipefail
+          headers="$(curl -sS -o /dev/null -D - --max-time 30 "https://$ALIAS_HOST/")"
+          status="$(printf '%s' "$headers" | head -n1 | awk '{print $2}')"
+          location="$(printf '%s' "$headers" | tr -d '\r' | awk 'tolower($1)=="location:" {print $2}')"
+          if [ "$status" != "302" ] && [ "$status" != "401" ]; then
+            echo "::error::Anonymous request to https://$ALIAS_HOST/ returned $status; Vercel Authentication must protect the review alias."
+            exit 1
+          fi
+          if [ "$status" = "302" ] && [[ "$location" != https://vercel.com/sso-api* ]]; then
+            echo "::error::Anonymous request was redirected to $location instead of Vercel Authentication."
+            exit 1
+          fi
+          echo "https://$ALIAS_HOST/ is protected and now serves the deployment from $GITHUB_SHA."

--- a/apps/review/.env.example
+++ b/apps/review/.env.example
@@ -1,7 +1,7 @@
 # Access: enable Vercel Authentication for Preview in the project settings.
 # Private Vercel Blob store token, used by both the app and publisher.
 BLOB_READ_WRITE_TOKEN=
-# Publisher: the deployed review app's origin.
+# Publisher: the review app's stable alias origin (not a per-deployment URL).
 OPENWORK_REVIEW_URL=
 # Optional local artifact directory, shared by the local app and publisher.
 OPENWORK_REVIEW_LOCAL_DIR=

--- a/apps/review/README.md
+++ b/apps/review/README.md
@@ -32,8 +32,17 @@ Create a project with root directory `apps/review`, enable source files outside
 that directory, and connect a **private** Vercel Blob store. Configure
 `BLOB_READ_WRITE_TOKEN` for the Preview environment. Enable **Vercel Authentication**
 under Deployment Protection with **Standard Protection** (or All Deployments).
-Deploy with `vercel deploy --target preview` and use that protected preview URL
-for `OPENWORK_REVIEW_URL`.
+Deploy with `vercel deploy --target preview`, then give the deployment a stable
+alias and use that alias for `OPENWORK_REVIEW_URL`:
+
+```sh
+vercel alias set <deployment-url> openwork-review-<team>.vercel.app
+```
+
+Never use a deployment URL (`<project>-<hash>-<team>.vercel.app`) for
+`OPENWORK_REVIEW_URL`: it is an immutable snapshot, so every report link would
+keep opening the app version from that one deploy. Aliases on `*.vercel.app`
+stay under Standard Protection; do not alias a production custom domain.
 
 Teammates open the PR's report link using their existing Vercel account with
 access to this project. There is no app password. Vercel authenticates requests
@@ -48,8 +57,15 @@ and image routes must return Vercel's authentication response. An authenticated
 request (or `vercel curl` for verification) must reach the app with no Basic
 authorization header. See [Vercel Authentication](https://vercel.com/docs/deployment-protection/methods-to-protect-deployments/vercel-authentication).
 
-The app only rebuilds when it or its dependencies change. Report publication
-uploads data to the existing app; it never creates a deployment.
+The **Review app deploy** workflow redeploys the app whenever `apps/review`,
+`packages/review`, or the lockfile changes on the default branch (or on manual
+dispatch) and moves the alias named by `OPENWORK_REVIEW_URL` to the new
+deployment, then checks that the alias still answers anonymous requests with
+Vercel Authentication. It needs repository variables
+`OPENWORK_REVIEW_VERCEL_ORG_ID` and `OPENWORK_REVIEW_VERCEL_PROJECT_ID` (from
+`.vercel/project.json` after `vercel link`) and the `VERCEL_TOKEN` secret.
+Report publication uploads data to the existing app; it never creates a
+deployment.
 
 Set `OPENWORK_REVIEW_URL` and `BLOB_READ_WRITE_TOKEN` in the publishing
 environment. The existing command publishes a compact link when configured:


### PR DESCRIPTION
## Problem

PR evidence comments link to `vars.OPENWORK_REVIEW_URL`, which is currently a single Vercel **deployment** URL (`openwork-review-<hash>-<team>.vercel.app`). Deployment URLs are immutable snapshots, and the review project has no Git integration, so nothing has redeployed it since the first manual `vercel deploy` and the variable could never follow a new deploy anyway. Every report link keeps opening the app as it was on that first deploy.

## Fix

- New `Review app deploy` workflow: on pushes to `dev` touching `apps/review/**`, `packages/review/**`, or the lockfile (and on manual dispatch), deploy the app to the protected Preview environment with `vercel deploy --target preview`, move the alias named by `OPENWORK_REVIEW_URL` to the new deployment, and fail if an anonymous request to the alias is not answered by Vercel Authentication.
- The workflow refuses to run when `OPENWORK_REVIEW_URL` still looks like a per-deployment URL, so the misconfiguration is loud instead of silent.
- README / `.env.example`: require a stable `*.vercel.app` alias for `OPENWORK_REVIEW_URL` and document the new variables.

## Operator follow-up (not in code)

1. `vercel alias set <current-deployment> <stable-alias>.vercel.app`
2. Set repo variable `OPENWORK_REVIEW_URL` to `https://<stable-alias>.vercel.app`
3. Set repo variables `OPENWORK_REVIEW_VERCEL_ORG_ID` and `OPENWORK_REVIEW_VERCEL_PROJECT_ID` (from `.vercel/project.json`); `VERCEL_TOKEN` secret already exists.
4. Run the workflow once via dispatch.

## Verification

- `actionlint .github/workflows/review-app-deploy.yml` passes.
- Alias-vs-deployment host heuristic checked against the current deployment URL and two alias shapes.